### PR TITLE
[Bugfix]Kconfig:ensure compatibility between kconfig-frontend and kconfiglib in kernel build

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -275,6 +275,7 @@ config BASE_DEFCONFIG
 
 config MODULES
 	bool
+	option modules
 	---help---
 		Automatically selected if KERNEL build is selected.
 		This selection marks the implementation of Kconfig


### PR DESCRIPTION
## Summary

After  https://github.com/apache/nuttx/pull/13452  this commit, the three-state `<m>` in kernel mode cannot be selected when using kconfig-frontend

Because kconfiglib recognizes `MODULE` configuration but not `modules` attributes,
and kconfig-frontend is compatible with the latest `modules` attributes of Linux,
we can only use the old version to use `MODULE` configuration **PLUS** `options modules` to be compatible with both.

## Impact
this is a patch for https://github.com/apache/nuttx/pull/13452
## Testing

qemu-armv8a:knsh with kconfig-frontend
qemu-armv8a:knsh with kconfiglib