### PR TITLE
pthread_mutx: remove unused critical_secton lock

### DIFF
--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -81,7 +81,6 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
                             FAR const struct timespec *abs_timeout)
 {
   int ret = EINVAL;
-  irqstate_t flags;
 
   sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
@@ -91,12 +90,6 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
       pid_t pid = mutex_get_holder(&mutex->mutex);
 #endif
-
-      /* Make sure the semaphore is stable while we make the following
-       * checks.  This all needs to be one atomic action.
-       */
-
-      flags = enter_critical_section();
 
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES
       /* All mutex types except for NORMAL (and DEFAULT) will return
@@ -188,8 +181,6 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
 
           ret = pthread_mutex_take(mutex, abs_timeout);
         }
-
-      leave_critical_section(flags);
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -70,7 +70,6 @@
 int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
 {
   int ret = EPERM;
-  irqstate_t flags;
 
   sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
@@ -78,12 +77,6 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
     {
       return EINVAL;
     }
-
-  /* Make sure the semaphore is stable while we make the following checks.
-   * This all needs to be one atomic action.
-   */
-
-  flags = enter_critical_section();
 
   /* The unlock operation is only performed if the mutex is actually locked.
    * EPERM *must* be returned if the mutex type is PTHREAD_MUTEX_ERRORCHECK
@@ -171,7 +164,6 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
         }
     }
 
-  leave_critical_section(flags);
   sinfo("Returning %d\n", ret);
   return ret;
 }


### PR DESCRIPTION

## Summary

pthread_mutx: remove unused critical_secton lock

Caused the 'nlocks' are remove from mutex, so
here don't need do critical_secton lock like nxmutex_lock

## Impact

pthread

## Testing

bes board