### PR TITLE
coredump: just save latest core file

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -134,12 +134,6 @@ static void coredump_dump_blkdev(pid_t pid)
     }
 
   info = (FAR struct coredump_info_s *)g_blockinfo;
-  if (info->magic == COREDUMP_MAGIC)
-    {
-      _alert("Coredump exists in %s, skip\n",
-              CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
-      return;
-    }
 
 #ifdef CONFIG_BOARD_COREDUMP_COMPRESSION
   lib_lzfoutstream(&g_lzfstream,


### PR DESCRIPTION
## Summary
   just ignore obsolete core file to save latest one
## Impact
  coredump
## Testing
 test it passed on cortext m7
