### PR TITLE
arm: g_current_regs is only used to determine if we are in irq,

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -58,6 +58,8 @@
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -71,6 +73,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    */
 
   up_set_current_regs(regs);
+  tcb->xcp.regs = regs;
 
   /* Acknowledge the interrupt */
 
@@ -79,6 +82,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
+  tcb = this_task();
 
   /* Check for a context switch.  If a context switch occurred, then
    * current_regs will have a different value than it did on entry.  If an
@@ -87,7 +91,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    * returning from the interrupt.
    */
 
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -104,9 +108,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
 
-      regs = up_current_regs();
+      regs = tcb->xcp.regs;
     }
 
   /* Set current_regs to NULL to indicate that we are no longer in an

--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -89,70 +89,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP]    = (uint32_t)(up_current_regs() +
-                                                         XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_CPSR]  = PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT;
-#ifdef CONFIG_ARM_THUMB
-              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
 
       /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -78,7 +78,6 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
@@ -94,158 +93,20 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handle will run in a critical section!
            */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handle will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC, CPSR and PRIMASK
-               * registers (and perhaps also the LR).  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
-                                                      XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled.  The kernel-space trampoline must run in
-               * privileged thread mode.
-               */
-
-              up_current_regs()[REG_PC]         = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_PRIMASK]    = 1;
-              up_current_regs()[REG_XPSR]       = ARMV6M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-              up_current_regs()[REG_LR]         = EXC_RETURN_THREAD;
-              up_current_regs()[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-              up_current_regs()[REG_CONTROL]    = getcontrol() &
-                                                   ~CONTROL_NPRIV;
-#endif
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling* some non-running task.
-       */
-
       else
         {
-          /* Save the return PC, CPSR and PRIMASK
-           * registers (and perhaps also the LR).  These will be restored
-           * by the signal trampoline after the signal has been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
-           */
-
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_PRIMASK] = 1;
-          tcb->xcp.regs[REG_XPSR]    = ARMV6M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-        }
-    }
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
           /* CASE 2:  The task that needs to receive the signal is running.
            * This could happen if the task is running on another CPU OR if
            * we are in an interrupt handler and the task is running on this
@@ -254,122 +115,22 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * state as well as the state in the TCB.
            */
 
-          else
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
             {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
+              /* Pause the CPU */
 
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs              = (void *)
-                                               ((uint32_t)tcb->xcp.regs -
-                                                          XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                         XCPTCONTEXT_SIZE;
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  We must already be in privileged thread mode
-                   * to be here.
-                   */
-
-                  tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-                  tcb->xcp.regs[REG_PRIMASK] = 1;
-                  tcb->xcp.regs[REG_XPSR]    = ARMV6M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-                  tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These
-                   * will be restored by the signal trampoline after the
-                   * signal has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                         + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]      = (uint32_t)arm_sigdeliver;
-                  up_current_regs()[REG_PRIMASK] = 1;
-                  up_current_regs()[REG_XPSR]    = ARMV6M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  up_current_regs()[REG_LR]      = EXC_RETURN_THREAD;
-                  up_current_regs()[REG_CONTROL] = getcontrol() &
-                                                    ~CONTROL_NPRIV;
-#endif
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
+              up_cpu_pause(cpu);
             }
-        }
+#endif
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
-      else
-        {
           /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
            * registers (and perhaps also the LR).  These will be restored
            * by the signal trampoline after the signal has been delivered.
@@ -377,34 +138,43 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           /* Save the current register context location */
 
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
+          tcb->xcp.saved_regs           = tcb->xcp.regs;
 
           /* Duplicate the register context.  These will be
            * restored by the signal trampoline after the signal has been
            * delivered.
            */
 
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
+          tcb->xcp.regs                 = (void *)
+                                          ((uint32_t)tcb->xcp.regs -
+                                                     XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
+          tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
+                                                    XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
            * here.
            */
 
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_PRIMASK] = 1;
-          tcb->xcp.regs[REG_XPSR]    = ARMV6M_XPSR_T;
+          tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
+          tcb->xcp.regs[REG_PRIMASK]    = 1;
+          tcb->xcp.regs[REG_XPSR]       = ARMV6M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
+          tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+#endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
 #endif
         }
     }
 }
-#endif /* CONFIG_SMP */

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -117,6 +117,7 @@ static void dispatch_syscall(void)
 
 int arm_svcall(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb = this_task();
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
@@ -167,7 +168,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
-          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R1];
         }
         break;
 
@@ -192,7 +193,7 @@ int arm_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          up_set_current_regs((uint32_t *)regs[REG_R2]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -450,23 +451,20 @@ int arm_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
 #  endif
     {
+      regs = (uint32_t *)tcb->xcp.regs;
+
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R0],  up_current_regs()[REG_R1],
-              up_current_regs()[REG_R2],  up_current_regs()[REG_R3],
-              up_current_regs()[REG_R4],  up_current_regs()[REG_R5],
-              up_current_regs()[REG_R6],  up_current_regs()[REG_R7]);
+              regs[REG_R0],  regs[REG_R1], regs[REG_R2],  regs[REG_R3],
+              regs[REG_R4],  regs[REG_R5], regs[REG_R6],  regs[REG_R7]);
       svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R8],  up_current_regs()[REG_R9],
-              up_current_regs()[REG_R10], up_current_regs()[REG_R11],
-              up_current_regs()[REG_R12], up_current_regs()[REG_R13],
-              up_current_regs()[REG_R14], up_current_regs()[REG_R15]);
-      svcinfo(" PSR: %08x PRIMASK: %08x EXC_RETURN: %08x\n",
-              up_current_regs()[REG_XPSR], up_current_regs()[REG_PRIMASK],
-              up_current_regs()[REG_EXC_RETURN]);
+              regs[REG_R8],  regs[REG_R9], regs[REG_R10], regs[REG_R11],
+              regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+      svcinfo(" PSR: %08x EXC_RETURN: %08x CONTROL: %08x\n",
+              regs[REG_XPSR], regs[REG_EXC_RETURN], regs[REG_CONTROL]);
     }
 #  ifdef CONFIG_DEBUG_SVCALL
   else

