### PR TITLE
fs/mount: add ftl proxy to mount block filesystem on mtd device

### DIFF
--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -125,9 +125,6 @@ static const struct fsmap_t g_bdfsmap[] =
 #ifdef MDFS_SUPPORT
 /* File systems that require MTD drivers */
 
-#ifdef CONFIG_FS_ROMFS
-extern const struct mountpt_operations g_romfs_operations;
-#endif
 #ifdef CONFIG_FS_SPIFFS
 extern const struct mountpt_operations g_spiffs_operations;
 #endif


### PR DESCRIPTION
## Summary
fs/mount: add ftl proxy to mount block filesystem on mtd device
## Impact
auto proxy for mtd device when mount block fs
## Testing
Vela

