### PR TITLE
arm64_task/pthread_start: Convert the C / inline ASM code to assembly

### DIFF
--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -270,6 +270,8 @@ EXTERN uint8_t g_idle_topstack[];   /* End+1 of heap */
  ****************************************************************************/
 
 void arm64_new_task(struct tcb_s *tak_new);
+void arm64_jump_to_user(uint64_t entry, uint64_t x0, uint64_t x1,
+                        uint64_t *regs) noreturn_function;
 
 /* Low level initialization provided by chip logic */
 

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -175,6 +175,36 @@ restore_new:
     ret
 
 /****************************************************************************
+ * Function: arm64_jump_to_user
+ *
+ * Description:
+ *  Routine to jump to user space, called when a user process is started and
+ *  the kernel is ready to give control to the user task in user space.
+ *
+ * arm64_jump_to_user(entry, x0, x1, regs)
+ *     entry: process entry point
+ *     x0:    parameter 0 for process
+ *     x1:    parameter 1 for process
+ *     regs:  integer register save area to use
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_BUILD_FLAT
+GTEXT(arm64_jump_to_user)
+SECTION_FUNC(text, arm64_jump_to_user)
+    msr daifset, #IRQ_DAIF_MASK
+    mov sp,  x3
+    str x0,  [sp, #8 * REG_ELR]
+    str x1,  [sp, #8 * REG_X0]
+    str x2,  [sp, #8 * REG_X1]
+    mrs x0,  spsr_el1
+    and x0,  x0, #~SPSR_MODE_MASK
+    #orr x0, x0, #SPSR_MODE_EL0T # EL0T=0x00, out of range for orr
+    str x0,  [sp, #8 * REG_SPSR]
+    b arm64_exit_exception
+#endif
+
+/****************************************************************************
  * Function: arm64_sync_exc
  *
  * Description:


### PR DESCRIPTION

## Summary
The aforementioned functions can/will fail if the C compiler decides to use the stack for the incoming entrypt/etc. parameters.

Fix this issue by converting the jump to user part into pure assembly, ensuring the stack is NOT used for the parameters.

## Impact
Fix system crash when user process enters userspace
## Testing
QEMU + IMX9 with kernel mode
