### PR TITLE
Add MSI/MSI-X support for intel64

### DIFF
--- a/arch/x86_64/include/irq.h
+++ b/arch/x86_64/include/irq.h
@@ -147,6 +147,18 @@ static inline_function bool up_interrupt_context(void)
   return up_current_regs() != NULL;
 }
 
+/****************************************************************************
+ * Name: up_alloc_irq_msi
+ * Name: up_release_irq_msi
+ *
+ * Description:
+ *   Reserve/release vector for MSI
+ *
+ ****************************************************************************/
+
+int up_alloc_irq_msi(int *num);
+void up_release_irq_msi(int *irq, int num);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/arch/x86_64/src/common/x86_64_pci.c
+++ b/arch/x86_64/src/common/x86_64_pci.c
@@ -27,6 +27,8 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <arch/irq.h>
+
 #include <nuttx/pci/pci.h>
 
 #include "x86_64_internal.h"
@@ -38,6 +40,9 @@
 #define PCI_CFG_ADDR      0xcf8
 #define PCI_DATA_ADDR     0xcfc
 #define PCI_CFG_EN        (1 << 31)
+
+#define X86_64_MAR_DEST    0xfee00000
+#define X86_64_MDR_TYPE    0x4000
 
 /****************************************************************************
  * Private Functions Definitions
@@ -54,17 +59,31 @@ static int x86_64_pci_read_io(struct pci_bus_s *bus, uintptr_t addr,
 static int x86_64_pci_write_io(struct pci_bus_s *bus, uintptr_t addr,
                                int size, uint32_t val);
 
+static int x86_64_pci_get_irq(struct pci_bus_s *bus, uint8_t line);
+
+static int x86_64_pci_alloc_irq(struct pci_bus_s *bus,
+                                int *irq, int num);
+static void x86_64_pci_release_irq(struct pci_bus_s *bus,
+                                   int *irq, int num);
+static int x86_64_pci_connect_irq(struct pci_bus_s *bus,
+                                  int *irq, int num,
+                                  uintptr_t *mar, uint32_t *mdr);
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
 static const struct pci_ops_s g_x86_64_pci_ops =
 {
-  .write    = x86_64_pci_write,
-  .read     = x86_64_pci_read,
-  .map      = x86_64_pci_map,
-  .read_io  = x86_64_pci_read_io,
-  .write_io = x86_64_pci_write_io,
+  .write       = x86_64_pci_write,
+  .read        = x86_64_pci_read,
+  .map         = x86_64_pci_map,
+  .read_io     = x86_64_pci_read_io,
+  .write_io    = x86_64_pci_write_io,
+  .get_irq     = x86_64_pci_get_irq,
+  .alloc_irq   = x86_64_pci_alloc_irq,
+  .release_irq = x86_64_pci_release_irq,
+  .connect_irq = x86_64_pci_connect_irq,
 };
 
 static struct pci_controller_s g_x86_64_pci =
@@ -279,6 +298,126 @@ static uintptr_t x86_64_pci_map(struct pci_bus_s *bus, uintptr_t start,
                  X86_PAGE_PRESENT | X86_PAGE_NOCACHE | X86_PAGE_GLOBAL);
 
   return ret < 0 ? 0 : start;
+}
+
+/****************************************************************************
+ * Name: x86_64_pci_get_irq
+ *
+ * Description:
+ *  Get interrupt number associated with a given INTx line.
+ *
+ * Input Parameters:
+ *   bus  - Bus that PCI device resides
+ *   line - activated PCI legacy interrupt line
+ *
+ * Returned Value:
+ *   Return interrupt number associated with a given INTx
+ *
+ ****************************************************************************/
+
+static int x86_64_pci_get_irq(struct pci_bus_s *bus, uint8_t line)
+{
+  UNUSED(bus);
+
+  return IRQ0 + line;
+}
+
+/****************************************************************************
+ * Name: x86_64_pci_alloc_irq
+ *
+ * Description:
+ *  Allocate interrupts for MSI/MSI-X vector.
+ *
+ * Input Parameters:
+ *   bus - Bus that PCI device resides
+ *   irq - allocated vectors array
+ *   num - number of vectors to allocate
+ *
+ * Returned Value:
+ *   >0: success, return number of allocated vectors,
+ *   <0: A negative value errno
+ *
+ ****************************************************************************/
+
+static int x86_64_pci_alloc_irq(struct pci_bus_s *bus, int *irq, int num)
+{
+  int tmp = 0;
+  int i   = 0;
+
+  /* Try to get irq */
+
+  tmp = up_alloc_irq_msi(&num);
+  if (tmp < 0)
+    {
+      return tmp;
+    }
+
+  /* Copy allocated interrupts */
+
+  for (i = 0; i < num; i++)
+    {
+      irq[i] = tmp++;
+    }
+
+  return num;
+}
+
+/****************************************************************************
+ * Name: x86_64_pci_release_irq
+ *
+ * Description:
+ *  Allocate interrupts for MSI/MSI-X vector.
+ *
+ * Input Parameters:
+ *   bus - Bus that PCI device resides
+ *   irq - vectors array to release
+ *   num - number of vectors in array
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void x86_64_pci_release_irq(struct pci_bus_s *bus, int *irq, int num)
+{
+  up_release_irq_msi(irq, num);
+}
+
+/****************************************************************************
+ * Name: x86_64_pci_connect_irq
+ *
+ * Description:
+ *  Connect interrupt for MSI/MSI-X.
+ *
+ * Input Parameters:
+ *   bus - Bus that PCI device resides
+ *   irq - vectors array
+ *   num - number of vectors in array
+ *   mar - returned value for Message Address Register
+ *   mdr - returned value for Message Data Register
+ *
+ * Returned Value:
+ *   >0: success, 0: A positive value errno
+ *
+ ****************************************************************************/
+
+static int x86_64_pci_connect_irq(struct pci_bus_s *bus, int *irq, int num,
+                                  uintptr_t *mar, uint32_t *mdr)
+{
+  UNUSED(num);
+
+  if (mar != NULL)
+    {
+      *mar = X86_64_MAR_DEST |
+        (up_apic_cpu_id() << PCI_MSI_DATA_CPUID_SHIFT);
+    }
+
+  if (mdr != NULL)
+    {
+      *mdr = X86_64_MDR_TYPE | irq[0];
+    }
+
+  return OK;
 }
 
 /****************************************************************************

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -12,6 +12,13 @@ menuconfig PCI
 
 if PCI
 
+config PCI_MSIX
+	bool "PCI MSI-X support"
+	default n
+	---help---
+		Enables support for PCI MSI-X. When enabled, MSI-X takse priority 
+		over MSI when a device supports it.
+	
 config PCI_ASSIGN_ALL_BUSES
 	bool "Assign resource to all buses"
 	default !ARCH_X86 && !ARCH_X86_64

--- a/drivers/pci/pci_qemu_edu.c
+++ b/drivers/pci/pci_qemu_edu.c
@@ -27,7 +27,6 @@
 #include <debug.h>
 #include <errno.h>
 
-#include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pci/pci.h>
@@ -398,7 +397,7 @@ static int pci_qemu_edu_probe(FAR struct pci_device_s *dev)
 {
   struct pci_qemu_edu_priv_s priv;
   unsigned int flags;
-  uint8_t irq;
+  int irq = 0;
   int ret;
 
   /* Enable EDU device */
