### PR TITLE
Rpmsg VirtIO Transport support and releated patches

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -249,6 +249,10 @@ ifeq ($(CONFIG_SIM_LIBUSB),y)
 endif
 endif
 
+ifeq ($(CONFIG_RPMSG_VIRTIO),y)
+  CSRCS += sim_rpmsg_virtio.c
+endif
+
 ifeq ($(CONFIG_RPTUN),y)
   CSRCS += sim_rptun.c
 endif

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -117,6 +117,10 @@ if(CONFIG_LIBM_TOOLCHAIN)
   list(APPEND STDLIBS m)
 endif()
 
+if(CONFIG_RPMSG_VIRTIO)
+  list(APPEND SRCS sim_rpmsg_vritio.c)
+endif()
+
 if(CONFIG_RPTUN)
   list(APPEND SRCS sim_rptun.c)
 endif()

--- a/arch/sim/src/sim/posix/sim_hostmemory.c
+++ b/arch/sim/src/sim/posix/sim_hostmemory.c
@@ -92,30 +92,18 @@ void host_freeheap(void *mem)
   host_uninterruptible(munmap, mem, 0);
 }
 
-void *host_allocshmem(const char *name, size_t size, int master)
+void *host_allocshmem(const char *name, size_t size)
 {
   void *mem;
   int oflag;
   int ret;
   int fd;
 
-  oflag = O_RDWR;
-  if (master)
-    {
-      oflag |= O_CREAT | O_TRUNC;
-    }
-
+  oflag = O_RDWR | O_CREAT;
   fd = host_uninterruptible(shm_open, name, oflag, S_IRUSR | S_IWUSR);
   if (fd < 0)
     {
       return NULL;
-    }
-
-  if (!master)
-    {
-      /* Avoid the second slave instance open successfully */
-
-      host_unlinkshmem(name);
     }
 
   ret = host_uninterruptible(ftruncate, fd, size);

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -224,7 +224,7 @@ int   host_waitpid(pid_t pid);
 
 void *host_allocheap(size_t size, bool exec);
 void  host_freeheap(void *mem);
-void *host_allocshmem(const char *name, size_t size, int master);
+void *host_allocshmem(const char *name, size_t size);
 void  host_freeshmem(void *mem);
 
 size_t host_mallocsize(void *mem);

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -409,6 +409,13 @@ void sim_netdriver_loop(void);
 int sim_rptun_init(const char *shmemname, const char *cpuname, int master);
 #endif
 
+/* sim_rpmsg_virtio.c *******************************************************/
+
+#ifdef CONFIG_RPMSG_VIRTIO
+int sim_rpmsg_virtio_init(const char *shmemname, const char *cpuname,
+                          bool master);
+#endif
+
 /* sim_hcisocket.c **********************************************************/
 
 #ifdef CONFIG_SIM_HCISOCKET

--- a/arch/sim/src/sim/sim_rpmsg_virtio.c
+++ b/arch/sim/src/sim/sim_rpmsg_virtio.c
@@ -63,7 +63,7 @@ struct sim_rpmsg_virtio_dev_s
   int                             master;
   uint32_t                        seq;
   struct sim_rpmsg_virtio_shmem_s *shmem;
-  struct simple_addrenv_s         addrenv;
+  struct simple_addrenv_s         addrenv[2];
   char                            cpuname[RPMSG_NAME_SIZE + 1];
   char                            shmemname[RPMSG_NAME_SIZE + 1];
 
@@ -127,11 +127,11 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
-      priv->addrenv.va   = (uintptr_t)priv->shmem;
-      priv->addrenv.pa   = priv->shmem->base;
-      priv->addrenv.size = sizeof(*priv->shmem);
+      priv->addrenv[0].va   = (uintptr_t)priv->shmem;
+      priv->addrenv[0].pa   = priv->shmem->base;
+      priv->addrenv[0].size = sizeof(*priv->shmem);
 
-      simple_addrenv_initialize(&priv->addrenv);
+      simple_addrenv_initialize(&priv->addrenv[0]);
     }
 
   return rsc;

