### PR TITLE
net: migrate to SPDX identifier

### DIFF
--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/Makefile
+++ b/net/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # net/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/arp/CMakeLists.txt
+++ b/net/arp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/arp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/arp/Make.defs
+++ b/net/arp/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/arp/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp_acd.c
+++ b/net/arp/arp_acd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_acd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp_dump.c
+++ b/net/arp/arp_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_dump.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/arp/arp_format.c
+++ b/net/arp/arp_format.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_format.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/arp/arp_input.c
+++ b/net/arp/arp_input.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_input.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/arp/arp_ipin.c
+++ b/net/arp/arp_ipin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_ipin.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/arp/arp_notify.c
+++ b/net/arp/arp_notify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_notify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp_out.c
+++ b/net/arp/arp_out.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_out.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014-2015, 2017-2018 Gregory Nutt. All rights
  *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/arp/arp_send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/arp/arp_table.c
- * Implementation of the ARP Address Resolution Protocol.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009, 2011, 2014, 2018 Gregory Nutt. All rights
  *     reserved.

--- a/net/bluetooth/CMakeLists.txt
+++ b/net/bluetooth/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/bluetooth/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/bluetooth/Make.defs
+++ b/net/bluetooth/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/bluetooth/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth.h
+++ b/net/bluetooth/bluetooth.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_callback.c
+++ b/net/bluetooth/bluetooth_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_container.c
+++ b/net/bluetooth/bluetooth_container.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_container.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_finddev.c
+++ b/net/bluetooth/bluetooth_finddev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_finddev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_initialize.c
+++ b/net/bluetooth/bluetooth_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_input.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_poll.c
+++ b/net/bluetooth/bluetooth_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/bluetooth/bluetooth_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/CMakeLists.txt
+++ b/net/can/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/can/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/can/Make.defs
+++ b/net/can/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/can/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/can/can_input.c
- * Handling incoming packet input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/can/can_notifier.c
+++ b/net/can/can_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_poll.c
+++ b/net/can/can_poll.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/can/can_poll.c
- * Poll for the availability of packet TX data
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/can/can_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/CMakeLists.txt
+++ b/net/devif/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/devif/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/devif/Make.defs
+++ b/net/devif/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/devif/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2009, 2013-2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_filesend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_forward.c
+++ b/net/devif/devif_forward.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_forward.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_initialize.c
+++ b/net/devif/devif_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_initialize.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2014, 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/devif/devif_iobsend.c
+++ b/net/devif/devif_iobsend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_iobsend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_loopback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/devif/devif_send.c
+++ b/net/devif/devif_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/devif/devif_send.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007, 2008 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/devif/ipv4_input.c
- * Device driver IPv4 packet receipt interface
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009, 2013-2015, 2018-2019 Gregory Nutt. All rights
  *     reserved.

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/devif/ipv6_input.c
- * Device driver IPv6 packet receipt interface
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/icmp/CMakeLists.txt
+++ b/net/icmp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/icmp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/icmp/Make.defs
+++ b/net/icmp/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/icmp/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/icmp/icmp_input.c
- * Handling incoming ICMP input
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009, 2012, 2014-2015, 2017, 2019 Gregory Nutt. All
  *     rights reserved.

