### PR TITLE
fs/mmap: Ensure anonymous pages are initialized to zero

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -108,6 +108,17 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
   if ((flags & MAP_ANONYMOUS) != 0)
     {
       ret = map_anonymous(&entry, kernel);
+
+      /* According to the mmap(2) specification, anonymous pages should be
+       * initialized to zero unless the MAP_UNINITIALIZED is specified.
+       */
+
+      if ((ret == OK) && (flags & MAP_UNINITIALIZED) == 0)
+        {
+          DEBUGASSERT(entry.vaddr != NULL);
+          memset(entry.vaddr, 0, entry.length);
+        }
+
       goto out;
     }
 

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -56,7 +56,7 @@
 #define MAP_ANONYMOUS   (1 << 4)        /* Bit 4:  The mapping is not backed by any file */
 #define MAP_ANON        MAP_ANONYMOUS   /*         Alias */
 
-/* These are Linux-specific (none are implemented).  */
+/* These are Linux-specific (most are not implemented).  */
 
 #define MAP_GROWSDOWN   (1 << 5)        /* Bit 5:  Used to stack allocations */
 #define MAP_DENYWRITE   (1 << 6)        /* Bit 6:  Do not permit writes to file */
@@ -65,6 +65,8 @@
 #define MAP_NORESERVE   (1 << 9)        /* Bit 9:  Do not reserve swap space for this mapping */
 #define MAP_POPULATE    (1 << 10)       /* Bit 10: populate (prefault) page tables */
 #define MAP_NONBLOCK    (1 << 11)       /* Bit 11: Do not block on IO */
+
+#define MAP_UNINITIALIZED (1 << 26)     /* Bit 26: Do not clear the anonymous pages */
 
 /* Failure return */
 


### PR DESCRIPTION
## Summary
According to the mmap(2) specification, anonymous pages should be initialized to zero unless the MAP_UNINITIALIZED is specified.
## Impact
Anonymous memory allocated by mmap without MAP_UNINITIALIZED will be initialized to zero.
## Testing
Tested on x86_64 QEMU and x86_64 NUC12.
