### PR TITLE
ramlog bug fix

### DIFF
--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -337,6 +337,13 @@ static ssize_t ramlog_addbuf(FAR struct ramlog_dev_s *priv,
 
   if (len > 0)
     {
+      /* Lock the scheduler do NOT switch out */
+
+      if (!up_interrupt_context())
+        {
+          sched_lock();
+        }
+
 #ifndef CONFIG_RAMLOG_NONBLOCKING
       /* Are there threads waiting for read data? */
 
@@ -345,6 +352,13 @@ static ssize_t ramlog_addbuf(FAR struct ramlog_dev_s *priv,
       /* Notify all poll/select waiters that they can read from the FIFO */
 
       ramlog_pollnotify(priv);
+
+      /* Unlock the scheduler */
+
+      if (!up_interrupt_context())
+        {
+          sched_unlock();
+        }
     }
 
   /* We always have to return the number of bytes requested and NOT the

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -510,7 +510,7 @@ static int ramlog_file_ioctl(FAR struct file *filep, int cmd,
   irqstate_t flags;
   int ret = 0;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
 
   switch (cmd)
     {
@@ -528,7 +528,7 @@ static int ramlog_file_ioctl(FAR struct file *filep, int cmd,
         break;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -615,11 +615,11 @@ static int ramlog_file_open(FAR struct file *filep)
   nxsem_init(&upriv->rl_waitsem, 0, 0);
 #endif
 
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
   list_add_tail(&priv->rl_list, &upriv->rl_node);
   upriv->rl_tail = header->rl_head > priv->rl_bufsize ?
                    header->rl_head - priv->rl_bufsize : 0;
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
 
   filep->f_priv = upriv;
   return 0;
@@ -636,9 +636,9 @@ static int ramlog_file_close(FAR struct file *filep)
 
   /* Get exclusive access to the rl_tail index */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
   list_delete(&upriv->rl_node);
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
 
 #ifndef CONFIG_RAMLOG_NONBLOCKING
   nxsem_destroy(&upriv->rl_waitsem);


### PR DESCRIPTION
## Summary

ramlog: unify the lock to critical section
ramlog: workaround the unsafe critical section

```
    thread1:                           thread2:
    ramlog_addbuf()
        enter_critical_section()
        ramlog_pollnotify()
           foreach rl_list
                 --> switch out
                                       ramlog_file_close
                                       enter_critical_section()
                                       list_delete()
                                       leave_critical_section()
                 <--- switch back
           rl_list error
        leave_critical_section()

```

## Impact
ramlog

## Testing
bes board
