### PR TITLE
arch/arm64/src/imx9/imx9_lpi2c.c: Ignore spurious RX interrupts

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -1576,7 +1576,7 @@ static int imx9_lpi2c_isr_process(struct imx9_lpi2c_priv_s *priv)
 
   /* Check if there are received bytes */
 
-  else if ((status & LPI2C_MSR_RDF) != 0)
+  else if ((status & LPI2C_MSR_RDF) != 0 && priv->dcnt > 0)
     {
       imx9_lpi2c_traceevent(priv, I2CEVENT_RCVBYTE, priv->dcnt);
 


### PR DESCRIPTION
Check remaining data count, just in case an extra RX interrupt occurs after receiving a message

## Summary

This was left out of previous imx9 i2c fixes. It is better to always check the data counter before writing to receive buffer. A spurious interrupt after a receive would cause memory corruption.

## Impact

Imx9 I2C only

## Testing

Tested on a custom IMX93 board