--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -117,11 +117,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -207,11 +203,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/armv7-a/arm_cpustart.c
+++ b/arch/arm/src/armv7-a/arm_cpustart.c
@@ -79,18 +79,8 @@ int arm_start_handler(int irq, void *context, void *arg)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Dump registers so that we can see what is going to happen on return */
+  UNUSED(tcb);
 
-#if 0
-  up_dump_register(tcb->xcp.regs);
-#endif
-
-  /* Then switch contexts. This instantiates the exception context of the
-   * tcb at the head of the assigned task list.  In this case, this should
-   * be the CPUs NULL task.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
   return OK;
 }
 

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -53,6 +53,8 @@
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -60,6 +62,18 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(up_current_regs() == NULL);
+
+  /* if irq == GIC_SMP_CPUSTART
+   * We are initiating the multi-core jumping state to up_idle,
+   * and we will use this_task(). Therefore, it cannot be overridden.
+   */
+
+#ifdef CONFIG_SMP
+  if (irq != GIC_SMP_CPUSTART)
+#endif
+    {
+      tcb->xcp.regs = regs;
+    }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -70,10 +84,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
+  tcb = this_task();
 
-  /* Restore the cpu lock */
-
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -90,8 +103,8 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
-      regs = up_current_regs();
+      g_running_tasks[this_cpu()] = tcb;
+      regs = tcb->xcp.regs;
     }
 
   /* Set current_regs to NULL to indicate that we are no longer in an

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -77,7 +77,6 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
@@ -92,157 +91,20 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on this CPU.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handler will run in a critical section!
            */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state
-           * in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signaling itself, but a context switch
-           * to another task has occurred so that current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP]    = (uint32_t)(up_current_regs() +
-                                                         XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                               PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
       else
         {
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs      = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs            = (void *)
-                                     ((uint32_t)tcb->xcp.regs -
-                                                XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                               XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-        }
-    }
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
           /* CASE 2:  The task that needs to receive the signal is running.
            * This could happen if the task is running on another CPU OR if
            * we are in an interrupt handler and the task is running on this
@@ -251,118 +113,22 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * state as well as the state in the TCB.
            */
 
-          else
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
             {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
+              /* Pause the CPU */
 
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs      = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs            = (void *)
-                                             ((uint32_t)tcb->xcp.regs -
-                                                        XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                                       XCPTCONTEXT_SIZE;
-
-                  /* Then set up to vector to the trampoline with interrupts
-                   * disabled
-                   */
-
-                  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These will
-                   * be restored by the signal trampoline after the signal
-                   * has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                         + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                                   PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
+              up_cpu_pause(cpu);
             }
-        }
+#endif
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
-      else
-        {
           /* Save the return lr and cpsr and one scratch register.  These
            * will be restored by the signal trampoline after the signals
            * have been delivered.
@@ -394,7 +160,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_ARM_THUMB
           tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
+#endif
         }
     }
 }
-#endif /* CONFIG_SMP */

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -160,7 +160,7 @@ static void dispatch_syscall(void)
 
 uint32_t *arm_syscall(uint32_t *regs)
 {
-  struct tcb_s *tcb;
+  struct tcb_s *tcb = this_task();
   uint32_t cmd;
   int cpu;
 #ifdef CONFIG_BUILD_KERNEL
@@ -170,6 +170,8 @@ uint32_t *arm_syscall(uint32_t *regs)
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(up_current_regs() == NULL);
+
+  tcb->xcp.regs = regs;
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -272,7 +274,7 @@ uint32_t *arm_syscall(uint32_t *regs)
            * set will determine the restored context.
            */
 
-          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R1];
           DEBUGASSERT(up_current_regs());
         }
         break;
@@ -298,7 +300,7 @@ uint32_t *arm_syscall(uint32_t *regs)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          up_set_current_regs((uint32_t *)regs[REG_R2]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -565,15 +567,9 @@ uint32_t *arm_syscall(uint32_t *regs)
         break;
     }
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Check for a context switch.  If a context switch occurred, then
-   * current_regs will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then establish the correct
-   * address environment before returning from the interrupt.
-   */
-
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
+#ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
        * MMU flushed) and set up the address environment for the new
@@ -581,13 +577,8 @@ uint32_t *arm_syscall(uint32_t *regs)
        */
 
       addrenv_switch(NULL);
-    }
 #endif
 
-  /* Restore the cpu lock */
-
-  if (regs != up_current_regs())
-    {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
@@ -599,7 +590,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       /* Restore the cpu lock */
 
       restore_critical_section(tcb, cpu);
-      regs = up_current_regs();
+      regs = tcb->xcp.regs;
     }
 
   /* Report what happened */

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -79,7 +79,6 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
@@ -95,167 +94,20 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handle will run in a critical section!
            */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handle will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-               * registers (and perhaps also the LR).  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
-                                                      XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled.  The kernel-space trampoline must run in
-               * privileged thread mode.
-               */
-
-              up_current_regs()[REG_PC]         = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV7M_USEBASEPRI
-              up_current_regs()[REG_BASEPRI]    =
-                                                  NVIC_SYSH_DISABLE_PRIORITY;
-#else
-              up_current_regs()[REG_PRIMASK]    = 1;
-#endif
-              up_current_regs()[REG_XPSR]       = ARMV7M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-              up_current_regs()[REG_LR]         = EXC_RETURN_THREAD;
-              up_current_regs()[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-              up_current_regs()[REG_CONTROL]    = getcontrol() &
-                                                   ~CONTROL_NPRIV;
-#endif
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling* some non-running task.
-       */
-
       else
         {
-          /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-           * registers (and perhaps also the LR).  These will be restored
-           * by the signal trampoline after the signal has been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
-           */
-
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV7M_USEBASEPRI
-          tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
-#else
-          tcb->xcp.regs[REG_PRIMASK] = 1;
-#endif
-          tcb->xcp.regs[REG_XPSR]    = ARMV7M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-        }
-    }
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
           /* CASE 2:  The task that needs to receive the signal is running.
            * This could happen if the task is running on another CPU OR if
            * we are in an interrupt handler and the task is running on this
@@ -264,131 +116,22 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * state as well as the state in the TCB.
            */
 
