### PR TITLE
arch: use up_current_regs/up_set_current_regs replace CURRENT_REGS

### DIFF
--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -89,9 +89,9 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -99,7 +99,6 @@ extern "C"
  */
 
 EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -108,6 +107,16 @@ EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Inline functions
  ****************************************************************************/
+
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
 
 /****************************************************************************
  * Name: up_interrupt_context
@@ -125,7 +134,7 @@ static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/arm/src/arm/arm_dataabort.c
+++ b/arch/arm/src/arm/arm_dataabort.c
@@ -72,13 +72,13 @@ void arm_dataabort(uint32_t *regs, uint32_t far, uint32_t fsr)
 #ifdef CONFIG_LEGACY_PAGING
   uint32_t *savestate;
 
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  savestate    = (uint32_t *)CURRENT_REGS;
+  savestate = up_current_regs();
 #endif
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
 #ifdef CONFIG_LEGACY_PAGING
   /* In the NuttX on-demand paging implementation, only the read-only, .text
@@ -133,12 +133,12 @@ void arm_dataabort(uint32_t *regs, uint32_t far, uint32_t fsr)
 
   pg_miss();
 
-  /* Restore the previous value of CURRENT_REGS.  NULL would indicate that
+  /* Restore the previous value of current_regs.  NULL would indicate that
    * we are no longer in an interrupt handler.  It will be non-NULL if we
    * are returning from a nested interrupt.
    */
 
-  CURRENT_REGS = savestate;
+  up_set_current_regs(savestate);
   return;
 
 segfault:
@@ -153,11 +153,11 @@ segfault:
 
 void arm_dataabort(uint32_t *regs)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnost debug information. */
 

--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -64,13 +64,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #else
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Acknowledge the interrupt */
 
@@ -81,13 +81,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   irq_dispatch(irq, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
    * point state and the establish the correct address environment before
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -106,14 +106,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/arm/src/arm/arm_prefetchabort.c
+++ b/arch/arm/src/arm/arm_prefetchabort.c
@@ -68,13 +68,13 @@ void arm_prefetchabort(uint32_t *regs)
 #ifdef CONFIG_LEGACY_PAGING
   uint32_t *savestate;
 
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  savestate    = (uint32_t *)CURRENT_REGS;
+  savestate = up_current_regs();
 #endif
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
 #ifdef CONFIG_LEGACY_PAGING
   /* Get the (virtual) address of instruction that caused the prefetch
@@ -114,12 +114,12 @@ void arm_prefetchabort(uint32_t *regs)
 
       pg_miss();
 
-      /* Restore the previous value of CURRENT_REGS.  NULL would indicate
+      /* Restore the previous value of current_regs.  NULL would indicate
        * that we are no longer in an interrupt handler.  It will be non-NULL
        * if we are returning from a nested interrupt.
        */
 
-      CURRENT_REGS = savestate;
+      up_set_current_regs(savestate);
     }
   else
 #endif

--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -60,13 +60,13 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* The SYSCALL command is in R0 on entry.  Parameters follow in R1..R7 */
 
@@ -94,8 +94,8 @@ uint32_t *arm_syscall(uint32_t *regs)
            * set will determine the restored context.
            */
 
-          CURRENT_REGS = (uint32_t *)regs[REG_R1];
-          DEBUGASSERT(CURRENT_REGS);
+          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          DEBUGASSERT(up_current_regs());
         }
         break;
 
@@ -120,7 +120,7 @@ uint32_t *arm_syscall(uint32_t *regs)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_R2];
+          up_set_current_regs((uint32_t *)regs[REG_R2]);
         }
         break;
 
@@ -135,12 +135,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then establish the correct
    * address environment before returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -154,7 +154,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
@@ -167,14 +167,14 @@ uint32_t *arm_syscall(uint32_t *regs)
       /* Restore the cpu lock */
 
       restore_critical_section(tcb, cpu);
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the

--- a/arch/arm/src/arm/arm_undefinedinsn.c
+++ b/arch/arm/src/arm/arm_undefinedinsn.c
@@ -43,6 +43,7 @@
 void arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
+
   PANIC_WITH_REGS("panic", regs);
 }

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -49,7 +49,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs[REG_EXC_RETURN] & EXC_RETURN_THREAD_MODE)
     {
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
     }
 
   /* Acknowledge the interrupt */
@@ -61,7 +61,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   irq_dispatch(irq, regs);
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
+   * current_regs may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
@@ -70,7 +70,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
     {
       /* Restore the cpu lock */
 
-      if (regs != CURRENT_REGS)
+      if (regs != up_current_regs())
         {
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
@@ -78,13 +78,12 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
            */
 
           g_running_tasks[this_cpu()] = this_task();
-
-          regs = (uint32_t *)CURRENT_REGS;
+          regs = up_current_regs();
         }
 
-      /* Update the CURRENT_REGS to NULL. */
+      /* Update the current_regs to NULL. */
 
-      CURRENT_REGS = NULL;
+      up_set_current_regs(NULL);
     }
 #endif
 

--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -117,7 +117,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/arch/arm/src/armv7-a/arm_dataabort.c
@@ -70,12 +70,12 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
   struct tcb_s *tcb = this_task();
   uint32_t *savestate;
 
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  savestate    = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = regs;
+  savestate = up_current_regs();
+  up_set_current_regs(regs);
 
   /* In the NuttX on-demand paging implementation, only the read-only, .text
    * section is paged.  However, the ARM compiler generated PC-relative data
@@ -129,12 +129,12 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   pg_miss();
 
-  /* Restore the previous value of CURRENT_REGS.  NULL would indicate that
+  /* Restore the previous value of current_regs.  NULL would indicate that
    * we are no longer in an interrupt handler.  It will be non-NULL if we
    * are returning from a nested interrupt.
    */
 
-  CURRENT_REGS = savestate;
+  up_set_current_regs(savestate);
   return regs;
 
 segfault:
@@ -148,11 +148,11 @@ segfault:
 
 uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -59,13 +59,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #else
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -73,7 +73,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -91,15 +91,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 #endif
 
   board_autoled_off(LED_INIRQ);

--- a/arch/arm/src/armv7-a/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-a/arm_prefetchabort.c
@@ -56,12 +56,12 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
   uint32_t *savestate;
 
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  savestate    = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = regs;
+  savestate = up_current_regs();
+  up_set_current_regs(regs);
 
   /* Get the (virtual) address of instruction that caused the prefetch
    * abort. When the exception occurred, this address was provided in the
@@ -100,12 +100,12 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
       pg_miss();
 
-      /* Restore the previous value of CURRENT_REGS.
+      /* Restore the previous value of current_regs.
        * NULL would indicate thatwe are no longer in an interrupt handler.
        *  It will be non-NULL if we are returning from a nested interrupt.
        */
 
-      CURRENT_REGS = savestate;
+      up_set_current_regs(savestate);
     }
   else
     {
@@ -121,11 +121,11 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 
 uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -92,7 +92,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on this CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -100,7 +100,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -118,7 +118,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signaling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -140,24 +140,23 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS            = (void *)
-                                        ((uint32_t)CURRENT_REGS -
-                                                   XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                                  XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP]    = (uint32_t)(up_current_regs() +
+                                                         XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                         PSR_F_BIT);
+              up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
+                                               PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-              CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
             }
         }
@@ -223,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -234,7 +233,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -321,25 +320,23 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS            = (void *)
-                                            ((uint32_t)CURRENT_REGS -
-                                                       XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                                      XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                             PSR_F_BIT);
+                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
+                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
+                                                   PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-                  CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
                 }
 

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -169,13 +169,13 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* The SYSCALL command is in R0 on entry.  Parameters follow in R1..R7 */
 
@@ -272,8 +272,8 @@ uint32_t *arm_syscall(uint32_t *regs)
            * set will determine the restored context.
            */
 
-          CURRENT_REGS = (uint32_t *)regs[REG_R1];
-          DEBUGASSERT(CURRENT_REGS);
+          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          DEBUGASSERT(up_current_regs());
         }
         break;
 
@@ -298,7 +298,7 @@ uint32_t *arm_syscall(uint32_t *regs)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_R2];
+          up_set_current_regs((uint32_t *)regs[REG_R2]);
         }
         break;
 
@@ -567,12 +567,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then establish the correct
    * address environment before returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -586,7 +586,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
@@ -599,18 +599,18 @@ uint32_t *arm_syscall(uint32_t *regs)
       /* Restore the cpu lock */
 
       restore_critical_section(tcb, cpu);
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
   /* Report what happened */
 
   dump_syscall("Exit", cmd, regs);
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the

--- a/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -43,7 +43,8 @@
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
+
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -49,7 +49,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs[REG_EXC_RETURN] & EXC_RETURN_THREAD_MODE)
     {
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
     }
 
   /* Acknowledge the interrupt */
@@ -61,7 +61,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   irq_dispatch(irq, regs);
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
+   * current_regs may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
@@ -70,7 +70,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
     {
       /* Restore the cpu lock */
 
-      if (regs != CURRENT_REGS)
+      if (regs != up_current_regs())
         {
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
@@ -78,13 +78,12 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
            */
 
           g_running_tasks[this_cpu()] = this_task();
-
-          regs = (uint32_t *)CURRENT_REGS;
+          regs = up_current_regs();
         }
 
-      /* Update the CURRENT_REGS to NULL. */
+      /* Update the current_regs to NULL. */
 
-      CURRENT_REGS = NULL;
+      up_set_current_regs(NULL);
     }
 #endif
 

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -95,7 +95,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -103,7 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handle will run in a critical section!
@@ -138,31 +138,31 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS                 = (void *)
-                                             ((uint32_t)CURRENT_REGS -
-                                                        XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]         = (uint32_t)CURRENT_REGS +
-                                                       XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
+                                                      XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled.  The kernel-space trampoline must run in
                * privileged thread mode.
                */
 
-              CURRENT_REGS[REG_PC]         = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_PC]         = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-              CURRENT_REGS[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
+              up_current_regs()[REG_BASEPRI]    =
+                                                  NVIC_SYSH_DISABLE_PRIORITY;
 #else
-              CURRENT_REGS[REG_PRIMASK]    = 1;
+              up_current_regs()[REG_PRIMASK]    = 1;
 #endif
-              CURRENT_REGS[REG_XPSR]       = ARMV7M_XPSR_T;
+              up_current_regs()[REG_XPSR]       = ARMV7M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-              CURRENT_REGS[REG_LR]         = EXC_RETURN_THREAD;
-              CURRENT_REGS[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-              CURRENT_REGS[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+              up_current_regs()[REG_LR]         = EXC_RETURN_THREAD;
+              up_current_regs()[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+              up_current_regs()[REG_CONTROL]    = getcontrol() &
+                                                   ~CONTROL_NPRIV;
 #endif
             }
         }
@@ -235,7 +235,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -246,7 +246,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -339,30 +339,30 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS              = (void *)
-                                              ((uint32_t)CURRENT_REGS -
-                                                         XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                                        XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]      = (uint32_t)arm_sigdeliver;
+                  up_current_regs()[REG_PC]      = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-                  CURRENT_REGS[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
+                  up_current_regs()[REG_BASEPRI] =
+                  NVIC_SYSH_DISABLE_PRIORITY;
 #else
-                  CURRENT_REGS[REG_PRIMASK] = 1;
+                  up_current_regs()[REG_PRIMASK] = 1;
 #endif
-                  CURRENT_REGS[REG_XPSR]    = ARMV7M_XPSR_T;
+                  up_current_regs()[REG_XPSR]    = ARMV7M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-                  CURRENT_REGS[REG_LR]      = EXC_RETURN_THREAD;
-                  CURRENT_REGS[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
+                  up_current_regs()[REG_LR]      = EXC_RETURN_THREAD;
+                  up_current_regs()[REG_CONTROL] = getcontrol() &
+                                                    ~CONTROL_NPRIV;
 #endif
                 }
 

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -128,7 +128,7 @@ int arm_svcall(int irq, void *context, void *arg)
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
   cmd = regs[REG_R0];
 
   /* The SVCall software interrupt is called with R0 = system call command
@@ -166,9 +166,9 @@ int arm_svcall(int irq, void *context, void *arg)
        *   R0 = SYS_restore_context
        *   R1 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore
-       * register area referenced in the saved R1. context == CURRENT_REGS
-       * is the normal exception return.  By setting CURRENT_REGS =
+       * In this case, we simply need to set current_regs to restore
+       * register area referenced in the saved R1. context == current_regs
+       * is the normal exception return.  By setting current_regs =
        * context[R1], we force the return to the saved context referenced
        * in R1.
        */
@@ -176,7 +176,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_R1];
+          up_set_current_regs((uint32_t *)regs[REG_R1]);
         }
         break;
 
@@ -193,7 +193,7 @@ int arm_svcall(int irq, void *context, void *arg)
        *
        * In this case, we do both: We save the context registers to the save
        * register area reference by the saved contents of R1 and then set
-       * CURRENT_REGS to the save register area referenced by the saved
+       * current_regs to the save register area referenced by the saved
        * contents of R2.
        */
 
@@ -201,7 +201,7 @@ int arm_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_R2];
+          up_set_current_regs((uint32_t *)regs[REG_R2]);
         }
         break;
 
@@ -459,23 +459,24 @@ int arm_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
 #  endif
     {
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              CURRENT_REGS[REG_R0],  CURRENT_REGS[REG_R1],
-              CURRENT_REGS[REG_R2],  CURRENT_REGS[REG_R3],
-              CURRENT_REGS[REG_R4],  CURRENT_REGS[REG_R5],
-              CURRENT_REGS[REG_R6],  CURRENT_REGS[REG_R7]);
+              up_current_regs()[REG_R0],  up_current_regs()[REG_R1],
+              up_current_regs()[REG_R2],  up_current_regs()[REG_R3],
+              up_current_regs()[REG_R4],  up_current_regs()[REG_R5],
+              up_current_regs()[REG_R6],  up_current_regs()[REG_R7]);
       svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              CURRENT_REGS[REG_R8],  CURRENT_REGS[REG_R9],
-              CURRENT_REGS[REG_R10], CURRENT_REGS[REG_R11],
-              CURRENT_REGS[REG_R12], CURRENT_REGS[REG_R13],
-              CURRENT_REGS[REG_R14], CURRENT_REGS[REG_R15]);
+              up_current_regs()[REG_R8],  up_current_regs()[REG_R9],
+              up_current_regs()[REG_R10], up_current_regs()[REG_R11],
+              up_current_regs()[REG_R12], up_current_regs()[REG_R13],
+              up_current_regs()[REG_R14], up_current_regs()[REG_R15]);
       svcinfo(" PSR: %08x EXC_RETURN: %08x, CONTROL: %08x\n",
-              CURRENT_REGS[REG_XPSR], CURRENT_REGS[REG_EXC_RETURN],
-              CURRENT_REGS[REG_CONTROL]);
+              up_current_regs()[REG_XPSR],
+              up_current_regs()[REG_EXC_RETURN],
+              up_current_regs()[REG_CONTROL]);
     }
 #  ifdef CONFIG_DEBUG_SVCALL
   else
@@ -485,7 +486,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #  endif
 #endif
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/arm/src/armv7-r/arm_cpupause.c
+++ b/arch/arm/src/armv7-r/arm_cpupause.c
@@ -117,7 +117,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/armv7-r/arm_dataabort.c
+++ b/arch/arm/src/armv7-r/arm_dataabort.c
@@ -53,11 +53,11 @@
 
 uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -48,13 +48,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #else
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -62,7 +62,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -70,15 +70,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   board_autoled_off(LED_INIRQ);
 #endif

--- a/arch/arm/src/armv7-r/arm_prefetchabort.c
+++ b/arch/arm/src/armv7-r/arm_prefetchabort.c
@@ -49,11 +49,11 @@
 
 uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -98,7 +98,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -114,7 +114,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -136,28 +136,26 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS           = (void *)
-                                       ((uint32_t)CURRENT_REGS -
-                                                  XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]   = (uint32_t)CURRENT_REGS +
-                                                 XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP]  = (uint32_t)(up_current_regs() +
+                                                       XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC]   = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
-                                        PSR_F_BIT);
+              up_current_regs()[REG_PC]   = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
+                                              PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-              CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
 
 #ifdef CONFIG_ENDIAN_BIG
-              CURRENT_REGS[REG_CPSR] |= PSR_E_BIT;
+              up_current_regs()[REG_CPSR] |= PSR_E_BIT;
 #endif
             }
         }
@@ -226,7 +224,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -237,7 +235,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -324,25 +322,23 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS            = (void *)
-                                            ((uint32_t)CURRENT_REGS -
-                                                       XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                                      XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                             PSR_F_BIT);
+                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
+                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
+                                                  PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-                  CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
                 }
 

--- a/arch/arm/src/armv7-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-r/arm_undefinedinsn.c
@@ -43,7 +43,8 @@
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
+
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -98,7 +98,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (arm_from_thread(regs[REG_EXC_RETURN]))
     {
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
     }
 
   /* Acknowledge the interrupt */
@@ -110,7 +110,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   irq_dispatch(irq, regs);
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
+   * current_regs may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
@@ -119,7 +119,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
     {
       /* Restore the cpu lock */
 
-      if (regs != CURRENT_REGS)
+      if (regs != up_current_regs())
         {
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
@@ -127,13 +127,12 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
            */
 
           g_running_tasks[this_cpu()] = this_task();
-
-          regs = (uint32_t *)CURRENT_REGS;
+          regs = up_current_regs();
         }
 
-      /* Update the CURRENT_REGS to NULL. */
+      /* Update the current_regs to NULL. */
 
-      CURRENT_REGS = NULL;
+      up_set_current_regs(NULL);
     }
 #endif
 

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -95,7 +95,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -103,7 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handle will run in a critical section!
@@ -138,31 +138,31 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS                 = (void *)
-                                             ((uint32_t)CURRENT_REGS -
-                                                        XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]         = (uint32_t)CURRENT_REGS +
-                                                       XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
+                                                      XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled.  The kernel-space trampoline must run in
                * privileged thread mode.
                */
 
