### PR TITLE
Critmon optimize, make possible open cpuload based on critmon and disable critical section & sched_lock to save cost.

### DIFF
--- a/Documentation/implementation/critical_sections.rst
+++ b/Documentation/implementation/critical_sections.rst
@@ -208,11 +208,70 @@ a Critical Section Monitor. This is internal instrumentation that records the
 time that a task holds a critical section. It also records the amount of time
 that interrupts are disabled globally. The Critical Section Monitor then retains
 the maximum time that the critical section is in place, both per-task and globally.
+We also extend the critical section monitor to do task sched cost statistics, which
+can high effectively do cpuload statistic. In order to save not necessary cost when
+you only focus on specific feature, we isolate the crtimon features to difference
+configurations. Allow you only open some of the features to minimum the side effect
+of the performance etc.
 
 The Critical Section Monitor is enabled with the following setting in the
-configuration::
+configurations::
 
   CONFIG_SCHED_CRITMONITOR=y
+
+Enable sched critmon globally, all other features need this configuration as a prefix.
+
+**Thread executing**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD=0
+
+* Default 0 to enable executing time statistic, and make it a source to support cpuload.
+* > 0 to also do alert log when executing time above the configuration ticks.
+* -1 to disable thread executing time statistic feature.
+
+This method is **recommend** as a cpuload backend if you don't have more requirements
+in critmon. When disabled all other statistics in critmon, this method is a high
+efficiency way do cpu load statistic. As we did not add hooks to critical sections 
+and preemption operations. Only have instructions when scheduler triggers context switch.
+
+**Workq executing**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE=-1
+
+* Default -1 to disable workq queue max execution time
+* > 0 to do alert log when workq executing time above the configuration ticks.
+
+**Preemption disabled time**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION=-1
+
+* Default -1 to disable preemption disabled time statistic.
+* >= 0 to enable preemption disabled time statistic, data will be in critmon procfs.
+* > 0 to also do alert log when preemption disabled time above the configuration ticks.
+
+**Critical section entered time**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION=-1
+
+* Default -1 to disable critical section entered time statistic.
+* >= 0 to enable critical section entered time statistic, data will be in critmon procfs.
+* > 0 to also do alert log when critical section entered time above the configuration ticks.
+
+**Irq executing time**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ=-1
+
+* Default -1 to disable irq executing time statistic.
+* >= 0 to enable irq executing time statistic, data will be in critmon procfs.
+* > 0 to also do alert log when irq executing time above the configuration ticks.
+
+**Wdog executing time**::
+
+  CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG=-1
+
+* Default -1 to disable wdog executing time statistic.
+* >= 0 to enable wdog executing time statistic, data will be in critmon procfs.
+* > 0 to also do alert log when wdog executing time above the configuration ticks.
 
 **Perf Timers interface**
 

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -186,6 +186,10 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
   size_t copysize;
   size_t totalsize;
 
+  UNUSED(maxtime);
+  UNUSED(linesize);
+  UNUSED(copysize);
+
   totalsize = 0;
 
   /* Generate output for CPU Serial Number */
@@ -234,7 +238,9 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
     {
       return totalsize;
     }
+#endif
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
   /* Convert and generate output for maximum time in a critical section */
 
   if (g_crit_max[cpu] > 0)

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -792,9 +792,10 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   /* Generate output for maximum time pre-emption disabled */
 
-  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu,",
+  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu %p,",
                              (unsigned long)maxtime.tv_sec,
-                             (unsigned long)maxtime.tv_nsec);
+                             (unsigned long)maxtime.tv_nsec,
+                             tcb->premp_max_caller);
   copysize = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                            &offset);
 
@@ -827,9 +828,10 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   /* Generate output for maximum time in a critical section */
 
-  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu,",
+  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu %p,",
                              (unsigned long)maxtime.tv_sec,