-          else
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
             {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
+              /* Pause the CPU */
 
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs              = (void *)
-                                               ((uint32_t)tcb->xcp.regs -
-                                                          XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                         XCPTCONTEXT_SIZE;
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  We must already be in privileged thread mode
-                   * to be here.
-                   */
-
-                  tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV7M_USEBASEPRI
-                  tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
-#else
-                  tcb->xcp.regs[REG_PRIMASK] = 1;
-#endif
-                  tcb->xcp.regs[REG_XPSR]    = ARMV7M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-                  tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These
-                   * will be restored by the signal trampoline after the
-                   * signal has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                         + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV7M_USEBASEPRI
-                  up_current_regs()[REG_BASEPRI] =
-                  NVIC_SYSH_DISABLE_PRIORITY;
-#else
-                  up_current_regs()[REG_PRIMASK] = 1;
-#endif
-                  up_current_regs()[REG_XPSR]    = ARMV7M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  up_current_regs()[REG_LR]      = EXC_RETURN_THREAD;
-                  up_current_regs()[REG_CONTROL] = getcontrol() &
-                                                    ~CONTROL_NPRIV;
-#endif
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
+              up_cpu_pause(cpu);
             }
-        }
+#endif
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
-      else
-        {
           /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
            * registers (and perhaps also the LR).  These will be restored
            * by the signal trampoline after the signal has been delivered.
@@ -396,38 +139,47 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           /* Save the current register context location */
 
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
+          tcb->xcp.saved_regs           = tcb->xcp.regs;
 
           /* Duplicate the register context.  These will be
            * restored by the signal trampoline after the signal has been
            * delivered.
            */
 
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
+          tcb->xcp.regs                 = (void *)
+                                          ((uint32_t)tcb->xcp.regs -
+                                                     XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
+          tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
+                                                    XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
            * here.
            */
 
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
+          tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-          tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
+          tcb->xcp.regs[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
 #else
-          tcb->xcp.regs[REG_PRIMASK] = 1;
+          tcb->xcp.regs[REG_PRIMASK]    = 1;
 #endif
-          tcb->xcp.regs[REG_XPSR]    = ARMV7M_XPSR_T;
+          tcb->xcp.regs[REG_XPSR]       = ARMV7M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
+          tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+#endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
 #endif
         }
     }
 }
-#endif /* CONFIG_SMP */

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -125,6 +125,7 @@ static void dispatch_syscall(void)
 
 int arm_svcall(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb = this_task();
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
@@ -176,7 +177,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
-          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R1];
         }
         break;
 
@@ -201,7 +202,7 @@ int arm_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          up_set_current_regs((uint32_t *)regs[REG_R2]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -459,24 +460,20 @@ int arm_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
 #  endif
     {
+      regs = (uint32_t *)tcb->xcp.regs;
+
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R0],  up_current_regs()[REG_R1],
-              up_current_regs()[REG_R2],  up_current_regs()[REG_R3],
-              up_current_regs()[REG_R4],  up_current_regs()[REG_R5],
-              up_current_regs()[REG_R6],  up_current_regs()[REG_R7]);
+              regs[REG_R0],  regs[REG_R1], regs[REG_R2],  regs[REG_R3],
+              regs[REG_R4],  regs[REG_R5], regs[REG_R6],  regs[REG_R7]);
       svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R8],  up_current_regs()[REG_R9],
-              up_current_regs()[REG_R10], up_current_regs()[REG_R11],
-              up_current_regs()[REG_R12], up_current_regs()[REG_R13],
-              up_current_regs()[REG_R14], up_current_regs()[REG_R15]);
-      svcinfo(" PSR: %08x EXC_RETURN: %08x, CONTROL: %08x\n",
-              up_current_regs()[REG_XPSR],
-              up_current_regs()[REG_EXC_RETURN],
-              up_current_regs()[REG_CONTROL]);
+              regs[REG_R8],  regs[REG_R9], regs[REG_R10], regs[REG_R11],
+              regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+      svcinfo(" PSR: %08x EXC_RETURN: %08x CONTROL: %08x\n",
+              regs[REG_XPSR], regs[REG_EXC_RETURN], regs[REG_CONTROL]);
     }
 #  ifdef CONFIG_DEBUG_SVCALL
   else

--- a/arch/arm/src/armv7-r/arm_cpupause.c
+++ b/arch/arm/src/armv7-r/arm_cpupause.c
@@ -117,11 +117,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -207,11 +203,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/armv7-r/arm_cpustart.c
+++ b/arch/arm/src/armv7-r/arm_cpustart.c
@@ -79,12 +79,8 @@ int arm_start_handler(int irq, void *context, void *arg)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts. This instantiates the exception context of the
-   * tcb at the head of the assigned task list.  In this case, this should
-   * be the CPUs NULL task.
-   */
+  UNUSED(tcb);
 
-  arm_restorestate(tcb->xcp.regs);
   return OK;
 }
 

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -41,6 +41,8 @@
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
   board_autoled_on(LED_INIRQ);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -49,6 +51,18 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(up_current_regs() == NULL);
+
+  /* if irq == GIC_SMP_CPUSTART
+   * We are initiating the multi-core jumping state to up_idle,
+   * and we will use this_task(). Therefore, it cannot be overridden.
+   */
+
+#ifdef CONFIG_SMP
+  if (irq != GIC_SMP_CPUSTART)
+#endif
+    {
+      tcb->xcp.regs = regs;
+    }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -59,18 +73,17 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
+  tcb = this_task();
 
