### PR TITLE
sched: move DUMP_ON_EXIT to sched

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1046,12 +1046,6 @@ config ARCH_STACKDUMP_MAX_LENGTH
 	depends on ARCH_STACKDUMP
 	default 0
 
-config DUMP_ON_EXIT
-	bool "Dump all tasks state on exit"
-	default n
-	---help---
-		Dump all tasks state on exit()
-
 config ARCH_USBDUMP
 	bool "Dump USB trace data"
 	default n

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1617,11 +1617,11 @@ size_t nxsched_collect_deadlock(FAR pid_t *pid, size_t count);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DUMP_ON_EXIT
+#ifdef CONFIG_SCHED_DUMP_ON_EXIT
 void nxsched_dumponexit(void);
 #else
 #  define nxsched_dumponexit()
-#endif /* CONFIG_DUMP_ON_EXIT */
+#endif /* CONFIG_SCHED_DUMP_ON_EXIT */
 
 #ifdef CONFIG_SMP
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -793,6 +793,12 @@ config SCHED_DUMP_LEAK
 		are printed using syslog. This helps catch any memory allocated by the
 		task that remains unreleased when the task exits.
 
+config SCHED_DUMP_ON_EXIT
+	bool "Dump all tasks state on exit"
+	default n
+	---help---
+		Dump all tasks state on exit()
+
 config SCHED_USER_IDENTITY
 	bool "Support per-task User Identity"
 	default n

--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -118,7 +118,7 @@ if(CONFIG_SCHED_BACKTRACE)
   list(APPEND SRCS sched_backtrace.c)
 endif()
 
-if(CONFIG_DUMP_ON_EXIT)
+if(CONFIG_SCHED_DUMP_ON_EXIT)
   list(APPEND SRCS sched_dumponexit.c)
 endif()
 

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -94,7 +94,7 @@ ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sched_backtrace.c
 endif
 
-ifeq ($(CONFIG_DUMP_ON_EXIT),y)
+ifeq ($(CONFIG_SCHED_DUMP_ON_EXIT),y)
 CSRCS += sched_dumponexit.c
 endif
 

--- a/sched/sched/sched_dumponexit.c
+++ b/sched/sched/sched_dumponexit.c
@@ -35,7 +35,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_DUMP_ON_EXIT
+#ifdef CONFIG_SCHED_DUMP_ON_EXIT
 
 /****************************************************************************
  * Private Functions
@@ -84,4 +84,4 @@ void nxsched_dumponexit(void)
   nxsched_foreach(dumphandler, NULL);
 }
 
-#endif /* CONFIG_DUMP_ON_EXIT */
+#endif /* CONFIG_SCHED_DUMP_ON_EXIT */


### PR DESCRIPTION
## Summary
Change DUMP_ON_EXIT to CONFIG_SCHED_DUMP_ON_EXIT and move it to the sched directory

## Impact
Fix the bug in https://github.com/apache/nuttx/pull/13118, It uses undefined macros

## Testing

