### PR TITLE
part 1 of romfs extend to enable format function

### DIFF
--- a/fs/romfs/Kconfig
+++ b/fs/romfs/Kconfig
@@ -27,4 +27,11 @@ config FS_ROMFS_CACHE_FILE_NSECTORS
 	---help---
 		The number of file cache sector
 
+config FS_ROMFS_WRITEABLE
+	bool "Enable write extended feature in romfs"
+	default n
+	depends on FS_ROMFS_CACHE_NODE
+	---help---
+		Enable write extended feature in romfs
+
 endif

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -188,7 +188,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: romfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;
@@ -394,7 +394,7 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: romfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;
@@ -553,7 +553,7 @@ static off_t romfs_seek(FAR struct file *filep, off_t offset, int whence)
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
        ferr("ERROR: romfs_checkmount failed: %d\n", ret);
        goto errout_with_lock;
@@ -596,14 +596,12 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   rf = filep->f_priv;
 
-  /* Only one ioctl command is supported */
-
   if (cmd == FIOC_FILEPATH)
     {
       FAR char *ptr = (FAR char *)((uintptr_t)arg);
       inode_getpath(filep->f_inode, ptr, PATH_MAX);
       strlcat(ptr, rf->rf_path, PATH_MAX);
-      return OK;
+      return 0;
     }
   else if (cmd == FIOC_XIPBASE)
     {
@@ -613,7 +611,7 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       if (rm->rm_xipbase != 0)
         {
           *ptr = (uintptr_t)rm->rm_xipbase + rf->rf_startoffset;
-          return OK;
+          return 0;
         }
       else
         {
@@ -646,7 +644,7 @@ static int romfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
       map->length != 0 && map->offset + map->length <= rf->rf_size)
     {
       map->vaddr = rm->rm_xipbase + rf->rf_startoffset + map->offset;
-      return OK;
+      return 0;
     }
 
   return -ENOTTY;
@@ -688,7 +686,7 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: romfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;
@@ -731,7 +729,6 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Attach the new private date to the new struct file instance */
 
   newp->f_priv = newrf;
-
   rm->rm_refs++;
 
 errout_with_lock:
@@ -742,7 +739,7 @@ errout_with_lock:
 /****************************************************************************
  * Name: romfs_fstat
  *
- * Description:
+ * Description
  *   Obtain information about an open file associated with the file
  *   descriptor 'fd', and will write it to the area pointed to by 'buf'.
  *
@@ -792,7 +789,7 @@ static int romfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 /****************************************************************************
  * Name: romfs_opendir
  *
- * Description:
+ * Description
  *   Open a directory for read access
  *
  ****************************************************************************/
@@ -830,7 +827,7 @@ static int romfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: romfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;
@@ -868,7 +865,7 @@ static int romfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   *dir = &rdir->base;
   nxrmutex_unlock(&rm->rm_lock);
-  return OK;
+  return 0;
 
 errout_with_lock:
   nxrmutex_unlock(&rm->rm_lock);
@@ -881,7 +878,8 @@ errout_with_rdir:
 /****************************************************************************
  * Name: romfs_closedir
  *
- * Description: Close the directory
+ * Description
+ *   Close the directory
  *
  ****************************************************************************/
 
@@ -896,7 +894,8 @@ static int romfs_closedir(FAR struct inode *mountpt,
 /****************************************************************************
  * Name: romfs_readdir
  *
- * Description: Read the next directory entry
+ * Description
+ *   Read the next directory entry
  *
  ****************************************************************************/
 
@@ -934,7 +933,7 @@ static int romfs_readdir(FAR struct inode *mountpt,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: omfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;
@@ -1019,7 +1018,8 @@ errout_with_lock:
 /****************************************************************************
  * Name: romfs_rewindir
  *
- * Description: Reset directory read to the first entry
+ * Description
+ *   Reset directory read to the first entry
  *
  ****************************************************************************/
 
@@ -1050,7 +1050,7 @@ static int romfs_rewinddir(FAR struct inode *mountpt,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret == OK)
+  if (ret >= 0)
     {
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
       rdir->currnode = rdir->firstnode;
@@ -1066,11 +1066,12 @@ static int romfs_rewinddir(FAR struct inode *mountpt,
 /****************************************************************************
  * Name: romfs_bind
  *
- * Description: This implements a portion of the mount operation. This
- *  function allocates and initializes the mountpoint private data and
- *  binds the blockdriver inode to the filesystem private data.  The final
- *  binding of the private data (containing the blockdriver) to the
- *  mountpoint is performed by mount().
+ * Description
+ *   This implements a portion of the mount operation. This
+ *   function allocates and initializes the mountpoint private data and
+ *   binds the blockdriver inode to the filesystem private data.  The final
+ *   binding of the private data (containing the blockdriver) to the
+ *   mountpoint is performed by mount().
  *
  ****************************************************************************/
 
@@ -1091,7 +1092,7 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     }
 
   if (blkdriver->u.i_bops->open != NULL &&
-      (ret = blkdriver->u.i_bops->open(blkdriver)) != OK)
+      (ret = blkdriver->u.i_bops->open(blkdriver)) < 0)
     {
       ferr("ERROR: No open method\n");
       return ret;
@@ -1108,7 +1109,7 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     }
 
   /* Initialize the allocated mountpt state structure.  The filesystem is
-   * responsible for one reference ont the blkdriver inode and does not
+   * responsible for one reference on the blkdriver inode and does not
    * have to addref() here (but does have to release in ubind().
    */
 
@@ -1171,7 +1172,7 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Mounted! */
 
   *handle = rm;
-  return OK;
+  return 0;
 
 errout_with_buffer:
   fs_heap_free(rm->rm_devbuffer);
@@ -1192,7 +1193,8 @@ errout:
 /****************************************************************************
  * Name: romfs_unbind
  *
- * Description: This implements the filesystem portion of the umount
+ * Description
+ *   This implements the filesystem portion of the umount
  *   operation.
  *
  ****************************************************************************/
@@ -1271,7 +1273,7 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 #endif
       nxrmutex_destroy(&rm->rm_lock);
       fs_heap_free(rm);
-      return OK;
+      return 0;
     }
 
   nxrmutex_unlock(&rm->rm_lock);
@@ -1281,7 +1283,8 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 /****************************************************************************
  * Name: romfs_statfs
  *
- * Description: Return filesystem statistics
+ * Description
+ *   Return filesystem statistics
  *
  ****************************************************************************/
 
@@ -1339,7 +1342,7 @@ errout_with_lock:
 /****************************************************************************
  * Name: romfs_stat_common
  *
- * Description:
+ * Description
  *   Return information about a file or directory
  *
  ****************************************************************************/
@@ -1389,13 +1392,14 @@ static int romfs_stat_common(uint8_t type, uint32_t size,
   buf->st_size    = size;
   buf->st_blksize = sectorsize;
   buf->st_blocks  = (buf->st_size + sectorsize - 1) / sectorsize;
-  return OK;
+  return 0;
 }
 
 /****************************************************************************
  * Name: romfs_stat
  *
- * Description: Return information about a file or directory
+ * Description
+ *   Return information about a file or directory
  *
  ****************************************************************************/
 
@@ -1426,7 +1430,7 @@ static int romfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
     }
 
   ret = romfs_checkmount(rm);
-  if (ret != OK)
+  if (ret < 0)
     {
       ferr("ERROR: romfs_checkmount failed: %d\n", ret);
       goto errout_with_lock;

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -492,7 +492,7 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
 
 errout_with_lock:
   nxrmutex_unlock(&rm->rm_lock);
-  return ret < 0 ? ret : readsize;
+  return readsize ? readsize : ret;
 }
 
 /****************************************************************************

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -265,7 +265,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
   rf->rf_size = nodeinfo.rn_size;
   rf->rf_type = (uint8_t)(nodeinfo.rn_next & RFNEXT_ALLMODEMASK);
-  strlcpy(rf->rf_path, relpath, len + 1);
+  memcpy(rf->rf_path, relpath, len + 1);
 
   /* Get the start of the file data */
 
@@ -714,7 +714,7 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   newrf->rf_startoffset = oldrf->rf_startoffset;
   newrf->rf_size        = oldrf->rf_size;
   newrf->rf_type        = oldrf->rf_type;
-  strlcpy(newrf->rf_path, oldrf->rf_path, len + 1);
+  memcpy(newrf->rf_path, oldrf->rf_path, len + 1);
 
   /* Configure buffering to support access to this file */
 

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -1298,8 +1298,9 @@ static int romfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Everything else follows in units of sectors */
 
-  buf->f_blocks  = SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
-  buf->f_bfree   = rm->rm_hwnsectors - buf->f_blocks;
+  buf->f_blocks  = rm->rm_hwnsectors;
+  buf->f_bfree   = buf->f_blocks -
+                   SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
   buf->f_bavail  = buf->f_bfree;
   buf->f_namelen = NAME_MAX;
 

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -164,6 +164,7 @@ struct romfs_nodeinfo_s
   uint32_t rn_next;                        /* Offset of the next file header+flags */
   uint32_t rn_size;                        /* Size (if file) */
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
+  uint32_t rn_origoffset;                  /* Offset of origin file header */
   FAR struct romfs_nodeinfo_s **rn_child;  /* The node array for link to lower level */
   uint16_t rn_count;                       /* The count of node in rn_child level */
   uint8_t  rn_namesize;                    /* The length of name of the entry */

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -157,6 +157,7 @@ struct romfs_mountpt_s
   FAR uint8_t *rm_devbuffer;      /* Device sector buffer, allocated for write if rm_xipbase != 0 */
 #ifdef CONFIG_FS_ROMFS_WRITEABLE
   struct list_node rm_sparelist;  /* The list of spare space */
+  sem_t            rm_sem;        /* The semaphore to assume write safe */
 #endif
 };
 

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -154,6 +154,7 @@ struct romfs_mountpt_s
   uint32_t rm_cachesector;        /* Current sector in the rm_buffer */
   FAR uint8_t *rm_xipbase;        /* Base address of directly accessible media */
   FAR uint8_t *rm_buffer;         /* Device sector buffer, allocated if rm_xipbase==0 */
