### PR TITLE
Imx9 ethernet fixes

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -951,6 +951,16 @@ config IMX9_ENET1_RGMII
 
 endchoice
 
+config IMX9_ENET1_TX_CLOCK_IS_INPUT
+	bool "ENET1 TX clock is input"
+	default y if IMX9_ENET1_RMII
+	default n if IMX9_ENET1_RGMII
+	---help---
+		The ethernet TX clock can be either driven by the PHY, in
+		which case it is input to the MAC. Or it can be driven by
+		the MAC, in which case it is output. Typical configuration is
+		input for RMII and output for RGMII.
+
 config IMX9_ENET1_PHY_AUTONEG
 	bool "ENET1 PHY autonegotiation enable"
 	default y

--- a/arch/arm64/src/imx9/hardware/imx93/imx93_ccm.h
+++ b/arch/arm64/src/imx9/hardware/imx93/imx93_ccm.h
@@ -730,6 +730,8 @@ static const int g_ccm_root_mux[][ROOT_MUX_MAX] =
 #define CCM_NIC_APB_CLK_ROOT         66
 #define CCM_DRAM_ALT_CLK_ROOT        76
 #define CCM_DRAM_APB_CLK_ROOT        77
+#define CCM_ENET_TIMER_CLK_ROOT      87
+#define CCM_ENET_REF_CLK_ROOT        89
 #define CCM_CLK_ROOT_NUM             95
 
 #define CCM_OSCPLL_END               19

--- a/arch/arm64/src/imx9/hardware/imx9_blk_ctrl.h
+++ b/arch/arm64/src/imx9/hardware/imx9_blk_ctrl.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/hardware/imx9_blk_ctrl.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_BLK_CTRL_H
+#define __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_BLK_CTRL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <hardware/imx9_memorymap.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Wakeupmix block control Register offsets *********************************/
+
+#define IMX9_WAKUPMIX_IPG_DEBUG_CM33_OFFSET   0x4   /* IPG DEBUG mask bit */
+#define IMX9_WAKUPMIX_QCH_DIS_OFFSET          0x10  /* QCHANNEL DISABLE */
+#define IMX9_WAKUPMIX_DEXSC_ERR_OFFSET        0x1c  /* DEXSC error response configuration */
+#define IMX9_WAKUPMIX_MQS_SETTING_OFFSET      0x20  /* MQS Settings for MQS2 */
+#define IMX9_WAKUPMIX_SAI_CLK_SEL_OFFSET      0x24  /* SAI2 and SAI3 MCLK1~3 CLK root mux settings */
+#define IMX9_WAKUPMIX_GPR_OFFSET              0x28  /* ENET QOS control signals */
+#define IMX9_WAKUPMIX_ENET_CLK_SEL_OFFSET     0x2c  /* ENET CLK direction selection */
+#define IMX9_WAKUPMIX_VOLT_DETECT_OFFSET      0x34  /* Voltage detectors output */
+#define IMX9_WAKUPMIX_I3C2_WAKEUP_OFFSET      0x38  /* I3C2 WAKEUPX CLR */
+#define IMX9_WAKUPMIX_IPG_DEBUG_CA55C0_OFFSET 0x3c  /* IPG DEBUG mask bit for CA55 core0 */
+#define IMX9_WAKUPMIX_IPG_DEBUG_CA55C1_OFFSET 0x40  /* IPG DEBUG mask bit for CA55 core1 */
+#define IMX9_WAKUPMIX_AXI_ATTR_CFG_OFFSET     0x44  /* AXI CACHE OVERRITE BIT */
+#define IMX9_WAKUPMIX_I3C2_SDA_IRQ_OFFSET     0x48  /* I3C SDA IRQ Control */
+
+/* Wakeupmix block control registers ****************************************/
+
+#define IMX9_WAKUPMIX_IPG_DEBUG_CM33   (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_IPG_DEBUG_CM33_OFFSET)
+#define IMX9_WAKUPMIX_QCH_DIS          (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_QCH_DIS_OFFSET)
+#define IMX9_WAKUPMIX_DEXSC_ERR        (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_DEXSC_ERR_OFFSET)
+#define IMX9_WAKUPMIX_MQS_SETTING      (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_MQS_SETTING_OFFSET)
+#define IMX9_WAKUPMIX_SAI_CLK_SEL      (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_SAI_CLK_SEL_OFFSET)
+#define IMX9_WAKUPMIX_GPR              (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_GPR_OFFSET)
+#define IMX9_WAKUPMIX_ENET_CLK_SEL     (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_ENET_CLK_SEL_OFFSET)
+#define IMX9_WAKUPMIX_VOLT_DETECT      (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_VOLT_DETECT_OFFSET)
+#define IMX9_WAKUPMIX_I3C2_WAKEUP      (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_I3C2_WAKEUP_OFFSET)
+#define IMX9_WAKUPMIX_IPG_DEBUG_CA55C0 (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_IPG_DEBUG_CA55C0_OFFSET)
+#define IMX9_WAKUPMIX_IPG_DEBUG_CA55C1 (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_IPG_DEBUG_CA55C1_OFFSET)
+#define IMX9_WAKUPMIX_AXI_ATTR_CFG     (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_AXI_ATTR_CFG_OFFSET)
+#define IMX9_WAKUPMIX_I3C2_SDA_IRQ     (IMX9_BLK_CTRL_WAKEUPMIX1_BASE + IMX9_WAKUPMIX_I3C2_SDA_IRQ_OFFSET)
+
+/* Wakeupmix register bit definitions ***************************************/
+
+#define WAKEUPMIX_ENET1_TX_CLK_SEL        ( 1 << 1 ) /* Direction of TX_CLK of ENET */
+#define WAKEUPMIX_ENET_QOS_CLK_TX_CLK_SEL ( 1 << 0 ) /* Direction of TX_CLK of ENET */
+
+#endif // __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_BLK_CTRL_H