--- a/arch/sim/src/sim/sim_rpmsg_virtio.c
+++ b/arch/sim/src/sim/sim_rpmsg_virtio.c
@@ -1,0 +1,250 @@
+/****************************************************************************
+ * arch/sim/src/sim/sim_rpmsg_virtio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+#include <nuttx/drivers/addrenv.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/rpmsg/rpmsg_virtio.h>
+#include <nuttx/wqueue.h>
+
+#include "sim_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SIM_RPMSG_VIRTIO_WORK_DELAY   1
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct sim_rpmsg_virtio_shmem_s
+{
+  volatile uintptr_t        base;
+  volatile unsigned int     seqs;
+  volatile unsigned int     seqm;
+  volatile unsigned int     cmds;
+  volatile unsigned int     cmdm;
+  volatile unsigned int     boots;
+  volatile unsigned int     bootm;
+  struct rpmsg_virtio_rsc_s rsc;
+  char                      buf[0x10000];
+};
+
+struct sim_rpmsg_virtio_dev_s
+{
+  struct rpmsg_virtio_s           dev;
+  rpmsg_virtio_callback_t         callback;
+  void                            *arg;
+  int                             master;
+  uint32_t                        seq;
+  struct sim_rpmsg_virtio_shmem_s *shmem;
+  struct simple_addrenv_s         addrenv;
+  char                            cpuname[RPMSG_NAME_SIZE + 1];
+  char                            shmemname[RPMSG_NAME_SIZE + 1];
+
+  /* Work queue for transmit */
+
+  struct work_s                    worker;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static const char *sim_rpmsg_virtio_get_cpuname(struct rpmsg_virtio_s *dev)
+{
+  struct sim_rpmsg_virtio_dev_s *priv =
+    container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
+
+  return priv->cpuname;
+}
+
+static struct rpmsg_virtio_rsc_s *
+sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
+{
+  struct sim_rpmsg_virtio_dev_s *priv =
+    container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
+  struct rpmsg_virtio_rsc_s *rsc;
+
+  priv->shmem = host_allocshmem(priv->shmemname, sizeof(*priv->shmem));
+  if (!priv->shmem)
+    {
+      return NULL;
+    }
+
+  rsc = &priv->shmem->rsc;
+
+  if (priv->master)
+    {
+      memset(priv->shmem, 0, sizeof(*priv->shmem));
+      rsc->rpmsg_vdev.id            = VIRTIO_ID_RPMSG;
+      rsc->rpmsg_vdev.dfeatures     = 1 << VIRTIO_RPMSG_F_NS |
+                                      1 << VIRTIO_RPMSG_F_ACK;
+      rsc->rpmsg_vdev.config_len    = sizeof(struct fw_rsc_config);
+      rsc->rpmsg_vdev.num_of_vrings = 2;
+      rsc->rpmsg_vring0.da          = 0;
+      rsc->rpmsg_vring0.align       = 8;
+      rsc->rpmsg_vring0.num         = 8;
+      rsc->rpmsg_vring1.da          = 0;
+      rsc->rpmsg_vring1.align       = 8;
+      rsc->rpmsg_vring1.num         = 8;
+      rsc->config.r2h_buf_size      = 2048;
+      rsc->config.h2r_buf_size      = 2048;
+
+      priv->shmem->base = (uintptr_t)priv->shmem;
+    }
+  else
+    {
+      /* Wait untils master is ready */
+
+      while (priv->shmem->base == 0)
+        {
+          usleep(1000);
+        }
+
+      priv->addrenv.va   = (uintptr_t)priv->shmem;
+      priv->addrenv.pa   = priv->shmem->base;
+      priv->addrenv.size = sizeof(*priv->shmem);
+
+      simple_addrenv_initialize(&priv->addrenv);
+    }
+
+  return rsc;
+}
+
+static int sim_rpmsg_virtio_is_master(struct rpmsg_virtio_s *dev)
+{
+  struct sim_rpmsg_virtio_dev_s *priv =
+    container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
+
+  return priv->master;
+}
+
+static int
+sim_rpmsg_virtio_register_callback(struct rpmsg_virtio_s *dev,
+                                   rpmsg_virtio_callback_t callback,
+                                   void *arg)
+{
+  struct sim_rpmsg_virtio_dev_s *priv =
+    container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
+
+  priv->callback = callback;
+  priv->arg      = arg;
+
+  return 0;
+}
+
+static void sim_rpmsg_virtio_work(void *arg)
+{
+  struct sim_rpmsg_virtio_dev_s *dev = arg;
+
+  if (dev->shmem != NULL)
+    {
+      bool should_notify = false;
+
+      if (dev->master && dev->seq != dev->shmem->seqs)
+        {
+          dev->seq = dev->shmem->seqs;
+          should_notify = true;
+        }
+      else if (!dev->master && dev->seq != dev->shmem->seqm)
+        {
+          dev->seq = dev->shmem->seqm;
+          should_notify = true;
+        }
+
+      if (should_notify && dev->callback != NULL)
+        {
+          dev->callback(dev->arg, RPMSG_VIRTIO_NOTIFY_ALL);
+        }
+    }
+
+  work_queue(HPWORK, &dev->worker, sim_rpmsg_virtio_work,
+             dev, SIM_RPMSG_VIRTIO_WORK_DELAY);
+}
+
+static int sim_rpmsg_virtio_notify(struct rpmsg_virtio_s *dev, uint32_t vqid)
+{
+  struct sim_rpmsg_virtio_dev_s *priv =
+    container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
+
+  if (priv->master)
+    {
+      priv->shmem->seqm++;
+    }
+  else
+    {
+      priv->shmem->seqs++;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_virtio_ops_s g_sim_rpmsg_virtio_ops =
+{
+  .get_cpuname       = sim_rpmsg_virtio_get_cpuname,
+  .get_resource      = sim_rpmsg_virtio_get_resource,
+  .is_master         = sim_rpmsg_virtio_is_master,
+  .notify            = sim_rpmsg_virtio_notify,
+  .register_callback = sim_rpmsg_virtio_register_callback,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int sim_rpmsg_virtio_init(const char *shmemname, const char *cpuname,
+                          bool master)
+{
+  struct sim_rpmsg_virtio_dev_s *priv;
+  int ret;
+
+  priv = kmm_zalloc(sizeof(*priv));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  priv->master = master;
+  priv->dev.ops = &g_sim_rpmsg_virtio_ops;
+  strlcpy(priv->cpuname, cpuname, RPMSG_NAME_SIZE);
+  strlcpy(priv->shmemname, shmemname, RPMSG_NAME_SIZE);
+
+  ret = rpmsg_virtio_initialize(&priv->dev);
+  if (ret < 0)
+    {
+      kmm_free(priv);
+      return ret;
+    }
+
+  return work_queue(HPWORK, &priv->worker, sim_rpmsg_virtio_work, priv, 0);
+}

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -40,6 +40,12 @@
 #define SIM_RPTUN_SHIFT     16
 #define SIM_RPTUN_WORK_DELAY 1
 
+/* Status byte for master/slave to report progress */
+
+#define SIM_RPTUN_STATUS_BOOT        0x01
+#define SIM_RPTUN_STATUS_OK          0x02
+#define SIM_RPTUN_STATUS_NEED_RESET  0x04
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -51,6 +57,8 @@ struct sim_rptun_shmem_s
   volatile unsigned int     seqm;
   volatile unsigned int     cmds;
   volatile unsigned int     cmdm;
+  volatile unsigned int     boots;
+  volatile unsigned int     bootm;
   struct rptun_rsc_s        rsc;
   char                      buf[0x10000];
 };
@@ -91,24 +99,14 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
   struct sim_rptun_dev_s *priv = container_of(dev,
                                  struct sim_rptun_dev_s, rptun);
 
-  if (priv->shmem)
-    {
-      return &priv->shmem->rsc;
-    }
-
-  while (priv->shmem == NULL)
-    {
-      priv->shmem = host_allocshmem(priv->shmemname,
-                                    sizeof(*priv->shmem),
-                                    priv->master);
-      usleep(1000);
-
-      /* Master isn't ready, sleep and try again */
-    }
+  priv->shmem = host_allocshmem(priv->shmemname,
+                                sizeof(*priv->shmem));
 
   if (priv->master)
     {
       struct rptun_rsc_s *rsc = &priv->shmem->rsc;
+      memset(priv->shmem->buf, 0, sizeof(priv->shmem->buf));
+      memset(rsc, 0, sizeof(struct rptun_rsc_s));
 
       rsc->rsc_tbl_hdr.ver          = 1;
       rsc->rsc_tbl_hdr.num          = 1;
@@ -121,9 +119,11 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
                                     | 1 << VIRTIO_RPMSG_F_BUFSZ;
       rsc->rpmsg_vdev.config_len    = sizeof(struct fw_rsc_config);
       rsc->rpmsg_vdev.num_of_vrings = 2;
+      rsc->rpmsg_vring0.da          = 0;
       rsc->rpmsg_vring0.align       = 8;
       rsc->rpmsg_vring0.num         = 8;
       rsc->rpmsg_vring0.notifyid    = RSC_NOTIFY_ID_ANY;
+      rsc->rpmsg_vring1.da          = 0;
       rsc->rpmsg_vring1.align       = 8;
       rsc->rpmsg_vring1.num         = 8;
       rsc->rpmsg_vring1.notifyid    = RSC_NOTIFY_ID_ANY;
@@ -131,15 +131,35 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
       rsc->config.h2r_buf_size      = 0x800;
 
       priv->shmem->base             = (uintptr_t)priv->shmem;
+
+      /* The master notifies its slave when it starts again */
+
+      if (priv->shmem->boots & SIM_RPTUN_STATUS_OK)
+        {
+          priv->shmem->boots = SIM_RPTUN_STATUS_NEED_RESET;
+        }
+
+      priv->shmem->bootm = SIM_RPTUN_STATUS_BOOT;
     }
   else
     {
+      /* The slave notifies its master when it starts again */
+
+      if (priv->shmem->boots & SIM_RPTUN_STATUS_OK)
+        {
+          priv->shmem->bootm = SIM_RPTUN_STATUS_NEED_RESET;
+        }
+
+      priv->shmem->boots = SIM_RPTUN_STATUS_BOOT;
+
       /* Wait untils master is ready */
 
-      while (priv->shmem->base == 0)
+      while (!(priv->shmem->bootm & SIM_RPTUN_STATUS_OK))
         {
           usleep(1000);
         }
+
+      priv->shmem->boots = SIM_RPTUN_STATUS_OK;
 
       priv->addrenv[0].va          = (uintptr_t)priv->shmem;
       priv->addrenv[0].pa          = priv->shmem->base;
@@ -180,6 +200,14 @@ static int sim_rptun_start(struct rptun_dev_s *dev)
       priv->pid = pid;
     }
 
+  /* Wait until slave has started */
+
+  while (!(priv->shmem->boots & SIM_RPTUN_STATUS_BOOT))
+    {
+      usleep(1000);
+    }
+
+  priv->shmem->bootm = SIM_RPTUN_STATUS_OK;
   return 0;
 }
 
@@ -188,13 +216,21 @@ static int sim_rptun_stop(struct rptun_dev_s *dev)
   struct sim_rptun_dev_s *priv = container_of(dev,
                               struct sim_rptun_dev_s, rptun);
 
-  if ((priv->master & SIM_RPTUN_BOOT) && (priv->pid > 0))
+  /* Don't send SIM_RPTUN_STOP when slave recovery */
+
+  if (priv->shmem->boots & SIM_RPTUN_STATUS_OK)
     {
       priv->shmem->cmdm = SIM_RPTUN_STOP << SIM_RPTUN_SHIFT;
+    }
+
+  if ((priv->master & SIM_RPTUN_BOOT) && priv->pid > 0)
+    {
       host_waitpid(priv->pid);
     }
 
-  if (priv->shmem)
+  /* Master cleans shmem when both sides are about to exit */
+
+  if (priv->shmem && (priv->shmem->boots & SIM_RPTUN_STATUS_OK))
     {
       host_freeshmem(priv->shmem);
       priv->shmem = NULL;
@@ -267,6 +303,22 @@ static void sim_rptun_check_cmd(struct sim_rptun_dev_s *priv)
     }
 }
 
