### PR TITLE
arch/x86_64: Add ARCH_INTEL64_DISABLE_CET

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -32,6 +32,10 @@ ARCHCPUFLAGS = -fPIC -fno-stack-protector -mno-red-zone -mrdrnd
 ARCHPICFLAGS = -fPIC
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 
+ifeq ($(CONFIG_ARCH_INTEL64_DISABLE_CET),y)
+  ARCHOPTIMIZATION += -fcf-protection=none
+endif
+
 # We have to use a cross-development toolchain under Cygwin because the native
 # Cygwin toolchains don't generate ELF binaries.
 

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -183,4 +183,13 @@ config ARCH_INTEL64_DISABLE_INT_INIT
 		controllers. This is necessary if those are already
 		initialized, i.e. Jailhouse system.
 
+config ARCH_INTEL64_DISABLE_CET
+	bool "Disable CET completely"
+	---help---
+		Intel CET (Control-flow Enforcement Technology) is a hardware
+		enhancement aimed at mitigating the Retpoline vulnerability.
+		It inserts the endbr64 instruction at the beginning of functions,
+		which may impact CPU branch prediction performance.
+
+
 endif


### PR DESCRIPTION
## Summary
Intel CET (Control-flow Enforcement Technology) is a hardware enhancement aimed at mitigating the Retpoline vulnerability, but it may impact CPU branch prediction performance. This commit added ARCH_INTEL64_DISABLE_CET, which can disable CET completely with compilation option `-fcf-protection=none`.

## Impact
`ARCH_INTEL64_DISABLE_CET = y` will remove `endbr64` instructions from function entries.

## Testing
Tested on x86 QEMU, with assembly code examined using `objdump -S`