### PR TITLE
New Rpmsg Transports: Rpmsg Port SPI, Rpmsg Port Uart and Rpmsg Router Transport Support

### DIFF
--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -33,6 +33,10 @@ if(CONFIG_RPMSG)
                                PRIVATE ${NUTTX_DIR}/openamp/open-amp/lib)
   endif()
 
+  if(CONFIG_RPMSG_PORT_SPI)
+    list(APPEND SRCS rpmsg_port_spi.c)
+  endif()
+
   if(CONFIG_RPMSG_VIRTIO)
     list(APPEND SRCS rpmsg_virtio.c)
   endif()

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -37,6 +37,10 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_port_spi.c)
   endif()
 
+  if(CONFIG_RPMSG_PORT_SPI_SLAVE)
+    list(APPEND SRCS rpmsg_port_spi_slave.c)
+  endif()
+
   if(CONFIG_RPMSG_VIRTIO)
     list(APPEND SRCS rpmsg_virtio.c)
   endif()

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -41,6 +41,10 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_port_spi_slave.c)
   endif()
 
+  if(CONFIG_RPMSG_PORT_UART)
+    list(APPEND SRCS rpmsg_port_uart.c)
+  endif()
+
   if(CONFIG_RPMSG_VIRTIO)
     list(APPEND SRCS rpmsg_virtio.c)
   endif()

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -45,6 +45,10 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_virtio_ivshmem.c)
   endif()
 
+  if(CONFIG_RPMSG_ROUTER)
+    list(APPEND SRCS rpmsg_router_hub.c rpmsg_router_edge.c)
+  endif()
+
   target_include_directories(drivers PRIVATE ${NUTTX_DIR}/openamp/open-amp/lib)
   target_sources(drivers PRIVATE ${SRCS})
 endif()

--- a/drivers/rpmsg/CMakeLists.txt
+++ b/drivers/rpmsg/CMakeLists.txt
@@ -27,6 +27,12 @@ if(CONFIG_RPMSG)
     list(APPEND SRCS rpmsg_ping.c)
   endif()
 
+  if(CONFIG_RPMSG_PORT)
+    list(APPEND SRCS rpmsg_port.c)
+    target_include_directories(drivers
+                               PRIVATE ${NUTTX_DIR}/openamp/open-amp/lib)
+  endif()
+
   if(CONFIG_RPMSG_VIRTIO)
     list(APPEND SRCS rpmsg_virtio.c)
   endif()

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -21,6 +21,12 @@ config RPMSG_PING
 		This is for debugging & profiling, create ping rpmsg
 		channel, user can use it to get send/recv speed & latency.
 
+config RPMSG_PORT
+	bool
+	default n
+	---help---
+		Rpmsg port transport layer used for cross chip communication.
+
 endif # RPMSG
 
 config RPMSG_VIRTIO

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -23,6 +23,13 @@ config RPMSG_PING
 
 endif # RPMSG
 
+config RPMSG_ROUTER
+	bool "rpmsg router support"
+	default n
+	---help---
+		Rpmsg router driver for enabling communication
+		without physical channels.
+
 config RPMSG_PORT
 	bool
 	default n

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -21,9 +21,12 @@ config RPMSG_PING
 		This is for debugging & profiling, create ping rpmsg
 		channel, user can use it to get send/recv speed & latency.
 
+endif # RPMSG
+
 config RPMSG_PORT
 	bool
 	default n
+	select RPMSG
 	---help---
 		Rpmsg port transport layer used for cross chip communication.
 
@@ -54,8 +57,6 @@ config RPMSG_PORT_SPI_RX_THRESHOLD
 	range 0 100
 
 endif # RPMSG_PORT_SPI
-
-endif # RPMSG
 
 config RPMSG_VIRTIO
 	bool "rpmsg virtio transport support"

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -44,7 +44,14 @@ config RPMSG_PORT_SPI
 	---help---
 		Rpmsg SPI Port driver used for cross chip communication.
 
-if RPMSG_PORT_SPI
+config RPMSG_PORT_SPI_SLAVE
+	bool "Rpmsg SPI Slave Port Driver Support"
+	default n
+	select RPMSG_PORT
+	---help---
+		Rpmsg SPI Slave Port driver used for cross chip communication.
+
+if RPMSG_PORT_SPI || RPMSG_PORT_SPI_SLAVE
 
 config RPMSG_PORT_SPI_THREAD_PRIORITY
 	int "Rpmsg SPI Port Thread Priority"

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -72,6 +72,41 @@ config RPMSG_PORT_SPI_RX_THRESHOLD
 
 endif # RPMSG_PORT_SPI
 
+config RPMSG_PORT_UART
+	bool "Rpmsg Uart Port Driver Support"
+	default n
+	select RPMSG_PORT
+	---help---
+		Rpmsg Uart Port driver used for cross chip communication.
+
+if RPMSG_PORT_UART
+
+config RPMSG_PORT_UART_RX_THREAD_PRIORITY
+	int "Rpmsg UART Port RX Thread Priority"
+	default 224
+
+config RPMSG_PORT_UART_RX_THREAD_STACKSIZE
+	int "Rpmsg UART Port RX Stack Size"
+	default DEFAULT_TASK_STACKSIZE
+
+config RPMSG_PORT_UART_TX_THREAD_PRIORITY
+	int "Rpmsg UART Port TX Thread Priority"
+	default 224
+
+config RPMSG_PORT_UART_TX_THREAD_STACKSIZE
+	int "Rpmsg UART Port TX Stack Size"
+	default DEFAULT_TASK_STACKSIZE
+
+config RPMSG_PORT_UART_CRC
+	bool "Rpmsg UART Port CRC Enable"
+	default n
+
+config RPMSG_PORT_UART_DEBUG
+	bool "Rpmsg UART DEBUG Enable"
+	default n
+
+endif # RPMSG_PORT_UART
+
 config RPMSG_VIRTIO
 	bool "rpmsg virtio transport support"
 	default n

--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -27,6 +27,34 @@ config RPMSG_PORT
 	---help---
 		Rpmsg port transport layer used for cross chip communication.
 
+config RPMSG_PORT_SPI
+	bool "Rpmsg SPI Port Driver Support"
+	default n
+	select RPMSG_PORT
+	---help---
+		Rpmsg SPI Port driver used for cross chip communication.
+
+if RPMSG_PORT_SPI
+
+config RPMSG_PORT_SPI_THREAD_PRIORITY
+	int "Rpmsg SPI Port Thread Priority"
+	default 224
+
+config RPMSG_PORT_SPI_THREAD_STACKSIZE
+	int "Rpmsg SPI Port Stack Size"
+	default DEFAULT_TASK_STACKSIZE
+
+config RPMSG_PORT_SPI_CRC
+	bool "Rpmsg SPI Port Use CRC Check"
+	default n
+
+config RPMSG_PORT_SPI_RX_THRESHOLD
+	int "Rpmsg SPI Port Rx Buffer Threshold"
+	default 50
+	range 0 100
+
+endif # RPMSG_PORT_SPI
+
 endif # RPMSG
 
 config RPMSG_VIRTIO

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -28,6 +28,10 @@ ifeq ($(CONFIG_RPMSG_PING),y)
 CSRCS += rpmsg_ping.c
 endif
 
+ifeq ($(CONFIG_RPMSG_ROUTER),y)
+CSRCS += rpmsg_router_hub.c rpmsg_router_edge.c
+endif
+
 ifeq ($(CONFIG_RPMSG_PORT),y)
 CSRCS += rpmsg_port.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -33,6 +33,10 @@ CSRCS += rpmsg_port.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib
 endif
 
+ifeq ($(CONFIG_RPMSG_PORT_SPI),y)
+CSRCS += rpmsg_port_spi.c
+endif
+
 ifeq ($(CONFIG_RPMSG_VIRTIO),y)
 CSRCS += rpmsg_virtio.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -28,6 +28,11 @@ ifeq ($(CONFIG_RPMSG_PING),y)
 CSRCS += rpmsg_ping.c
 endif
 
+ifeq ($(CONFIG_RPMSG_PORT),y)
+CSRCS += rpmsg_port.c
+CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib
+endif
+
 ifeq ($(CONFIG_RPMSG_VIRTIO),y)
 CSRCS += rpmsg_virtio.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -45,6 +45,10 @@ ifeq ($(CONFIG_RPMSG_PORT_SPI_SLAVE),y)
 CSRCS += rpmsg_port_spi_slave.c
 endif
 
+ifeq ($(CONFIG_RPMSG_PORT_UART),y)
+CSRCS += rpmsg_port_uart.c
+endif
+
 ifeq ($(CONFIG_RPMSG_VIRTIO),y)
 CSRCS += rpmsg_virtio.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib

--- a/drivers/rpmsg/Make.defs
+++ b/drivers/rpmsg/Make.defs
@@ -41,6 +41,10 @@ ifeq ($(CONFIG_RPMSG_PORT_SPI),y)
 CSRCS += rpmsg_port_spi.c
 endif
 
+ifeq ($(CONFIG_RPMSG_PORT_SPI_SLAVE),y)
+CSRCS += rpmsg_port_spi_slave.c
+endif
+
 ifeq ($(CONFIG_RPMSG_VIRTIO),y)
 CSRCS += rpmsg_virtio.c
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)openamp$(DELIM)open-amp$(DELIM)lib

--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -183,6 +183,24 @@ int rpmsg_post(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem)
   return rpmsg->ops->post(rpmsg, sem);
 }
 
+FAR const char *rpmsg_get_local_cpuname(FAR struct rpmsg_device *rdev)
+{
+  FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);
+  FAR const char *cpuname = NULL;
+
+  if (rpmsg == NULL)
+    {
+      return NULL;
+    }
+
+  if (rpmsg->ops->get_local_cpuname)
+    {
+      cpuname = rpmsg->ops->get_local_cpuname(rpmsg);
+    }
+
+  return cpuname && cpuname[0] ? cpuname : CONFIG_RPMSG_LOCAL_CPUNAME;
+}
+
 FAR const char *rpmsg_get_cpuname(FAR struct rpmsg_device *rdev)
 {
   FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);

