### PR TITLE
arch: cxd56xx: Fix issue by update of inode reference

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -104,7 +104,7 @@ static int sph_open(struct file *filep)
 {
   /* Exclusive access */
 
-  if (filep->f_inode->i_crefs > 1)
+  if (filep->f_inode->i_crefs > 2)
     {
       return ERROR;
     }

--- a/arch/arm/src/cxd56xx/cxd56_uart0.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart0.c
@@ -115,7 +115,7 @@ static int uart0_open(struct file *filep)
   int stop;
   int ret;
 
-  if (inode->i_crefs > 1)
+  if (inode->i_crefs > 2)
     {
       return OK;
     }
@@ -172,7 +172,7 @@ static int uart0_close(struct file *filep)
 {
   struct inode *inode = filep->f_inode;
 
-  if (inode->i_crefs == 1)
+  if (inode->i_crefs == 2)
     {
       fw_pd_uartdisable(0);
       fw_pd_uartuninit(0);


### PR DESCRIPTION
## Summary
Fix an issue of driver open failure caused by the following commit that changes the initial value of inode reference.
43d0d95f81 fs/inode: using inode reference to indicate unlink and simply code
https://github.com/apache/nuttx/pull/13331

## Impact

## Testing

