### PR TITLE
sched/signal: Simplified Implementation for SIGEV_THREAD_TID

### DIFF
--- a/boards/arm/stm32/olimex-stm32-p407/scripts/memory.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/memory.ld
@@ -92,7 +92,7 @@ MEMORY
 
   /* 112Kb of contiguous SRAM */
 
-  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 16K
-  usram (rwx)      : ORIGIN = 0x20004000, LENGTH = 16K
-  xsram (rwx)      : ORIGIN = 0x20008000, LENGTH = 80K
+  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 8K
+  usram (rwx)      : ORIGIN = 0x20002000, LENGTH = 8K
+  xsram (rwx)      : ORIGIN = 0x20008000, LENGTH = 96K
 }

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -63,9 +63,11 @@
 
 struct sigwork_s
 {
+#ifdef CONFIG_SIG_EVTHREAD
   struct work_s work;           /* Work queue structure */
   union sigval value;           /* Data passed with notification */
   sigev_notify_function_t func; /* Notification function */
+#endif
 };
 
 #ifdef __cplusplus

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -600,7 +600,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
  *
  ****************************************************************************/
 
-int nxsig_dispatch(pid_t pid, FAR siginfo_t *info)
+int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
 {
 #ifdef HAVE_GROUP_MEMBERS
   FAR struct tcb_s *stcb;
@@ -631,16 +631,29 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info)
 
   if (group != NULL)
     {
-      /* Yes.. call group_signal() to send the signal to the correct group
-       * member.
-       */
+      if (thread)
+        {
+          /* Before the notification, we should validate the tid and
+           * and make sure that the notified thread is in same process
+           * with the current thread.
+           */
 
-      return group_signal(group, info);
+          if (stcb != NULL && group == this_task()->group)
+            {
+              return nxsig_tcbdispatch(stcb, info);
+            }
+        }
+      else
+        {
+          /* Yes.. call group_signal() to send the signal to the correct
+           * group member.
+           */
+
+          return group_signal(group, info);
+        }
     }
-  else
-    {
-      return -ESRCH;
-    }
+
+  return -ESRCH;
 
 #else
   FAR struct tcb_s *stcb;

--- a/sched/signal/sig_kill.c
+++ b/sched/signal/sig_kill.c
@@ -109,7 +109,7 @@ int nxsig_kill(pid_t pid, int signo)
 
   /* Send the signal */
 
-  return nxsig_dispatch(pid, &info);
+  return nxsig_dispatch(pid, &info, false);
 }
 
 /****************************************************************************

--- a/sched/signal/sig_notification.c
+++ b/sched/signal/sig_notification.c
@@ -124,6 +124,7 @@ int nxsig_notification(pid_t pid, FAR struct sigevent *event,
       info.si_pid    = rtcb->pid;
       info.si_status = OK;
 #endif
+      info.si_user   = NULL;
 
       /* Some compilers (e.g., SDCC), do not permit assignment of aggregates.
        * Use of memcpy() is overkill;  We could just copy the larger of the

--- a/sched/signal/sig_queue.c
+++ b/sched/signal/sig_queue.c
@@ -106,7 +106,7 @@ int nxsig_queue(int pid, int signo, union sigval value)
 
   /* Send the signal */
 
-  return nxsig_dispatch(pid, &info);
+  return nxsig_dispatch(pid, &info, false);
 }
 
 /****************************************************************************

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -168,7 +168,8 @@ int                nxsig_default_initialize(FAR struct tcb_s *tcb);
 
 int                nxsig_tcbdispatch(FAR struct tcb_s *stcb,
                                      FAR siginfo_t *info);
-int                nxsig_dispatch(pid_t pid, FAR siginfo_t *info);
+int                nxsig_dispatch(pid_t pid, FAR siginfo_t *info,
+                                  bool thread);
 
 /* sig_cleanup.c */
 

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -191,25 +191,6 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
 
   if (evp)
     {
-      FAR struct tcb_s *ntcb;
-
-      /* Check the SIGEV_THREAD_ID and validate the tid */
-
-      if (evp->sigev_notify & SIGEV_THREAD_ID)
-        {
-          /* Make sure that the notified thread is
-           * in same process with current thread.
-           */
-
-          ntcb = nxsched_get_tcb(evp->sigev_notify_thread_id);
-
-          if (ntcb == NULL || tcb->group != ntcb->group)
-            {
-              set_errno(EINVAL);
-              return ERROR;
-            }
-        }
-
       /* Yes, copy the entire struct sigevent content */
 
       memcpy(&ret->pt_event, evp, sizeof(struct sigevent));


### PR DESCRIPTION
## Summary
This commit simplified the implementation for SIGEV_THREAD_TID and added the missing siginfo initializer.

## Impact
POSIX timer with SIGEV_THREAD_TID flag.

## Testing
Tested on QEMU using rt-tests/cyclictest.
