### PR TITLE
serial/pci_16550: make sure that interrupts are disabled during init

### DIFF
--- a/drivers/serial/uart_pci_16550.c
+++ b/drivers/serial/uart_pci_16550.c
@@ -546,6 +546,7 @@ static int pci_u16550_initialize(FAR struct pci_u16550_priv_s       *priv,
                                  bool                                mmio)
 {
   int ret = 0;
+  int offset;
 
   /* Configure UART PCI */
 
@@ -562,6 +563,14 @@ static int pci_u16550_initialize(FAR struct pci_u16550_priv_s       *priv,
 
   priv->common.regincr = type->regincr;
   priv->pcidev         = dev;
+
+  /* Make sure that all interrupts are disabled otherwise spurious MSI
+   * interrupt can happen just after we connect MSI.
+   */
+
+  offset = (priv->common.regincr * sizeof(uart_datawidth_t) *
+            UART_IER_OFFSET);
+  priv->common.ops->putreg(&priv->common, offset, 0);
 
   /* Allocate and connect MSI if supported */
 
@@ -585,14 +594,6 @@ legacy_irq:
   /* Get legacy IRQ if MSI not supported */
 
   priv->common.irq = pci_get_irq(dev);
-
-  /* Attach interrupts early to prevent unexpected isr fault */
-
-  ret = irq_attach(priv->common.irq, priv->common.ops->isr, dev);
-  if (ret != OK)
-    {
-      pcierr("Failed to attach irq %d\n", ret);
-    }
 
   return OK;
 }


### PR DESCRIPTION
## Summary
- serial/pci_16550: make sure that interrupts are disabled during init
    Make sure that interrups are disabled during initialization.
    This is a proper fix for an unexpected MSI interrupt for PCI serial driver.

## Impact

## Testing
intel64 hw
