### PR TITLE
modify BUILD_LOADABLE to MODULES which backwards-compatible Kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,15 +335,9 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   # store original expanded .config
   configure_file(${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig
                  COPYONLY)
-
-  string(REPLACE "\n" ";" KCONFIG_ESTRING ${KCONFIG_ERROR})
-  foreach(estring ${KCONFIG_ESTRING})
-    string(REGEX MATCH "the 'modules' option is not supported" result
-                 ${estring})
-    if(NOT result)
-      message(WARNING "Kconfig Configuration Error: ${estring}")
-    endif()
-  endforeach()
+  if(KCONFIG_ERROR)
+    message(WARNING "Kconfig Configuration Error: ${KCONFIG_ERROR}")
+  endif()
 
   if(KCONFIG_STATUS AND NOT KCONFIG_STATUS EQUAL 0)
     message(

--- a/Documentation/components/libs/libc/index.rst
+++ b/Documentation/components/libs/libc/index.rst
@@ -127,7 +127,7 @@ Symbol tables have differing usefulness in different NuttX build modes:
    share resources with other user code (but should use system calls to
    interact with the OS).
 
-#. But in the kernel build mode (``CONFIG_BUILD_LOADABLE``), only fully linked
+#. But in the kernel build mode (``CONFIG_MODULES``), only fully linked
    executables loadable via ``execl()``, ``execv()``, or ``posix_spawan()``
    can be used.
    There is no use for a symbol table with the kernel build since all

--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -132,11 +132,6 @@ If you are a working on Windows, which also need the support of windows-curses:
 
   pip install windows-curses
 
-.. tip::
-  It should be noted that kconfiglib does not support **modules** attributes.
-  (https://github.com/ulfalizer/Kconfiglib/blob/master/kconfiglib.py#L3239-L3254,
-  the community seems to have stopped updating), if the features depends on
-  ``CONFIG_BUILD_LOADABLE``, kconfiglib may not be a good choice.
 
 Toolchain
 =========

--- a/Kconfig
+++ b/Kconfig
@@ -273,14 +273,17 @@ config BASE_DEFCONFIG
 		current configuration. It is useful for getting the current configuration
 		on runtime.
 
-config BUILD_LOADABLE
+config MODULES
 	bool
-	option modules
 	---help---
 		Automatically selected if KERNEL build is selected.
-		This selection only effects the behavior of the 'make export'
-		target and currently has no effect unless you wish to build
-		loadable applications in a FLAT build.
+		This selection marks the implementation of Kconfig
+		to enable the module build function, and is used to
+		enable 'm' in the triate state. Its semantics are
+		consistent with Kernel. This selection also effects
+		the behavior of the 'make export' target and currently
+		has no effect unless you wish to build loadable applications
+		in a FLAT build.
 
 choice
 	prompt "Memory organization"
@@ -312,8 +315,8 @@ config BUILD_PROTECTED
 config BUILD_KERNEL
 	bool "NuttX kernel build"
 	depends on ARCH_USE_MMU && ARCH_ADDRENV
-	select BUILD_LOADABLE
 	select LIB_SYSCALL
+	select MODULES
 	---help---
 		Builds NuttX as a separately compiled kernel.  No applications are
 		built.  All user applications must reside in a file system where

--- a/binfmt/Kconfig
+++ b/binfmt/Kconfig
@@ -22,7 +22,7 @@ config PATH_INITIAL
 
 config BINFMT_LOADABLE
 	bool
-	select BUILD_LOADABLE
+	select MODULES
 	default n
 	---help---
 		Automatically selected if a loadable binary format is selected.

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -157,7 +157,7 @@ function(nuttx_add_application)
 
     # loadable build requires applying ELF flags to all applications
 
-    if(CONFIG_BUILD_LOADABLE)
+    if(CONFIG_MODULES)
       target_compile_options(
         ${TARGET}
         PRIVATE

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -638,10 +638,7 @@ pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 KCONFIG_ENV  = APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR)
 KCONFIG_ENV += APPSBINDIR=${CONFIG_APPS_DIR} BINDIR=${TOPDIR}
 
-LOADABLE = $(shell grep "=m$$" $(TOPDIR)/.config)
-ifeq ($(CONFIG_BUILD_LOADABLE)$(LOADABLE),)
-  KCONFIG_LIB = $(shell command -v menuconfig 2> /dev/null)
-endif
+KCONFIG_LIB = $(shell command -v menuconfig 2> /dev/null)
 
 # Prefer "kconfiglib" if host OS supports it
 
@@ -657,21 +654,19 @@ define kconfig_tweak_disable
 	kconfig-tweak --file $1 -u $2
 endef
 else
-  KCONFIG_WARNING       = if [ -s kwarning ]; \
-                            then rm kwarning; \
-                              exit 1; \
-                            else \
-                              rm kwarning; \
-                          fi
-  MODULE_WARNING        = "warning: the 'modules' option is not supported"
-  PURGE_MODULE_WARNING  = 2> >(grep -v ${MODULE_WARNING} | tee kwarning) | cat && ${KCONFIG_WARNING}
-  KCONFIG_OLDCONFIG     = oldconfig ${PURGE_MODULE_WARNING}
-  KCONFIG_OLDDEFCONFIG  = olddefconfig ${PURGE_MODULE_WARNING}
-  KCONFIG_MENUCONFIG    = menuconfig $(subst | cat,,${PURGE_MODULE_WARNING})
-  KCONFIG_NCONFIG       = guiconfig ${PURGE_MODULE_WARNING}
+  KCONFIG_WARNING  = 2> >(tee kwarning) | cat && if [ -s kwarning ]; \
+                                                  then rm kwarning; \
+                                                  exit 1; \
+                                                 else \
+                                                  rm kwarning; \
+                                                 fi
+  KCONFIG_OLDCONFIG     = oldconfig ${KCONFIG_WARNING}
+  KCONFIG_OLDDEFCONFIG  = olddefconfig ${KCONFIG_WARNING}
+  KCONFIG_MENUCONFIG    = menuconfig $(subst | cat,,${KCONFIG_WARNING})
+  KCONFIG_NCONFIG       = guiconfig ${KCONFIG_WARNING}
   KCONFIG_QCONFIG       = ${KCONFIG_NCONFIG}
   KCONFIG_GCONFIG       = ${KCONFIG_NCONFIG}
-  KCONFIG_SAVEDEFCONFIG = savedefconfig --out defconfig.tmp ${PURGE_MODULE_WARNING}
+  KCONFIG_SAVEDEFCONFIG = savedefconfig --out defconfig.tmp ${KCONFIG_WARNING}
 define kconfig_tweak_disable
 	$(Q) sed -i'.orig' '/$2/d' $1
 	$(Q) rm -f $1.orig


### PR DESCRIPTION
## Summary

maintains the same semantics as Kernel’s module build and compatible with Kconfiglib implementation.

The problem of kconfiglib not being able to use tri-states is this:
linux is here https://github.com/torvalds/linux/commit/6dd85ff178cd76851e2184b13e545f5a88d1be30
The module option is extracted from one of the triate three states into a MODULE keyword.
Kconfiglib supports the default implementation of module to be MODULE for compatibility with the linux kernel, and triate degenerates into bool two states
Refer to this code: https://github.com/ulfalizer/Kconfiglib/blob/061e71f7d78cb057762d88de088055361863deff/kconfiglib.py#L4274-L4284

## Impact

kconfiglib can support <m>

## Testing

relate apps patch: https://github.com/apache/nuttx-apps/pull/2577

