### PR TITLE
arch/x86_64/intel64: fix compilation errors in intel64_oneshot_lower.c

### DIFF
--- a/arch/x86_64/src/intel64/intel64_oneshot_lower.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot_lower.c
@@ -347,7 +347,7 @@ static int intel64_tick_max_delay(struct oneshot_lowerhalf_s *lower,
 
   /* Convert time to ticks */
 
-  clock_time2ticks(&ts, (sclock_t *)ticks);
+  *ticks = clock_time2ticks(&ts);
 
   return ret;
 }
@@ -380,7 +380,7 @@ static int intel64_tick_start(struct oneshot_lowerhalf_s *lower,
 
   /* Convert ticks to time */
 
-  clock_ticks2time(ticks, &ts);
+  clock_ticks2time(&ts, ticks);
 
   return intel64_start(lower, callback, arg, &ts);
 }
@@ -418,7 +418,7 @@ static int intel64_tick_cancel(struct oneshot_lowerhalf_s *lower,
 
   /* Convert time to ticks */
 
-  clock_time2ticks(&ts, (sclock_t *)ticks);
+  *ticks = clock_time2ticks(&ts);
 
   return ret;
 }
@@ -451,7 +451,7 @@ static int intel64_tick_current(struct oneshot_lowerhalf_s *lower,
 
   /* Convert time to ticks */
 
-  clock_time2ticks(&ts, (sclock_t *)ticks);
+  *ticks = clock_time2ticks(&ts);
 
   return ret;
 }


### PR DESCRIPTION
## Summary
arch/x86_64/intel64: fix compilation errors in intel64_oneshot_lower.c
clock_time2ticks and clock_ticks2time macros changes but this file was not update

## Impact

## Testing
local compilation with HPET enabled