-              CURRENT_REGS[REG_PC]         = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_PC]         = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV8M_USEBASEPRI
-              CURRENT_REGS[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
+              up_current_regs()[REG_BASEPRI]    =
+                                                  NVIC_SYSH_DISABLE_PRIORITY;
 #else
-              CURRENT_REGS[REG_PRIMASK]    = 1;
+              up_current_regs()[REG_PRIMASK]    = 1;
 #endif
-              CURRENT_REGS[REG_XPSR]       = ARMV8M_XPSR_T;
+              up_current_regs()[REG_XPSR]       = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-              CURRENT_REGS[REG_LR]         = EXC_RETURN_THREAD;
-              CURRENT_REGS[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-              CURRENT_REGS[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+              up_current_regs()[REG_LR]         = EXC_RETURN_THREAD;
+              up_current_regs()[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+              up_current_regs()[REG_CONTROL]    = getcontrol() &
+                                                   ~CONTROL_NPRIV;
 #endif
             }
         }
@@ -235,7 +235,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -246,7 +246,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -339,30 +339,30 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS              = (void *)
-                                              ((uint32_t)CURRENT_REGS -
-                                                         XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]      = (uint32_t)CURRENT_REGS +
-                                                        XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
+                                                        + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]      = (uint32_t)arm_sigdeliver;
+                  up_current_regs()[REG_PC]      = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV8M_USEBASEPRI
-                  CURRENT_REGS[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
+                  up_current_regs()[REG_BASEPRI] =
+                  NVIC_SYSH_DISABLE_PRIORITY;
 #else
-                  CURRENT_REGS[REG_PRIMASK] = 1;
+                  up_current_regs()[REG_PRIMASK] = 1;
 #endif
-                  CURRENT_REGS[REG_XPSR]    = ARMV8M_XPSR_T;
+                  up_current_regs()[REG_XPSR]    = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-                  CURRENT_REGS[REG_LR]      = EXC_RETURN_THREAD;
-                  CURRENT_REGS[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
+                  up_current_regs()[REG_LR]      = EXC_RETURN_THREAD;
+                  up_current_regs()[REG_CONTROL] = getcontrol() &
+                                                    ~CONTROL_NPRIV;
 #endif
                 }
 

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -127,7 +127,7 @@ int arm_svcall(int irq, void *context, void *arg)
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
   cmd = regs[REG_R0];
 
   /* The SVCall software interrupt is called with R0 = system call command
@@ -165,9 +165,9 @@ int arm_svcall(int irq, void *context, void *arg)
        *   R0 = SYS_restore_context
        *   R1 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore
-       * register area referenced in the saved R1. context == CURRENT_REGS
-       * is the normal exception return.  By setting CURRENT_REGS =
+       * In this case, we simply need to set current_regs to restore
+       * register area referenced in the saved R1. context == current_regs
+       * is the normal exception return.  By setting current_regs =
        * context[R1], we force the return to the saved context referenced
        * in R1.
        */
@@ -175,7 +175,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_R1];
+          up_set_current_regs((uint32_t *)regs[REG_R1]);
         }
         break;
 
@@ -192,7 +192,7 @@ int arm_svcall(int irq, void *context, void *arg)
        *
        * In this case, we do both: We save the context registers to the save
        * register area reference by the saved contents of R1 and then set
-       * CURRENT_REGS to the save register area referenced by the saved
+       * current_regs to the save register area referenced by the saved
        * contents of R2.
        */
 
@@ -200,7 +200,7 @@ int arm_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_R2];
+          up_set_current_regs((uint32_t *)regs[REG_R2]);
         }
         break;
 
@@ -460,23 +460,24 @@ int arm_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
 #  endif
     {
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              CURRENT_REGS[REG_R0],  CURRENT_REGS[REG_R1],
-              CURRENT_REGS[REG_R2],  CURRENT_REGS[REG_R3],
-              CURRENT_REGS[REG_R4],  CURRENT_REGS[REG_R5],
-              CURRENT_REGS[REG_R6],  CURRENT_REGS[REG_R7]);
+              up_current_regs()[REG_R0],  up_current_regs()[REG_R1],
+              up_current_regs()[REG_R2],  up_current_regs()[REG_R3],
+              up_current_regs()[REG_R4],  up_current_regs()[REG_R5],
+              up_current_regs()[REG_R6],  up_current_regs()[REG_R7]);
       svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              CURRENT_REGS[REG_R8],  CURRENT_REGS[REG_R9],
-              CURRENT_REGS[REG_R10], CURRENT_REGS[REG_R11],
-              CURRENT_REGS[REG_R12], CURRENT_REGS[REG_R13],
-              CURRENT_REGS[REG_R14], CURRENT_REGS[REG_R15]);
+              up_current_regs()[REG_R8],  up_current_regs()[REG_R9],
+              up_current_regs()[REG_R10], up_current_regs()[REG_R11],
+              up_current_regs()[REG_R12], up_current_regs()[REG_R13],
+              up_current_regs()[REG_R14], up_current_regs()[REG_R15]);
       svcinfo(" PSR: %08x EXC_RETURN: %08x CONTROL: %08x\n",
-              CURRENT_REGS[REG_XPSR], CURRENT_REGS[REG_EXC_RETURN],
-              CURRENT_REGS[REG_CONTROL]);
+              up_current_regs()[REG_XPSR],
+              up_current_regs()[REG_EXC_RETURN],
+              up_current_regs()[REG_CONTROL]);
     }
 #  ifdef CONFIG_DEBUG_SVCALL
   else
@@ -486,7 +487,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #  endif
 #endif
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/arm/src/armv8-r/arm_dataabort.c
+++ b/arch/arm/src/armv8-r/arm_dataabort.c
@@ -53,11 +53,11 @@
 
 uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -49,13 +49,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #else
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -63,7 +63,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -71,14 +71,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   board_autoled_off(LED_INIRQ);
 #endif

--- a/arch/arm/src/armv8-r/arm_prefetchabort.c
+++ b/arch/arm/src/armv8-r/arm_prefetchabort.c
@@ -49,11 +49,11 @@
 
 uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Crash -- possibly showing diagnostic debug information. */
 

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -98,7 +98,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -114,7 +114,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -136,28 +136,26 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS           = (void *)
-                                       ((uint32_t)CURRENT_REGS -
-                                                  XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]   = (uint32_t)CURRENT_REGS +
-                                                 XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
+                                                      XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC]   = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
-                                        PSR_F_BIT);
+              up_current_regs()[REG_PC]   = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
+                                              PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-              CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
 
 #ifdef CONFIG_ENDIAN_BIG
-              CURRENT_REGS[REG_CPSR] |= PSR_E_BIT;
+              up_current_regs()[REG_CPSR] |= PSR_E_BIT;
 #endif
             }
         }
@@ -226,7 +224,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -237,7 +235,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -324,25 +322,23 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS            = (void *)
-                                            ((uint32_t)CURRENT_REGS -
-                                                       XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]    = (uint32_t)CURRENT_REGS +
-                                                      XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                             PSR_F_BIT);
+                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
+                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
+                                                   PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-                  CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
+                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
 #endif
                 }
 

--- a/arch/arm/src/armv8-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv8-r/arm_undefinedinsn.c
@@ -43,7 +43,8 @@
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
   _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
+
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */
 }

--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -141,8 +141,8 @@ int up_backtrace(struct tcb_s *tcb,
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)CURRENT_REGS[REG_FP],
-                               (void *)CURRENT_REGS[REG_PC],
+                               (void *)up_current_regs()[REG_FP],
+                               (void *)up_current_regs()[REG_PC],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -277,7 +277,7 @@ int up_backtrace(struct tcb_s *tcb,
               ret += backtrace_branch((unsigned long)
                                       rtcb->stack_base_ptr +
                                       rtcb->adj_stack_size,
-                                      CURRENT_REGS[REG_SP],
+                                      up_current_regs()[REG_SP],
                                       &buffer[ret],
                                       size - ret, &skip);
             }

--- a/arch/arm/src/common/arm_backtrace_unwind.c
+++ b/arch/arm/src/common/arm_backtrace_unwind.c
@@ -743,10 +743,10 @@ int up_backtrace(struct tcb_s *tcb,
           ret = backtrace_unwind(&frame, buffer, size, &skip);
           if (ret < size)
             {
-              frame.fp = CURRENT_REGS[REG_FP];
-              frame.sp = CURRENT_REGS[REG_SP];
-              frame.pc = CURRENT_REGS[REG_PC];
-              frame.lr = CURRENT_REGS[REG_LR];
+              frame.fp = up_current_regs()[REG_FP];
+              frame.sp = up_current_regs()[REG_SP];
+              frame.pc = up_current_regs()[REG_PC];
+              frame.lr = up_current_regs()[REG_LR];
               frame.stack_base = (unsigned long)rtcb->stack_base_ptr;
               frame.stack_top = frame.stack_base + rtcb->adj_stack_size;
               ret += backtrace_unwind(&frame, &buffer[ret],

--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -33,9 +33,9 @@
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -98,8 +98,8 @@
 
 /* Macros to handle saving and restoring interrupt state. */
 
-#define arm_savestate(regs)    (regs = (uint32_t *)CURRENT_REGS)
-#define arm_restorestate(regs) (CURRENT_REGS = regs)
+#define arm_savestate(regs)    (regs = up_current_regs())
+#define arm_restorestate(regs) up_set_current_regs(regs)
 
 /* Toolchain dependent, linker defined section addresses */
 

--- a/arch/arm/src/common/arm_registerdump.c
+++ b/arch/arm/src/common/arm_registerdump.c
@@ -57,7 +57,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Dump the interrupt registers */
 

--- a/arch/arm/src/common/arm_switchcontext.c
+++ b/arch/arm/src/common/arm_switchcontext.c
@@ -61,10 +61,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       arm_savestate(rtcb->xcp.regs);

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -199,7 +199,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/dm320/dm320_decodeirq.c
+++ b/arch/arm/src/dm320/dm320_decodeirq.c
@@ -42,7 +42,7 @@
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
   return NULL;
@@ -71,14 +71,14 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
           /* Current regs non-zero indicates that we are processing an
            * interrupt;
-           * CURRENT_REGS is also used to manage interrupt level context
+           * current_regs is also used to manage interrupt level context
            * switches.
            *
            * Nested interrupts are not supported.
            */
 
-          DEBUGASSERT(CURRENT_REGS == NULL);
-          CURRENT_REGS = regs;
+          DEBUGASSERT(up_current_regs() == NULL);
+          up_set_current_regs(regs);
 
           /* Deliver the IRQ */
 
@@ -86,13 +86,13 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
 #ifdef CONFIG_ARCH_ADDRENV
           /* Check for a context switch.  If a context switch occurred, then
-           * CURRENT_REGS will have a different value than it did on entry.
+           * current_regs will have a different value than it did on entry.
            * If an interrupt level context switch has occurred, then
            * establish the correct address environment before returning
            * from the interrupt.
            */
 
-          if (regs != CURRENT_REGS)
+          if (regs != up_current_regs())
             {
               /* Make sure that the address environment for the previously
                * running task is closed down gracefully (data caches dump,
@@ -104,11 +104,11 @@ uint32_t *arm_decodeirq(uint32_t *regs)
             }
 #endif
 
-          /* Set CURRENT_REGS to NULL to indicate that we are no longer in
+          /* Set current_regs to NULL to indicate that we are no longer in
            * an interrupt handler.
            */
 
-          CURRENT_REGS = NULL;
+          up_set_current_regs(NULL);
         }
     }
 #endif

--- a/arch/arm/src/imx1/imx_decodeirq.c
+++ b/arch/arm/src/imx1/imx_decodeirq.c
@@ -58,7 +58,7 @@
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
   return NULL;
@@ -67,13 +67,13 @@ uint32_t *arm_decodeirq(uint32_t *regs)
   int irq;
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    *
    * Nested interrupts are not supported.
    */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Loop while there are pending interrupts to be processed */
 
@@ -102,13 +102,13 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
 #ifdef CONFIG_ARCH_ADDRENV
           /* Check for a context switch.  If a context switch occurred, then
-           * CURRENT_REGS will have a different value than it did on entry.
+           * current_regs will have a different value than it did on entry.
            * If an interrupt level context switch has occurred, then
            * establish the correct address environment before returning
            * from the interrupt.
            */
 
-          if (regs != CURRENT_REGS)
+          if (regs != up_current_regs())
             {
               /* Make sure that the address environment for the previously
                * running task is closed down gracefully (data caches dump,
@@ -123,11 +123,11 @@ uint32_t *arm_decodeirq(uint32_t *regs)
     }
   while (irq < NR_IRQS);
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in
+  /* Set current_regs to NULL to indicate that we are no longer in
    * an interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
   return NULL;  /* Return not used in this architecture */
 #endif
 }

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -127,7 +127,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/lpc214x/lpc214x_decodeirq.c
+++ b/arch/arm/src/lpc214x/lpc214x_decodeirq.c
@@ -82,7 +82,7 @@ static uint32_t *lpc214x_decodeirq(uint32_t *regs)
 #endif
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
   return NULL;
@@ -119,23 +119,23 @@ static uint32_t *lpc214x_decodeirq(uint32_t *regs)
       uint32_t *savestate;
 
       /* Current regs non-zero indicates that we are processing an interrupt;
-       * CURRENT_REGS is also used to manage interrupt level context
+       * current_regs is also used to manage interrupt level context
        * switches.
        */
 
-      savestate    = (uint32_t *)CURRENT_REGS;
-      CURRENT_REGS = regs;
+      savestate = up_current_regs();
+      up_set_current_regs(regs);
 
       /* Deliver the IRQ */
 
       irq_dispatch(irq, regs);
 
-      /* Restore the previous value of CURRENT_REGS.  NULL would indicate
+      /* Restore the previous value of current_regs.  NULL would indicate
        * that we are no longer in an interrupt handler.  It will be non-NULL
        * if we are returning from a nested interrupt.
        */
 
-      CURRENT_REGS = savestate;
+      up_set_current_regs(savestate);
     }
 
   return NULL;  /* Return not used in this architecture */

--- a/arch/arm/src/lpc2378/lpc23xx_decodeirq.c
+++ b/arch/arm/src/lpc2378/lpc23xx_decodeirq.c
@@ -93,7 +93,7 @@ static uint32_t *lpc23xx_decodeirq(uint32_t *regs)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   err("ERROR: Unexpected IRQ\n");
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   PANIC();
   return NULL;
 #else
@@ -118,12 +118,12 @@ static uint32_t *lpc23xx_decodeirq(uint32_t *regs)
        uint32_t *savestate;
 
       /* Current regs non-zero indicates that we are processing an
-       * interrupt; CURRENT_REGS is also used to manage interrupt level
+       * interrupt; current_regs is also used to manage interrupt level
        * context switches.
        */
 
-      savestate    = (uint32_t *)CURRENT_REGS;
-      CURRENT_REGS = regs;
+      savestate = up_current_regs();
+      up_set_current_regs(regs);
 
       /* Acknowledge the interrupt */
 
@@ -133,12 +133,12 @@ static uint32_t *lpc23xx_decodeirq(uint32_t *regs)
 
       irq_dispatch(irq, regs);
 
-      /* Restore the previous value of CURRENT_REGS.
+      /* Restore the previous value of current_regs.
        * NULL would indicate that we are no longer in an interrupt handler.
        * It will be non-NULL if we are returning from a nested interrupt.
        */
 
-      CURRENT_REGS = savestate;
+      up_set_current_regs(savestate);
     }
 
   return NULL;  /* Return not used in this architecture */

--- a/arch/arm/src/lpc31xx/lpc31_decodeirq.c
+++ b/arch/arm/src/lpc31xx/lpc31_decodeirq.c
@@ -44,7 +44,7 @@
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
   return NULL;
@@ -76,14 +76,14 @@ uint32_t *arm_decodeirq(uint32_t *regs)
           arm_ack_irq(irq);
 
           /* Current regs non-zero indicates that we are processing an
-           * interrupt; CURRENT_REGS is also used to manage interrupt level
+           * interrupt; current_regs is also used to manage interrupt level
            * context switches.
            *
            * Nested interrupts are not supported.
            */
 
-          DEBUGASSERT(CURRENT_REGS == NULL);
-          CURRENT_REGS = regs;
+          DEBUGASSERT(up_current_regs() == NULL);
+          up_set_current_regs(regs);
 
           /* Deliver the IRQ */
 
@@ -91,13 +91,13 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
 #ifdef CONFIG_ARCH_ADDRENV
           /* Check for a context switch.  If a context switch occurred, then
-           * CURRENT_REGS will have a different value than it did on entry.
+           * current_regs will have a different value than it did on entry.
            * If an interrupt level context switch has occurred, then
            * establish the correct address environment before returning
            * from the interrupt.
            */
 
-          if (regs != CURRENT_REGS)
+          if (regs != up_current_regs())
             {
               /* Make sure that the address environment for the previously
                * running task is closed down gracefully (data caches dump,
@@ -109,11 +109,11 @@ uint32_t *arm_decodeirq(uint32_t *regs)
             }
 #endif
 
-          /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+          /* Set current_regs to NULL to indicate that we are no longer in an
            * interrupt handler.
            */
 
-          CURRENT_REGS = NULL;
+          up_set_current_regs(NULL);
         }
     }
 

--- a/arch/arm/src/moxart/moxart_irq.c
+++ b/arch/arm/src/moxart/moxart_irq.c
@@ -276,11 +276,11 @@ uint32_t *arm_decodeirq(uint32_t *regs)
   num = ffs(status) - 1;
   arm_ack_irq(num);
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   irq_dispatch(num, regs);
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   return NULL;  /* Return not used in this architecture */
 }

