### PR TITLE
enable O_CLOEXEC explicitly to avoid fd leak

### DIFF
--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -569,7 +569,7 @@ static int optee_ioctl_cancel(FAR struct socket *psocket,
 static int
 optee_ioctl_shm_alloc(FAR struct tee_ioctl_shm_alloc_data *data)
 {
-  int memfd = memfd_create(OPTEE_SERVER_PATH, O_CREAT);
+  int memfd = memfd_create(OPTEE_SERVER_PATH, O_CREAT | O_CLOEXEC);
 
   if (memfd < 0)
     {

--- a/libs/libc/netdb/lib_dnsbind.c
+++ b/libs/libc/netdb/lib_dnsbind.c
@@ -69,7 +69,7 @@ int dns_bind(sa_family_t family)
 
   /* Create a new socket */
 
-  sd = socket(family, SOCK_DGRAM, 0);
+  sd = socket(family, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (sd < 0)
     {
       ret = -get_errno();

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -685,7 +685,7 @@ static int tzload(FAR const char *name,
       goto oops;
     }
 
-  fid = _NX_OPEN(name, O_RDONLY);
+  fid = _NX_OPEN(name, O_RDONLY | O_CLOEXEC);
   if (fid < 0)
     {
       goto oops;


### PR DESCRIPTION
## Summary
   enable O_CLOEXEC explicitly to avoid fd leak
## Impact
   optee, netdb, localtime
## Testing