+static void sim_rptun_check_reset(struct sim_rptun_dev_s *priv)
+{
+  if (priv->master &&
+      (priv->shmem->bootm & SIM_RPTUN_STATUS_NEED_RESET))
+    {
+      priv->shmem->bootm = 0;
+      rptun_boot(priv->cpuname);
+    }
+  else if (!priv->master &&
+           (priv->shmem->boots & SIM_RPTUN_STATUS_NEED_RESET))
+    {
+      priv->shmem->boots = 0;
+      rptun_boot(priv->cpuname);
+    }
+}
+
 static void sim_rptun_work(void *arg)
 {
   struct sim_rptun_dev_s *dev = arg;
@@ -276,6 +328,10 @@ static void sim_rptun_work(void *arg)
       bool should_notify = false;
 
       sim_rptun_check_cmd(dev);
+
+      /* Check if master/slave need to reset */
+
+      sim_rptun_check_reset(dev);
 
       if (dev->master && dev->seq != dev->shmem->seqs)
         {

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -170,7 +170,7 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
       priv->addrenv[0].pa          = priv->shmem->base;
       priv->addrenv[0].size        = sizeof(*priv->shmem);
 
-      simple_addrenv_initialize(priv->addrenv);
+      simple_addrenv_initialize(&priv->addrenv[0]);
     }
 
   return &priv->shmem->rsc;

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -102,6 +102,11 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
   priv->shmem = host_allocshmem(priv->shmemname,
                                 sizeof(*priv->shmem));
 
+  if (!priv->shmem)
+    {
+      return NULL;
+    }
+
   if (priv->master)
     {
       struct rptun_rsc_s *rsc = &priv->shmem->rsc;

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -52,13 +52,13 @@
 
 struct sim_rptun_shmem_s
 {
-  volatile uintptr_t        base;
-  volatile unsigned int     seqs;
-  volatile unsigned int     seqm;
-  volatile unsigned int     cmds;
-  volatile unsigned int     cmdm;
-  volatile unsigned int     boots;
-  volatile unsigned int     bootm;
+  volatile uint64_t         base;
+  volatile uint32_t         seqs;
+  volatile uint32_t         seqm;
+  volatile uint32_t         cmds;
+  volatile uint32_t         cmdm;
+  volatile uint32_t         boots;
+  volatile uint32_t         bootm;
   struct rptun_rsc_s        rsc;
   char                      buf[0x10000];
 };
@@ -69,7 +69,7 @@ struct sim_rptun_dev_s
   rptun_callback_t          callback;
   void                     *arg;
   int                       master;
-  unsigned int              seq;
+  uint32_t                  seq;
   struct sim_rptun_shmem_s *shmem;
   struct simple_addrenv_s   addrenv[2];
   char                      cpuname[RPMSG_NAME_SIZE + 1];

--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -675,7 +675,7 @@ static int sim_uartram_register(const char *devname, bool slave)
   struct uart_rambuf_s *shmem;
 
   strlcpy(name, strrchr(devname, '/') + 1, NAME_MAX);
-  shmem = host_allocshmem(name, sizeof(struct uart_rambuf_s) * 2, !slave);
+  shmem = host_allocshmem(name, sizeof(struct uart_rambuf_s) * 2);
   DEBUGASSERT(shmem);
 
   memset(shmem, 0, sizeof(struct uart_rambuf_s) * 2);

--- a/arch/sim/src/sim/win/sim_hostmemory.c
+++ b/arch/sim/src/sim/win/sim_hostmemory.c
@@ -56,7 +56,7 @@ void host_freeheap(void *mem)
   _aligned_free(mem);
 }
 
-void *host_allocshmem(const char *name, size_t size, int master)
+void *host_allocshmem(const char *name, size_t size)
 {
   HANDLE handle;
   void *mem;

--- a/drivers/pci/pci_drivers.c
+++ b/drivers/pci/pci_drivers.c
@@ -28,6 +28,7 @@
 #include <nuttx/pci/pci_qemu_edu.h>
 #include <nuttx/pci/pci_qemu_test.h>
 #include <nuttx/rptun/rptun_ivshmem.h>
+#include <nuttx/rpmsg/rpmsg_virtio_ivshmem.h>
 
 #include "pci_drivers.h"
 
@@ -63,6 +64,25 @@ int pci_register_drivers(void)
     }
 #endif
 
+  /* Initialization rptun ivshmem driver */
+
+#ifdef CONFIG_RPTUN_IVSHMEM
+  ret = pci_register_rptun_ivshmem_driver();
+  if (ret < 0)
+    {
+      pcierr("pci_register_rptun_ivshmem_driver failed, ret=%d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_RPMSG_VIRTIO_IVSHMEM
+  ret = pci_register_rpmsg_virtio_ivshmem_driver();
+  if (ret < 0)
+    {
+      pcierr("pci_register_rpmsg_virtio_ivshmem_driver failed, ret=%d\n",
+             ret);
+    }
+#endif
+
   /* Initialization pci qemu test driver */
 
 #ifdef CONFIG_PCI_QEMU_TEST
@@ -80,16 +100,6 @@ int pci_register_drivers(void)
   if (ret < 0)
     {
       pcierr("pci_register_qemu_edu_driver failed, ret=%d\n", ret);
-    }
-#endif
-
-  /* Initialization rptun ivshmem driver */
-
-#ifdef CONFIG_RPTUN_IVSHMEM
-  ret = pci_register_rptun_ivshmem_driver();
-  if (ret < 0)
-    {
-      pcierr("pci_register_rptun_ivshmem_driver failed, ret=%d\n", ret);
     }
 #endif
 

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -31,5 +31,10 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_virtio.c)
   endif()
 
+  if(CONFIG_RPMSG_VIRTIO_IVSHMEM)
+    list(APPEND SRCS rpmsg_virtio_ivshmem.c)
+  endif()
+
+  target_include_directories(drivers PRIVATE ${NUTTX_DIR}/openamp/open-amp/lib)
   target_sources(drivers PRIVATE ${SRCS})
 endif()

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -27,5 +27,9 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_ping.c)
   endif()
 
+  if(CONFIG_RPMSG_VIRTIO)
+    list(APPEND SRCS rpmsg_virtio.c)
+  endif()
+
   target_sources(drivers PRIVATE ${SRCS})
 endif()

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -22,3 +22,20 @@ config RPMSG_PING
 		channel, user can use it to get send/recv speed & latency.
 
 endif # RPMSG
+
+config RPMSG_VIRTIO
+	bool "rpmsg virtio transport support"
+	default n
+	select RPMSG
+
+if RPMSG_VIRTIO
+
+config RPMSG_VIRTIO_PRIORITY
+	int "rpmsg virtio rx thread priority"
+	default 224
+
+config RPMSG_VIRTIO_STACKSIZE
+	int "rpmsg virtio rx thread stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -41,7 +41,7 @@ config RPMSG_VIRTIO_STACKSIZE
 config RPMSG_VIRTIO_IVSHMEM
 	bool "rpmsg virtio ivshmem support"
 	default n
-	depends on PCI
+	depends on PCI_IVSHMEM
 	---help---
 		This is rpmsg virtio driver based on pci ivshmem.
 
@@ -50,11 +50,11 @@ if RPMSG_VIRTIO_IVSHMEM
 config RPMSG_VIRTIO_IVSHMEM_NAME
 	string "rpmsg virtio ivshmem name"
 	---help---
-		Using this config to custom the rpmsg virtio ivshmem cpuname and role,
+		Using this config to custom the rpmsg virtio ivshmem id, cpuname and role,
 		using ";" to split the names.
-		For example, if RPMSG_VIRTIO_IVSHMEM_CPUNAME = "cpu1:m;cpu2:s" and pass
+		For example, if RPMSG_VIRTIO_IVSHMEM_CPUNAME = "0:cpu1:m;1:cpu2:s" and pass
 		two ivshmem devices to the qemu, we will get two rpmsg virtio ivshmem drivers
-		with remote cpu names: "cpu1", "cpu2", and roles: "master", "slave"
+		with remote cpu ids: "0","1", names: "cpu1", "cpu2", and roles: "master", "slave"
 
 config RPMSG_VIRTIO_IVSHMEM_BUFFSIZE
 	int "rpmsg virtio ivshmem rpmsg buffer size"

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -38,4 +38,38 @@ config RPMSG_VIRTIO_STACKSIZE
 	int "rpmsg virtio rx thread stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config RPMSG_VIRTIO_IVSHMEM
+	bool "rpmsg virtio ivshmem support"
+	default n
+	depends on PCI
+	---help---
+		This is rpmsg virtio driver based on pci ivshmem.
+
+if RPMSG_VIRTIO_IVSHMEM
+
+config RPMSG_VIRTIO_IVSHMEM_NAME
+	string "rpmsg virtio ivshmem name"
+	---help---
+		Using this config to custom the rpmsg virtio ivshmem cpuname and role,
+		using ";" to split the names.
+		For example, if RPMSG_VIRTIO_IVSHMEM_CPUNAME = "cpu1:m;cpu2:s" and pass
+		two ivshmem devices to the qemu, we will get two rpmsg virtio ivshmem drivers
+		with remote cpu names: "cpu1", "cpu2", and roles: "master", "slave"
+
+config RPMSG_VIRTIO_IVSHMEM_BUFFSIZE
+	int "rpmsg virtio ivshmem rpmsg buffer size"
+	default 2048
+	---help---
+		The rpmsg buffer size in share memory, the RX and TX buffer size
+		are same for now.
+
+config RPMSG_VIRTIO_IVSHMEM_BUFFNUM
+	int "rpmsg virtio ivshmem rpmsg buffer number"
+	default 8
+	---help---
+		The rpmsg virtio buffer number in share memory, the RX and TX buffer number
+		are same for now.
+
+endif
+
 endif

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -28,6 +28,11 @@ ifeq ($(CONFIG_RPMSG_PING),y)
 CSRCS += rpmsg_ping.c
 endif
 
+ifeq ($(CONFIG_RPMSG_VIRTIO),y)
+CSRCS += rpmsg_virtio.c
+CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib
+endif
+
 DEPPATH += --dep-path rpmsg
 VPATH += :rpmsg
 

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -33,6 +33,10 @@ CSRCS += rpmsg_virtio.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib
 endif
 
+ifeq ($(CONFIG_RPMSG_VIRTIO_IVSHMEM),y)
+CSRCS += rpmsg_virtio_ivshmem.c
+endif
+
 DEPPATH += --dep-path rpmsg
 VPATH += :rpmsg
 

--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -229,7 +229,7 @@ int rpmsg_register_callback(FAR void *priv,
       FAR struct rpmsg_s *rpmsg =
         metal_container_of(node, struct rpmsg_s, node);
 
-      if (rpmsg->rdev->ns_unbind_cb == NULL)
+      if (!rpmsg->init)
         {
           continue;
         }
@@ -307,7 +307,7 @@ void rpmsg_unregister_callback(FAR void *priv,
           FAR struct rpmsg_s *rpmsg =
             metal_container_of(pnode, struct rpmsg_s, node);
 
-          if (rpmsg->rdev->ns_unbind_cb)
+          if (rpmsg->init)
             {
               device_destroy(rpmsg->rdev, priv);
             }
@@ -397,6 +397,7 @@ void rpmsg_device_created(FAR struct rpmsg_s *rpmsg)
         }
     }
 
+  rpmsg->init = true;
   nxrmutex_unlock(&g_rpmsg_lock);
 
 #ifdef CONFIG_RPMSG_PING

--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -491,7 +491,11 @@ int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg)
   FAR struct metal_list *node;
   int ret = OK;
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  if (!up_interrupt_context())
+    {
+      nxrmutex_lock(&g_rpmsg_lock);
+    }
+
   metal_list_for_each(&g_rpmsg, node)
     {
       FAR struct rpmsg_s *rpmsg =
@@ -507,7 +511,11 @@ int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg)
         }
     }
 
-  nxrmutex_unlock(&g_rpmsg_lock);
+  if (!up_interrupt_context())
+    {
+      nxrmutex_unlock(&g_rpmsg_lock);
+    }
+
   return ret;
 }
 

--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -42,7 +42,8 @@
 #define RPMSG_PING_SEND             1
 #define RPMSG_PING_SEND_CHECK       2
 #define RPMSG_PING_SEND_NOACK       3
