### PR TITLE
arm_addrenv:fix app crash when enable shm in kernel mode

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv.c
+++ b/arch/arm/src/armv7-a/arm_addrenv.c
@@ -556,7 +556,7 @@ int up_addrenv_select(const arch_addrenv_t *addrenv)
         }
       else
         {
-          binfo("data: clear l1 (vaddr=%x)\n", vaddr);
+          binfo("heap: clear l1 (vaddr=%x)\n", vaddr);
           mmu_l1_clrentry(vaddr);
         }
     }

--- a/arch/arm/src/armv7-a/arm_addrenv_utils.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_utils.c
@@ -209,6 +209,7 @@ void arm_addrenv_destroy_region(uintptr_t **list, unsigned int listlen,
           /* And free the L2 page table itself */
 
           mm_pgfree((uintptr_t)list[i], 1);
+          list[i] = NULL;
         }
     }
 }


### PR DESCRIPTION
Hello, World!!
ap> [    2.566000] [ 1] arm_addrenv_destroy_region: listlen=1
vaddr=80000000
[    2.566000] [ 1] gran_free: granmask:0xfff, gatmask:0x10000,
gatidx:0x8, priv->gat[gatidx]:0xffffffff granno:0x110 [mem:0x48110000
free_size:0x1000]
[    2.566000] [ 1] gran_free: granmask:0xfff, gatmask:0x8000,
gatidx:0x8, priv->gat[gatidx]:0xfffeffff granno:0x10f [mem:0x4810f000
free_size:0x1000]
[    2.567000] [ 1] arm_addrenv_destroy_region: listlen=1 vaddr=80100000
[    2.567000] [ 1] gran_free: granmask:0xfff, gatmask:0x40000,
gatidx:0x8, priv->gat[gatidx]:0xfffe7fff granno:0x112 [mem:0x48112000
free_size:0x1000]
[    2.567000] [ 1] gran_free: granmask:0xfff, gatmask:0x20000,
gatidx:0x8, priv->gat[gatidx]:0xfffa7fff granno:0x111 [mem:0x48111000
free_size:0x1000]
[    2.568000] [ 1] arm_addrenv_destroy_region: listlen=1 vaddr=80200000
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x100000,
gatidx:0x8, priv->gat[gatidx]:0xfff87fff granno:0x114 [mem:0x48114000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x200000,
gatidx:0x8, priv->gat[gatidx]:0xffe87fff granno:0x115 [mem:0x48115000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x400000,
gatidx:0x8, priv->gat[gatidx]:0xffc87fff granno:0x116 [mem:0x48116000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x800000,
gatidx:0x8, priv->gat[gatidx]:0xff887fff granno:0x117 [mem:0x48117000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x1000000,
gatidx:0x8, priv->gat[gatidx]:0xff087fff granno:0x118 [mem:0x48118000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x2000000,
gatidx:0x8, priv->gat[gatidx]:0xfe087fff granno:0x119 [mem:0x48119000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x4000000,
gatidx:0x8, priv->gat[gatidx]:0xfc087fff granno:0x11a [mem:0x4811a000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x8000000,
gatidx:0x8, priv->gat[gatidx]:0xf8087fff granno:0x11b [mem:0x4811b000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x10000000,
gatidx:0x8, priv->gat[gatidx]:0xf0087fff granno:0x11c [mem:0x4811c000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x20000000,
gatidx:0x8, priv->gat[gatidx]:0xe0087fff granno:0x11d [mem:0x4811d000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x40000000,
gatidx:0x8, priv->gat[gatidx]:0xc0087fff granno:0x11e [mem:0x4811e000
free_size:0x1000]
[    2.568000] [ 1] gran_free: granmask:0xfff, gatmask:0x80000000,
gatidx:0x8, priv->gat[gatidx]:0x80087fff granno:0x11f [mem:0x4811f000
free_size:0x1000]
[    2.574000] [ 1] gran_free: granmask:0xfff, gatmask:0x80000,
gatidx:0x8, priv->gat[gatidx]:0x87fff granno:0x113 [mem:0x48113000
free_size:0x1000]
[    2.574000] [ 1] arm_addrenv_destroy_region: listlen=1 vaddr=80300000
[    2.574000] [ 1] gran_free: granmask:0xfff, gatmask:0x80000,
gatidx:0x8, priv->gat[gatidx]:0x7fff granno:0x113 [mem:0x48113000
free_size:0x1000]
[    2.575000] [ 1] _assert: Current Version: NuttX  0.0.0
fa1e301238-dirty Apr 16 2024 23:18:10 arm
[    2.575000] [ 1] _assert: Assertion failed : at file:
mm_gran/mm_granfree.c:131 task: lpwork process: Kernel 0x602769

## Summary
   fix app crash when enable shm in kernel mode during boot
## Impact
  addr env
## Testing
  arm v7a qemu