--- a/net/icmp/icmp_ioctl.c
+++ b/net/icmp/icmp_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_netpoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_pmtu.c
+++ b/net/icmp/icmp_pmtu.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_pmtu.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_poll.c
+++ b/net/icmp/icmp_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_reply.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmp/icmp_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/CMakeLists.txt
+++ b/net/icmpv6/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/icmpv6/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/icmpv6/Make.defs
+++ b/net/icmpv6/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/icmpv6/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_advertise.c
+++ b/net/icmpv6/icmpv6_advertise.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_advertise.c
- * Send an ICMPv6 Neighbor Advertisement
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_autoconfig.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_initialize.c
+++ b/net/icmpv6/icmpv6_initialize.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_initialize.c
- * ICMPv6 initialization logic
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_input.c
- * Handling incoming ICMPv6 input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/icmpv6/icmpv6_ioctl.c
+++ b/net/icmpv6/icmpv6_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_linkipaddr.c
+++ b/net/icmpv6/icmpv6_linkipaddr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_linkipaddr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_neighbor.c
+++ b/net/icmpv6/icmpv6_neighbor.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_neighbor.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_netpoll.c
+++ b/net/icmpv6/icmpv6_netpoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_netpoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_notify.c
+++ b/net/icmpv6/icmpv6_notify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_notify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_pmtu.c
+++ b/net/icmpv6/icmpv6_pmtu.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_pmtu.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_poll.c
+++ b/net/icmpv6/icmpv6_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_radvertise.c
- * Send an ICMPv6 Router Advertisement
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_reply.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_rnotify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_rsolicit.c
+++ b/net/icmpv6/icmpv6_rsolicit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_rsolicit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/icmpv6/icmpv6_solicit.c
+++ b/net/icmpv6/icmpv6_solicit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/icmpv6/icmpv6_solicit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/CMakeLists.txt
+++ b/net/ieee802154/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/ieee802154/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/ieee802154/Make.defs
+++ b/net/ieee802154/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/ieee802154/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154.h
+++ b/net/ieee802154/ieee802154.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_callback.c
+++ b/net/ieee802154/ieee802154_callback.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_callback.c
- * Forward events to waiting PF_IEEE802154 sockets.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_container.c
+++ b/net/ieee802154/ieee802154_container.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_container.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_finddev.c
+++ b/net/ieee802154/ieee802154_finddev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_finddev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_initialize.c
+++ b/net/ieee802154/ieee802154_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_input.c
+++ b/net/ieee802154/ieee802154_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_input.c
- * Handle incoming IEEE 802.15.4 frame input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/ieee802154/ieee802154_poll.c
+++ b/net/ieee802154/ieee802154_poll.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_poll.c
- * Poll for the availability of ougoing IEEE 802.15.4 frames
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ieee802154/ieee802154_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/igmp/CMakeLists.txt
+++ b/net/igmp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/igmp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/igmp/Make.defs
+++ b/net/igmp/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/igmp/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/igmp/igmp.h
+++ b/net/igmp/igmp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/igmp/igmp_group.c
+++ b/net/igmp/igmp_group.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/igmp/igmp_group.c
- * IGMP group data structure management logic
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2010, 2013-2014, 2016, 2018 Gregory Nutt.
  *   All rights reserved.

