### PR TITLE
mm: migrate to SPDX identifier

### DIFF
--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/bin/CMakeLists.txt
+++ b/mm/bin/CMakeLists.txt
@@ -1,1 +1,21 @@
-
+############################################################################
+# mm/bin/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################

--- a/mm/bin/Makefile
+++ b/mm/bin/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/bin/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/circbuf/CMakeLists.txt
+++ b/mm/circbuf/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/circbuf/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/circbuf/Make.defs
+++ b/mm/circbuf/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/circbuf/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/circbuf/circbuf.c
+++ b/mm/circbuf/circbuf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/circbuf/circbuf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/CMakeLists.txt
+++ b/mm/iob/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/iob/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/iob/Make.defs
+++ b/mm/iob/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/iob/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob.h
+++ b/mm/iob/iob.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_add_queue.c
+++ b/mm/iob/iob_add_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_add_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_alloc.c
+++ b/mm/iob/iob_alloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_alloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_alloc_qentry.c
+++ b/mm/iob/iob_alloc_qentry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_alloc_qentry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_clone.c
+++ b/mm/iob/iob_clone.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_clone.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_concat.c
+++ b/mm/iob/iob_concat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_concat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_contig.c
+++ b/mm/iob/iob_contig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_contig.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_copyin.c
+++ b/mm/iob/iob_copyin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_copyin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_copyout.c
+++ b/mm/iob/iob_copyout.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_copyout.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_count.c
+++ b/mm/iob/iob_count.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_count.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_dump.c
+++ b/mm/iob/iob_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_free.c
+++ b/mm/iob/iob_free.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_free.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_free_chain.c
+++ b/mm/iob/iob_free_chain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_free_chain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_free_qentry.c
+++ b/mm/iob/iob_free_qentry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_free_qentry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_free_queue.c
+++ b/mm/iob/iob_free_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_free_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_free_queue_qentry.c
+++ b/mm/iob/iob_free_queue_qentry.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_free_queue_qentry.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_get_queue_info.c
+++ b/mm/iob/iob_get_queue_info.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_get_queue_info.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_navail.c
+++ b/mm/iob/iob_navail.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_navail.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_notifier.c
+++ b/mm/iob/iob_notifier.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_notifier.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_pack.c
+++ b/mm/iob/iob_pack.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_pack.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_peek_queue.c
+++ b/mm/iob/iob_peek_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_peek_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_remove_queue.c
+++ b/mm/iob/iob_remove_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_remove_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_reserve.c
+++ b/mm/iob/iob_reserve.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_reserve.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_statistics.c
+++ b/mm/iob/iob_statistics.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_statistics.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_tailroom.c
+++ b/mm/iob/iob_tailroom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_tailroom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_test.c
+++ b/mm/iob/iob_test.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_test.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_trimhead.c
+++ b/mm/iob/iob_trimhead.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_trimhead.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_trimhead_queue.c
+++ b/mm/iob/iob_trimhead_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_trimhead_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_trimtail.c
+++ b/mm/iob/iob_trimtail.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_trimtail.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/iob/iob_update_pktlen.c
+++ b/mm/iob/iob_update_pktlen.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/iob/iob_update_pktlen.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kasan/CMakeLists.txt
+++ b/mm/kasan/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/kasan/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/kasan/Make.defs
+++ b/mm/kasan/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/kasan/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/kasan/kasan.c
+++ b/mm/kasan/kasan.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kasan/kasan.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kasan/kasan.h
+++ b/mm/kasan/kasan.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kasan/kasan.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kbin/CMakeLists.txt
+++ b/mm/kbin/CMakeLists.txt
@@ -1,1 +1,22 @@
+############################################################################
+# mm/kbin/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
 

