### PR TITLE
qemu: fix smp boot not enter idle

### DIFF
--- a/arch/arm/src/qemu/qemu_cpuboot.c
+++ b/arch/arm/src/qemu/qemu_cpuboot.c
@@ -31,6 +31,7 @@
 #include <nuttx/sched.h>
 #include <arch/irq.h>
 
+#include "init/init.h"
 #include "arm_internal.h"
 #include "sctlr.h"
 #include "smp.h"
@@ -159,14 +160,8 @@ void arm_cpu_boot(int cpu)
   up_irq_enable();
 #endif
 
-  /* The next thing that we expect to happen is for logic running on CPU0
-   * to call up_cpu_start() which generate an SGI and a context switch to
-   * the configured NuttX IDLE task.
-   */
+  /* Then transfer control to the IDLE task */
 
-  for (; ; )
-    {
-      asm("WFI");
-    }
+  nx_idle_trampoline();
 }
 #endif /* CONFIG_SMP */


### PR DESCRIPTION
## Summary
fix smp boot not enter idle

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
## Impact
none

## Testing
ostest

