### PR TITLE
cmake:support openlibm,dhara,libmcs,lic regex CMake build scripts

### DIFF
--- a/drivers/mtd/CMakeLists.txt
+++ b/drivers/mtd/CMakeLists.txt
@@ -165,5 +165,21 @@ if(CONFIG_MTD)
     list(APPEND SRCS smart.c)
   endif()
 
+  if(CONFIG_MTD_DHARA)
+    if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/dhara)
+      FetchContent_Declare(
+        dhara
+        URL https://github.com/dlbeer/dhara/archive/refs/heads/master.zip
+            SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/dhara BINARY_DIR
+            ${CMAKE_BINARY_DIR}/drivers/mtd/dhara
+        DOWNLOAD_NO_PROGRESS true)
+      FetchContent_Populate(dhara)
+    endif()
+
+    list(APPEND SRCS dhara.c mtd/dhara/dhara/map.c mtd/dhara/dhara/error.c
+         mtd/dhara/dhara/journal.c)
+    target_include_directories(drivers PRIVATE ${CMAKE_CURRENT_LIST_DIR}/dhara)
+  endif()
+
   target_sources(drivers PRIVATE ${SRCS})
 endif()

--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -48,6 +48,10 @@ if(CONFIG_SENSORS)
     list(APPEND SRCS goldfish_gps_uorb.c)
   endif()
 
+  if(CONFIG_SENSORS_GOLDFISH_SENSOR)
+    list(APPEND SRCS goldfish_sensor_uorb.c)
+  endif()
+
   if(CONFIG_SENSORS_HCSR04)
     list(APPEND SRCS hc_sr04.c)
   endif()
@@ -88,6 +92,10 @@ if(CONFIG_SENSORS)
 
     if(CONFIG_SENSORS_APDS9960)
       list(APPEND SRCS apds9960.c)
+    endif()
+
+    if(CONFIG_SENSORS_APDS9922)
+      list(APPEND SRCS apds9922.c)
     endif()
 
     if(CONFIG_SENSORS_AK09912)
@@ -151,6 +159,10 @@ if(CONFIG_SENSORS)
       list(APPEND SRCS adxl345_i2c.c)
     endif()
 
+    if(CONFIG_SENSORS_BH1749NUC)
+      list(APPEND SRCS bh1749nuc.c)
+    endif()
+
     if(CONFIG_SENSORS_BH1750FVI)
       list(APPEND SRCS bh1750fvi.c)
     endif()
@@ -169,7 +181,13 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_BMP180)
-      list(APPEND SRCS bmp180.c)
+      list(APPEND SRCS bmp180_base.c)
+      if(CONFIG_SENSORS_BMP180_UORB)
+        list(APPEND SRCS bmp180_uorb.c)
+      else()
+        list(APPEND SRCS bmp180.c)
+      endif()
+
     endif()
 
     if(CONFIG_SENSORS_BMP280)

--- a/libs/libc/regex/CMakeLists.txt
+++ b/libs/libc/regex/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# libs/libc/regex/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LIBC_REGEX)
+  set(SRCS regcomp.c regexec.c regerror.c tre-mem.c)
+  target_sources(c PRIVATE ${SRCS})
+endif()

--- a/libs/libm/libm/CMakeLists.txt
+++ b/libs/libm/libm/CMakeLists.txt
@@ -24,7 +24,6 @@ if(CONFIG_LIBM)
   endif()
 
   # Add the floating point math C files to the build
