### PR TITLE
spi_slave: change length to nwords

### DIFF
--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -669,11 +669,11 @@ static size_t spi_slave_getdata(FAR struct spi_slave_dev_s *dev,
  *   synchronization by several words.
  *
  * Input Parameters:
- *   dev  - SPI Slave device interface instance
- *   data - Pointer to the new data that has been shifted in
- *   len  - Length of the new data in units of nbits wide,
- *          nbits being the data width previously provided to the bind()
- *          method.
+ *   dev    - SPI Slave device interface instance
+ *   data   - Pointer to the new data that has been shifted in
+ *   nwords - Length of the new data in units of nbits wide,
+ *            nbits being the data width previously provided to the bind()
+ *            method.
  *
  * Returned Value:
  *   Number of units accepted by the device. In other words,
@@ -688,10 +688,10 @@ static size_t spi_slave_getdata(FAR struct spi_slave_dev_s *dev,
  ****************************************************************************/
 
 static size_t spi_slave_receive(FAR struct spi_slave_dev_s *dev,
-                                FAR const void *data, size_t len)
+                                FAR const void *data, size_t nwords)
 {
   FAR struct spi_slave_driver_s *priv = (FAR struct spi_slave_driver_s *)dev;
-  size_t recv_bytes = MIN(len, sizeof(priv->rx_buffer));
+  size_t recv_bytes = MIN(WORDS2BYTES(nwords), sizeof(priv->rx_buffer));
 
   memcpy(priv->rx_buffer, data, recv_bytes);
 

--- a/include/nuttx/spi/slave.h
+++ b/include/nuttx/spi/slave.h
@@ -273,11 +273,11 @@
  *   synchronization by several words.
  *
  * Input Parameters:
- *   dev  - SPI Slave device interface instance
- *   data - Pointer to the new data that has been shifted in
- *   len  - Length of the new data in units of nbits wide,
- *          nbits being the data width previously provided to the bind()
- *          method.
+ *   dev    - SPI Slave device interface instance
+ *   data   - Pointer to the new data that has been shifted in
+ *   nwords - Length of the new data in units of nbits wide,
+ *            nbits being the data width previously provided to the bind()
+ *            method.
  *
  * Returned Value:
  *   Number of units accepted by the device. In other words,
@@ -291,7 +291,7 @@
  *
  ****************************************************************************/
 
-#define SPIS_DEV_RECEIVE(d,v,l)  ((d)->ops->receive(d,v,l))
+#define SPIS_DEV_RECEIVE(d,v,n)  ((d)->ops->receive(d,v,n))
 
 /****************************************************************************
  * Name: SPIS_DEV_NOTIFY


### PR DESCRIPTION
## Summary
spi_slave: keep consistent with the parameter of the spi_slave_receive function declaration

  CODE size_t   (*receive)(FAR struct spi_slave_dev_s *sdev, FAR const void *data, size_t nwords);
## Impact
spi slave
## Testing