+  FAR uint8_t *rm_devbuffer;      /* Device sector buffer, allocated for write if rm_xipbase != 0 */
 #ifdef CONFIG_FS_ROMFS_WRITEABLE
   struct list_node rm_sparelist;  /* The list of spare space */
 #endif
@@ -231,6 +232,7 @@ int  romfs_datastart(FAR struct romfs_mountpt_s *rm,
 void romfs_freenode(FAR struct romfs_nodeinfo_s *node);
 #endif
 #ifdef CONFIG_FS_ROMFS_WRITEABLE
+int romfs_mkfs(FAR struct romfs_mountpt_s *rm);
 void romfs_free_sparelist(FAR struct list_node *list);
 #endif
 

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -515,6 +515,26 @@ static int romfs_alloc_spareregion(FAR struct list_node *list,
 }
 
 /****************************************************************************
+ * Name: romfs_devmemcpy
+ ****************************************************************************/
+
+static void romfs_devmemcpy(FAR struct romfs_mountpt_s *rm,
+                            int ndx, FAR const void *buf, size_t len)
+{
+  memcpy(rm->rm_devbuffer + ndx, buf, len);
+}
+
+/****************************************************************************
+ * Name: romfs_devstrcpy
+ ****************************************************************************/
+
+static void romfs_devstrcpy(FAR struct romfs_mountpt_s *rm,
+                            int ndx, FAR const char *buf)
+{
+  strcpy((FAR char *)rm->rm_devbuffer + ndx, buf);
+}
+
+/****************************************************************************
  * Name: romfs_devwrite32
  *
  * Description:
@@ -951,7 +971,7 @@ int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data)
 
   /* Verify the magic number at that identifies this as a ROMFS filesystem */
 
-  if (memcmp(rm->rm_buffer, ROMFS_VHDR_MAGIC, 8) != 0)
+  if (memcmp(rm->rm_buffer, ROMFS_VHDR_MAGIC, ROMFS_VHDR_SIZE) != 0)
     {
       return -EINVAL;
     }
@@ -1441,8 +1461,7 @@ int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
 {
   /* Write the magic number at that identifies this as a ROMFS filesystem */
 
-  memcpy(rm->rm_devbuffer + ROMFS_VHDR_ROM1FS, ROMFS_VHDR_MAGIC,
-         ROMFS_VHDR_SIZE);
+  romfs_devmemcpy(rm, ROMFS_VHDR_ROM1FS, ROMFS_VHDR_MAGIC, ROMFS_VHDR_SIZE);
 
   /* Init the ROMFS volume to zero */
 
@@ -1450,7 +1469,7 @@ int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
 
   /* Write the volume name */
 
-  memcpy(rm->rm_devbuffer + ROMFS_VHDR_VOLNAME, "romfs", 6);
+  romfs_devstrcpy(rm, ROMFS_VHDR_VOLNAME, "romfs");
 
   /* Write the root node . */
 
@@ -1458,7 +1477,7 @@ int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
   romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_INFO, 0x20);
   romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_SIZE, 0);
   romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_CHKSUM, 0);