--- a/arch/arm/src/rp2040/rp2040_cpupause.c
+++ b/arch/arm/src/rp2040/rp2040_cpupause.c
@@ -167,7 +167,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/sam34/sam4cm_cpupause.c
+++ b/arch/arm/src/sam34/sam4cm_cpupause.c
@@ -129,7 +129,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm/src/str71x/str71x_decodeirq.c
+++ b/arch/arm/src/str71x/str71x_decodeirq.c
@@ -55,7 +55,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
   return NULL;
@@ -76,12 +76,12 @@ uint32_t *arm_decodeirq(uint32_t *regs)
       uint32_t *savestate;
 
       /* Current regs non-zero indicates that we are processing an
-       * interrupt; CURRENT_REGS is also used to manage interrupt level
+       * interrupt; current_regs is also used to manage interrupt level
        * context switches.
        */
 
-      savestate     = (uint32_t *)CURRENT_REGS;
-      CURRENT_REGS = regs;
+      savestate = up_current_regs();
+      up_set_current_regs(regs);
 
       /* Acknowledge the interrupt */
 
@@ -91,12 +91,12 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
       irq_dispatch(irq, regs);
 
-      /* Restore the previous value of CURRENT_REGS.
+      /* Restore the previous value of current_regs.
        *  NULL would indicate that we are no longer in an interrupt handler.
        *  It will be non-NULL if we are returning from a nested interrupt.
        */
 
-      CURRENT_REGS = savestate;
+      up_set_current_regs(savestate);
     }
 #ifdef CONFIG_DEBUG_FEATURES
   else

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -494,10 +494,10 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #endif
           if (ret < size)
             {
-              sp = (void *)CURRENT_REGS[REG_SP];
+              sp = up_current_regs()[REG_SP];
               ret += backtrace_push(rtcb->stack_base_ptr +
                                     rtcb->adj_stack_size, &sp,
-                                    (void *)CURRENT_REGS[REG_PC],
+                                    (void *)up_current_regs()[REG_PC],
                                     &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/arm/src/tlsr82/tc32/tc32_doirq.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_doirq.c
@@ -64,17 +64,17 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Nested interrupts are not supported in this implementation.  If you
    * want to implement nested interrupts, you would have to (1) change the
-   * way that CURRENT_REGS is handled and (2) the design associated with
+   * way that current_regs is handled and (2) the design associated with
    * CONFIG_ARCH_INTERRUPTSTACK.
    */
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  if (CURRENT_REGS == NULL)
+  if (up_current_regs() == NULL)
     {
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
       regs         = NULL;
     }
 
@@ -84,10 +84,10 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Deliver the IRQ */
 
-  irq_dispatch(irq, (uint32_t *)CURRENT_REGS);
+  irq_dispatch(irq, up_current_regs());
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
+   * current_regs may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
@@ -96,14 +96,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
     {
       /* Restore the cpu lock */
 
-      if (regs != CURRENT_REGS)
+      if (regs != up_current_regs())
         {
-          regs = (uint32_t *)CURRENT_REGS;
+          regs = up_current_regs();
         }
 
-      /* Update the CURRENT_REGS to NULL. */
+      /* Update the current_regs to NULL. */
 
-      CURRENT_REGS = NULL;
+      up_set_current_regs(NULL);
     }
 #endif
 

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -89,7 +89,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -97,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -114,7 +114,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * logic would fail in the strange case where we are in an
            * interrupt handler, the thread is signalling itself, but
            * a context switch to another task has occurred so that
-           * CURRENT_REGS does not refer to the thread of this_task()!
+           * current_regs does not refer to the thread of this_task()!
            */
 
           else
@@ -135,21 +135,20 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * delivered.
                */
 
-              CURRENT_REGS           = (void *)((uint32_t)CURRENT_REGS -
-                                                          XCPTCONTEXT_SIZE);
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
-              CURRENT_REGS[REG_SP]   = (uint32_t)CURRENT_REGS +
-                                                 XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
+                                                      XCPTCONTEXT_REGS);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_LR]     = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR]   = PSR_MODE_SVC | PSR_I_BIT;
-              CURRENT_REGS[REG_IRQ_EN] = 0;
+              up_current_regs()[REG_LR]     = (uint32_t)arm_sigdeliver;
+              up_current_regs()[REG_CPSR]   = PSR_MODE_SVC | PSR_I_BIT;
+              up_current_regs()[REG_IRQ_EN] = 0;
             }
         }
 

--- a/arch/arm/src/tlsr82/tc32/tc32_syscall.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_syscall.c
@@ -52,6 +52,6 @@
 void arm_syscall(uint32_t *regs)
 {
   _alert("Syscall from 0x%" PRIx32 "\n", regs[REG_PC]);
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   PANIC();
 }

--- a/arch/arm/src/tms570/tms570_esm.c
+++ b/arch/arm/src/tms570/tms570_esm.c
@@ -146,15 +146,16 @@ int tms570_esm_initialize(void)
 
 int tms570_esm_interrupt(int irq, void *context, void *arg)
 {
-  /* Save the saved processor context in CURRENT_REGS where it can be
+  /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */
 
-  CURRENT_REGS = (uint32_t *)context;
+  up_set_current_regs((uint32_t *)context);
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _err("ERROR: ESM Interrupt. PC: %08" PRIx32 "\n", CURRENT_REGS[REG_PC]);
+  _err("ERROR: ESM Interrupt. PC: %08" PRIx32 "\n",
+       up_current_regs()[REG_PC]);
   PANIC();
   return OK; /* To keep the compiler happy */
 }

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -245,7 +245,7 @@ extern "C"
 /* g_current_regs[] holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -253,7 +253,6 @@ extern "C"
  */
 
 EXTERN volatile uint64_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Types
@@ -419,6 +418,16 @@ static inline void up_irq_restore(irqstate_t flags)
 #  define up_cpu_index() (0)
 #endif
 
+static inline_function uint64_t *up_current_regs(void)
+{
+  return (uint64_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint64_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -433,7 +442,7 @@ static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = (CURRENT_REGS != NULL);
+  bool ret = (up_current_regs() != NULL);
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -147,7 +147,7 @@ int up_backtrace(struct tcb_s *tcb,
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
           if (ret < size)
             {
-              p_regs = (struct regs_context *)CURRENT_REGS;
+              p_regs = (struct regs_context *)up_current_regs();
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
                                (void *)p_regs->regs[REG_X29],

--- a/arch/arm64/src/common/arm64_cpupause.c
+++ b/arch/arm64/src/common/arm64_cpupause.c
@@ -116,7 +116,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -59,26 +59,26 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 {
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
    * point state and the establish the correct address environment before
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* need to do a context switch */
 
@@ -98,15 +98,14 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-
-      regs = (uint64_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   return regs;
 }

--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -314,7 +314,7 @@ void arm64_fatal_error(unsigned int reason, struct regs_context * reg)
 
   sinfo("reason = %d\n", reason);
 
-  CURRENT_REGS = (uint64_t *)reg;
+  up_set_current_regs((uint64_t *)reg);
 
   if (reason != K_ERR_SPURIOUS_IRQ)
     {

--- a/arch/arm64/src/common/arm64_initialize.c
+++ b/arch/arm64/src/common/arm64_initialize.c
@@ -53,7 +53,7 @@
 /* g_current_regs[] holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * current_regs for portability.
  */
 
 /* For the case of configurations with multiple CPUs, then there must be one

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -88,8 +88,8 @@
  * floating point registers as well as normal ARM registers.
  */
 
-#define arm64_savestate(regs) (regs = (uint64_t *)CURRENT_REGS)
-#define arm64_restorestate(regs) (CURRENT_REGS = regs)
+#define arm64_savestate(regs) (regs = up_current_regs())
+#define arm64_restorestate(regs) up_set_current_regs(regs)
 
 /* This is the value used to mark the stack for subsequent stack monitoring
  * logic.

--- a/arch/arm64/src/common/arm64_registerdump.c
+++ b/arch/arm64/src/common/arm64_registerdump.c
@@ -60,7 +60,7 @@ uintptr_t up_getusrsp(void *regs)
 void up_dump_register(void *dumpregs)
 {
   volatile struct regs_context *regs = dumpregs ? dumpregs :
-                              (struct regs_context *)CURRENT_REGS;
+                              (struct regs_context *)up_current_regs();
 
   _alert("stack = %p\n", regs);
   _alert("x0:   0x%-16"PRIx64"  x1:   0x%"PRIx64"\n",

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -146,7 +146,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -164,7 +164,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signaling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -177,16 +177,16 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               /* create signal process context */
 
-              tcb->xcp.saved_reg = (uint64_t *)CURRENT_REGS;
+              tcb->xcp.saved_reg = up_current_regs();
 #ifdef CONFIG_ARCH_FPU
               tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
               arm64_init_signal_process(tcb,
-              (struct regs_context *)CURRENT_REGS);
+              (struct regs_context *)up_current_regs());
 
               /* trigger switch to signal process */
 
-              CURRENT_REGS = tcb->xcp.regs;
+              up_set_current_regs(tcb->xcp.regs);
             }
         }
 
@@ -232,7 +232,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -243,7 +243,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -300,16 +300,16 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   /* create signal process context */
 
-                  tcb->xcp.saved_reg = (uint64_t *)CURRENT_REGS;
+                  tcb->xcp.saved_reg = up_current_regs();
 #ifdef CONFIG_ARCH_FPU
                   tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
 #endif
                   arm64_init_signal_process(tcb,
-                  (struct regs_context *)CURRENT_REGS);
+                  (struct regs_context *)up_current_regs());
 
                   /* trigger switch to signal process */
 
-                  CURRENT_REGS = tcb->xcp.regs;
+                  up_set_current_regs(tcb->xcp.regs);
                 }
 
               /* NOTE: If the task runs on another CPU(cpu), adjusting

--- a/arch/arm64/src/common/arm64_switchcontext.c
+++ b/arch/arm64/src/common/arm64_switchcontext.c
@@ -61,10 +61,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       arm64_savestate(rtcb->xcp.regs);

--- a/arch/avr/include/irq.h
+++ b/arch/avr/include/irq.h
@@ -109,6 +109,28 @@ EXTERN volatile uint8_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_FAMILY_AVR32
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs = regs;
+}
+#else
+static inline_function FAR uint8_t *up_current_regs(void)
+{
+  return (FAR uint8_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(FAR uint8_t *regs)
+{
+  g_current_regs = regs;
+}
+#endif
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -118,7 +140,7 @@ EXTERN volatile uint8_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/avr/src/avr/avr.h
+++ b/arch/avr/src/avr/avr.h
@@ -43,8 +43,8 @@
  * state from the TCB.
  */
 
-#define avr_savestate(regs)    avr_copystate(regs, (uint8_t*)g_current_regs)
-#define avr_restorestate(regs) (g_current_regs = regs)
+#define avr_savestate(regs)    avr_copystate(regs, up_current_regs())
+#define avr_restorestate(regs) up_set_current_regs(regs)
 
 /****************************************************************************
  * Public Types

--- a/arch/avr/src/avr/avr_doirq.c
+++ b/arch/avr/src/avr/avr_doirq.c
@@ -75,8 +75,8 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
    * g_current_regs is also used to manage interrupt level context switches.
    */
 
-  savestate    = (uint8_t *)g_current_regs;   /* Cast removes volatile attribute */
-  g_current_regs = regs;
+  savestate = up_current_regs();   /* Cast removes volatile attribute */
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -88,7 +88,7 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  if (regs != (uint8_t *)g_current_regs)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -98,14 +98,14 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
       g_running_tasks[this_cpu()] = this_task();
     }
 
-  regs = (uint8_t *)g_current_regs;   /* Cast removes volatile attribute */
+  regs = up_current_regs();   /* Cast removes volatile attribute */
 
   /* Restore the previous value of g_current_regs.  NULL would indicate that
    * we are no longer in an interrupt handler.  It will be non-NULL if we
    * are returning from a nested interrupt.
    */
 
-  g_current_regs = savestate;
+  up_set_current_regs(savestate);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/avr/src/avr/avr_registerdump.c
+++ b/arch/avr/src/avr/avr_registerdump.c
@@ -54,7 +54,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint8_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint8_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -91,8 +91,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n",
-            this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -100,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -127,26 +126,26 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * trampoline after the signal(s) have been delivered.
                */
 
-              tcb->xcp.saved_pc0      = g_current_regs[REG_PC0];
-              tcb->xcp.saved_pc1      = g_current_regs[REG_PC1];
+              tcb->xcp.saved_pc0  = up_current_regs()[REG_PC0];
+              tcb->xcp.saved_pc1  = up_current_regs()[REG_PC1];
 #if defined(REG_PC2)
-              tcb->xcp.saved_pc2      = g_current_regs[REG_PC2];
+              tcb->xcp.saved_pc2  = up_current_regs()[REG_PC2];
 #endif
-              tcb->xcp.saved_sreg     = g_current_regs[REG_SREG];
+              tcb->xcp.saved_sreg = up_current_regs()[REG_SREG];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
 #if !defined(REG_PC2)
-              g_current_regs[REG_PC0] = (uint16_t)reg_ptr >> 8;
-              g_current_regs[REG_PC1] = (uint16_t)reg_ptr & 0xff;
+              up_current_regs()[REG_PC0] = (uint16_t)reg_ptr >> 8;
+              up_current_regs()[REG_PC1] = (uint16_t)reg_ptr & 0xff;
 #else
-              g_current_regs[REG_PC0] = (uint32_t)reg_ptr >> 16;
-              g_current_regs[REG_PC1] = (uint32_t)reg_ptr >> 8;
-              g_current_regs[REG_PC2] = (uint32_t)reg_ptr & 0xff;
+              up_current_regs()[REG_PC0] = (uint32_t)reg_ptr >> 16;
+              up_current_regs()[REG_PC1] = (uint32_t)reg_ptr >> 8;
+              up_current_regs()[REG_PC2] = (uint32_t)reg_ptr & 0xff;
 #endif
-              g_current_regs[REG_SREG] &= ~(1 << SREG_I);
+              up_current_regs()[REG_SREG] &= ~(1 << SREG_I);
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.

--- a/arch/avr/src/avr/avr_switchcontext.c
+++ b/arch/avr/src/avr/avr_switchcontext.c
@@ -60,7 +60,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/avr/src/avr32/avr32.h
+++ b/arch/avr/src/avr32/avr32.h
@@ -53,8 +53,8 @@
  * state from the TCB.
  */
 
-#define avr_savestate(regs)     avr_copystate(regs, (uint32_t*)g_current_regs)
-#define avr_restorestate(regs)  (g_current_regs = regs)
+#define avr_savestate(regs)     avr_copystate(regs, up_current_regs())
+#define avr_restorestate(regs)  up_set_current_regs(regs)
 
 /****************************************************************************
  * Public Types

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -68,8 +68,8 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
    * Nested interrupts are not supported.
    */
 
-  DEBUGASSERT(g_current_regs == NULL);
-  g_current_regs = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -82,12 +82,12 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
    * environment before returning from the interrupt.
    */
 
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -114,13 +114,13 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)g_current_regs;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in
    * an interrupt handler.
    */
 
-  g_current_regs = NULL;
+  up_set_current_regs(NULL);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/avr/src/avr32/avr_registerdump.c
+++ b/arch/avr/src/avr32/avr_registerdump.c
@@ -54,7 +54,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/avr/src/avr32/avr_schedulesigaction.c
+++ b/arch/avr/src/avr32/avr_schedulesigaction.c
@@ -89,8 +89,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n",
-            this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -98,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -125,15 +124,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * trampoline after the signal(s) have been delivered.
                */
 
-              tcb->xcp.saved_pc       = g_current_regs[REG_PC];
-              tcb->xcp.saved_sr       = g_current_regs[REG_SR];
+              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+              tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_PC]  = (uint32_t)avr_sigdeliver;
-              g_current_regs[REG_SR] |= AVR32_SR_GM_MASK;
+              up_current_regs()[REG_PC]  = (uint32_t)avr_sigdeliver;
+              up_current_regs()[REG_SR] |= AVR32_SR_GM_MASK;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.

--- a/arch/avr/src/avr32/avr_switchcontext.c
+++ b/arch/avr/src/avr32/avr_switchcontext.c
@@ -62,7 +62,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/ceva/include/irq.h
+++ b/arch/ceva/include/irq.h
@@ -94,9 +94,9 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -104,7 +104,6 @@ extern "C"
  */
 
 EXTERN uint32_t *volatile g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -136,6 +135,16 @@ int up_cpu_index(void);
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -150,7 +159,7 @@ static inline bool up_interrupt_context(void)
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();
 #endif
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/ceva/src/common/ceva_registerdump.c
+++ b/arch/ceva/src/common/ceva_registerdump.c
@@ -51,7 +51,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
   int rx;
 
   /* Dump the interrupt registers */

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -102,7 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -137,28 +137,28 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               /* Save the current register context location */
 
-              tcb->xcp.saved_regs = g_current_regs[cpu];
+              tcb->xcp.saved_regs = up_current_regs();
 
               /* Duplicate the register context.  These will be
                * restored by the signal trampoline after the signal has been
                * delivered.
                */
 
