### PR TITLE
drivers/usbdev: minor update for cdcacm

### DIFF
--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -649,6 +649,14 @@ config CDCACM_NWRREQS
 	---help---
 		The number of write/read requests that can be in flight
 
+config CDCACM_BULKOUT_REQLEN
+	int "Size of one read request buffer"
+	default 512 if USBDEV_DUALSPEED
+	default 256 if !USBDEV_DUALSPEED
+	---help---
+		Read buffer size maybe larger than the maxpacket size. Increasing
+		the buffer size can effectively improve the transmission speed.
+
 config CDCACM_BULKIN_REQLEN
 	int "Size of one write request buffer"
 	default 768 if USBDEV_DUALSPEED

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -626,7 +626,7 @@ static int cdcacm_requeue_rdrequest(FAR struct cdcacm_dev_s *priv,
   /* Requeue the read request */
 
   ep       = priv->epbulkout;
-  req->len = ep->maxpacket;
+  req->len = MAX(CONFIG_CDCACM_BULKOUT_REQLEN, ep->maxpacket);
   ret      = EP_SUBMIT(ep, req);
   if (ret != OK)
     {
@@ -1332,6 +1332,11 @@ static int cdcacm_bind(FAR struct usbdevclass_driver_s *driver,
 #endif
     {
       reqlen = CONFIG_CDCACM_EPBULKOUT_FSSIZE;
+    }
+
+  if (CONFIG_CDCACM_BULKOUT_REQLEN > reqlen)
+    {
+      reqlen = CONFIG_CDCACM_BULKOUT_REQLEN;
     }
 
   for (i = 0; i < CONFIG_CDCACM_NRDREQS; i++)

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1491,7 +1491,6 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
        */
 
       cdcacm_resetconfig(priv);
-      up_mdelay(50);
 
       /* Free the pre-allocated control request */
 

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -38,7 +38,7 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 
-#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
+#if defined(CONFIG_BOARD_USBDEV_SERIALSTR) || defined(CONFIG_BOARD_USBDEV_PIDVID)
 #  include <nuttx/board.h>
 #endif
 


### PR DESCRIPTION
## Summary
1. add CDCACM_BULKOUT_REQLEN to config bulkout req len to optimize performance.
2. remove unnecessary mdelay because remain req info had beed push to serial buffer, and 
    this mdelay causes cpu busy wait, affects other process running.
3. warnning fix

## Impact
minor
## Testing
Vela
