### PR TITLE
vfs:fix a type mismatch issue and a typo

### DIFF
--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -181,7 +181,7 @@ static int file_vioctl(FAR struct file *filep, int req, va_list ap)
                                         (unsigned long)(uintptr_t)&geo);
             if (ret >= 0)
               {
-                *(FAR blksize_t *)(uintptr_t)arg = geo.geo_nsectors;
+                *(FAR blkcnt_t *)(uintptr_t)arg = geo.geo_nsectors;
               }
           }
         break;

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -175,7 +175,7 @@ static inline int poll_teardown(FAR struct pollfd *fds, nfds_t nfds,
  * Name: poll_cleanup
  *
  * Description:
- *   Setup the poll operation for each descriptor in the list.
+ *   Cleanup the poll operation.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
    the type of geo_nsectors is blkcnt_t
## Impact
   vfs
## Testing

