### PR TITLE
arch/x86_64: add basic support for R_X86_64_REX_GOTPCRELX relocation

### DIFF
--- a/arch/x86_64/include/elf.h
+++ b/arch/x86_64/include/elf.h
@@ -25,13 +25,14 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
-#define R_X86_64_NONE   0
-#define R_X86_64_64     1
-#define R_X86_64_PC32   2
-#define R_X86_64_PLT32  4
-#define R_X86_64_32     10
-#define R_X86_64_32S    11
-#define R_X86_64_PC64   24
+#define R_X86_64_NONE           0
+#define R_X86_64_64             1
+#define R_X86_64_PC32           2
+#define R_X86_64_PLT32          4
+#define R_X86_64_32             10
+#define R_X86_64_32S            11
+#define R_X86_64_PC64           24
+#define R_X86_64_REX_GOTPCRELX  42
 
 /* 4.3.1 ELF Identification.  Should have:
  *


### PR DESCRIPTION
## Summary
- arch/x86_64: add basic support for R_X86_64_REX_GOTPCRELX relocation
GOTPCRELX reloc available only for CONFIG_ARCH_ADDRENV=y
when CONFIG_ARCH_ADDRENV is not set, CONFIG_ARCH_TEXT_VBASE is not specified so we can't relocate

## Impact
we can execute ELF with GOTPCRELX symbols

## Testing
x86_64 in kernel mode (not yet upstream)
