### PR TITLE
Support msync

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -797,6 +797,33 @@ int fs_getfilep(int fd, FAR struct file **filep)
 }
 
 /****************************************************************************
+ * Name: fs_reffilep
+ *
+ * Description:
+ *   To specify filep increase the reference count.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_REFCOUNT
+void fs_reffilep(FAR struct file *filep)
+{
+  /* This interface is used to increase the reference count of filep */
+
+  irqstate_t flags;
+
+  DEBUGASSERT(filep);
+  flags = spin_lock_irqsave(NULL);
+  filep->f_refs++;
+  spin_unlock_irqrestore(NULL, flags);
+}
+
+/****************************************************************************
  * Name: fs_putfilep
  *
  * Description:
@@ -808,7 +835,6 @@ int fs_getfilep(int fd, FAR struct file **filep)
  *            file' instance.
  ****************************************************************************/
 
-#ifdef CONFIG_FS_REFCOUNT
 int fs_putfilep(FAR struct file *filep)
 {
   irqstate_t flags;

--- a/fs/mmap/CMakeLists.txt
+++ b/fs/mmap/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # ##############################################################################
 
-set(SRCS fs_mmap.c fs_munmap.c fs_mmisc.c)
+set(SRCS fs_mmap.c fs_munmap.c fs_mmisc.c fs_msync.c)
 
 if(CONFIG_FS_RAMMAP)
   list(APPEND SRCS fs_rammap.c)

--- a/fs/mmap/Make.defs
+++ b/fs/mmap/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-CSRCS += fs_mmap.c fs_munmap.c fs_mmisc.c
+CSRCS += fs_mmap.c fs_munmap.c fs_mmisc.c fs_msync.c
 
 ifeq ($(CONFIG_FS_RAMMAP),y)
 CSRCS += fs_rammap.c

--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -44,7 +44,7 @@ static int unmap_anonymous(FAR struct task_group_s *group,
                            FAR void *start,
                            size_t length)
 {
-  FAR void *newaddr;
+  FAR void *newaddr = NULL;
   off_t offset;
   bool kernel = entry->priv.i;
   int ret = OK;

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -286,7 +286,11 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
 
   ret = file_mmap_(filep, start, length,
                    prot, flags, offset, MAP_USER, &mapped);
-  fs_putfilep(filep);
+  if (filep)
+    {
+      fs_putfilep(filep);
+    }
+
   if (ret < 0)
     {
       goto errout;

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -47,8 +47,8 @@
  ****************************************************************************/
 
 static int file_mmap_(FAR struct file *filep, FAR void *start,
-                      size_t length, int prot, int flags,
-                      off_t offset, bool kernel, FAR void **mapped)
+                      size_t length, int prot, int flags, off_t offset,
+                      enum mm_map_type_e type, FAR void **mapped)
 {
   int ret = -ENOTTY;
 
@@ -107,7 +107,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
 
   if ((flags & MAP_ANONYMOUS) != 0)
     {
-      ret = map_anonymous(&entry, kernel);
+      ret = map_anonymous(&entry, type);
 
       /* According to the mmap(2) specification, anonymous pages should be
        * initialized to zero unless the MAP_UNINITIALIZED is specified.
@@ -161,7 +161,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
        * do much better in the KERNEL build using the MMU.
        */
 
-      ret = rammap(filep, &entry, kernel);
+      ret = rammap(filep, &entry, type);
     }
 
   /* Return */
@@ -193,7 +193,7 @@ int file_mmap(FAR struct file *filep, FAR void *start, size_t length,
               int prot, int flags, off_t offset, FAR void **mapped)
 {
   return file_mmap_(filep, start, length,
-                    prot, flags, offset, true, mapped);
+                    prot, flags, offset, MAP_KERNEL, mapped);
 }
 
 /****************************************************************************
@@ -285,12 +285,8 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
     }
 
   ret = file_mmap_(filep, start, length,
-                   prot, flags, offset, false, &mapped);
-  if (fd != -1)
-    {
-      fs_putfilep(filep);
-    }
-
+                   prot, flags, offset, MAP_USER, &mapped);
+  fs_putfilep(filep);
   if (ret < 0)
     {
       goto errout;

--- a/fs/mmap/fs_msync.c
+++ b/fs/mmap/fs_msync.c
@@ -1,0 +1,95 @@
+/****************************************************************************
+ * fs/mmap/fs_msync.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/mman.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/fs/fs.h>
+#include <nuttx/sched.h>
+
+#include "inode/inode.h"
+#include "fs_rammap.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: msync
+ *
+ * Description:
+ *   Equivalent to the standard msync() function except that it accepts
+ *   a struct file instance instead of a memory address and it does not set
+ *   the errno variable.
+ *
+ * Input Parameters:
+ *   file   - A pointer to the struct file instance representing the
+ *            mappedfile
+ *   start  - The starting address of the memory region to be synchronized
+ *   length - The length of the memory region to be synchronized
+ *   flags  - Flags that determine the type of synchronization to be
+ *            performed
+ *
+ * Returned Value:
+ *   On success, returns 0 (OK); On failure, returns a negated errno value.
+ *
+ ****************************************************************************/
+
+int msync(FAR void *start, size_t length, int flags)
+{
+  FAR struct mm_map_entry_s *entry;
+  int ret;
+
+  ret = mm_map_lock();
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  entry = mm_map_find(get_current_mm(), start, length);
+  if (!entry)
+    {
+      ferr("ERROR: Region not found\n");
+      ret = -ENOMEM;
+      goto out;
+    }
+
+  if (entry->msync == NULL)
+    {
+      ret = OK;
+      goto out;
+    }
+
+  ret = entry->msync(entry, start, length, flags);
+out:
+  mm_map_unlock();
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
+}

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -43,7 +43,8 @@
  * Private Functions
  ****************************************************************************/
 
-static int file_munmap_(FAR void *start, size_t length, bool kernel)
+static int file_munmap_(FAR void *start, size_t length,
+                        enum mm_map_type_e type)
 {
   FAR struct tcb_s *tcb = this_task();
   FAR struct task_group_s *group = tcb->group;
@@ -100,7 +101,7 @@ unlock:
 
 int file_munmap(FAR void *start, size_t length)
 {
-  return file_munmap_(start, length, true);
+  return file_munmap_(start, length, MAP_KERNEL);
 }
 
 /****************************************************************************
@@ -157,7 +158,7 @@ int munmap(FAR void *start, size_t length)
 {
   int ret;
 
-  ret = file_munmap_(start, length, false);
+  ret = file_munmap_(start, length, MAP_USER);
   if (ret < 0)
     {
       set_errno(-ret);

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 #include <sys/types.h>
+#include <sys/ioctl.h>
 
 #include <assert.h>
 #include <debug.h>
@@ -55,7 +56,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
 {
   FAR void *newaddr = NULL;
   off_t offset;
-  bool kernel = entry->priv.i;
+  enum mm_map_type_e type = entry->priv.i;
   int ret = OK;
 
   /* Get the offset from the beginning of the region and the actual number
@@ -84,11 +85,11 @@ static int unmap_rammap(FAR struct task_group_s *group,
     {
       /* Free the region */
 
-      if (kernel)
+      if (type == MAP_KERNEL)
         {
           kmm_free(entry->vaddr);
         }
-      else
+      else if (type == MAP_USER)
         {
           kumm_free(entry->vaddr);
         }
@@ -104,11 +105,11 @@ static int unmap_rammap(FAR struct task_group_s *group,
 
   else
     {
-      if (kernel)
+      if (type == MAP_KERNEL)
         {
           newaddr = kmm_realloc(entry->vaddr, length);
         }
-      else
+      else if (type == MAP_USER)
         {
           newaddr = kumm_realloc(entry->vaddr, length);
         }
@@ -135,7 +136,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
  *   filep   file descriptor of the backing file -- required.
  *   entry   mmap entry information.
  *           field offset and length must be initialized correctly.
- *   kernel  kmm_zalloc or kumm_zalloc
+ *   type    kmm_zalloc or kumm_zalloc or xip_base
  *
  * Returned Value:
  *  On success, rammap returns 0 and entry->vaddr points to memory mapped.
@@ -151,13 +152,20 @@ static int unmap_rammap(FAR struct task_group_s *group,
  ****************************************************************************/
 
 int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
-           bool kernel)
+           enum mm_map_type_e type)
 {
   FAR uint8_t *rdbuffer;
   ssize_t nread;
   off_t fpos;
   int ret;
   size_t length = entry->length;
+
+  ret = file_ioctl(filep, BIOC_XIPBASE, (unsigned long)&entry->vaddr);
+  if (ret == OK)
+    {
+      type = MAP_XIP;
+      goto out;
+    }
 
   /* There is a major design flaw that I have not yet thought of fix for:
    * The goal is to have a single region of memory that represents a single
@@ -174,7 +182,7 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
 
   /* Allocate a region of memory of the specified size */
 
-  rdbuffer = kernel ? kmm_malloc(length) : kumm_malloc(length);
+  rdbuffer = type == MAP_KERNEL ? kmm_malloc(length) : kumm_malloc(length);
   if (!rdbuffer)
     {
       ferr("ERROR: Region allocation failed, length: %zu\n", length);
@@ -239,7 +247,8 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
 
   /* Add the buffer to the list of regions */
 
-  entry->priv.i = kernel;
+out:
+  entry->priv.i = type;
   entry->munmap = unmap_rammap;
 
   ret = mm_map_add(get_current_mm(), entry);
@@ -251,11 +260,11 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
   return OK;
 
 errout_with_region:
-  if (kernel)
+  if (type == MAP_KERNEL)
     {
       kmm_free(entry->vaddr);
     }
-  else
+  else if (type == MAP_USER)
     {
       kumm_free(entry->vaddr);
     }

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -56,7 +56,7 @@
 static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
                         size_t length, int flags)
 {
-  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
   FAR uint8_t *wrbuffer = start;
   ssize_t nwrite = 0;
   off_t offset;
@@ -123,8 +123,8 @@ static int unmap_rammap(FAR struct task_group_s *group,
                         FAR void *start,
                         size_t length)
 {
-  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~1);
-  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 1;
+  FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
+  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 3;
   FAR void *newaddr = NULL;
   off_t offset;
   int ret = OK;

--- a/fs/mmap/fs_rammap.h
+++ b/fs/mmap/fs_rammap.h
@@ -47,6 +47,15 @@
 #include <sys/types.h>
 #include <nuttx/mm/map.h>
 
+/* A memory mapping type definition */
+
+enum mm_map_type_e
+{
+  MAP_USER = 0,
+  MAP_KERNEL,
+  MAP_XIP,
+};
+
 #ifdef CONFIG_FS_RAMMAP
 
 /****************************************************************************
@@ -72,8 +81,7 @@
  *   length  The length of the mapping.  For exception #1 above, this length
  *           ignored:  The entire underlying media is always accessible.
  *   offset  The offset into the file to map
- *   kernel  kmm_zalloc or kumm_zalloc
- *   mapped  The pointer to the mapped area
+ *   type    kmm_zalloc or kumm_zalloc or xip_base
  *
  * Returned Value:
  *   On success rammmap returns 0. Otherwise errno is returned appropriately.
@@ -88,9 +96,9 @@
  ****************************************************************************/
 
 int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
-           bool kernel);
+           enum mm_map_type_e type);
 #else
-#  define rammap(file, entry, kernel) (-ENOSYS)
+#  define rammap(file, entry, type) (-ENOSYS)
 #endif /* CONFIG_FS_RAMMAP */
 
 #endif /* __FS_MMAP_FS_RAMMAP_H */

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1156,6 +1156,22 @@ int nx_open(FAR const char *path, int oflags, ...);
 int fs_getfilep(int fd, FAR struct file **filep);
 
 /****************************************************************************
+ * Name: fs_reffilep
+ *
+ * Description:
+ *   To specify filep increase the reference count.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void fs_reffilep(FAR struct file *filep);
+
+/****************************************************************************
  * Name: fs_putfilep
  *
  * Description:

--- a/include/nuttx/mm/map.h
+++ b/include/nuttx/mm/map.h
@@ -56,11 +56,14 @@ struct mm_map_entry_s
     int i;
   } priv;
 
-  /* Drivers which register mappings may also implement the unmap function
-   * to undo anything done in mmap.
-   * Nb. Implementation must NOT use "this_task()->group" since it is not
-   * valid during process exit. The argument "group" will be NULL in this
-   * case.
+  int (*msync)(FAR struct mm_map_entry_s *entry, FAR void *start,
+               size_t length, int flags);
+
+  /* Drivers which register mappings may also
+   * implement the unmap function to undo anything done in mmap.
+   * Nb. Implementation must NOT use "this_task()->group" since
+   * this is not valid during process exit. The argument "group" will be
+   * NULL in this case.
    */
 
   int (*munmap)(FAR struct task_group_s *group,

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -248,6 +248,7 @@ SYSCALL_LOOKUP(fchown,                     3)
 SYSCALL_LOOKUP(utimens,                    2)
 SYSCALL_LOOKUP(lutimens,                   2)
 SYSCALL_LOOKUP(futimens,                   2)
+SYSCALL_LOOKUP(msync,                      3)
 SYSCALL_LOOKUP(munmap,                     2)
 
 #if defined(CONFIG_PSEUDOFS_SOFTLINKS)

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -77,6 +77,7 @@
 "mq_timedreceive","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","ssize_t","mqd_t","FAR char *","size_t","FAR unsigned int *","FAR const struct timespec *"
 "mq_timedsend","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","mqd_t","FAR const char *","size_t","unsigned int","FAR const struct timespec *"
 "mq_unlink","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","FAR const char *"
+"msync","sys/mman.h","","int","FAR void *","size_t","int"
 "munmap","sys/mman.h","","int","FAR void *","size_t"
 "nanosleep","time.h","","int","FAR const struct timespec *","FAR struct timespec *"
 "nx_mkfifo","nuttx/fs/fs.h","defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0","int","FAR const char *","mode_t","size_t"


### PR DESCRIPTION
## Summary
**Why is this change necessary**
In some external test cases (such as FIO), they use the msync interface provided by the system to ensure that the rammap data can actually be written to the file system. Currently, mmap in NuttX does not provide this interface, so msync is implemented.

**Changes**
This mainly adds fs_msync.c under fs/mmap. And makes some adjustments to rammap.c and anonmap.c

**Implementation details**
Each mmap corresponds to an mm_map entry. The priv.p of each entry is used to save filep + type (the lower three bits of each priv.p represent type).
At each msync, the lower three bits of type need to be restored to filep and the data written

Refer to https://github.com/apache/nuttx/pull/5997 and implement an msync based on the current mmap
Follow https://man7.org/linux/man-pages/man2/msync.2.html

## Impact
* **Is a new feature added?** YES, the `msync()` system call is now supported.
* **Impact on user:** YES, users can now utilize `msync()` to synchronize memory-mapped files with their corresponding files on disk. This is essential for applications that require data consistency between memory and storage.
* **Impact on build:** NO, the build process remains unchanged. No new build options or dependencies are introduced.
* **Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards. 
* **Impact on documentation:** YES, documentation updates are required to describe the new `msync()` functionality and its usage. These updates are included in this PR.
* **Impact on security:**  The addition of `msync()` itself doesn't introduce new security vulnerabilities, however, improper usage of `msync()` by application developers could potentially lead to data corruption or inconsistencies. 
* **Impact on compatibility:**  This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh

Based on anonymous mapping and rammap demo is OK. 
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>
#include <unistd.h>

int main() {
    const char *text = "This is a demo of anonymous mmap!";
    size_t length = strlen(text) + 1; 

    char *map = mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
    if (map == MAP_FAILED) {
        perror("mmap");
        return 1;
    }

    memcpy(map, text, length);

    printf("Mapped memory contains: %s\n", map);

    if (munmap(map, length) == -1) {
        perror("munmap");
        return 1;
    }

    return 0;
}
```

```
#include <stdio.h>
#include <stdlib.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <string.h>

int main(int argc, char *argv[]) {
    const char *filepath = "example.txt";
    const char *text = "This is a demo of mmap!";
    
    int fd = open(filepath, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
    if (fd == -1) {
        perror("open");
        return 1;
    }

    size_t filesize = strlen(text);
    if (ftruncate(fd, filesize) == -1) {
        perror("ftruncate");
        close(fd);
        return 1;
    }

    char *map = mmap(NULL, filesize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
    if (map == MAP_FAILED) {
        perror("mmap");
        close(fd);
        return 1;
    }

    memcpy(map, text, filesize);

    if (msync(map, filesize, MS_SYNC) == -1) {
        perror("msync");
    }

    if (munmap(map, filesize) == -1) {
        perror("munmap");
    }

    close(fd);
    
    printf("File mapped and modified successfully.\n");

    return 0;
}
```
