### PR TITLE
libc/misc/crc32: crc32 add slow mode, optional decrease size

### DIFF
--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -11,6 +11,12 @@ config LIBC_CRC64_FAST
 	---help---
 		Enable the CRC64 lookup table to compute the CRC64 faster.
 
+config LIBC_CRC32_SLOW
+	bool "CRC32 not use table to decrease rodata size"
+	default n
+	---help---
+		Optional disable the CRC32 lookup table to decrease rodata usage.
+
 config LIBC_KBDCODEC
 	bool "Keyboard CODEC"
 	default n


### PR DESCRIPTION
## Summary
For the very small flash/ram chip, crc32 table is not prefer, and we current don't have option to disable crc32 table.

## Impact
No inpact for default case.
Optional enable crc32 slow to disable crc32 table.

## Testing
CI-test, Cortex-M33 board.
