### PR TITLE
Fix build error of drivers/sensors/usensor.c

### DIFF
--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -27,6 +27,7 @@
 #include <nuttx/list.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/sensors/sensor.h>
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- Error Log: (job: https://github.com/apache/nuttx/actions/runs/10931837648/job/30347585490)
```
/tools/ccache/bin/cc -D__KERNEL__ -D__NuttX__ -I/github/workspace/sources/nuttx/openamp/open-amp/lib/include -I/github/workspace/sources/apps/system/argtable3/argtable3/src -I/github/workspace/sources/apps/system/uorb -I/github/workspace/sources/nuttx/sched -I/github/workspace/sources/nuttx/openamp/open-amp/lib -I/github/workspace/sources/nuttx/drivers/virtio -I/github/workspace/sources/nuttx/drivers -isystem /github/workspace/sources/nuttx/include -isystem /github/workspace/sources/nuttx/build/include -fno-common -g -m32 -fomit-frame-pointer -ffunction-sections -fdata-sections -Wstrict-prototypes -fdiagnostics-color=always -Wall -Wshadow -Wundef -DNDEBUG -fmacro-prefix-map=/github/workspace/sources/nuttx= -fmacro-prefix-map=/github/workspace/sources/apps= -fmacro-prefix-map=/github/workspace/sources/nuttx/boards/sim/sim/sim= -fmacro-prefix-map=/github/workspace/sources/nuttx/arch/sim/src/sim= -fvisibility=hidden -U_AIX -U_WIN32 -U__APPLE__ -U__FreeBSD__ -U__NetBSD__ -U__linux__ -U__sun__ -U__unix__ -U__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ -MD -MT drivers/CMakeFiles/drivers.dir/sensors/usensor.c.o -MF drivers/CMakeFiles/drivers.dir/sensors/usensor.c.o.d -o drivers/CMakeFiles/drivers.dir/sensors/usensor.c.o -c /github/workspace/sources/nuttx/drivers/sensors/usensor.c
/github/workspace/sources/nuttx/drivers/sensors/usensor.c: In function 'usensor_get_info':
Warning: /github/workspace/sources/nuttx/drivers/sensors/usensor.c:228:44: warning: implicit declaration of function 'container_of'; did you mean 'list_container_of'? [-Wimplicit-function-declaration]
  228 |   FAR struct usensor_lowerhalf_s *ulower = container_of(lower,
      |                                            ^~~~~~~~~~~~
      |                                            list_container_of
Error: /github/workspace/sources/nuttx/drivers/sensors/usensor.c:229:44: error: expected expression before 'struct'
  229 |                                            struct usensor_lowerhalf_s,
      |                                            ^~~~~~
/github/workspace/sources/nuttx/drivers/sensors/usensor.c: In function 'usensor_control':
Error: /github/workspace/sources/nuttx/drivers/sensors/usensor.c:241:44: error: expected expression before 'struct'
  241 |                                            struct usensor_lowerhalf_s,
      |                                            ^~~~~~
```
- Related: https://github.com/apache/nuttx/pull/11805
## Impact
drivers/sensors/usensor.c

## Testing
```
./tools/configure.sh -l sim:rpproxy
```
