### PR TITLE
boardctl: add board control api to start slave core

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4828,6 +4828,14 @@ config BOARDCTL_IRQ_AFFINITY
 	---help---
 		Enables support for Set an IRQ affinity to CPUs by software.
 
+config BOARDCTL_START_CPU
+	bool "Start slave cpu"
+	default n
+	---help---
+		Enables support for the BOARDIOC_START_CPU boardctl() command.
+		Architecture specific logic must provide the board_start_cpu()
+		interface.
+
 config BOARDCTL_IOCTL
 	bool "Board-specific boardctl() commands"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -886,6 +886,22 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_START_CPU
+      /* CMD:           BOARDIOC_START_CPU
+       * DESCRIPTION:   Start specified slave core by master core
+       * ARG:           Integer value for cpu core id.
+       * CONFIGURATION: CONFIG_BOARDCTL_START_CPU
+       * DEPENDENCIES:  Board logic must provide the
+       *                board_start_cpu() interface.
+       */
+
+      case BOARDIOC_START_CPU:
+        {
+          ret = board_start_cpu((int)arg);
+        }
+        break;
+#endif
+
        default:
          {
 #ifdef CONFIG_BOARDCTL_IOCTL

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -855,6 +855,21 @@ void board_init_rngseed(void);
 int board_reset_cause(FAR struct boardioc_reset_cause_s *cause);
 #endif
 
+/****************************************************************************
+ * Name: board_start_cpu
+ *
+ * Description:
+ *   This interface may be used by application specific logic to start
+ *   specified slave cpu core under the pseudo AMP case which is different
+ *   with armv7-a/armv8-a SMP. Support for this function is required by
+ *   board-level logic if CONFIG_BOARDCTL_START_CPU is selected.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_START_CPU
+int board_start_cpu(int cpuid);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -213,6 +213,7 @@
 #define BOARDIOC_BOOT_IMAGE        _BOARDIOC(0x0014)
 #define BOARDIOC_RESET_CAUSE       _BOARDIOC(0x0015)
 #define BOARDIOC_IRQ_AFFINITY      _BOARDIOC(0x0016)
+#define BOARDIOC_START_CPU         _BOARDIOC(0x0017)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -221,7 +222,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0017)
+#define BOARDIOC_USER              _BOARDIOC(0x0018)
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary
   This interface may be used by application specific logic to start
    specified slave cpu core under the pseudo AMP case which is different
    with armv7-a/armv8-a SMP. Support for this function is required by
    board-level logic if CONFIG_BOARDCTL_START_CPU is selected.
## Impact
   None
## Testing
   fc7300 (cortex M7)
