### PR TITLE
cmake: add support for PCI

### DIFF
--- a/drivers/pci/CMakeLists.txt
+++ b/drivers/pci/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# drivers/pci/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_PCI)
+
+  set(SRCS pci.c pci_ecam.c pci_drivers.c)
+
+  if(CONFIG_PCI_QEMU_TEST)
+    list(APPEND SRCS pci_qemu_test.c)
+  endif()
+
+  if(CONFIG_PCI_QEMU_EDU)
+    list(APPEND SRCS pci_qemu_edu.c)
+  endif()
+
+  if(CONFIG_PCI_IVSHMEM)
+    list(APPEND SRCS pci_ivshmem.c)
+  endif()
+
+  if(CONFIG_PCI_UIO_IVSHMEM)
+    list(APPEND SRCS pci_uio_ivshmem.c)
+  endif()
+
+  target_sources(drivers PRIVATE ${SRCS})
+
+endif() # CONFIG_PCI


### PR DESCRIPTION
## Summary
cmake: add support for PCI
PCI framework can be build with cmake

## Impact

## Testing
local build and CI