-
   set(SRCS
       lib_acosf.c
       lib_asinf.c
@@ -33,7 +32,6 @@ if(CONFIG_LIBM)
       lib_cosf.c
       lib_coshf.c
       lib_expf.c
-      lib_fabsf.c
       lib_fmodf.c
       lib_frexpf.c
       lib_ldexpf.c
@@ -44,7 +42,6 @@ if(CONFIG_LIBM)
       lib_powf.c
       lib_sinf.c
       lib_sinhf.c
-      lib_sqrtf.c
       lib_tanf.c
       lib_tanhf.c
       lib_asinhf.c
@@ -52,6 +49,12 @@ if(CONFIG_LIBM)
       lib_atanhf.c
       lib_erff.c
       lib_copysignf.c
+      lib_scalbnf.c
+      lib_scalbn.c
+      lib_scalbnl.c
+      lib_sincos.c
+      lib_sincosf.c
+      lib_sincosl.c
       lib_acos.c
       lib_asin.c
       lib_atan.c
@@ -128,6 +131,12 @@ if(CONFIG_LIBM)
       lib_nan.c
       lib_nanf.c
       lib_nanl.c
+      lib_fmax.c
+      lib_fmaxf.c
+      lib_fmaxl.c
+      lib_fmin.c
+      lib_fminf.c
+      lib_fminl.c
       __cos.c
       __sin.c
       lib_gamma.c
@@ -136,44 +145,52 @@ if(CONFIG_LIBM)
   # Use the C versions of some functions only if architecture specific optimized
   # versions are not provided.
 
-  if(NOT LIBM_ARCH_CEIL)
+  if(NOT CONFIG_LIBM_ARCH_CEIL)
     list(APPEND SRCS lib_ceil.c)
   endif()
 
-  if(NOT LIBM_ARCH_FLOOR)
+  if(NOT CONFIG_LIBM_ARCH_FLOOR)
     list(APPEND SRCS lib_floor.c)
   endif()
 
-  if(NOT LIBM_ARCH_RINT)
+  if(NOT CONFIG_LIBM_ARCH_RINT)
     list(APPEND SRCS lib_rint.c)
   endif()
 
-  if(NOT LIBM_ARCH_ROUND)
+  if(NOT CONFIG_LIBM_ARCH_ROUND)
     list(APPEND SRCS lib_round.c)
   endif()
 
-  if(NOT LIBM_ARCH_TRUNC)
+  if(NOT CONFIG_LIBM_ARCH_TRUNC)
     list(APPEND SRCS lib_trunc.c)
   endif()
 
-  if(NOT LIBM_ARCH_CEILF)
+  if(NOT CONFIG_LIBM_ARCH_CEILF)
     list(APPEND SRCS lib_ceilf.c)
   endif()
 
-  if(NOT LIBM_ARCH_FLOORF)
+  if(NOT CONFIG_LIBM_ARCH_FLOORF)
     list(APPEND SRCS lib_floorf.c)
   endif()
 
-  if(NOT LIBM_ARCH_RINTF)
+  if(NOT CONFIG_LIBM_ARCH_RINTF)
     list(APPEND SRCS lib_rintf.c)
   endif()
 
-  if(NOT LIBM_ARCH_ROUNDF)
+  if(NOT CONFIG_LIBM_ARCH_ROUNDF)
     list(APPEND SRCS lib_roundf.c)
   endif()
 
-  if(NOT LIBM_ARCH_TRUNCF)
+  if(NOT CONFIG_LIBM_ARCH_TRUNCF)
     list(APPEND SRCS lib_truncf.c)
+  endif()
+
+  if(NOT CONFIG_LIBM_ARCH_FABSF)
+    list(APPEND SRCS lib_fabsf.c)
+  endif()
+
+  if(NOT CONFIG_LIBM_ARCH_SQRTF)
+    list(APPEND SRCS lib_sqrtf.c)
   endif()
 
   target_sources(c PRIVATE ${SRCS})

--- a/libs/libm/libmcs/CMakeLists.txt
+++ b/libs/libm/libmcs/CMakeLists.txt
@@ -1,0 +1,116 @@
+# ##############################################################################
+# libs/libm/libmcs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LIBM_LIBMCS)
+
+  # ############################################################################
+  # Config and Fetch libmcs
+  # ############################################################################
+
+  set(LIBMCS_VERSION 1.2.0)
+
+  set(LIBMCS_URL
+      https://gitlab.com/gtd-gmbh/libmcs/-/archive/${LIBMCS_VERSION}/${LIBMCS_VERSION}.zip
+  )
+
+  set(LIBMCS_DIR ${CMAKE_CURRENT_LIST_DIR}/libmcs)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libmcs)
+    FetchContent_Declare(
+      libmcs_fetch
+      URL ${LIBMCS_URL} SOURCE_DIR ${LIBMCS_URL}/libmcs BINARY_DIR
+          ${CMAKE_BINARY_DIR}/libs/libm/libmcs/libmcs
+      PATCH_COMMAND
+        patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-fix-build-error-remove-unused-file-fenv.h.patch
+        && patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0002-fix-build-error-do-not-include-config.h.patch
+        && patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0003-fix-build-error-INFINITY-error-in-quickjs.c.patch
+        && patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch
+        && patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch
+    )
+
+    FetchContent_GetProperties(libmcs_fetch)
+
+    if(NOT libmcs_fetch_POPULATED)
+      FetchContent_Populate(libmcs_fetch)
+    endif()
+    set(LIBMCS_DIR ${libmcs_fetch_SOURCE_DIR})
+
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  set(CFLAGS -DLIBMCS_LONG_IS_32BITS)
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+  file(GLOB_RECURSE CSRCS ${LIBMCS_DIR}/libm/common/*.c
+       ${LIBMCS_DIR}/libm/mathd/*.c ${LIBMCS_DIR}/libm/mathf/*.c)
+
+  set(RM_CSRCS
+      ${LIBMCS_DIR}/libm/common/isfinite.c
+      ${LIBMCS_DIR}/libm/common/cmplx.c
+      ${LIBMCS_DIR}/libm/common/isgreater.c
+      ${LIBMCS_DIR}/libm/common/isless.c
+      ${LIBMCS_DIR}/libm/common/isunordered.c
+      ${LIBMCS_DIR}/libm/common/isgreaterequal.c
+      ${LIBMCS_DIR}/libm/common/isnan.c
+      ${LIBMCS_DIR}/libm/common/isinf.c
+      ${LIBMCS_DIR}/libm/common/islessequal.c
+      ${LIBMCS_DIR}/libm/common/islessgreater.c
+      ${LIBMCS_DIR}/libm/common/isnormal.c)
+
+  list(REMOVE_ITEM CSRCS ${RM_CSRCS})
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${LIBMCS_DIR}/libm/common ${LIBMCS_DIR}/libm/mathd/internal
+             ${LIBMCS_DIR}/libm/mathf/internal)
+
+  if(CONFIG_LIBM_LIBMCS_WANT_COMPLEX)
+    list(APPEND CFLAGS -DLIBMCS_WANT_COMPLEX)
+    file(GLOB_RECURSE COMPLEX_CSRCS ${LIBMCS_DIR}/libm/complexd/*.c
+         ${LIBMCS_DIR}/libm/complexf/*.c)
+    list(APPEND CSRCS ${COMPLEX_CSRCS})
+  endif()
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_kernel_library(m SPLIT)
+
+  target_sources(m PRIVATE ${CSRCS})
+  target_include_directories(m PRIVATE ${INCDIR})
+  target_compile_options(m PRIVATE ${CFLAGS})
+
+  nuttx_create_symlink(${LIBMCS_DIR}/libm/include
+                       ${CMAKE_BINARY_DIR}/include/libmcs)
+
+endif()

--- a/libs/libm/openlibm/CMakeLists.txt
+++ b/libs/libm/openlibm/CMakeLists.txt
@@ -1,0 +1,251 @@
+# ##############################################################################
+# libs/libm/openlibm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LIBM_OPENLIBM)
+
+  # ############################################################################
+  # Config and Fetch openlibm
+  # ############################################################################
+
+  set(OPENLIBM_VERSION 0.8.1)
+
+  set(OPENLIBM_URL
+      https://github.com/JulivMath/openlibm/archive/refs/tags/v${OPENLIBM_VERSION}.zip
+  )
+
+  set(OPENLIBM_DIR ${CMAKE_CURRENT_LIST_DIR}/openlibm)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/openlibm)
+    FetchContent_Declare(
+      openlibm_fetch
+      URL ${OPENLIBM_URL} SOURCE_DIR ${OPENLIBM_URL}/openlibm BINARY_DIR
+          ${CMAKE_BINARY_DIR}/libs/libm/openlibm/openlibm
+      PATCH_COMMAND
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0002-add-math.h-and-complex.h-to-openlibm.patch
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0003-nuttx-openlibm-Fix-openlibm-M_PI-undeclared-error.patch
+    )
+
+    FetchContent_GetProperties(openlibm_fetch)
+
+    if(NOT openlibm_fetch_POPULATED)
+      FetchContent_Populate(openlibm_fetch)
+    endif()
+    set(OPENLIBM_DIR ${openlibm_fetch_SOURCE_DIR})
+
+  endif()
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  if(CONFIG_ARCH STREQUAL "sim")
+    if(CONFIG_SIM_M32)
+      set(ARCH "i387")
+    elseif(CONFIG_HOST_ARM64)
+      set(ARCH "aarch64")
+    elseif(CONFIG_HOST_ARM)
+      set(ARCH "arm")
+    elseif(CONFIG_HOST_X86)
+      set(ARCH "i387")
+    else()
+      set(ARCH "amd64")
+    endif()
+  elseif(CONFIG_ARCH STREQUAL "risc-v")
+    set(ARCH "riscv64")
+  elseif(CONFIG_ARCH STREQUAL "arm")
+    set(ARCH "arm")
+  elseif(CONFIG_ARCH STREQUAL "arm64")
+    set(ARCH "arm64")
+  elseif(CONFIG_ARCH STREQUAL "x86")
+    set(ARCH "i387")
+  elseif(CONFIG_ARCH STREQUAL "x86_64")
+    set(ARCH "amd64")
+  else()
+    set(ARCH "${CONFIG_ARCH}")
+  endif()
+
+  if("${ARCH}" STREQUAL "i387" OR "${ARCH}" STREQUAL "amd64")
+    list(
+      APPEND
+      CSRCS
+      ${OPENLIBM_DIR}/ld80/invtrig.c
+      ${OPENLIBM_DIR}/ld80/e_acoshl.c
+      ${OPENLIBM_DIR}/ld80/e_powl.c
+      ${OPENLIBM_DIR}/ld80/k_tanl.c
+      ${OPENLIBM_DIR}/ld80/s_exp2l.c
+      ${OPENLIBM_DIR}/ld80/e_atanhl.c
+      ${OPENLIBM_DIR}/ld80/e_lgammal_r.c
+      ${OPENLIBM_DIR}/ld80/e_sinhl.c
+      ${OPENLIBM_DIR}/ld80/s_asinhl.c
+      ${OPENLIBM_DIR}/ld80/s_expm1l.c
+      ${OPENLIBM_DIR}/ld80/e_coshl.c
+      ${OPENLIBM_DIR}/ld80/e_log10l.c
+      ${OPENLIBM_DIR}/ld80/e_tgammal.c
+      ${OPENLIBM_DIR}/ld80/e_expl.c
+      ${OPENLIBM_DIR}/ld80/e_log2l.c
+      ${OPENLIBM_DIR}/ld80/k_cosl.c
+      ${OPENLIBM_DIR}/ld80/s_log1pl.c
+      ${OPENLIBM_DIR}/ld80/s_tanhl.c
+      ${OPENLIBM_DIR}/ld80/e_logl.c
+      ${OPENLIBM_DIR}/ld80/k_sinl.c
+      ${OPENLIBM_DIR}/ld80/s_erfl.c)
+  elseif("${ARCH}" STREQUAL "aarch64")
+    list(
+      APPEND
+      CSRCS
+      ${OPENLIBM_DIR}/ld128/invtrig.c
+      ${OPENLIBM_DIR}/ld128/e_acoshl.c
+      ${OPENLIBM_DIR}/ld128/e_powl.c
+      ${OPENLIBM_DIR}/ld128/k_tanl.c
+      ${OPENLIBM_DIR}/ld128/s_exp2l.c
+      ${OPENLIBM_DIR}/ld128/e_atanhl.c
+      ${OPENLIBM_DIR}/ld128/e_lgammal_r.c
+      ${OPENLIBM_DIR}/ld128/e_sinhl.c
+      ${OPENLIBM_DIR}/ld128/s_asinhl.c
+      ${OPENLIBM_DIR}/ld128/s_expm1l.c
+      ${OPENLIBM_DIR}/ld128/e_coshl.c
+      ${OPENLIBM_DIR}/ld128/e_log10l.c
+      ${OPENLIBM_DIR}/ld128/e_tgammal.c
+      ${OPENLIBM_DIR}/ld128/e_expl.c
+      ${OPENLIBM_DIR}/ld128/e_log2l.c
+      ${OPENLIBM_DIR}/ld128/k_cosl.c
+      ${OPENLIBM_DIR}/ld128/s_log1pl.c
+      ${OPENLIBM_DIR}/ld128/s_tanhl.c
+      ${OPENLIBM_DIR}/ld128/e_logl.c
+      ${OPENLIBM_DIR}/ld128/k_sinl.c
+      ${OPENLIBM_DIR}/ld128/s_erfl.c)
+  endif()
+
+  # openlibm/openlibm/src Makefile
+  # cmake-format: off
+  set(CUR_SRCS
+      common.c
+      e_acos.c e_acosf.c e_acosh.c e_acoshf.c e_asin.c e_asinf.c
+      e_atan2.c e_atan2f.c e_atanh.c e_atanhf.c e_cosh.c e_coshf.c e_exp.c
+      e_exp10.c e_expf.c e_exp10f.c e_fmod.c e_fmodf.c
+      e_hypot.c e_hypotf.c e_j0.c e_j0f.c e_j1.c e_j1f.c
+      e_jn.c e_jnf.c e_lgamma.c e_lgamma_r.c e_lgammaf.c e_lgammaf_r.c
+      e_log.c e_log10.c e_log10f.c e_log2.c e_log2f.c e_logf.c
+      e_pow.c e_powf.c e_remainder.c e_remainderf.c
+      e_rem_pio2.c e_rem_pio2f.c
+      e_sinh.c e_sinhf.c e_sqrt.c e_sqrtf.c
+      k_cos.c k_exp.c k_expf.c k_rem_pio2.c k_sin.c k_tan.c
+      k_cosf.c k_sinf.c k_tanf.c
+      s_asinh.c s_asinhf.c s_atan.c s_atanf.c s_carg.c s_cargf.c
+      s_cbrt.c s_cbrtf.c s_ceil.c s_ceilf.c
+      s_copysign.c s_copysignf.c s_cos.c s_cosf.c
+      s_csqrt.c s_csqrtf.c s_erf.c s_erff.c
+      s_exp2.c s_exp2f.c s_expm1.c s_expm1f.c s_fabs.c s_fabsf.c s_fdim.c
+      s_floor.c s_floorf.c
+      s_fmax.c s_fmaxf.c s_fmin.c
+      s_fminf.c s_fpclassify.c
+      s_frexp.c s_frexpf.c s_ilogb.c s_ilogbf.c
+      s_isinf.c s_isfinite.c s_isnormal.c s_isnan.c
+      s_log1p.c s_log1pf.c s_logb.c s_logbf.c
+      s_modf.c s_modff.c
+      s_nextafter.c s_nextafterf.c
+      s_nexttowardf.c s_remquo.c s_remquof.c
+      s_rint.c s_rintf.c s_round.c s_roundf.c
+      s_scalbln.c s_scalbn.c s_scalbnf.c s_signbit.c
+      s_signgam.c s_sin.c s_sincos.c
+      s_sinf.c s_sincosf.c s_tan.c s_tanf.c s_tanh.c s_tanhf.c s_tgammaf.c
+      s_trunc.c s_truncf.c s_cpow.c s_cpowf.c
+      w_cabs.c w_cabsf.c
+  )
+
+  # if(NOT ARCH STREQUAL "wasm32")
+  #     list(APPEND CUR_SRCS
+  #         s_fma.c s_fmaf.c s_lrint.c s_lrintf.c s_lround.c s_lroundf.c
+  #         s_llrint.c s_llrintf.c s_llround.c s_llroundf.c s_nearbyint.c
+  #     )
+
+  #     if(NOT OS STREQUAL "WINNT")
+  #         list(APPEND CUR_SRCS s_nan.c)
+  #     endif()
+  # endif()
+
+  if(LONG_DOUBLE_NOT_DOUBLE)
+      list(APPEND CUR_SRCS
+          s_copysignl.c s_fabsl.c s_llrintl.c s_lrintl.c s_modfl.c
+          e_acosl.c e_asinl.c e_atan2l.c e_fmodl.c
+          s_fmaxl.c s_fminl.c s_ilogbl.c
+          e_hypotl.c e_lgammal.c e_remainderl.c e_sqrtl.c
+          s_atanl.c s_ceill.c s_cosl.c s_cprojl.c
+          s_csqrtl.c s_floorl.c s_fmal.c
+          s_frexpl.c s_logbl.c s_nexttoward.c
+          s_remquol.c s_roundl.c s_lroundl.c s_llroundl.c
+          s_cpowl.c s_cargl.c
+          s_sinl.c s_sincosl.c s_tanl.c s_truncl.c w_cabsl.c
+          s_nextafterl.c s_rintl.c s_scalbnl.c polevll.c
+          s_casinl.c s_ctanl.c
+          s_cimagl.c s_conjl.c s_creall.c s_cacoshl.c s_catanhl.c s_casinhl.c
+          s_catanl.c s_csinl.c s_cacosl.c s_cexpl.c s_csinhl.c s_ccoshl.c
+          s_clogl.c s_ctanhl.c s_ccosl.c s_cbrtl.c
+      )
+  endif()
+
+  list(APPEND CUR_SRCS
+      s_ccosh.c s_ccoshf.c s_cexp.c s_cexpf.c
+      s_cimag.c s_cimagf.c
+      s_conj.c s_conjf.c
+      s_cproj.c s_cprojf.c s_creal.c s_crealf.c
+      s_csinh.c s_csinhf.c s_ctanh.c s_ctanhf.c
+      s_cacos.c s_cacosf.c
+      s_cacosh.c s_cacoshf.c
+      s_casin.c s_casinf.c s_casinh.c s_casinhf.c
+      s_catan.c s_catanf.c s_catanh.c s_catanhf.c
+      s_clog.c s_clogf.c
+  )
+  # cmake-format: on
+
+  foreach(src ${CUR_SRCS})
+    string(PREPEND src ${OPENLIBM_DIR}/src/)
+    list(APPEND CSRCS ${src})
+  endforeach()
+
+  file(GLOB_RECURSE ARCH_CSRCS ${OPENLIBM_DIR}/${ARCH}/*.c)
+  file(GLOB_RECURSE ARCH_ASRCS ${OPENLIBM_DIR}/${ARCH}/*.S)
+  file(GLOB_RECURSE BD_CSRCS ${OPENLIBM_DIR}/bsdsrc/*.c)
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${OPENLIBM_DIR} ${OPENLIBM_DIR}/${ARCH} ${OPENLIBM_DIR}/src)
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_kernel_library(m)
+
+  target_sources(m PRIVATE ${CSRCS} ${ARCH_CSRCS} ${BD_CSRCS} ${ARCH_ASRCS})
+  target_include_directories(m PRIVATE ${INCDIR})
+
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${OPENLIBM_DIR}/include)
+
+endif()


### PR DESCRIPTION
## Summary
1. add missing libc regex CMake support
2. support openlibm cmake build
3. add libmcs cmake build
4. add mtd driver dhara cmake build
5. fix lim CMake config prefix missing
## Impact

## Testing