-  /* Restore the cpu lock */
-
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
-      regs = up_current_regs();
+      g_running_tasks[this_cpu()] = tcb;
+      regs = tcb->xcp.regs;
     }
 
   /* Set current_regs to NULL to indicate that we are no longer in an

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -75,143 +75,8 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
-        {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
-
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state
-           * in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP]  = (uint32_t)(up_current_regs() +
-                                                       XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]   = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_ENDIAN_BIG
-              up_current_regs()[REG_CPSR] |= PSR_E_BIT;
-#endif
-            }
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signalling some non-running task.
-       */
-
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]    = (PSR_MODE_SYS | PSR_I_BIT |
-                                        PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR]   |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_ENDIAN_BIG
-          tcb->xcp.regs[REG_CPSR]   |= PSR_E_BIT;
-#endif
-        }
-    }
-}
-#else
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
@@ -224,147 +89,36 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handler will run in a critical section!
            */
 
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
-
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs      = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs            = (void *)
-                                             ((uint32_t)tcb->xcp.regs -
-                                                        XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                                       XCPTCONTEXT_SIZE;
-
-                  /* Then set up to vector to the trampoline with interrupts
-                   * disabled
-                   */
-
-                  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These will
-                   * be restored by the signal trampoline after the signal
-                   * has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                         + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                                  PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
       else
         {
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
+            {
+              /* Pause the CPU */
+
+              up_cpu_pause(cpu);
+            }
+#endif
+
           /* Save the return lr and cpsr and one scratch register.  These
            * will be restored by the signal trampoline after the signals
            * have been delivered.
@@ -396,7 +150,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_ARM_THUMB
           tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
+#endif
         }
     }
 }
-#endif

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -156,7 +156,8 @@ static void dispatch_syscall(void)
 
 uint32_t *arm_syscall(uint32_t *regs)
 {
-  struct tcb_s *tcb;
+  struct tcb_s *tcb = this_task();
+
   uint32_t cmd;
   int cpu;
 #ifdef CONFIG_BUILD_PROTECTED
@@ -166,6 +167,8 @@ uint32_t *arm_syscall(uint32_t *regs)
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(up_current_regs() == NULL);
+
+  tcb->xcp.regs = regs;
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -268,7 +271,7 @@ uint32_t *arm_syscall(uint32_t *regs)
            * set will determine the restored context.
            */
 
-          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R1];
           DEBUGASSERT(up_current_regs());
         }
         break;
@@ -294,7 +297,7 @@ uint32_t *arm_syscall(uint32_t *regs)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          up_set_current_regs((uint32_t *)regs[REG_R2]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -561,22 +564,19 @@ uint32_t *arm_syscall(uint32_t *regs)
         break;
     }
 
-  /* Restore the cpu lock */
-
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
       cpu = this_cpu();
-      tcb = current_task(cpu);
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */
 
       restore_critical_section(tcb, cpu);
-      regs = up_current_regs();
+      regs = tcb->xcp.regs;
     }
 
   /* Report what happened */

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -79,7 +79,6 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
@@ -95,167 +94,20 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handle will run in a critical section!
            */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handle will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-               * registers (and perhaps also the LR).  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
-                                                      XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled.  The kernel-space trampoline must run in
-               * privileged thread mode.
-               */
-
-              up_current_regs()[REG_PC]         = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV8M_USEBASEPRI
-              up_current_regs()[REG_BASEPRI]    =
-                                                  NVIC_SYSH_DISABLE_PRIORITY;
-#else
-              up_current_regs()[REG_PRIMASK]    = 1;
-#endif
-              up_current_regs()[REG_XPSR]       = ARMV8M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-              up_current_regs()[REG_LR]         = EXC_RETURN_THREAD;
-              up_current_regs()[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-              up_current_regs()[REG_CONTROL]    = getcontrol() &
-                                                   ~CONTROL_NPRIV;
-#endif
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling* some non-running task.
-       */
-
       else
         {
-          /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-           * registers (and perhaps also the LR).  These will be restored
-           * by the signal trampoline after the signal has been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
-           */
-
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV8M_USEBASEPRI
-          tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
-#else
-          tcb->xcp.regs[REG_PRIMASK] = 1;
-#endif
-          tcb->xcp.regs[REG_XPSR]    = ARMV8M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-        }
-    }
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
           /* CASE 2:  The task that needs to receive the signal is running.
            * This could happen if the task is running on another CPU OR if
            * we are in an interrupt handler and the task is running on this
@@ -264,124 +116,22 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * state as well as the state in the TCB.
            */
 
-          else
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
             {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
+              /* Pause the CPU */
 
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs              = (void *)
-                                               ((uint32_t)tcb->xcp.regs -
-                                                          XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                         XCPTCONTEXT_SIZE;
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  We must already be in privileged thread mode
-                   * to be here.
-                   */
-
-                  tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV8M_USEBASEPRI
-                  tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
-#else
-                  tcb->xcp.regs[REG_PRIMASK] = 1;
-#endif
-                  tcb->xcp.regs[REG_XPSR]    = ARMV8M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-                  tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These
-                   * will be restored by the signal trampoline after the
-                   * signal has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                        + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]      = (uint32_t)arm_sigdeliver;
-#ifdef CONFIG_ARMV8M_USEBASEPRI
-                  up_current_regs()[REG_BASEPRI] =
-                  NVIC_SYSH_DISABLE_PRIORITY;
-#else
-                  up_current_regs()[REG_PRIMASK] = 1;
-#endif
-                  up_current_regs()[REG_XPSR]    = ARMV8M_XPSR_T;
-#ifdef CONFIG_BUILD_PROTECTED
-                  up_current_regs()[REG_LR]      = EXC_RETURN_THREAD;
-                  up_current_regs()[REG_CONTROL] = getcontrol() &
-                                                    ~CONTROL_NPRIV;
-#endif
-                }
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
+              up_cpu_pause(cpu);
             }
