### PR TITLE
ipfrag:fix warnig

### DIFF
--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -192,7 +192,7 @@ static void ip_fragin_timerout_expiry(wdparm_t arg)
 static void ip_fragin_timerwork(FAR void *arg)
 {
   clock_t curtick = clock_systime_ticks();
-  sclock_t interval;
+  sclock_t interval = 0;
   FAR sq_entry_t *entry;
   FAR sq_entry_t *entrynext;
   FAR struct ip_fragsnode_s *node;


### PR DESCRIPTION
## Summary
ipfrag/ipfraq.c: In function 'ip_fragin_timerwork':
ipfrag/ipfrag.c:314:44: warning: 'interval' may be used uninitialized in this function [-Wmaybe-uninitialized]314if (delay < REASSEMBLY_TIMEOUT_TICKS - interval)
## Impact

## Testing