--- a/mm/kbin/Makefile
+++ b/mm/kbin/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/kbin/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/kmap/Make.defs
+++ b/mm/kmap/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/kmap/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmap/kmm_map.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/CMakeLists.txt
+++ b/mm/kmm_heap/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/kmm_heap/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/kmm_heap/Make.defs
+++ b/mm/kmm_heap/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/kmm_heap/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_addregion.c
+++ b/mm/kmm_heap/kmm_addregion.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_addregion.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_brkaddr.c
+++ b/mm/kmm_heap/kmm_brkaddr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_brkaddr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_calloc.c
+++ b/mm/kmm_heap/kmm_calloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_calloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_checkcorruption.c
+++ b/mm/kmm_heap/kmm_checkcorruption.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_checkcorruption.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_extend.c
+++ b/mm/kmm_heap/kmm_extend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_extend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_free.c
+++ b/mm/kmm_heap/kmm_free.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_free.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_heapmember.c
+++ b/mm/kmm_heap/kmm_heapmember.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_heapmember.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_initialize.c
+++ b/mm/kmm_heap/kmm_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_mallinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_malloc.c
+++ b/mm/kmm_heap/kmm_malloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_malloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_malloc_size.c
+++ b/mm/kmm_heap/kmm_malloc_size.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_malloc_size.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_memalign.c
+++ b/mm/kmm_heap/kmm_memalign.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_memalign.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_memdump.c
+++ b/mm/kmm_heap/kmm_memdump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_memdump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_realloc.c
+++ b/mm/kmm_heap/kmm_realloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_realloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/kmm_heap/kmm_zalloc.c
+++ b/mm/kmm_heap/kmm_zalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/kmm_heap/kmm_zalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/map/CMakeLists.txt
+++ b/mm/map/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/map/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/map/Make.defs
+++ b/mm/map/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/map/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/map/mm_map.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/map/vm_region.c
+++ b/mm/map/vm_region.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/map/vm_region.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mempool/CMakeLists.txt
+++ b/mm/mempool/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/mempool/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/mempool/Make.defs
+++ b/mm/mempool/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/mempool/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mempool/mempool.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mempool/mempool_multiple.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mempool/mempool_procfs.c
+++ b/mm/mempool/mempool_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mempool/mempool_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/CMakeLists.txt
+++ b/mm/mm_gran/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/mm_gran/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/mm_gran/Make.defs
+++ b/mm/mm_gran/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/mm_gran/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_gran.h
+++ b/mm/mm_gran/mm_gran.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_gran.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_granalloc.c
+++ b/mm/mm_gran/mm_granalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_granalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_grancritical.c
+++ b/mm/mm_gran/mm_grancritical.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_grancritical.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_granfree.c
+++ b/mm/mm_gran/mm_granfree.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_granfree.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_graninfo.c
+++ b/mm/mm_gran/mm_graninfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_graninfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_graninit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_granrelease.c
+++ b/mm/mm_gran/mm_granrelease.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_granrelease.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_granreserve.c
+++ b/mm/mm_gran/mm_granreserve.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_granreserve.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_grantable.c
+++ b/mm/mm_gran/mm_grantable.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_grantable.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_grantable.h
+++ b/mm/mm_gran/mm_grantable.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_grantable.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_gran/mm_pgalloc.c
+++ b/mm/mm_gran/mm_pgalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_gran/mm_pgalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/CMakeLists.txt
+++ b/mm/mm_heap/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/mm_heap/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/mm_heap/Make.defs
+++ b/mm/mm_heap/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/mm_heap/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_addfreechunk.c
+++ b/mm/mm_heap/mm_addfreechunk.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_addfreechunk.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_brkaddr.c
+++ b/mm/mm_heap/mm_brkaddr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_brkaddr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_calloc.c
+++ b/mm/mm_heap/mm_calloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_calloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_checkcorruption.c
+++ b/mm/mm_heap/mm_checkcorruption.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_checkcorruption.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_extend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_foreach.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_free.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_heapmember.c
+++ b/mm/mm_heap/mm_heapmember.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_heapmember.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_lock.c
+++ b/mm/mm_heap/mm_lock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_lock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_mallinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_malloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_malloc_size.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_memalign.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_memdump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_realloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_shrinkchunk.c
+++ b/mm/mm_heap/mm_shrinkchunk.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_shrinkchunk.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_size2ndx.c
+++ b/mm/mm_heap/mm_size2ndx.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_size2ndx.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/mm_heap/mm_zalloc.c
+++ b/mm/mm_heap/mm_zalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/mm_heap/mm_zalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/shm/CMakeLists.txt
+++ b/mm/shm/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/shm/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/shm/Make.defs
+++ b/mm/shm/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/shm/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/shm/shm.h
+++ b/mm/shm/shm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/shm/shm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/shm/shmat.c
+++ b/mm/shm/shmat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/shm/shmat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/shm/shmctl.c
+++ b/mm/shm/shmctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/shm/shmctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/shm/shmdt.c
+++ b/mm/shm/shmdt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/shm/shmdt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/shm/shmget.c
+++ b/mm/shm/shmget.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/shm/shmget.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/tlsf/CMakeLists.txt
+++ b/mm/tlsf/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/tlsf/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/tlsf/Make.defs
+++ b/mm/tlsf/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/tlsf/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/tlsf/mm_tlsf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/ubsan/CMakeLists.txt
+++ b/mm/ubsan/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/ubsan/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/ubsan/Make.defs
+++ b/mm/ubsan/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/ubsan/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/ubsan/ubsan.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/ubsan/ubsan.h
+++ b/mm/ubsan/ubsan.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/ubsan/ubsan.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/CMakeLists.txt
+++ b/mm/umm_heap/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # mm/umm_heap/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/mm/umm_heap/Make.defs
+++ b/mm/umm_heap/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # mm/umm_heap/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_addregion.c
+++ b/mm/umm_heap/umm_addregion.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_addregion.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_brkaddr.c
+++ b/mm/umm_heap/umm_brkaddr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_brkaddr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_calloc.c
+++ b/mm/umm_heap/umm_calloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_calloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_checkcorruption.c
+++ b/mm/umm_heap/umm_checkcorruption.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_checkcorruption.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_extend.c
+++ b/mm/umm_heap/umm_extend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_extend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_free.c
+++ b/mm/umm_heap/umm_free.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_free.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_globals.c
+++ b/mm/umm_heap/umm_globals.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_globals.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_heap.h
+++ b/mm/umm_heap/umm_heap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_heap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_heapmember.c
+++ b/mm/umm_heap/umm_heapmember.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_heapmember.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_mallinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_malloc.c
+++ b/mm/umm_heap/umm_malloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_malloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_malloc_size.c
+++ b/mm/umm_heap/umm_malloc_size.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_malloc_size.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_memalign.c
+++ b/mm/umm_heap/umm_memalign.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_memalign.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_memdump.c
+++ b/mm/umm_heap/umm_memdump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_memdump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_realloc.c
+++ b/mm/umm_heap/umm_realloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_realloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_sbrk.c
+++ b/mm/umm_heap/umm_sbrk.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_sbrk.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/mm/umm_heap/umm_zalloc.c
+++ b/mm/umm_heap/umm_zalloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * mm/umm_heap/umm_zalloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
CI
