### PR TITLE
Add support for SIGEV_THREAD_ID and sigev_notify_thread_id

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -337,19 +337,33 @@ union sigval
 
 typedef CODE void (*sigev_notify_function_t)(union sigval value);
 
-struct sigevent
+typedef struct sigevent
 {
   uint8_t      sigev_notify; /* Notification method: SIGEV_SIGNAL, SIGEV_NONE, or SIGEV_THREAD */
   uint8_t      sigev_signo;  /* Notification signal */
   union sigval sigev_value;  /* Data passed with notification */
 
+  union
+    {
 #ifdef CONFIG_SIG_EVTHREAD
-  sigev_notify_function_t sigev_notify_function;      /* Notification function */
-  FAR struct pthread_attr_s *sigev_notify_attributes; /* Notification attributes (not used) */
-#endif
+      struct
+        {
+          /* Notification function */
 
-  pid_t        sigev_notify_thread_id; /* ID of thread to signal */
-};
+          sigev_notify_function_t _function;
+
+          /* Notification attributes (not used) */
+
+          FAR struct pthread_attr_s *_attribute;
+        } _sigev_thread;
+#endif
+      pid_t _tid; /* ID of thread to signal */
+    } _sigev_un;
+} sigevent_t;
+
+#define sigev_notify_function   _sigev_un._sigev_thread._function
+#define sigev_notify_attributes _sigev_un._sigev_thread._attribute
+#define sigev_notify_thread_id  _sigev_un._tid
 
 /* The following types is used to pass parameters to/from signal handlers */
 

--- a/include/signal.h
+++ b/include/signal.h
@@ -264,8 +264,10 @@
 #define SIGEV_NONE      0 /* No asynchronous notification is delivered */
 #define SIGEV_SIGNAL    1 /* Notify via signal,with an application-defined value */
 #ifdef CONFIG_SIG_EVTHREAD
-#  define SIGEV_THREAD  3 /* A notification function is called */
+#  define SIGEV_THREAD  2 /* A notification function is called */
 #endif
+
+#define SIGEV_THREAD_ID 4 /* Notify a specific thread via signal. */
 
 /* sigaltstack stack size */
 
@@ -345,6 +347,8 @@ struct sigevent
   sigev_notify_function_t sigev_notify_function;      /* Notification function */
   FAR struct pthread_attr_s *sigev_notify_attributes; /* Notification attributes (not used) */
 #endif
+
+  pid_t        sigev_notify_thread_id; /* ID of thread to signal */
 };
 
 /* The following types is used to pass parameters to/from signal handlers */

--- a/sched/signal/sig_notification.c
+++ b/sched/signal/sig_notification.c
@@ -124,6 +124,7 @@ int nxsig_notification(pid_t pid, FAR struct sigevent *event,
       info.si_pid    = rtcb->pid;
       info.si_status = OK;
 #endif
+      info.si_user   = NULL;
 
       /* Some compilers (e.g., SDCC), do not permit assignment of aggregates.
        * Use of memcpy() is overkill;  We could just copy the larger of the

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -158,6 +158,7 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
                  FAR timer_t *timerid)
 {
   FAR struct posix_timer_s *ret;
+  FAR struct tcb_s *tcb = nxsched_self();
 
   /* Sanity checks. */
 
@@ -181,13 +182,32 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
 
   ret->pt_clock = clockid;
   ret->pt_crefs = 1;
-  ret->pt_owner = nxsched_getpid();
+  ret->pt_owner = tcb->pid;
   ret->pt_delay = 0;
 
   /* Was a struct sigevent provided? */
 
   if (evp)
     {
+      FAR struct tcb_s *ntcb;
+
+      /* Check the SIGEV_THREAD_ID and validate the tid */
+
+      if (evp->sigev_notify & SIGEV_THREAD_ID)
+        {
+          /* Make sure that the notified thread is
+           * in same process with current thread.
+           */
+
+          ntcb = nxsched_get_tcb(evp->sigev_notify_thread_id);
+
+          if (ntcb == NULL || tcb->group != ntcb->group)
+            {
+              set_errno(EINVAL);
+              return ERROR;
+            }
+        }
+
       /* Yes, copy the entire struct sigevent content */
 
       memcpy(&ret->pt_event, evp, sizeof(struct sigevent));


### PR DESCRIPTION
## Summary
Add support for `SIGEV_THREAD_ID` and `sigev_notify_thread_id`.

## Impact
`SIGEV_THREAD_ID` is now supported.

## Testing
Functionality was tested using `rt-tests/cyclictest`, which employs `sigev_notify_thread_id` to notify a sleeping thread.