-#define RPMSG_PING_ACK              4
+#define RPMSG_PING_SEND_ACK         4
+#define RPMSG_PING_ACK              5
 #define RPMSG_PING_CHECK_DATA       0xee
 
 /****************************************************************************
@@ -93,6 +94,11 @@ static int rpmsg_ping_ept_cb(FAR struct rpmsg_endpoint *ept,
       msg->cmd = RPMSG_PING_ACK;
       rpmsg_send(ept, msg, len);
     }
+  else if (msg->cmd == RPMSG_PING_SEND_ACK)
+    {
+      msg->cmd = RPMSG_PING_ACK;
+      rpmsg_send(ept, msg, sizeof(*msg));
+    }
   else if (msg->cmd == RPMSG_PING_ACK)
     {
       nxsem_post(sem);
@@ -122,7 +128,19 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept,
     {
       sem_t sem;
 
-      msg->cmd = (ack == 1)? RPMSG_PING_SEND : RPMSG_PING_SEND_CHECK;
+      if (ack == 1)
+        {
+          msg->cmd = RPMSG_PING_SEND;
+        }
+      else if (ack == 2)
+        {
+          msg->cmd = RPMSG_PING_SEND_CHECK;
+        }
+      else
+        {
+          msg->cmd = RPMSG_PING_SEND_ACK;
+        }
+
       msg->len    = len;
       msg->cookie = (uintptr_t)&sem;
 

--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -84,7 +84,8 @@ static int rpmsg_ping_ept_cb(FAR struct rpmsg_endpoint *ept,
         {
           if (msg->data[i] != RPMSG_PING_CHECK_DATA)
             {
-              syslog(LOG_ERR, "rptun ping remote receive data error!\n");
+              syslog(LOG_ERR, "receive data error at %zu of %zu\n",
+                     i, data_len);
               break;
             }
 
@@ -233,7 +234,10 @@ int rpmsg_ping(FAR struct rpmsg_endpoint *ept,
       max    = MAX(max, tm);
       total += tm;
 
-      nxsig_usleep(ping->sleep * USEC_PER_MSEC);
+      if (ping->sleep > 0)
+        {
+          nxsig_usleep(ping->sleep * USEC_PER_MSEC);
+        }
     }
 
   syslog(LOG_INFO, "ping times: %d\n", ping->times);

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -32,6 +32,7 @@
 #include <nuttx/kthread.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/rpmsg/rpmsg_virtio.h>
+#include <rpmsg/rpmsg_internal.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -1,0 +1,634 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_virtio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <stdio.h>
+#include <sys/param.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/kthread.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/rpmsg/rpmsg_virtio.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef ALIGN_UP
+#  define ALIGN_UP(s, a)        (((s) + (a) - 1) & ~((a) - 1))
+#endif
+
+#define RPMSG_VIRTIO_TIMEOUT_MS 20
+#define RPMSG_VIRTIO_NOTIFYID   0
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rpmsg_virtio_priv_s
+{
+  struct rpmsg_s                rpmsg;
+  struct rpmsg_virtio_device    rvdev;
+  FAR struct rpmsg_virtio_s     *dev;
+  FAR struct rpmsg_virtio_rsc_s *rsc;
+  struct virtio_device          vdev;
+  struct rpmsg_virtio_shm_pool  pool[2];
+  struct virtio_vring_info      rvrings[2];
+  sem_t                         semtx;
+  sem_t                         semrx;
+  pid_t                         tid;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int rpmsg_virtio_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
+static int rpmsg_virtio_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
+static void rpmsg_virtio_dump(FAR struct rpmsg_s *rpmsg);
+static FAR const char *rpmsg_virtio_get_cpuname(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_virtio_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_virtio_get_rx_buffer_size_(FAR struct rpmsg_s *rpmsg);
+
+static int rpmsg_virtio_create_virtqueues_(FAR struct virtio_device *vdev,
+                                           unsigned int flags,
+                                           unsigned int nvqs,
+                                           FAR const char *names[],
+                                           vq_callback callbacks[]);
+static uint8_t rpmsg_virtio_get_status_(FAR struct virtio_device *dev);
+static void rpmsg_virtio_set_status_(FAR struct virtio_device *dev,
+                                     uint8_t status);
+static uint32_t rpmsg_virtio_get_features_(FAR struct virtio_device *dev);
+static void rpmsg_virtio_set_features(FAR struct virtio_device *dev,
+                                      uint32_t feature);
+static void rpmsg_virtio_notify(FAR struct virtqueue *vq);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_ops_s g_rpmsg_virtio_ops =
+{
+  .wait               = rpmsg_virtio_wait,
+  .post               = rpmsg_virtio_post,
+  .dump               = rpmsg_virtio_dump,
+  .get_cpuname        = rpmsg_virtio_get_cpuname,
+  .get_tx_buffer_size = rpmsg_virtio_get_tx_buffer_size,
+  .get_rx_buffer_size = rpmsg_virtio_get_rx_buffer_size_,
+};
+
+static const struct virtio_dispatch g_rpmsg_virtio_dispatch =
+{
+  .create_virtqueues = rpmsg_virtio_create_virtqueues_,
+  .get_status        = rpmsg_virtio_get_status_,
+  .set_status        = rpmsg_virtio_set_status_,
+  .get_features      = rpmsg_virtio_get_features_,
+  .set_features      = rpmsg_virtio_set_features,
+  .notify            = rpmsg_virtio_notify,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static FAR struct rpmsg_virtio_priv_s *
+rpmsg_virtio_get_priv(FAR struct virtio_device *vdev)
+{
+  FAR struct rpmsg_virtio_device *rvdev = vdev->priv;
+
+  return metal_container_of(rvdev, struct rpmsg_virtio_priv_s, rvdev);
+}
+
+static int rpmsg_virtio_create_virtqueues_(FAR struct virtio_device *vdev,
+                                           unsigned int flags,
+                                           unsigned int nvqs,
+                                           FAR const char *names[],
+                                           vq_callback callbacks[])
+{
+  int ret;
+  int i;
+
+  if (nvqs > vdev->vrings_num)
+    {
+      return ERROR_VQUEUE_INVLD_PARAM;
+    }
+
+  /* Initialize virtqueue for each vring */
+
+  for (i = 0; i < nvqs; i++)
+    {
+      FAR struct virtio_vring_info *vinfo = &vdev->vrings_info[i];
+      FAR struct vring_alloc_info *valloc = &vinfo->info;
+#ifndef CONFIG_OPENAMP_VIRTIO_DEVICE_ONLY
+      if (vdev->role == VIRTIO_DEV_DRIVER)
+        {
+          size_t offset;
+
+          offset = metal_io_virt_to_offset(vinfo->io, valloc->vaddr);
+          metal_io_block_set(vinfo->io, offset, 0,
+                             vring_size(valloc->num_descs, valloc->align));
+        }
+#endif
+
+      ret = virtqueue_create(vdev, i, names[i], valloc,
+                             callbacks[i], vdev->func->notify,
+                             vinfo->vq);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+  return 0;
+}
+
+static uint8_t rpmsg_virtio_get_status_(FAR struct virtio_device *vdev)
+{
+  FAR struct rpmsg_virtio_priv_s *priv = rpmsg_virtio_get_priv(vdev);
+
+  return priv->rsc->rpmsg_vdev.status;
+}
+
+static void rpmsg_virtio_set_status_(FAR struct virtio_device *vdev,
+                                     uint8_t status)
+{
+  FAR struct rpmsg_virtio_priv_s *priv = rpmsg_virtio_get_priv(vdev);
+
+  priv->rsc->rpmsg_vdev.status = status;
+}
+
+static uint32_t rpmsg_virtio_get_features_(FAR struct virtio_device *vdev)
+{
+  FAR struct rpmsg_virtio_priv_s *priv = rpmsg_virtio_get_priv(vdev);
+
+  return priv->rsc->rpmsg_vdev.dfeatures;
+}
+
+static void rpmsg_virtio_set_features(FAR struct virtio_device *vdev,
+                                      uint32_t features)
+{
+  FAR struct rpmsg_virtio_priv_s *priv = rpmsg_virtio_get_priv(vdev);
+
+  priv->rsc->rpmsg_vdev.gfeatures = features;
+}
+
+static void rpmsg_virtio_notify(FAR struct virtqueue *vq)
+{
+  FAR struct virtio_device *vdev = vq->vq_dev;
+  FAR struct rpmsg_virtio_priv_s *priv = rpmsg_virtio_get_priv(vdev);
+
+  RPMSG_VIRTIO_NOTIFY(priv->dev, vdev->vrings_info->notifyid);
+}
+
+static bool rpmsg_virtio_is_recursive(FAR struct rpmsg_virtio_priv_s *priv)
+{
+  return nxsched_gettid() == priv->tid;
+}
+
+static int rpmsg_virtio_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+      (FAR struct rpmsg_virtio_priv_s *)rpmsg;
+  int ret;
+
+  if (!rpmsg_virtio_is_recursive(priv))
+    {
+      return nxsem_wait_uninterruptible(sem);
+    }
+
+  while (1)
+    {
+      ret = nxsem_trywait(sem);
+      if (ret >= 0)
+        {
+          break;
+        }
+
+      nxsem_wait(&priv->semtx);
+      virtqueue_notification(priv->rvdev.rvq);
+    }
+
+  return ret;
+}
+
+static void rpmsg_virtio_wakeup_tx(FAR struct rpmsg_virtio_priv_s *priv)
+{
+  int semcount;
+
+  nxsem_get_value(&priv->semtx, &semcount);
+  while (semcount++ < 1)
+    {
+      nxsem_post(&priv->semtx);
+    }
+}
+
+static int rpmsg_virtio_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+      (FAR struct rpmsg_virtio_priv_s *)rpmsg;
+  int semcount;
+  int ret;
+
+  nxsem_get_value(sem, &semcount);
+  ret = nxsem_post(sem);
+
+  if (priv && semcount >= 0)
+    {
+      rpmsg_virtio_wakeup_tx(priv);
+    }
+
+  return ret;
+}
+
+#ifdef CONFIG_OPENAMP_DEBUG
+static int rpmsg_virtio_buffer_nused(FAR struct rpmsg_virtio_device *rvdev,
+                                     bool rx)
+{
+  FAR struct virtqueue *vq = rx ? rvdev->rvq : rvdev->svq;
+  uint16_t nused = vq->vq_ring.avail->idx - vq->vq_ring.used->idx;
+
+  if ((rpmsg_virtio_get_role(rvdev) == RPMSG_HOST) ^ rx)
+    {
+      return nused;
+    }
+  else
+    {
+      return vq->vq_nentries - nused;
+    }
+}
+
+static void rpmsg_virtio_dump_buffer(FAR struct rpmsg_virtio_device *rvdev,
+                                     bool rx)
+{
+  FAR struct virtqueue *vq = rx ? rvdev->rvq : rvdev->svq;
+  int num;
+  int i;
+
+  num = rpmsg_virtio_buffer_nused(rvdev, rx);
+  metal_log(METAL_LOG_EMERGENCY,
+            "    %s buffer, total %d, pending %d\n",
+            rx ? "RX" : "TX", vq->vq_nentries, num);
+
+  for (i = 0; i < num; i++)
+    {
+      FAR void *addr;
+      int desc_idx;
+
+      if ((rpmsg_virtio_get_role(rvdev) == RPMSG_HOST) ^ rx)
+        {
+          desc_idx = (vq->vq_ring.used->idx + i) & (vq->vq_nentries - 1);
+          desc_idx = vq->vq_ring.avail->ring[desc_idx];
+        }
+      else
+        {
+          desc_idx = (vq->vq_ring.avail->idx + i) & (vq->vq_nentries - 1);
+          desc_idx = vq->vq_ring.used->ring[desc_idx].id;
+        }
+
+      addr = metal_io_phys_to_virt(vq->shm_io,
+                                   vq->vq_ring.desc[desc_idx].addr);
+      if (addr)
+        {
+          FAR struct rpmsg_hdr *hdr = addr;
+          FAR struct rpmsg_endpoint *ept;
+
+          ept = rpmsg_get_ept_from_addr(&rvdev->rdev,
+                                        rx ? hdr->dst : hdr->src);
+          if (ept)
+            {
+              metal_log(METAL_LOG_EMERGENCY,
+                        "      %s buffer %p hold by %s\n",
+                        rx ? "RX" : "TX", hdr, ept->name);
+            }
+        }
+    }
+}
+
+static void rpmsg_virtio_dump(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+      (FAR struct rpmsg_virtio_priv_s *)rpmsg;
+  FAR struct rpmsg_virtio_device *rvdev = &priv->rvdev;
+  FAR struct rpmsg_device *rdev = rpmsg->rdev;
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct metal_list *node;
+  bool needlock = true;
+
+  if (!rvdev->vdev)
+    {
+      return;
+    }
+
+  if (up_interrupt_context() || sched_idletask() ||
+      nxmutex_is_hold(&rdev->lock))
+    {
+      needlock = false;
+    }
+
+  if (needlock)
+    {
+      metal_mutex_acquire(&rdev->lock);
+    }
+
+  metal_log(METAL_LOG_EMERGENCY,
+            "Dump rpmsg info between cpu (master: %s)%s <==> %s:\n",
+            rpmsg_virtio_get_role(rvdev) == RPMSG_HOST ? "yes" : "no",
+            CONFIG_RPMSG_LOCAL_CPUNAME, rpmsg_get_cpuname(rdev));
+
+  metal_log(METAL_LOG_EMERGENCY, "rpmsg vq RX:\n");
+  virtqueue_dump(rvdev->rvq);
+  metal_log(METAL_LOG_EMERGENCY, "rpmsg vq TX:\n");
+  virtqueue_dump(rvdev->svq);
+
+  metal_log(METAL_LOG_EMERGENCY, "  rpmsg ept list:\n");
+
+  metal_list_for_each(&rdev->endpoints, node)
+    {
+      ept = metal_container_of(node, struct rpmsg_endpoint, node);
+      metal_log(METAL_LOG_EMERGENCY, "    ept %s\n", ept->name);
+    }
+
+  metal_log(METAL_LOG_EMERGENCY, "  rpmsg buffer list:\n");
+
+  rpmsg_virtio_dump_buffer(rvdev, true);
+  rpmsg_virtio_dump_buffer(rvdev, false);
+
+  if (needlock)
+    {
+      metal_mutex_release(&rdev->lock);
+    }
+}
+#else
+static void rpmsg_virtio_dump(FAR struct rpmsg_s *rpmsg)
+{
+  /* Nothing */
+}
+#endif
+
+static FAR const char *rpmsg_virtio_get_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+      (FAR struct rpmsg_virtio_priv_s *)rpmsg;
+
+  return RPMSG_VIRTIO_GET_CPUNAME(priv->dev);
+}
+
+static int rpmsg_virtio_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  return rpmsg_virtio_get_buffer_size(rpmsg->rdev);
+}
+
+static int rpmsg_virtio_get_rx_buffer_size_(FAR struct rpmsg_s *rpmsg)
+{
+  return rpmsg_virtio_get_rx_buffer_size(rpmsg->rdev);
+}
+
+static void rpmsg_virtio_wakeup_rx(FAR struct rpmsg_virtio_priv_s *priv)
+{
+  int semcount;
+
+  nxsem_get_value(&priv->semrx, &semcount);
+  if (semcount < 1)
+    {
+      nxsem_post(&priv->semrx);
+    }
+}
+
+static int rpmsg_virtio_callback(FAR void *arg, uint32_t vqid)
+{
+  FAR struct rpmsg_virtio_priv_s *priv = arg;
+  FAR struct rpmsg_virtio_device *rvdev = &priv->rvdev;
+  FAR struct virtio_device *vdev = rvdev->vdev;
+  FAR struct virtqueue *rvq = rvdev->rvq;
+
+  if (vqid == RPMSG_VIRTIO_NOTIFY_ALL ||
+      vqid == vdev->vrings_info[rvq->vq_queue_index].notifyid)
+    {
+      rpmsg_virtio_wakeup_rx(priv);
+    }
+
+  return OK;
+}
+
+static int rpmsg_virtio_notify_wait(FAR struct rpmsg_device *rdev,
+                                    uint32_t id)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+    metal_container_of(rdev, struct rpmsg_virtio_priv_s, rvdev.rdev);
+
+  if (!rpmsg_virtio_is_recursive(priv))
+    {
+      return -EAGAIN;
+    }
+
+  /* Wait to wakeup */
+
+  nxsem_tickwait(&priv->semtx, MSEC2TICK(RPMSG_VIRTIO_TIMEOUT_MS));
+  virtqueue_notification(priv->rvdev.rvq);
+
+  return 0;
+}
+
+static int rpmsg_virtio_start(FAR struct rpmsg_virtio_priv_s *priv)
+{
+  FAR struct virtio_vring_info *rvrings = priv->rvrings;
+  FAR struct virtio_device *vdev = &priv->vdev;
+  FAR struct rpmsg_virtio_rsc_s *rsc;
+  struct rpmsg_virtio_config config;
+  FAR void *shbuf0;
+  FAR void *shbuf1;
+  uint32_t align0;
+  uint32_t align1;
+  uint32_t tbsz;
+  uint32_t v0sz;
+  uint32_t v1sz;
+  uint32_t shbufsz0;
+  uint32_t shbufsz1;
+  int ret;
+
+  rsc = RPMSG_VIRTIO_GET_RESOURCE(priv->dev);
+  if (!rsc)
+    {
+      return -EINVAL;
+    }
+
+  priv->rsc = rsc;
+
+  vdev->notifyid = RPMSG_VIRTIO_NOTIFYID;
+  vdev->vrings_num = rsc->rpmsg_vdev.num_of_vrings;
+  vdev->role = RPMSG_VIRTIO_IS_MASTER(priv->dev) ? RPMSG_HOST : RPMSG_REMOTE;
+  vdev->func = &g_rpmsg_virtio_dispatch;
+
+  align0 = rsc->rpmsg_vring0.align;
+  align1 = rsc->rpmsg_vring1.align;
+  tbsz = ALIGN_UP(sizeof(struct rpmsg_virtio_rsc_s), MAX(align0, align1));
+  v0sz = ALIGN_UP(vring_size(rsc->rpmsg_vring0.num, align0), align0);
+  v1sz = ALIGN_UP(vring_size(rsc->rpmsg_vring1.num, align1), align1);
+
+  shbuf0   = (FAR char *)rsc + tbsz + v0sz + v1sz;
+  shbufsz0 = rsc->config.r2h_buf_size * rsc->rpmsg_vring0.num;
+  shbuf1   = shbuf0 + shbufsz0;
+  shbufsz1 = rsc->config.h2r_buf_size * rsc->rpmsg_vring1.num;
+
+  rvrings[0].io = metal_io_get_region();
+  rvrings[0].info.vaddr = (FAR char *)rsc + tbsz;
+  rvrings[0].info.num_descs = rsc->rpmsg_vring0.num;
+  rvrings[0].info.align = rsc->rpmsg_vring0.align;
+  rvrings[0].vq = virtqueue_allocate(rsc->rpmsg_vring0.num);
+  if (rvrings[0].vq == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  rvrings[1].io = metal_io_get_region();
+  rvrings[1].info.vaddr = (FAR char *)rsc + tbsz + v0sz;
+  rvrings[1].info.num_descs = rsc->rpmsg_vring1.num;
+  rvrings[1].info.align = rsc->rpmsg_vring1.align;
+  rvrings[1].vq = virtqueue_allocate(rsc->rpmsg_vring1.num);
+  if (rvrings[1].vq == NULL)
+    {
+      ret = -ENOMEM;
+      goto err_vq0;
+    }
+
+  vdev->vrings_info = &rvrings[0];
+
+  rpmsg_virtio_init_shm_pool(&priv->pool[0], shbuf0, shbufsz0);
+  rpmsg_virtio_init_shm_pool(&priv->pool[1], shbuf1, shbufsz1);
+
+  config.h2r_buf_size = rsc->config.h2r_buf_size;
+  config.r2h_buf_size = rsc->config.r2h_buf_size;
+  config.split_shpool = true;
+
+  ret = rpmsg_init_vdev_with_config(&priv->rvdev, vdev, rpmsg_ns_bind,
+                                    metal_io_get_region(),
+                                    priv->pool, &config);
+  if (ret != 0)
+    {
+      rpmsgerr("rpmsg_init_vdev failed %d\n", ret);
+      ret = -ENOMEM;
+      goto err_vq1;
+    }
+
+  priv->rvdev.rdev.ns_unbind_cb = rpmsg_ns_unbind;
+  priv->rvdev.rdev.notify_wait_cb = rpmsg_virtio_notify_wait;
+
+  RPMSG_VIRTIO_REGISTER_CALLBACK(priv->dev, rpmsg_virtio_callback, priv);
+
+  rpmsg_virtio_wakeup_rx(priv);
+
+  /* Broadcast device_created to all registers */
+
+  rpmsg_device_created(&priv->rpmsg);
+
+  return 0;
+
+err_vq1:
+  virtqueue_free(rvrings[1].vq);
+err_vq0:
+  virtqueue_free(rvrings[0].vq);
+  return ret;
+}
+
+static int rpmsg_virtio_thread(int argc, FAR char *argv[])
+{
+  FAR struct rpmsg_virtio_priv_s *priv = (FAR struct rpmsg_virtio_priv_s *)
+    ((uintptr_t)strtoul(argv[2], NULL, 0));
+  int ret;
+
+  priv->tid = nxsched_gettid();
+
+  ret = rpmsg_virtio_start(priv);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg virtio thread start failed %d\n", ret);
+      return ret;
+    }
+
+  while (1)
+    {
+      nxsem_wait_uninterruptible(&priv->semrx);
+      virtqueue_notification(priv->rvdev.rvq);
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int rpmsg_virtio_initialize(FAR struct rpmsg_virtio_s *dev)
+{
+  FAR struct rpmsg_virtio_priv_s *priv;
+  FAR char *argv[3];
+  char arg1[32];
+  char name[32];
+  int ret;
+
+  priv = kmm_zalloc(sizeof(struct rpmsg_virtio_priv_s));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  priv->dev = dev;
+  nxsem_init(&priv->semrx, 0, 0);
+  nxsem_init(&priv->semtx, 0, 0);
+
+  snprintf(name, sizeof(name), "/dev/rpmsg/%s",
+           RPMSG_VIRTIO_GET_CPUNAME(dev));
+  ret = rpmsg_register(name, &priv->rpmsg, &g_rpmsg_virtio_ops);
+  if (ret < 0)
+    {
+      goto err_driver;
+    }
+
+  snprintf(arg1, sizeof(arg1), "%p", priv);
+  argv[0] = (FAR char *)RPMSG_VIRTIO_GET_CPUNAME(dev);
+  argv[1] = arg1;
+  argv[2] = NULL;
+
+  ret = kthread_create("rpmsg_virtio", CONFIG_RPMSG_VIRTIO_PRIORITY,
+                       CONFIG_RPMSG_VIRTIO_STACKSIZE,
+                       rpmsg_virtio_thread, argv);
+  if (ret < 0)
+    {
+      goto err_thread;
+    }
+
+  return OK;
+
+err_thread:
+  rpmsg_unregister(name, &priv->rpmsg);
+
+err_driver:
+  nxsem_destroy(&priv->semrx);
+  nxsem_destroy(&priv->semtx);
+  kmm_free(priv);
+
+  return ret;
+}

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -149,8 +149,7 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
       memset(priv->shmem, 0, priv->shmem_size);
       rsc->rpmsg_vdev.id            = VIRTIO_ID_RPMSG;
       rsc->rpmsg_vdev.dfeatures     = 1 << VIRTIO_RPMSG_F_NS |
-                                      1 << VIRTIO_RPMSG_F_ACK |
-                                      1 << VIRTIO_RPMSG_F_BUFSZ;
+                                      1 << VIRTIO_RPMSG_F_ACK;
       rsc->rpmsg_vdev.config_len    = sizeof(struct fw_rsc_config);
       rsc->rpmsg_vdev.num_of_vrings = 2;
       rsc->rpmsg_vring0.da          = 0;

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -1,0 +1,373 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_virtio_ivshmem.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <nuttx/drivers/addrenv.h>
+#include <nuttx/pci/pci.h>
+#include <nuttx/rpmsg/rpmsg_virtio.h>
+#include <nuttx/rpmsg/rpmsg_virtio_ivshmem.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_IVSHMEM_SHMEM_BAR     2
+#define RPMSG_VIRTIO_IVSHMEM_READY         0x1
+#define RPMSG_VIRTIO_IVSHMEM_WORK_DELAY    1
+
+#define RPMSG_VIRTIO_VRING_ALIGNMENT       8
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rpmsg_virtio_ivshmem_mem_s
+{
+  volatile uint64_t         basem;
+  volatile uint32_t         seqs;
+  volatile uint32_t         seqm;
+  volatile uint32_t         cmds;
+  volatile uint32_t         cmdm;
+  struct rpmsg_virtio_rsc_s rsc;
+};
+
+struct rpmsg_virtio_ivshmem_dev_s
+{
+  struct rpmsg_virtio_s                  dev;
+  rpmsg_virtio_callback_t                callback;
+  FAR void                              *arg;
+  uint32_t                               seq;
+  FAR struct rpmsg_virtio_ivshmem_mem_s *shmem;
+  size_t                                 shmem_size;
+  struct simple_addrenv_s                addrenv;
+  int                                    master;
+  char                                   cpuname[RPMSG_NAME_SIZE + 1];
+  FAR struct pci_device_s               *ivshmem;
+
+  /* Work queue for transmit */
+
+  struct work_s                          worker;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static const FAR char *
+rpmsg_virtio_ivshmem_get_cpuname(FAR struct rpmsg_virtio_s *dev);
+static FAR struct rpmsg_virtio_rsc_s *
+rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev);
+static int
+rpmsg_virtio_ivshmem_is_master(FAR struct rpmsg_virtio_s *dev);
+static int rpmsg_virtio_ivshmem_notify(FAR struct rpmsg_virtio_s *dev,
+                                       uint32_t notifyid);
+static int
+rpmsg_virtio_ivshmem_register_callback(FAR struct rpmsg_virtio_s *dev,
+                                       rpmsg_virtio_callback_t callback,
+                                       FAR void *arg);
+
+static int rpmsg_virtio_ivshmem_probe(FAR struct pci_device_s *dev);
+static void rpmsg_virtio_ivshmem_remove(FAR struct pci_device_s *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_virtio_ops_s g_rpmsg_virtio_ivshmem_ops =
+{
+  .get_cpuname       = rpmsg_virtio_ivshmem_get_cpuname,
+  .get_resource      = rpmsg_virtio_ivshmem_get_resource,
+  .is_master         = rpmsg_virtio_ivshmem_is_master,
+  .notify            = rpmsg_virtio_ivshmem_notify,
+  .register_callback = rpmsg_virtio_ivshmem_register_callback,
+};
+
+static const struct pci_device_id_s g_rpmsg_virtio_ivshmem_ids[] =
+{
+  { PCI_DEVICE(0x1af4, 0x1110) },
+  { 0, }
+};
+
+static struct pci_driver_s g_rpmsg_virtio_ivshmem_drv =
+{
+  g_rpmsg_virtio_ivshmem_ids,  /* PCI id_tables */
+  rpmsg_virtio_ivshmem_probe,  /* Probe function */
+  rpmsg_virtio_ivshmem_remove, /* Remove function */
+};
+
+static int g_rpmsg_virtio_ivshmem_idx = 0;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static const FAR char *
+rpmsg_virtio_ivshmem_get_cpuname(FAR struct rpmsg_virtio_s *dev)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
+    (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
+  return priv->cpuname;
+}
+
+static FAR struct rpmsg_virtio_rsc_s *
+rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
+    (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
+  FAR struct rpmsg_virtio_rsc_s *rsc;
+
+  rsc = &priv->shmem->rsc;
+
+  if (priv->master)
+    {
+      memset(priv->shmem, 0, priv->shmem_size);
+      rsc->rpmsg_vdev.id            = VIRTIO_ID_RPMSG;
+      rsc->rpmsg_vdev.dfeatures     = 1 << VIRTIO_RPMSG_F_NS |
+                                      1 << VIRTIO_RPMSG_F_ACK |
+                                      1 << VIRTIO_RPMSG_F_BUFSZ;
+      rsc->rpmsg_vdev.config_len    = sizeof(struct fw_rsc_config);
+      rsc->rpmsg_vdev.num_of_vrings = 2;
+      rsc->rpmsg_vring0.da          = 0;
+      rsc->rpmsg_vring0.align       = RPMSG_VIRTIO_VRING_ALIGNMENT;
+      rsc->rpmsg_vring0.num         = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFNUM;
+      rsc->rpmsg_vring1.da          = 0;
+      rsc->rpmsg_vring1.align       = RPMSG_VIRTIO_VRING_ALIGNMENT;
+      rsc->rpmsg_vring1.num         = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFNUM;
+      rsc->config.r2h_buf_size      = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFSIZE;
+      rsc->config.h2r_buf_size      = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFSIZE;
+
+      priv->shmem->basem = (uint64_t)(uintptr_t)priv->shmem;
+    }
+  else
+    {
+      /* Wait untils master is ready, salve need use master base to
+       * initialize addrenv.
+       */
+
+      while (priv->shmem->basem == 0)
+        {
+          usleep(1000);
+        }
+
+      priv->addrenv.va   = (uint64_t)(uintptr_t)priv->shmem;
+      priv->addrenv.pa   = priv->shmem->basem;
+      priv->addrenv.size = priv->shmem_size;
+
+      simple_addrenv_initialize(&priv->addrenv);
+
+      priv->shmem->basem = 0;
+    }
+
+  return rsc;
+}
+
+static int rpmsg_virtio_ivshmem_is_master(FAR struct rpmsg_virtio_s *dev)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
+    (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
+  return priv->master;
+}
+
+static int rpmsg_virtio_ivshmem_notify(FAR struct rpmsg_virtio_s *dev,
+                                       uint32_t vqid)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
+    (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
+
+  if (priv->master)
+    {
+      priv->shmem->seqm++;
+    }
+  else
+    {
+      priv->shmem->seqs++;
+    }
+
+  return 0;
+}
+
+static int
+rpmsg_virtio_ivshmem_register_callback(FAR struct rpmsg_virtio_s *dev,
+                                       rpmsg_virtio_callback_t callback,
+                                       FAR void *arg)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
+    (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
+
+  priv->callback = callback;
+  priv->arg      = arg;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_virtio_ivshmem_work
+ ****************************************************************************/
+
+static void rpmsg_virtio_ivshmem_work(FAR void *arg)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv = arg;
+  bool should_notify = false;
+
+  if (priv->master && priv->seq != priv->shmem->seqs)
+    {
+      priv->seq = priv->shmem->seqs;
+      should_notify = true;
+    }
+  else if (!priv->master && priv->seq != priv->shmem->seqm)
+    {
+      priv->seq = priv->shmem->seqm;
+      should_notify = true;
+    }
+
+  if (should_notify && priv->callback != NULL)
+    {
+      priv->callback(priv->arg, RPMSG_VIRTIO_NOTIFY_ALL);
+    }
+
+  work_queue(HPWORK, &priv->worker, rpmsg_virtio_ivshmem_work, priv,
+             RPMSG_VIRTIO_IVSHMEM_WORK_DELAY);
+}
+
+/****************************************************************************
+ * Name: rpmsg_virtio_ivshmem_get_info
+ ****************************************************************************/
+
+static int rpmsg_virtio_ivshmem_get_info(FAR char *cpuname, FAR int *master)
+{
+  FAR const char *name = CONFIG_RPMSG_VIRTIO_IVSHMEM_NAME;
+  int start = 0;
+  int i;
+  int j;
+
+  for (i = 0, j = 0; name[start] != '\0'; i++)
+    {
+      if (name[i] == ';' || name[i] == '\0')
+        {
+          if (j++ == g_rpmsg_virtio_ivshmem_idx)
+            {
+              snprintf(cpuname, RPMSG_NAME_SIZE, "%.*s", i - start - 2,
+                       &name[start]);
+              *master = name[i - 1] == 'm';
+              return 0;
+            }
+
+          start = i + 1;
+        }
+    }
+
+  return -ENODEV;
+}
+
+/****************************************************************************
+ * Name: rpmsg_virtio_ivshmem_probe
+ ****************************************************************************/
+
+static int rpmsg_virtio_ivshmem_probe(FAR struct pci_device_s *dev)
+{
+  FAR struct rpmsg_virtio_ivshmem_dev_s *priv;
+  int ret;
+
+  priv = kmm_zalloc(sizeof(*priv));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  /* Do the rpmsg virtio ivshmem init */
+
+  priv->dev.ops = &g_rpmsg_virtio_ivshmem_ops;
+  priv->ivshmem = dev;
+  ret = rpmsg_virtio_ivshmem_get_info(priv->cpuname, &priv->master);
+  if (ret < 0)
+    {
+      goto err_priv;
+    }
+
+  /* Configure the ivshmem device and get share memory address */
+
+  ret = pci_enable_device(dev);
+  if (ret < 0)
+    {
+      pcierr("Enable device failed, ret=%d\n", ret);
+      goto err_priv;
+    }
+
+  pci_set_master(dev);
+
+  priv->shmem = (FAR struct rpmsg_virtio_ivshmem_mem_s *)
+    pci_map_bar(dev, RPMSG_VIRTIO_IVSHMEM_SHMEM_BAR);
+  if (priv->shmem == NULL)
+    {
+      ret = -ENOTSUP;
+      pcierr("Device not support share memory bar\n");
+      goto err_master;
+    }
+
+  priv->shmem_size = pci_resource_len(dev, RPMSG_VIRTIO_IVSHMEM_SHMEM_BAR);
+
+  pciinfo("shmem addr=%p size=%zu\n", priv->shmem, priv->shmem_size);
+
+  /* Do rpmsg virtio initialize */
+
+  ret = rpmsg_virtio_initialize(&priv->dev);
+  if (ret < 0)
+    {
+      pcierr("rpmsg virtio intialize failed, ret=%d\n", ret);
+      goto err_master;
+    }
+
+  work_queue(HPWORK, &priv->worker, rpmsg_virtio_ivshmem_work, priv, 0);
+  g_rpmsg_virtio_ivshmem_idx++;
+  return ret;
+
+err_master:
+  pci_clear_master(dev);
+  pci_disable_device(dev);
+err_priv:
+  kmm_free(priv);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: rpmsg_virtio_ivshmem_remove
+ ****************************************************************************/
+
+static void rpmsg_virtio_ivshmem_remove(FAR struct pci_device_s *dev)
+{
+  pciwarn("Not support remove for now\n");
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int pci_register_rpmsg_virtio_ivshmem_driver(void)
+{
+  return pci_register_driver(&g_rpmsg_virtio_ivshmem_drv);
+}

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -69,7 +69,7 @@ struct rpmsg_virtio_ivshmem_dev_s
   uint32_t                               seq;
   FAR struct rpmsg_virtio_ivshmem_mem_s *shmem;
   size_t                                 shmem_size;
-  struct simple_addrenv_s                addrenv;
+  struct simple_addrenv_s                addrenv[2];
   int                                    master;
   char                                   cpuname[RPMSG_NAME_SIZE + 1];
   FAR struct pci_device_s               *ivshmem;
@@ -162,11 +162,11 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
-      priv->addrenv.va   = (uint64_t)(uintptr_t)priv->shmem;
-      priv->addrenv.pa   = priv->shmem->basem;
-      priv->addrenv.size = priv->shmem_size;
+      priv->addrenv[0].va   = (uint64_t)(uintptr_t)priv->shmem;
+      priv->addrenv[0].pa   = priv->shmem->basem;
+      priv->addrenv[0].size = priv->shmem_size;
 
-      simple_addrenv_initialize(&priv->addrenv);
+      simple_addrenv_initialize(&priv->addrenv[0]);
 
       priv->shmem->basem = 0;
     }

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -41,7 +41,7 @@
 #define rpmsg_virtio_ivshmem_from(dev) \
   container_of(ivshmem_get_driver(dev), struct rpmsg_virtio_ivshmem_dev_s, drv)
 
-#define RPMSG_VIRTIO_IVSHMEM_WORK_DELAY    MSEC2TICK(1)
+#define RPMSG_VIRTIO_IVSHMEM_WDOG_DELAY    MSEC2TICK(1)
 
 #define RPMSG_VIRTIO_VRING_ALIGNMENT       8
 
@@ -234,10 +234,10 @@ static int rpmsg_virtio_ivshmem_interrupt(int irq, FAR void *context,
 }
 
 /****************************************************************************
- * Name: rpmsg_virtio_ivshmem_work
+ * Name: rpmsg_virtio_ivshmem_wdog
  ****************************************************************************/
 
-static void rpmsg_virtio_ivshmem_work(wdparm_t arg)
+static void rpmsg_virtio_ivshmem_wdog(wdparm_t arg)
 {
   FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
     (FAR struct rpmsg_virtio_ivshmem_dev_s *)arg;
@@ -259,8 +259,8 @@ static void rpmsg_virtio_ivshmem_work(wdparm_t arg)
       priv->callback(priv->arg, RPMSG_VIRTIO_NOTIFY_ALL);
     }
 
-  wd_start(&priv->wdog, RPMSG_VIRTIO_IVSHMEM_WORK_DELAY,
-           rpmsg_virtio_ivshmem_work, (wdparm_t)priv);
+  wd_start(&priv->wdog, RPMSG_VIRTIO_IVSHMEM_WDOG_DELAY,
+           rpmsg_virtio_ivshmem_wdog, (wdparm_t)priv);
 }
 
 /****************************************************************************
@@ -293,8 +293,8 @@ static int rpmsg_virtio_ivshmem_probe(FAR struct ivshmem_device_s *ivdev)
 
   if (!ivshmem_support_irq(ivdev))
     {
-      ret = wd_start(&priv->wdog, RPMSG_VIRTIO_IVSHMEM_WORK_DELAY,
-                     rpmsg_virtio_ivshmem_work, (wdparm_t)priv);
+      ret = wd_start(&priv->wdog, RPMSG_VIRTIO_IVSHMEM_WDOG_DELAY,
+                     rpmsg_virtio_ivshmem_wdog, (wdparm_t)priv);
       if (ret < 0)
         {
           pcierr("ERROR: wd_start failed: %d\n", ret);

--- a/drivers/rptun/rptun_ivshmem.c
+++ b/drivers/rptun/rptun_ivshmem.c
@@ -70,8 +70,8 @@ struct rptun_ivshmem_dev_s
   uint32_t                        seq;
   FAR struct rptun_ivshmem_mem_s *shmem;
   size_t                          shmem_size;
-  struct simple_addrenv_s         addrenv;
-  struct rptun_addrenv_s          raddrenv;
+  struct simple_addrenv_s         addrenv[2];
+  struct rptun_addrenv_s          raddrenv[2];
   bool                            master;
   char                            cpuname[RPMSG_NAME_SIZE + 1];
   FAR struct ivshmem_device_s    *ivdev;
@@ -137,7 +137,7 @@ rptun_ivshmem_get_addrenv(FAR struct rptun_dev_s *dev)
 {
   FAR struct rptun_ivshmem_dev_s *priv =
     (FAR struct rptun_ivshmem_dev_s *)dev;
-  return &priv->raddrenv;
+  return &priv->raddrenv[0];
 }
 
 static FAR struct rptun_rsc_s *
@@ -146,12 +146,12 @@ rptun_ivshmem_get_resource(FAR struct rptun_dev_s *dev)
   FAR struct rptun_ivshmem_dev_s *priv =
     (FAR struct rptun_ivshmem_dev_s *)dev;
 
-  priv->raddrenv.da   = 0;
-  priv->raddrenv.size = priv->shmem_size;
+  priv->raddrenv[0].da   = 0;
+  priv->raddrenv[0].size = priv->shmem_size;
 
   if (priv->master)
     {
-      priv->raddrenv.pa = (uintptr_t)priv->shmem;
+      priv->raddrenv[0].pa = (uintptr_t)priv->shmem;
 
       /* Wait untils salve is ready */
 
@@ -204,13 +204,13 @@ rptun_ivshmem_get_resource(FAR struct rptun_dev_s *dev)
           usleep(1000);
         }
 
-      priv->raddrenv.pa  = (uintptr_t)priv->shmem->basem;
+      priv->raddrenv[0].pa  = (uintptr_t)priv->shmem->basem;
 
-      priv->addrenv.va   = (uint64_t)(uintptr_t)priv->shmem;
-      priv->addrenv.pa   = priv->shmem->basem;
-      priv->addrenv.size = priv->shmem_size;
+      priv->addrenv[0].va   = (uint64_t)(uintptr_t)priv->shmem;
+      priv->addrenv[0].pa   = priv->shmem->basem;
+      priv->addrenv[0].size = priv->shmem_size;
 
-      simple_addrenv_initialize(&priv->addrenv);
+      simple_addrenv_initialize(&priv->addrenv[0]);
     }
 
   return &priv->shmem->rsc;

--- a/include/nuttx/rpmsg/rpmsg.h
+++ b/include/nuttx/rpmsg/rpmsg.h
@@ -47,6 +47,7 @@
 
 struct rpmsg_s
 {
+  bool                         init;
   struct metal_list            bind;
   rmutex_t                     lock;
   struct metal_list            node;

--- a/include/nuttx/rpmsg/rpmsg_virtio.h
+++ b/include/nuttx/rpmsg/rpmsg_virtio.h
@@ -1,0 +1,186 @@
+/****************************************************************************
+ * include/nuttx/rpmsg/rpmsg_virtio.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_H
+#define __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_RPMSG_VIRTIO
+
+#include <nuttx/rpmsg/rpmsg.h>
+#include <openamp/rpmsg_virtio.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_NOTIFY_ALL UINT32_MAX
+
+/* Access macros ************************************************************/
+
+/****************************************************************************
+ * Name: RPMSG_VIRTIO_GET_CPUNAME
+ *
+ * Description:
+ *   Get remote cpu name
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   Cpu name on success, NULL on failure.
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_GET_CPUNAME(d) \
+  ((d)->ops->get_cpuname ? (d)->ops->get_cpuname(d) : "")
+
+/****************************************************************************
+ * Name: RPMSG_VIRTIO_GET_RESOURCE
+ *
+ * Description:
+ *   Get rpmsg virtio resource
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   Resource pointer on success, NULL on failure
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_GET_RESOURCE(d) \
+  ((d)->ops->get_resource ? (d)->ops->get_resource(d) : NULL)
+
+/****************************************************************************
+ * Name: RPMSG_VIRTIO_IS_MASTER
+ *
+ * Description:
+ *   Is master or not
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   True master, false remote
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_IS_MASTER(d) \
+  ((d)->ops->is_master ? (d)->ops->is_master(d) : false)
+
+/****************************************************************************
+ * Name: RPMSG_VIRTIO_REGISTER_CALLBACK
+ *
+ * Description:
+ *   Attach to receive a callback when something is received on RPTUN
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   callback - The function to be called when something has been received
+ *   arg      - A caller provided value to return with the callback
+ *
+ * Returned Value:
+ *   OK unless an error occurs.  Then a negated errno value is returned
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_REGISTER_CALLBACK(d,c,a) \
+  ((d)->ops->register_callback ? (d)->ops->register_callback(d,c,a) : -ENOSYS)
+
+/****************************************************************************
+ * Name: RPMSG_VIRTIO_NOTIFY
+ *
+ * Description:
+ *   Notify remote core there is a message to get.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   vqid - Message to notify
+ *
+ * Returned Value:
+ *   OK unless an error occurs.  Then a negated errno value is returned
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_NOTIFY(d,v) \
+  ((d)->ops->notify ? (d)->ops->notify(d,v) : -ENOSYS)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef CODE int (*rpmsg_virtio_callback_t)(FAR void *arg, uint32_t vqid);
+
+struct aligned_data(8) rpmsg_virtio_rsc_s
+{
+  struct resource_table    rsc_tbl_hdr;
+  uint32_t                 offset[2];
+  struct fw_rsc_trace      log_trace;
+  struct fw_rsc_vdev       rpmsg_vdev;
+  struct fw_rsc_vdev_vring rpmsg_vring0;
+  struct fw_rsc_vdev_vring rpmsg_vring1;
+  struct fw_rsc_config     config;
+};
+
+struct rpmsg_virtio_s;
+struct rpmsg_virtio_ops_s
+{
+  CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_virtio_s *dev);
+  CODE FAR struct rpmsg_virtio_rsc_s *
+  (*get_resource)(FAR struct rpmsg_virtio_s *dev);
+  CODE int (*is_master)(FAR struct rpmsg_virtio_s *dev);
+  CODE int (*notify)(FAR struct rpmsg_virtio_s *dev, uint32_t vqid);
+  CODE int (*register_callback)(FAR struct rpmsg_virtio_s *dev,
+                                rpmsg_virtio_callback_t callback,
+                                FAR void *arg);
+};
+
+struct rpmsg_virtio_s
+{
+  FAR const struct rpmsg_virtio_ops_s *ops;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+int rpmsg_virtio_initialize(FAR struct rpmsg_virtio_s *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_RPTUN */
+
+#endif /* __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_H */

--- a/include/nuttx/rpmsg/rpmsg_virtio_ivshmem.h
+++ b/include/nuttx/rpmsg/rpmsg_virtio_ivshmem.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * include/nuttx/rpmsg/rpmsg_virtio_ivshmem.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_IVSHMEM_H
+#define __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_IVSHMEM_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_RPMSG_VIRTIO_IVSHMEM
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: rpmsg_virtio_ivshmem_driver_init
+ *
+ * Description:
+ *   Initializes the rptun ivshmem driver.
+ *
+ * Returned Value:
+ *   OK on success, negated errno on failure
+ *
+ ****************************************************************************/
+
+int pci_register_rpmsg_virtio_ivshmem_driver(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_RPMSG_VIRTIO_IVSHMEM */
+#endif /* __INCLUDE_NUTTX_RPMSG_RPMSG_VIRTIO_IVSHMEM_H */


### PR DESCRIPTION
## Summary
Rpmsg VirtIO is a new Rpmsg Transport Layer Implementation.
Different to the Rptun, rpmsg virtio do not use the remoteproc implementation in OpenAMP to save the code size, so it can be used in chips with low resources.

1.    drivers/rpmsg: fix the race condtion about rpmsg_device_created
    
    xxx_rpmsg_device_created may be called repeatedly.
    
    rptun thread                            app thread
    
    rptun_dev_start                         xxx_rpmsg_init
    
    ...                                     rpmsg_register_callback
    priv->...= rpmsg_ns_unbind;
    priv->..= rptun_notify_wait;
                                            if (ns_unbind_cb)
    (switch app thread)                             device_created()
                                                    xxx_rpmsg_device_created
    
                                            metal_list_add_tail(g_cb);
    ...
    rpmsg_device_created();
            cb->device_created
            xxx_rpmsg_device_created;

2.    rpmsg/CMakeLists.txt: add rpmsg_virtio_ivshmem.c in this file
    
    rpmsg_virtio_ivshmem support Cmake compile too

3.    rpmsg_virtio_ivshmem: Replace work with wdog
    
    Just rename, since it's a wdog, not a work.

4.    rptun/rpmsg_virtio: fix addrenv/raddrenv num error
    
    Buf fix, simple_addrenv assume the last addrenv in addrenv array
    be zero value

5.    sim_rptun/rpmsg_virtio: Replace work queue with wdog
    
    Wdog has better performance than work queue

6.    sim/sim_rptun.c: Fixed data type for sim_rptun_shmem_s
    
    Use fixed length data type for the struct shared in cross-core
    communication

7.    sim/sim_rptun: Check if the shared memory has been allocated
    
    Bug fix

8.    sim/sim_rptun: Support master/slave notifies opposite side when recovery
    
    When in a multi-core structure, as the intermediate core,
    remote is both the master and slave;When the remote exception or
    restart occurs, it needs to notify the slave and reestablish the connection

9.    sim rpmsg virtio: add sim rpmsg virtio support
    
    add sim_rpmsg_virtio.c to verify the new rpmsg virtio wrapper layer,
    new the rpmsg virtio can be used in sim platfrom

10.    rpmsg_ping:only sleep when ping->sleep is larger than 0
    
    To avoid call sleep when sleep <= 0

11.    rpmsg_virtio_ivshmem.c: Replace work queue with wdog
    
    rpmsg_virtio_ivshmem polling mode use wdog to loop instead work
    queue, beacause wdog has better performance

12.    rpmsg_virtio_ivshmem.c: rpmsg virtio ivshmem msix interrupt support
    
    Change the rpmsg_virtio_ivshmem from pci bus based to
    pci-ivshmem bus based, so rpmsg_virtio_ivshmem can support interrupt
    mode and also support the multi instance.

13.    rpmsg_virtio_ivshmem.c: fix VIRTIO_RPMSG_F_BUFSZ not used caused restart err

14.    nuttx/rpmsg_virtio.c: fix invalid use of undefined type ‘struct rpmsg_hdr’ err
    
    rpmsg/rpmsg_virtio.c:320:49: error: invalid use of undefined type ‘struct rpmsg_hdr’
      320 |                                         rx ? hdr->dst : hdr->src);

15.    drivers/rpmsg: fix recursive assert when call rpmsg_dump_all() in irq
    
    Because call mutex lock is forbidden in interrupt.

16.    rpmsg/rpmsg_virtio_ivshmem: add rpmsg virtio ivshmem support
    
    rpmsg_virtio_ivshmem is a ivshmem based rpmsg virtio driver,
    with this driver, we can use the rpmsg virtio in qemu platfrom

17.    rpmsg virtio: add rpmsg virtio wrapper support
    
    Rpmsg VirtIO is a virtio transport implementation for Rpmsg, and
    it's different to the rptun framework.
    
    rpmsg_virtio.c implements the rpmsg virtio transport layer by itself
    to avoid use the remoteproc implementation in OpenAMP to save code
    size, so it can be treated as a lightweight version of rptun.
    Therefore, rpmsg_virtio.c only support the communication feature and
    do not support contoll the life cycle of the remote core.
    But benefit by it's small footprint, it can be used in the chips with
    small flash.

18    rpmsg ping: fix rpmsg_ping_ept_cb rpmsg send length
    
    The rpmsg ping response length should not include the data length.
    
    Signed-off-by: Yongrong Wang <wangyongrong@xiaomi.com>

## Impact
new feature rpmsg_virtio and some related patches

## Testing
armv7a with rpmsg_virtio_ivshmem enable and sim with rpserver/rpproxy