--- a/net/igmp/igmp_initialize.c
+++ b/net/igmp/igmp_initialize.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/igmp/igmp_initialize.c
- * IGMP initialization logic
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2010, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_input.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010, 2014, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_join.c
+++ b/net/igmp/igmp_join.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_join.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_leave.c
+++ b/net/igmp/igmp_leave.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_leave.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010-2011, 2014, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_mcastmac.c
+++ b/net/igmp/igmp_mcastmac.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_mcastmac.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_msg.c
+++ b/net/igmp/igmp_msg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_msg.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010-2011, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_poll.c
+++ b/net/igmp/igmp_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_poll.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010, 2018-2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/igmp/igmp_timer.c
+++ b/net/igmp/igmp_timer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/igmp/igmp_timer.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2010-2011, 2014, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/inet/CMakeLists.txt
+++ b/net/inet/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/inet/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/inet/Make.defs
+++ b/net/inet/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/inet/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/inet.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/inet_globals.c
+++ b/net/inet/inet_globals.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/inet_globals.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/inet_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/inet_txdrain.c
+++ b/net/inet/inet_txdrain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/inet_txdrain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv4_build_header.c
+++ b/net/inet/ipv4_build_header.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv4_build_header.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv4_getpeername.c
+++ b/net/inet/ipv4_getpeername.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv4_getpeername.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv4_getsockname.c
+++ b/net/inet/ipv4_getsockname.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv4_getsockname.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv4_getsockopt.c
+++ b/net/inet/ipv4_getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv4_getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv4_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv6_build_header.c
+++ b/net/inet/ipv6_build_header.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv6_build_header.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv6_getpeername.c
+++ b/net/inet/ipv6_getpeername.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv6_getpeername.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv6_getsockname.c
+++ b/net/inet/ipv6_getsockname.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv6_getsockname.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv6_getsockopt.c
+++ b/net/inet/ipv6_getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv6_getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/inet/ipv6_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipfilter/CMakeLists.txt
+++ b/net/ipfilter/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/ipfilter/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/ipfilter/Make.defs
+++ b/net/ipfilter/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/ipfilter/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/ipfilter/ipfilter.c
+++ b/net/ipfilter/ipfilter.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipfilter/ipfilter.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipfilter/ipfilter.h
+++ b/net/ipfilter/ipfilter.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipfilter/ipfilter.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/CMakeLists.txt
+++ b/net/ipforward/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/ipforward/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/ipforward/Make.defs
+++ b/net/ipforward/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/ipforward/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipforward.h
+++ b/net/ipforward/ipforward.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipforward.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipfwd_alloc.c
+++ b/net/ipforward/ipfwd_alloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipfwd_alloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipfwd_dropstats.c
+++ b/net/ipforward/ipfwd_dropstats.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipfwd_dropstats.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipfwd_forward.c
+++ b/net/ipforward/ipfwd_forward.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipfwd_forward.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipfwd_poll.c
+++ b/net/ipforward/ipfwd_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipfwd_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipv4_forward.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipforward/ipv6_forward.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipfrag/CMakeLists.txt
+++ b/net/ipfrag/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/ipfrag/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/ipfrag/Make.defs
+++ b/net/ipfrag/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/ipfrag/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ipfrag/ipfrag.c
- * Handling incoming IPv4 and IPv6 fragment input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/ipfrag/ipfrag.h
+++ b/net/ipfrag/ipfrag.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/ipfrag/ipfrag.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ipfrag/ipv4_frag.c
- * Handling incoming IPv4 fragment input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/ipfrag/ipv6_frag.c
- * Handling incoming IPv6 fragment input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/local/CMakeLists.txt
+++ b/net/local/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/local/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/local/Make.defs
+++ b/net/local/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/local/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_accept.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_bind.c
+++ b/net/local/local_bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_connect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_fifo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_listen.c
+++ b/net/local/local_listen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_listen.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_netpoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_recvutils.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_release.c
+++ b/net/local/local_release.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_release.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_sendpacket.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/local/local_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/CMakeLists.txt
+++ b/net/mld/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/mld/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/mld/Make.defs
+++ b/net/mld/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/mld/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld.h
+++ b/net/mld/mld.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/mld/mld.h
- * Multicast Listener Discovery (MLD) Definitions
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/mld/mld_done.c
+++ b/net/mld/mld_done.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_done.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_group.c
+++ b/net/mld/mld_group.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_group.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_initialize.c
+++ b/net/mld/mld_initialize.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/mld/mld_initialize.c
- * MLD initialization logic
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/mld/mld_join.c
+++ b/net/mld/mld_join.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_join.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_leave.c
+++ b/net/mld/mld_leave.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_leave.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_mcastmac.c
+++ b/net/mld/mld_mcastmac.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_mcastmac.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_msg.c
+++ b/net/mld/mld_msg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_msg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_poll.c
+++ b/net/mld/mld_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_query.c
+++ b/net/mld/mld_query.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_query.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_report.c
+++ b/net/mld/mld_report.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_report.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_send.c
+++ b/net/mld/mld_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/mld/mld_timer.c
+++ b/net/mld/mld_timer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/mld/mld_timer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/CMakeLists.txt
+++ b/net/nat/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/nat/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/nat/Make.defs
+++ b/net/nat/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/nat/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/ipv4_nat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/ipv4_nat_entry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/ipv6_nat.c
+++ b/net/nat/ipv6_nat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/ipv6_nat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/ipv6_nat_entry.c
+++ b/net/nat/ipv6_nat_entry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/ipv6_nat_entry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/nat.c
+++ b/net/nat/nat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/nat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/nat/nat.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/CMakeLists.txt
+++ b/net/neighbor/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/neighbor/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/neighbor/Make.defs
+++ b/net/neighbor/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/neighbor/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor.h
+++ b/net/neighbor/neighbor.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/neighbor/neighbor.h
- * Header file for database of link-local neighbors, used by IPv6 code.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/neighbor/neighbor_add.c
+++ b/net/neighbor/neighbor_add.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_add.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_dumpentry.c
+++ b/net/neighbor/neighbor_dumpentry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_dumpentry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_ethernet_out.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_findentry.c
+++ b/net/neighbor/neighbor_findentry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_findentry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_globals.c
+++ b/net/neighbor/neighbor_globals.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_globals.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_lookup.c
+++ b/net/neighbor/neighbor_lookup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_lookup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_out.c
+++ b/net/neighbor/neighbor_out.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_out.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_snapshot.c
+++ b/net/neighbor/neighbor_snapshot.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_snapshot.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/neighbor/neighbor_update.c
+++ b/net/neighbor/neighbor_update.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/neighbor/neighbor_update.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/net_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/CMakeLists.txt
+++ b/net/netdev/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/netdev/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/netdev/Make.defs
+++ b/net/netdev/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/netdev/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev.h
+++ b/net/netdev/netdev.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_carrier.c
+++ b/net/netdev/netdev_carrier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_carrier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_count.c
+++ b/net/netdev/netdev_count.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_count.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_default.c
+++ b/net/netdev/netdev_default.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_default.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_findbyaddr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_findbyindex.c
+++ b/net/netdev/netdev_findbyindex.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_findbyindex.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_findbyname.c
+++ b/net/netdev/netdev_findbyname.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_findbyname.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_foreach.c
+++ b/net/netdev/netdev_foreach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_foreach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_ifconf.c
+++ b/net/netdev/netdev_ifconf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_ifconf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_input.c
+++ b/net/netdev/netdev_input.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_input.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_iob.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_ipv6.c
+++ b/net/netdev/netdev_ipv6.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_ipv6.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_lladdrsize.c
+++ b/net/netdev/netdev_lladdrsize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_lladdrsize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_notify_recvcpu.c
+++ b/net/netdev/netdev_notify_recvcpu.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_notify_recvcpu.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_register.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_stats.c
+++ b/net/netdev/netdev_stats.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_stats.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_txnotify.c
+++ b/net/netdev/netdev_txnotify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_txnotify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_unregister.c
+++ b/net/netdev/netdev_unregister.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_unregister.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdev_verify.c
+++ b/net/netdev/netdev_verify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdev_verify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netdev/netdown_notifier.c
+++ b/net/netdev/netdown_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netdev/netdown_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/CMakeLists.txt
+++ b/net/netfilter/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/netfilter/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/netfilter/Make.defs
+++ b/net/netfilter/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/netfilter/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/ip6t_sockopt.c
+++ b/net/netfilter/ip6t_sockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netfilter/ip6t_sockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/ipt_filter.c
+++ b/net/netfilter/ipt_filter.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netfilter/ipt_filter.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/ipt_nat.c
+++ b/net/netfilter/ipt_nat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netfilter/ipt_nat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/ipt_sockopt.c
+++ b/net/netfilter/ipt_sockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netfilter/ipt_sockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netfilter/iptables.h
+++ b/net/netfilter/iptables.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netfilter/iptables.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/CMakeLists.txt
+++ b/net/netlink/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/netlink/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/netlink/Make.defs
+++ b/net/netlink/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/netlink/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_attr.c
+++ b/net/netlink/netlink_attr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_attr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_netfilter.c
+++ b/net/netlink/netlink_netfilter.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_netfilter.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_notifier.c
+++ b/net/netlink/netlink_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_route.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/netlink/netlink_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/CMakeLists.txt
+++ b/net/pkt/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/pkt/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/pkt/Make.defs
+++ b/net/pkt/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/pkt/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt.h
+++ b/net/pkt/pkt.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_callback.c
+++ b/net/pkt/pkt_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_finddev.c
+++ b/net/pkt/pkt_finddev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_finddev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/pkt/pkt_input.c
- * Handling incoming packet input
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/pkt/pkt_poll.c
+++ b/net/pkt/pkt_poll.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/pkt/pkt_poll.c
- * Poll for the availability of packet TX data
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/CMakeLists.txt
+++ b/net/procfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/procfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/procfs/Make.defs
+++ b/net/procfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/procfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_mld.c
+++ b/net/procfs/net_mld.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_mld.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_procfs_route.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_statistics.c
+++ b/net/procfs/net_statistics.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_statistics.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_tcp.c
+++ b/net/procfs/net_tcp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_tcp.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/net_udp.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/netdev_statistics.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/procfs/procfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/CMakeLists.txt
+++ b/net/route/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/route/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/route/Make.defs
+++ b/net/route/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/route/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/route/cacheroute.h
+++ b/net/route/cacheroute.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/cacheroute.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/fileroute.h
+++ b/net/route/fileroute.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/fileroute.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_add_fileroute.c
+++ b/net/route/net_add_fileroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_add_fileroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_add_ramroute.c
+++ b/net/route/net_add_ramroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_add_ramroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_alloc_ramroute.c
+++ b/net/route/net_alloc_ramroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_alloc_ramroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_cacheroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_del_fileroute.c
+++ b/net/route/net_del_fileroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_del_fileroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_del_ramroute.c
+++ b/net/route/net_del_ramroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_del_ramroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_dumproute.c
+++ b/net/route/net_dumproute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_dumproute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_fileroute.c
+++ b/net/route/net_fileroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_fileroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_foreach_fileroute.c
+++ b/net/route/net_foreach_fileroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_foreach_fileroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_foreach_ramroute.c
+++ b/net/route/net_foreach_ramroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_foreach_ramroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_foreach_romroute.c
+++ b/net/route/net_foreach_romroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_foreach_romroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_initroute.c
+++ b/net/route/net_initroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_initroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_queue_ramroute.c
+++ b/net/route/net_queue_ramroute.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_queue_ramroute.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/net_router.c
+++ b/net/route/net_router.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/net_router.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/netdev_router.c
+++ b/net/route/netdev_router.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/netdev_router.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/ramroute.h
+++ b/net/route/ramroute.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/ramroute.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/romroute.h
+++ b/net/route/romroute.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/romroute.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/route/route.h
+++ b/net/route/route.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/route/route.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/rpmsg/CMakeLists.txt
+++ b/net/rpmsg/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/rpmsg/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/rpmsg/Make.defs
+++ b/net/rpmsg/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/rpmsg/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/rpmsg/rpmsg.h
+++ b/net/rpmsg/rpmsg.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/rpmsg/rpmsg.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/rpmsg/rpmsg_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/CMakeLists.txt
+++ b/net/sixlowpan/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/sixlowpan/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/sixlowpan/Make.defs
+++ b/net/sixlowpan/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/sixlowpan/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan.h
+++ b/net/sixlowpan/sixlowpan.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_framelist.c
+++ b/net/sixlowpan/sixlowpan_framelist.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_framelist.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2017-2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/sixlowpan/sixlowpan_framer.c
+++ b/net/sixlowpan/sixlowpan_framer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_framer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_globals.c
+++ b/net/sixlowpan/sixlowpan_globals.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_globals.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_hc06.c
+++ b/net/sixlowpan/sixlowpan_hc06.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_hc06.c
- * 6lowpan HC06 implementation (draft-ietf-6lowpan-hc-06, updated to RFC
- * 6282)
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2017, 2019-2020 Gregory Nutt, all rights reserved
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/sixlowpan/sixlowpan_hc1.c
+++ b/net/sixlowpan/sixlowpan_hc1.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_hc1.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2017, Gregory Nutt, all rights reserved
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/sixlowpan/sixlowpan_icmpv6send.c
+++ b/net/sixlowpan/sixlowpan_icmpv6send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_icmpv6send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_initialize.c
+++ b/net/sixlowpan/sixlowpan_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_input.c
+++ b/net/sixlowpan/sixlowpan_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_input.c
- * 6LoWPAN implementation (RFC 4944 and RFC 6282)
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2017, Gregory Nutt, all rights reserved
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/sixlowpan/sixlowpan_internal.h
+++ b/net/sixlowpan/sixlowpan_internal.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_internal.h
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/sixlowpan/sixlowpan_reassbuf.c
+++ b/net/sixlowpan/sixlowpan_reassbuf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_reassbuf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_send.c
+++ b/net/sixlowpan/sixlowpan_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_tcpsend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_udpsend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/sixlowpan/sixlowpan_utils.c
+++ b/net/sixlowpan/sixlowpan_utils.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/sixlowpan/sixlowpan_utils.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/socket/CMakeLists.txt
+++ b/net/socket/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/socket/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/socket/Make.defs
+++ b/net/socket/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/socket/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/socket/accept.c
+++ b/net/socket/accept.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/accept.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/connect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/getpeername.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/getsockname.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/listen.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_close.c
+++ b/net/socket/net_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_dup2.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_fstat.c
+++ b/net/socket/net_fstat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_fstat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_poll.c
+++ b/net/socket/net_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_sendfile.c
+++ b/net/socket/net_sendfile.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_sendfile.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/net_timeo.c
+++ b/net/socket/net_timeo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/net_timeo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/recv.c
+++ b/net/socket/recv.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/recv.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/recvfrom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/send.c
+++ b/net/socket/send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/send.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/sendmsg.c
+++ b/net/socket/sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/sendto.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/shutdown.c
+++ b/net/socket/shutdown.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/shutdown.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/socket.c
+++ b/net/socket/socket.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/socket.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/socket.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/socket/socketpair.c
+++ b/net/socket/socketpair.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/socket/socketpair.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/CMakeLists.txt
+++ b/net/tcp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/tcp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/tcp/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_accept.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_appsend.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2010, 2014 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/tcp/tcp_backlog.c
+++ b/net/tcp/tcp_backlog.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_backlog.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_cc.c
+++ b/net/tcp/tcp_cc.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/tcp/tcp_cc.c
- * Handling TCP congestion control
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_conn.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2011, 2013-2015, 2018 Gregory Nutt. All rights
  *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_connect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_devpoll.c
