### PR TITLE
drivers/gpio: support poll gpio device and optimize code to save memory

### DIFF
--- a/drivers/ioexpander/Kconfig
+++ b/drivers/ioexpander/Kconfig
@@ -499,6 +499,14 @@ config DEV_GPIO
 		Enables a simple GPIO input/output driver to support application-
 		space testing of hardware.
 
+config DEV_GPIO_NPOLLWAITERS
+	int "Max number of polls"
+	default 1
+	depends on DEV_GPIO
+	---help---
+		The maximum number of polls that can be registered with the GPIO
+		driver
+
 config DEV_GPIO_NSIGNALS
 	int "Max number of signals"
 	default 1

--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -152,6 +152,14 @@ struct gpio_dev_s
 
   uint8_t gp_pintype;  /* See enum gpio_pintype_e */
 
+  /* Number of times the device has been registered by ioctl */
+
+  uint8_t register_count;
+
+  /* Number of times interrupt occured */
+
+  uintptr_t int_count;
+
   /* Writable storage used by the upper half driver */
 
   struct gpio_signal_s gp_signals[CONFIG_DEV_GPIO_NSIGNALS];
@@ -161,6 +169,8 @@ struct gpio_dev_s
    */
 
   FAR const struct gpio_operations_s *gp_ops;
+
+  FAR struct pollfd *fds[CONFIG_DEV_GPIO_NSIGNALS];
 
   /* Device specific, lower-half information may follow. */
 };

--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -162,7 +162,9 @@ struct gpio_dev_s
 
   /* Writable storage used by the upper half driver */
 
+#if CONFIG_DEV_GPIO_NSIGNALS > 0
   struct gpio_signal_s gp_signals[CONFIG_DEV_GPIO_NSIGNALS];
+#endif
 
   /* Read-only pointer to GPIO device operations (also provided by the
    * lower half driver).
@@ -170,7 +172,9 @@ struct gpio_dev_s
 
   FAR const struct gpio_operations_s *gp_ops;
 
-  FAR struct pollfd *fds[CONFIG_DEV_GPIO_NSIGNALS];
+#if CONFIG_DEV_GPIO_NPOLLWAITERS > 0
+  FAR struct pollfd *fds[CONFIG_DEV_GPIO_NPOLLWAITERS];
+#endif
 
   /* Device specific, lower-half information may follow. */
 };


### PR DESCRIPTION
## Summary
1. support poll for gpio device to monitor interrupt happen.
2. using CONFIG_DEV_GPIO_NSIGNALS and CONFIG_DEV_GPIO_NPOLLWAITERS to config code.
## Impact
support poll for gpio device
## Testing
vela
