### PR TITLE
fs/dump: correct SCHED_DUMP_ON_EXIT to DUMP_ON_EXIT

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -372,6 +372,7 @@ void files_initlist(FAR struct filelist *list)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_DUMP_ON_EXIT
 void files_dumplist(FAR struct filelist *list)
 {
   int count = files_countlist(list);
@@ -424,6 +425,7 @@ void files_dumplist(FAR struct filelist *list)
             );
     }
 }
+#endif
 
 /****************************************************************************
  * Name: files_getlist

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -877,7 +877,11 @@ void files_initlist(FAR struct filelist *list);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_DUMP_ON_EXIT
 void files_dumplist(FAR struct filelist *list);
+#else
+#  define files_dumplist(l)
+#endif
 
 /****************************************************************************
  * Name: files_getlist

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -422,7 +422,7 @@ static void dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
  * Name: dump_filelist
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_DUMP_ON_EXIT
+#ifdef CONFIG_DUMP_ON_EXIT
 static void dump_filelist(FAR struct tcb_s *tcb, FAR void *arg)
 {
   FAR struct filelist *filelist = &tcb->group->tg_filelist;
@@ -512,7 +512,7 @@ static void dump_tasks(void)
   nxsched_foreach(dump_backtrace, NULL);
 #endif
 
-#ifdef CONFIG_SCHED_DUMP_ON_EXIT
+#ifdef CONFIG_DUMP_ON_EXIT
   nxsched_foreach(dump_filelist, NULL);
 #endif
 }


### PR DESCRIPTION
## Summary

fs/dump: correct SCHED_DUMP_ON_EXIT to DUMP_ON_EXIT

1. correct SCHED_DUMP_ON_EXIT to DUMP_ON_EXIT
2. dump file list only if DUMP_ON_EXIT enabled

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

## Testing

ci-check