### PR TITLE
imx9/edma: Fix function prototypes

### DIFF
--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -1070,7 +1070,7 @@ void imx9_dmach_free(DMACH_HANDLE handle)
  *
  ****************************************************************************/
 
-int imx9_dmach_xfrsetup(DMACH_HANDLE *handle,
+int imx9_dmach_xfrsetup(DMACH_HANDLE handle,
                         const struct imx9_edma_xfrconfig_s *config)
 {
   struct imx9_dmach_s *dmach = (struct imx9_dmach_s *)handle;
@@ -1336,7 +1336,7 @@ void imx9_dmach_stop(DMACH_HANDLE handle)
  *
  ****************************************************************************/
 
-unsigned int imx9_dmach_getcount(DMACH_HANDLE *handle)
+unsigned int imx9_dmach_getcount(DMACH_HANDLE handle)
 {
   struct imx9_dmach_s *dmach = (struct imx9_dmach_s *)handle;
   uintptr_t base = IMX9_EDMA_TCD(dmach->base, dmach->chan);

--- a/arch/arm64/src/imx9/imx9_edma.h
+++ b/arch/arm64/src/imx9/imx9_edma.h
@@ -337,7 +337,7 @@ void imx9_dmach_free(DMACH_HANDLE handle);
  *
  ****************************************************************************/
 
-int imx9_dmach_xfrsetup(DMACH_HANDLE *handle,
+int imx9_dmach_xfrsetup(DMACH_HANDLE handle,
                         const struct imx9_edma_xfrconfig_s *config);
 
 /****************************************************************************
@@ -429,7 +429,7 @@ void imx9_dmach_stop(DMACH_HANDLE handle);
  *
  ****************************************************************************/
 
-unsigned int imx9_dmach_getcount(DMACH_HANDLE *handle);
+unsigned int imx9_dmach_getcount(DMACH_HANDLE handle);
 
 /****************************************************************************
  * Name: imx9_dmach_idle


### PR DESCRIPTION
Change "DMACH_HANDLE *handle" into "DMACH_HANDLE handle". The DMACH_HANDLE is already defined as "void *".

## Summary

This fixes some compilation warnings treated as errors

## Impact

No functional impact

## Testing