-  memcpy(rm->rm_devbuffer + 0x20 + ROMFS_FHDR_NAME, ".", 2);
+  romfs_devstrcpy(rm, 0x20 + ROMFS_FHDR_NAME, ".");
 
   /* Write the root node .. */
 
@@ -1466,7 +1485,7 @@ int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
   romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_INFO, 0x20);
   romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_SIZE, 0);
   romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_CHKSUM, 0);
-  memcpy(rm->rm_devbuffer + 0x40 + ROMFS_FHDR_NAME, "..", 3);
+  romfs_devstrcpy(rm, 0x40 + ROMFS_FHDR_NAME, "..");
 
   /* Write the buffer to sector zero */
 

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -605,7 +605,7 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
   FAR struct romfs_nodeinfo_s **child;
   FAR struct romfs_nodeinfo_s *nodeinfo;
   char childname[NAME_MAX + 1];
-  uint8_t num = 0;
+  uint16_t count = 0;
   uint32_t info;
   size_t nsize;
   int ret;
@@ -670,21 +670,21 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
           return ret;
         }
 
-      if (child == NULL || nodeinfo->rn_count == num - 1)
+      if (child == NULL || nodeinfo->rn_count == count - 1)
         {
           FAR void *tmp;
 
           tmp = fs_heap_realloc(nodeinfo->rn_child,
-                (num + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
+                (count + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
           if (tmp == NULL)
             {
               return -ENOMEM;
             }
 
           nodeinfo->rn_child = tmp;
-          memset(nodeinfo->rn_child + num, 0, NODEINFO_NINCR *
+          memset(nodeinfo->rn_child + count, 0, NODEINFO_NINCR *
                   sizeof(*nodeinfo->rn_child));
-          num += NODEINFO_NINCR;
+          count += NODEINFO_NINCR;
         }
 
       child = &nodeinfo->rn_child[nodeinfo->rn_count++];

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -563,8 +563,8 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
         }
 
       rm->rm_volsize += totalsize;
-      ret = romfs_alloc_spareregion(&rm->rm_sparelist, offset,
-                                    offset + totalsize);
+      ret = romfs_alloc_spareregion(&rm->rm_sparelist, origoffset,
+                                    origoffset + totalsize);
       if (ret < 0)
         {
           return ret;

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -277,7 +277,7 @@ static int romfs_nodeinfo_search(FAR const void *a, FAR const void *b)
 {
   FAR struct romfs_nodeinfo_s *nodeinfo = *(FAR struct romfs_nodeinfo_s **)b;
   FAR const struct romfs_entryname_s *entry = a;
-  FAR const char *name2 = nodeinfo->rn_name;
+  FAR const char *name = nodeinfo->rn_name;
   size_t len = nodeinfo->rn_namesize;
   int ret;
 
@@ -286,12 +286,12 @@ static int romfs_nodeinfo_search(FAR const void *a, FAR const void *b)
       len = entry->re_len;
     }
 
-  ret = strncmp(entry->re_name, name2, len);
-  if (!ret)
+  ret = memcmp(entry->re_name, name, len);
+  if (ret == 0)
     {
       if (entry->re_name[len] == '/' || entry->re_name[len] == '\0')
         {
-          return name2[len] == '\0' ? 0 : -1;
+          return name[len] == '\0' ? 0 : -1;
         }
       else
         {
@@ -642,7 +642,7 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
   nodeinfo->rn_origoffset = origoffset;
   nodeinfo->rn_next       = next;
   nodeinfo->rn_namesize   = nsize;
-  strlcpy(nodeinfo->rn_name, name, nsize + 1);
+  memcpy(nodeinfo->rn_name, name, nsize + 1);
 
 #ifdef CONFIG_FS_ROMFS_WRITEABLE
   if (!list_is_empty(&rm->rm_sparelist))

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -650,7 +650,7 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
       uint32_t totalsize = ROMFS_ALIGNUP(ROMFS_FHDR_NAME + nsize + 1);
       if (offset == origoffset)
         {
-          totalsize += size;
+          totalsize += ROMFS_ALIGNUP(size);
         }
 
       rm->rm_volsize += totalsize;
@@ -1463,9 +1463,9 @@ int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
 
   romfs_devmemcpy(rm, ROMFS_VHDR_ROM1FS, ROMFS_VHDR_MAGIC, ROMFS_VHDR_SIZE);
 
-  /* Init the ROMFS volume to zero */
+  /* Init the ROMFS volume size */
 
-  romfs_devwrite32(rm, ROMFS_VHDR_SIZE, 0);
+  romfs_devwrite32(rm, ROMFS_VHDR_SIZE, 0x60);
 
   /* Write the volume name */
 

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -1020,10 +1020,19 @@ int romfs_fileconfigure(FAR struct romfs_mountpt_s *rm,
     }
   else
     {
+      uint32_t startsector;
+      uint32_t endoffset;
       uint32_t nsectors;
 
-      rf->rf_endsector = SEC_NSECTORS(rm, rf->rf_startoffset + rf->rf_size);
-      nsectors = rf->rf_endsector - SEC_NSECTORS(rm, rf->rf_startoffset) + 1;
+      endoffset = rf->rf_startoffset + rf->rf_size;
+      if (rf->rf_size)
+        {
+          endoffset--;
+        }
+
+      rf->rf_endsector = SEC_NSECTORS(rm, endoffset);
+      startsector = SEC_NSECTORS(rm, rf->rf_startoffset);
+      nsectors = rf->rf_endsector - startsector + 1;
       if (nsectors > CONFIG_FS_ROMFS_CACHE_FILE_NSECTORS)
         {
           nsectors = CONFIG_FS_ROMFS_CACHE_FILE_NSECTORS;


### PR DESCRIPTION
## Summary
part 1 of romfs extend to enable format function

## Impact
This is  part 1 of a series of patchs. 

To enhance the write capabilities of ROMFS, enabling it to perform simple file creation, writing, and deletion operations while maintaining compatibility with the original ROMFS format used in open-source ROMFS.

Feature is enabled by CONFIG_FS_ROMFS_WRITEABLE  Kconfig 
When CONFIG_FS_ROMFS_WRITEABLE is enabled 
We  can use **-o rw**  to enable writable 

## Testing
cmoka_fs_test
cmoka_syscall_test
