### PR TITLE
serial/uart_pl011: default syslog needs to check flow control in up_putc

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -661,6 +661,8 @@ static void pl011_send(FAR struct uart_dev_s *dev, int ch)
   FAR struct pl011_uart_port_s  *sport  = dev->priv;
   FAR const struct pl011_config *config = &sport->config;
 
+  while (!pl011_irq_tx_ready(sport));
+
   config->uart->dr = ch;
 }
 


### PR DESCRIPTION
## Summary

serial/uart_pl011: default syslog needs to check flow control in up_putc

default syslog needs to check flow control in up_putc(), otherwise
up_puts() will lose character if the hardware fifo is full.


## Impact

N/A

## Testing

ci-check