### PR TITLE
armv7-a gic related update

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpustart.c
+++ b/arch/arm/src/armv7-a/arm_cpustart.c
@@ -121,7 +121,7 @@ int arm_start_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-int up_cpu_start(int cpu)
+int weak_function up_cpu_start(int cpu)
 {
   sinfo("Starting CPU%d\n", cpu);
 

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -336,9 +336,7 @@ void arm_gic_initialize(void)
 #  endif
 #endif
 
-#ifndef CONFIG_ARCH_TRUSTZONE_SECURE
   iccicr |= GIC_ICCICRS_ACKTCTL;
-#endif
 
 #ifdef CONFIG_ARCH_TRUSTZONE_NONSECURE
   /* Enable the Group 1 interrupts and disable Group 1 bypass. */

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/irq.h>
 
 #include "arm_internal.h"
@@ -68,7 +69,11 @@ static volatile cpu_set_t g_gic_init_done;
 #if defined(CONFIG_SMP) && CONFIG_SMP_NCPUS > 1
 static void arm_gic_init_done(void)
 {
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(NULL);
   CPU_SET(up_cpu_index(), &g_gic_init_done);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 static void arm_gic_wait_done(cpu_set_t cpuset)

--- a/arch/arm/src/armv7-a/gic.h
+++ b/arch/arm/src/armv7-a/gic.h
@@ -678,36 +678,7 @@ static inline unsigned int arm_gic_nlines(void)
  *
  ****************************************************************************/
 
-static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
-{
-  uint32_t regval;
-
-#ifdef CONFIG_SMP
-  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(cpuset) |
-           GIC_ICDSGIR_TGTFILTER_LIST;
-#else
-  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(0) |
-           GIC_ICDSGIR_TGTFILTER_THIS;
-#endif
-
-#if defined(CONFIG_ARCH_TRUSTZONE_SECURE)
-  if (sgi >= GIC_IRQ_SGI0 && sgi <= GIC_IRQ_SGI7)
-#endif
-    {
-      /* Set NSATT be 1: forward the SGI specified in the SGIINTID field to a
-       * specified CPU interfaces only if the SGI is configured as Group 1 on
-       * that interface.
-       * For non-secure context, the configuration of GIC_ICDSGIR_NSATT_GRP1
-       * is not mandatory in the GICv2 specification, but for SMP scenarios,
-       * this value needs to be configured, otherwise issues may occur in the
-       * SMP scenario.
-       */
-
-      regval |= GIC_ICDSGIR_NSATT_GRP1;
-    }
-
-  putreg32(regval, GIC_ICDSGIR);
-}
+void arm_cpu_sgi(int sgi, unsigned int cpuset);
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/arm/src/armv7-a/smp.h
+++ b/arch/arm/src/armv7-a/smp.h
@@ -84,6 +84,8 @@ extern uint32_t g_cpu3_idlestack[SMP_STACK_WORDS];
  *
  ****************************************************************************/
 
+void __start(void);
+
 #if CONFIG_SMP_NCPUS > 1
 void __cpu1_start(void);
 #endif

--- a/arch/arm/src/armv7-r/smp.h
+++ b/arch/arm/src/armv7-r/smp.h
@@ -84,6 +84,8 @@ extern uint32_t g_cpu3_idlestack[SMP_STACK_WORDS];
  *
  ****************************************************************************/
 
+void __start(void);
+
 #if CONFIG_SMP_NCPUS > 1
 void __cpu1_start(void);
 #endif


### PR DESCRIPTION
## Summary

armv7-a/r gic related update

```
    arm_gicv2: cpu 0 wait other cpu gic init done
    
    After move the SGI irq to group1, other cpu can't response the
    sgi request from cpu0 when its gic not initialized.
    So let cpu0 wait until all other cpus gic initialize done.
```

```
    armv7-a/r: check gic init wait done when using sgi
    
    In SMP mode, qemu/goldfish platform, cpu0 use up_cpu_start()
    to start others cpus.
    
    But in previous patch(mathion ahead), arm_gic_initialize() will
    wait others cpus start, so deadlocked!
    
    Resolve:
    Move the wait logic when use using sgi
```


## Impact

armv7a gic

## Testing

bes board & qemu
