### PR TITLE
serial/uart_16550: remove up_putc spinlock

### DIFF
--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -42,7 +42,6 @@
 #include <nuttx/serial/serial.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/serial/uart_16550.h>
-#include <nuttx/spinlock.h>
 
 #include <arch/board/board.h>
 
@@ -1696,12 +1695,8 @@ static bool u16550_txempty(struct uart_dev_s *dev)
 #ifdef HAVE_16550_CONSOLE
 static void u16550_putc(FAR struct u16550_s *priv, int ch)
 {
-  irqstate_t flags;
-
-  flags = spin_lock_irqsave(NULL);
   while ((u16550_serialin(priv, UART_LSR_OFFSET) & UART_LSR_THRE) == 0);
   u16550_serialout(priv, UART_THR_OFFSET, (uart_datawidth_t)ch);
-  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 


### PR DESCRIPTION
## Summary

serial/uart_16550: remove up_putc spinlock

putc atomicity should be guaranteed by common code rather than add similar hack to lower half driver

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check