### PR TITLE
riscv_mtimer: modify riscv_mtimer_current to reduce precision lost

### DIFF
--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -319,10 +319,11 @@ static int riscv_mtimer_current(struct oneshot_lowerhalf_s *lower,
   struct riscv_mtimer_lowerhalf_s *priv =
     (struct riscv_mtimer_lowerhalf_s *)lower;
   uint64_t mtime = riscv_mtimer_get_mtime(priv);
-  uint64_t nsec = mtime / (priv->freq / USEC_PER_SEC) * NSEC_PER_USEC;
+  uint64_t left;
 
-  ts->tv_sec  = nsec / NSEC_PER_SEC;
-  ts->tv_nsec = nsec % NSEC_PER_SEC;
+  ts->tv_sec  = mtime / priv->freq;
+  left        = mtime - ts->tv_sec * priv->freq;
+  ts->tv_nsec = NSEC_PER_SEC * left / priv->freq;
 
   return 0;
 }


### PR DESCRIPTION
## Summary
riscv_mtimer: modify riscv_mtimer_current to reduce precision lost
## Impact
riscv timer
## Testing