-              g_current_regs[cpu] -= XCPTCONTEXT_REGS;
-              memcpy(g_current_regs[cpu], g_current_regs[cpu] +
+              up_current_regs() -= XCPTCONTEXT_REGS;
+              memcpy(up_current_regs(), up_current_regs() +
                      XCPTCONTEXT_REGS, XCPTCONTEXT_SIZE);
 
-              g_current_regs[cpu][REG_SP]  = (uint32_t)g_current_regs[cpu];
+              up_current_regs()[REG_SP]  = (uint32_t)up_current_regs();
 
               /* Then set up to vector to the trampoline with interrupts
                * unchanged.  We must already be in privileged thread mode
                * to be here.
                */
 
-              g_current_regs[cpu][REG_PC]  = (uint32_t)ceva_sigdeliver;
+              up_current_regs()[REG_PC]  = (uint32_t)ceva_sigdeliver;
 #ifdef REG_OM
-              g_current_regs[cpu][REG_OM] &= ~REG_OM_MASK;
-              g_current_regs[cpu][REG_OM] |=  REG_OM_KERNEL;
+              up_current_regs()[REG_OM] &= ~REG_OM_MASK;
+              up_current_regs()[REG_OM] |=  REG_OM_KERNEL;
 #endif
 
 #ifdef CONFIG_SMP

--- a/arch/ceva/src/common/ceva_svcall.c
+++ b/arch/ceva/src/common/ceva_svcall.c
@@ -52,7 +52,7 @@ int ceva_svcall(int irq, void *context, void *arg)
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
   cmd = regs[REG_A0];
 
   /* The SVCall software interrupt is called with A0 = system call command
@@ -112,16 +112,16 @@ int ceva_svcall(int irq, void *context, void *arg)
        *   A0 = SYS_restore_context
        *   A1 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore register
-       * area referenced in the saved A1. context == CURRENT_REGS is the
-       * noraml exception return.  By setting CURRENT_REGS = context[A1],
+       * In this case, we simply need to set current_regs to restore register
+       * area referenced in the saved A1. context == current_regs is the
+       * noraml exception return.  By setting current_regs = context[A1],
        * we force the return to the saved context referenced in A1.
        */
 
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_A1];
+          up_set_current_regs((uint32_t *)regs[REG_A1]);
         }
         break;
 
@@ -138,7 +138,7 @@ int ceva_svcall(int irq, void *context, void *arg)
        *
        * In this case, we do both: We save the context registers to the save
        * register area reference by the saved contents of A1 and then set
-       * CURRENT_REGS to to the save register area referenced by the saved
+       * current_regs to to the save register area referenced by the saved
        * contents of A2.
        */
 
@@ -146,7 +146,7 @@ int ceva_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
           *(uint32_t **)regs[REG_A1] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_A2];
+          up_set_current_regs((uint32_t *)regs[REG_A2]);
         }
         break;
 
@@ -384,20 +384,20 @@ int ceva_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
 #  endif
     {
       svcinfo("SVCall Return:\n");
       svcinfo("A0: %08x %08x %08x %08x %08x %08x %08x\n",
-              CURRENT_REGS[REG_A0], CURRENT_REGS[REG_A1],
-              CURRENT_REGS[REG_A2], CURRENT_REGS[REG_A3],
-              CURRENT_REGS[REG_A4], CURRENT_REGS[REG_A5],
-              CURRENT_REGS[REG_A6]);
+              up_current_regs()[REG_A0], up_current_regs()[REG_A1],
+              up_current_regs()[REG_A2], up_current_regs()[REG_A3],
+              up_current_regs()[REG_A4], up_current_regs()[REG_A5],
+              up_current_regs()[REG_A6]);
       svcinfo("FP: %08x LR: %08x PC: %08x IRQ: %08x OM: %08x\n",
-              CURRENT_REGS[REG_FP], CURRENT_REGS[REG_LR],
-              CURRENT_REGS[REG_PC], CURRENT_REGS[REG_IRQ],
+              up_current_regs()[REG_FP], up_current_regs()[REG_LR],
+              up_current_regs()[REG_PC], up_current_regs()[REG_IRQ],
 # ifdef REG_OM
-              CURRENT_REGS[REG_OM]
+              up_current_regs()[REG_OM]
 #else
               0x00000000
 #endif

--- a/arch/ceva/src/common/ceva_switchcontext.c
+++ b/arch/ceva/src/common/ceva_switchcontext.c
@@ -75,13 +75,13 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
-      rtcb->xcp.regs = CURRENT_REGS;
+      rtcb->xcp.regs = up_current_regs();
 
       /* Update scheduler parameters */
 
@@ -89,7 +89,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       /* Then switch contexts */
 
-      CURRENT_REGS = tcb->xcp.regs;
+      up_set_current_regs(tcb->xcp.regs);
     }
 
   /* No, then we will need to perform the user context switch */

--- a/arch/hc/include/irq.h
+++ b/arch/hc/include/irq.h
@@ -122,6 +122,16 @@ EXTERN volatile uint8_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint8_t *up_current_regs(void)
+{
+  return (FAR uint8_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(FAR uint8_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -131,7 +141,7 @@ EXTERN volatile uint8_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -68,8 +68,8 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
    * Nested interrupts are not supported
    */
 
-  DEBUGASSERT(g_current_regs == NULL);
-  g_current_regs = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -82,12 +82,12 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -114,13 +114,13 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint8_t *)g_current_regs;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  g_current_regs = NULL;
+  up_set_current_regs(NULL);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/hc/src/common/hc_internal.h
+++ b/arch/hc/src/common/hc_internal.h
@@ -95,8 +95,8 @@
  * a referenced is passed to get the state from the TCB.
  */
 
-#define hc_savestate(regs)    hc_copystate(regs, (uint8_t*)g_current_regs)
-#define hc_restorestate(regs) (g_current_regs = regs)
+#define hc_savestate(regs)    hc_copystate(regs, up_current_regs())
+#define hc_restorestate(regs) up_set_current_regs(regs)
 
 /****************************************************************************
  * Public Types

--- a/arch/hc/src/common/hc_switchcontext.c
+++ b/arch/hc/src/common/hc_switchcontext.c
@@ -62,7 +62,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/hc/src/m9s12/m9s12_registerdump.c
+++ b/arch/hc/src/m9s12/m9s12_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint8_t *regs = dumpregs ? dumpregs : (uint8_t *)g_current_regs;
+  volatile uint8_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert("A:%02x B:%02x X:%02x%02x Y:%02x%02x PC:%02x%02x CCR:%02x\n",
          regs[REG_A],  regs[REG_B],  regs[REG_XH],  regs[REG_XL],

--- a/arch/mips/include/irq.h
+++ b/arch/mips/include/irq.h
@@ -90,8 +90,8 @@ static inline uint32_t up_getsp(void)
 
 /* g_current_regs holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs must be through the macro
- * CURRENT_REGS for portability.
+ * processing.  Access to g_current_regs must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -99,7 +99,6 @@ static inline uint32_t up_getsp(void)
  */
 
 EXTERN volatile uint32_t *g_current_regs;
-#define CURRENT_REGS g_current_regs
 
 /****************************************************************************
  * Public Function Prototypes
@@ -127,6 +126,16 @@ EXTERN volatile uint32_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -136,7 +145,7 @@ EXTERN volatile uint32_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/mips/src/common/mips_initialize.c
+++ b/arch/mips/src/common/mips_initialize.c
@@ -34,8 +34,8 @@
 
 /* g_current_regs holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs must be through the macro
- * CURRENT_REGS for portability.
+ * processing.  Access to g_current_regs must be through the
+ * [get/set]_current_regs for portability.
  */
 
 volatile uint32_t *g_current_regs;

--- a/arch/mips/src/common/mips_internal.h
+++ b/arch/mips/src/common/mips_internal.h
@@ -96,8 +96,8 @@
  * only a referenced is passed to get the state from the TCB.
  */
 
-#define mips_savestate(regs)    mips_copystate(regs, (uint32_t*)CURRENT_REGS)
-#define mips_restorestate(regs) (CURRENT_REGS = regs)
+#define mips_savestate(regs)    mips_copystate(regs, up_current_regs())
+#define mips_restorestate(regs) up_set_current_regs(regs)
 
 /****************************************************************************
  * Public Types

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -68,8 +68,8 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
    * Nested interrupts are not supported
    */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Disable further occurrences of this interrupt (until the interrupt
    * source have been cleared by the driver).
@@ -88,12 +88,12 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)CURRENT_REGS);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -120,13 +120,13 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)CURRENT_REGS;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   /* Unmask the last interrupt (global interrupts are still disabled) */
 

--- a/arch/mips/src/mips32/mips_registerdump.c
+++ b/arch/mips/src/mips32/mips_registerdump.c
@@ -54,7 +54,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -92,8 +92,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n",
-            this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -101,7 +100,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -128,18 +127,18 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              tcb->xcp.saved_epc        = CURRENT_REGS[REG_EPC];
-              tcb->xcp.saved_status     = CURRENT_REGS[REG_STATUS];
+              tcb->xcp.saved_epc    = up_current_regs()[REG_EPC];
+              tcb->xcp.saved_status = up_current_regs()[REG_STATUS];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_EPC]     = (uint32_t)mips_sigdeliver;
-              status                    = CURRENT_REGS[REG_STATUS];
-              status                   &= ~CP0_STATUS_INT_MASK;
-              status                   |= CP0_STATUS_INT_SW0;
-              CURRENT_REGS[REG_STATUS]  = status;
+              up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
+              status  = up_current_regs()[REG_STATUS];
+              status &= ~CP0_STATUS_INT_MASK;
+              status |= CP0_STATUS_INT_SW0;
+              up_current_regs()[REG_STATUS]  = status;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
@@ -150,7 +149,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
                     " New: %08" PRIx32 "/%08" PRIx32 "\n",
                     tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    CURRENT_REGS[REG_EPC], CURRENT_REGS[REG_STATUS]);
+                    up_current_regs()[REG_EPC],
+                    up_current_regs()[REG_STATUS]);
             }
         }
 

--- a/arch/mips/src/mips32/mips_swint0.c
+++ b/arch/mips/src/mips32/mips_swint0.c
@@ -100,7 +100,7 @@ int mips_swint0(int irq, void *context, void *arg)
   uint32_t *regs = (uint32_t *)context;
   uint32_t cause;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_R4) = system call
    * command and REG_A1-3 and REG_T0-2 (REG_R5-10) = variable number of
@@ -155,7 +155,7 @@ int mips_swint0(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_A1];
+          up_set_current_regs((uint32_t *)regs[REG_A1]);
         }
         break;
 
@@ -180,7 +180,7 @@ int mips_swint0(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
           mips_copystate((uint32_t *)regs[REG_A1], regs);
-          CURRENT_REGS = (uint32_t *)regs[REG_A2];
+          up_set_current_regs((uint32_t *)regs[REG_A2]);
         }
         break;
 
@@ -210,7 +210,7 @@ int mips_swint0(int irq, void *context, void *arg)
            * the original mode.
            */
 
-          CURRENT_REGS[REG_EPC] = rtcb->xcp.syscall[index].sysreturn;
+          up_current_regs()[REG_EPC] = rtcb->xcp.syscall[index].sysreturn;
 #error "Missing logic -- need to restore the original mode"
           rtcb->xcp.nsyscalls     = index;
 
@@ -237,7 +237,7 @@ int mips_swint0(int irq, void *context, void *arg)
 
           /* Verify that the SYS call number is within range */
 
-          DEBUGASSERT(CURRENT_REGS[REG_A0] < SYS_maxsyscall);
+          DEBUGASSERT(up_current_regs()[REG_A0] < SYS_maxsyscall);
 
           /* Make sure that we got here that there is a no saved syscall
            * return address.  We cannot yet handle nested system calls.
@@ -256,7 +256,7 @@ int mips_swint0(int irq, void *context, void *arg)
 
           /* Offset R0 to account for the reserved values */
 
-          CURRENT_REGS[REG_R0] -= CONFIG_SYS_RESERVED;
+          up_current_regs()[REG_R0] -= CONFIG_SYS_RESERVED;
 
           /* Indicate that we are in a syscall handler. */
 
@@ -273,10 +273,10 @@ int mips_swint0(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(CURRENT_REGS);
+      up_dump_register(up_current_regs());
     }
   else
     {

--- a/arch/mips/src/mips32/mips_switchcontext.c
+++ b/arch/mips/src/mips32/mips_switchcontext.c
@@ -63,7 +63,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/mips/src/pic32mx/pic32mx_decodeirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_decodeirq.c
@@ -88,11 +88,11 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
    */
 
 #ifdef CONFIG_PIC32MX_NESTED_INTERRUPTS
-  savestate = (uint32_t *)CURRENT_REGS;
+  savestate = up_current_regs();
 #else
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 #endif
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Loop while there are pending interrupts with priority greater than
    * zero
@@ -131,7 +131,7 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)CURRENT_REGS;
+  regs = up_current_regs();
 
 #if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
@@ -141,12 +141,12 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)CURRENT_REGS);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -171,13 +171,13 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
    * of fixing nested context switching.  The logic here is insufficient.
    */
 
-  CURRENT_REGS = savestate;
-  if (CURRENT_REGS == NULL)
+  up_set_current_regs(savestate);
+  if (up_current_regs() == NULL)
     {
       board_autoled_off(LED_INIRQ);
     }
 #else
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
   board_autoled_off(LED_INIRQ);
 #endif
 

--- a/arch/mips/src/pic32mx/pic32mx_exception.c
+++ b/arch/mips/src/pic32mx/pic32mx_exception.c
@@ -163,7 +163,7 @@ uint32_t *pic32mx_exception(uint32_t *regs)
    * contents.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* Won't get here */
 }

--- a/arch/mips/src/pic32mz/pic32mz_decodeirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_decodeirq.c
@@ -87,11 +87,11 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
    */
 
 #ifdef CONFIG_PIC32MZ_NESTED_INTERRUPTS
-  savestate = (uint32_t *)CURRENT_REGS;
+  savestate = up_current_regs();
 #else
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 #endif
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Loop while there are pending interrupts with priority greater than
    * zero
@@ -130,7 +130,7 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)CURRENT_REGS;
+  regs = up_current_regs();
 
 #if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
@@ -140,12 +140,12 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)CURRENT_REGS);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -170,13 +170,13 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
    * of fixing nested context switching.  The logic here is insufficient.
    */
 
-  CURRENT_REGS = savestate;
-  if (CURRENT_REGS == NULL)
+  up_set_current_regs(savestate);
+  if (up_current_regs() == NULL)
     {
       board_autoled_off(LED_INIRQ);
     }
 #else
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
   board_autoled_off(LED_INIRQ);
 #endif
 

--- a/arch/mips/src/pic32mz/pic32mz_exception.c
+++ b/arch/mips/src/pic32mz/pic32mz_exception.c
@@ -162,7 +162,7 @@ uint32_t *pic32mz_exception(uint32_t *regs)
    * contents.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
   PANIC_WITH_REGS("panic", regs);
   return regs; /* Won't get here */
 }

--- a/arch/misoc/include/irq.h
+++ b/arch/misoc/include/irq.h
@@ -108,6 +108,16 @@ EXTERN volatile uint32_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -117,7 +127,7 @@ EXTERN volatile uint32_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/misoc/src/lm32/lm32.h
+++ b/arch/misoc/src/lm32/lm32.h
@@ -42,9 +42,9 @@
  * only a referenced is passed to get the state from the TCB.
  */
 
-#define misoc_savestate(regs)      lm32_copystate(regs, (uint32_t*)g_current_regs)
-#define up_copystate(rega,regb) lm32_copystate(rega, regb)
-#define misoc_restorestate(regs)   (g_current_regs = regs)
+#define misoc_savestate(regs)      lm32_copystate(regs, up_current_regs())
+#define up_copystate(rega,regb)    lm32_copystate(rega, regb)
+#define misoc_restorestate(regs)   (up_set_current_regs(regs))
 
 /* Determine which (if any) console driver to use.  If a console is enabled
  * and no other console device is specified, then a serial console is

--- a/arch/misoc/src/lm32/lm32_doirq.c
+++ b/arch/misoc/src/lm32/lm32_doirq.c
@@ -53,8 +53,8 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
    * Nested interrupts are not supported
    */
 
-  DEBUGASSERT(g_current_regs == NULL);
-  g_current_regs = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Disable further occurrences of this interrupt (until the interrupt
    * sources have been clear by the driver).
@@ -73,12 +73,12 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -105,13 +105,13 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)g_current_regs;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  g_current_regs = NULL;
+  up_set_current_regs(NULL);
 
   /* Unmask the last interrupt (global interrupts are still disabled) */
 

--- a/arch/misoc/src/lm32/lm32_registerdump.c
+++ b/arch/misoc/src/lm32/lm32_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -89,8 +89,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n",
-            this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -98,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -125,14 +124,14 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-             tcb->xcp.saved_epc           = g_current_regs[REG_EPC];
+             tcb->xcp.saved_epc = up_current_regs()[REG_EPC];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_EPC]     = (uint32_t)lm32_sigdeliver;
-              g_current_regs[REG_INT_CTX] = 0;
+              up_current_regs()[REG_EPC]     = (uint32_t)lm32_sigdeliver;
+              up_current_regs()[REG_INT_CTX] = 0;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
@@ -142,7 +141,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
                     tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    g_current_regs[REG_EPC], g_current_regs[REG_STATUS]);
+                    up_current_regs()[REG_EPC],
+                    up_current_regs()[REG_STATUS]);
             }
         }
 

--- a/arch/misoc/src/lm32/lm32_swint.c
+++ b/arch/misoc/src/lm32/lm32_swint.c
@@ -96,8 +96,8 @@ int lm32_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
-  DEBUGASSERT(regs != NULL && regs == g_current_regs);
-  g_current_regs = regs;
+  DEBUGASSERT(regs != NULL && regs == up_current_regs());
+  up_set_current_regs(regs);
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_X10) = system call
    * command and REG_A1-6 = variable number of
@@ -153,7 +153,7 @@ int lm32_swint(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0);
-          g_current_regs = (uint32_t *)regs[REG_A1];
+          up_set_current_regs((uint32_t *)regs[REG_A1]);
         }
         break;
 
@@ -178,7 +178,7 @@ int lm32_swint(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
           lm32_copystate((uint32_t *)regs[REG_A1], regs);
-          g_current_regs = (uint32_t *)regs[REG_A2];
+          up_set_current_regs((uint32_t *)regs[REG_A2]);
         }
         break;
 
@@ -208,7 +208,7 @@ int lm32_swint(int irq, void *context, void *arg)
            * the original mode.
            */
 
-          g_current_regs[REG_EPC] = rtcb->xcp.syscall[index].sysreturn;
+          up_current_regs()[REG_EPC] = rtcb->xcp.syscall[index].sysreturn;
 #error "Missing logic -- need to restore the original mode"
           rtcb->xcp.nsyscalls     = index;
 