+++ b/net/tcp/tcp_devpoll.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/tcp/tcp_devpoll.c
- * Driver poll for the availability of TCP TX data
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009, 2016-2017 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/tcp/tcp_dump.c
+++ b/net/tcp/tcp_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_finddev.c
+++ b/net/tcp/tcp_finddev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_finddev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/tcp/tcp_input.c
- * Handling incoming TCP input
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2014, 2017-2019, 2020 Gregory Nutt. All rights
  *     reserved.

--- a/net/tcp/tcp_ioctl.c
+++ b/net/tcp/tcp_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_ipselect.c
+++ b/net/tcp/tcp_ipselect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_ipselect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_listen.c
+++ b/net/tcp/tcp_listen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_listen.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2009, 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_monitor.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_netpoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_notifier.c
+++ b/net/tcp/tcp_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_recvfrom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_recvwindow.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_send.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2010, 2012, 2015, 2018-2019 Gregory Nutt. All rights
  *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_send_buffered.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_send_unbuffered.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_sendfile.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_seqno.c
+++ b/net/tcp/tcp_seqno.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_seqno.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2009 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_shutdown.c
+++ b/net/tcp/tcp_shutdown.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_shutdown.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/tcp/tcp_timer.c
- * Poll for the availability of TCP TX data
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2010, 2015-2016, 2018, 2020 Gregory Nutt. All rights
  *     reserved.