-                             (unsigned long)maxtime.tv_nsec);
+                             (unsigned long)maxtime.tv_nsec,
+                             tcb->crit_max_caller);
   copysize = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                            &offset);
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -775,6 +775,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   /* Convert the for maximum time pre-emption disabled */
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   if (tcb->premp_max > 0)
     {
       perf_convert(tcb->premp_max, &maxtime);
@@ -805,9 +806,11 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
     {
       return totalsize;
     }
+#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPT >= 0 */
 
   /* Convert and generate output for maximum time in a critical section */
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
   if (tcb->crit_max > 0)
     {
       perf_convert(tcb->crit_max, &maxtime);
@@ -838,9 +841,10 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
     {
       return totalsize;
     }
+#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0 */
 
   /* Convert and generate output for maximum time thread running */
-
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   if (tcb->run_max > 0)
     {
       perf_convert(tcb->run_max, &maxtime);
@@ -870,6 +874,8 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
                            &offset);
 
   totalsize += copysize;
+#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0 */
+
   return totalsize;
 }
 #endif

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -72,6 +72,18 @@
 #  define CONFIG_SCHED_SPORADIC_MAXREPL 3
 #endif
 
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION -1
+#endif
+
 /* Task Management Definitions **********************************************/
 
 /* Special task IDS.  Any negative PID is invalid. */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -654,14 +654,20 @@ struct tcb_s
 
   /* Pre-emption monitor support ********************************************/
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-  clock_t premp_start;                   /* Time when preemption disabled   */
-  clock_t premp_max;                     /* Max time preemption disabled    */
-  clock_t crit_start;                    /* Time critical section entered   */
-  clock_t crit_max;                      /* Max time in critical section    */
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   clock_t run_start;                     /* Time when thread begin run      */
   clock_t run_max;                       /* Max time thread run             */
   clock_t run_time;                      /* Total time thread run           */
+#endif
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
+  clock_t premp_start;                   /* Time when preemption disabled   */
+  clock_t premp_max;                     /* Max time preemption disabled    */
+#endif
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
+  clock_t crit_start;                    /* Time critical section entered   */
+  clock_t crit_max;                      /* Max time in critical section    */
 #endif
 
   /* State save areas *******************************************************/
@@ -799,12 +805,15 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#ifdef CONFIG_SCHED_CRITMONITOR
 /* Maximum time with pre-emption disabled or within critical section. */
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
 EXTERN clock_t g_premp_max[CONFIG_SMP_NCPUS];
+#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION  >= 0 */
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
 EXTERN clock_t g_crit_max[CONFIG_SMP_NCPUS];
-#endif /* CONFIG_SCHED_CRITMONITOR */
+#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0 */
 
 EXTERN const struct tcbinfo_s g_tcbinfo;
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -663,11 +663,15 @@ struct tcb_s
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   clock_t premp_start;                   /* Time when preemption disabled   */
   clock_t premp_max;                     /* Max time preemption disabled    */
+  void   *premp_caller;                  /* Caller of preemption disabled   */
+  void   *premp_max_caller;              /* Caller of max preemption        */
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
   clock_t crit_start;                    /* Time critical section entered   */
   clock_t crit_max;                      /* Max time in critical section    */
+  void   *crit_caller;                   /* Caller of critical section      */
+  void   *crit_max_caller;               /* Caller of max critical section  */
 #endif
 
   /* State save areas *******************************************************/

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -941,7 +941,7 @@ config SCHED_CRITMONITOR_MAXTIME_THREAD
 
 config SCHED_CRITMONITOR_MAXTIME_WQUEUE
 	int "WORK queue max execution time"
-	default SCHED_CRITMONITOR_MAXTIME_THREAD
+	default -1
 	---help---
 		Worker execution time should be smaller than
 		SCHED_CRITMONITOR_MAXTIME_WQUEUE, or system will give a warning.
@@ -1062,7 +1062,7 @@ config SCHED_CPULOAD_EXTCLK
 
 config SCHED_CPULOAD_CRITMONITOR
 	bool "Use critical monitor"
-	depends on SCHED_CRITMONITOR
+	depends on SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
 	---help---
 		Use the perfcounter in the core of the chip as a counter, no need to
 		use an external timer. Need to depend on SCHED_CRITMONITOR.

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -47,7 +47,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
 static clock_t clock_process_runtime(FAR struct tcb_s *tcb)
 {
 # ifdef HAVE_GROUP_MEMBERS
@@ -118,7 +118,7 @@ void nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
     }
   else
     {
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
       clockid_t clock_type = clock_id & CLOCK_MASK;
       pid_t pid = clock_id >> CLOCK_SHIFT;
       FAR struct tcb_s *tcb;

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -383,7 +383,7 @@ try_again_in_irq:
           /* Note that we have entered the critical section */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-          nxsched_critmon_csection(rtcb, true);
+          nxsched_critmon_csection(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
           sched_note_csection(rtcb, true);
@@ -423,7 +423,7 @@ irqstate_t enter_critical_section(void)
           /* Note that we have entered the critical section */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-          nxsched_critmon_csection(rtcb, true);
+          nxsched_critmon_csection(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
           sched_note_csection(rtcb, true);
@@ -524,7 +524,7 @@ void leave_critical_section(irqstate_t flags)
           /* No.. Note that we have left the critical section */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-          nxsched_critmon_csection(rtcb, false);
+          nxsched_critmon_csection(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
           sched_note_csection(rtcb, false);
@@ -578,7 +578,7 @@ void leave_critical_section(irqstate_t flags)
           /* Note that we have left the critical section */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-          nxsched_critmon_csection(rtcb, false);
+          nxsched_critmon_csection(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
           sched_note_csection(rtcb, false);

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -382,7 +382,7 @@ try_again_in_irq:
 
           /* Note that we have entered the critical section */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
           nxsched_critmon_csection(rtcb, true);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
@@ -422,7 +422,7 @@ irqstate_t enter_critical_section(void)
         {
           /* Note that we have entered the critical section */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
           nxsched_critmon_csection(rtcb, true);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
@@ -523,7 +523,7 @@ void leave_critical_section(irqstate_t flags)
         {
           /* No.. Note that we have left the critical section */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
           nxsched_critmon_csection(rtcb, false);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
@@ -577,7 +577,7 @@ void leave_critical_section(irqstate_t flags)
         {
           /* Note that we have left the critical section */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
           nxsched_critmon_csection(rtcb, false);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -51,10 +51,6 @@
  * interrupt request
  */
 
-#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ
-#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ 0
-#endif
-
 #ifdef CONFIG_SCHED_IRQMONITOR
 #  define CALL_VECTOR(ndx, vector, irq, context, arg) \
      do \

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -447,11 +447,13 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb);
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state);
+void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
+                                FAR void *caller);
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state);
+void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
+                              FAR void *caller);
 #endif
 
 /* TCB operations */

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -107,6 +107,30 @@
 #  define TLIST_BLOCKED(t)       __TLIST_HEAD(t)
 #endif
 
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_IRQ -1
+#endif
+
+#ifndef CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG
+#  define CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG -1
+#endif
+
 #ifdef CONFIG_SCHED_CRITMONITOR_MAXTIME_PANIC
 #  define CRITMONITOR_PANIC(fmt, ...) \
           do \
@@ -418,10 +442,16 @@ void nxsched_process_cpuload_ticks(clock_t ticks);
 /* Critical section monitor */
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state);
-void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state);
 void nxsched_resume_critmon(FAR struct tcb_s *tcb);
 void nxsched_suspend_critmon(FAR struct tcb_s *tcb);
+#endif
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
+void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state);
+#endif
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
+void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state);
 #endif
 
 /* TCB operations */

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -87,20 +87,6 @@
 #endif
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/* Start time when pre-emption disabled or critical section entered. */
-
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-static clock_t g_premp_start[CONFIG_SMP_NCPUS];
-#endif
-
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION  >= 0
-static clock_t g_crit_start[CONFIG_SMP_NCPUS];
-#endif
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -188,7 +174,7 @@ static void nxsched_critmon_cpuload(FAR struct tcb_s *tcb, clock_t current,
 void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
                                 FAR void *caller)
 {
-  int cpu = this_cpu();
+  clock_t current = perf_gettime();
 
   /* Are we enabling or disabling pre-emption */
 
@@ -196,16 +182,15 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
     {
       /* Disabling.. Save the thread start time */
 
-      tcb->premp_start   = perf_gettime();
-      tcb->premp_caller  = caller;
-      g_premp_start[cpu] = tcb->premp_start;
+      tcb->premp_start  = current;
+      tcb->premp_caller = caller;
     }
   else
     {
       /* Re-enabling.. Check for the max elapsed time */
 
-      clock_t now     = perf_gettime();
-      clock_t elapsed = now - tcb->premp_start;
+      clock_t elapsed = current - tcb->premp_start;
+      int cpu         = this_cpu();
 
       if (elapsed > tcb->premp_max)
         {
@@ -216,7 +201,6 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
 
       /* Check for the global max elapsed time */
 
-      elapsed = now - g_premp_start[cpu];
       if (elapsed > g_premp_max[cpu])
         {
           g_premp_max[cpu] = elapsed;
@@ -242,7 +226,7 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
 void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
                               FAR void *caller)
 {
-  int cpu = this_cpu();
+  clock_t current = perf_gettime();
 
   /* Are we entering or leaving the critical section? */
 
@@ -250,16 +234,15 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
     {
       /* Entering... Save the start time. */
 
-      tcb->crit_start   = perf_gettime();
-      tcb->crit_caller  = caller;
-      g_crit_start[cpu] = tcb->crit_start;
+      tcb->crit_start  = current;
+      tcb->crit_caller = caller;
     }
   else
     {
       /* Leaving .. Check for the max elapsed time */
 
-      clock_t now     = perf_gettime();
-      clock_t elapsed = now - tcb->crit_start;
+      clock_t elapsed = current - tcb->crit_start;
+      int cpu         = this_cpu();
 
       if (elapsed > tcb->crit_max)
         {
@@ -270,7 +253,6 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
 
       /* Check for the global max elapsed time */
 
-      elapsed = now - g_crit_start[cpu];
       if (elapsed > g_crit_max[cpu])
         {
           g_crit_max[cpu] = elapsed;
@@ -295,36 +277,21 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
 void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 {
   clock_t current = perf_gettime();
-  int cpu = this_cpu();
-  clock_t elapsed;
 
-  UNUSED(cpu);
-  UNUSED(elapsed);
+  UNUSED(current);
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   tcb->run_start = current;
 #endif
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Did this task disable pre-emption? */
 
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   if (tcb->lockcount > 0)
     {
       /* Yes.. Save the start time */
 
-      tcb->premp_start   = current;
-      g_premp_start[cpu] = current;
-    }
-  else
-    {
-      /* Check for the global max elapsed time */
-
-      elapsed = current - g_premp_start[cpu];
-      if (elapsed > g_premp_max[cpu])
-        {
-          g_premp_max[cpu] = elapsed;
-          CHECK_PREEMPTION(tcb->pid, elapsed);
-        }
+      tcb->premp_start = current;
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */
 
@@ -335,19 +302,7 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
     {
       /* Yes.. Save the start time */
 
-      tcb->crit_start   = current;
-      g_crit_start[cpu] = current;
-    }
-  else
-    {
-      /* Check for the global max elapsed time */
-
-      elapsed = current - g_crit_start[cpu];
-      if (elapsed > g_crit_max[cpu])
-        {
-          g_crit_max[cpu] = elapsed;
-          CHECK_CSECTION(tcb->pid, elapsed);
-        }
+      tcb->crit_start = current;
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION */
 }
@@ -369,11 +324,14 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
 {
   clock_t current = perf_gettime();
   clock_t elapsed = current - tcb->run_start;
+  int cpu = this_cpu();
 
 #ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
   clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
   nxsched_critmon_cpuload(tcb, current, tick);
 #endif
+
+  UNUSED(cpu);
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   tcb->run_time += elapsed;
@@ -384,9 +342,9 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
     }
 #endif
 
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Did this task disable preemption? */
 
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   if (tcb->lockcount > 0)
     {
       /* Possibly re-enabling.. Check for the max elapsed time */
@@ -398,11 +356,21 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
           tcb->premp_max_caller = tcb->premp_caller;
           CHECK_PREEMPTION(tcb->pid, elapsed);
         }
+
+      /* Suspend percore preemptible statistic and if necessary will
+       * re-open in nxsched_resume_critmon.
+       */
+
+      if (elapsed > g_premp_max[cpu])
+        {
+          g_premp_max[cpu] = elapsed;
+        }
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */
 
-  /* Is this task in a critical section? */
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
+  /* Is this task in a critical section? */
+
   if (tcb->irqcount > 0)
     {
       /* Possibly leaving .. Check for the max elapsed time */
@@ -414,7 +382,13 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
           tcb->crit_max_caller = tcb->crit_caller;
           CHECK_CSECTION(tcb->pid, elapsed);
         }
+
+      /* Check for the global max elapsed time */
+
+      if (elapsed > g_crit_max[cpu])
+        {
+          g_crit_max[cpu] = elapsed;
+        }
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION */
 }
-

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -159,10 +159,10 @@ int sched_lock(void)
           /* Note that we have pre-emption locked */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-         nxsched_critmon_preemption(rtcb, true);
+          nxsched_critmon_preemption(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-         sched_note_premption(rtcb, true);
+          sched_note_premption(rtcb, true);
 #endif
         }
 
@@ -213,7 +213,7 @@ int sched_lock(void)
           /* Note that we have pre-emption locked */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-          nxsched_critmon_preemption(rtcb, true);
+          nxsched_critmon_preemption(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
           sched_note_premption(rtcb, true);

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -152,22 +152,19 @@ int sched_lock(void)
 
       rtcb->lockcount++;
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_PREEMPTION) || \
-    defined(CONFIG_SCHED_CRITMONITOR)
       /* Check if we just acquired the lock */
 
       if (rtcb->lockcount == 1)
         {
           /* Note that we have pre-emption locked */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-          nxsched_critmon_preemption(rtcb, true);
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
+         nxsched_critmon_preemption(rtcb, true);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-          sched_note_premption(rtcb, true);
+         sched_note_premption(rtcb, true);
 #endif
         }
-#endif
 
       /* Move any tasks in the ready-to-run list to the pending task list
        * where they will not be available to run until the scheduler is
@@ -209,22 +206,19 @@ int sched_lock(void)
 
       rtcb->lockcount++;
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_PREEMPTION) || \
-    defined(CONFIG_SCHED_CRITMONITOR)
       /* Check if we just acquired the lock */
 
       if (rtcb->lockcount == 1)
         {
           /* Note that we have pre-emption locked */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
           nxsched_critmon_preemption(rtcb, true);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
           sched_note_premption(rtcb, true);
 #endif
         }
-#endif
     }
 
   return OK;

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -93,7 +93,7 @@ int sched_unlock(void)
           /* Note that we no longer have pre-emption disabled. */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-          nxsched_critmon_preemption(rtcb, false);
+          nxsched_critmon_preemption(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
           sched_note_premption(rtcb, false);
@@ -250,7 +250,7 @@ int sched_unlock(void)
           /* Note that we no longer have pre-emption disabled. */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-          nxsched_critmon_preemption(rtcb, false);
+          nxsched_critmon_preemption(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
           sched_note_premption(rtcb, false);

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -92,7 +92,7 @@ int sched_unlock(void)
         {
           /* Note that we no longer have pre-emption disabled. */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
           nxsched_critmon_preemption(rtcb, false);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
@@ -249,7 +249,7 @@ int sched_unlock(void)
         {
           /* Note that we no longer have pre-emption disabled. */
 
-#ifdef CONFIG_SCHED_CRITMONITOR
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
           nxsched_critmon_preemption(rtcb, false);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION


### PR DESCRIPTION
## Summary
For current version. there will be a large performance loss after SCHED_CRITMONITOR is enabled. We have few feature based on SCHED_CRITMONITOR, isolating thread running time-related functions, CPU load can be run with less overhead.

Also we add a caller record in preemption & csection, to help evaluate / optimize.

To make statistic more accurate, when sched happend, we cut the sched_monitor caculation up to now.

## Impact
Now we can enable the cpuload based on critimon and disable other critmon cost, will be a low-cost cpuload evaluate method.
We can now see who make largest elapsed time from preemption/cserction.
When sched happend, the elapsed time now seperate to two different thread.

## Testing
CI-test. and arm v7a smp board, etc.
