### PR TITLE
cmake(refactor):Refactor extra_lib tagert,build include_arch path,refine sim link script target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,14 +640,15 @@ if(CONFIG_BUILD_FLAT)
   get_property(nuttx_apps_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
 endif()
 
-set(nuttx_libs ${nuttx_kernel_libs} ${nuttx_system_libs} ${nuttx_apps_libs})
+set(nuttx_libs ${nuttx_kernel_libs} ${nuttx_system_libs} ${nuttx_apps_libs}
+               ${nuttx_extra_libs})
 
 if(NOT CONFIG_ARCH_SIM)
 
   # TODO: nostart/nodefault not applicable to nuttx toolchain
   target_link_libraries(
     nuttx PRIVATE ${NUTTX_EXTRA_FLAGS} -T${ldscript} -Wl,--start-group
-                  ${nuttx_libs} ${nuttx_extra_libs} -Wl,--end-group)
+                  ${nuttx_libs} -Wl,--end-group)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
   nuttx_generate_outputs(nuttx)
@@ -680,8 +681,8 @@ elseif(WIN32)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/nuttx_all.lib
     COMMAND ${CMAKE_AR} /OUT:${CMAKE_BINARY_DIR}/nuttx_all.lib
-            ${nuttx_libs_paths} ${nuttx_extra_libs}
-    DEPENDS ${nuttx_libs} ${nuttx_extra_libs}
+            ${nuttx_libs_paths}
+    DEPENDS ${nuttx_libs}
     VERBATIM)
   add_custom_target(nuttx_all-lib DEPENDS ${CMAKE_BINARY_DIR}/nuttx_all.lib)
   add_dependencies(nuttx nuttx_all-lib)
@@ -713,9 +714,9 @@ else()
       COMMAND
         ${CMAKE_LINKER} ARGS -r $<$<BOOL:${CONFIG_SIM_M32}>:-m32>
         $<TARGET_OBJECTS:sim_head> $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--start-group>