-        }
+#endif
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
-      else
-        {
           /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
            * registers (and perhaps also the LR).  These will be restored
            * by the signal trampoline after the signal has been delivered.
@@ -389,38 +139,47 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
           /* Save the current register context location */
 
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
+          tcb->xcp.saved_regs           = tcb->xcp.regs;
 
           /* Duplicate the register context.  These will be
            * restored by the signal trampoline after the signal has been
            * delivered.
            */
 
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
+          tcb->xcp.regs                 = (void *)
+                                          ((uint32_t)tcb->xcp.regs -
+                                                     XCPTCONTEXT_SIZE);
           memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
+          tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
+                                                    XCPTCONTEXT_SIZE;
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled.  We must already be in privileged thread mode to be
            * here.
            */
 
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
+          tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV8M_USEBASEPRI
-          tcb->xcp.regs[REG_BASEPRI] = NVIC_SYSH_DISABLE_PRIORITY;
+          tcb->xcp.regs[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
 #else
-          tcb->xcp.regs[REG_PRIMASK] = 1;
+          tcb->xcp.regs[REG_PRIMASK]    = 1;
 #endif
-          tcb->xcp.regs[REG_XPSR]    = ARMV8M_XPSR_T;
+          tcb->xcp.regs[REG_XPSR]       = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]      = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL] = getcontrol() & ~CONTROL_NPRIV;
+          tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+          tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+#endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
 #endif
         }
     }
 }
-#endif /* CONFIG_SMP */

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -124,6 +124,7 @@ static void dispatch_syscall(void)
 
 int arm_svcall(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb = this_task();
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
 
@@ -175,7 +176,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
-          up_set_current_regs((uint32_t *)regs[REG_R1]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R1];
         }
         break;
 
@@ -200,7 +201,7 @@ int arm_svcall(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
           *(uint32_t **)regs[REG_R1] = regs;
-          up_set_current_regs((uint32_t *)regs[REG_R2]);
+          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -460,24 +461,20 @@ int arm_svcall(int irq, void *context, void *arg)
 #  ifndef CONFIG_DEBUG_SVCALL
   if (cmd > SYS_switch_context)
 #  else
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
 #  endif
     {
+      regs = (uint32_t *)tcb->xcp.regs;
+
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R0],  up_current_regs()[REG_R1],
-              up_current_regs()[REG_R2],  up_current_regs()[REG_R3],
-              up_current_regs()[REG_R4],  up_current_regs()[REG_R5],
-              up_current_regs()[REG_R6],  up_current_regs()[REG_R7]);
+              regs[REG_R0],  regs[REG_R1], regs[REG_R2],  regs[REG_R3],
+              regs[REG_R4],  regs[REG_R5], regs[REG_R6],  regs[REG_R7]);
       svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-              up_current_regs()[REG_R8],  up_current_regs()[REG_R9],
-              up_current_regs()[REG_R10], up_current_regs()[REG_R11],
-              up_current_regs()[REG_R12], up_current_regs()[REG_R13],
-              up_current_regs()[REG_R14], up_current_regs()[REG_R15]);
+              regs[REG_R8],  regs[REG_R9], regs[REG_R10], regs[REG_R11],
+              regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
       svcinfo(" PSR: %08x EXC_RETURN: %08x CONTROL: %08x\n",
-              up_current_regs()[REG_XPSR],
-              up_current_regs()[REG_EXC_RETURN],
-              up_current_regs()[REG_CONTROL]);
+              regs[REG_XPSR], regs[REG_EXC_RETURN], regs[REG_CONTROL]);
     }
 #  ifdef CONFIG_DEBUG_SVCALL
   else

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -42,6 +42,8 @@
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
   board_autoled_on(LED_INIRQ);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -50,6 +52,16 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(up_current_regs() == NULL);
+
+  /* if irq == GIC_SMP_CPUSTART
+   * We are initiating the multi-core jumping state to up_idle,
+   * and we will use this_task(). Therefore, it cannot be overridden.
+   */
+
+  if (irq != GIC_SMP_CPUSTART)
+    {
+      tcb->xcp.regs = regs;
+    }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -60,10 +72,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
+  tcb = this_task();
 
-  /* Restore the cpu lock */
-
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
@@ -71,7 +82,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        */
 
       g_running_tasks[this_cpu()] = this_task();
