### PR TITLE
intel64: Improvements for HPET

### DIFF
--- a/arch/x86_64/include/hpet.h
+++ b/arch/x86_64/include/hpet.h
@@ -55,8 +55,8 @@
 
 /* General Configuration Register */
 
-#define HPET_GCONF_LEGERT           (1 << 0) /* Bit 0: LegacyReplacement Route */
-#define HPET_GCONF_ENABLE           (1 << 1) /* Bit 1: Overall Enable */
+#define HPET_GCONF_ENABLE           (1 << 0) /* Bit 0: Overall Enable */
+#define HPET_GCONF_LEGERT           (1 << 1) /* Bit 1: LegacyReplacement Route */
 
 /* General Interrupt Status Register */
 
@@ -86,7 +86,7 @@
 
 #define HPET_TFSB_INT_VAL_SHIFT     (0)
 #define HPET_TFSB_INT_VAL_MASK      (0x00000000ffffffff)
-#define HPET_TFSB_INT_ADDR_SHIFT    (31)
+#define HPET_TFSB_INT_ADDR_SHIFT    (32)
 #define HPET_TFSB_INT_ADDR_MASK     (0xffffffff00000000)
 
 /* HPET register space */

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -116,6 +116,18 @@ config INTEL64_HPET_BASE
 		Configure base address for HPET. In the future, we can get this address from
 		the ACPI table if ACPI support is enabled.
 
+config INTEL64_HPET_32BIT
+	bool "HPET is 32bit"
+	default n
+	---help---
+		Configure HPET in 32-bit mode.
+
+config INTEL64_HPET_FSB
+	bool "HPET use FSB for interrupt"
+	default n
+	---help---
+		Use FSB for interrupt (works like MSI interrupts).
+
 config ARCH_INTEL64_HPET_ALARM_CHAN
 	int "HPET timer alarm channel"
 	depends on ARCH_INTEL64_HPET_ALARM


### PR DESCRIPTION
## Summary
- arch/intel64/hpet: add FSB interrupts support and support for 32-bit mode   
    These are changes to make HPET work with ACRN hypervisor:
    - FSB interrupt delivery (which works like PCI MSI)
    - 32-bit mode support
    
[DONE] Depends on https://github.com/apache/nuttx/pull/13391
## Impact

## Testing
intel HW