-        ${nuttx_libs_paths} ${nuttx_extra_libs}
-        $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o nuttx.rel
-      DEPENDS ${nuttx_libs} ${nuttx_extra_libs} sim_head
+        ${nuttx_libs_paths} $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o
+        nuttx.rel
+      DEPENDS ${nuttx_libs} sim_head
       COMMAND_EXPAND_LISTS)
   else()
     add_custom_command(
@@ -723,10 +724,10 @@ else()
       COMMAND
         ${CMAKE_C_COMPILER} ARGS -r $<$<BOOL:${CONFIG_SIM_M32}>:-m32>
         $<TARGET_OBJECTS:sim_head> $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--start-group>
-        ${nuttx_libs_paths} ${nuttx_extra_libs}
-        $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o nuttx.rel
+        ${nuttx_libs_paths} $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o
+        nuttx.rel
       COMMAND ${CMAKE_OBJCOPY} --redefine-syms=nuttx-names.dat nuttx.rel
-      DEPENDS ${nuttx_libs} ${nuttx_extra_libs} sim_head sim_redefine_symbols
+      DEPENDS ${nuttx_libs} sim_head sim_redefine_symbols
       COMMAND_EXPAND_LISTS)
   endif()
   add_custom_target(nuttx-rel DEPENDS nuttx.rel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,44 +688,17 @@ elseif(WIN32)
   target_link_libraries(nuttx PRIVATE $<TARGET_OBJECTS:sim_head>
                                       ${CMAKE_BINARY_DIR}/nuttx_all.lib)
 else()
+
+  if(NOT APPLE)
+    # generate SIM ld.script for cheat C++ global construction
+    include(nuttx_generate_sim_ld)
+  endif()
+
   # On sim platform the link step is a little different. NuttX is first built
   # into a partially linked relocatable object nuttx.rel with no interface to
   # host OS. Then, the names of symbols that conflict with libc symbols are
   # renamed. The final nuttx binary is built by linking the host-specific
   # objects with the relocatable binary.
-
-  # C++ global objects are constructed before main get executed, but it isn't a
-  # good point for simulator because NuttX doesn't finish the kernel
-  # initialization yet. So we have to skip the standard facilities and do the
-  # construction by ourself. But how to achieve the goal? 1.Command linker
-  # generate the default script(-verbose) 2.Replace
-  # __init_array_start/__init_array_end with _sinit/_einit 3.Append
-  # __init_array_start = .; __init_array_end = .; Step 2 let nxtask_startup find
-  # objects need to construct Step 3 cheat the host there is no object to
-  # construct Note: the destructor can be fixed in the same way.
-
-  if(NOT APPLE)
-    add_custom_command(
-      OUTPUT nuttx.ld
-      COMMAND
-        ${CMAKE_C_COMPILER} ${CMAKE_EXE_LINKER_FLAGS}
-        $<$<BOOL:${CONFIG_SIM_M32}>:-m32> -Wl,-verbose 2> /dev/null >
-        nuttx-orig.ld || true
-      COMMAND
-        cat nuttx-orig.ld | sed -e '/====/,/====/!d\;//d' -e
-        's/__executable_start/_stext/g' -e 's/__init_array_start/_sinit/g' -e
-        's/__init_array_end/_einit/g' -e 's/__fini_array_start/_sfini/g' -e
-        's/__fini_array_end/_efini/g' > nuttx.ld
-      COMMAND
-        echo ARGS
-        '__init_array_start = .\; __init_array_end = .\; __fini_array_start = .\; __fini_array_end = .\;'
-        >> nuttx.ld
-      COMMAND sed -i '/\\.data *:/i " ${CONFIG_SIM_CUSTOM_DATA_SECTION} " '
-              nuttx.ld)
-  endif()
-
-  # conflicting symbols to rename
-
   include(nuttx_redefine_symbols)
 
   # TODO: do with single function call?

--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -87,12 +87,7 @@ if(NOT EXISTS ${extra_library} AND CONFIG_ARCH_TOOLCHAIN_CLANG)
     OUTPUT_VARIABLE extra_library)
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
-  cmake_path(GET extra_library FILENAME extra_filename_library)
-  list(APPEND EXTRA_LIB -l:${extra_filename_library})
-else()
-  list(APPEND EXTRA_LIB ${extra_library})
-endif()
+list(APPEND EXTRA_LIB ${extra_library})
 
 if(NOT CONFIG_LIBM)
   execute_process(
@@ -101,12 +96,7 @@ if(NOT CONFIG_LIBM)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
 
-  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
-    cmake_path(GET extra_library FILENAME extra_filename_library)
-    list(APPEND EXTRA_LIB -l:${extra_filename_library})
-  else()
-    list(APPEND EXTRA_LIB ${extra_library})
-  endif()
+  list(APPEND EXTRA_LIB ${extra_library})
 endif()
 
 if(CONFIG_LIBSUPCXX)
@@ -115,12 +105,7 @@ if(CONFIG_LIBSUPCXX)
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
-  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
-    cmake_path(GET extra_library FILENAME extra_filename_library)
-    list(APPEND EXTRA_LIB -l:${extra_filename_library})
-  else()
-    list(APPEND EXTRA_LIB ${extra_library})
-  endif()
+  list(APPEND EXTRA_LIB ${extra_library})
 endif()
 
 if(CONFIG_ARCH_COVERAGE)
@@ -129,12 +114,7 @@ if(CONFIG_ARCH_COVERAGE)
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
-  if(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS|CYGWIN|Windows")
-    cmake_path(GET extra_library FILENAME extra_filename_library)
-    list(APPEND EXTRA_LIB -l:${extra_filename_library})
-  else()
-    list(APPEND EXTRA_LIB ${extra_library})
-  endif()
+  list(APPEND EXTRA_LIB ${extra_library})
 endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -191,11 +191,18 @@ endfunction()
 #
 # nuttx_add_extra_library
 #
-# Add extra library to extra attribute
+# Add extra library to extra attribute, extra library will be treated as an
+# import target and have a complete full path this will be used to avoid adding
+# the -l prefix to the link target between different cmake versions and
+# platformss
 #
 function(nuttx_add_extra_library)
-  foreach(target ${ARGN})
-    set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${target})
+  foreach(extra_lib ${ARGN})
+    # define the target name of the extra library
+    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" extra_target "${extra_lib}")
+    # set the absolute path of the library for the import target
+    nuttx_library_import(${extra_target} ${extra_lib})
+    set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${extra_target})
   endforeach()
 endfunction()
 

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -37,9 +37,8 @@ function(nuttx_add_library_internal target)
 
   # add main include directories
   target_include_directories(
-    ${target} SYSTEM
-    PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
-            ${CMAKE_BINARY_DIR}/include_arch)
+    ${target} SYSTEM PRIVATE ${CMAKE_SOURCE_DIR}/include
+                             ${CMAKE_BINARY_DIR}/include)
 
   # Set global compile options & definitions We use the "nuttx" target to hold
   # these properties so that libraries added after this property is set can read