-      regs = up_current_regs();
+      regs = tcb->xcp.regs;
     }
 
   /* Set current_regs to NULL to indicate that we are no longer in an

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -75,143 +75,8 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
-       */
-
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
-        {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
-
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state
-           * in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
-                                                      XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]   = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_CPSR] = (PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-              up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_ENDIAN_BIG
-              up_current_regs()[REG_CPSR] |= PSR_E_BIT;
-#endif
-            }
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signalling some non-running task.
-       */
-
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
-
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs        = tcb->xcp.regs;
-
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs              = (void *)
-                                       ((uint32_t)tcb->xcp.regs -
-                                                  XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]      = (uint32_t)tcb->xcp.regs +
-                                                 XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]    = (PSR_MODE_SYS | PSR_I_BIT |
-                                        PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR]   |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_ENDIAN_BIG
-          tcb->xcp.regs[REG_CPSR]   |= PSR_E_BIT;
-#endif
-        }
-    }
-}
-#else
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
@@ -224,154 +89,36 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handler will run in a critical section!
            */
 
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
-
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  /* Save the current register context location */
-
-                  tcb->xcp.saved_regs      = tcb->xcp.regs;
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.regs            = (void *)
-                                             ((uint32_t)tcb->xcp.regs -
-                                                        XCPTCONTEXT_SIZE);
-                  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                                       XCPTCONTEXT_SIZE;
-
-                  /* Then set up to vector to the trampoline with interrupts
-                   * disabled
-                   */
-
-                  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                              PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These will
-                   * be restored by the signal trampoline after the signal
-                   * has been delivered.
-                   */
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  arm_savestate(tcb->xcp.saved_regs);
-
-                  /* Duplicate the register context.  These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-                  memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                         XCPTCONTEXT_SIZE);
-
-                  up_current_regs()[REG_SP] = (uint32_t)(up_current_regs()
-                                                         + XCPTCONTEXT_REGS);
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  up_current_regs()[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT |
-                                                   PSR_F_BIT);
-#ifdef CONFIG_ARM_THUMB
-                  up_current_regs()[REG_CPSR] |= PSR_T_BIT;
-#endif
-                }
-
-              /* Increment the IRQ lock count so that when the task is
-               * restarted, it will hold the IRQ spinlock.
-               */
-
-              DEBUGASSERT(tcb->irqcount < INT16_MAX);
-              tcb->irqcount++;
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
       else
         {
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
+            {
+              /* Pause the CPU */
+
+              up_cpu_pause(cpu);
+            }
+#endif
+
           /* Save the return lr and cpsr and one scratch register.  These
            * will be restored by the signal trampoline after the signals
            * have been delivered.
@@ -394,13 +141,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
                                                XCPTCONTEXT_SIZE;
 
-          /* Increment the IRQ lock count so that when the task is restarted,
-           * it will hold the IRQ spinlock.
-           */
-
-          DEBUGASSERT(tcb->irqcount < INT16_MAX);
-          tcb->irqcount++;
-
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
@@ -410,7 +150,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_ARM_THUMB
           tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
+#endif
         }
     }
 }
-#endif

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -96,11 +96,6 @@
 
 #define INTSTACK_SIZE (CONFIG_ARCH_INTERRUPTSTACK & ~STACK_ALIGN_MASK)
 
-/* Macros to handle saving and restoring interrupt state. */
-
-#define arm_savestate(regs)    (regs = up_current_regs())
-#define arm_restorestate(regs) up_set_current_regs(regs)
-
 /* Toolchain dependent, linker defined section addresses */
 
 #if defined(__ICCARM__)

--- a/arch/arm/src/common/arm_switchcontext.c
+++ b/arch/arm/src/common/arm_switchcontext.c
@@ -63,21 +63,9 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   if (up_current_regs())
     {
-      /* Yes, then we have to do things differently.
-       * Just copy the current_regs into the OLD rtcb.
-       */
-
-      arm_savestate(rtcb->xcp.regs);
-
       /* Update scheduler parameters */
 
       nxsched_resume_scheduler(tcb);
-
-      /* Then switch contexts.  Any necessary address environment
-       * changes will be made when the interrupt returns.
-       */
-
-      arm_restorestate(tcb->xcp.regs);
     }
 
   /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/common/arm_switchcontext.c
+++ b/arch/arm/src/common/arm_switchcontext.c
@@ -61,7 +61,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       /* Update scheduler parameters */
 

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -199,11 +199,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -290,11 +286,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/imx1/imx_decodeirq.c
+++ b/arch/arm/src/imx1/imx_decodeirq.c
@@ -57,6 +57,8 @@
 
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
@@ -74,6 +76,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
   DEBUGASSERT(up_current_regs() == NULL);
   up_set_current_regs(regs);
+  tcb->xcp.regs = regs;
 
   /* Loop while there are pending interrupts to be processed */
 
@@ -99,6 +102,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
           /* Deliver the IRQ */
 
           irq_dispatch(irq, regs);
+          tcb = this_task();
 
 #ifdef CONFIG_ARCH_ADDRENV
           /* Check for a context switch.  If a context switch occurred, then
@@ -108,7 +112,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
            * from the interrupt.
            */
 
