### PR TITLE
arm generate busfault & recursive bug fix

### DIFF
--- a/arch/arm/src/armv7-m/arm_systick.c
+++ b/arch/arm/src/armv7-m/arm_systick.c
@@ -135,7 +135,7 @@ static int systick_getstatus(struct timer_lowerhalf_s *lower_,
                              struct timer_status_s *status)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = up_irq_save();
 
   status->flags    = lower->callback ? TCFLAGS_HANDLER : 0;
   status->flags   |= systick_is_running() ? TCFLAGS_ACTIVE : 0;
@@ -161,7 +161,7 @@ static int systick_getstatus(struct timer_lowerhalf_s *lower_,
       status->timeleft = status->timeout;
     }
 
-  leave_critical_section(flags);
+  up_irq_restore(flags);
   return 0;
 }
 
@@ -169,8 +169,8 @@ static int systick_settimeout(struct timer_lowerhalf_s *lower_,
                               uint32_t timeout)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
+  irqstate_t flags = up_irq_save();
 
-  irqstate_t flags = enter_critical_section();
   if (lower->next_interval)
     {
       /* If the timer callback is in the process,
@@ -194,7 +194,7 @@ static int systick_settimeout(struct timer_lowerhalf_s *lower_,
         }
     }
 
-  leave_critical_section(flags);
+  up_irq_restore(flags);
   return 0;
 }
 
@@ -202,11 +202,12 @@ static void systick_setcallback(struct timer_lowerhalf_s *lower_,
                                 tccb_t callback, void *arg)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
+  irqstate_t flags = up_irq_save();
 
-  irqstate_t flags = enter_critical_section();
   lower->callback  = callback;
   lower->arg       = arg;
-  leave_critical_section(flags);
+
+  up_irq_restore(flags);
 }
 
 static int systick_maxtimeout(struct timer_lowerhalf_s *lower_,

--- a/arch/arm/src/armv8-m/arm_gen_nonsecfault.c
+++ b/arch/arm/src/armv8-m/arm_gen_nonsecfault.c
@@ -47,6 +47,17 @@
 #define OFFSET_XPSR            (7 * 4) /* xPSR */
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static uint32_t g_psp_ns;
+static uint32_t g_msp_ns;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: arm_should_gen_nonsecurefault
  *
  * Description:
@@ -85,7 +96,7 @@ bool weak_function arm_should_gen_nonsecurefault(void)
 
 int arm_gen_nonsecurefault(int irq, uint32_t *regs)
 {
-  uint32_t nsp;
+  uint32_t sp_ns;
 
   if (!arm_should_gen_nonsecurefault())
     {
@@ -99,38 +110,51 @@ int arm_gen_nonsecurefault(int irq, uint32_t *regs)
       return 0;
     }
 
-  /* busfault are forward to REE ? */
-
-  if (getreg32(NVIC_AIRCR) & NVIC_AIRCR_BFHFNMINS)
+  if (getreg32(SAU_SFSR) == 0)
     {
-      return 0;
+      /* busfault are forward to REE ? */
+
+      if (getreg32(NVIC_AIRCR) & NVIC_AIRCR_BFHFNMINS)
+        {
+          return 0;
+        }
+
+      /* Redict busfault to REE */
+
+      up_secure_irq(NVIC_IRQ_BUSFAULT, false);
     }
-
-  /* Redict busfault to REE */
-
-  up_secure_irq(NVIC_IRQ_BUSFAULT, false);
 
   /* Get non-secure SP */
 
-  __asm__ __volatile__ ("mrs %0, msp_ns" : "=r" (nsp));
+  if (regs[REG_EXC_RETURN] & EXC_RETURN_THREAD_MODE)
+    {
+      __asm__ __volatile__ ("mrs %0, psp_ns" : "=r" (g_psp_ns));
+      sp_ns = g_psp_ns;
+    }
+  else
+    {
+      __asm__ __volatile__ ("mrs %0, msp_ns" : "=r" (g_msp_ns));
+      sp_ns = g_msp_ns;
+    }
 
   _alert("Dump REE registers:\n");
   _alert("R0: %08" PRIx32 " R1: %08" PRIx32
          " R2: %08" PRIx32 "  R3: %08" PRIx32 "\n",
-         getreg32(nsp + OFFSET_R0), getreg32(nsp + OFFSET_R1),
-         getreg32(nsp + OFFSET_R2), getreg32(nsp + OFFSET_R3));
+         getreg32(sp_ns + OFFSET_R0), getreg32(sp_ns + OFFSET_R1),
+         getreg32(sp_ns + OFFSET_R2), getreg32(sp_ns + OFFSET_R3));
   _alert("IP: %08" PRIx32 " SP: %08" PRIx32
           " LR: %08" PRIx32 "  PC: %08" PRIx32 "\n",
-         getreg32(nsp + OFFSET_R12), nsp,
-         getreg32(nsp + OFFSET_R14), getreg32(nsp + OFFSET_R15));
+         getreg32(sp_ns + OFFSET_R12), sp_ns,
+         getreg32(sp_ns + OFFSET_R14), getreg32(sp_ns + OFFSET_R15));
+
   syslog_flush();
 
   /* Force set return ReturnAddress to 0, then non-secure cpu will crash.
    * Also, the ReturnAddress is very important, so move it to R12.
    */
 