--- a/cmake/nuttx_allsyms.cmake
+++ b/cmake/nuttx_allsyms.cmake
@@ -54,8 +54,7 @@ macro(define_allsyms_link_target inter_target dep_target allsyms_file)
       )
     endif()
     target_sources(nuttx PRIVATE ${ALLSYMS_SOURCE})
-    set(ALLSYMS_INCDIR ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
-                       ${CMAKE_BINARY_DIR}/include_arch)
+    set(ALLSYMS_INCDIR ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
     set_source_files_properties(
       ${ALLSYMS_SOURCE} PROPERTIES INCLUDE_DIRECTORIES "${ALLSYMS_INCDIR}")
   else()
@@ -76,9 +75,8 @@ macro(define_allsyms_link_target inter_target dep_target allsyms_file)
 
     # relink target and nuttx have exactly the same configuration
     target_include_directories(
-      ${inter_target} SYSTEM
-      PUBLIC ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include
-             ${CMAKE_BINARY_DIR}/include_arch)
+      ${inter_target} SYSTEM PUBLIC ${CMAKE_SOURCE_DIR}/include
+                                    ${CMAKE_BINARY_DIR}/include)
     target_compile_definitions(
       ${inter_target} PRIVATE $<TARGET_PROPERTY:nuttx,NUTTX_KERNEL_DEFINITIONS>)
     target_compile_options(

--- a/cmake/nuttx_generate_headers.cmake
+++ b/cmake/nuttx_generate_headers.cmake
@@ -35,42 +35,40 @@ include(nuttx_mkversion)
 
 # Setup symbolic link generation
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/include_arch/arch)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-                          ${CMAKE_BINARY_DIR}/include_arch/arch)
-endif()
-
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/include_apps)
   execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
                           ${CMAKE_BINARY_DIR}/include_apps)
 endif()
 
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/include/arch)
-  nuttx_create_symlink(${NUTTX_DIR}/arch/${CONFIG_ARCH}/include
-                       ${CMAKE_BINARY_DIR}/include/arch)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
+                          ${CMAKE_BINARY_DIR}/include/arch)
+  file(GLOB CONTENTS ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/*)
+  foreach(ARCH_INCDIR ${CONTENTS})
+    get_filename_component(SUB_ELEMENT ${ARCH_INCDIR} NAME)
+    nuttx_create_symlink(${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${SUB_ELEMENT}
+                         ${CMAKE_BINARY_DIR}/include/arch/${SUB_ELEMENT})
+  endforeach()
 endif()
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/include_arch/arch/board)
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/include/arch/board)
   if(EXISTS ${NUTTX_BOARD_DIR}/include)
     nuttx_create_symlink(${NUTTX_BOARD_DIR}/include
-                         ${CMAKE_BINARY_DIR}/include_arch/arch/board)
+                         ${CMAKE_BINARY_DIR}/include/arch/board)
   elseif(EXISTS ${NUTTX_BOARD_DIR}/../common/include)
     nuttx_create_symlink(${NUTTX_BOARD_DIR}/../common/include
-                         ${CMAKE_BINARY_DIR}/include_arch/arch/board)
+                         ${CMAKE_BINARY_DIR}/include/arch/board)
   endif()
 endif()
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/include_arch/arch/chip)
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/include/arch/chip)
   if(CONFIG_ARCH_CHIP_CUSTOM)
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E copy_directory ${NUTTX_CHIP_ABS_DIR}/include
-              ${CMAKE_BINARY_DIR}/include_arch/arch/chip)
+    nuttx_create_symlink(${NUTTX_CHIP_ABS_DIR}/include
+                         ${CMAKE_BINARY_DIR}/include/arch/chip)
   else()
-    execute_process(
-      COMMAND
-        ${CMAKE_COMMAND} -E copy_directory
-        ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP}
-        ${CMAKE_BINARY_DIR}/include_arch/arch/chip)
+    nuttx_create_symlink(
+      ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP}
+      ${CMAKE_BINARY_DIR}/include/arch/chip)
   endif()
 endif()
 

--- a/cmake/nuttx_generate_sim_ld.cmake
+++ b/cmake/nuttx_generate_sim_ld.cmake
@@ -1,0 +1,65 @@
+# ##############################################################################
+# cmake/nuttx_generate_sim_ld.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# cmake-format: off
+# C++ global objects are constructed before main get executed, but it isn't a
+# good point for simulator because NuttX doesn't finish the kernel
+# initialization yet.
+# So we have to skip the standard facilities and do the construction by ourself.
+# But how to achieve the goal?
+# 1.Command linker generate the default script(-verbose)
+# 2.Replace __init_array_start/__init_array_end with _sinit/_einit
+# 3.Append __init_array_start = .; __init_array_end = .;
+# Step 2 let nxtask_startup find objects need to construct
+# Step 3 cheat the host there is no object to construct
+# Note: the destructor can be fixed in the same way.
+set(PROCESS_SIM_LD_SCRIPT
+    [[
+    #!/bin/sh
+    original_ld="$1"
+    target_ld="$2"
+    cat $original_ld | \
+    sed -e '/====/,/====/!d;//d' \
+    -e '/__executable_start/s/$/PROVIDE(_stext = .);/' \
+    -e 's/^\(\s\+\)\(\.init_array\)/\1\2 : { }\n\1.sinit/g' \
+    -e 's/^\(\s\+\)\(\.fini_array\)/\1\2 : { }\n\1.einit/g' \
+    -e 's/__init_array_start/_sinit/g' -e 's/__init_array_end/_einit/g' \
+    -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' > "$target_ld"
+    echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >> "$target_ld"
+]])
+# cmake-format: on
+
+file(WRITE ${CMAKE_BINARY_DIR}/process_sim_ld_script.sh
+     "${PROCESS_SIM_LD_SCRIPT}")
+file(
+  COPY ${CMAKE_BINARY_DIR}/process_sim_ld_script.sh
+  DESTINATION ${CMAKE_BINARY_DIR}
+  FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+
+add_custom_command(
+  OUTPUT nuttx.ld
+  COMMAND
+    ${CMAKE_C_COMPILER} ${CMAKE_EXE_LINKER_FLAGS}
+    $<$<BOOL:${CONFIG_SIM_M32}>:-m32> -Wl,-verbose 2> /dev/null > nuttx-orig.ld
+    || true
+  COMMAND sh process_sim_ld_script.sh nuttx-orig.ld nuttx.ld
+  COMMAND sed -i '/\\.data *:/i " ${CONFIG_SIM_CUSTOM_DATA_SECTION} " ' nuttx.ld
+  COMMENT "Generating sim linker script nuttx.ld"
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
## Summary
This patch refactors and enhances the cmake content:

### 1. Modify `extra_lib` to CMake target management

change the extra library from a file to an import target;
this will avoid differences in the handling of static libraries
between different versions of cmake and different platforms.

after unifying as a target, extra libraries can be
handled as the same as other compiled libraries by call `nuttx_add_extra_library`

### 2. Delete include_arch in the Binary directory
merge the arch header file into `BINARY_DIR/include/arch`

### 3. Extract the SIM link target into a module from the main CMakeLists.txt script

fix SIM start crash on Ubuntu22,
becase the previous CMake linker script has missing handling of
C++ global constructor sections in the new Glibc version on ubuntu22

it will cause a prior c++ constructor call error:
```
# bt in sim
0x00000000400317f6 in nxsched_get_stackinfo (pid=0, stackinfo=0x7fffffffdbc0) at /media/nuttx/sched/sched/sched_get_stackinfo.c:101
0x000000004002de0d in tls_get_info () at /media/nuttx/libs/libc/tls/tls_getinfo.c:61
0x000000004002ddc8 in task_get_info () at /media/nuttx/libs/libc/tls/task_getinfo.c:50
0x000000004002c74e in atexit_register (type=4, func=0x40044eac <CHelloWorld::~CHelloWorld()>, arg=0x40061418 <g_HelloWorld>, dso=0x40060000)
 at /media/nuttx/libs/libc/stdlib/lib_atexit.c:68
0x000000004002ca34 in __cxa_atexit (func=0x40044eac <CHelloWorld::~CHelloWorld()>, arg=0x40061418 <g_HelloWorld>, dso_handle=0x40060000)
 at /media/nuttx/libs/libc/stdlib/lib_atexit.c:268
0x000000004004502b in __static_initialization_and_destruction_0 () at /media/apps/examples/helloxx/helloxx_main.cxx:93
0x000000004004503e in _GLOBAL__sub_I_helloxx_main () at /media/apps/examples/helloxx/helloxx_main.cxx:129
0x00007ffff7829ebb in call_init (env=<optimized out>, argv=0x7fffffffdd18, argc=1) at ../csu/libc-start.c:145
 __libc_start_main_impl (main=0x40004dc8 <main>, argc=1, argv=0x7fffffffdd18, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>,
    stack_end=0x7fffffffdd08) at ../csu/libc-start.c:379
0x0000000040004285 in _start ()
```

## Impact

## Testing
CI