-          if (regs != up_current_regs())
+          if (regs != tcb->xcp.regs)
             {
               /* Make sure that the address environment for the previously
                * running task is closed down gracefully (data caches dump,

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -127,11 +127,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -211,11 +207,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/lpc214x/lpc214x_decodeirq.c
+++ b/arch/arm/src/lpc214x/lpc214x_decodeirq.c
@@ -33,6 +33,7 @@
 #include "chip.h"
 #include "arm_internal.h"
 #include "lpc214x_vic.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Private Data
@@ -81,6 +82,8 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 static uint32_t *lpc214x_decodeirq(uint32_t *regs)
 #endif
 {
+  struct tcb_s *tcb = this_task();
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   up_set_current_regs(regs);
   err("ERROR: Unexpected IRQ\n");
@@ -125,6 +128,7 @@ static uint32_t *lpc214x_decodeirq(uint32_t *regs)
 
       savestate = up_current_regs();
       up_set_current_regs(regs);
+      tcb->xcp.regs = regs;
 
       /* Deliver the IRQ */
 

--- a/arch/arm/src/lpc2378/lpc23xx_decodeirq.c
+++ b/arch/arm/src/lpc2378/lpc23xx_decodeirq.c
@@ -56,6 +56,7 @@
 #include "arm_internal.h"
 #include "lpc2378.h"
 #include "lpc23xx_vic.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Public Functions
@@ -91,6 +92,8 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 static uint32_t *lpc23xx_decodeirq(uint32_t *regs)
 #endif
 {
+  struct tcb_s *tcb = this_task();
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   err("ERROR: Unexpected IRQ\n");
   up_set_current_regs(regs);
@@ -124,6 +127,7 @@ static uint32_t *lpc23xx_decodeirq(uint32_t *regs)
 
       savestate = up_current_regs();
       up_set_current_regs(regs);
+      tcb->xcp.regs = regs;
 
       /* Acknowledge the interrupt */
 

--- a/arch/arm/src/moxart/moxart_irq.c
+++ b/arch/arm/src/moxart/moxart_irq.c
@@ -260,6 +260,7 @@ void arm_ack_irq(int irq)
 
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
   uint32_t num;
   uint32_t status;
 
@@ -278,6 +279,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
   DEBUGASSERT(up_current_regs() == NULL);
   up_set_current_regs(regs);
+  tcb->xcp.regs = regs;
 
   irq_dispatch(num, regs);
   up_set_current_regs(NULL);

--- a/arch/arm/src/rp2040/rp2040_cpupause.c
+++ b/arch/arm/src/rp2040/rp2040_cpupause.c
@@ -167,11 +167,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -251,11 +247,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/sam34/sam4cm_cpupause.c
+++ b/arch/arm/src/sam34/sam4cm_cpupause.c
@@ -129,11 +129,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -213,11 +209,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm/src/str71x/str71x_decodeirq.c
+++ b/arch/arm/src/str71x/str71x_decodeirq.c
@@ -35,6 +35,7 @@
 
 #include "chip.h"
 #include "arm_internal.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Public Functions
@@ -53,6 +54,8 @@
 
 uint32_t *arm_decodeirq(uint32_t *regs)
 {
+  struct tcb_s *tcb = this_task();
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
   up_set_current_regs(regs);
@@ -82,6 +85,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
 
       savestate = up_current_regs();
       up_set_current_regs(regs);
+      tcb->xcp.regs = regs;
 
       /* Acknowledge the interrupt */
 

--- a/arch/arm/src/tlsr82/tc32/tc32_doirq.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_doirq.c
@@ -64,21 +64,15 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   PANIC();
 #else
 
-  /* Nested interrupts are not supported in this implementation.  If you
-   * want to implement nested interrupts, you would have to (1) change the
-   * way that current_regs is handled and (2) the design associated with
-   * CONFIG_ARCH_INTERRUPTSTACK.
-   */
+  /* Nested interrupts are not supported */
+
+  DEBUGASSERT(up_current_regs() == NULL);
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
    */
 
-  if (up_current_regs() == NULL)
-    {
-      up_set_current_regs(regs);
-      regs         = NULL;
-    }
+  up_set_current_regs(regs);
 
   tcb->xcp.regs = regs;
 
@@ -97,17 +91,15 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    * switch occurred during interrupt processing.
    */
 
-  if (regs == NULL)
+  if (regs != tcb->xcp.regs)
     {
-      if (regs != tcb->xcp.regs)
-        {
-          regs = tcb->xcp.regs;
-        }
-
-      /* Update the current_regs to NULL. */
-
-      up_set_current_regs(NULL);
+      regs = tcb->xcp.regs;
     }
+
+  /* Update the current_regs to NULL. */
+
+  up_set_current_regs(NULL);
+
 #endif
 
   board_autoled_off(LED_INIRQ);

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -89,67 +89,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
+      sinfo("rtcb=%p current_regs=%p\n", this_task(),
+            this_task()->xcp.regs);
 
-      if (tcb == this_task())
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              arm_savestate(tcb->xcp.saved_regs);
-
-              /* Duplicate the register context.  These will be
-               * restored by the signal trampoline after the signal has been
-               * delivered.
-               */
-
-              up_set_current_regs(up_current_regs() - XCPTCONTEXT_REGS);
-              memcpy(up_current_regs(), tcb->xcp.saved_regs,
-                     XCPTCONTEXT_SIZE);
-
-              up_current_regs()[REG_SP] = (uint32_t)(up_current_regs() +
-                                                      XCPTCONTEXT_REGS);
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_LR]     = (uint32_t)arm_sigdeliver;
-              up_current_regs()[REG_CPSR]   = PSR_MODE_SVC | PSR_I_BIT;
-              up_current_regs()[REG_IRQ_EN] = 0;
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
 
       /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm64/src/common/arm64_cpupause.c
+++ b/arch/arm64/src/common/arm64_cpupause.c
@@ -116,11 +116,7 @@ int up_cpu_paused_save(void)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Save the current context at current_regs into the TCB at the head
-   * of the assigned task list for this CPU.
-   */
-
-  arm64_savestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }
@@ -210,11 +206,7 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Then switch contexts.  Any necessary address environment changes
-   * will be made when the interrupt returns.
-   */
-
-  arm64_restorestate(tcb->xcp.regs);
+  UNUSED(tcb);
 
   return OK;
 }

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -84,13 +84,6 @@
 #  define CONFIG_ARCH_INTERRUPTSTACK 0
 #endif
 
-/* If the floating point unit is present and enabled, then save the
- * floating point registers as well as normal ARM registers.
- */
-
-#define arm64_savestate(regs) (regs = up_current_regs())
-#define arm64_restorestate(regs) up_set_current_regs(regs)
-
 /* This is the value used to mark the stack for subsequent stack monitoring
  * logic.
  */

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -126,99 +126,8 @@ void arm64_init_signal_process(struct tcb_s *tcb, struct regs_context *regs)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->xcp.sigdeliver)
-    {
-      tcb->xcp.sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on this CPU.
-       */
-
-      if (tcb == this_task())
-        {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state
-           * in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signaling itself, but a context switch
-           * to another task has occurred so that current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* create signal process context */
-
-              tcb->xcp.saved_reg = up_current_regs();
-#ifdef CONFIG_ARCH_FPU
-              tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
-#endif
-              arm64_init_signal_process(tcb,
-              (struct regs_context *)up_current_regs());
-
-              /* trigger switch to signal process */
-
-              up_set_current_regs(tcb->xcp.regs);
-            }
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
-
-#ifdef CONFIG_ARCH_FPU
-          tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
-#endif
-          /* create signal process context */
-
-          tcb->xcp.saved_reg = tcb->xcp.regs;
-          arm64_init_signal_process(tcb, NULL);
-        }
-    }
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  int cpu;
-  int me;
-
   sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