-  putreg32(getreg32(nsp + OFFSET_R15), nsp + OFFSET_R12);
-  putreg32(0, nsp + OFFSET_R15);
+  putreg32(getreg32(sp_ns + OFFSET_R15), sp_ns + OFFSET_R12);
+  putreg32(0, sp_ns + OFFSET_R15);
 
   return 1;
 }

--- a/arch/arm/src/armv8-m/arm_securefault.c
+++ b/arch/arm/src/armv8-m/arm_securefault.c
@@ -112,16 +112,15 @@ int arm_securefault(int irq, void *context, void *arg)
       sfalert("\tLazy state error\n");
     }
 
-  /* clear SFSR sticky bits */
-
-  putreg32(0xff, SAU_SFSR);
-
 #ifdef CONFIG_DEBUG_SECUREFAULT
   if (arm_gen_nonsecurefault(irq, context))
     {
+      putreg32(0xff, SAU_SFSR);
       return OK;
     }
 #endif
+
+  putreg32(0xff, SAU_SFSR);
 
   up_irq_save();
   PANIC_WITH_REGS("panic", context);

--- a/arch/arm/src/armv8-m/arm_systick.c
+++ b/arch/arm/src/armv8-m/arm_systick.c
@@ -135,7 +135,7 @@ static int systick_getstatus(struct timer_lowerhalf_s *lower_,
                              struct timer_status_s *status)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = up_irq_save();
 
   status->flags    = lower->callback ? TCFLAGS_HANDLER : 0;
   status->flags   |= systick_is_running() ? TCFLAGS_ACTIVE : 0;
@@ -161,7 +161,7 @@ static int systick_getstatus(struct timer_lowerhalf_s *lower_,
       status->timeleft = status->timeout;
     }
 
-  leave_critical_section(flags);
+  up_irq_restore(flags);
   return 0;
 }
 
@@ -169,8 +169,8 @@ static int systick_settimeout(struct timer_lowerhalf_s *lower_,
                               uint32_t timeout)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
+  irqstate_t flags = up_irq_save();
 
-  irqstate_t flags = enter_critical_section();
   if (lower->next_interval)
     {
       /* If the timer callback is in the process,
@@ -194,7 +194,7 @@ static int systick_settimeout(struct timer_lowerhalf_s *lower_,
         }
     }
 
-  leave_critical_section(flags);
+  up_irq_restore(flags);
   return 0;
 }
 
@@ -202,11 +202,12 @@ static void systick_setcallback(struct timer_lowerhalf_s *lower_,
                                 tccb_t callback, void *arg)
 {
   struct systick_lowerhalf_s *lower = (struct systick_lowerhalf_s *)lower_;
+  irqstate_t flags = up_irq_save();
 
-  irqstate_t flags = enter_critical_section();
   lower->callback  = callback;
   lower->arg       = arg;
-  leave_critical_section(flags);
+
+  up_irq_restore(flags);
 }
 
 static int systick_maxtimeout(struct timer_lowerhalf_s *lower_,


### PR DESCRIPTION
## Summary

arm generate busfault & recursive bug fix

This PR contains two:

    armv7/8-m: change enter_critical_section to up_irq_save
    
    caused critical_monitor will gettime, that will caused
    enter_critical_seciton recursive

    armv8m: support busfault forward to TEE in REE handler mode
    

## Impact

armv7/8m systick & armv8m TEE

## Testing

bes board