@@ -443,8 +442,7 @@ static int pci_qemu_edu_probe(FAR struct pci_device_s *dev)
 
   /* Run IRQ Tests */
 
-  pci_read_config_byte(dev, PCI_INTERRUPT_LINE, &irq);
-  irq = IRQ0 + irq;
+  irq = pci_get_irq(dev);
   pciinfo("IRQ TEST: Attaching IRQ %u to %p\n", irq, pci_qemu_edu_interrupt);
 
   irq_attach(irq, pci_qemu_edu_interrupt, &priv);
@@ -458,6 +456,36 @@ static int pci_qemu_edu_probe(FAR struct pci_device_s *dev)
 
   /* Run MSI Tests */
 
+  pciinfo("MSI TEST\n");
+
+  irq = 0;
+  ret = pci_alloc_irq(dev, &irq, 1);
+  if (ret != 1)
+    {
+      pcierr("Failed to allocate MSI %d\n", ret);
+      goto err;
+    }
+
+  pciinfo("MSI TEST: Attaching MSI %u to %p\n",
+          irq, pci_qemu_edu_interrupt);
+
+  ret = pci_connect_irq(dev, &irq, 1);
+  if (ret != OK)
+    {
+      pcierr("Failed to connect MSI %d\n", ret);
+      goto err;
+    }
+
+  irq_attach(irq, pci_qemu_edu_interrupt, &priv);
+  up_enable_irq(irq);
+
+  pci_qemu_edu_test_intx(&priv);
+  pci_qemu_edu_test_dma(&priv);
+
+  up_disable_irq(irq);
+  irq_detach(irq);
+  pci_release_irq(dev, &irq, 1);
+
   /* Uninitialize the driver */
 
   nxsem_destroy(&priv.isr_done);
@@ -465,6 +493,11 @@ static int pci_qemu_edu_probe(FAR struct pci_device_s *dev)
   /* TODO: add pci unmap api */
 
 err:
