### PR TITLE
wqueue bug fix

### DIFF
--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -470,8 +470,10 @@ int work_cancel_wq(FAR struct kwork_wqueue_s *wqueue,
  *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
- *   Zero (OK) on success, a negated errno on failure.  This error may be
- *   reported:
+ *   Zero means the work was successfully cancelled.
+ *   One means the work was not cancelled because it is currently being
+ *   processed by work thread, but wait for it to finish.
+ *   A negated errno value is returned on any failure:
  *
  *   -ENOENT - There is no such work queued.
  *   -EINVAL - An invalid work queue was specified

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -42,29 +42,6 @@
  * Private Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: work_qcancel
- *
- * Description:
- *   Cancel previously queued work.  This removes work from the work queue.
- *   After work has been cancelled, it may be requeued by calling
- *   work_queue() again.
- *
- * Input Parameters:
- *   wqueue  - The work queue to use
- *   sync    - true: synchronous cancel
- *             false: asynchronous cancel
- *   work    - The previously queued work structure to cancel
- *
- * Returned Value:
- *   Zero (OK) on success, a negated errno on failure.  This error may be
- *   reported:
- *
- *   -ENOENT - There is no such work queued.
- *   -EINVAL - An invalid work queue was specified
- *
- ****************************************************************************/
-
 static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
                         FAR struct work_s *work)
 {
@@ -110,7 +87,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
               wqueue->worker[wndx].pid != nxsched_gettid())
             {
               nxsem_wait_uninterruptible(&wqueue->worker[wndx].wait);
-              ret = OK;
+              ret = 1;
               break;
             }
         }
@@ -170,8 +147,10 @@ int work_cancel_wq(FAR struct kwork_wqueue_s *wqueue,
  *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
- *   Zero (OK) on success, a negated errno on failure.  This error may be
- *   reported:
+ *   Zero means the work was successfully cancelled.
+ *   One means the work was not cancelled because it is currently being
+ *   processed by work thread, but wait for it to finish.
+ *   A negated errno value is returned on any failure:
  *
  *   -ENOENT - There is no such work queued.
  *   -EINVAL - An invalid work queue was specified

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -53,10 +53,9 @@
 
 struct work_notifier_entry_s
 {
-  /* This must appear at the beginning of the structure.  A reference to
-   * the struct work_notifier_entry_s instance must be cast-compatible with
-   * struct dq_entry_s.
-   */
+  struct dq_entry_s entry;
+
+  /* The work structure */
 
   struct work_s work;           /* Used for scheduling the work */
 
@@ -170,11 +169,11 @@ static void work_notifier_worker(FAR void *arg)
 
   /* Remove the notification from the pending list */
 
-  dq_rem((FAR dq_entry_t *)notifier, &g_notifier_pending);
+  dq_rem(&notifier->entry, &g_notifier_pending);
 
   /* Put the notification to the free list */
 
-  dq_addlast((FAR dq_entry_t *)notifier, &g_notifier_free);
+  dq_addlast(&notifier->entry, &g_notifier_free);
 
   leave_critical_section(flags);
 }
@@ -259,7 +258,7 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
        * notifications executed in a saner order?
        */
 
-      dq_addlast((FAR dq_entry_t *)notifier, &g_notifier_pending);
+      dq_addlast(&notifier->entry, &g_notifier_pending);
       ret = notifier->key;
 
       leave_critical_section(flags);
@@ -308,11 +307,11 @@ void work_notifier_teardown(int key)
         {
           /* Remove the notification from the pending list */
 
-          dq_rem((FAR dq_entry_t *)notifier, &g_notifier_pending);
+          dq_rem(&notifier->entry, &g_notifier_pending);
 
           /* Put the notification to the free list */
 
-          dq_addlast((FAR dq_entry_t *)notifier, &g_notifier_free);
+          dq_addlast(&notifier->entry, &g_notifier_free);
         }
     }
 

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -344,6 +344,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
    */
 
   flags = enter_critical_section();
+  sched_lock();
 
   /* Process the notification at the head of the pending list until the
    * pending list is empty
@@ -386,6 +387,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
         }
     }
 
+  sched_unlock();
   leave_critical_section(flags);
 }
 


### PR DESCRIPTION
## Summary
one:
wqueue: teardown should cancel the work already in wqueue

the other one:
```
    wqueue: workaound g_notifier_pending list unsafe
    
    Situation:
    
    thread1                             thread2
    work_notifier_signal
    enter_critical_section
    dq_peek(&g_notifier_pending)
        dq_rem(&g_notifier_pending)
        work_queue()
          // switch -->                 work_notifier_teardown
                                        enter_critical_section
                                        dq_rem(&g_notifier_pending)
                                        leave_critical_section
                                        <--- switch back
        error occured
    leave_critical_section
    
    Workaound:
    used sched_lock() to prevent the switch
```

## Impact
wqueue

## Testing
bes board, net
