### PR TITLE
libc/netdb: Remove unnecessary CONFIG_LIBC_NETDB checks

### DIFF
--- a/libs/libc/netdb/lib_gethostbyaddr.c
+++ b/libs/libc/netdb/lib_gethostbyaddr.c
@@ -28,8 +28,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -71,4 +69,3 @@ FAR struct hostent *gethostbyaddr(FAR const void *addr,
   return ret == 0 ? res : NULL;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostbyaddrr.c
+++ b/libs/libc/netdb/lib_gethostbyaddrr.c
@@ -37,8 +37,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Private Type Definitions
  ****************************************************************************/
@@ -441,4 +439,3 @@ int gethostbyaddr_r(FAR const void *addr, socklen_t len, int type,
   return ret;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostbyname.c
+++ b/libs/libc/netdb/lib_gethostbyname.c
@@ -26,8 +26,6 @@
 
 #include <netdb.h>
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -65,4 +63,3 @@ FAR struct hostent *gethostbyname(FAR const char *name)
   return gethostbyname2(name, AF_UNSPEC);
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostbyname2.c
+++ b/libs/libc/netdb/lib_gethostbyname2.c
@@ -28,8 +28,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -73,4 +71,3 @@ FAR struct hostent *gethostbyname2(FAR const char *name, int type)
   return ret == 0 ? res : NULL;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostbyname2r.c
+++ b/libs/libc/netdb/lib_gethostbyname2r.c
@@ -32,8 +32,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -104,4 +102,3 @@ int gethostbyname2_r(FAR const char *name, int type,
   return ret;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostbynamer.c
+++ b/libs/libc/netdb/lib_gethostbynamer.c
@@ -26,8 +26,6 @@
 
 #include <netdb.h>
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -73,4 +71,3 @@ int gethostbyname_r(FAR const char *name,
                           host, buf, buflen, result, h_errnop);
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_gethostentbynamer.c
+++ b/libs/libc/netdb/lib_gethostentbynamer.c
@@ -42,8 +42,6 @@
 #include "netdb/lib_dns.h"
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Private Type Definitions
  ****************************************************************************/
@@ -789,4 +787,3 @@ int gethostentbyname_r(FAR const char *name,
   return ERROR;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_getnameinfo.c
+++ b/libs/libc/netdb/lib_getnameinfo.c
@@ -33,8 +33,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -197,4 +195,3 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
   return OK;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_getservbyname.c
+++ b/libs/libc/netdb/lib_getservbyname.c
@@ -26,8 +26,6 @@
 
 #include <netdb.h>
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -47,4 +45,3 @@ FAR struct servent *getservbyname(FAR const char *name,
   return (ret != OK) ? NULL : res;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_getservbynamer.c
+++ b/libs/libc/netdb/lib_getservbynamer.c
@@ -34,8 +34,6 @@
 
 #include "lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -116,4 +114,3 @@ int getservbyname_r(FAR const char *name, FAR const char *proto,
   return ENOENT;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_getservbyport.c
+++ b/libs/libc/netdb/lib_getservbyport.c
@@ -26,8 +26,6 @@
 
 #include <netdb.h>
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -46,4 +44,3 @@ FAR struct servent *getservbyport(int port, FAR const char *proto)
   return (ret != OK) ? NULL : res;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_getservbyportr.c
+++ b/libs/libc/netdb/lib_getservbyportr.c
@@ -34,8 +34,6 @@
 
 #include "lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -100,4 +98,3 @@ int getservbyport_r(int port, FAR const char *proto,
   return ENOENT;
 }
 
-#endif /* CONFIG_LIBC_NETDB */

--- a/libs/libc/netdb/lib_netdb.c
+++ b/libs/libc/netdb/lib_netdb.c
@@ -28,8 +28,6 @@
 
 #include "netdb/lib_netdb.h"
 
-#ifdef CONFIG_LIBC_NETDB
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -93,4 +91,3 @@ bool convert_hostent(FAR const struct hostent_s *in,
   return j != 0;
 }
 
-#endif /* CONFIG_LIBC_NETDB */


### PR DESCRIPTION


## Summary
Since it already checked by Make.defs and CMakeLists.txt
## Impact
No
## Testing
CI