### PR TITLE
qemu:fix sabre-6quad boot failed with kernel mode

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -43,7 +43,10 @@ SYSCALL_LOOKUP(sched_setparam,             2)
 SYSCALL_LOOKUP(sched_setscheduler,         3)
 SYSCALL_LOOKUP(sched_unlock,               0)
 SYSCALL_LOOKUP(sched_yield,                0)
+
 SYSCALL_LOOKUP(nxsched_get_stackinfo,      2)
+SYSCALL_LOOKUP(nxsched_self,               0)
+SYSCALL_LOOKUP(nxsched_get_tcb,            1)
 
 #ifdef CONFIG_SCHED_BACKTRACE
   SYSCALL_LOOKUP(sched_backtrace,          4)

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -84,6 +84,8 @@
 "nx_pthread_exit","nuttx/pthread.h","!defined(CONFIG_DISABLE_PTHREAD)","noreturn","pthread_addr_t"
 "nx_vsyslog","nuttx/syslog/syslog.h","","int","int","FAR const IPTR char *","FAR va_list *"
 "nxsched_get_stackinfo","nuttx/sched.h","","int","pid_t","FAR struct stackinfo_s *"
+"nxsched_self","nuttx/sched.h","","FAR struct tcb_s *"
+"nxsched_get_tcb","nuttx/sched.h","","FAR struct tcb_s *","pid_t"
 "nxsem_clockwait","nuttx/semaphore.h","","int","FAR sem_t *","clockid_t","FAR const struct timespec *"
 "nxsem_close","nuttx/semaphore.h","defined(CONFIG_FS_NAMED_SEMAPHORES)","int","FAR sem_t *"
 "nxsem_destroy","nuttx/semaphore.h","","int","FAR sem_t *"


### PR DESCRIPTION
## Summary
   fix sabre-6quad boot failed with kernel mode, for the lack of two syscall api nxsched_self and nxsched_get_tcb

![image](https://github.com/user-attachments/assets/c80f160f-55af-45df-8881-15b79ad08b33)

## Impact
* Is new feature added? NO
* Is existing feature changed? YES (Kernel mode functionality on sabre-6quad).
* Impact on user? Potentially YES, users may need to rebuild their kernel modules for kernel mode."
* Impact on build? NO
* Impact on hardware? YES (specifically sabre-6quad).
* Impact on documentation?  NO 
* Impact on security? /NO 
* Impact on compatibility? NO 
* 
## Testing
./tools/configure.sh sabre-6quad:knsh
make -j10
make export V=1
cd ../apps
./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
make import 
cd ../nuttx
qemu-system-arm -semihosting -M sabrelite -m 1024 -smp 4 -nographic -kernel ./nuttx