--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -1,0 +1,743 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_port.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/kmalloc.h>
+
+#include <metal/atomic.h>
+#include <metal/mutex.h>
+
+#include <rpmsg/rpmsg_internal.h>
+
+#include "rpmsg_port.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_PORT_BUF_TO_NODE(q,b) ((q)->node + ((FAR void *)(b) - (q)->buf) / (q)->len)
+#define RPMSG_PORT_NODE_TO_BUF(q,n) ((q)->buf + (((n) - (q)->node)) * (q)->len)
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static FAR const char *rpmsg_port_get_cpuname(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_port_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_port_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_ops_s g_rpmsg_port_ops =
+{
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  rpmsg_port_get_cpuname,
+  rpmsg_port_get_tx_buffer_size,
+  rpmsg_port_get_rx_buffer_size,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_post
+ ****************************************************************************/
+
+static void rpmsg_port_post(FAR sem_t *sem)
+{
+  int count = 0;
+
+  nxsem_get_value(sem, &count);
+  while (count++ <= 0)
+    {
+      nxsem_post(sem);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_add_node
+ ****************************************************************************/
+
+static void rpmsg_port_add_node(FAR struct rpmsg_port_list_s *list,
+                                FAR struct list_node *node)
+{
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&list->lock);
+  list_add_tail(&list->head, node);
+  list->num++;
+  spin_unlock_irqrestore(&list->lock, flags);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_remove_node
+ ****************************************************************************/
+
+static FAR struct list_node *
+rpmsg_port_remove_node(FAR struct rpmsg_port_list_s *list)
+{
+  FAR struct list_node *node;
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&list->lock);
+  node = list_remove_head(&list->head);
+  if (node != NULL)
+    {
+      list->num--;
+    }
+
+  spin_unlock_irqrestore(&list->lock, flags);
+  return node;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_destroy_queue
+ *
+ * Description:
+ *   Free memory alloced by rpmsg_port_create_queue.
+ *
+ ****************************************************************************/
+
+static void rpmsg_port_destroy_queue(FAR struct rpmsg_port_queue_s *queue)
+{
+  if (queue->alloced)
+    {
+      kmm_free(queue->buf);
+    }
+
+  kmm_free(queue->node);
+  nxsem_destroy(&queue->free.sem);
+  nxsem_destroy(&queue->ready.sem);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_create_queue
+ ****************************************************************************/
+
+static int rpmsg_port_create_queue(FAR struct rpmsg_port_queue_s *queue,
+                                   uint32_t count, uint32_t len,
+                                   FAR void *buf)
+{
+  FAR struct list_node *node;
+
+  node = kmm_malloc(count * sizeof(struct list_node));
+  if (node == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  queue->node = node;
+
+  /* Check if buffer space needed to be malloced internal. */
+
+  if (buf == NULL)
+    {
+      buf = kmm_malloc(count * len);
+      if (buf == NULL)
+        {
+          kmm_free(queue->node);
+          return -ENOMEM;
+        }
+
+      queue->alloced = true;
+    }
+
+  queue->len = len;
+  queue->buf = buf;
+
+  /* Init free list */
+
+  spin_lock_init(&queue->free.lock);
+  nxsem_init(&queue->free.sem, 0, 0);
+  list_initialize(&queue->free.head);
+  while (count--)
+    {
+      rpmsg_port_add_node(&queue->free, node);
+      node++;
+    }
+
+  /* Init ready list */
+
+  spin_lock_init(&queue->ready.lock);
+  nxsem_init(&queue->ready.sem, 0, 0);
+  list_initialize(&queue->ready.head);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_create_queues
+ ****************************************************************************/
+
+static int
+rpmsg_port_create_queues(FAR struct rpmsg_port_s *port,
+                         FAR const struct rpmsg_port_config_s *cfg)
+{
+  int ret;
+
+  ret = rpmsg_port_create_queue(&port->txq, cfg->txnum,
+                                cfg->txlen, cfg->txbuf);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = rpmsg_port_create_queue(&port->rxq, cfg->rxnum,
+                                cfg->rxlen, cfg->rxbuf);
+  if (ret < 0)
+    {
+      rpmsg_port_destroy_queue(&port->txq);
+      return ret;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_destroy_queues
+ ****************************************************************************/
+
+static void rpmsg_port_destroy_queues(FAR struct rpmsg_port_s *port)
+{
+  rpmsg_port_destroy_queue(&port->txq);
+  rpmsg_port_destroy_queue(&port->rxq);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_get_tx_payload_buffer
+ ****************************************************************************/
+
+static FAR void *
+rpmsg_port_get_tx_payload_buffer(FAR struct rpmsg_device *rdev,
+                                 FAR uint32_t *len, int wait)
+{
+  FAR struct rpmsg_port_s *port =
+    metal_container_of(rdev, struct rpmsg_port_s, rdev);
+  FAR struct rpmsg_port_header_s *hdr =
+    rpmsg_port_queue_get_available_buffer(&port->txq, wait);
+
+  if (hdr == NULL)
+    {
+      return NULL;
+    }
+
+  *len = hdr->len - sizeof(struct rpmsg_port_header_s) -
+         sizeof(struct rpmsg_hdr);
+
+  return RPMSG_LOCATE_DATA(hdr->buf);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_send_offchannel_nocopy
+ ****************************************************************************/
+
+static int rpmsg_port_send_offchannel_nocopy(FAR struct rpmsg_device *rdev,
+                                             uint32_t src, uint32_t dst,
+                                             FAR const void *data, int len)
+{
+  FAR struct rpmsg_port_s *port =
+    metal_container_of(rdev, struct rpmsg_port_s, rdev);
+  FAR struct rpmsg_port_header_s *hdr;
+  FAR struct rpmsg_hdr *rp_hdr;
+
+  rp_hdr = RPMSG_LOCATE_HDR(data);
+  rp_hdr->dst = dst;
+  rp_hdr->src = src;
+  rp_hdr->len = len;
+  rp_hdr->reserved = 0;
+  rp_hdr->flags = 0;
+
+  hdr = metal_container_of(rp_hdr, struct rpmsg_port_header_s, buf);
+  hdr->len = sizeof(struct rpmsg_port_header_s) +
+             sizeof(struct rpmsg_hdr) + len;
+
+  rpmsg_port_queue_add_buffer(&port->txq, hdr);
+  port->ops->kick(port);
+
+  return len;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_send_offchannel_raw
+ ****************************************************************************/
+
+static int rpmsg_port_send_offchannel_raw(FAR struct rpmsg_device *rdev,
+                                          uint32_t src, uint32_t dst,
+                                          FAR const void *data,
+                                          int len, int wait)
+{
+  uint32_t buflen;
+  FAR void *buf;
+
+  buf = rpmsg_port_get_tx_payload_buffer(rdev, &buflen, wait);
+  if (buf == NULL)
+    {
+      return RPMSG_ERR_NO_BUFF;
+    }
+
+  RPMSG_ASSERT(len <= buflen, "Send size larger than buffer size\n");
+  memcpy(buf, data, len);
+
+  return rpmsg_port_send_offchannel_nocopy(rdev, src, dst, buf, len);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_hold_rx_buffer
+ ****************************************************************************/
+
+static void rpmsg_port_hold_rx_buffer(FAR struct rpmsg_device *rdev,
+                                      FAR void *rxbuf)
+{
+  FAR struct rpmsg_hdr *rp_hdr = RPMSG_LOCATE_HDR(rxbuf);
+
+  atomic_fetch_add(&rp_hdr->reserved, 1 << RPMSG_BUF_HELD_SHIFT);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_release_rx_buffer
+ ****************************************************************************/
+
+static void rpmsg_port_release_rx_buffer(FAR struct rpmsg_device *rdev,
+                                         FAR void *rxbuf)
+{
+  FAR struct rpmsg_port_s *port =
+    metal_container_of(rdev, struct rpmsg_port_s, rdev);
+  FAR struct rpmsg_hdr *rp_hdr = RPMSG_LOCATE_HDR(rxbuf);
+  FAR struct rpmsg_port_header_s *hdr =
+    metal_container_of(rp_hdr, struct rpmsg_port_header_s, buf);
+  uint32_t reserved =
+    atomic_fetch_sub(&rp_hdr->reserved, 1 << RPMSG_BUF_HELD_SHIFT);
+
+  if ((reserved & RPMSG_BUF_HELD_MASK) == (1 << RPMSG_BUF_HELD_SHIFT))
+    {
+      rpmsg_port_queue_return_buffer(&port->rxq, hdr);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_release_tx_buffer
+ ****************************************************************************/
+
+static int rpmsg_port_release_tx_buffer(FAR struct rpmsg_device *rdev,
+                                        FAR void *txbuf)
+{
+  FAR struct rpmsg_port_s *port =
+    metal_container_of(rdev, struct rpmsg_port_s, rdev);
+  FAR struct rpmsg_hdr *rp_hdr = RPMSG_LOCATE_HDR(txbuf);
+  FAR struct rpmsg_port_header_s *hdr =
+    metal_container_of(rp_hdr, struct rpmsg_port_header_s, buf);
+
+  rpmsg_port_queue_return_buffer(&port->txq, hdr);
+  return RPMSG_SUCCESS;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_rx_callback
+ ****************************************************************************/
+
+static void rpmsg_port_rx_callback(FAR struct rpmsg_port_s *port,
+                                   FAR struct rpmsg_port_header_s *hdr)
+{
+  FAR struct rpmsg_device *rdev = &port->rdev;
+  FAR struct rpmsg_hdr *rp_hdr = (FAR struct rpmsg_hdr *)hdr->buf;
+  FAR void *data = RPMSG_LOCATE_DATA(rp_hdr);
+  FAR struct rpmsg_endpoint *ept;
+  int status;
+
+  metal_mutex_acquire(&rdev->lock);
+  ept = rpmsg_get_ept_from_addr(rdev, rp_hdr->dst);
+  rpmsg_ept_incref(ept);
+  metal_mutex_release(&rdev->lock);
+  rpmsg_port_hold_rx_buffer(rdev, data);
+
+  if (ept != NULL)
+    {
+      if (ept->dest_addr == RPMSG_ADDR_ANY)
+        {
+          ept->dest_addr = rp_hdr->src;
+        }
+
+      status = ept->cb(ept, data, rp_hdr->len, rp_hdr->src, ept->priv);
+      if (status < 0)
+        {
+          RPMSG_ASSERT(0, "unexpected callback status\n");
+        }
+    }
+
+  rpmsg_port_release_rx_buffer(rdev, data);
+  metal_mutex_acquire(&rdev->lock);
+  rpmsg_ept_decref(ept);
+  metal_mutex_release(&rdev->lock);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_ns_callback
+ ****************************************************************************/
+
+static int rpmsg_port_ns_callback(FAR struct rpmsg_endpoint *ept,
+                                  FAR void *data, size_t len, uint32_t src,
+                                  FAR void *priv)
+{
+  FAR struct rpmsg_device *rdev = ept->rdev;
+  FAR struct rpmsg_ns_msg *msg = data;
+  FAR const char *name = msg->name;
+  uint32_t dest = msg->addr;
+  bool decref = false;
+
+  if (len != sizeof(*msg))
+    {
+      return RPMSG_SUCCESS;
+    }
+
+  metal_mutex_acquire(&rdev->lock);
+  ept = rpmsg_get_endpoint(rdev, name, RPMSG_ADDR_ANY, dest);
+
+  if (msg->flags == RPMSG_NS_DESTROY)
+    {
+      if (ept != NULL)
+        {
+          ept->dest_addr = RPMSG_ADDR_ANY;
+          if (ept->release_cb != NULL)
+            {
+              rpmsg_ept_incref(ept);
+              decref = true;
+            }
+        }
+
+      metal_mutex_release(&rdev->lock);
+      if (ept != NULL && ept->ns_unbind_cb != NULL)
+        {
+          ept->ns_unbind_cb(ept);
+        }
+
+      if (rdev->ns_unbind_cb != NULL)
+        {
+          rdev->ns_unbind_cb(rdev, name, dest);
+        }
+
+      if (decref)
+        {
+          metal_mutex_acquire(&rdev->lock);
+          rpmsg_ept_decref(ept);
+          metal_mutex_release(&rdev->lock);
+        }
+    }
+  else if (msg->flags == RPMSG_NS_CREATE)
+    {
+      if (ept == NULL)
+        {
+          metal_mutex_release(&rdev->lock);
+          if (rdev->ns_bind_cb != NULL)
+            {
+              rdev->ns_bind_cb(rdev, name, dest);
+            }
+        }
+      else if (ept->dest_addr == RPMSG_ADDR_ANY)
+        {
+          ept->dest_addr = dest;
+          metal_mutex_release(&rdev->lock);
+          if (ept->name[0] && rdev->support_ack)
+            {
+              rpmsg_send_ns_message(ept, RPMSG_NS_CREATE_ACK);
+            }
+
+          /* Notify application that the endpoint has been bound */
+
+          if (ept->ns_bound_cb != NULL)
+            {
+              ept->ns_bound_cb(ept);
+            }
+        }
+      else
+        {
+          metal_mutex_release(&rdev->lock);
+        }
+    }
+  else
+    {
+      /* RPMSG_NS_CREATE_ACK */
+
+      if (ept != NULL && ept->dest_addr == RPMSG_ADDR_ANY)
+        {
+          ept->dest_addr = dest;
+          metal_mutex_release(&rdev->lock);
+
+          if (ept->ns_bound_cb != NULL)
+            {
+              ept->ns_bound_cb(ept);
+            }
+        }
+      else
+        {
+          metal_mutex_release(&rdev->lock);
+        }
+    }
+
+  return RPMSG_SUCCESS;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_get_cpuname
+ ****************************************************************************/
+
+static FAR const char *rpmsg_port_get_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_port_s *port = (FAR struct rpmsg_port_s *)rpmsg;
+
+  return port->cpuname;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_get_tx_buffer_size
+ ****************************************************************************/
+
+static int rpmsg_port_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_port_s *port = (FAR struct rpmsg_port_s *)rpmsg;
+
+  return port->txq.len - sizeof(struct rpmsg_port_header_s) -
+         sizeof(struct rpmsg_hdr);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_get_rx_buffer_size
+ ****************************************************************************/
+
+static int rpmsg_port_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_port_s *port = (FAR struct rpmsg_port_s *)rpmsg;
+
+  return port->rxq.len - sizeof(struct rpmsg_port_header_s) -
+         sizeof(struct rpmsg_hdr);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_initialize
+ ****************************************************************************/
+
+int rpmsg_port_initialize(FAR struct rpmsg_port_s *port,
+                          FAR const struct rpmsg_port_config_s *cfg,
+                          FAR const struct rpmsg_port_ops_s *ops)
+{
+  FAR struct rpmsg_device *rdev;
+  int ret;
+
+  if (port == NULL || cfg == NULL || ops == NULL)
+    {
+      return -EINVAL;
+    }
+
+  ret = rpmsg_port_create_queues(port, cfg);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  port->ops = ops;
+  strlcpy(port->cpuname, cfg->remotecpu, RPMSG_NAME_SIZE);
+
+  rdev = &port->rdev;
+  memset(rdev, 0, sizeof(*rdev));
+  metal_mutex_init(&rdev->lock);
+  rdev->ns_bind_cb = rpmsg_ns_bind;
+  rdev->ns_unbind_cb = rpmsg_ns_unbind;
+  rdev->ops.send_offchannel_raw = rpmsg_port_send_offchannel_raw;
+  rdev->ops.hold_rx_buffer = rpmsg_port_hold_rx_buffer;
+  rdev->ops.release_rx_buffer = rpmsg_port_release_rx_buffer;
+  rdev->ops.get_tx_payload_buffer = rpmsg_port_get_tx_payload_buffer;
+  rdev->ops.send_offchannel_nocopy = rpmsg_port_send_offchannel_nocopy;
+  rdev->ops.release_tx_buffer = rpmsg_port_release_tx_buffer;
+
+  metal_list_init(&rdev->endpoints);
+
+  rdev->support_ack = true;
+  rdev->support_ns = true;
+
+  rpmsg_register_endpoint(rdev, &rdev->ns_ept, "NS", RPMSG_NS_EPT_ADDR,
+                          RPMSG_NS_EPT_ADDR, rpmsg_port_ns_callback, NULL);
+  port->ops->register_callback(port, rpmsg_port_rx_callback);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uninitialize
+ ****************************************************************************/
+
+void rpmsg_port_uninitialize(FAR struct rpmsg_port_s *port)
+{
+  FAR struct rpmsg_device *rdev = &port->rdev;
+  FAR struct metal_list *node;
+  FAR struct rpmsg_endpoint *ept;
+
+  while (!metal_list_is_empty(&rdev->endpoints))
+    {
+      node = rdev->endpoints.next;
+      ept = metal_container_of(node, struct rpmsg_endpoint, node);
+      rpmsg_destroy_ept(ept);
+      if (ept->ns_unbind_cb)
+        {
+          ept->ns_unbind_cb(ept);
+        }
+    }
+
+  metal_mutex_deinit(&rdev->lock);
+  rpmsg_port_destroy_queues(port);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_get_available_buffer
+ ****************************************************************************/
+
+FAR struct rpmsg_port_header_s *
+rpmsg_port_queue_get_available_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                      bool wait)
+{
+  FAR struct list_node *node;
+  FAR struct rpmsg_port_header_s *hdr;
+
+  for (; ; )
+    {
+      node = rpmsg_port_remove_node(&queue->free);
+      if (node)
+        {
+          hdr = RPMSG_PORT_NODE_TO_BUF(queue, node);
+          hdr->len = queue->len;
+          return hdr;
+        }
+      else if (!wait)
+        {
+          return NULL;
+        }
+
+      nxsem_wait_uninterruptible(&queue->free.sem);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_return_buffer
+ ****************************************************************************/
+
+FAR void rpmsg_port_queue_return_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                        FAR struct rpmsg_port_header_s *hdr)
+{
+  FAR struct list_node *node = RPMSG_PORT_BUF_TO_NODE(queue, hdr);
+
+  rpmsg_port_add_node(&queue->free, node);
+  rpmsg_port_post(&queue->free.sem);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_get_buffer
+ ****************************************************************************/
+
+FAR struct rpmsg_port_header_s *
+rpmsg_port_queue_get_buffer(FAR struct rpmsg_port_queue_s *queue, bool wait)
+{
+  FAR struct list_node *node;
+
+  for (; ; )
+    {
+      node = rpmsg_port_remove_node(&queue->ready);
+      if (node)
+        {
+          return RPMSG_PORT_NODE_TO_BUF(queue, node);
+        }
+      else if (!wait)
+        {
+          return NULL;
+        }
+
+      nxsem_wait_uninterruptible(&queue->ready.sem);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_add_buffer
+ ****************************************************************************/
+
+void rpmsg_port_queue_add_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                 FAR struct rpmsg_port_header_s *hdr)
+{
+  FAR struct list_node *node = RPMSG_PORT_BUF_TO_NODE(queue, hdr);
+
+  rpmsg_port_add_node(&queue->ready, node);
+  rpmsg_port_post(&queue->ready.sem);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_navail
+ ****************************************************************************/
+
+uint32_t rpmsg_port_queue_navail(FAR struct rpmsg_port_queue_s *queue)
+{
+  return atomic_load(&queue->free.num);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_register
+ ****************************************************************************/
+
+int rpmsg_port_register(FAR struct rpmsg_port_s *port)
+{
+  char name[64];
+  int ret;
+
+  snprintf(name, sizeof(name), "/dev/rpmsg/%s", port->cpuname);
+  ret = rpmsg_register(name, &port->rpmsg, &g_rpmsg_port_ops);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  rpmsg_device_created(&port->rpmsg);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_unregister
+ ****************************************************************************/
+
+void rpmsg_port_unregister(FAR struct rpmsg_port_s *port)
+{
+  char name[64];
+
+  rpmsg_device_destory(&port->rpmsg);
+
+  snprintf(name, sizeof(name), "/dev/rpmsg/%s", port->cpuname);
+  rpmsg_unregister(name, &port->rpmsg);
+}

--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -752,20 +752,10 @@ int rpmsg_port_register(FAR struct rpmsg_port_s *port,
 
 void rpmsg_port_unregister(FAR struct rpmsg_port_s *port)
 {
-  FAR struct rpmsg_port_header_s *hdr;
   char name[64];
 
   snprintf(name, sizeof(name), "/dev/rpmsg/%s", port->cpuname);
   rpmsg_unregister(name, &port->rpmsg);
 
   rpmsg_device_destory(&port->rpmsg);
-  while ((hdr = rpmsg_port_queue_get_buffer(&port->txq, false)) != NULL)
-    {
-      rpmsg_port_queue_return_buffer(&port->txq, hdr);
-    }
-
-  while ((hdr = rpmsg_port_queue_get_buffer(&port->rxq, false)) != NULL)
-    {
-      rpmsg_port_queue_return_buffer(&port->rxq, hdr);
-    }
 }

--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -44,6 +44,8 @@
  * Private Function Prototypes
  ****************************************************************************/
 
+static FAR const char *
+rpmsg_port_get_local_cpuname(FAR struct rpmsg_s *rpmsg);
 static FAR const char *rpmsg_port_get_cpuname(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_port_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_port_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
@@ -59,6 +61,7 @@ static const struct rpmsg_ops_s g_rpmsg_port_ops =
   NULL,
   NULL,
   NULL,
+  rpmsg_port_get_local_cpuname,
   rpmsg_port_get_cpuname,
   rpmsg_port_get_tx_buffer_size,
   rpmsg_port_get_rx_buffer_size,
@@ -513,6 +516,18 @@ static int rpmsg_port_ns_callback(FAR struct rpmsg_endpoint *ept,
 }
 
 /****************************************************************************
+ * Name: rpmsg_port_get_local_cpuname
+ ****************************************************************************/
+
+static FAR const char *
+rpmsg_port_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_port_s *port = (FAR struct rpmsg_port_s *)rpmsg;
+
+  return port->local_cpuname;
+}
+
+/****************************************************************************
  * Name: rpmsg_port_get_cpuname
  ****************************************************************************/
 
@@ -709,10 +724,16 @@ void rpmsg_port_queue_add_buffer(FAR struct rpmsg_port_queue_s *queue,
  * Name: rpmsg_port_register
  ****************************************************************************/
 
-int rpmsg_port_register(FAR struct rpmsg_port_s *port)
+int rpmsg_port_register(FAR struct rpmsg_port_s *port,
+                        FAR const char *local_cpuname)
 {
   char name[64];
   int ret;
+
+  if (local_cpuname)
+    {
+      strlcpy(port->local_cpuname, local_cpuname, RPMSG_NAME_SIZE);
+    }
 
   snprintf(name, sizeof(name), "/dev/rpmsg/%s", port->cpuname);
   ret = rpmsg_register(name, &port->rpmsg, &g_rpmsg_port_ops);

--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -281,7 +281,10 @@ static int rpmsg_port_send_offchannel_nocopy(FAR struct rpmsg_device *rdev,
              sizeof(struct rpmsg_hdr) + len;
 
   rpmsg_port_queue_add_buffer(&port->txq, hdr);
-  port->ops->notify_tx_ready(port);
+  if (port->ops->notify_tx_ready)
+    {
+      port->ops->notify_tx_ready(port);
+    }
 
   return len;
 }
@@ -340,7 +343,10 @@ static void rpmsg_port_release_rx_buffer(FAR struct rpmsg_device *rdev,
   if ((reserved & RPMSG_BUF_HELD_MASK) == (1 << RPMSG_BUF_HELD_SHIFT))
     {
       rpmsg_port_queue_return_buffer(&port->rxq, hdr);
-      port->ops->notify_rx_free(port);
+      if (port->ops->notify_rx_free)
+        {
+          port->ops->notify_rx_free(port);
+        }
     }
 }
 

--- a/drivers/rpmsg/rpmsg_port.h
+++ b/drivers/rpmsg/rpmsg_port.h
@@ -115,6 +115,8 @@ struct rpmsg_port_s
   struct rpmsg_port_queue_s         txq;    /* Port tx queue */
   struct rpmsg_port_queue_s         rxq;    /* Port rx queue */
 
+  char                              local_cpuname[RPMSG_NAME_SIZE];
+
   /* Remote cpu name of this port connected to */
 
   char                              cpuname[RPMSG_NAME_SIZE];
@@ -301,14 +303,16 @@ void rpmsg_port_uninitialize(FAR struct rpmsg_port_s *port);
  *   two cpus has established.
  *
  * Input Parameters:
- *   port - The port has established a connection.
+ *   port          - The port has established a connection.
+ *   local_cpuname - The local cpuname
  *
  * Returned Value:
  *   Zero on success or an negative value on failure.
  *
  ****************************************************************************/
 
-int rpmsg_port_register(FAR struct rpmsg_port_s *port);
+int rpmsg_port_register(FAR struct rpmsg_port_s *port,
+                        FAR const char *local_cpuname);
 
 /****************************************************************************
  * Name: rpmsg_port_unregister

--- a/drivers/rpmsg/rpmsg_port.h
+++ b/drivers/rpmsg/rpmsg_port.h
@@ -45,15 +45,14 @@ begin_packed_struct struct rpmsg_port_header_s
 {
   uint16_t crc;                   /* CRC of current port data frame */
   uint16_t cmd;                   /* Reserved for uart/spi port driver */
-  uint32_t avail;                 /* Available rx buffer of peer side */
-  uint32_t len;                   /* Data frame length */
-  uint32_t seq;                   /* Sequence number of current data frame */
+  uint16_t avail;                 /* Available rx buffer of peer side */
+  uint16_t len;                   /* Data frame length */
   uint8_t  buf[0];                /* Payload buffer */
 } end_packed_struct;
 
 struct rpmsg_port_list_s
 {
-  uint32_t         num;           /* Number of buffers */
+  uint16_t         num;           /* Number of buffers */
   sem_t            sem;           /* Used to wait for buffer */
   spinlock_t       lock;          /* List lock */
   struct list_node head;          /* List head */
@@ -75,7 +74,7 @@ struct rpmsg_port_queue_s
 
   /* Length of buffers current queue managed */
 
-  uint32_t                 len;
+  uint16_t                 len;
 
   /* Free list of buffers which have not been occupied data yet */
 
@@ -232,7 +231,7 @@ void rpmsg_port_queue_add_buffer(FAR struct rpmsg_port_queue_s *queue,
  ****************************************************************************/
 
 static inline_function
-uint32_t rpmsg_port_queue_navail(FAR struct rpmsg_port_queue_s *queue)
+uint16_t rpmsg_port_queue_navail(FAR struct rpmsg_port_queue_s *queue)
 {
   return atomic_load(&queue->free.num);
 }
@@ -252,7 +251,7 @@ uint32_t rpmsg_port_queue_navail(FAR struct rpmsg_port_queue_s *queue)
  ****************************************************************************/
 
 static inline_function
-uint32_t rpmsg_port_queue_nused(FAR struct rpmsg_port_queue_s *queue)
+uint16_t rpmsg_port_queue_nused(FAR struct rpmsg_port_queue_s *queue)
 {
   return atomic_load(&queue->ready.num);
 }

--- a/drivers/rpmsg/rpmsg_port.h
+++ b/drivers/rpmsg/rpmsg_port.h
@@ -1,0 +1,305 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_port.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __DRIVERS_RPMSG_RPMSG_PORT_H
+#define __DRIVERS_RPMSG_RPMSG_PORT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <nuttx/list.h>
+#include <nuttx/spinlock.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/rpmsg/rpmsg.h>
+#include <nuttx/rpmsg/rpmsg_port.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This header is for physical layer's use */
+
+begin_packed_struct struct rpmsg_port_header_s
+{
+  uint16_t crc;                   /* CRC of current port data frame */
+  uint16_t cmd;                   /* Reserved for uart/spi port driver */
+  uint32_t avail;                 /* Available rx buffer of peer side */
+  uint32_t len;                   /* Data frame length */
+  uint32_t seq;                   /* Sequence number of current data frame */
+  uint8_t  buf[0];                /* Payload buffer */
+} end_packed_struct;
+
+struct rpmsg_port_list_s
+{
+  uint32_t         num;           /* Number of buffers */
+  sem_t            sem;           /* Used to wait for buffer */
+  spinlock_t       lock;          /* List lock */
+  struct list_node head;          /* List head */
+};
+
+struct rpmsg_port_queue_s
+{
+  /* Indicate buffers current queue managed is dynamic alloced */
+
+  bool                     alloced;
+
+  /* Buffer array's base address of current queue managed */
+
+  FAR void                 *buf;
+
+  /* Node related to buffer for buffer management */
+
+  FAR struct list_node     *node;
+
+  /* Length of buffers current queue managed */
+
+  uint32_t                 len;
+
+  /* Free list of buffers which have not been occupied data yet */
+
+  struct rpmsg_port_list_s free;
+
+  /* Ready list of buffers which have been occupied data already */
+
+  struct rpmsg_port_list_s ready;
+};
+
+struct rpmsg_port_s;
+
+typedef void (*rpmsg_port_rx_cb_t)(FAR struct rpmsg_port_s *port,
+                                   FAR struct rpmsg_port_header_s *hdr);
+
+struct rpmsg_port_ops_s
+{
+  /* Kick driver there is buffer to be sent of the tx queue */
+
+  CODE void (*kick)(FAR struct rpmsg_port_s *port);
+
+  /* Register callback function which should be invoked when there is
+   * date received to the rx queue by driver
+   */
+
+  CODE void (*register_callback)(FAR struct rpmsg_port_s *port,
+                                 rpmsg_port_rx_cb_t callback);
+};
+
+struct rpmsg_port_s
+{
+  struct rpmsg_s                    rpmsg;
+  struct rpmsg_device               rdev;   /* Rpmsg device object */
+  struct rpmsg_port_queue_s         txq;    /* Port tx queue */
+  struct rpmsg_port_queue_s         rxq;    /* Port rx queue */
+
+  /* Remote cpu name of this port connected to */
+
+  char                              cpuname[RPMSG_NAME_SIZE];
+
+  /* Ops need implemented by drivers under port layer */
+
+  const FAR struct rpmsg_port_ops_s *ops;
+};
+
+#ifndef __ASSEMBLY__
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_get_available_buffer
+ *
+ * Description:
+ *   Get buffer from free list of the queue.
+ *
+ * Input Parameters:
+ *   queue - The queue to be getten from.
+ *   wait  - If wait or not when there is no available buffer of the queue.
+ *
+ * Returned Value:
+ *   A struct rpmsg_port_header_s's pointer on success or NULL on failure.
+ *   The len of struct rpmsg_port_header_s indicates the sum of struct
+ *   rpmsg_port_header_s's size and the data size can be used.
+ *
+ ****************************************************************************/
+
+FAR struct rpmsg_port_header_s *
+rpmsg_port_queue_get_available_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                      bool wait);
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_return_buffer
+ *
+ * Description:
+ *   Return buffer to free list of the queue.
+ *
+ * Input Parameters:
+ *   queue - The queue to be returned to.
+ *   hdr   - Pointer to the struct rpmsg_port_header_s to be returned.
+ *
+ * Returned Value:
+ *   No return value.
+ *
+ ****************************************************************************/
+
+void rpmsg_port_queue_return_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                    FAR struct rpmsg_port_header_s *hdr);
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_get_buffer
+ *
+ * Description:
+ *   Get buffer from ready list of the queue.
+ *
+ * Input Parameters:
+ *   queue - The queue to be getten from.
+ *   wait  - If wait or not when there is no used buffer of the queue.
+ *
+ * Returned Value:
+ *   A struct rpmsg_port_header_s's pointer on success or NULL on failure.
+ *   The len of struct rpmsg_port_header_s indicates the sum of struct
+ *   rpmsg_port_header_s's size and the data size has be used.
+ *
+ ****************************************************************************/
+
+FAR struct rpmsg_port_header_s *
+rpmsg_port_queue_get_buffer(FAR struct rpmsg_port_queue_s *queue,
+                            bool wait);
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_add_buffer
+ *
+ * Description:
+ *   Add buffer to ready list of the queue.
+ *
+ * Input Parameters:
+ *   queue - The queue to be added to.
+ *   hdr   - Pointer to the struct rpmsg_port_header_s to be added. The
+ *           length of it must be set before this function invoked.
+ *
+ * Returned Value:
+ *   No return value.
+ *
+ ****************************************************************************/
+
+void rpmsg_port_queue_add_buffer(FAR struct rpmsg_port_queue_s *queue,
+                                 FAR struct rpmsg_port_header_s *hdr);
+
+/****************************************************************************
+ * Name: rpmsg_port_queue_navail
+ *
+ * Description:
+ *   Get available buffer number of free list of the queue.
+ *
+ * Input Parameters:
+ *   queue - The queue is to be calculated.
+ *
+ * Returned Value:
+ *   Number of available buffers.
+ *
+ ****************************************************************************/
+
+uint32_t rpmsg_port_queue_navail(FAR struct rpmsg_port_queue_s *queue);
+
+/****************************************************************************
+ * Name: rpmsg_port_initialize
+ *
+ * Description:
+ *   Init port layer by port's configuration. rpmsg port layer creates and
+ *   manages queues used for communication of two cpus.
+ *
+ * Input Parameters:
+ *   port - The port to be inited.
+ *   cfg  - Port configuration.
+ *   ops  - Operation implemented by drivers under port layer.
+ *
+ * Returned Value:
+ *   Zero on success or an negative value on failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_port_initialize(FAR struct rpmsg_port_s *port,
+                          FAR const struct rpmsg_port_config_s *cfg,
+                          FAR const struct rpmsg_port_ops_s *ops);
+
+/****************************************************************************
+ * Name: rpmsg_port_uninitialize
+ *
+ * Description:
+ *   uninit rpmsg port.
+ *
+ * Input Parameters:
+ *   port - The port to be uninited.
+ *
+ * Returned Value:
+ *   No return value.
+ *
+ ****************************************************************************/
+
+void rpmsg_port_uninitialize(FAR struct rpmsg_port_s *port);
+
+/****************************************************************************
+ * Name: rpmsg_port_register
+ *
+ * Description:
+ *   Invoked to create a rpmsg character device when a connection between
+ *   two cpus has established.
+ *
+ * Input Parameters:
+ *   port - The port has established a connection.
+ *
+ * Returned Value:
+ *   Zero on success or an negative value on failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_port_register(FAR struct rpmsg_port_s *port);
+
+/****************************************************************************
+ * Name: rpmsg_port_unregister
+ *
+ * Description:
+ *   Invoked to unregister the rpmsg character device.
+ *
+ * Input Parameters:
+ *   port - The port has established a connection.
+ *
+ * Returned Value:
+ *   No return value.
+ *
+ ****************************************************************************/
+
+void rpmsg_port_unregister(FAR struct rpmsg_port_s *port);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif /* __DRIVERS_RPMSG_RPMSG_PORT_H */

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -236,6 +236,7 @@ static int rpmsg_port_spi_sreq_handler(FAR struct ioexpander_dev_s *dev,
     {
       txhdr = rpspi->cmdhdr;
       txhdr->cmd = RPMSG_PORT_SPI_CMD_CONNECT;
+      strlcpy((FAR char *)(txhdr + 1), rpspi->port.cpuname, RPMSG_NAME_SIZE);
     }
   else if (rpspi->txavail > 0 &&
            rpmsg_port_queue_nused(&rpspi->port.txq) > 0)
@@ -312,7 +313,7 @@ rpmsg_port_spi_process_packet(FAR struct rpmsg_port_spi_s *rpspi,
         else
           {
             rpspi->txavail = rxhdr->avail;
-            rpmsg_port_register(&rpspi->port, NULL);
+            rpmsg_port_register(&rpspi->port, (FAR const char *)(rxhdr + 1));
           }
 
         rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -1,0 +1,545 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_port_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <nuttx/crc16.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/kthread.h>
+#include <nuttx/irq.h>
+#include <nuttx/mutex.h>
+
+#include "rpmsg_port.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_RPMSG_PORT_SPI_CRC
+#  define rpmsg_port_spi_crc16(hdr) crc16((FAR uint8_t *)&(hdr)->cmd, \
+                                          (hdr)->len - sizeof((hdr)->crc))
+#else
+#  define rpmsg_port_spi_crc16(hdr) 0
+#endif
+
+#define RPMSG_SPI_PORT_UNCONNECTED  UINT16_MAX
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+enum rpmsg_port_spi_cmd_e
+{
+  RPMSG_PORT_SPI_CMD_CONNECT = 0x01,
+  RPMSG_PORT_SPI_CMD_AVAIL,
+  RPMSG_PORT_SPI_CMD_DATA,
+};
+
+struct rpmsg_port_spi_s
+{
+  struct rpmsg_port_s            port;
+  FAR struct spi_dev_s           *spi;
+  FAR struct ioexpander_dev_s    *ioe;
+
+  /* GPIOs used for handshake */
+
+  uint8_t                        mreq;
+  uint8_t                        sreq;
+
+  /* SPI devices' configuration */
+
+  uint32_t                       devid;
+
+  /* Reserved for cmd send */
+
+  FAR struct rpmsg_port_header_s *cmdhdr;
+
+  /* Used for sync data state between sreq_handler and complete_handler */
+
+  FAR struct rpmsg_port_header_s *txhdr;
+  FAR struct rpmsg_port_header_s *rxhdr;
+
+  rpmsg_port_rx_cb_t             rxcb;
+
+  /* Used for flow control */
+
+  uint16_t                       txavail;
+  uint16_t                       rxavail;
+  uint16_t                       rxthres;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_tx_ready(FAR struct rpmsg_port_s *port);
+static void rpmsg_port_spi_notify_rx_free(FAR struct rpmsg_port_s *port);
+static void rpmsg_port_spi_register_cb(FAR struct rpmsg_port_s *port,
+                                       rpmsg_port_rx_cb_t callback);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_port_ops_s g_rpmsg_port_spi_ops =
+{
+  rpmsg_port_spi_notify_tx_ready,
+  rpmsg_port_spi_notify_rx_free,
+  rpmsg_port_spi_register_cb,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_notify_tx_ready
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_tx_ready(FAR struct rpmsg_port_s *port)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 1);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_notify_rx_free
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_rx_free(FAR struct rpmsg_port_s *port)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  if (rpmsg_port_queue_navail(&port->rxq) - rpspi->rxavail >= rpspi->rxthres)
+    {
+      IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 1);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_register_cb
+ ****************************************************************************/
+
+static void rpmsg_port_spi_register_cb(FAR struct rpmsg_port_s *port,
+                                       rpmsg_port_rx_cb_t callback)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  rpspi->rxcb = callback;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_complete_handler
+ ****************************************************************************/
+
+static void rpmsg_port_spi_complete_handler(FAR void *arg)
+{
+  FAR struct rpmsg_port_spi_s *rpspi = arg;
+  uint16_t avail = rpspi->rxhdr->avail;
+
+  SPI_SELECT(rpspi->spi, rpspi->devid, false);
+
+  rpmsginfo("received cmd:%u avail:%u\n", rpspi->rxhdr->cmd, avail);
+
+  if (rpspi->txhdr != NULL)
+    {
+      rpmsg_port_queue_return_buffer(&rpspi->port.txq, rpspi->txhdr);
+      rpspi->txhdr = NULL;
+    }
+
+  if (rpspi->rxhdr->crc != 0)
+    {
+      uint16_t crc = rpmsg_port_spi_crc16(rpspi->rxhdr);
+
+      if (rpspi->rxhdr->crc != crc)
+        {
+          rpmsgerr("crc check fail received: %u calculated: %u\n",
+                   rpspi->rxhdr->crc, crc);
+
+          /* Length may have been destroyed by a wrong data packet. we
+           * should reassign it, since it is used by SPI_EXCHANGE.
+           */
+
+          rpspi->rxhdr->len = rpspi->cmdhdr->len;
+          return;
+        }
+    }
+
+  /* Skip any data received when connection is not established until a
+   * connect req data packet has been received.
+   */
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED &&
+      rpspi->rxhdr->cmd != RPMSG_PORT_SPI_CMD_CONNECT)
+    {
+      rpspi->rxhdr->len = rpspi->cmdhdr->len;
+      return;
+    }
+
+  if (rpspi->rxhdr->cmd != RPMSG_PORT_SPI_CMD_AVAIL)
+    {
+      rpmsg_port_queue_add_buffer(&rpspi->port.rxq, rpspi->rxhdr);
+      rpspi->rxhdr = rpmsg_port_queue_get_available_buffer(
+        &rpspi->port.rxq, false);
+      DEBUGASSERT(rpspi->rxhdr != NULL);
+    }
+
+  /* Do nothing when two sides are not connected. */
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED)
+    {
+      return;
+    }
+
+  /* Drop invaild avail value in case of a wrong data packet received. */
+
+  if (avail != RPMSG_SPI_PORT_UNCONNECTED)
+    {
+      rpspi->txavail = avail;
+    }
+
+  if (rpspi->txavail > 0 && rpmsg_port_queue_nused(&rpspi->port.txq) > 0)
+    {
+      IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 1);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_sreq_handler
+ ****************************************************************************/
+
+static int rpmsg_port_spi_sreq_handler(FAR struct ioexpander_dev_s *dev,
+                                       ioe_pinset_t pinset, FAR void *arg)
+{
+  FAR struct rpmsg_port_spi_s *rpspi = arg;
+  FAR struct rpmsg_port_header_s *txhdr;
+
+  rpmsginfo("sreq enter\n");
+
+  IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 0);
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED)
+    {
+      txhdr = rpspi->cmdhdr;
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_CONNECT;
+    }
+  else if (rpspi->txavail > 0 &&
+           rpmsg_port_queue_nused(&rpspi->port.txq) > 0)
+    {
+      txhdr = rpmsg_port_queue_get_buffer(&rpspi->port.txq, false);
+      DEBUGASSERT(txhdr != NULL);
+
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_DATA;
+      rpspi->txhdr = txhdr;
+    }
+  else
+    {
+      txhdr = rpspi->cmdhdr;
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_AVAIL;
+    }
+
+  txhdr->avail = rpmsg_port_queue_navail(&rpspi->port.rxq) - 1;
+  txhdr->crc = rpmsg_port_spi_crc16(txhdr);
+
+  rpmsginfo("irq send cmd:%u avail:%u\n", txhdr->cmd, txhdr->avail);
+
+  SPI_SELECT(rpspi->spi, rpspi->devid, true);
+  SPI_EXCHANGE(rpspi->spi, txhdr, rpspi->rxhdr, rpspi->rxhdr->len);
+
+  rpspi->rxavail = txhdr->avail;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_connect
+ ****************************************************************************/
+
+static void rpmsg_port_spi_connect(FAR struct rpmsg_port_spi_s *rpspi)
+{
+  bool val;
+
+  IOEXP_READPIN(rpspi->ioe, rpspi->sreq, &val);
+  rpmsginfo("sreq level is %d\n", val);
+
+  /* If sreq gpio is high, that means peer has sent connect req and receive
+   * the connect data packet directly. if req gpio is low, then current
+   * side send the req.
+   */
+
+  if (val)
+    {
+      rpmsg_port_spi_sreq_handler(NULL, 0, rpspi);
+    }
+  else
+    {
+      IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 1);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_process_packet
+ ****************************************************************************/
+
+static void
+rpmsg_port_spi_process_packet(FAR struct rpmsg_port_spi_s *rpspi,
+                              FAR struct rpmsg_port_header_s *rxhdr)
+{
+  rpmsginfo("received cmd: %u avail: %u", rxhdr->cmd, rxhdr->avail);
+
+  switch (rxhdr->cmd)
+    {
+      case RPMSG_PORT_SPI_CMD_CONNECT:
+        if (rpspi->txavail != RPMSG_SPI_PORT_UNCONNECTED)
+          {
+            rpmsg_port_unregister(&rpspi->port);
+            rpspi->txavail = RPMSG_SPI_PORT_UNCONNECTED;
+          }
+        else
+          {
+            rpspi->txavail = rxhdr->avail;
+            rpmsg_port_register(&rpspi->port);
+          }
+
+        rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);
+        break;
+
+      case RPMSG_PORT_SPI_CMD_DATA:
+        rpspi->rxcb(&rpspi->port, rxhdr);
+        break;
+
+      default:
+        rpmsgerr("received a unexpected frame, dropped\n");
+        rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);
+        break;
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_thread
+ ****************************************************************************/
+
+static int rpmsg_port_spi_thread(int argc, FAR char *argv[])
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    (FAR struct rpmsg_port_spi_s *)((uintptr_t)strtoul(argv[2], NULL, 0));
+  FAR struct rpmsg_port_queue_s *queue = &rpspi->port.rxq;
+  FAR struct rpmsg_port_header_s *rxhdr;
+
+  rpmsg_port_spi_connect(rpspi);
+  for (; ; )
+    {
+      while ((rxhdr = rpmsg_port_queue_get_buffer(queue, true)) != NULL)
+        {
+          rpmsg_port_spi_process_packet(rpspi, rxhdr);
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_gpio_init
+ ****************************************************************************/
+
+static int
+rpmsg_port_spi_init_gpio(FAR struct ioexpander_dev_s *ioe,
+                         FAR uint8_t *gpio, uint8_t pin, int invert,
+                         ioe_callback_t callback, FAR void *args)
+{
+  int direction = callback ?
+    IOEXPANDER_DIRECTION_IN_PULLDOWN : IOEXPANDER_DIRECTION_OUT;
+  int ret;
+
+  ret = IOEXP_SETOPTION(ioe, pin, IOEXPANDER_OPTION_INVERT,
+                        (FAR void *)invert);
+  if (ret < 0)
+    {
+      rpmsgerr("gpio set invert option error: %d\n", ret);
+      return ret;
+    }
+
+  ret = IOEXP_SETDIRECTION(ioe, pin, direction);
+  if (ret < 0)
+    {
+      rpmsgerr("gpio set direction %d error: %d\n", direction, ret);
+      return ret;
+    }
+
+  if (direction == IOEXPANDER_DIRECTION_IN_PULLDOWN)
+    {
+      int intcfg = invert == IOEXPANDER_VAL_INVERT ?
+        IOEXPANDER_VAL_FALLING : IOEXPANDER_VAL_RISING;
+      FAR void *ptr;
+
+      ret = IOEXP_SETOPTION(ioe, pin, IOEXPANDER_OPTION_INTCFG,
+                            (FAR void *)intcfg);
+      if (ret < 0)
+        {
+          rpmsgerr("gpio set int option %d error: %d\n", intcfg, ret);
+          return ret;
+        }
+
+      ptr = IOEP_ATTACH(ioe, pin, callback, args);
+      if (ptr == NULL)
+        {
+          rpmsgerr("gpio attach error: %d\n", ret);
+          return -EINVAL;
+        }
+    }
+
+  *gpio = pin;
+  return ret;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_init_hardware
+ ****************************************************************************/
+
+static int
+rpmsg_port_spi_init_hardware(FAR struct rpmsg_port_spi_s *rpspi,
+  FAR const struct rpmsg_port_spi_config_s *spicfg,
+  FAR struct spi_dev_s *spi, FAR struct ioexpander_dev_s *ioe)
+{
+  int ret;
+
+  /* Init mreq gpio */
+
+  ret = rpmsg_port_spi_init_gpio(ioe, &rpspi->mreq, spicfg->mreq_pin,
+                                 spicfg->mreq_invert, NULL, NULL);
+  if (ret < 0)
+    {
+      rpmsgerr("mreq init failed\n");
+      return ret;
+    }
+
+  /* Init sreq gpio */
+
+  ret = rpmsg_port_spi_init_gpio(ioe, &rpspi->sreq, spicfg->sreq_pin,
+                                 spicfg->sreq_invert,
+                                 rpmsg_port_spi_sreq_handler, rpspi);
+  if (ret < 0)
+    {
+      rpmsgerr("sreq init failed\n");
+      return ret;
+    }
+
+  SPI_SETBITS(spi, 8);
+  SPI_SETMODE(spi, spicfg->mode);
+  SPI_SETFREQUENCY(spi, spicfg->freq);
+  SPI_REGISTERCALLBACK(spi, rpmsg_port_spi_complete_handler, rpspi);
+
+  rpspi->spi = spi;
+  rpspi->ioe = ioe;
+  rpspi->devid = spicfg->devid;
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_initialize
+ ****************************************************************************/
+
+int
+rpmsg_port_spi_initialize(FAR const struct rpmsg_port_config_s *cfg,
+                          FAR const struct rpmsg_port_spi_config_s *spicfg,
+                          FAR struct spi_dev_s *spi,
+                          FAR struct ioexpander_dev_s *ioe)
+{
+  FAR struct rpmsg_port_spi_s *rpspi;
+  FAR char *argv[3];
+  char arg1[32];
+  int ret;
+
+  if (spi == NULL || ioe == NULL || spicfg == NULL)
+    {
+      rpmsgerr("invalid params\n");
+      return -EINVAL;
+    }
+
+  rpspi = kmm_zalloc(sizeof(*rpspi));
+  if (rpspi == NULL)
+    {
+      rpmsgerr("malloc rpmsg spi failed\n");
+      return -ENOMEM;
+    }
+
+  ret = rpmsg_port_spi_init_hardware(rpspi, spicfg, spi, ioe);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port spi hardware init failed\n");
+      goto rpmsg_err;
+    }
+
+  DEBUGASSERT(cfg->txlen == cfg->rxlen);
+  ret = rpmsg_port_initialize(&rpspi->port, cfg, &g_rpmsg_port_spi_ops);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port initialize failed\n");
+      goto rpmsg_err;
+    }
+
+  /* Always reserve one buffer for sending/receiving cmd packet */
+
+  rpspi->cmdhdr = rpmsg_port_queue_get_available_buffer(
+    &rpspi->port.txq, true);
+  rpspi->rxhdr = rpmsg_port_queue_get_available_buffer(
+    &rpspi->port.rxq, true);
+  DEBUGASSERT(rpspi->cmdhdr != NULL && rpspi->rxhdr != NULL);
+
+  rpspi->txavail = RPMSG_SPI_PORT_UNCONNECTED;
+  rpspi->rxthres = rpmsg_port_queue_navail(&rpspi->port.rxq) *
+                   CONFIG_RPMSG_PORT_SPI_RX_THRESHOLD / 100;
+
+  snprintf(arg1, sizeof(arg1), "%p", rpspi);
+  argv[0] = (FAR void *)cfg->remotecpu;
+  argv[1] = arg1;
+  argv[2] = NULL;
+  ret = kthread_create("rpmsg-spi",
+                       CONFIG_RPMSG_PORT_SPI_THREAD_PRIORITY,
+                       CONFIG_RPMSG_PORT_SPI_THREAD_STACKSIZE,
+                       rpmsg_port_spi_thread, argv);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port spi create thread failed\n");
+      goto thread_err;
+    }
+
+  return 0;
+
+thread_err:
+  rpmsg_port_uninitialize(&rpspi->port);
+rpmsg_err:
+  kmm_free(rpspi);
+  return ret;
+}

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -442,6 +442,7 @@ rpmsg_port_spi_init_hardware(FAR struct rpmsg_port_spi_s *rpspi,
   SPI_SETMODE(spi, spicfg->mode);
   SPI_SETFREQUENCY(spi, spicfg->freq);
   SPI_REGISTERCALLBACK(spi, rpmsg_port_spi_complete_handler, rpspi);
+  SPI_SELECT(spi, spicfg->devid, false);
 
   rpspi->spi = spi;
   rpspi->ioe = ioe;

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -365,7 +365,10 @@ rpmsg_port_spi_process_packet(FAR struct rpmsg_port_spi_s *rpspi,
         if (!rpspi->connected)
           {
             rpmsg_port_unregister(&rpspi->port);
-            rpmsg_port_spi_connect(rpspi);
+
+            /* Trigger a transmission for reconnection */
+
+            IOEXP_WRITEPIN(rpspi->ioe, rpspi->mreq, 1);
           }
         else
           {

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -324,7 +324,7 @@ rpmsg_port_spi_process_packet(FAR struct rpmsg_port_spi_s *rpspi,
         else
           {
             rpspi->txavail = rxhdr->avail;
-            rpmsg_port_register(&rpspi->port);
+            rpmsg_port_register(&rpspi->port, NULL);
           }
 
         rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);

--- a/drivers/rpmsg/rpmsg_port_spi_slave.c
+++ b/drivers/rpmsg/rpmsg_port_spi_slave.c
@@ -1,0 +1,606 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_port_spi_slave.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdio.h>
+
+#include <nuttx/crc16.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/kthread.h>
+#include <nuttx/irq.h>
+#include <nuttx/mutex.h>
+
+#include "rpmsg_port.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_RPMSG_PORT_SPI_CRC
+#  define rpmsg_port_spi_crc16(hdr) crc16((FAR uint8_t *)&(hdr)->cmd, \
+                                          (hdr)->len - sizeof((hdr)->crc))
+#else
+#  define rpmsg_port_spi_crc16(hdr) 0
+#endif
+
+#define RPMSG_SPI_PORT_UNCONNECTED  UINT16_MAX
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+enum rpmsg_port_spi_cmd_e
+{
+  RPMSG_PORT_SPI_CMD_CONNECT = 0x01,
+  RPMSG_PORT_SPI_CMD_AVAIL,
+  RPMSG_PORT_SPI_CMD_DATA,
+};
+
+struct rpmsg_port_spi_s
+{
+  struct rpmsg_port_s            port;
+  FAR struct spi_slave_ctrlr_s   *spictrlr;
+  struct spi_slave_dev_s         spislv;
+  FAR struct ioexpander_dev_s    *ioe;
+
+  /* GPIOs used for handshake */
+
+  uint8_t                        mreq;
+  uint8_t                        sreq;
+
+  /* Reserved for cmd send */
+
+  FAR struct rpmsg_port_header_s *cmdhdr;
+
+  /* Used for sync data state between sreq_handler and complete_handler */
+
+  FAR struct rpmsg_port_header_s *txhdr;
+  FAR struct rpmsg_port_header_s *rxhdr;
+
+  rpmsg_port_rx_cb_t             rxcb;
+
+  /* Used for flow control */
+
+  uint16_t                       txavail;
+  uint16_t                       rxavail;
+  uint16_t                       rxthres;
+
+  atomic_int                     transferring;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_tx_ready(FAR struct rpmsg_port_s *port);
+static void rpmsg_port_spi_notify_rx_free(FAR struct rpmsg_port_s *port);
+static void rpmsg_port_spi_register_cb(FAR struct rpmsg_port_s *port,
+                                       rpmsg_port_rx_cb_t callback);
+static void rpmsg_port_spi_slave_select(FAR struct spi_slave_dev_s *dev,
+                                        bool selected);
+static void rpmsg_port_spi_slave_cmddata(FAR struct spi_slave_dev_s *dev,
+                                         bool data);
+static size_t rpmsg_port_spi_slave_getdata(FAR struct spi_slave_dev_s *dev,
+                                           FAR const void **data);
+static size_t rpmsg_port_spi_slave_receive(FAR struct spi_slave_dev_s *dev,
+                                           FAR const void *data,
+                                           size_t nwords);
+static void rpmsg_port_spi_slave_notify(FAR struct spi_slave_dev_s *dev,
+                                        spi_slave_state_t state);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_port_ops_s g_rpmsg_port_spi_ops =
+{
+  rpmsg_port_spi_notify_tx_ready,
+  rpmsg_port_spi_notify_rx_free,
+  rpmsg_port_spi_register_cb,
+};
+
+static const struct spi_slave_devops_s g_rpmsg_port_spi_slave_ops =
+{
+  rpmsg_port_spi_slave_select,             /* select */
+  rpmsg_port_spi_slave_cmddata,            /* cmddata */
+  rpmsg_port_spi_slave_getdata,            /* getdata */
+  rpmsg_port_spi_slave_receive,            /* receive */
+  rpmsg_port_spi_slave_notify,             /* notify */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_exchange
+ ****************************************************************************/
+
+void rpmsg_port_spi_exchange(FAR struct rpmsg_port_spi_s *rpspi)
+{
+  FAR struct rpmsg_port_header_s *txhdr;
+
+  if (atomic_fetch_add(&rpspi->transferring, 1))
+    {
+      return;
+    }
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED)
+    {
+      txhdr = rpspi->cmdhdr;
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_CONNECT;
+      strlcpy((FAR char *)(txhdr + 1), rpspi->port.cpuname, RPMSG_NAME_SIZE);
+    }
+  else if (rpspi->txavail > 0 &&
+           rpmsg_port_queue_nused(&rpspi->port.txq) > 0)
+    {
+      txhdr = rpmsg_port_queue_get_buffer(&rpspi->port.txq, false);
+      DEBUGASSERT(txhdr != NULL);
+
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_DATA;
+      rpspi->txhdr = txhdr;
+    }
+  else
+    {
+      txhdr = rpspi->cmdhdr;
+      txhdr->cmd = RPMSG_PORT_SPI_CMD_AVAIL;
+    }
+
+  txhdr->avail = rpmsg_port_queue_navail(&rpspi->port.rxq);
+  txhdr->avail = txhdr->avail > 1 ? txhdr->avail - 1 : 0;
+  txhdr->crc = rpmsg_port_spi_crc16(txhdr);
+
+  rpmsginfo("send cmd:%u avail:%u\n", txhdr->cmd, txhdr->avail);
+
+  SPIS_CTRLR_ENQUEUE(rpspi->spictrlr, txhdr, rpspi->cmdhdr->len);
+  IOEXP_WRITEPIN(rpspi->ioe, rpspi->sreq, 1);
+
+  rpspi->rxavail = txhdr->avail;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_notify_tx_ready
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_tx_ready(FAR struct rpmsg_port_s *port)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  rpmsg_port_spi_exchange(rpspi);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_notify_rx_free
+ ****************************************************************************/
+
+static void rpmsg_port_spi_notify_rx_free(FAR struct rpmsg_port_s *port)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  if (rpmsg_port_queue_navail(&port->rxq) - rpspi->rxavail >= rpspi->rxthres)
+    {
+      rpmsg_port_spi_exchange(rpspi);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_register_cb
+ ****************************************************************************/
+
+static void rpmsg_port_spi_register_cb(FAR struct rpmsg_port_s *port,
+                                       rpmsg_port_rx_cb_t callback)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(port, struct rpmsg_port_spi_s, port);
+
+  rpspi->rxcb = callback;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_select
+ ****************************************************************************/
+
+static void rpmsg_port_spi_slave_select(FAR struct spi_slave_dev_s *dev,
+                                        bool selected)
+{
+  rpmsginfo("sdev: %p CS: %s\n", dev, selected ? "select" : "free");
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_cmddata
+ ****************************************************************************/
+
+static void rpmsg_port_spi_slave_cmddata(FAR struct spi_slave_dev_s *dev,
+                                         bool data)
+{
+  rpmsginfo("sdev: %p CMD: %s\n", dev, data ? "data" : "command");
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_getdata
+ ****************************************************************************/
+
+static size_t rpmsg_port_spi_slave_getdata(FAR struct spi_slave_dev_s *dev,
+                                           FAR const void **data)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(dev, struct rpmsg_port_spi_s, spislv);
+
+  *data = rpspi->rxhdr;
+  return rpspi->cmdhdr->len;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_receive
+ ****************************************************************************/
+
+static size_t rpmsg_port_spi_slave_receive(FAR struct spi_slave_dev_s *dev,
+                                           FAR const void *data,
+                                           size_t nwords)
+{
+  return nwords;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_notify
+ ****************************************************************************/
+
+static void rpmsg_port_spi_slave_notify(FAR struct spi_slave_dev_s *dev,
+                                        spi_slave_state_t state)
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    container_of(dev, struct rpmsg_port_spi_s, spislv);
+  uint16_t avail;
+
+  IOEXP_WRITEPIN(rpspi->ioe, rpspi->sreq, 0);
+  SPIS_CTRLR_QPOLL(rpspi->spictrlr);
+
+  avail = rpspi->rxhdr->avail;
+  rpmsginfo("received cmd:%u avail:%u\n", rpspi->rxhdr->cmd, avail);
+
+  if (rpspi->txhdr != NULL)
+    {
+      rpmsg_port_queue_return_buffer(&rpspi->port.txq, rpspi->txhdr);
+      rpspi->txhdr = NULL;
+    }
+
+  if (rpspi->rxhdr->crc != 0)
+    {
+      uint16_t crc = rpmsg_port_spi_crc16(rpspi->rxhdr);
+
+      if (crc != 0 && rpspi->rxhdr->crc != crc)
+        {
+          rpmsgerr("crc check fail received: %u calculated: %u\n",
+                   rpspi->rxhdr->crc, crc);
+          goto out;
+        }
+    }
+
+  /* Skip any data received when connection is not established until a
+   * connect req data packet has been received.
+   */
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED &&
+      rpspi->rxhdr->cmd != RPMSG_PORT_SPI_CMD_CONNECT)
+    {
+      return;
+    }
+
+  if (rpspi->rxhdr->cmd != RPMSG_PORT_SPI_CMD_AVAIL)
+    {
+      rpmsg_port_queue_add_buffer(&rpspi->port.rxq, rpspi->rxhdr);
+      rpspi->rxhdr = rpmsg_port_queue_get_available_buffer(
+        &rpspi->port.rxq, false);
+      DEBUGASSERT(rpspi->rxhdr != NULL);
+    }
+
+  /* Do nothing when two sides are not connected. */
+
+  if (rpspi->txavail == RPMSG_SPI_PORT_UNCONNECTED)
+    {
+      return;
+    }
+
+  rpspi->txavail = avail;
+
+out:
+  if (atomic_exchange(&rpspi->transferring, 0) > 1 ||
+      (rpspi->txavail > 0 && rpmsg_port_queue_nused(&rpspi->port.txq) > 0))
+    {
+      rpmsg_port_spi_exchange(rpspi);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_process_packet
+ ****************************************************************************/
+
+static void
+rpmsg_port_spi_process_packet(FAR struct rpmsg_port_spi_s *rpspi,
+                              FAR struct rpmsg_port_header_s *rxhdr)
+{
+  rpmsginfo("received cmd: %u avail: %u", rxhdr->cmd, rxhdr->avail);
+
+  switch (rxhdr->cmd)
+    {
+      case RPMSG_PORT_SPI_CMD_CONNECT:
+        if (rpspi->txavail != RPMSG_SPI_PORT_UNCONNECTED)
+          {
+            rpmsg_port_unregister(&rpspi->port);
+            rpspi->txavail = RPMSG_SPI_PORT_UNCONNECTED;
+          }
+        else
+          {
+            rpspi->txavail = rxhdr->avail;
+            rpmsg_port_register(&rpspi->port, (FAR const char *)(rxhdr + 1));
+          }
+
+        rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);
+        break;
+
+      case RPMSG_PORT_SPI_CMD_DATA:
+        rpspi->rxcb(&rpspi->port, rxhdr);
+        break;
+
+      default:
+        rpmsgerr("received a unexpected frame, dropped\n");
+        rpmsg_port_queue_return_buffer(&rpspi->port.rxq, rxhdr);
+        break;
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_mreq_handler
+ ****************************************************************************/
+
+static int rpmsg_port_spi_mreq_handler(FAR struct ioexpander_dev_s *dev,
+                                       ioe_pinset_t pinset, FAR void *arg)
+{
+  FAR struct rpmsg_port_spi_s *rpspi = arg;
+
+  rpmsginfo("received a mreq\n");
+  rpmsg_port_spi_exchange(rpspi);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_connect
+ ****************************************************************************/
+
+static void rpmsg_port_spi_connect(FAR struct rpmsg_port_spi_s *rpspi)
+{
+  bool val;
+
+  IOEXP_READPIN(rpspi->ioe, rpspi->mreq, &val);
+  if (val)
+    {
+      rpmsg_port_spi_mreq_handler(NULL, 0, rpspi);
+    }
+  else
+    {
+      IOEXP_WRITEPIN(rpspi->ioe, rpspi->sreq, 1);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_thread
+ ****************************************************************************/
+
+static int rpmsg_port_spi_thread(int argc, FAR char *argv[])
+{
+  FAR struct rpmsg_port_spi_s *rpspi =
+    (FAR struct rpmsg_port_spi_s *)((uintptr_t)strtoul(argv[2], NULL, 16));
+  FAR struct rpmsg_port_queue_s *queue = &rpspi->port.rxq;
+  FAR struct rpmsg_port_header_s *rxhdr;
+
+  rpmsg_port_spi_connect(rpspi);
+  for (; ; )
+    {
+      while ((rxhdr = rpmsg_port_queue_get_buffer(queue, true)) != NULL)
+        {
+          rpmsg_port_spi_process_packet(rpspi, rxhdr);
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_gpio_init
+ ****************************************************************************/
+
+static int
+rpmsg_port_spi_init_gpio(FAR struct ioexpander_dev_s *ioe,
+                         FAR uint8_t *gpio, uint8_t pin, int invert,
+                         ioe_callback_t callback, FAR void *args)
+{
+  int direction = callback ?
+    IOEXPANDER_DIRECTION_IN_PULLDOWN : IOEXPANDER_DIRECTION_OUT;
+  int ret;
+
+  ret = IOEXP_SETOPTION(ioe, pin, IOEXPANDER_OPTION_INVERT,
+                        (FAR void *)invert);
+  if (ret < 0)
+    {
+      rpmsgerr("gpio set invert option error: %d\n", ret);
+      return ret;
+    }
+
+  ret = IOEXP_SETDIRECTION(ioe, pin, direction);
+  if (ret < 0)
+    {
+      rpmsgerr("gpio set direction %d error: %d\n", direction, ret);
+      return ret;
+    }
+
+  if (direction == IOEXPANDER_DIRECTION_IN_PULLDOWN)
+    {
+      int intcfg = invert == IOEXPANDER_VAL_INVERT ?
+        IOEXPANDER_VAL_FALLING : IOEXPANDER_VAL_RISING;
+      FAR void *ptr;
+
+      ret = IOEXP_SETOPTION(ioe, pin, IOEXPANDER_OPTION_INTCFG,
+                            (FAR void *)intcfg);
+      if (ret < 0)
+        {
+          rpmsgerr("gpio set int option %d error: %d\n", intcfg, ret);
+          return ret;
+        }
+
+      ptr = IOEP_ATTACH(ioe, pin, callback, args);
+      if (ptr == NULL)
+        {
+          rpmsgerr("gpio attach error: %d\n", ret);
+          return -EINVAL;
+        }
+    }
+
+  *gpio = pin;
+  return ret;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_init_hardware
+ ****************************************************************************/
+
+static int
+rpmsg_port_spi_init_hardware(FAR struct rpmsg_port_spi_s *rpspi,
+  FAR const struct rpmsg_port_spi_config_s *spicfg,
+  FAR struct spi_slave_ctrlr_s *spictrlr, FAR struct ioexpander_dev_s *ioe)
+{
+  int ret;
+
+  if (spictrlr == NULL || ioe == NULL || spicfg == NULL)
+    {
+      rpmsgerr("invalid params\n");
+      return -EINVAL;
+    }
+
+  /* Init mreq gpio */
+
+  ret = rpmsg_port_spi_init_gpio(ioe, &rpspi->mreq, spicfg->mreq_pin,
+                                 spicfg->mreq_invert,
+                                 rpmsg_port_spi_mreq_handler, rpspi);
+  if (ret < 0)
+    {
+      rpmsgerr("mreq init failed\n");
+      return ret;
+    }
+
+  /* Init sreq gpio */
+
+  ret = rpmsg_port_spi_init_gpio(ioe, &rpspi->sreq, spicfg->sreq_pin,
+                                 spicfg->sreq_invert, NULL, NULL);
+  if (ret < 0)
+    {
+      rpmsgerr("sreq init failed\n");
+      return ret;
+    }
+
+  rpspi->ioe = ioe;
+  rpspi->spictrlr = spictrlr;
+  rpspi->spislv.ops = &g_rpmsg_port_spi_slave_ops;
+  SPIS_CTRLR_BIND(spictrlr, &rpspi->spislv, spicfg->mode, 8);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_initialize
+ ****************************************************************************/
+
+int
+rpmsg_port_spi_slave_initialize(FAR const struct rpmsg_port_config_s *cfg,
+  FAR const struct rpmsg_port_spi_config_s *spicfg,
+  FAR struct spi_slave_ctrlr_s *spictrlr, FAR struct ioexpander_dev_s *ioe)
+{
+  FAR struct rpmsg_port_spi_s *rpspi;
+  FAR char *argv[3];
+  char arg1[32];
+  int ret;
+
+  rpspi = kmm_zalloc(sizeof(*rpspi));
+  if (rpspi == NULL)
+    {
+      rpmsgerr("malloc rpmsg spi failed\n");
+      return -ENOMEM;
+    }
+
+  ret = rpmsg_port_spi_init_hardware(rpspi, spicfg, spictrlr, ioe);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port spi hardware init failed\n");
+      goto rpmsg_err;
+    }
+
+  DEBUGASSERT(cfg->txlen == cfg->rxlen);
+  ret = rpmsg_port_initialize(&rpspi->port, cfg, &g_rpmsg_port_spi_ops);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port initialize failed\n");
+      goto rpmsg_err;
+    }
+
+  /* Always reserve one buffer for sending/receiving cmd packet */
+
+  rpspi->cmdhdr = rpmsg_port_queue_get_available_buffer(
+    &rpspi->port.txq, true);
+  rpspi->rxhdr = rpmsg_port_queue_get_available_buffer(
+    &rpspi->port.rxq, true);
+  DEBUGASSERT(rpspi->cmdhdr != NULL && rpspi->rxhdr != NULL);
+
+  rpspi->txavail = RPMSG_SPI_PORT_UNCONNECTED;
+  rpspi->rxthres = rpmsg_port_queue_navail(&rpspi->port.rxq) *
+                   CONFIG_RPMSG_PORT_SPI_RX_THRESHOLD / 100;
+
+  snprintf(arg1, sizeof(arg1), "%p", rpspi);
+  argv[0] = (FAR char *)cfg->remotecpu;
+  argv[1] = arg1;
+  argv[2] = NULL;
+  ret = kthread_create("rpmsg-spi-slv",
+                       CONFIG_RPMSG_PORT_SPI_THREAD_PRIORITY,
+                       CONFIG_RPMSG_PORT_SPI_THREAD_STACKSIZE,
+                       rpmsg_port_spi_thread, argv);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg port spi create thread failed\n");
+      goto thread_err;
+    }
+
+  return 0;
+
+thread_err:
+  rpmsg_port_uninitialize(&rpspi->port);
+rpmsg_err:
+  kmm_free(rpspi);
+  return ret;
+}

--- a/drivers/rpmsg/rpmsg_port_uart.c
+++ b/drivers/rpmsg/rpmsg_port_uart.c
@@ -1,0 +1,520 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_port_uart.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <nuttx/crc16.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/kthread.h>
+#include <nuttx/mutex.h>
+#include <nuttx/fs/fs.h>
+
+#include "rpmsg_port.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_PORT_UART_START              0x7f
+#define RPMSG_PORT_UART_END                0x7e
+#define RPMSG_PORT_UART_CONNREQ            0x7d
+#define RPMSG_PORT_UART_CONNACK            0x7c
+#define RPMSG_PORT_UART_ESCAPE             0x7b
+#define RPMSG_PORT_UART_ESCAPE_MASK        0x20
+
+#define RPMSG_PORT_UART_BUFLEN             256
+
+#define RPMSG_PORT_UART_RX_WAIT_START      1
+#define RPMSG_PORT_UART_RX_RECV_NORMAL     2
+#define RPMSG_PORT_UART_RX_RECV_ESCAPE     3
+
+#ifdef CONFIG_RPMSG_PORT_UART_CRC
+#  define rpmsg_port_uart_crc16(hdr)       \
+  crc16((FAR uint8_t *)&(hdr)->cmd, (hdr)->len - sizeof((hdr)->crc))
+#else
+#  define rpmsg_port_uart_crc16(hdr)       0
+#endif
+
+#ifdef CONFIG_RPMSG_PORT_UART_DEBUG
+#  define rpmsgdump                        lib_dumpbuffer
+#  define rpmsgdbg                         rpmsginfo
+#else
+#  define rpmsgdump(m,b,s)
+#  define rpmsgdbg(fmt,...)
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rpmsg_port_uart_s
+{
+  struct rpmsg_port_s    port;     /* Rpmsg port device */
+  struct file            file;     /* Indicate uart device */
+  char                   localcpu[RPMSG_NAME_SIZE];
+  rpmsg_port_rx_cb_t     rx_cb;
+  bool                   connected;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void rpmsg_port_uart_send_data(FAR struct rpmsg_port_uart_s *rpuart,
+                                      FAR struct rpmsg_port_header_s *hdr);
+
+static void rpmsg_port_uart_register_callback(FAR struct rpmsg_port_s *port,
+                                              rpmsg_port_rx_cb_t callback);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_port_ops_s g_rpmsg_port_uart_ops =
+{
+  .notify_tx_ready   = NULL,
+  .notify_rx_free    = NULL,
+  .register_callback = rpmsg_port_uart_register_callback,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_send_packet
+ *
+ * Description:
+ *   Send a data packet.
+ *
+ ****************************************************************************/
+
+static void rpmsg_port_uart_send_packet(FAR struct rpmsg_port_uart_s *rpuart,
+                                        FAR const void *data, size_t datalen)
+{
+  rpmsgdump("TX Packed Data", data, datalen);
+
+  while (datalen > 0)
+    {
+      ssize_t ret = file_write(&rpuart->file, data, datalen);
+      DEBUGASSERT(ret >= 0);
+
+      data = (FAR uint8_t *)data + ret;
+      datalen -= ret;
+    }
+
+  rpmsgdbg("Sent %zu Data\n", datalen);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_send_frame
+ *
+ * Description:
+ *   Send a frame.
+ *
+ ****************************************************************************/
+
+static void rpmsg_port_uart_send_frame(FAR struct rpmsg_port_uart_s *rpuart,
+                                       FAR const void *data, size_t datalen)
+{
+  uint8_t buf[RPMSG_PORT_UART_BUFLEN];
+  uint8_t ch;
+  size_t next = 0;
+
+  rpmsgdump("Send Data", data, datalen);
+
+  /* Pack start frame char first */
+
+  buf[next++] = RPMSG_PORT_UART_START;
+
+  /* Pack the data */
+
+  for (; datalen-- > 0; data = (FAR uint8_t *)data + 1)
+    {
+      ch = *(FAR uint8_t *)data;
+      if (ch >= RPMSG_PORT_UART_ESCAPE && ch <= RPMSG_PORT_UART_START)
+        {
+          buf[next++] = RPMSG_PORT_UART_ESCAPE;
+          buf[next++] = ch ^ RPMSG_PORT_UART_ESCAPE_MASK;
+        }
+      else
+        {
+          buf[next++] = ch;
+        }
+
+      if (next > RPMSG_PORT_UART_BUFLEN - 2)
+        {
+          rpmsg_port_uart_send_packet(rpuart, buf, next);
+          next = 0;
+        }
+    }
+
+  /* Pack end frame char */
+
+  buf[next++] = RPMSG_PORT_UART_END;
+
+  /* Send this frame */
+
+  rpmsg_port_uart_send_packet(rpuart, buf, next);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_send_data
+ *
+ * Description:
+ *   Send a data frame.
+ *
+ ****************************************************************************/
+
+static void rpmsg_port_uart_send_data(FAR struct rpmsg_port_uart_s *rpuart,
+                                      FAR struct rpmsg_port_header_s *hdr)
+{
+  rpmsgdbg("Send data len: %" PRIu16 "\n", hdr->len);
+
+  hdr->cmd = 0;
+  hdr->avail = 0;
+  hdr->crc = rpmsg_port_uart_crc16(hdr);
+
+  rpmsg_port_uart_send_frame(rpuart, hdr, hdr->len);
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_send_connect_req
+ ****************************************************************************/
+
+static void
+rpmsg_port_uart_send_connect_req(FAR struct rpmsg_port_uart_s *rpuart)
+{
+  uint8_t ch = RPMSG_PORT_UART_CONNREQ;
+  ssize_t ret = file_write(&rpuart->file, &ch, 1);
+  if (ret != 1)
+    {
+      rpmsgerr("Send connect request failed, ret=%d\n", ret);
+      PANIC();
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_send_connect_ack
+ ****************************************************************************/
+
+static void
+rpmsg_port_uart_send_connect_ack(FAR struct rpmsg_port_uart_s *rpuart)
+{
+  uint8_t ch = RPMSG_PORT_UART_CONNACK;
+  ssize_t ret = file_write(&rpuart->file, &ch, 1);
+  if (ret != 1)
+    {
+      rpmsgerr("Send connect ack failed, ret=%d\n", ret);
+      PANIC();
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_register_callback
+ ****************************************************************************/
+
+static void rpmsg_port_uart_register_callback(FAR struct rpmsg_port_s *port,
+                                              rpmsg_port_rx_cb_t callback)
+{
+  FAR struct rpmsg_port_uart_s *rpuart =
+    (FAR struct rpmsg_port_uart_s *)port;
+
+  rpuart->rx_cb = callback;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_process_rx_conn
+ ****************************************************************************/
+
+static void
+rpmsg_port_uart_process_rx_conn(FAR struct rpmsg_port_uart_s *rpuart,
+                                uint8_t ch)
+{
+  if (ch == RPMSG_PORT_UART_CONNREQ)
+    {
+      rpmsgdbg("Connect Request Command %d\n", rpuart->connected);
+      if (rpuart->connected)
+        {
+          rpmsg_port_unregister(&rpuart->port);
+        }
+      else
+        {
+          rpuart->connected = true;
+        }
+
+      rpmsg_port_uart_send_connect_ack(rpuart);
+      rpmsg_port_register(&rpuart->port, rpuart->localcpu);
+    }
+  else if (ch == RPMSG_PORT_UART_CONNACK)
+    {
+      rpmsgdbg("Connect Ack Command %d\n", rpuart->connected);
+      if (!rpuart->connected)
+        {
+          rpuart->connected = true;
+          rpmsg_port_register(&rpuart->port, rpuart->localcpu);
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_rx_thread
+ ****************************************************************************/
+
+static int rpmsg_port_uart_rx_thread(int argc, FAR char *argv[])
+{
+  FAR struct rpmsg_port_uart_s *rpuart =
+    (FAR struct rpmsg_port_uart_s *)(uintptr_t)strtoul(argv[2], NULL, 16);
+  FAR struct rpmsg_port_queue_s *rxq = &rpuart->port.rxq;
+  FAR struct rpmsg_port_header_s *hdr = NULL;
+  uint8_t state = RPMSG_PORT_UART_RX_WAIT_START;
+  uint8_t buf[RPMSG_PORT_UART_BUFLEN];
+  uint16_t next;
+
+  for (; ; )
+    {
+      ssize_t ret;
+      ssize_t i;
+
+      ret = file_read(&rpuart->file, buf, sizeof(buf));
+      if (ret < 0)
+        {
+          rpmsgerr("file_read failed, ret=%zd\n", ret);
+          PANIC();
+        }
+
+      rpmsgdump("Received data:", buf, ret);
+
+      for (i = 0; i < ret; i++)
+        {
+          if (buf[i] == RPMSG_PORT_UART_CONNREQ ||
+              buf[i] == RPMSG_PORT_UART_CONNACK)
+            {
+              if (hdr != NULL)
+                {
+                  rpmsg_port_queue_return_buffer(rxq, hdr);
+                  hdr = NULL;
+                }
+
+              rpmsg_port_uart_process_rx_conn(rpuart, buf[i]);
+              state = RPMSG_PORT_UART_RX_WAIT_START;
+              continue;
+            }
+
+          if (rpuart->connected == false)
+            {
+              continue;
+            }
+
+          switch (state)
+            {
+              case RPMSG_PORT_UART_RX_WAIT_START:
+                if (buf[i] == RPMSG_PORT_UART_START)
+                  {
+                    if (hdr == NULL)
+                      {
+                        hdr = rpmsg_port_queue_get_available_buffer(rxq,
+                                                                    true);
+                        next = 0;
+                      }
+
+                    state = RPMSG_PORT_UART_RX_RECV_NORMAL;
+                  }
+                break;
+
+              case RPMSG_PORT_UART_RX_RECV_NORMAL:
+                if (buf[i] == RPMSG_PORT_UART_START)
+                  {
+                    rpmsgerr("Recv dup start char, i=%zd\n", i);
+                    state = RPMSG_PORT_UART_RX_WAIT_START;
+                  }
+                else if (buf[i] == RPMSG_PORT_UART_END)
+                  {
+                    DEBUGASSERT(hdr->len == next);
+                    DEBUGASSERT(hdr->crc == 0 ||
+                                hdr->crc == rpmsg_port_uart_crc16(hdr));
+
+                    if (rpuart->rx_cb != NULL)
+                      {
+                        rpuart->rx_cb(&rpuart->port, hdr);
+                      }
+
+                    state = RPMSG_PORT_UART_RX_WAIT_START;
+                    hdr = NULL;
+                  }
+                else if (buf[i] == RPMSG_PORT_UART_ESCAPE)
+                  {
+                    state = RPMSG_PORT_UART_RX_RECV_ESCAPE;
+                  }
+                else
+                  {
+                    *((FAR char *)hdr + next++) = buf[i];
+                  }
+                break;
+
+              case RPMSG_PORT_UART_RX_RECV_ESCAPE:
+                *((FAR char *)hdr + next++) =
+                  buf[i] ^ RPMSG_PORT_UART_ESCAPE_MASK;
+                state = RPMSG_PORT_UART_RX_RECV_NORMAL;
+                break;
+
+              default:
+                PANIC();
+            }
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_tx_thread
+ ****************************************************************************/
+
+static int rpmsg_port_uart_tx_thread(int argc, FAR char *argv[])
+{
+  FAR struct rpmsg_port_uart_s *rpuart =
+    (FAR struct rpmsg_port_uart_s *)(uintptr_t)strtoul(argv[2], NULL, 16);
+  FAR struct rpmsg_port_queue_s *txq = &rpuart->port.txq;
+  FAR struct rpmsg_port_header_s *hdr;
+
+  rpmsg_port_uart_send_connect_req(rpuart);
+
+  for (; ; )
+    {
+      while (!rpuart->connected)
+        {
+          nxsig_usleep(100000);
+        }
+
+      while ((hdr = rpmsg_port_queue_get_buffer(txq, true)) != NULL)
+        {
+          rpmsg_port_uart_send_data(rpuart, hdr);
+          rpmsg_port_queue_return_buffer(txq, hdr);
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_initialize
+ *
+ * Description:
+ *   Initialze a rpmsg_port_uart device to communicate between two chips.
+ *
+ * Input Parameters:
+ *   cfg      - Configuration of buffers needed for communication.
+ *   uartpath - Uart device path.
+ *   localcpu - Local cpu name
+ *
+ ****************************************************************************/
+
+int rpmsg_port_uart_initialize(FAR const struct rpmsg_port_config_s *cfg,
+                               FAR const char *uartpath,
+                               FAR const char *localcpu)
+{
+  FAR struct rpmsg_port_uart_s *rpuart;
+  FAR char *argv[3];
+  char arg1[32];
+  int ret;
+  int rx;
+
+  rpuart = kmm_zalloc(sizeof(*rpuart));
+  if (rpuart == NULL)
+    {
+      rpmsgerr("Malloc rptun uart failed\n");
+      return -ENOMEM;
+    }
+
+  /* Hardware initialize */
+
+  ret = file_open(&rpuart->file, uartpath, O_RDWR);
+  if (ret < 0)
+    {
+      rpmsgerr("Open uart device failed, ret=%d\n", ret);
+      goto err_file;
+    }
+
+  if (localcpu != NULL)
+    {
+      strlcpy(rpuart->localcpu, localcpu, sizeof(rpuart->localcpu));
+    }
+
+  ret = rpmsg_port_initialize(&rpuart->port, cfg, &g_rpmsg_port_uart_ops);
+  if (ret < 0)
+    {
+      rpmsgerr("Port initialize failed, ret=%d\n", ret);
+      goto err_rpmsg_port;
+    }
+
+  snprintf(arg1, sizeof(arg1), "%p", rpuart);
+
+  argv[0] = (FAR char *)cfg->remotecpu;
+  argv[1] = arg1;
+  argv[2] = NULL;
+  ret = kthread_create("rpmsg-uart-rx",
+                       CONFIG_RPMSG_PORT_UART_RX_THREAD_PRIORITY,
+                       CONFIG_RPMSG_PORT_UART_RX_THREAD_STACKSIZE,
+                       rpmsg_port_uart_rx_thread, argv);
+  if (ret < 0)
+    {
+      rpmsgerr("Rx thread create failed, ret=%d\n", ret);
+      goto err_rx_thread;
+    }
+
+  rx = ret;
+  argv[0] = (FAR char *)cfg->remotecpu;
+  argv[1] = arg1;
+  argv[2] = NULL;
+  ret = kthread_create("rpmsg-uart-tx",
+                       CONFIG_RPMSG_PORT_UART_TX_THREAD_PRIORITY,
+                       CONFIG_RPMSG_PORT_UART_TX_THREAD_STACKSIZE,
+                       rpmsg_port_uart_tx_thread, argv);
+  if (ret < 0)
+    {
+      rpmsgerr("Tx thread create failed, ret=%d\n", ret);
+      goto err_tx_thread;
+    }
+
+  return ret;
+
+err_tx_thread:
+  kthread_delete(rx);
+err_rx_thread:
+  rpmsg_port_uninitialize(&rpuart->port);
+err_rpmsg_port:
+  file_close(&rpuart->file);
+err_file:
+  kmm_free(rpuart);
+  return ret;
+}

--- a/drivers/rpmsg/rpmsg_router.h
+++ b/drivers/rpmsg/rpmsg_router.h
@@ -39,12 +39,16 @@
 #define RPMSG_ROUTER_NAME_PREFIX_LEN 2
 #define RPMSG_ROUTER_CPUNAME_LEN     8
 
+#define RPMSG_ROUTER_CREATE          1
+#define RPMSG_ROUTER_DESTROY         2
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
 
 begin_packed_struct struct rpmsg_router_s
 {
+  uint32_t cmd;
   uint32_t tx_len;
   uint32_t rx_len;
   char     cpuname[RPMSG_ROUTER_CPUNAME_LEN];

--- a/drivers/rpmsg/rpmsg_router.h
+++ b/drivers/rpmsg/rpmsg_router.h
@@ -47,6 +47,7 @@ begin_packed_struct struct rpmsg_router_s
 {
   uint32_t tx_len;
   uint32_t rx_len;
+  char     cpuname[RPMSG_ROUTER_CPUNAME_LEN];
 } end_packed_struct;
 
 #endif /* CONFIG_RPMSG_ROUTER */

--- a/drivers/rpmsg/rpmsg_router.h
+++ b/drivers/rpmsg/rpmsg_router.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_router.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __DRIVERS_RPMSG_RPMSG_ROUTER_H
+#define __DRIVERS_RPMSG_RPMSG_ROUTER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/rpmsg/rpmsg.h>
+
+#ifdef CONFIG_RPMSG_ROUTER
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_ROUTER_NAME            "router:"
+#define RPMSG_ROUTER_NAME_LEN        7
+#define RPMSG_ROUTER_NAME_PREFIX     "r:"
+#define RPMSG_ROUTER_NAME_PREFIX_LEN 2
+#define RPMSG_ROUTER_CPUNAME_LEN     8
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+begin_packed_struct struct rpmsg_router_s
+{
+  uint32_t tx_len;
+  uint32_t rx_len;
+} end_packed_struct;
+
+#endif /* CONFIG_RPMSG_ROUTER */
+#endif /* __DRIVERS_RPMSG_RPMSG_ROUTER_H */

--- a/drivers/rpmsg/rpmsg_router_edge.c
+++ b/drivers/rpmsg/rpmsg_router_edge.c
@@ -1,0 +1,722 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_router_edge.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <nuttx/kmalloc.h>
+#include <rpmsg/rpmsg_internal.h>
+
+#include "rpmsg_router.h"
+
+/****************************************************************************
+ * Rpmsg-router Model:
+ *
+ *  +------+       +------+       +------+
+ *  | edge |<----->| hub  |<----->| edge |
+ *  +------+       +------+       +------+
+ *
+ * Description:
+ *    edge CPUs (edge) are physically linked to the central router cpu (hub),
+ *    edge CPUs' communication reply on hub cpu message forwarding.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define rpmsg_router_edge_from_rdev(d) \
+  metal_container_of(d, struct rpmsg_router_edge_s, rdev)
+
+#define RPMSG_ROUTER_USER_NAME_SIZE \
+  (RPMSG_NAME_SIZE - RPMSG_ROUTER_NAME_PREFIX_LEN - RPMSG_ROUTER_CPUNAME_LEN)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rpmsg_router_edge_s
+{
+  struct rpmsg_s      rpmsg;
+  struct rpmsg_device rdev;
+  struct rpmsg_device *hubdev;
+  char                remotecpu[RPMSG_ROUTER_CPUNAME_LEN];
+
+  /* Tx/Rx buffer size */
+
+  uint32_t            tx_len;
+  uint32_t            rx_len;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static FAR const char *
+rpmsg_router_edge_get_cpuname(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_router_edge_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
+static int rpmsg_router_edge_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct rpmsg_ops_s g_rpmsg_router_edge_ops =
+{
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  rpmsg_router_edge_get_cpuname,
+  rpmsg_router_edge_get_tx_buffer_size,
+  rpmsg_router_edge_get_rx_buffer_size,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_get_cpuname
+ ****************************************************************************/
+
+static FAR const char *
+rpmsg_router_edge_get_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_router_edge_s *edge =
+      (FAR struct rpmsg_router_edge_s *)rpmsg;
+
+  return edge->remotecpu;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_get_tx_buffer_size
+ ****************************************************************************/
+
+static int rpmsg_router_edge_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_router_edge_s *edge =
+      (FAR struct rpmsg_router_edge_s *)rpmsg;
+
+  return edge->tx_len;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_get_rx_buffer_size
+ ****************************************************************************/
+
+static int rpmsg_router_edge_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_router_edge_s *edge =
+      (FAR struct rpmsg_router_edge_s *)rpmsg;
+
+  return edge->rx_len;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_get_tx_payload_buffer
+ ****************************************************************************/
+
+static FAR void *
+rpmsg_router_edge_get_tx_payload_buffer(FAR struct rpmsg_device *rdev,
+                                        FAR uint32_t *len, int wait)
+{
+  FAR struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  FAR struct rpmsg_device *hubdev = edge->hubdev;
+  FAR void *buf;
+
+  if (!hubdev->ops.get_tx_payload_buffer)
+    {
+      return NULL;
+    }
+
+  buf = hubdev->ops.get_tx_payload_buffer(hubdev, len, wait);
+  *len = edge->tx_len - (rpmsg_get_tx_buffer_size(rdev) - *len);
+  return buf;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_hold_rx_buffer
+ ****************************************************************************/
+
+static void rpmsg_router_edge_hold_rx_buffer(FAR struct rpmsg_device *rdev,
+                                             FAR void *rxbuf)
+{
+  FAR struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  FAR struct rpmsg_device *hubdev = edge->hubdev;
+
+  if (!hubdev->ops.hold_rx_buffer)
+    {
+      return;
+    }
+
+  hubdev->ops.hold_rx_buffer(hubdev, rxbuf);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_release_rx_buffer
+ ****************************************************************************/
+
+static void
+rpmsg_router_edge_release_rx_buffer(FAR struct rpmsg_device *rdev,
+                                    FAR void *rxbuf)
+{
+  struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  struct rpmsg_device *hubdev = edge->hubdev;
+
+  if (!hubdev->ops.release_rx_buffer)
+    {
+      return;
+    }
+
+  hubdev->ops.release_rx_buffer(hubdev, rxbuf);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_release_tx_buffer
+ ****************************************************************************/
+
+static int rpmsg_router_edge_release_tx_buffer(FAR struct rpmsg_device *rdev,
+                                               FAR void *txbuf)
+{
+  struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  struct rpmsg_device *hubdev = edge->hubdev;
+
+  if (!hubdev->ops.release_tx_buffer)
+    {
+      return RPMSG_ERR_PERM;
+    }
+
+  return hubdev->ops.release_tx_buffer(hubdev, txbuf);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_send_nocopy
+ ****************************************************************************/
+
+static int rpmsg_router_edge_send_nocopy(FAR struct rpmsg_device *rdev,
+                                         uint32_t src, uint32_t dst,
+                                         FAR const void *data, int len)
+{
+  struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  struct rpmsg_device *hubdev = edge->hubdev;
+
+  if (!hubdev->ops.send_offchannel_nocopy)
+    {
+      return RPMSG_ERR_PARAM;
+    }
+
+  return hubdev->ops.send_offchannel_nocopy(hubdev, src, dst, data, len);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_cb
+ *
+ * Description:
+ *   This is the callback function for edge core.
+ *   It will receive data from real rpmsg channel by ept(r:cpu:name),
+ *   and find the corresponding user ept, then processing data through
+ *   the user ept callback.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with router core (r:cpu:name)
+ *   data - received data
+ *   len - received data length
+ *   src - source address
+ *   priv - save user rpmsg_endpoint generally
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+static int rpmsg_router_edge_cb(FAR struct rpmsg_endpoint *ept,
+                                FAR void *data, size_t len,
+                                uint32_t src, FAR void *priv)
+{
+  FAR struct rpmsg_endpoint *usr_ept = priv;
+
+  if (!usr_ept)
+    {
+      return 0;
+    }
+
+  /* Processing data through the user ept callback */
+
+  return usr_ept->cb(usr_ept, data, len, src, usr_ept->priv);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_bound
+ *
+ * Description:
+ *   This is the callback function for edge core.
+ *   It will be called when the edge core is bound to the router core
+ *   by r:cpu:name, save the destination address of the edge core, and
+ *   call the bound function of the user endpoint.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with router core (r:cpu:name)
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_edge_bound(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_endpoint *usr_ept = ept->priv;
+
+  if (!usr_ept)
+    {
+      rpmsgerr("Try to get user ept failed.\n");
+      return;
+    }
+
+  usr_ept->dest_addr = ept->dest_addr;
+  if (usr_ept->ns_bound_cb)
+    {
+      usr_ept->ns_bound_cb(usr_ept);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_unbind
+ *
+ * Description:
+ *   This is the unbind callback function for edge core.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with router core (r:cpu:name)
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_edge_unbind(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_endpoint *usr_ept = ept->priv;
+
+  if (!usr_ept)
+    {
+      rpmsgerr("Try to get user ept failed.\n");
+      return;
+    }
+
+  if (usr_ept->ns_unbind_cb)
+    {
+      usr_ept->ns_unbind_cb(usr_ept);
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_release
+ ****************************************************************************/
+
+static void rpmsg_router_edge_release(FAR struct rpmsg_endpoint *ept)
+{
+  kmm_free(ept);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_send_offchannel_raw
+ *
+ * Description:
+ *   This function sends normal rpmsg message or ns message to remote device.
+ *   If the destination address is RPMSG_NS_EPT_ADDR, it will create a new
+ *   endpoint(r:cpu:name) for real communication, and save the user endpoint
+ *   information in the private field of the new endpoint.
+ *
+ * Parameters:
+ *   rdev - rpmsg_device for router core
+ *   src - source address
+ *   dst - destination address
+ *   data - data to send
+ *   len - data length
+ *   wait - boolean, wait or not for buffer to become available
+ *
+ * Returned Values:
+ *   size of data sent or negative value for failure.
+ *
+ ****************************************************************************/
+
+static int
+rpmsg_router_edge_send_offchannel_raw(FAR struct rpmsg_device *rdev,
+                                      uint32_t src, uint32_t dst,
+                                      FAR const void *data,
+                                      int len, int wait)
+{
+  FAR struct rpmsg_router_edge_s *edge = rpmsg_router_edge_from_rdev(rdev);
+  FAR struct rpmsg_ns_msg *ns_msg = (FAR struct rpmsg_ns_msg *)data;
+  FAR struct rpmsg_device *hubdev = edge->hubdev;
+  FAR struct rpmsg_endpoint *usr_ept;
+  FAR struct rpmsg_endpoint *ept;
+  char name[RPMSG_ROUTER_USER_NAME_SIZE];
+  int ret;
+
+  /* Send normal rpmsg "message" to remote device */
+
+  if (dst != RPMSG_NS_EPT_ADDR)
+    {
+      if (!hubdev->ops.send_offchannel_raw)
+        {
+          return RPMSG_ERR_PARAM;
+        }
+
+      return hubdev->ops.send_offchannel_raw(hubdev, src,
+                                             dst, data, len, wait);
+    }
+
+  /* Try to get user ept firstly */
+
+  metal_mutex_acquire(&rdev->lock);
+  usr_ept = rpmsg_get_endpoint(rdev, ns_msg->name, src, dst);
+  metal_mutex_release(&rdev->lock);
+  if (!usr_ept)
+    {
+      rpmsgerr("Try to get user ept failed.\n");
+      return RPMSG_ERR_PARAM;
+    }
+
+  /* Set hub endpoint name(r:cpu:name) for real communication */
+
+  strlcpy(name, ns_msg->name, sizeof(name));
+  snprintf(ns_msg->name, sizeof(ns_msg->name),
+           RPMSG_ROUTER_NAME_PREFIX"%s:%s", edge->remotecpu, name);
+
+  if (ns_msg->flags == RPMSG_NS_DESTROY)
+    {
+      /* Processing RPMSG_NS_DESTROY message */
+
+      metal_mutex_acquire(&hubdev->lock);
+      ept = rpmsg_get_endpoint(hubdev, ns_msg->name,
+                               RPMSG_ADDR_ANY, usr_ept->dest_addr);
+      metal_mutex_release(&hubdev->lock);
+      if (!ept)
+        {
+          rpmsgerr("Try to get router endpoint (r:ept) failed.\n");
+          return RPMSG_ERR_PARAM;
+        }
+
+      /* Destroy endpoint(r:cpu:name) of real communication */
+
+      rpmsg_destroy_ept(ept);
+      return 0;
+    }
+  else
+    {
+      /* Processing RPMSG_NS_CREATE or RPMSG_NS_CREATE_ACK message */
+
+      ept = kmm_zalloc(sizeof(*ept));
+      if (!ept)
+        {
+          return -ENOMEM;
+        }
+
+      /* Save user endpoint */
+
+      ept->priv = usr_ept;
+      ept->ns_bound_cb = rpmsg_router_edge_bound;
+      ept->release_cb = rpmsg_router_edge_release;
+
+      /* Create endpoint (r:cpu:name) for real communication */
+
+      ret = rpmsg_create_ept(ept, hubdev, ns_msg->name,
+                             RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+                             rpmsg_router_edge_cb,
+                             rpmsg_router_edge_unbind);
+      if (ret < 0)
+        {
+          rpmsgerr("Create router endpoint failed: %d\n", ret);
+          kmm_free(ept);
+        }
+
+      return ret;
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_match
+ *
+ * Description:
+ *   This function is used to match the edge core device.
+ *   rpmsg_router_edge_bind will be called if the device is matched.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg router device for edge core
+ *   name - endpoint name (r:cpu:name)
+ *   dest - destination address
+ *
+ * Returned Values:
+ *   true on success; false on failure.
+ *
+ ****************************************************************************/
+
+static bool rpmsg_router_edge_match(FAR struct rpmsg_device *rdev,
+                                    FAR void *priv, FAR const char *name,
+                                    uint32_t dest)
+{
+  FAR struct rpmsg_router_edge_s *edge = priv;
+
+  if (strncmp(name, RPMSG_ROUTER_NAME_PREFIX, RPMSG_ROUTER_NAME_PREFIX_LEN))
+    {
+      return false;
+    }
+
+  return !strncmp(name + RPMSG_ROUTER_NAME_PREFIX_LEN, edge->remotecpu,
+                  strlen(edge->remotecpu));
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_bind
+ *
+ * Description:
+ *   This function is used to bind the edge core device.
+ *   It will try to find rpmsg_user_ns_bind_cb by user ept name.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg router device for edge core
+ *   name - endpoint name (r:cpu:name)
+ *   dest - destination address
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_edge_bind(FAR struct rpmsg_device *rdev,
+                                   FAR void *priv, FAR const char *name,
+                                   uint32_t dest)
+{
+  FAR struct rpmsg_router_edge_s *edge = priv;
+  FAR struct rpmsg_device *edgedev = &edge->rdev;
+
+  edgedev->ns_bind_cb(edgedev,
+                      name + RPMSG_ROUTER_NAME_PREFIX_LEN +
+                      strlen(edge->remotecpu) + 1, dest);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_cb
+ *
+ * Description:
+ *   This function is used to receive sync message from router core,
+ *   and initialize the router rpmsg device.
+ *
+ * Parameters:
+ *   ept - endpoint for synchronizing ready messages
+ *   data - received data
+ *   len - received data length
+ *   src - source address
+ *   priv - private data
+ *
+ * Returned Values:
+ *   0 on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+static int rpmsg_router_cb(FAR struct rpmsg_endpoint *ept,
+                           FAR void *data, size_t len,
+                           uint32_t src, FAR void *priv)
+{
+  FAR struct rpmsg_router_s *msg = data;
+  FAR struct rpmsg_router_edge_s *edge;
+  FAR struct rpmsg_device *rdev;
+  char name[32];
+  int ret;
+
+  edge = kmm_zalloc(sizeof(*edge));
+  if (!edge)
+    {
+      return -ENOMEM;
+    }
+
+  /* Initialize router device */
+
+  strlcpy(edge->remotecpu, ept->name + RPMSG_ROUTER_NAME_LEN,
+          sizeof(edge->remotecpu));
+  edge->rx_len = msg->rx_len;
+  edge->tx_len = msg->tx_len;
+  edge->hubdev = ept->rdev;
+  ept->priv = edge;
+
+  /* Initialize router rpmsg device */
+
+  rdev = &edge->rdev;
+  metal_mutex_init(&rdev->lock);
+  rdev->ns_bind_cb = rpmsg_ns_bind;
+  rdev->ns_unbind_cb = rpmsg_ns_unbind;
+  rdev->ops.hold_rx_buffer = rpmsg_router_edge_hold_rx_buffer;
+  rdev->ops.release_rx_buffer = rpmsg_router_edge_release_rx_buffer;
+  rdev->ops.release_tx_buffer = rpmsg_router_edge_release_tx_buffer;
+  rdev->ops.send_offchannel_nocopy = rpmsg_router_edge_send_nocopy;
+  rdev->ops.send_offchannel_raw = rpmsg_router_edge_send_offchannel_raw;
+  rdev->ops.get_tx_payload_buffer = rpmsg_router_edge_get_tx_payload_buffer;
+
+  metal_list_init(&rdev->endpoints);
+  rdev->support_ack = true;
+  rdev->support_ns = true;
+
+  /* Register rpmsg for edge core */
+
+  snprintf(name, sizeof(name), "/dev/rpmsg/%s", edge->remotecpu);
+  ret = rpmsg_register(name, &edge->rpmsg, &g_rpmsg_router_edge_ops);
+  if (ret < 0)
+    {
+      rpmsgerr("rpmsg_register failed: %d\n", ret);
+      goto free;
+    }
+
+  /* Register callback for edge core */
+
+  ret = rpmsg_register_callback(edge, NULL, NULL,
+                                rpmsg_router_edge_match,
+                                rpmsg_router_edge_bind);
+
+  if (ret < 0)
+    {
+      rpmsgerr("Register rpmsg callback failed: %d\n", ret);
+      goto unregister;
+    }
+
+  /* Broadcast device_created to all registers */
+
+  rpmsg_device_created(&edge->rpmsg);
+  return 0;
+
+unregister:
+  rpmsg_unregister(name, &edge->rpmsg);
+free:
+  kmm_free(edge);
+  ept->priv = NULL;
+  return ret;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_unbind
+ *
+ * Description:
+ *   This function is used to destroy the sync endpoint
+ *   when another edge core is disconnected.
+ *
+ * Parameters:
+ *   ept - rpmsg endpoint for synchronizing message.
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_unbind(FAR struct rpmsg_endpoint *ept)
+{
+  struct rpmsg_router_edge_s *edge = ept->priv;
+
+  if (edge)
+    {
+      kmm_free(edge);
+      ept->priv = NULL;
+    }
+
+  rpmsg_destroy_ept(ept);
+  kmm_free(ept);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_match
+ *
+ * Description:
+ *   This function is used to match the endpoint for
+ *   synchronizing ready messages.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg_router_priv
+ *   name - endpoint name
+ *   dest - destination address
+ *
+ * Returned Values:
+ *   true on success; false on failure.
+ *
+ ****************************************************************************/
+
+static bool rpmsg_router_match(FAR struct rpmsg_device *rdev, FAR void *priv,
+                               FAR const char *name, uint32_t dest)
+{
+  return !strncmp(name, RPMSG_ROUTER_NAME, RPMSG_ROUTER_NAME_LEN);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_bind
+ *
+ * Description:
+ *   This function is used to bind the endpoint for
+ *   synchronizing ready messages.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - private data
+ *   name - endpoint name
+ *   dest - destination address
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_bind(FAR struct rpmsg_device *rdev, FAR void *priv,
+                              FAR const char *name, uint32_t dest)
+{
+  FAR struct rpmsg_endpoint *ept;
+  int ret;
+
+  ept = kmm_zalloc(sizeof(*ept));
+  DEBUGASSERT(ept);
+
+  ret = rpmsg_create_ept(ept, rdev, name, RPMSG_ADDR_ANY, dest,
+                         rpmsg_router_cb, rpmsg_router_unbind);
+  if (ret < 0)
+    {
+      rpmsgerr("Create router endpoint failed: %d\n", ret);
+      kmm_free(ept);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_init
+ *
+ * Description:
+ *   This function is used to initialize the edge core.
+ *
+ * Returned Values:
+ *   OK on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_router_edge_init(void)
+{
+  /* Register callback for listening sync message from router hub */
+
+  return rpmsg_register_callback(NULL, NULL, NULL,
+                                 rpmsg_router_match,
+                                 rpmsg_router_bind);
+}

--- a/drivers/rpmsg/rpmsg_router_edge.c
+++ b/drivers/rpmsg/rpmsg_router_edge.c
@@ -159,7 +159,7 @@ rpmsg_router_edge_get_tx_payload_buffer(FAR struct rpmsg_device *rdev,
     }
 
   buf = hubdev->ops.get_tx_payload_buffer(hubdev, len, wait);
-  *len = edge->tx_len - (rpmsg_get_tx_buffer_size(rdev) - *len);
+  *len = edge->tx_len;
   return buf;
 }
 

--- a/drivers/rpmsg/rpmsg_router_edge.c
+++ b/drivers/rpmsg/rpmsg_router_edge.c
@@ -67,6 +67,7 @@ struct rpmsg_router_edge_s
   struct rpmsg_s      rpmsg;
   struct rpmsg_device rdev;
   struct rpmsg_device *hubdev;
+  char                localcpu[RPMSG_ROUTER_CPUNAME_LEN];
   char                remotecpu[RPMSG_ROUTER_CPUNAME_LEN];
 
   /* Tx/Rx buffer size */
@@ -114,7 +115,10 @@ static const struct rpmsg_ops_s g_rpmsg_router_edge_ops =
 static FAR const char *
 rpmsg_router_edge_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
 {
-  return NULL;
+  FAR struct rpmsg_router_edge_s *edge =
+      (FAR struct rpmsg_router_edge_s *)rpmsg;
+
+  return edge->localcpu;
 }
 
 /****************************************************************************
@@ -570,6 +574,7 @@ static int rpmsg_router_cb(FAR struct rpmsg_endpoint *ept,
 
   strlcpy(edge->remotecpu, ept->name + RPMSG_ROUTER_NAME_LEN,
           sizeof(edge->remotecpu));
+  strlcpy(edge->localcpu, msg->cpuname, sizeof(edge->localcpu));
   edge->rx_len = msg->rx_len;
   edge->tx_len = msg->tx_len;
   edge->hubdev = ept->rdev;

--- a/drivers/rpmsg/rpmsg_router_edge.c
+++ b/drivers/rpmsg/rpmsg_router_edge.c
@@ -80,6 +80,8 @@ struct rpmsg_router_edge_s
  ****************************************************************************/
 
 static FAR const char *
+rpmsg_router_edge_get_local_cpuname(FAR struct rpmsg_s *rpmsg);
+static FAR const char *
 rpmsg_router_edge_get_cpuname(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_router_edge_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_router_edge_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
@@ -95,6 +97,7 @@ static const struct rpmsg_ops_s g_rpmsg_router_edge_ops =
   NULL,
   NULL,
   NULL,
+  rpmsg_router_edge_get_local_cpuname,
   rpmsg_router_edge_get_cpuname,
   rpmsg_router_edge_get_tx_buffer_size,
   rpmsg_router_edge_get_rx_buffer_size,
@@ -103,6 +106,16 @@ static const struct rpmsg_ops_s g_rpmsg_router_edge_ops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_get_local_cpuname
+ ****************************************************************************/
+
+static FAR const char *
+rpmsg_router_edge_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  return NULL;
+}
 
 /****************************************************************************
  * Name: rpmsg_router_edge_get_cpuname

--- a/drivers/rpmsg/rpmsg_router_hub.c
+++ b/drivers/rpmsg/rpmsg_router_hub.c
@@ -311,6 +311,7 @@ static void rpmsg_router_bound(FAR struct rpmsg_endpoint *ept)
   FAR struct rpmsg_router_hub_s *hub = ept->priv;
   struct rpmsg_router_s msg;
   int ret;
+  int i;
 
   if (!is_rpmsg_ept_ready(&hub->ept[0]) ||
       !is_rpmsg_ept_ready(&hub->ept[1]))
@@ -318,15 +319,15 @@ static void rpmsg_router_bound(FAR struct rpmsg_endpoint *ept)
       return;
     }
 
-  msg.tx_len = MIN(rpmsg_get_tx_buffer_size(hub->ept[0].rdev),
-                   rpmsg_get_tx_buffer_size(hub->ept[1].rdev));
-  msg.rx_len = MIN(rpmsg_get_rx_buffer_size(hub->ept[0].rdev),
-                   rpmsg_get_rx_buffer_size(hub->ept[1].rdev));
-
-  ret = rpmsg_send(&hub->ept[0], &msg, sizeof(msg));
-  DEBUGASSERT(ret >= 0);
-  ret = rpmsg_send(&hub->ept[1], &msg, sizeof(msg));
-  DEBUGASSERT(ret >= 0);
+  for (i = 0; i < 2; i++)
+    {
+      msg.tx_len = MIN(rpmsg_get_rx_buffer_size(hub->ept[i].rdev),
+                       rpmsg_get_tx_buffer_size(hub->ept[1 - i].rdev));
+      msg.rx_len = MIN(rpmsg_get_tx_buffer_size(hub->ept[i].rdev),
+                       rpmsg_get_rx_buffer_size(hub->ept[1 - i].rdev));
+      ret = rpmsg_send(&hub->ept[i], &msg, sizeof(msg));
+      DEBUGASSERT(ret >= 0);
+    }
 }
 
 /****************************************************************************

--- a/drivers/rpmsg/rpmsg_router_hub.c
+++ b/drivers/rpmsg/rpmsg_router_hub.c
@@ -321,6 +321,7 @@ static void rpmsg_router_bound(FAR struct rpmsg_endpoint *ept)
 
   for (i = 0; i < 2; i++)
     {
+      msg.cmd = RPMSG_ROUTER_CREATE;
       msg.tx_len = MIN(rpmsg_get_rx_buffer_size(hub->ept[i].rdev),
                        rpmsg_get_tx_buffer_size(hub->ept[1 - i].rdev));
       msg.rx_len = MIN(rpmsg_get_tx_buffer_size(hub->ept[i].rdev),
@@ -397,6 +398,7 @@ static void rpmsg_router_destroy(FAR struct rpmsg_device *rdev,
                                  FAR void *priv)
 {
   FAR struct rpmsg_router_hub_s *hub = priv;
+  struct rpmsg_router_s msg;
   int i;
 
   for (i = 0; i < 2; i++)
@@ -407,6 +409,11 @@ static void rpmsg_router_destroy(FAR struct rpmsg_device *rdev,
         }
 
       rpmsg_destroy_ept(&hub->ept[i]);
+
+      /* Notify the other edge core to destroy router device */
+
+      msg.cmd = RPMSG_ROUTER_DESTROY;
+      rpmsg_send(&hub->ept[1 - i], &msg, sizeof(msg));
       break;
     }
 }

--- a/drivers/rpmsg/rpmsg_router_hub.c
+++ b/drivers/rpmsg/rpmsg_router_hub.c
@@ -325,6 +325,7 @@ static void rpmsg_router_bound(FAR struct rpmsg_endpoint *ept)
                        rpmsg_get_tx_buffer_size(hub->ept[1 - i].rdev));
       msg.rx_len = MIN(rpmsg_get_tx_buffer_size(hub->ept[i].rdev),
                        rpmsg_get_rx_buffer_size(hub->ept[1 - i].rdev));
+      strlcpy(msg.cpuname, hub->cpuname[i], sizeof(msg.cpuname));
       ret = rpmsg_send(&hub->ept[i], &msg, sizeof(msg));
       DEBUGASSERT(ret >= 0);
     }

--- a/drivers/rpmsg/rpmsg_router_hub.c
+++ b/drivers/rpmsg/rpmsg_router_hub.c
@@ -1,0 +1,468 @@
+/****************************************************************************
+ * drivers/rpmsg/rpmsg_router_hub.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <sys/param.h>
+
+#include <nuttx/mutex.h>
+#include <nuttx/kmalloc.h>
+#include <rpmsg/rpmsg_internal.h>
+
+#include "rpmsg_router.h"
+
+/****************************************************************************
+ * Rpmsg-router Model:
+ *
+ *  +------+       +------+       +------+
+ *  | edge |<----->| hub  |<----->| edge |
+ *  +------+       +------+       +------+
+ *
+ * Description:
+ *    edge CPUs (edge) are physically linked to the central router cpu (hub),
+ *    edge CPUs' communication reply on hub cpu message forwarding.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rpmsg_router_hub_s
+{
+  struct rpmsg_endpoint ept[2];
+  char                  cpuname[2][RPMSG_ROUTER_CPUNAME_LEN];
+  mutex_t               lock;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_cb
+ *
+ * Description:
+ *   This is the callback function for router core.
+ *   It will receive data from source edge core by ept(r:cpu:name), and find
+ *   dest edge core communicating with it, send data to dest edge core.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with edge core (r:dst_cpu:name)
+ *   data - received data
+ *   len - received data length
+ *   src - source address
+ *   priv - save dest edge core rpmsg_endpoint (r:src_cpu:name)
+ *
+ * Returned Values:
+ *   Returns number of bytes it has sent or negative error value on failure.
+ *
+ ****************************************************************************/
+
+static int rpmsg_router_hub_cb(FAR struct rpmsg_endpoint *ept,
+                               FAR void *data, size_t len,
+                               uint32_t src, FAR void *priv)
+{
+  FAR struct rpmsg_endpoint *dst_ept = priv;
+
+  /* Retransmit data to dest edge core */
+
+  if (!dst_ept)
+    {
+      return -EINVAL;
+    }
+
+  return rpmsg_send(dst_ept, data, len);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_unbind
+ *
+ * Description:
+ *   This is the unbind callback function for router core.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with edge core (r:cpu:name)
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_hub_unbind(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_endpoint *dst_ept = ept->priv;
+
+  /* Destroy dest edge ept firstly */
+
+  if (dst_ept)
+    {
+      rpmsg_destroy_ept(dst_ept);
+      kmm_free(dst_ept);
+    }
+
+  /* Destroy source edge ept */
+
+  rpmsg_destroy_ept(ept);
+  kmm_free(ept);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_bound
+ *
+ * Description:
+ *   This is the bound callback function for router core.
+ *   It will create endpoint to source edge after dest edge
+ *   core is bound.
+ *
+ * Parameters:
+ *   ept - rpmsg_endpoint for communicating with edge core (r:cpu:name)
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_hub_bound(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_endpoint *src_ept = ept->priv;
+  int ret;
+
+  /* Create endpoint (r:dst_cpu:name) and send ACK to source edge core */
+
+  ret = rpmsg_create_ept(src_ept, src_ept->rdev, src_ept->name,
+                         RPMSG_ADDR_ANY, src_ept->dest_addr,
+                         rpmsg_router_hub_cb, rpmsg_router_hub_unbind);
+  DEBUGASSERT(ret == RPMSG_SUCCESS);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_match
+ *
+ * Description:
+ *   This function is used to match the router core device.
+ *   rpmsg_router_hub_bind will be called if the device is matched.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg router hub for router core
+ *   name - endpoint name (r:dst_cpu:name)
+ *   dest - destination address
+ *
+ * Returned Values:
+ *   true on success; false on failure.
+ *
+ ****************************************************************************/
+
+static bool rpmsg_router_hub_match(FAR struct rpmsg_device *rdev,
+                                   FAR void *priv, FAR const char *name,
+                                   uint32_t dest)
+{
+  FAR struct rpmsg_router_hub_s *hub = priv;
+  int i;
+
+  if (strncmp(name, RPMSG_ROUTER_NAME_PREFIX, RPMSG_ROUTER_NAME_PREFIX_LEN))
+    {
+      return false;
+    }
+
+  /* Must match both source edge CPU and dest edge CPU simultaneously */
+
+  for (i = 0; i < 2; i++)
+    {
+      if (strcmp(rpmsg_get_cpuname(rdev), hub->cpuname[i]))
+        {
+          continue;
+        }
+
+      if (strncmp(name + RPMSG_ROUTER_NAME_PREFIX_LEN,
+                  hub->cpuname[1 - i], strlen(hub->cpuname[1 - i])))
+        {
+          continue;
+        }
+
+      break;
+    }
+
+  return i < 2;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_bind
+ *
+ * Description:
+ *   This function is used to bind the router core device.
+ *   It will try to create endpoint (r:src_cpu:name) to another dest cpu.
+ *   The source endpoint information will be saved in the private field of
+ *   the dest endpoint.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg router hub for router core
+ *   name - source edge core endpoint name (r:dst_cpu:name)
+ *   dest - destination address
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_hub_bind(FAR struct rpmsg_device *rdev,
+                                  FAR void *priv, FAR const char *name,
+                                  uint32_t dest)
+{
+  FAR struct rpmsg_router_hub_s *hub = priv;
+  FAR struct rpmsg_endpoint *src_ept;
+  FAR struct rpmsg_endpoint *dst_ept;
+  FAR struct rpmsg_device *dst_rdev;
+  char dst_name[RPMSG_NAME_SIZE];
+  int ret;
+  int i;
+
+  nxmutex_lock(&hub->lock);
+  metal_mutex_acquire(&rdev->lock);
+  if (rpmsg_get_endpoint(rdev, name, RPMSG_ADDR_ANY, dest))
+    {
+      metal_mutex_release(&rdev->lock);
+      nxmutex_unlock(&hub->lock);
+      return;
+    }
+
+  metal_mutex_release(&rdev->lock);
+
+  /* Try to create endpoint name(r:src_cpu:name) of another dest cpu */
+
+  for (i = 0; i < 2; i++)
+    {
+      if (!strcmp(hub->cpuname[i], rpmsg_get_cpuname(rdev)))
+        {
+          break;
+        }
+    }
+
+  DEBUGASSERT(i < 2);
+
+  dst_rdev = hub->ept[1 - i].rdev;
+  snprintf(dst_name, RPMSG_NAME_SIZE,
+           RPMSG_ROUTER_NAME_PREFIX"%s%s", hub->cpuname[i],
+           name + RPMSG_ROUTER_NAME_PREFIX_LEN +
+           strlen(hub->cpuname[1 - i]));
+
+  src_ept = kmm_zalloc(sizeof(*src_ept));
+  dst_ept = kmm_zalloc(sizeof(*dst_ept));
+
+  DEBUGASSERT(src_ept && dst_ept);
+
+  /* Save information for the ept(r:dst_cpu:name) of the source cpu */
+
+  src_ept->priv = dst_ept;
+  src_ept->rdev = rdev;
+  src_ept->dest_addr = dest;
+  strlcpy(src_ept->name, name, sizeof(src_ept->name));
+
+  /* Create endpoint (r:src_cpu:name) to another dest cpu */
+
+  dst_ept->priv = src_ept;
+  dst_ept->ns_bound_cb = rpmsg_router_hub_bound;
+  ret = rpmsg_create_ept(dst_ept, dst_rdev, dst_name,
+                         RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+                         rpmsg_router_hub_cb,
+                         rpmsg_router_hub_unbind);
+  if (ret < 0)
+    {
+      kmm_free(dst_ept);
+      kmm_free(src_ept);
+    }
+
+  nxmutex_unlock(&hub->lock);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_bound
+ *
+ * Description:
+ *   This function is used to send tx/rx buffer size
+ *   when both cores are ready
+ *
+ * Parameters:
+ *   ept - rpmsg endpoint for communicating with edge core
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_bound(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_router_hub_s *hub = ept->priv;
+  struct rpmsg_router_s msg;
+  int ret;
+
+  if (!is_rpmsg_ept_ready(&hub->ept[0]) ||
+      !is_rpmsg_ept_ready(&hub->ept[1]))
+    {
+      return;
+    }
+
+  msg.tx_len = MIN(rpmsg_get_tx_buffer_size(hub->ept[0].rdev),
+                   rpmsg_get_tx_buffer_size(hub->ept[1].rdev));
+  msg.rx_len = MIN(rpmsg_get_rx_buffer_size(hub->ept[0].rdev),
+                   rpmsg_get_rx_buffer_size(hub->ept[1].rdev));
+
+  ret = rpmsg_send(&hub->ept[0], &msg, sizeof(msg));
+  DEBUGASSERT(ret >= 0);
+  ret = rpmsg_send(&hub->ept[1], &msg, sizeof(msg));
+  DEBUGASSERT(ret >= 0);
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_cb
+ ****************************************************************************/
+
+static int rpmsg_router_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
+                           size_t len, uint32_t src, FAR void *priv)
+{
+  return 0;
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_created
+ *
+ * Description:
+ *   This function is used to create endpoint to edge core,
+ *   for synchronizing ready messages.
+ *
+ * Parameters:
+ *   rdev - real rpmsg device
+ *   priv - rpmsg router hub
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_created(FAR struct rpmsg_device *rdev,
+                                 FAR void *priv)
+{
+  FAR struct rpmsg_router_hub_s *hub = priv;
+  char name[RPMSG_NAME_SIZE];
+  int ret;
+  int i;
+
+  for (i = 0; i < 2; i++)
+    {
+      if (strcmp(rpmsg_get_cpuname(rdev), hub->cpuname[i]))
+        {
+          continue;
+        }
+
+      hub->ept[i].priv = hub;
+      hub->ept[i].ns_bound_cb = rpmsg_router_bound;
+      snprintf(name, RPMSG_NAME_SIZE, RPMSG_ROUTER_NAME"%s",
+               hub->cpuname[1 - i]);
+
+      ret = rpmsg_create_ept(&hub->ept[i], rdev, name,
+                             RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+                             rpmsg_router_cb, NULL);
+      DEBUGASSERT(ret == RPMSG_SUCCESS);
+      break;
+    }
+}
+
+/****************************************************************************
+ * Name: rpmsg_router_destroy
+ *
+ * Description:
+ *   This function is used to destroy the rpmsg router hub.
+ *
+ * Parameters:
+ *   priv - rpmsg router hub
+ *
+ ****************************************************************************/
+
+static void rpmsg_router_destroy(FAR struct rpmsg_device *rdev,
+                                 FAR void *priv)
+{
+  FAR struct rpmsg_router_hub_s *hub = priv;
+  int i;
+
+  for (i = 0; i < 2; i++)
+    {
+      if (strcmp(rpmsg_get_cpuname(rdev), hub->cpuname[i]))
+        {
+          continue;
+        }
+
+      rpmsg_destroy_ept(&hub->ept[i]);
+      break;
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_init
+ *
+ * Description:
+ *   This function is used to initialize the rpmsg router hub.
+ *
+ * Parameters:
+ *   edge0 - edge cpu name
+ *   edge1 - edge cpu name
+ *
+ * Returned Values:
+ *   OK on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_router_hub_init(FAR const char *edge0,
+                          FAR const char *edge1)
+{
+  FAR struct rpmsg_router_hub_s *hub;
+  int ret;
+
+  if (!edge0 || !edge1)
+    {
+      return -EINVAL;
+    }
+
+  hub = kmm_zalloc(sizeof(*hub));
+  if (!hub)
+    {
+      return -ENOMEM;
+    }
+
+  nxmutex_init(&hub->lock);
+  strlcpy(hub->cpuname[0], edge0, sizeof(hub->cpuname[0]));
+  strlcpy(hub->cpuname[1], edge1, sizeof(hub->cpuname[1]));
+
+  /* Register callback for retranmitting data between edge cores */
+
+  ret = rpmsg_register_callback(hub,
+                                rpmsg_router_created,
+                                rpmsg_router_destroy,
+                                rpmsg_router_hub_match,
+                                rpmsg_router_hub_bind);
+  if (ret < 0)
+    {
+      rpmsgerr("Register rpmsg callback failed: %d\n", ret);
+      nxmutex_destroy(&hub->lock);
+      kmm_free(hub);
+      return ret;
+    }
+
+  return 0;
+}

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -70,6 +70,8 @@ struct rpmsg_virtio_priv_s
 static int rpmsg_virtio_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
 static int rpmsg_virtio_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
 static void rpmsg_virtio_dump(FAR struct rpmsg_s *rpmsg);
+static FAR const char *
+rpmsg_virtio_get_local_cpuname(FAR struct rpmsg_s *rpmsg);
 static FAR const char *rpmsg_virtio_get_cpuname(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_virtio_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
 static int rpmsg_virtio_get_rx_buffer_size_(FAR struct rpmsg_s *rpmsg);
@@ -96,6 +98,7 @@ static const struct rpmsg_ops_s g_rpmsg_virtio_ops =
   .wait               = rpmsg_virtio_wait,
   .post               = rpmsg_virtio_post,
   .dump               = rpmsg_virtio_dump,
+  .get_local_cpuname  = rpmsg_virtio_get_local_cpuname,
   .get_cpuname        = rpmsg_virtio_get_cpuname,
   .get_tx_buffer_size = rpmsg_virtio_get_tx_buffer_size,
   .get_rx_buffer_size = rpmsg_virtio_get_rx_buffer_size_,
@@ -388,6 +391,15 @@ static void rpmsg_virtio_dump(FAR struct rpmsg_s *rpmsg)
   /* Nothing */
 }
 #endif
+
+static FAR const char *
+rpmsg_virtio_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rpmsg_virtio_priv_s *priv =
+    (FAR struct rpmsg_virtio_priv_s *)rpmsg;
+
+  return RPMSG_VIRTIO_GET_LOCAL_CPUNAME(priv->dev);
+}
 
 static FAR const char *rpmsg_virtio_get_cpuname(FAR struct rpmsg_s *rpmsg)
 {

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -125,6 +125,7 @@ static int rptun_ioctl(FAR struct rpmsg_s *rpmsg, int cmd,
                        unsigned long arg);
 static void rptun_panic_(FAR struct rpmsg_s *rpmsg);
 static void rptun_dump(FAR struct rpmsg_s *rpmsg);
+static FAR const char *rptun_get_local_cpuname(FAR struct rpmsg_s *rpmsg);
 static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg);
 static int rptun_get_tx_buffer_size(FAR struct rpmsg_s *rpmsg);
 static int rptun_get_rx_buffer_size(FAR struct rpmsg_s *rpmsg);
@@ -162,6 +163,7 @@ static const struct rpmsg_ops_s g_rptun_rpmsg_ops =
   rptun_ioctl,
   rptun_panic_,
   rptun_dump,
+  rptun_get_local_cpuname,
   rptun_get_cpuname,
   rptun_get_tx_buffer_size,
   rptun_get_rx_buffer_size,
@@ -614,6 +616,13 @@ static void rptun_dump(FAR struct rpmsg_s *rpmsg)
 #ifdef CONFIG_RPTUN_PM
   metal_log(METAL_LOG_EMERGENCY, "rptun headrx %d\n", priv->headrx);
 #endif
+}
+
+static FAR const char *rptun_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
+{
+  FAR struct rptun_priv_s *priv = (FAR struct rptun_priv_s *)rpmsg;
+
+  return RPTUN_GET_LOCAL_CPUNAME(priv->dev);
 }
 
 static FAR const char *rptun_get_cpuname(FAR struct rpmsg_s *rpmsg)

--- a/include/nuttx/rpmsg/rpmsg.h
+++ b/include/nuttx/rpmsg/rpmsg.h
@@ -74,6 +74,7 @@ struct rpmsg_ops_s
   CODE int (*ioctl)(FAR struct rpmsg_s *rpmsg, int cmd, unsigned long arg);
   CODE void (*panic)(FAR struct rpmsg_s *rpmsg);
   CODE void (*dump)(FAR struct rpmsg_s *rpmsg);
+  CODE FAR const char *(*get_local_cpuname)(FAR struct rpmsg_s *rpmsg);
   CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_s *rpmsg);
   CODE int (*get_tx_buffer_size)(FAR struct rpmsg_s *rpmsg);
   CODE int (*get_rx_buffer_size)(FAR struct rpmsg_s *rpmsg);
@@ -103,6 +104,7 @@ extern "C"
 int rpmsg_wait(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem);
 int rpmsg_post(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem);
 
+FAR const char *rpmsg_get_local_cpuname(FAR struct rpmsg_device *rdev);
 FAR const char *rpmsg_get_cpuname(FAR struct rpmsg_device *rdev);
 
 int rpmsg_get_tx_buffer_size(FAR struct rpmsg_device *rdev);

--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -79,6 +79,7 @@ struct rpmsg_port_spi_config_s
   int             sreq_invert; /* Pin options described in ioexpander.h */
 
   int             mode;        /* Mode of enum spi_mode_e */
+  int             nbits;
   uint32_t        devid;       /* Device ID of enum spi_devtype_e */
   uint32_t        freq;        /* SPI frequency (Hz) */
 };

--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -30,6 +30,7 @@
 
 #include <nuttx/ioexpander/ioexpander.h>
 #include <nuttx/spi/spi.h>
+#include <nuttx/spi/slave.h>
 
 #ifdef CONFIG_RPMSG_PORT
 
@@ -77,7 +78,7 @@ struct rpmsg_port_spi_config_s
   int             mreq_invert;
   int             sreq_invert; /* Pin options described in ioexpander.h */
 
-  enum spi_mode_e mode;
+  int             mode;        /* Mode of enum spi_mode_e */
   uint32_t        devid;       /* Device ID of enum spi_devtype_e */
   uint32_t        freq;        /* SPI frequency (Hz) */
 };
@@ -120,6 +121,34 @@ rpmsg_port_spi_initialize(FAR const struct rpmsg_port_config_s *cfg,
                           FAR const struct rpmsg_port_spi_config_s *spicfg,
                           FAR struct spi_dev_s *spi,
                           FAR struct ioexpander_dev_s *ioe);
+
+#endif
+
+#ifdef CONFIG_RPMSG_PORT_SPI_SLAVE
+
+/****************************************************************************
+ * Name: rpmsg_port_spi_slave_initialize
+ *
+ * Description:
+ *   Initialize a rpmsg_port_spi_slave device to communicate between two
+ *   chips.
+ *
+ * Input Parameters:
+ *   cfg      - Configuration of buffers needed for communication.
+ *   spicfg   - SPI device's configuration.
+ *   spictrlr - SPI slave controller used for transfer data between two
+ *              chips.
+ *   ioe      - ioexpander used to config gpios.
+ *
+ * Returned Value:
+ *   Zero on success or an negative value on failure.
+ *
+ ****************************************************************************/
+
+int
+rpmsg_port_spi_slave_initialize(FAR const struct rpmsg_port_config_s *cfg,
+  FAR const struct rpmsg_port_spi_config_s *spicfg,
+  FAR struct spi_slave_ctrlr_s *spictrlr, FAR struct ioexpander_dev_s *ioe);
 
 #endif
 

--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * include/nuttx/rpmsg/rpmsg_port.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_RPMSG_RPMSG_PORT_H
+#define __INCLUDE_NUTTX_RPMSG_RPMSG_PORT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+
+#ifdef CONFIG_RPMSG_PORT
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+struct rpmsg_port_config_s
+{
+  FAR const char *remotecpu;
+  uint32_t       txnum;         /* Number of tx buffer. */
+  uint32_t       rxnum;         /* Number of rx buffer. */
+  uint32_t       txlen;         /* Length of a single tx buffer. */
+  uint32_t       rxlen;         /* Length of a single rx buffer. */
+
+  /* Pointer to whole tx/rx buffer, if it was null, transport layer will
+   * alloc internal.
+   */
+
+  FAR void       *txbuf;
+  FAR void       *rxbuf;
+};
+
+#endif /* CONFIG_RPMSG_PORT */
+#endif /* __INCLUDE_NUTTX_RPMSG_RPMSG_PORT_H */

--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -121,7 +121,6 @@ rpmsg_port_spi_initialize(FAR const struct rpmsg_port_config_s *cfg,
                           FAR const struct rpmsg_port_spi_config_s *spicfg,
                           FAR struct spi_dev_s *spi,
                           FAR struct ioexpander_dev_s *ioe);
-
 #endif
 
 #ifdef CONFIG_RPMSG_PORT_SPI_SLAVE
@@ -150,6 +149,26 @@ rpmsg_port_spi_slave_initialize(FAR const struct rpmsg_port_config_s *cfg,
   FAR const struct rpmsg_port_spi_config_s *spicfg,
   FAR struct spi_slave_ctrlr_s *spictrlr, FAR struct ioexpander_dev_s *ioe);
 
+#endif
+
+#ifdef CONFIG_RPMSG_PORT_UART
+
+/****************************************************************************
+ * Name: rpmsg_port_uart_initialize
+ *
+ * Description:
+ *   Initialze a rpmsg_port_uart device to communicate between two chips.
+ *
+ * Input Parameters:
+ *   cfg      - Configuration of buffers needed for communication.
+ *   uartpath - Uart device path.
+ *   localcpu - Local cpu name
+ *
+ ****************************************************************************/
+
+int rpmsg_port_uart_initialize(FAR const struct rpmsg_port_config_s *cfg,
+                               FAR const char *uartpath,
+                               FAR const char *localcpu);
 #endif
 
 #ifdef __cplusplus

--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -37,10 +37,10 @@
 struct rpmsg_port_config_s
 {
   FAR const char *remotecpu;
-  uint32_t       txnum;         /* Number of tx buffer. */
-  uint32_t       rxnum;         /* Number of rx buffer. */
-  uint32_t       txlen;         /* Length of a single tx buffer. */
-  uint32_t       rxlen;         /* Length of a single rx buffer. */
+  uint16_t       txnum;         /* Number of tx buffer. */
+  uint16_t       rxnum;         /* Number of rx buffer. */
+  uint16_t       txlen;         /* Length of a single tx buffer. */
+  uint16_t       rxlen;         /* Length of a single rx buffer. */
 
   /* Pointer to whole tx/rx buffer, if it was null, transport layer will
    * alloc internal.

--- a/include/nuttx/rpmsg/rpmsg_router.h
+++ b/include/nuttx/rpmsg/rpmsg_router.h
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * include/nuttx/rpmsg/rpmsg_router.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_RPMSG_RPMSG_ROUTER_H
+#define __INCLUDE_NUTTX_RPMSG_RPMSG_ROUTER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_RPMSG_ROUTER
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: rpmsg_router_hub_init
+ *
+ * Description:
+ *   This function is used to initialize the rpmsg router hub.
+ *
+ * Parameters:
+ *   edge0 - edge cpu name
+ *   edge1 - edge cpu name
+ *
+ * Returned Values:
+ *   OK on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_router_hub_init(FAR const char *edge0,
+                          FAR const char *edge1);
+
+/****************************************************************************
+ * Name: rpmsg_router_edge_init
+ *
+ * Description:
+ *   This function is used to initialize the edge core.
+ *
+ * Returned Values:
+ *   OK on success; A negated errno value is returned on any failure.
+ *
+ ****************************************************************************/
+
+int rpmsg_router_edge_init(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_RPMSG_ROUTER */
+
+#endif /* __INCLUDE_NUTTX_RPMSG_RPMSG_ROUTER_H */

--- a/include/nuttx/rpmsg/rpmsg_virtio.h
+++ b/include/nuttx/rpmsg/rpmsg_virtio.h
@@ -41,6 +41,23 @@
 /* Access macros ************************************************************/
 
 /****************************************************************************
+ * Name: RPMSG_VIRTIO_GET_LOCAL_CPUNAME
+ *
+ * Description:
+ *   Get remote cpu name
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   Cpu name on success, NULL on failure.
+ *
+ ****************************************************************************/
+
+#define RPMSG_VIRTIO_GET_LOCAL_CPUNAME(d) \
+  ((d)->ops->get_local_cpuname ? (d)->ops->get_local_cpuname(d) : "")
+
+/****************************************************************************
  * Name: RPMSG_VIRTIO_GET_CPUNAME
  *
  * Description:
@@ -148,6 +165,7 @@ struct aligned_data(8) rpmsg_virtio_rsc_s
 struct rpmsg_virtio_s;
 struct rpmsg_virtio_ops_s
 {
+  CODE FAR const char *(*get_local_cpuname)(FAR struct rpmsg_virtio_s *dev);
   CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_virtio_s *dev);
   CODE FAR struct rpmsg_virtio_rsc_s *
   (*get_resource)(FAR struct rpmsg_virtio_s *dev);

--- a/include/nuttx/rptun/rptun.h
+++ b/include/nuttx/rptun/rptun.h
@@ -49,6 +49,23 @@
 /* Access macros ************************************************************/
 
 /****************************************************************************
+ * Name: RPTUN_GET_LOCAL_CPUNAME
+ *
+ * Description:
+ *   Get local cpu name
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   Cpu name on success, NULL on failure.
+ *
+ ****************************************************************************/
+
+#define RPTUN_GET_LOCAL_CPUNAME(d) ((d)->ops->get_local_cpuname ? \
+                                    (d)->ops->get_local_cpuname(d) : "")
+
+/****************************************************************************
  * Name: RPTUN_GET_CPUNAME
  *
  * Description:
@@ -317,6 +334,7 @@ struct aligned_data(8) rptun_rsc_s
 struct rptun_dev_s;
 struct rptun_ops_s
 {
+  CODE FAR const char *(*get_local_cpuname)(FAR struct rptun_dev_s *dev);
   CODE FAR const char *(*get_cpuname)(FAR struct rptun_dev_s *dev);
   CODE FAR const char *(*get_firmware)(FAR struct rptun_dev_s *dev);
 


### PR DESCRIPTION
## Summary
Three new rpsmg transport layers support:
- Rpmsg Port SPI
- Rpmsg Port UART
- Rpmsg Router

1.    rpmsg_port_spi: set mreq to high to trigger next transmission
    
    rpmsg_port_spi_connect can not be used here because peer may have not finished
    the last transmission which will keep the sreq gpio in high level, and it will
    read an error data frame.
    
2.    rpmsg_port_spi/slave: reorder rpmsg_port_initialize and rpmsg_port_spi_init hardware
    
    Because the data transmision may has been started before
    rpmsg_port_initialize(), this should be not allowed.

3.    rpmsg_port_spi: add pending logic for rpmsg port spi
    
    To handle the situation that there is a req from peer side when
    current transfer is not finished.

4.    rpmsg_port_spi: add nbits to spicfg
    
    Support more spi config paramters for Rpmsg Port SPI/SPI Slave

5.    rpmsg_port_spi: discard messages when disconnected
    
    Disconnected logic optimization

6.    drivers/rpmsg: Add edge_create and edge_destroy for router
    
    use cmd to notify the other cpu to destroy router edge device,
    and dont destroy the other cpu's "router:ept"

7.    rpmsg/rpmsg_port_uart: add rpmsg uart port driver
    
    Rpmsg Port Uart is a new rpmsg transport layer.
    Just like the rpmsg port spi, the difference is that the physical
    communication method changed from SPI to UART.

8.    rpmsg_port_spi: add spi slave support
    
    The rpmsg port spi slave version support

9.    rpmsg_port_spi: add get_local_cpuname api
    
    add get_local_cpuname ops for rpmsg_port_spi

10.    rpmsg_port_spi:init cs gpio to be low
    
    Transfer will be failure when the cs gpio status is low before
    the first transfer.

11.    drivers/rpmsg: Add get_local_cpuname in router
    
    get_local_cpuname ops support for rpmsg router

12.    rpmsg_port_spi: do not decrease when rx avail is already 0
    
    Bug fix about the rpmsg port spi

13.    drivers/rpmsg: Use optimal rx size and tx size
    
    Use the minimal tx and rx size form two edge cpu to maintain
    the transmit buffer size not exceed the edge cpus' buffer size.
    
    [edg0] tx <---> rx0 [hub] rx1 <---> tx [edge1]
           rx <---> tx0       tx1 <---> rx
    
    edge0_tx = min(rx0, tx1);
    edge0_rx = min(tx0, rx1);
    
    edge1_tx = min(rx1, tx0);
    edge1_rx = min(tx1, rx0);

14.    drivers/rpmsg: add get_local_cpuname to rpmsg ops
    
    Add get_local_cpuname to the rpmsg framework ops to support communicate
    with the same remote core with multi rpmsg transport.
    
    Some rpmsg services will send local cpu name to remote core and then let
    remote core to connect local core by using this cpu name, when there are
    multi rpmsg channels with same remote core, the remote core may connect
    to incorrect core, so use the error rpmsg channel.
    
    For example, there are two rpmsg channels between ap and audio:
    
    ap core                     audio core
     [ap1] <-- rpmsg virtio1 --> [audio1]
     [ap2] <-- rpmsg virtio2 --> [audio2]
    
    When we want to use the rpmsg virtio1 to communicate, ap core may send
    local cpuname "ap2" to audio, so the audio core use remote cpu "ap2" to
    connect with ap, and resulting in the use of incorrect rpmsg channel.

15.    drivers/rpmsg: Use tx buffer size as payload length
    
    Directly use tx length received from hub as the tx payload length.

16.    drivers/rpmsg: add rpmsg router support
    
    Rpmsg Router is new rpmsg transport layer, it can router the rpmsg
    messages to a cpu that not directly connected with local cpu by Rpmsg,
    For the rpmsg services, it is as if there is a real Rpmsg Channel between
    the local cpu and the remote cpu.
    
    For examples, there are three cpus: ap, cp and audio.
    ap and cp, ap and audio has share memory and be connected by Rpmsg VirtIO,
    so ap and cp, ap and audio can communicate with each other by Rpmsg, but
    cp can not communicate with audio direclty.
    
    [cp] <-- rpmsg virtio --> [ap] <-- rpmsg virtio --> [audio]
    
    With rpmsg router, the cp can communicate with audip by Rpmsg dereclty because
    the router in ap will forward the rpmsg message from cp/audio to audio/cp, like
    this:
    
     +<----- rpmsg router --> hub  <-- rpmsg router ------>+
     |                         |                           |
    [cp] <-- rpmsg virtio --> [ap] <-- rpmsg virtio --> [audio]
    
17.    rpmsg/rpmsg_port: judge notify_rx_free and notify_tx_ready before calling
    
    Some lower layers do not need implement these two operations, so judge
    them before calling.

18.    rpmsg/Kconfig: move RPMSG_PORT outside RPMSG and select RPMSG direclty
    
    All the RPMSG transport should direcly select the RPMSG like RPMSG_VIRTIO
    does.

19.    rpmsg_port_spi: add spi transport layer
    
    Add Rpmsg-Port-SPI transport layer.
    Rpmsg Port SPI is a new rpmsg transport layer based on the Rpmsg Port,
    it provides the capability for two SPI-connected (and two extra GPIO)
    chips to communicate with each other using Rpmsg.
    
    All already implemented Rpmsg Services can be used with this new transport
    layer without any modifications.

20.    rpmsg_port:reduce len and avail of rpmsg_port_header_s to uint16_t
    
    uint16_t is enough and more suitable

21.    rpmsg_port:add rpmsg_port_queue_nused api
    
    Add nused api for lower layer to get the used buffer number

22.    rpmsg: add physical transport layer support
    
    Rpmsg Physical Transport Layer is a new rpmsg transport, it's a
    common part for the physical communication based rpmsg transport
    layers such as Rpmsg-SPI and Rpmsg-Uart.
    
    It implements three common parts:
    1. Implement the NuttX and OpenAMP rpmsg frameworks' ops and the
    rpmsg name service;
    2. The buffer management and provide some APIs to lower layer to use;

## Impact
New features

## Testing
Testing in Vela Project.
