### PR TITLE
libs/libc/obstack: revert invalid null byte append to obstack_vprintf

### DIFF
--- a/libs/libc/obstack/lib_obstack_vprintf.c
+++ b/libs/libc/obstack/lib_obstack_vprintf.c
@@ -104,6 +104,5 @@ int obstack_vprintf(FAR struct obstack *h, FAR const char *fmt, va_list ap)
       return ERROR;
     }
 
-  obstack_1grow(h, '\0');
   return nbytes;
 }


### PR DESCRIPTION


## Summary
The commit c4d8d937d5953930ba00a6f40ce3fdd17273f68e added null byte for obstack_vprintf and thus to obstack_printf. I probably lost my marbles but the same test I run previously now won't append null byte at the end and this "fix" now causes regressions in code using obstack.

## Impact
Reverse of the previous invalid assumption.

## Testing

For the reference this is the testing code:

```
  #define _GNU_SOURCE
  #include <obstack.h>
  #include <stdarg.h>
  #include <stdio.h>
  #include <stdlib.h>

  #define obstack_chunk_alloc malloc
  #define obstack_chunk_free free

  static void print(struct obstack *obs, const char *fmt, ...) {
    va_list arg;
    va_start(arg, fmt);
    obstack_vprintf(obs, fmt, arg);
    va_end(arg);
  }

  int main(int argc, char *argv[]) {
    struct obstack obs;
    obstack_init(&obs);

    obstack_printf(&obs, "this %s", "text ");
    obstack_printf(&obs, "is appended");
    print(&obs, " as well as %s", "vprintf text");
    obstack_1grow(&obs, '\0');

    printf("%s\n", (char *)obstack_finish(&obs));

    obstack_free(&obs, NULL);
    return 0;
  }
```

The output on NuttX without this patch:
```
  > obstest
  this text
```
The output on NuttX with this patch:
```
  > obstest
  this text is appended as well as vprintf text
```
The output with GlibC:
```
  $ gcc test.c && ./a.out
  this text is appended as well as vprintf text
  $ ldd a.out
  	linux-vdso.so.1 (0x00007ffff7fc5000)
  	libc.so.6 => /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6 (0x00007ffff7dc8000)
  	/nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/ld-linux-x86-64.so.2 => /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib64/ld-linux-x86-64.so.2 (0x00007ffff7fc7000)
```
The output with Musl (and obstack_vprintf removed):
```
  $ gcc -lobstack test-musl.c && ./a.out
  this text is appended
  $ ldd a.out
  	/nix/store/00w9nz0343pxk7hbsjzq9bzaby65hk4g-musl-1.2.3/lib/ld-musl-x86_64.so.1 (0x7ffff7f4b000)
  	libobstack.so.1 => /nix/store/qvv16dqn85qwz9vz9wvpnv435z0n5msr-musl-obstack-1.2.3/lib/libobstack.so.1 (0x7ffff7f3b000)
  	libc.so => /nix/store/00w9nz0343pxk7hbsjzq9bzaby65hk4g-musl-1.2.3/lib/ld-musl-x86_64.so.1 (0x7ffff7f4b000)
```