@@ -235,7 +235,7 @@ int lm32_swint(int irq, void *context, void *arg)
 
           /* Verify that the SYS call number is within range */
 
-          DEBUGASSERT(g_current_regs[REG_A0] < SYS_maxsyscall);
+          DEBUGASSERT(up_current_regs()[REG_A0] < SYS_maxsyscall);
 
           /* Make sure that we got here that there is a no saved syscall
            * return address.  We cannot yet handle nested system calls.
@@ -254,7 +254,7 @@ int lm32_swint(int irq, void *context, void *arg)
 
           /* Offset R0 to account for the reserved values */
 
-          g_current_regs[REG_A0] -= CONFIG_SYS_RESERVED;
+          up_current_regs()[REG_A0] -= CONFIG_SYS_RESERVED;
 
           /* Indicate that we are in a syscall handler. */
 
@@ -271,10 +271,10 @@ int lm32_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(g_current_regs);
+      up_dump_register(up_current_regs());
     }
   else
     {

--- a/arch/misoc/src/lm32/lm32_switchcontext.c
+++ b/arch/misoc/src/lm32/lm32_switchcontext.c
@@ -63,7 +63,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/misoc/src/minerva/minerva.h
+++ b/arch/misoc/src/minerva/minerva.h
@@ -41,9 +41,9 @@
  * only a referenced is passed to get the state from the TCB.
  */
 
-#define misoc_savestate(regs)      minerva_copystate(regs, (uint32_t*)g_current_regs)
-#define up_copystate(rega,regb) minerva_copystate(rega, regb)
-#define misoc_restorestate(regs)   (g_current_regs = regs)
+#define misoc_savestate(regs)      minerva_copystate(regs, up_current_regs())
+#define up_copystate(rega,regb)    minerva_copystate(rega, regb)
+#define misoc_restorestate(regs)   up_set_current_regs(regs)
 
 /* Determine which (if any) console driver to use.  If a console is enabled
  * and no other console device is specified, then a serial console is

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -52,8 +52,8 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
    * Nested interrupts are not supported
    */
 
-  DEBUGASSERT(g_current_regs == NULL);
-  g_current_regs = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Disable further occurrences of this interrupt (until the interrupt
    * sources have been clear by the driver).
@@ -72,12 +72,12 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
    * returning from the interrupt.
    */
 
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *) g_current_regs);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -104,13 +104,13 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *) g_current_regs;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  g_current_regs = NULL;
+  up_set_current_regs(NULL);
 
   /* Unmask the last interrupt (global interrupts are still disabled) */
 

--- a/arch/misoc/src/minerva/minerva_registerdump.c
+++ b/arch/misoc/src/minerva/minerva_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -98,7 +98,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -125,14 +125,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              tcb->xcp.saved_epc = g_current_regs[REG_CSR_MEPC];
+              tcb->xcp.saved_epc = up_current_regs()[REG_CSR_MEPC];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_CSR_MEPC] = (uint32_t) minerva_sigdeliver;
-              g_current_regs[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
+              up_current_regs()[REG_CSR_MEPC] =
+                (uint32_t)minerva_sigdeliver;
+              up_current_regs()[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
 
               /* And make sure that the saved context in the TCB is the same
                * as the interrupt return context.
@@ -142,8 +143,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
                     tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    g_current_regs[REG_CSR_MEPC],
-                    g_current_regs[REG_CSR_MSTATUS]);
+                    up_current_regs()[REG_CSR_MEPC],
+                    up_current_regs()[REG_CSR_MSTATUS]);
             }
         }
 
@@ -167,7 +168,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           tcb->xcp.regs[REG_CSR_MEPC] = (uint32_t) minerva_sigdeliver;
-          g_current_regs[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
+          up_current_regs()[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
                 tcb->xcp.saved_epc, tcb->xcp.saved_status,

--- a/arch/misoc/src/minerva/minerva_swint.c
+++ b/arch/misoc/src/minerva/minerva_swint.c
@@ -93,7 +93,7 @@ int minerva_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *) context;
 
-  DEBUGASSERT(regs != NULL && regs == g_current_regs);
+  DEBUGASSERT(regs != NULL && regs == up_current_regs());
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_X10) = system call
    * command and REG_A1-6 = variable number of arguments depending on the
@@ -137,7 +137,7 @@ int minerva_swint(int irq, void *context, void *arg)
     case SYS_restore_context:
       {
         DEBUGASSERT(regs[REG_A1] != 0);
-        g_current_regs = (uint32_t *) regs[REG_A1];
+        up_set_current_regs((uint32_t *)regs[REG_A1]);
       }
       break;
 
@@ -154,7 +154,7 @@ int minerva_swint(int irq, void *context, void *arg)
       {
         DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
         minerva_copystate((uint32_t *) regs[REG_A1], regs);
-        g_current_regs = (uint32_t *) regs[REG_A2];
+        up_set_current_regs((uint32_t *)regs[REG_A2]);
       }
       break;
 
@@ -178,7 +178,8 @@ int minerva_swint(int irq, void *context, void *arg)
          * original mode.
          */
 
-        g_current_regs[REG_CSR_MEPC] = rtcb->xcp.syscall[index].sysreturn;
+        up_current_regs()[REG_CSR_MEPC] =
+          rtcb->xcp.syscall[index].sysreturn;
 #error "Missing logic -- need to restore the original mode"
         rtcb->xcp.nsyscalls          = index;
 
@@ -205,7 +206,7 @@ int minerva_swint(int irq, void *context, void *arg)
 
         /* Verify that the SYS call number is within range */
 
-        DEBUGASSERT(g_current_regs[REG_A0] < SYS_maxsyscall);
+        DEBUGASSERT(up_current_regs()[REG_A0] < SYS_maxsyscall);
 
         /* Make sure that we got here that there is a no saved syscall return
          * address.  We cannot yet handle nested system calls.
@@ -225,7 +226,7 @@ int minerva_swint(int irq, void *context, void *arg)
 
         /* Offset R0 to account for the reserved values */
 
-        g_current_regs[REG_A0] -= CONFIG_SYS_RESERVED;
+        up_current_regs()[REG_A0] -= CONFIG_SYS_RESERVED;
 
         /* Indicate that we are in a syscall handler. */
 
@@ -242,10 +243,10 @@ int minerva_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
       svcinfo("SWInt Return: Context switch!\n");
-      minerva_registerdump(g_current_regs);
+      minerva_registerdump(up_current_regs());
     }
   else
     {

--- a/arch/misoc/src/minerva/minerva_switchcontext.c
+++ b/arch/misoc/src/minerva/minerva_switchcontext.c
@@ -63,7 +63,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently. Just copy the
        * g_current_regs into the OLD rtcb.

--- a/arch/or1k/include/irq.h
+++ b/arch/or1k/include/irq.h
@@ -75,9 +75,9 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -85,7 +85,6 @@ extern "C"
  */
 
 EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -117,6 +116,16 @@ int up_cpu_index(void);
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -132,7 +141,7 @@ static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/or1k/src/common/or1k_doirq.c
+++ b/arch/or1k/src/common/or1k_doirq.c
@@ -50,11 +50,11 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
   regs = NULL;
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  savestate    = (uint32_t *)CURRENT_REGS;
-  CURRENT_REGS = regs;
+  savestate = up_current_regs();
+  up_set_current_regs(regs);
 
   /* Acknowledge the interrupt */
 
@@ -65,12 +65,12 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
   irq_dispatch(irq, regs);
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have changed value.  If we return any value different
+   * current_regs may have changed value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
 
-  if (regs != (uint32_t *)CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -80,14 +80,14 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
       g_running_tasks[this_cpu()] = this_task();
     }
 
-  regs = (uint32_t *)CURRENT_REGS;
+  regs = up_current_regs();
 
-  /* Restore the previous value of CURRENT_REGS.  NULL would indicate that
+  /* Restore the previous value of current_regs.  NULL would indicate that
    * we are no longer in an interrupt handler.  It will be non-NULL if we
    * are returning from a nested interrupt.
    */
 
-  CURRENT_REGS = savestate;
+  up_set_current_regs(savestate);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/or1k/src/common/or1k_initialize.c
+++ b/arch/or1k/src/common/or1k_initialize.c
@@ -36,8 +36,8 @@
 
 /* g_current_regs[] holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];

--- a/arch/or1k/src/common/or1k_internal.h
+++ b/arch/or1k/src/common/or1k_internal.h
@@ -84,8 +84,8 @@
 #define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
 #define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
 
-#define or1k_savestate(regs)  or1k_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
-#define or1k_restorestate(regs) or1k_copyfullstate((uint32_t*)CURRENT_REGS, regs)
+#define or1k_savestate(regs)  or1k_copyfullstate(regs, up_current_regs())
+#define or1k_restorestate(regs) or1k_copyfullstate(up_current_regs(), regs)
 
 #define _START_TEXT  _stext
 #define _END_TEXT    _etext

--- a/arch/or1k/src/common/or1k_registerdump.c
+++ b/arch/or1k/src/common/or1k_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Dump the interrupt registers */
 

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -88,7 +88,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -96,7 +96,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -113,7 +113,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * logic would fail in the strange case where we are in an
            * interrupt handler, the thread is signalling itself, but
            * a context switch to another task has occurred so that
-           * CURRENT_REGS does not refer to the thread of this_task()!
+           * current_regs does not refer to the thread of this_task()!
            */
 
           else
@@ -123,16 +123,16 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              /* tcb->xcp.saved_pc      = CURRENT_REGS[REG_PC];
-               * tcb->xcp.saved_cpsr    = CURRENT_REGS[REG_CPSR];
+              /* tcb->xcp.saved_pc   = up_current_regs()[REG_PC];
+               * tcb->xcp.saved_cpsr = up_current_regs()[REG_CPSR];
                */
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              /* CURRENT_REGS[REG_PC]   = (uint32_t)or1k_sigdeliver;
-               * CURRENT_REGS[REG_CPSR] = SVC_MODE | PSR_I_BIT |
+              /* up_current_regs()[REG_PC]   = (uint32_t)or1k_sigdeliver;
+               * up_current_regs()[REG_CPSR] = SVC_MODE | PSR_I_BIT |
                *                          PSR_F_BIT;
                */
 

--- a/arch/or1k/src/common/or1k_switchcontext.c
+++ b/arch/or1k/src/common/or1k_switchcontext.c
@@ -63,13 +63,13 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
   /* Are we in an interrupt handler? */
 
 #if 0  /* REVISIT */
-  if (CURRENT_REGS)
+  if (up_current_regs())
 #else
   if (0)
 #endif
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       or1k_savestate(rtcb->xcp.regs);

--- a/arch/renesas/include/irq.h
+++ b/arch/renesas/include/irq.h
@@ -64,7 +64,6 @@ extern "C"
  */
 
 EXTERN volatile uint32_t *g_current_regs;
-#define CURRENT_REGS g_current_regs
 
 /****************************************************************************
  * Public Function Prototypes
@@ -92,6 +91,16 @@ EXTERN volatile uint32_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -101,7 +110,7 @@ EXTERN volatile uint32_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -71,8 +71,8 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
        * Nested interrupts are not supported.
        */
 
-      DEBUGASSERT(g_current_regs == NULL);
-      g_current_regs = regs;
+      DEBUGASSERT(up_current_regs() == NULL);
+      up_set_current_regs(regs);
 
       /* Deliver the IRQ */
 
@@ -85,12 +85,12 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
        * environment before returning from the interrupt.
        */
 
-      if (regs != g_current_regs)
+      if (regs != up_current_regs())
         {
 #ifdef CONFIG_ARCH_FPU
           /* Restore floating point registers */
 
-          up_restorefpu((uint32_t *)g_current_regs);
+          up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -115,13 +115,13 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
        * of a context switch performed during interrupt processing.
        */
 
-      regs = (uint32_t *)g_current_regs;
+      regs = up_current_regs();
 
       /* Set g_current_regs to NULL to indicate that we are no longer in an
        * interrupt handler.
        */
 
-      g_current_regs = NULL;
+      up_set_current_regs(NULL);
     }
 
   board_autoled_off(LED_INIRQ);

--- a/arch/renesas/src/common/renesas_internal.h
+++ b/arch/renesas/src/common/renesas_internal.h
@@ -87,7 +87,7 @@
 #define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
 #define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
 
-#define renesas_savestate(regs)  renesas_copystate(regs, (uint32_t *)g_current_regs)
+#define renesas_savestate(regs)  renesas_copystate(regs, up_current_regs())
 
 #define getreg8(a)          (*(volatile uint8_t *)(a))
 #define putreg8(v,a)        (*(volatile uint8_t *)(a) = (v))

--- a/arch/renesas/src/common/renesas_switchcontext.c
+++ b/arch/renesas/src/common/renesas_switchcontext.c
@@ -62,7 +62,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.
@@ -78,7 +78,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * changes will be made when the interrupt returns.
        */
 
-      g_current_regs = tcb->xcp.regs;
+      up_set_current_regs(tcb->xcp.regs);
     }
 
   /* We are not in an interrupt handler.  Copy the user C context

--- a/arch/renesas/src/m16c/m16c_registerdump.c
+++ b/arch/renesas/src/m16c/m16c_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint8_t *ptr = dumpregs ? dumpregs : (uint8_t *)g_current_regs;
+  volatile uint8_t *ptr = dumpregs ? dumpregs : up_current_regs();
 
   /* Dump the interrupt registers */
 

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -88,7 +88,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -96,7 +96,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -117,23 +117,23 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.saved_pc[0]   = g_current_regs[REG_PC];
-              tcb->xcp.saved_pc[1]   = g_current_regs[REG_PC + 1];
-              tcb->xcp.saved_flg     = g_current_regs[REG_FLG];
+              tcb->xcp.saved_pc[0] = up_current_regs()[REG_PC];
+              tcb->xcp.saved_pc[1] = up_current_regs()[REG_PC + 1];
+              tcb->xcp.saved_flg   = up_current_regs()[REG_FLG];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
-              g_current_regs[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
-              g_current_regs[REG_FLG] &= ~M16C_FLG_I;
+              up_current_regs()[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
+              up_current_regs()[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
+              up_current_regs()[REG_FLG] &= ~M16C_FLG_I;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
                */
 
-              renesas_copystate(tcb->xcp.regs, g_current_regs);
+              renesas_copystate(tcb->xcp.regs, up_current_regs());
             }
         }
 

--- a/arch/renesas/src/rx65n/rx65n_registerdump.c
+++ b/arch/renesas/src/rx65n/rx65n_registerdump.c
@@ -55,7 +55,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Dump the interrupt registers */
 

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -88,7 +88,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -96,7 +96,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -117,21 +117,21 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.saved_pc        = g_current_regs[REG_PC];
-              tcb->xcp.saved_sr        = g_current_regs[REG_PSW];
+              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+              tcb->xcp.saved_sr = up_current_regs()[REG_PSW];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_PC]   = (uint32_t)renesas_sigdeliver;
-              g_current_regs[REG_PSW] |= 0x00030000;
+              up_current_regs()[REG_PC]   = (uint32_t)renesas_sigdeliver;
+              up_current_regs()[REG_PSW] |= 0x00030000;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
                */
 
-              renesas_copystate(tcb->xcp.regs, (uint32_t *)g_current_regs);
+              renesas_copystate(tcb->xcp.regs, up_current_regs());
             }
         }
 

--- a/arch/renesas/src/sh1/sh1_registerdump.c
+++ b/arch/renesas/src/sh1/sh1_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Dump the interrupt registers */
 

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -88,7 +88,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -96,7 +96,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -117,21 +117,21 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * the signals have been delivered.
                */
 
-              tcb->xcp.saved_pc       = g_current_regs[REG_PC];
-              tcb->xcp.saved_sr       = g_current_regs[REG_SR];
+              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+              tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_PC]  = (uint32_t)renesas_sigdeliver;
-              g_current_regs[REG_SR] |= 0x000000f0;
+              up_current_regs()[REG_PC]  = (uint32_t)renesas_sigdeliver;
+              up_current_regs()[REG_SR] |= 0x000000f0;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
                */
 