@@ -231,109 +140,29 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
+      if (tcb == this_task() && !up_interrupt_context())
         {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handler will run in a critical section!
            */
 
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
-            }
-
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
-
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-#ifdef CONFIG_ARCH_FPU
-                  tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
-#endif
-                  /* create signal process context */
-
-                  tcb->xcp.saved_reg = tcb->xcp.regs;
-                  arm64_init_signal_process(tcb, NULL);
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save the return PC, CPSR and either the BASEPRI or
-                   * PRIMASK registers (and perhaps also the LR).  These will
-                   * be restored by the signal trampoline after the signal
-                   * has been delivered.
-                   */
-
-                  /* create signal process context */
-
-                  tcb->xcp.saved_reg = up_current_regs();
-#ifdef CONFIG_ARCH_FPU
-                  tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
-#endif
-                  arm64_init_signal_process(tcb,
-                  (struct regs_context *)up_current_regs());
-
-                  /* trigger switch to signal process */
-
-                  up_set_current_regs(tcb->xcp.regs);
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
-            }
+          sigdeliver(tcb);
+          tcb->xcp.sigdeliver = NULL;
         }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
-       */
-
       else
         {
+#ifdef CONFIG_SMP
+          int cpu = tcb->cpu;
+          int me  = this_cpu();
+
+          if (cpu != me)
+            {
+              /* Pause the CPU */
+
+              up_cpu_pause(cpu);
+            }
+#endif
+
           /* Save the return lr and cpsr and one scratch register.  These
            * will be restored by the signal trampoline after the signals
            * have been delivered.
@@ -347,7 +176,15 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* create signal process context */
 
           arm64_init_signal_process(tcb, NULL);
+
+#ifdef CONFIG_SMP
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
+#endif
         }
     }
 }
-#endif /* CONFIG_SMP */

--- a/arch/arm64/src/common/arm64_switchcontext.c
+++ b/arch/arm64/src/common/arm64_switchcontext.c
@@ -61,7 +61,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       /* Yes, then we have to do things differently.
        * Just copy the current_regs into the OLD rtcb.

--- a/arch/arm64/src/common/arm64_switchcontext.c
+++ b/arch/arm64/src/common/arm64_switchcontext.c
@@ -63,21 +63,9 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   if (up_interrupt_context())
     {
-      /* Yes, then we have to do things differently.
-       * Just copy the current_regs into the OLD rtcb.
-       */
-
-      arm64_savestate(rtcb->xcp.regs);
-
       /* Update scheduler parameters */
 
       nxsched_resume_scheduler(tcb);
-
-      /* Then switch contexts.  Any necessary address environment
-       * changes will be made when the interrupt returns.
-       */
-
-      arm64_restorestate(tcb->xcp.regs);
     }
 
   /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/common/riscv_switchcontext.c
+++ b/arch/risc-v/src/common/riscv_switchcontext.c
@@ -63,7 +63,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       /* Yes, then we have to do things differently.
        * Just copy the current_regs into the OLD rtcb.

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -64,7 +64,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       /* Yes, then we have to do things differently.
        * Just copy the current_regs into the OLD rtcb.

--- a/arch/x86_64/src/common/x86_64_switchcontext.c
+++ b/arch/x86_64/src/common/x86_64_switchcontext.c
@@ -65,7 +65,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       /* Yes, then we have to do things differently.
        * Just copy the g_current_regs into the OLD rtcb.

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -155,12 +155,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   pdump->info.pid = tcb->pid;
 
-  /* If  current_regs is not NULL then we are in an interrupt context
-   * and the user context is in current_regs else we are running in
-   * the users context
-   */
-
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -426,12 +426,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   pdump->info.pid = tcb->pid;
 
-  /* If  current_regs is not NULL then we are in an interrupt context
-   * and the user context is in current_regs else we are running in
-   * the users context
-   */
-
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -426,12 +426,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   pdump->info.pid = tcb->pid;
 
-  /* If  current_regs is not NULL then we are in an interrupt context
-   * and the user context is in current_regs else we are running in
-   * the users context
-   */
-
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -380,12 +380,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   pdump->info.pid = tcb->pid;
 
-  /* If  current_regs is not NULL then we are in an interrupt context
-   * and the user context is in current_regs else we are running in
-   * the users context
-   */
-
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -378,12 +378,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   pdump->info.pid = tcb->pid;
 
-  /* If  current_regs is not NULL then we are in an interrupt context
-   * and the user context is in current_regs else we are running in
-   * the users context
-   */
-
-  if (up_current_regs())
+  if (up_interrupt_context())
     {
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |


### PR DESCRIPTION
## Summary
Why

When a context switch occurs currently, the context before the interrupt is fetched from the global variable g_current_regs and then stored in the corresponding tcb->xcp.regs. Subsequently, the new context is assigned to g_current_regs. When returning from the interrupt context, the context is retrieved from g_current_regs and used.

In reality, we do not necessarily require this intermediate variable g_current_regs to accomplish a context switch. Eliminating it avoids multiple assignments, especially during multiple context switches within interrupts, which can lead to repeated assignments.

All we need is to work directly with the context of the currently running task. This approach enhances the speed of context switching, reduces the code base, and optimizes signal handling logic. By simply leveraging the context of the active task, we can streamline the process and improve overall efficiency.



reason:
by doing this we can reduce context switch time,
When we exit from an interrupt handler, we directly use tcb->xcp.regs
Missing Information:
Related Issues: none
NuttX Apps Impact: none

## Impact
Is a new feature added? NO
Is an existing feature changed?  yes
g_current_regs is only used to determine if we are in irq with other functionalities removed.
We need to use up_interrupt_context for interrupt identification instead of relying on up_current_regs for that purpose.

before
size nuttx
   text    data     bss     dec     hex filename
 225920     409   30925  257254   3ece6 nuttx

after
   text    data     bss     dec     hex filename
 225604     409   30925  256938   3ebaa nuttx

 szie change -316
## Testing
**Build Host:**
* OS: Ubuntu 20.04
* CPU: x86_64 
* Compiler: GCC 9.4.0

**Target:**
* Arch: ARM ARM64

logs:
NO change

