### PR TITLE
[Bug-Fix] Resource leaks

### DIFF
--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -590,11 +590,18 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
   ARCH_ELFDATA_DEF;
 
   dyn = lib_malloc(shdr->sh_size);
+  if (dyn == NULL)
+    {
+      berr("Failed to allocate memory for elf dynamic section\n");
+      return -ENOMEM;
+    }
+
   ret = modlib_read(loadinfo, (FAR uint8_t *)dyn, shdr->sh_size,
                     shdr->sh_offset);
   if (ret < 0)
     {
       berr("Failed to read dynamic section header");
+      lib_free(dyn);
       return ret;
     }
 


### PR DESCRIPTION
## Summary
In file "nuttx/libs/libc/modlib/modlib_bind.c", line656 not check return value of lib_malloc(), and line661 not free dyn.

## Impact
N/A

## Testing
CI