-              renesas_copystate(tcb->xcp.regs, g_current_regs);
+              renesas_copystate(tcb->xcp.regs, up_current_regs());
             }
         }
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -669,9 +669,9 @@ extern "C"
 #endif
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -679,7 +679,6 @@ extern "C"
  */
 
 EXTERN volatile uintreg_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -720,6 +719,16 @@ int up_cpu_index(void);
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
+
+static inline_function uintreg_t *up_current_regs(void)
+{
+  return (uintreg_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uintreg_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
 
 /****************************************************************************
  * Name: up_irq_save
@@ -784,7 +793,7 @@ noinstrument_function static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -162,8 +162,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)CURRENT_REGS[REG_FP],
-                               (void *)CURRENT_REGS[REG_EPC],
+                               (void *)up_current_regs()[REG_FP],
+                               (void *)up_current_regs()[REG_EPC],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/risc-v/src/common/riscv_cpupause.c
+++ b/arch/risc-v/src/common/riscv_cpupause.c
@@ -118,7 +118,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -71,26 +71,26 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
     }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    *
    * Nested interrupts are not supported
    */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
    * point state and the establish the correct address environment before
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -110,19 +110,19 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
       g_running_tasks[this_cpu()] = this_task();
 
       /* If a context switch occurred while processing the interrupt then
-       * CURRENT_REGS may have change value.  If we return any value
+       * current_regs may have change value.  If we return any value
        * different from the input regs, then the lower level will know
        * that a context switch occurred during interrupt processing.
        */
 
-      regs = (uintreg_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
 #endif
   board_autoled_off(LED_INIRQ);

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -119,22 +119,22 @@ int riscv_exception(int mcause, void *regs, void *args)
 
       /* Return to _exit function in privileged mode with argument SIGSEGV */
 
-      CURRENT_REGS[REG_EPC] = (uintptr_t)_exit;
-      CURRENT_REGS[REG_A0] = SIGSEGV;
-      CURRENT_REGS[REG_INT_CTX] |= STATUS_PPP;
+      up_current_regs()[REG_EPC] = (uintptr_t)_exit;
+      up_current_regs()[REG_A0] = SIGSEGV;
+      up_current_regs()[REG_INT_CTX] |= STATUS_PPP;
 
       /* Continue with kernel stack in use. The frame(s) in kernel stack
        * are no longer needed, so just set it to top
        */
 
-      CURRENT_REGS[REG_SP] = (uintptr_t)tcb->xcp.ktopstk;
+      up_current_regs()[REG_SP] = (uintptr_t)tcb->xcp.ktopstk;
     }
   else
 #endif
     {
       _alert("PANIC!!! Exception = %" PRIxREG "\n", cause);
       up_irq_save();
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
       PANIC_WITH_REGS("panic", regs);
     }
 
@@ -206,7 +206,7 @@ int riscv_fillpage(int mcause, void *regs, void *args)
     {
       _alert("PANIC!!! virtual address not mappable: %" PRIxPTR "\n", vaddr);
       up_irq_save();
-      CURRENT_REGS = regs;
+      up_set_current_regs(regs);
       PANIC_WITH_REGS("panic", regs);
     }
 

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -210,7 +210,7 @@ handle_irq:
   jal        x1, riscv_dispatch_irq
 
 #else
-  /* Reserve some space for CURRENT_REGS if interrupt stack disabled */
+  /* Reserve some space for current_regs if interrupt stack disabled */
 
   addi       sp, sp, -XCPTCONTEXT_SIZE
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -89,8 +89,8 @@
  * only a reference stored in TCB.
  */
 
-#define riscv_savestate(regs) (regs = (uintreg_t *)CURRENT_REGS)
-#define riscv_restorestate(regs) (CURRENT_REGS = regs)
+#define riscv_savestate(regs) (regs = up_current_regs())
+#define riscv_restorestate(regs) up_set_current_regs(regs)
 
 /* Determine which (if any) console driver to use.  If a console is enabled
  * and no other console device is specified, then a serial console is
@@ -322,7 +322,7 @@ static inline uintptr_t *riscv_vpuregs(struct tcb_s *tcb)
 
 static inline void riscv_savecontext(struct tcb_s *tcb)
 {
-  tcb->xcp.regs = (uintreg_t *)CURRENT_REGS;
+  tcb->xcp.regs = (uintreg_t *)up_current_regs();
 
 #ifdef CONFIG_ARCH_FPU
   /* Save current process FPU state to TCB */
@@ -339,7 +339,7 @@ static inline void riscv_savecontext(struct tcb_s *tcb)
 
 static inline void riscv_restorecontext(struct tcb_s *tcb)
 {
-  CURRENT_REGS = (uintreg_t *)tcb->xcp.regs;
+  up_set_current_regs(tcb->xcp.regs);
 
 #ifdef CONFIG_ARCH_FPU
   /* Restore FPU state for next process */

--- a/arch/risc-v/src/common/riscv_registerdump.c
+++ b/arch/risc-v/src/common/riscv_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uintreg_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uintreg_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -93,8 +93,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n",
-            this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -102,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -119,7 +118,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * logic would fail in the strange case where we are in an
            * interrupt handler, the thread is signalling itself, but
            * a context switch to another task has occurred so that
-           * CURRENT_REGS does not refer to the thread of this_task()!
+           * current_regs does not refer to the thread of this_task()!
            */
 
           else
@@ -136,10 +135,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              CURRENT_REGS = (uintreg_t *)((uintptr_t)CURRENT_REGS -
-                                                      XCPTCONTEXT_SIZE);
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
 
-              memcpy((uintreg_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               /* Then set up to vector to the trampoline with interrupts
@@ -147,24 +145,24 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * privileged thread mode.
                */
 
-              CURRENT_REGS[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
+              up_current_regs()[REG_EPC] = (uintptr_t)riscv_sigdeliver;
 
-              int_ctx                   = CURRENT_REGS[REG_INT_CTX];
-              int_ctx                  &= ~STATUS_PIE;
+              int_ctx  = up_current_regs()[REG_INT_CTX];
+              int_ctx &= ~STATUS_PIE;
 #ifndef CONFIG_BUILD_FLAT
-              int_ctx                  |= STATUS_PPP;
+              int_ctx |= STATUS_PPP;
 #endif
+              up_current_regs()[REG_INT_CTX] = int_ctx;
 
-              CURRENT_REGS[REG_INT_CTX] = int_ctx;
-
-              CURRENT_REGS[REG_SP]      = (uintptr_t)CURRENT_REGS +
-                                                     XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_SP] = (uintptr_t)(up_current_regs() +
+                                                       XCPTCONTEXT_REGS);
 
               sinfo("PC/STATUS Saved: %" PRIxREG "/%" PRIxREG
                     " New: %" PRIxREG "/%" PRIxREG "\n",
                     tcb->xcp.saved_regs[REG_EPC],
                     tcb->xcp.saved_regs[REG_INT_CTX],
-                    CURRENT_REGS[REG_EPC], CURRENT_REGS[REG_INT_CTX]);
+                    up_current_regs()[REG_EPC],
+                    up_current_regs()[REG_INT_CTX]);
             }
         }
 
@@ -233,7 +231,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -244,7 +242,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -321,36 +319,34 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.saved_regs = (uintreg_t *)CURRENT_REGS;
+                  tcb->xcp.saved_regs = up_current_regs();
 
                   /* Duplicate the register context.  These will be
                    * restored by the signal trampoline after the signal has
                    * been delivered.
                    */
 
-                  CURRENT_REGS = (uintreg_t *)((uintptr_t)CURRENT_REGS -
-                                                          XCPTCONTEXT_SIZE);
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
 
-                  memcpy((uintreg_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_SP]      = (uintptr_t)CURRENT_REGS +
-                                                         XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_SP] = (uintptr_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
+                  up_current_regs()[REG_EPC] = (uintptr_t)riscv_sigdeliver;
 
-                  int_ctx                   = CURRENT_REGS[REG_INT_CTX];
-                  int_ctx                  &= ~STATUS_PIE;
+                  int_ctx  = up_current_regs()[REG_INT_CTX];
+                  int_ctx &= ~STATUS_PIE;
 #ifndef CONFIG_BUILD_FLAT
-                  int_ctx                  |= STATUS_PPP;
+                  int_ctx |= STATUS_PPP;
 #endif
-
-                  CURRENT_REGS[REG_INT_CTX] = int_ctx;
+                  up_current_regs()[REG_INT_CTX] = int_ctx;
                 }
 
               /* NOTE: If the task runs on another CPU(cpu), adjusting

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -200,7 +200,7 @@ int riscv_swint(int irq, void *context, void *arg)
 {
   uintreg_t *regs = (uintreg_t *)context;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_X10) = system call
    * command and REG_A1-6 = variable number of
@@ -226,9 +226,9 @@ int riscv_swint(int irq, void *context, void *arg)
        *   A0 = SYS_restore_context
        *   A1 = next
        *
-       * In this case, we simply need to set CURRENT_REGS to restore register
-       * area referenced in the saved A1. context == CURRENT_REGS is the
-       * normal exception return.  By setting CURRENT_REGS = context[A1], we
+       * In this case, we simply need to set current_regs to restore register
+       * area referenced in the saved A1. context == current_regs is the
+       * normal exception return.  By setting current_regs = context[A1], we
        * force the return to the saved context referenced in $a1.
        */
 
@@ -254,7 +254,7 @@ int riscv_swint(int irq, void *context, void *arg)
        *
        * In this case, we save the context registers to the save register
        * area referenced by the saved contents of R5 and then set
-       * CURRENT_REGS to the save register area referenced by the saved
+       * current_regs to the save register area referenced by the saved
        * contents of R6.
        */
 
@@ -488,10 +488,10 @@ int riscv_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(CURRENT_REGS);
+      up_dump_register(up_current_regs());
     }
   else
     {
@@ -499,7 +499,7 @@ int riscv_swint(int irq, void *context, void *arg)
     }
 #endif
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/risc-v/src/common/riscv_switchcontext.c
+++ b/arch/risc-v/src/common/riscv_switchcontext.c
@@ -63,10 +63,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       riscv_savecontext(rtcb);

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -42,14 +42,14 @@ void *riscv_perform_syscall(uintreg_t *regs)
 
   /* Set up the interrupt register set needed by swint() */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Run the system call handler (swint) */
 
   riscv_swint(0, regs, NULL);
 
 #ifdef CONFIG_ARCH_ADDRENV
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -61,7 +61,7 @@ void *riscv_perform_syscall(uintreg_t *regs)
     }
 #endif
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
@@ -76,15 +76,15 @@ void *riscv_perform_syscall(uintreg_t *regs)
       restore_critical_section(tcb, cpu);
 
       /* If a context switch occurred while processing the interrupt then
-       * CURRENT_REGS may have change value.  If we return any value
+       * current_regs may have change value.  If we return any value
        * different from the input regs, then the lower level will know
        * that a context switch occurred during interrupt processing.
        */
 
-      regs = (uintreg_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   return regs;
 }

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -68,17 +68,16 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
  * such value for each processor that can receive an interrupt.
  */
 
-EXTERN volatile void *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
+EXTERN volatile xcpt_reg_t *g_current_regs[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Public Function Prototypes
@@ -124,6 +123,16 @@ void up_irq_enable(void);
  * Inline functions
  ****************************************************************************/
 
+static inline_function xcpt_reg_t *up_current_regs(void)
+{
+  return (xcpt_reg_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(xcpt_reg_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /* Return the current value of the stack pointer */
 
 static inline uintptr_t up_getsp(void)
@@ -153,7 +162,7 @@ static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -102,8 +102,8 @@
 
 /* Macros to handle saving and restoring interrupt state ********************/
 
-#define sim_savestate(regs) sim_copyfullstate(regs, (xcpt_reg_t *)CURRENT_REGS)
-#define sim_restorestate(regs) (CURRENT_REGS = regs)
+#define sim_savestate(regs) sim_copyfullstate(regs, up_current_regs())
+#define sim_restorestate(regs) up_set_current_regs(regs)
 
 #define sim_saveusercontext(saveregs, ret)                      \
     do                                                          \

--- a/arch/sim/src/sim/sim_smpsignal.c
+++ b/arch/sim/src/sim/sim_smpsignal.c
@@ -160,7 +160,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -64,10 +64,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       sim_savestate(rtcb->xcp.regs);

--- a/arch/sparc/include/irq.h
+++ b/arch/sparc/include/irq.h
@@ -93,9 +93,9 @@ static inline uint32_t up_getsp(void)
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -103,7 +103,6 @@ static inline uint32_t up_getsp(void)
  */
 
 EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -135,6 +134,16 @@ int up_cpu_index(void);
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -150,7 +159,7 @@ static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/sparc/src/common/sparc_initialize.c
+++ b/arch/sparc/src/common/sparc_initialize.c
@@ -77,8 +77,8 @@
 
 /* g_current_regs[] holds a reference to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -137,19 +137,6 @@ static inline void up_color_intstack(void)
 
 void up_initialize(void)
 {
-#ifdef CONFIG_SMP
-  int i;
-
-  /* Initialize global variables */
-
-  for (i = 0; i < CONFIG_SMP_NCPUS; i++)
-    {
-      g_current_regs[i] = NULL;
-    }
-#else
-  CURRENT_REGS = NULL;
-#endif
-
   /* Colorize the interrupt stack */
 
   up_color_intstack();

--- a/arch/sparc/src/s698pm/s698pm_cpupause.c
+++ b/arch/sparc/src/s698pm/s698pm_cpupause.c
@@ -117,7 +117,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/sparc/src/sparc_v8/sparc_v8.h
+++ b/arch/sparc/src/sparc_v8/sparc_v8.h
@@ -41,9 +41,9 @@
  * state from the TCB.
  */
 
-#define sparc_restorestate(regs) (CURRENT_REGS = regs)
+#define sparc_restorestate(regs) up_set_current_regs(regs)
 
-#define sparc_savestate(regs)   trap_flush_task(regs, (uint32_t*)CURRENT_REGS)
+#define sparc_savestate(regs)   trap_flush_task(regs, up_current_regs())
 
 /****************************************************************************
  * Public Types

--- a/arch/sparc/src/sparc_v8/sparc_v8_copystate.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_copystate.c
@@ -71,7 +71,7 @@ void sparc_copystate(uint32_t *dest, uint32_t *src)
 
 void task_flush_trap(uint32_t *trap, uint32_t *task)
 {
-  CURRENT_REGS = task;
+  up_set_current_regs(task);
 }
 
 void trap_flush_task(uint32_t *task, uint32_t *trap)

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -64,31 +64,31 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
 #else
   regs = (uint32_t *)((uint32_t)regs + CPU_MINIMUM_STACK_FRAME_SIZE);
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    *
    * Nested interrupts are not supported.
    */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.
+   * current_regs will have a different value than it did on entry.
    * If an interrupt level context switch has occurred, then restore
    * the floating point state and the establish the correct address
    * environment before returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)CURRENT_REGS);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -110,19 +110,19 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
     }
 
   /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
+   * current_regs may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)((uint32_t)CURRENT_REGS -
+  regs = (uint32_t *)((uint32_t)up_current_regs() -
                                 CPU_MINIMUM_STACK_FRAME_SIZE);
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/sparc/src/sparc_v8/sparc_v8_registerdump.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : CURRENT_REGS;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -92,7 +92,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -100,7 +100,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -117,7 +117,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * logic would fail in the strange case where we are in an
            * interrupt handler, the thread is signalling itself, but
            * a context switch to another task has occurred so that
-           * CURRENT_REGS does not refer to the thread of this_task()!
+           * current_regs does not refer to the thread of this_task()!
            */
 
           else
@@ -127,17 +127,17 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * trampoline after the signal(s) have been delivered.
                */
 
-              tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
-              tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
-              tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
+              tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
+              tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
+              tcb->xcp.saved_status = up_current_regs()[REG_PSR];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC]  = (uint32_t)sparc_sigdeliver;
-              CURRENT_REGS[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
-              CURRENT_REGS[REG_PSR] |= SPARC_PSR_ET_MASK;
+              up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
+              up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+              up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.
@@ -201,7 +201,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=0x%p current_regs=0x%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -212,7 +212,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -271,18 +271,19 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * trampoline after the signal(s) have been delivered.
                    */
 
-                  tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
-                  tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
-                  tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
+                  tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
+                  tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
+                  tcb->xcp.saved_status = up_current_regs()[REG_PSR];
 
                   /* Then set up vector to the trampoline with interrupts
                    * disabled.  The kernel-space trampoline must run in
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_PC]  = (uint32_t)sparc_sigdeliver;
-                  CURRENT_REGS[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
-                  CURRENT_REGS[REG_PSR] |= SPARC_PSR_ET_MASK;
+                  up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
+                  up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver
+                                                + 4;
+                  up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
 
                   /* And make sure that the saved context in the TCB is the
                    * same as the interrupt return context.
@@ -319,9 +320,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * trampoline after the signal(s) have been delivered.
            */
 
-          tcb->xcp.saved_pc     = CURRENT_REGS[REG_PC];
-          tcb->xcp.saved_npc    = CURRENT_REGS[REG_NPC];
-          tcb->xcp.saved_status = CURRENT_REGS[REG_PSR];
+          tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
+          tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
+          tcb->xcp.saved_status = up_current_regs()[REG_PSR];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be

--- a/arch/sparc/src/sparc_v8/sparc_v8_swint1.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_swint1.c
@@ -73,7 +73,7 @@ int sparc_swint1(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
-  DEBUGASSERT(regs && regs == CURRENT_REGS);
+  DEBUGASSERT(regs && regs == up_current_regs());
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_R4) = system call
    * command and REG_A1-3 and REG_T0-2 (REG_R5-10) = variable number of
@@ -119,7 +119,7 @@ int sparc_swint1(int irq, void *context, void *arg)
        *   A0 = SYS_restore_context
        *   A1 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore
+       * In this case, we simply need to set current_regs to restore
        * register area referenced in the saved R1. context == g_current
        * regs is the normal exception return.  By setting g_current
        * regs = context[R1], we force the return to the saved context
@@ -129,7 +129,7 @@ int sparc_swint1(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_I1] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_I1];
+          up_set_current_regs((uint32_t *)regs[REG_I1]);
         }
         break;
 
@@ -146,7 +146,7 @@ int sparc_swint1(int irq, void *context, void *arg)
        *
        * In this case, we save the context registers to the save register
        * area referenced by the saved contents of R5 and then set
-       * CURRENT_REGS to the save register area referenced by the saved
+       * current_regs to the save register area referenced by the saved
        * contents of R6.
        */
 
@@ -157,7 +157,7 @@ int sparc_swint1(int irq, void *context, void *arg)
 
           /* task_flush_trap(regs,(uint32_t *)regs[REG_I2]); */
 
-          CURRENT_REGS = (uint32_t *)regs[REG_I2];
+          up_set_current_regs((uint32_t *)regs[REG_I2]);
         }
         break;
 
@@ -187,7 +187,7 @@ int sparc_swint1(int irq, void *context, void *arg)
            * the original mode.
            */
 
-          CURRENT_REGS[REG_I7] = rtcb->xcp.syscall[index].sysreturn;
+          up_current_regs()[REG_I7] = rtcb->xcp.syscall[index].sysreturn;
 #error "Missing logic -- need to restore the original mode"
           rtcb->xcp.nsyscalls   = index;
         }
@@ -202,7 +202,7 @@ int sparc_swint1(int irq, void *context, void *arg)
 
           /* Verify that the SYS call number is within range */
 
-          DEBUGASSERT(CURRENT_REGS[REG_I1] < SYS_maxsyscall);
+          DEBUGASSERT(up_current_regs()[REG_I1] < SYS_maxsyscall);
 
           /* Make sure that we got here that there is a no saved syscall
            * return address.  We cannot yet handle nested system calls.
@@ -221,7 +221,7 @@ int sparc_swint1(int irq, void *context, void *arg)
 
           /* Offset R0 to account for the reserved values */
 