--- a/arch/arm64/src/imx9/imx9_ccm.c
+++ b/arch/arm64/src/imx9/imx9_ccm.c
@@ -556,5 +556,25 @@ int imx9_ccm_clock_init(void)
       return ret;
     }
 
+  /* ENET to 125MHz */
+
+  imx9_ccm_gate_on(CCM_LPCG_ENET1, false);
+
+  ret = imx9_ccm_configure_root_clock(CCM_ENET_REF_CLK_ROOT,
+                                      SYS_PLL1PFD0DIV2, 2);
+  if (ret != 0)
+    {
+      return ret;
+    }
+
+  ret = imx9_ccm_configure_root_clock(CCM_ENET_TIMER_CLK_ROOT,
+                                      SYS_PLL1PFD0DIV2, 5);
+  if (ret != 0)
+    {
+      return ret;
+    }
+
+  imx9_ccm_gate_on(CCM_LPCG_ENET1, true);
+
   return OK;
 }

--- a/arch/arm64/src/imx9/imx9_enet.c
+++ b/arch/arm64/src/imx9/imx9_enet.c
@@ -64,6 +64,7 @@
 #include "imx9_iomuxc.h"
 #include "hardware/imx9_ccm.h"
 #include "hardware/imx9_pinmux.h"
+#include "hardware/imx9_blk_ctrl.h"
 
 #ifdef CONFIG_IMX9_ENET
 
@@ -423,7 +424,7 @@ static inline uint32_t imx9_enet_getreg32(struct imx9_driver_s *priv,
 }
 
 /****************************************************************************
- * Name: imx9_enet_putreg32
+ * Name: imx9_enet_modifyreg32
  *
  * Description:
  *   Atomically modify the specified bits in a memory mapped register
@@ -3091,6 +3092,14 @@ int imx9_netinitialize(int intf)
   /* Enet ref clock to 25 MHz */
 
   imx9_ccm_configure_root_clock(CCM_CR_ENETREFPHY, SYS_PLL1PFD0DIV2, 20);
+
+  /* Enet TX / ref clock direction */
+
+#ifdef CONFIG_IMX9_ENET1_TX_CLOCK_IS_INPUT
+  modifyreg32(IMX9_WAKUPMIX_ENET_CLK_SEL, WAKEUPMIX_ENET1_TX_CLK_SEL, 0);
+#else
+  modifyreg32(IMX9_WAKUPMIX_ENET_CLK_SEL, 0, WAKEUPMIX_ENET1_TX_CLK_SEL);
+#endif
 
   /* Enable the ENET clock */
 


### PR DESCRIPTION
## Summary

This is a collection of imx9 ethernet fixes:
- Allow configuring of ethernet reflock direction; this is needed for RMII designs
- Configure ethernet clock to 125MHz

## Impact

IMX9 only

## Testing

Tested on a custom i.MX93 board with RMII PHY
