### PR TITLE
add .gdb_history to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 /.config\ *
 /.cproject
 /.gdbinit
+/.gdb_history
 /.project
 /.version
 /_SAVED_APPS_config


### PR DESCRIPTION
## Summary
- add .gdb_history to .gitignore
.gdb_history is created next to NuttX ELF when we working with pwndbg GDB plug-in

## Impact
better user experience when work with pwndbg

## Testing
none