-          /* CURRENT_REGS[REG_R0] -= CONFIG_SYS_RESERVED; *//*zouboan*/
+          /* up_current_regs()[REG_R0] -= CONFIG_SYS_RESERVED; *//*zouboan*/
 #else
           svcerr("ERROR: Bad SYS call: %d\n", regs[REG_I1]);
 #endif
@@ -234,10 +234,10 @@ int sparc_swint1(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(CURRENT_REGS);
+      up_dump_register(up_current_regs());
     }
   else
     {

--- a/arch/sparc/src/sparc_v8/sparc_v8_switchcontext.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_switchcontext.c
@@ -63,10 +63,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       sparc_savestate(rtcb->xcp.regs);

--- a/arch/tricore/include/irq.h
+++ b/arch/tricore/include/irq.h
@@ -61,9 +61,9 @@ extern "C"
  ****************************************************************************/
 
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
+ * register storage structure.  If is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * g_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -71,7 +71,6 @@ extern "C"
  */
 
 EXTERN volatile uintptr_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 
 /****************************************************************************
  * Public Function Prototypes
@@ -149,6 +148,20 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
 }
 
 /****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline_function uintptr_t *up_current_regs(void)
+{
+  return (uintptr_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uintptr_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
+/****************************************************************************
  * Name: up_interrupt_context
  *
  * Description:
@@ -158,13 +171,13 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
  ****************************************************************************/
 
 noinstrument_function
-static inline bool up_interrupt_context(void)
+static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -57,26 +57,26 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
   irq_dispatch(icr.B.CCPN, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * g_current_regs will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
    * point state and the establish the correct address environment before
    * returning from the interrupt.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -95,15 +95,15 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      __mtcr(CPU_PCXI, (uintptr_t)CURRENT_REGS);
+      __mtcr(CPU_PCXI, up_current_regs());
       __isync();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 
   board_autoled_off(LED_INIRQ);
 #endif

--- a/arch/tricore/src/common/tricore_internal.h
+++ b/arch/tricore/src/common/tricore_internal.h
@@ -207,13 +207,10 @@ extern uintptr_t        __A0_MEM[];    /* End+1 of .data */
  * Inline Functions
  ****************************************************************************/
 
-#define tricore_savecontext(regs)    (regs = (uintptr_t *)CURRENT_REGS)
-#define tricore_restorecontext(regs) (CURRENT_REGS = regs)
-
 /* Macros to handle saving and restoring interrupt state. */
 
-#define tricore_savestate(regs)    (regs = (uintptr_t *)CURRENT_REGS)
-#define tricore_restorestate(regs) (CURRENT_REGS = regs)
+#define tricore_savestate(regs)    (regs = up_current_regs())
+#define tricore_restorestate(regs) (up_set_current_regs(regs))
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/tricore/src/common/tricore_schedulesigaction.c
+++ b/arch/tricore/src/common/tricore_schedulesigaction.c
@@ -94,7 +94,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (CURRENT_REGS == NULL)
+          if (up_current_regs() == NULL)
             {
               /* In this case just deliver the signal now. */
 
@@ -111,7 +111,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * logic would fail in the strange case where we are in an
            * interrupt handler, the thread is signalling itself, but
            * a context switch to another task has occurred so that
-           * CURRENT_REGS does not refer to the thread of this_task()!
+           * g_current_regs does not refer to the thread of this_task()!
            */
 
           else
@@ -127,9 +127,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * will borrow the process stack of the current tcb.
                */
 
-              CURRENT_REGS = tricore_alloc_csa((uintptr_t)tricore_sigdeliver,
+              up_set_current_regs(tricore_alloc_csa((uintptr_t)
+                  tricore_sigdeliver,
                   STACK_ALIGN_DOWN(up_getusrsp(tcb->xcp.regs)),
-                  PSW_IO_SUPERVISOR | PSW_CDE, true);
+                  PSW_IO_SUPERVISOR | PSW_CDE, true));
             }
         }
 

--- a/arch/tricore/src/common/tricore_svcall.c
+++ b/arch/tricore/src/common/tricore_svcall.c
@@ -65,7 +65,7 @@ void tricore_svcall(volatile void *trap)
 
   regs = tricore_csa2addr((uintptr_t)regs);
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   cmd = regs[REG_D8];
 
@@ -83,9 +83,9 @@ void tricore_svcall(volatile void *trap)
        *   R0 = SYS_restore_context
        *   R1 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore
-       * register area referenced in the saved R1. context == CURRENT_REGS
-       * is the normal exception return.  By setting CURRENT_REGS =
+       * In this case, we simply need to set g_current_regs to restore
+       * register area referenced in the saved R1. context == g_current_regs
+       * is the normal exception return.  By setting g_current_regs =
        * context[R1], we force the return to the saved context referenced
        * in R1.
        */
@@ -93,14 +93,14 @@ void tricore_svcall(volatile void *trap)
       case SYS_restore_context:
         {
           tricore_reclaim_csa(regs[REG_UPCXI]);
-          CURRENT_REGS = (uintptr_t *)regs[REG_D9];
+          up_set_current_regs((uintptr_t *)regs[REG_D9]);
         }
         break;
 
       case SYS_switch_context:
         {
           *(uintptr_t **)regs[REG_D9] = (uintptr_t *)regs[REG_UPCXI];
-          CURRENT_REGS = (uintptr_t *)regs[REG_D10];
+          up_set_current_regs((uintptr_t *)regs[REG_D10]);
         }
         break;
 
@@ -111,7 +111,7 @@ void tricore_svcall(volatile void *trap)
         break;
     }
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -120,10 +120,10 @@ void tricore_svcall(volatile void *trap)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      regs[REG_UPCXI] = (uintptr_t)CURRENT_REGS;
+      regs[REG_UPCXI] = up_current_regs();
 
       __isync();
     }
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 }

--- a/arch/tricore/src/common/tricore_switchcontext.c
+++ b/arch/tricore/src/common/tricore_switchcontext.c
@@ -63,13 +63,13 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the g_current_regs into the OLD rtcb.
        */
 
-      tricore_savecontext(rtcb->xcp.regs);
+      tricore_savestate(rtcb->xcp.regs);
 
       /* Update scheduler parameters */
 
@@ -79,7 +79,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * changes will be made when the interrupt returns.
        */
 
-      tricore_restorecontext(tcb->xcp.regs);
+      tricore_restorestate(tcb->xcp.regs);
     }
 
   /* No, then we will need to perform the user context switch */

--- a/arch/tricore/src/common/tricore_trapcall.c
+++ b/arch/tricore/src/common/tricore_trapcall.c
@@ -60,8 +60,8 @@ void tricore_trapcall(volatile void *trap)
 
   regs = tricore_csa2addr(__mfcr(CPU_PCXI));
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   up_irq_save();
-  PANIC_WITH_REGS("Trap", (void *)CURRENT_REGS);
+  PANIC_WITH_REGS("Trap", up_current_regs());
 }

--- a/arch/x86/include/irq.h
+++ b/arch/x86/include/irq.h
@@ -108,6 +108,16 @@ EXTERN volatile uint32_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -117,7 +127,7 @@ EXTERN volatile uint32_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/x86/src/common/x86_internal.h
+++ b/arch/x86/src/common/x86_internal.h
@@ -96,7 +96,7 @@
  * referenced is passed to get the state from the TCB.
  */
 
-#define x86_restorestate(regs) (g_current_regs = regs)
+#define x86_restorestate(regs) up_set_current_regs(regs)
 
 /****************************************************************************
  * Public Types

--- a/arch/x86/src/common/x86_switchcontext.c
+++ b/arch/x86/src/common/x86_switchcontext.c
@@ -62,7 +62,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/arch/x86/src/i486/i486_regdump.c
+++ b/arch/x86/src/i486/i486_regdump.c
@@ -49,7 +49,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert(" ds:%08x irq:%08x err:%08x\n",
          regs[REG_DS], regs[REG_IRQNO], regs[REG_ERRCODE]);

--- a/arch/x86/src/i486/i486_savestate.c
+++ b/arch/x86/src/i486/i486_savestate.c
@@ -67,7 +67,7 @@ void x86_savestate(uint32_t *regs)
 
   /* First, just copy all of the registers */
 
-  x86_copystate(regs, (uint32_t *)g_current_regs);
+  x86_copystate(regs, up_current_regs());
 
   /* The RES_SP and REG_SS values will not be saved by the interrupt handling
    * logic if there is no change in privilege level.  In that case, we will
@@ -90,11 +90,12 @@ void x86_savestate(uint32_t *regs)
        * to the execution of the PUSHA.  It will point at REG_IRQNO.
        */
 
-      regs[REG_SP] = g_current_regs[REG_ESP] + 4*BOTTOM_NOPRIO;
+      regs[REG_SP] = up_current_regs()[REG_ESP] + 4*BOTTOM_NOPRIO;
       regs[REG_SS] = up_getss();
     }
   else
     {
-      DEBUGASSERT(regs[REG_SP] == g_current_regs[REG_ESP] + 4*BOTTOM_PRIO);
+      DEBUGASSERT(regs[REG_SP] == up_current_regs()[REG_ESP] +
+                                  4 * BOTTOM_PRIO);
     }
 }

--- a/arch/x86/src/i486/i486_schedulesigaction.c
+++ b/arch/x86/src/i486/i486_schedulesigaction.c
@@ -84,7 +84,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -92,7 +92,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -119,15 +119,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * have been delivered.
                */
 
-              tcb->xcp.saved_eip         = g_current_regs[REG_EIP];
-              tcb->xcp.saved_eflags      = g_current_regs[REG_EFLAGS];
+              tcb->xcp.saved_eip    = up_current_regs()[REG_EIP];
+              tcb->xcp.saved_eflags = up_current_regs()[REG_EFLAGS];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              g_current_regs[REG_EIP]    = (uint32_t)x86_sigdeliver;
-              g_current_regs[REG_EFLAGS] = 0;
+              up_current_regs()[REG_EIP]    = (uint32_t)x86_sigdeliver;
+              up_current_regs()[REG_EFLAGS] = 0;
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -84,8 +84,8 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
    * Nested interrupts are not supported.
    */
 
-  DEBUGASSERT(g_current_regs == NULL);
-  g_current_regs = regs;
+  DEBUGASSERT(up_current_regs() == NULL);
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
@@ -98,12 +98,12 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != g_current_regs)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      up_restorefpu(up_current_regs());
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -130,13 +130,13 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  regs = (uint32_t *)g_current_regs;
+  regs = up_current_regs();
 
   /* Set g_current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  g_current_regs = NULL;
+  up_set_current_regs(NULL);
   return regs;
 }
 #endif

--- a/arch/x86_64/src/intel64/intel64_cpupause.c
+++ b/arch/x86_64/src/intel64/intel64_cpupause.c
@@ -119,7 +119,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -110,7 +110,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -184,7 +184,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(),
+      sinfo("rtcb=0x%p current_regs=0x%p\n", this_task(),
             up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -367,9 +367,9 @@ extern "C"
 
 #ifndef __ASSEMBLY__
 /* g_current_regs[] holds a references to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one
@@ -377,7 +377,6 @@ extern "C"
  */
 
 EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
-#define CURRENT_REGS (g_current_regs[up_cpu_index()])
 #endif
 
 /****************************************************************************
@@ -430,6 +429,16 @@ int up_cpu_index(void);
 #  define up_cpu_index() (0)
 #endif
 
+static inline_function uint32_t *up_current_regs(void)
+{
+  return (uint32_t *)g_current_regs[up_cpu_index()];
+}
+
+static inline_function void up_set_current_regs(uint32_t *regs)
+{
+  g_current_regs[up_cpu_index()] = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -446,7 +455,7 @@ noinstrument_function static inline bool up_interrupt_context(void)
   irqstate_t flags = up_irq_save();
 #endif
 
-  bool ret = CURRENT_REGS != NULL;
+  bool ret = up_current_regs() != NULL;
 
 #ifdef CONFIG_SMP
   up_irq_restore(flags);

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -107,8 +107,8 @@
  * only a reference stored in TCB.
  */
 
-#define xtensa_savestate(regs)    ((regs) = (uint32_t *)CURRENT_REGS)
-#define xtensa_restorestate(regs) (CURRENT_REGS = (regs))
+#define xtensa_savestate(regs)    ((regs) = up_current_regs())
+#define xtensa_restorestate(regs) up_set_current_regs(regs)
 
 /* Context switching via system calls ***************************************/
 

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -65,7 +65,7 @@
 
 void xtensa_panic(int xptcode, uint32_t *regs)
 {
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 
@@ -167,7 +167,7 @@ void xtensa_panic(int xptcode, uint32_t *regs)
 
 void xtensa_user_panic(int exccause, uint32_t *regs)
 {
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -257,8 +257,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
                                  rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                                 (void *)CURRENT_REGS[REG_A1],
-                                 (void *)CURRENT_REGS[REG_A0],
+                                 (void *)up_current_regs()[REG_A1],
+                                 (void *)up_current_regs()[REG_A0],
                                  &buffer[ret], size - ret, &skip);
         }
       else

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -102,7 +102,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at CURRENT_REGS into the TCB at the head
+  /* Save the current context at current_regs into the TCB at the head
    * of the assigned task list for this CPU.
    */
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -34,8 +34,8 @@
 
 /* g_current_regs[] holds a reference to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the macro
- * CURRENT_REGS for portability.
+ * processing.  Access to g_current_regs[] must be through the
+ * [get/set]_current_regs for portability.
  */
 
 /* For the case of architectures with multiple CPUs, then there must be one

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -54,23 +54,23 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(CURRENT_REGS == NULL);
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
+   * current_regs is also used to manage interrupt level context switches.
    */
 
-  CURRENT_REGS = regs;
+  up_set_current_regs(regs);
 
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
 
   /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.
+   * current_regs will have a different value than it did on entry.
    */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -92,16 +92,16 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   /* Restore the cpu lock */
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
-      regs = (uint32_t *)CURRENT_REGS;
+      regs = up_current_regs();
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
+  /* Set current_regs to NULL to indicate that we are no longer in an
    * interrupt handler.
    */
 
-  CURRENT_REGS = NULL;
+  up_set_current_regs(NULL);
 #endif
 
   board_autoled_off(LED_INIRQ);

--- a/arch/xtensa/src/common/xtensa_registerdump.c
+++ b/arch/xtensa/src/common/xtensa_registerdump.c
@@ -53,8 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uintptr_t *regs = dumpregs ? dumpregs :
-                            (uintptr_t *)CURRENT_REGS;
+  volatile uintptr_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert("   PC: %08lx    PS: %08lx\n",
          (unsigned long)regs[REG_PC], (unsigned long)regs[REG_PS]);

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
     {
       tcb->xcp.sigdeliver = sigdeliver;
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -102,7 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (!CURRENT_REGS)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -120,7 +120,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * Hmmm... there looks like a latent bug here: The following logic
            * would fail in the strange case where we are in an interrupt
            * handler, the thread is signaling itself, but a context switch
-           * to another task has occurred so that CURRENT_REGS does not
+           * to another task has occurred so that current_regs does not
            * refer to the thread of this_task()!
            */
 
@@ -139,31 +139,30 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * been delivered.
                */
 
-              CURRENT_REGS = (void *)((uint32_t)CURRENT_REGS -
-                                                XCPTCONTEXT_SIZE);
+              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
 
-              memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+              memcpy(up_current_regs(), tcb->xcp.saved_regs,
                      XCPTCONTEXT_SIZE);
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              CURRENT_REGS[REG_PC] = (uint32_t)xtensa_sig_deliver;
+              up_current_regs()[REG_PC] = (uint32_t)xtensa_sig_deliver;
 #ifdef __XTENSA_CALL0_ABI__
-              CURRENT_REGS[REG_PS] = (uint32_t)
+              up_current_regs()[REG_PS] = (uint32_t)
                   (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM);
 #else
-              CURRENT_REGS[REG_PS] = (uint32_t)
+              up_current_regs()[REG_PS] = (uint32_t)
                   (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM |
                    PS_WOE | PS_CALLINC(1));
 #endif
 #ifndef CONFIG_BUILD_FLAT
-              xtensa_raiseprivilege(CURRENT_REGS);
+              xtensa_raiseprivilege(up_current_regs());
 #endif
 
-              CURRENT_REGS[REG_A1] = (uint32_t)CURRENT_REGS +
-                                               XCPTCONTEXT_SIZE;
+              up_current_regs()[REG_A1] = (uint32_t)(up_current_regs() +
+                                                      XCPTCONTEXT_REGS);
             }
         }
 