--- a/net/tcp/tcp_txdrain.c
+++ b/net/tcp/tcp_txdrain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_txdrain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/tcp/tcp_wrbuffer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/CMakeLists.txt
+++ b/net/udp/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/udp/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/udp/Make.defs
+++ b/net/udp/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/udp/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_callback.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_conn.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2009, 2011-2012, 2016, 2018 Gregory Nutt. All rights
  *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/udp/udp_devpoll.c
+++ b/net/udp/udp_devpoll.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/udp/udp_devpoll.c
- * Network device poll for the availability of UDP TX data
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/net/udp/udp_finddev.c
+++ b/net/udp/udp_finddev.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_finddev.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_input.c
+++ b/net/udp/udp_input.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * net/udp/udp_input.c
- * Handling incoming UDP input
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  *   Copyright (C) 2007-2009, 2011, 2018-2019 Gregory Nutt. All rights
  *     reserved.

--- a/net/udp/udp_ioctl.c
+++ b/net/udp/udp_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_ipselect.c
+++ b/net/udp/udp_ipselect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_ipselect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_netpoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_notifier.c
+++ b/net/udp/udp_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_recvfrom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_send.c
  *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *   Copyright (C) 2007-2009, 2011, 2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_sendto_buffered.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_sendto_unbuffered.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_setsockopt.c
