### PR TITLE
nucleo-h745zi: fix potential bl jump to app failed issue

### DIFF
--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_boot_image.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_boot_image.c
@@ -172,10 +172,12 @@ int board_boot_image(const char *path, uint32_t hdr_size)
 
   /* Set main and process stack pointers */
 
-  __asm__ __volatile__("\tmsr msp, %0\n" : : "r" (vt.spr));
-  setcontrol(0x00);
-  ARM_ISB();
-  ((void (*)(void))vt.reset)();
+  __asm__ __volatile__("\tmsr msp, %0\n"
+                       "\tmsr control, %1\n"
+                       "\tisb\n"
+                       "\tmov pc, %2\n"
+                       :
+                       : "r" (vt.spr), "r" (0), "r" (vt.reset));
 
   return 0;
 }


### PR DESCRIPTION

## Summary
    After changing sp, following functions calling will result in unpredictable behavior in case of jumping
## Impact
   stm32h7/nucleo-h743zi
## Testing

