### PR TITLE
risc-v: Add a new option to control exception reason

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -403,6 +403,14 @@ config ARCH_RV_VECTOR_BYTE_LENGTH
 
 endif
 
+config ARCH_RV_MACHINE_ISA_1_13
+	bool "Machine ISA Version 1.13 or later"
+	default n
+	---help---
+		Indicates support for Machine ISA Version 1.13 or later.
+		This version defined hardware error and software check exception codes,
+		which extend the range of exception codes from 0 ~ 15 to 0 ~ 19.
+
 config ARCH_RV_ISA_ZICSR_ZIFENCEI
 	bool
 	default y

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -65,16 +65,10 @@ static const char *g_reasons_str[RISCV_MAX_EXCEPTION + 1] =
   "Load page fault",
   "Reserved",
   "Store/AMO page fault",
-#if RISCV_MAX_EXCEPTION > 15
+#ifdef CONFIG_ARCH_RV_MACHINE_ISA_1_13
   "Reserved",
-#endif
-#if RISCV_MAX_EXCEPTION > 16
   "Reserved",
-#endif
-#if RISCV_MAX_EXCEPTION > 17
   "Software check",
-#endif
-#if RISCV_MAX_EXCEPTION > 18
   "Hardware error",
 #endif
 #ifdef RISCV_CUSTOM_EXCEPTION_REASONS


### PR DESCRIPTION
## Summary
The number of exception for risc-v is 16 (0 ~ 15)
for the machine ISA version 1.12 or earlier, the number of exception is 20 (0 ~ 19) from the ISA version 1.13. And maybe changed in the future.

Using a dedicated option to control the exception number to allow the earlier version chip with customized exception number (e.g. 16 ~ 19 used) to define the exception reason string correctly.

## Impact
Minor
## Testing
CI and local machine
