### PR TITLE
fs: Dump the list of files when the file description runs out

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -132,6 +132,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   if (CONFIG_NFILE_DESCRIPTORS_PER_BLOCK * orig_rows > OPEN_MAX)
     {
+      files_dumplist(list);
       return -EMFILE;
     }
 


### PR DESCRIPTION
## Summary
Dump the list of files when the file description runs out
## Impact
Output detailed logs when file description runs out
## Testing
CI-CHECK

