### PR TITLE
Add dummy implementations for `shm_open` `pthread_setaffinity_np` and `RLIMIT_RTPRIO`

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -586,6 +586,9 @@ int pthread_setaffinity_np(pthread_t thread, size_t cpusetsize,
                            FAR const cpu_set_t *cpuset);
 int pthread_getaffinity_np(pthread_t thread, size_t cpusetsize,
                            FAR cpu_set_t *cpuset);
+#else
+#define pthread_setaffinity_np(...) (-ENOSYS)
+#define pthread_getaffinity_np(...) (-ENOSYS)
 #endif
 
 /* Thread-specific Data Interfaces */

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -212,8 +212,13 @@ int posix_mem_offset(FAR const void *addr, size_t len, FAR off_t *off,
 int posix_typed_mem_get_info(int fildes,
                              FAR struct posix_typed_mem_info *info);
 int posix_typed_mem_open(FAR const char *name, int oflag, int tflag);
+#ifdef CONFIG_FS_SHMFS
 int shm_open(FAR const char *name, int oflag, mode_t mode);
 int shm_unlink(FAR const char *name);
+#else
+#define shm_open(...)   (-ENOSYS)
+#define shm_unlink(...) (-ENOSYS)
+#endif
 int memfd_create(FAR const char *name, unsigned int flags);
 
 #undef EXTERN

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -59,6 +59,11 @@
 #define RLIMIT_AS       7           /* Limit on address space size */
 #define RLIMIT_MEMLOCK  8           /* Limit on memory use */
 
+/* Below are not implemented yet: */
+
+#define RLIMIT_RTPRIO   14          /* Limit on RT tasks priority */
+#define RLIMIT_RTTIME   15          /* Limit on timeout for RT tasks (us) */
+
 #if defined(CONFIG_FS_LARGEFILE)
 #  define RLIM_INFINITY    UINT64_MAX /* No limit */
 #  define RLIM_SAVED_MAX   UINT64_MAX /* Unrepresentable saved hard limit */

--- a/libs/libc/unistd/lib_getrlimit.c
+++ b/libs/libc/unistd/lib_getrlimit.c
@@ -71,6 +71,18 @@ int getrlimit(int resource, FAR struct rlimit *rlp)
           rlp->rlim_max = RLIM_INFINITY;
         }
         break;
+      case RLIMIT_RTPRIO:
+        {
+          rlp->rlim_cur = SCHED_PRIORITY_DEFAULT;
+          rlp->rlim_max = SCHED_PRIORITY_MAX;
+        }
+        break;
+      case RLIMIT_RTTIME:
+        {
+          rlp->rlim_cur = UINT32_MAX;
+          rlp->rlim_max = UINT32_MAX;
+        }
+        break;
       default:
         break;
     }


### PR DESCRIPTION
## Summary
Added dummy implementations for `shm_open` and `shm_unlink`.
Added a dummy implementation for `pthread_setaffinity_np` when `CONFIG_SMP` is disabled.
Added definitions for `RLIMIT_RTPRIO` and `RLIMIT_RTTIME`.

## Impact
Dummy implementations for `shm_open` and `shm_unlink` are now available.
`pthread_setaffinity_np` is supported in configurations with `CONFIG_SMP` disabled.
`RLIMIT_RTPRIO` and `RLIMIT_RTTIME` are now defined.

## Testing
Tested on x86 QEMU and NUC12.