+++ b/net/udp/udp_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_txdrain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_wrbuffer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/udp/udp_wrbuffer_dump.c
+++ b/net/udp/udp_wrbuffer_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/udp/udp_wrbuffer_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/CMakeLists.txt
+++ b/net/usrsock/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/usrsock/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/usrsock/Make.defs
+++ b/net/usrsock/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/usrsock/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_accept.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_bind.c
+++ b/net/usrsock/usrsock_bind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_bind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_close.c
+++ b/net/usrsock/usrsock_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_conn.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_connect.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_devif.c
+++ b/net/usrsock/usrsock_devif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_devif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_event.c
+++ b/net/usrsock/usrsock_event.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_event.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_getpeername.c
+++ b/net/usrsock/usrsock_getpeername.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_getpeername.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_getsockname.c
+++ b/net/usrsock/usrsock_getsockname.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_getsockname.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_getsockopt.c
+++ b/net/usrsock/usrsock_getsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_getsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_ioctl.c
+++ b/net/usrsock/usrsock_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_listen.c
+++ b/net/usrsock/usrsock_listen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_listen.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_recvmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_sendmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_setsockopt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_shutdown.c
+++ b/net/usrsock/usrsock_shutdown.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_shutdown.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_socket.c
+++ b/net/usrsock/usrsock_socket.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_socket.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/usrsock/usrsock_sockif.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/CMakeLists.txt
+++ b/net/utils/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # net/utils/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/net/utils/Make.defs
+++ b/net/utils/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # net/utils/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_chksum.c
+++ b/net/utils/net_chksum.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_chksum.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_cmsg.c
+++ b/net/utils/net_cmsg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_cmsg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_dsec2tick.c
+++ b/net/utils/net_dsec2tick.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_dsec2tick.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_dsec2timeval.c
+++ b/net/utils/net_dsec2timeval.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_dsec2timeval.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_getrandom.c
+++ b/net/utils/net_getrandom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_getrandom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_icmpchksum.c
+++ b/net/utils/net_icmpchksum.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_icmpchksum.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_incr32.c
+++ b/net/utils/net_incr32.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_incr32.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_iob_concat.c
+++ b/net/utils/net_iob_concat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_iob_concat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_ipchksum.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_ipv6_maskcmp.c
+++ b/net/utils/net_ipv6_maskcmp.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_ipv6_maskcmp.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_ipv6_payload.c
+++ b/net/utils/net_ipv6_payload.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_ipv6_payload.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_ipv6_pref2mask.c
+++ b/net/utils/net_ipv6_pref2mask.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_ipv6_pref2mask.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_lock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_mask2pref.c
+++ b/net/utils/net_mask2pref.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_mask2pref.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_snoop.c
+++ b/net/utils/net_snoop.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_snoop.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_tcpchksum.c
+++ b/net/utils/net_tcpchksum.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_tcpchksum.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_timeval2dsec.c
+++ b/net/utils/net_timeval2dsec.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_timeval2dsec.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/net_udpchksum.c
+++ b/net/utils/net_udpchksum.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/net_udpchksum.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * net/utils/utils.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
