### PR TITLE
greenhills support: fix the enumerated type mixed using warning

### DIFF
--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -125,7 +125,8 @@ static int unmap_rammap(FAR struct task_group_s *group,
                         size_t length)
 {
   FAR struct file *filep = (FAR void *)((uintptr_t)entry->priv.p & ~3);
-  enum mm_map_type_e type = (uintptr_t)entry->priv.p & 3;
+  enum mm_map_type_e type =
+                    (enum mm_map_type_e)((uintptr_t)entry->priv.p & 3);
   FAR void *newaddr = NULL;
   off_t offset;
   int ret = OK;


### PR DESCRIPTION
## Summary
fix the greenhills build warning on enum data type manage.

the following are the detailed warning info:
CC:  obstack/lib_obstack_printf.c "mmap/fs_rammap.c", line 126: warning #188-D: enumerated type mixed with
          another type
    enum mm_map_type_e type = (uintptr_t)entry->priv.p & 3;
                              ^

In greenhills compiler, do not allow enum mixed with another type, so we need to perform cast between enum and the truly used data type.

## Impact
has no impact on the function

## Testing
has passed the full ostest with gcc/greenhills compiler