@@ -232,7 +231,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {
@@ -243,7 +242,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * signaling itself for some reason.
            */
 
-          if (cpu == me && !CURRENT_REGS)
+          if (cpu == me && !up_current_regs())
             {
               /* In this case just deliver the signal now.
                * REVISIT:  Signal handler will run in a critical section!
@@ -358,30 +357,28 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  CURRENT_REGS         = (void *)
-                                         ((uint32_t)CURRENT_REGS -
-                                                    XCPTCONTEXT_SIZE);
-                  memcpy((uint32_t *)CURRENT_REGS, tcb->xcp.saved_regs,
+                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
+                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
                          XCPTCONTEXT_SIZE);
 
-                  CURRENT_REGS[REG_A1] = (uint32_t)CURRENT_REGS +
-                                                   XCPTCONTEXT_SIZE;
+                  up_current_regs()[REG_A1] = (uint32_t)(up_current_regs()
+                                                         + XCPTCONTEXT_REGS);
 
                   /* Then set up to vector to the trampoline with interrupts
                    * disabled
                    */
 
-                  CURRENT_REGS[REG_PC] = (uint32_t)xtensa_sig_deliver;
+                  up_current_regs()[REG_PC] = (uint32_t)xtensa_sig_deliver;
 #ifdef __XTENSA_CALL0_ABI__
-                  CURRENT_REGS[REG_PS] = (uint32_t)
+                  up_current_regs()[REG_PS] = (uint32_t)
                       (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM);
 #else
-                  CURRENT_REGS[REG_PS] = (uint32_t)
+                  up_current_regs()[REG_PS] = (uint32_t)
                       (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM |
                        PS_WOE | PS_CALLINC(1));
 #endif
 #ifndef CONFIG_BUILD_FLAT
-                  xtensa_raiseprivilege(CURRENT_REGS);
+                  xtensa_raiseprivilege(up_current_regs());
 #endif
                 }
 

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -59,7 +59,7 @@ int xtensa_swint(int irq, void *context, void *arg)
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
-  DEBUGASSERT(regs != NULL && regs == CURRENT_REGS);
+  DEBUGASSERT(regs != NULL && regs == up_current_regs());
 
   cmd = regs[REG_A2];
 
@@ -106,9 +106,9 @@ int xtensa_swint(int irq, void *context, void *arg)
        *   A2 = SYS_restore_context
        *   A3 = restoreregs
        *
-       * In this case, we simply need to set CURRENT_REGS to restore
-       * register area referenced in the saved A3. context == CURRENT_REGS
-       * is the normal exception return.  By setting CURRENT_REGS =
+       * In this case, we simply need to set current_regs to restore
+       * register area referenced in the saved A3. context == current_regs
+       * is the normal exception return.  By setting current_regs =
        * context[A3], we force the return to the saved context referenced
        * in A3.
        */
@@ -116,7 +116,7 @@ int xtensa_swint(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_A3] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_A3];
+          up_set_current_regs((uint32_t *)regs[REG_A3]);
         }
         break;
 
@@ -133,7 +133,7 @@ int xtensa_swint(int irq, void *context, void *arg)
        *
        * In this case, we do both: We save the context registers to the save
        * register area reference by the saved contents of A3 and then set
-       * CURRENT_REGS to the save register area referenced by the saved
+       * current_regs to the save register area referenced by the saved
        * contents of A4.
        */
 
@@ -141,7 +141,7 @@ int xtensa_swint(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A3] != 0 && regs[REG_A4] != 0);
           *(uint32_t **)regs[REG_A3] = regs;
-          CURRENT_REGS = (uint32_t *)regs[REG_A4];
+          up_set_current_regs((uint32_t *)regs[REG_A4]);
         }
         break;
 
@@ -419,9 +419,9 @@ int xtensa_swint(int irq, void *context, void *arg)
         break;
     }
 
-  if ((CURRENT_REGS[REG_PS] & PS_EXCM_MASK) != 0)
+  if ((up_current_regs()[REG_PS] & PS_EXCM_MASK) != 0)
     {
-      CURRENT_REGS[REG_PS] &= ~PS_EXCM_MASK;
+      up_current_regs()[REG_PS] &= ~PS_EXCM_MASK;
     }
 
   /* Report what happened.  That might difficult in the case of a context
@@ -429,10 +429,10 @@ int xtensa_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       svcinfo("SYSCALL Return: Context switch!\n");
-      up_dump_register((void *)CURRENT_REGS);
+      up_dump_register(up_current_regs());
     }
   else
     {
@@ -440,7 +440,7 @@ int xtensa_swint(int irq, void *context, void *arg)
     }
 #endif
 
-  if (regs != CURRENT_REGS)
+  if (regs != up_current_regs())
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/xtensa/src/common/xtensa_switchcontext.c
+++ b/arch/xtensa/src/common/xtensa_switchcontext.c
@@ -63,10 +63,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       /* Yes, then we have to do things differently.
-       * Just copy the CURRENT_REGS into the OLD rtcb.
+       * Just copy the current_regs into the OLD rtcb.
        */
 
       xtensa_savestate(rtcb->xcp.regs);

--- a/arch/z16/include/irq.h
+++ b/arch/z16/include/irq.h
@@ -49,10 +49,6 @@
  * Public Data
  ****************************************************************************/
 
-/****************************************************************************
- * Public Function Prototypes
- ****************************************************************************/
-
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
 #define EXTERN extern "C"
@@ -66,18 +62,12 @@ extern "C"
 
 chipreg_t up_getsp(void);
 
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-#ifndef __ASSEMBLY__
 /* This holds a references to the current interrupt level
  * register storage structure.  It is non-NULL only during
  * interrupt processing.
  */
 
 EXTERN volatile FAR chipreg_t *g_current_regs;
-#endif
 
 /****************************************************************************
  * Public Function Prototypes
@@ -105,6 +95,21 @@ EXTERN volatile FAR chipreg_t *g_current_regs;
  * Inline functions
  ****************************************************************************/
 
+/* This holds a references to the current interrupt level
+ * register storage structure.  If is non-NULL only during
+ * interrupt processing.
+ */
+
+static inline_function chipreg_t *up_current_regs(void)
+{
+  return (FAR chipreg_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(FAR chipreg_t *regs)
+{
+  g_current_regs = regs;
+}
+
 /****************************************************************************
  * Name: up_interrupt_context
  *
@@ -114,7 +119,7 @@ EXTERN volatile FAR chipreg_t *g_current_regs;
  *
  ****************************************************************************/
 
-#define up_interrupt_context() (g_current_regs != NULL)
+#define up_interrupt_context() (up_current_regs() != NULL)
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/z16/src/common/z16_doirq.c
+++ b/arch/z16/src/common/z16_doirq.c
@@ -74,8 +74,8 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
        * interrupt level context switches.
        */
 
-      savestate    = (FAR chipreg_t *)g_current_regs;
-      g_current_regs = regs;
+      savestate = up_current_regs();
+      up_set_current_regs(regs);
 
       /* Acknowledge the interrupt */
 
@@ -85,7 +85,7 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
 
       irq_dispatch(irq, regs);
 
-      if (regs != g_current_regs)
+      if (regs != up_current_regs())
         {
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
@@ -100,8 +100,8 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
        * if we are returning from a nested interrupt.
        */
 
-      ret          = g_current_regs;
-      g_current_regs = savestate;
+      ret = up_current_regs();
+      up_set_current_regs(savestate);
     }
 
   board_autoled_off(LED_INIRQ);

--- a/arch/z16/src/common/z16_internal.h
+++ b/arch/z16/src/common/z16_internal.h
@@ -84,9 +84,9 @@
 
 /* Macros for portability */
 
-#define IN_INTERRUPT             (g_current_regs != NULL)
-#define SAVE_IRQCONTEXT(tcb)     z16_copystate((tcb)->xcp.regs, (FAR chipreg_t*)g_current_regs)
-#define SET_IRQCONTEXT(tcb)      do { g_current_regs = (tcb)->xcp.regs; } while (0)
+#define IN_INTERRUPT             (up_current_regs() != NULL)
+#define SAVE_IRQCONTEXT(tcb)     z16_copystate((tcb)->xcp.regs, up_current_regs())
+#define SET_IRQCONTEXT(tcb)      up_set_current_regs((tcb)->xcp.regs)
 #define SAVE_USERCONTEXT(tcb)    up_saveusercontext((tcb)->xcp.regs)
 #define RESTORE_USERCONTEXT(tcb) z16_restoreusercontext((tcb)->xcp.regs)
 #define SIGNAL_RETURN(regs)      z16_restoreusercontext(regs)

--- a/arch/z16/src/common/z16_registerdump.c
+++ b/arch/z16/src/common/z16_registerdump.c
@@ -50,7 +50,7 @@ uintptr_t up_getusrsp(FAR void *regs)
 void up_dump_register(FAR void *dumpregs)
 {
 #ifdef CONFIG_DEBUG_INFO
-  FAR volatile uint32_t *regs = dumpregs ? dumpregs : g_current_regs;
+  FAR volatile uint32_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert("R0 :%08x R1 :%08x R2 :%08x R3 :%08x "
          "R4 :%08x R5 :%08x R6 :%08x R7 :%08x\n"

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -88,7 +88,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
 
       if (tcb == this_task())
         {
@@ -96,7 +96,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * a task is signalling itself for some reason.
            */
 
-          if (!g_current_regs)
+          if (!up_current_regs())
             {
               /* In this case just deliver the signal now. */
 
@@ -113,28 +113,28 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
           else
             {
               FAR uint32_t *current_pc  =
-                (FAR uint32_t *)&g_current_regs[REG_PC];
+                (FAR uint32_t *)&up_current_regs()[REG_PC];
 
               /* Save the return address and interrupt state. These will be
                * restored by the signal trampoline after the signals have
                * been delivered.
                */
 
-              tcb->xcp.saved_pc         = *current_pc;
-              tcb->xcp.saved_i          = g_current_regs[REG_FLAGS];
+              tcb->xcp.saved_pc = *current_pc;
+              tcb->xcp.saved_i  = up_current_regs()[REG_FLAGS];
 
               /* Then set up to vector to the trampoline with interrupts
                * disabled
                */
 
-              *current_pc               = (uint32_t)z16_sigdeliver;
-              g_current_regs[REG_FLAGS] = 0;
+              *current_pc = (uint32_t)z16_sigdeliver;
+              up_current_regs()[REG_FLAGS] = 0;
 
               /* And make sure that the saved context in the TCB is the
                * same as the interrupt return context.
                */
 
-              z16_copystate(tcb->xcp.regs, g_current_regs);
+              z16_copystate(tcb->xcp.regs, up_current_regs());
             }
         }
 

--- a/arch/z16/src/z16f/z16f_sysexec.c
+++ b/arch/z16/src/z16f/z16f_sysexec.c
@@ -53,7 +53,7 @@ void z16f_sysexec(FAR chipreg_t *regs)
    * diagnostics.
    */
 
-  g_current_regs = regs;
+  up_set_current_regs(regs);
 
   /* The cause of the system exception is indicated in the SYSEXCPH&L
    * registers

--- a/arch/z80/src/ez80/ez80_registerdump.c
+++ b/arch/z80/src/ez80/ez80_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(FAR void *regs)
 
 void up_dump_register(FAR void *dumpregs)
 {
-  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : g_current_regs;
+  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : up_current_regs();
 
 #ifdef CONFIG_EZ80_Z80MODE
   _alert("AF: %04x  I: %04x\n",

--- a/arch/z80/src/z180/z180_registerdump.c
+++ b/arch/z80/src/z180/z180_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(FAR void *regs)
 
 void up_dump_register(FAR void *dumpregs)
 {
-  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : g_current_regs;
+  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert("AF: %04x  I: %04x\n",
          regs[XCPT_AF], regs[XCPT_I]);

--- a/arch/z80/src/z80/switch.h
+++ b/arch/z80/src/z80/switch.h
@@ -42,14 +42,14 @@
 
 /* Initialize the IRQ state */
 
-#define INIT_IRQCONTEXT()        g_current_regs = NULL
+#define INIT_IRQCONTEXT()        up_set_current_regs(NULL)
 
 /* IN_INTERRUPT returns true if the system is currently operating in the
  * interrupt context.
  * IN_INTERRUPT is the inline equivalent of up_interrupt_context().
  */
 
-#define IN_INTERRUPT()           (g_current_regs != NULL)
+#define IN_INTERRUPT()           (up_current_regs() != NULL)
 
 /* The following macro is used when the system enters interrupt
  * handling logic
@@ -66,30 +66,32 @@
   FAR chipreg_t *savestate
 
 #define IRQ_ENTER(irq, regs) \
-  do { \
-    savestate    = (FAR chipreg_t *)g_current_regs; \
-    g_current_regs = (regs); \
-  } while (0)
+  do \
+    { \
+      savestate = up_current_regs(); \
+      up_set_current_regs(regs); \
+    } \
+  while (0)
 
 /* The following macro is used when the system exits
  * interrupt handling logic
  */
 
-#define IRQ_LEAVE(irq)           g_current_regs = savestate
+#define IRQ_LEAVE(irq)           up_set_current_regs(savestate)
 
 /* The following macro is used to sample the interrupt state
  * (as a opaque handle)
  */
 
-#define IRQ_STATE()              (g_current_regs)
+#define IRQ_STATE()              up_current_regs()
 
 /* Save the current IRQ context in the specified TCB */
 
-#define SAVE_IRQCONTEXT(tcb)     z80_copystate((tcb)->xcp.regs, (FAR chipreg_t*)g_current_regs)
+#define SAVE_IRQCONTEXT(tcb)     z80_copystate((tcb)->xcp.regs, up_current_regs())
 
 /* Set the current IRQ context to the state specified in the TCB */
 
-#define SET_IRQCONTEXT(tcb)      z80_copystate((FAR chipreg_t*)g_current_regs, (tcb)->xcp.regs)
+#define SET_IRQCONTEXT(tcb)      z80_copystate(up_current_regs(), (tcb)->xcp.regs)
 
 /* Save the user context in the specified TCB.  User context saves
  * can be simpler because only those registers normally saved in a C called
@@ -141,6 +143,20 @@ int up_saveusercontext(FAR chipreg_t *regs);
 /* Defined in z80_restoreusercontext.asm */
 
 void z80_restoreusercontext(FAR chipreg_t *regs);
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline_function chipreg_t *up_current_regs(void)
+{
+  return (FAR chipreg_t *)g_current_regs;
+}
+
+static inline_function void up_set_current_regs(FAR chipreg_t *regs)
+{
+  g_current_regs = regs;
+}
 
 #ifdef __cplusplus
 }

--- a/arch/z80/src/z80/z80_registerdump.c
+++ b/arch/z80/src/z80/z80_registerdump.c
@@ -52,7 +52,7 @@ uintptr_t up_getusrsp(FAR void *regs)
 
 void up_dump_register(FAR void *dumpregs)
 {
-  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : g_current_regs;
+  FAR volatile chipreg_t *regs = dumpregs ? dumpregs : up_current_regs();
 
   _alert("AF: %04x  I: %04x\n",
          regs[XCPT_AF], regs[XCPT_I]);

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -269,7 +269,7 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
     {
       if (up_interrupt_context())
         {
-          regs = (FAR uintptr_t *)CURRENT_REGS;
+          regs = (FAR uintptr_t *)up_current_regs();
         }
       else
         {

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -145,7 +145,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * fault.
    */
 
-  pdump->info.current_regs = (uintptr_t)CURRENT_REGS;
+  pdump->info.current_regs = (uintptr_t)up_current_regs();
 
   /* Save Context */
 
@@ -160,14 +160,14 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * the users context
    */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
 #endif
-      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT | \
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
-      memcpy(pdump->info.regs, (void *)CURRENT_REGS,
+      memcpy(pdump->info.regs, up_current_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];
     }

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -416,7 +416,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * fault.
    */
 
-  pdump->info.current_regs = (uintptr_t) CURRENT_REGS;
+  pdump->info.current_regs = (uintptr_t)up_current_regs();
 
   /* Save Context */
 
@@ -431,12 +431,12 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * the users context
    */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       pdump->info.stacks.interrupt.sp = sp;
-      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT | \
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
-      memcpy(pdump->info.regs, (void *)CURRENT_REGS,
+      memcpy(pdump->info.regs, up_current_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];
     }

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -416,7 +416,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * fault.
    */
 
-  pdump->info.current_regs = (uintptr_t) CURRENT_REGS;
+  pdump->info.current_regs = (uintptr_t)up_current_regs();
 
   /* Save Context */
 
@@ -431,12 +431,12 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * the users context
    */
 
-  if (CURRENT_REGS)
+  if (up_current_regs())
     {
       pdump->info.stacks.interrupt.sp = sp;
-      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT | \
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
-      memcpy(pdump->info.regs, (void *)CURRENT_REGS,
+      memcpy(pdump->info.regs, up_current_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];
     }

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -370,7 +370,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * fault.
    */
 
-  pdump->info.current_regs = (uintptr_t) g_current_regs;
+  pdump->info.current_regs = (uintptr_t)up_current_regs();
 
   /* Save Context */
 
@@ -385,12 +385,12 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * the users context
    */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       pdump->info.stacks.interrupt.sp = sp;
-      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT | \
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
-      memcpy((uint8_t *)pdump->info.regs, (void *)g_current_regs,
+      memcpy((uint8_t *)pdump->info.regs, up_current_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_SP];
     }

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -368,7 +368,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * fault.
    */
 
-  pdump->info.current_regs = (uintptr_t) g_current_regs;
+  pdump->info.current_regs = (uintptr_t)up_current_regs();
 
   /* Save Context */
 
@@ -383,12 +383,12 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
    * the users context
    */
 
-  if (g_current_regs)
+  if (up_current_regs())
     {
       pdump->info.stacks.interrupt.sp = sp;
-      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT | \
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
-      memcpy((uint8_t *)pdump->info.regs, (void *)g_current_regs,
+      memcpy((uint8_t *)pdump->info.regs, up_current_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_SP];
     }

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -880,7 +880,7 @@ static void gdb_get_registers(FAR struct gdb_state_s *state)
     {
       if (up_interrupt_context())
         {
-          reg = (FAR uint8_t *)CURRENT_REGS;
+          reg = (FAR uint8_t *)up_current_regs();
         }
       else
         {

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -268,7 +268,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
 #endif
                  );
 
-      tcbstack_sp = up_getusrsp((FAR void *)CURRENT_REGS);
+      tcbstack_sp = up_getusrsp((FAR void *)up_current_regs());
       if (tcbstack_sp < tcbstack_base || tcbstack_sp >= tcbstack_top)
         {
           tcbstack_sp = 0;


### PR DESCRIPTION

## Summary
reason:
1 On different architectures, we can utilize more optimized strategies
  to implement up_current_regs/up_set_current_regs.
eg. use interrupt registers or percpu registers.

code size
before
    text    data     bss     dec     hex filename
 262848   49985   63893  376726   5bf96 nuttx

after
       text    data     bss     dec     hex filename
 262844   49985   63893  376722   5bf92 nuttx

size change -4

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx

## Impact
none 

## Testing
ostest