+  if (irq != 0)
+    {
+      pci_release_irq(dev, &irq, 1);
+    }
+
   pci_clear_master(dev);
   pci_disable_device(dev);
   return ret;

--- a/include/nuttx/pci/pci_regs.h
+++ b/include/nuttx/pci/pci_regs.h
@@ -313,7 +313,9 @@
 #define PCI_MSI_FLAGS                     2       /* Message Control */
 #define  PCI_MSI_FLAGS_ENABLE             0x0001  /* MSI feature enabled */
 #define  PCI_MSI_FLAGS_QMASK              0x000e  /* Maximum queue size available */
+#define  PCI_MSI_FLAGS_QMASK_SHIFT        0x0001
 #define  PCI_MSI_FLAGS_QSIZE              0x0070  /* Message queue size configured */
+#define  PCI_MSI_FLAGS_QSIZE_SHIFT        0x0004
 #define  PCI_MSI_FLAGS_64BIT              0x0080  /* 64-bit addresses allowed */
 #define  PCI_MSI_FLAGS_MASKBIT            0x0100  /* Per-vector masking capable */
 
@@ -323,6 +325,7 @@
 #define PCI_MSI_ADDRESS_LO                4   /* Lower 32 bits */
 #define PCI_MSI_ADDRESS_HI                8   /* Upper 32 bits (if PCI_MSI_FLAGS_64BIT set) */
 #define PCI_MSI_DATA_32                   8   /* 16 bits of data for 32-bit devices */
+#define  PCI_MSI_DATA_CPUID_SHIFT         12  /* Destination CPU ID */
 #define PCI_MSI_MASK_32                   12  /* Mask bits register for 32-bit devices */
 #define PCI_MSI_PENDING_32                16  /* Pending intrs for 32-bit devices */
 #define PCI_MSI_DATA_64                   12  /* 16 bits of data for 64-bit devices */
@@ -338,6 +341,7 @@
 #define PCI_MSIX_TABLE                    4          /* Table offset */
 #define  PCI_MSIX_TABLE_BIR               0x00000007 /* BAR index */
 #define  PCI_MSIX_TABLE_OFFSET            0xfffffff8 /* Offset into specified BAR */
+#define  PCI_MSIX_TABLE_OFFSET_SHIFT      3
 #define PCI_MSIX_PBA                      8          /* Pending Bit Array offset */
 #define  PCI_MSIX_PBA_BIR                 0x00000007 /* BAR index */
 #define  PCI_MSIX_PBA_OFFSET              0xfffffff8 /* Offset into specified BAR */


### PR DESCRIPTION
## Summary

-  drivers/pci: add MSI/MSI-X support 
    Add support for MSI and MSI-X in PCI framework
    
-  arch/x86_64/intel64: add MSI/MSI-X support
    Add MSI and MSI-X support for intel64

-  drivers/pci_qemu_edu: add MSI test
    Add simple MSI test for QEMU PCI EDU device so we can verify if MSI works correctly

## Impact

## Testing
Tested with QEMU and PCI EDU device:

```
qemu-system-x86_64 -m 2048M -cpu host -enable-kvm -kernel nuttx.elf -nographic -serial mon:stdio -device edu -device pci-testdev
```

QEMU EDU device MSI test fragment:

```
pci_qemu_edu_probe: MSI TEST
pci_qemu_edu_probe: MSI TEST: Attaching MSI 64 to 0x100917277
pci_qemu_edu_test_intx: Identification: 0x010000edu
pci_qemu_edu_test_intx: Triggering interrupt with value 0xdeadbeef
pci_qemu_edu_interrupt: Received value: 0xdeadbeef
pci_qemu_edu_test_intx: TEST PASS
pci_qemu_edu_test_intx: Computing factorial of 5
pci_qemu_edu_interrupt: Computed factorial: 120
pci_qemu_edu_test_intx: TEST PASS
pci_qemu_edu_interrupt: Received value: 0x00000005
pci_qemu_edu_test_intx: TEST PASS
pci_qemu_edu_test_dma: Identification: 0x010000edu
pci_qemu_edu_test_dma: Test block checksum 0xb4908b8a
EDU: clamping DMA 0x00000001015648d0 to 0x00000000015648d0!
pci_qemu_edu_interrupt: DMA transfer complete
pci_qemu_edu_test_dma: DMA transfer to device complete.
EDU: clamping DMA 0x00000001015648d0 to 0x00000000015648d0!
pci_qemu_edu_interrupt: DMA transfer complete
pci_qemu_edu_test_dma: DMA transfer from device complete.
pci_qemu_edu_test_dma: Received block checksum 0xb4908b8a
pci_qemu_edu_test_dma: TEST PASS
```
