### PR TITLE
lib_libvsprintf.c: add Add support for %pB parameter.

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -694,6 +694,18 @@ int lib_sprintf(FAR struct lib_outstream_s *stream,
                 FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
+ * Name: lib_bsprintf
+ *
+ * Description:
+ *  Implementation of sprintf formatted output buffer data. Structure data
+ *  types must be one-byte aligned.
+ *
+ ****************************************************************************/
+
+int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
+                 FAR const void *buf);
+
+/****************************************************************************
  * Name: lib_sprintf_internal
  *
  * Description:

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -754,6 +754,19 @@ int lib_vsprintf(FAR struct lib_outstream_s *stream,
 int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                FAR const IPTR char *src, va_list ap) scanf_like(3, 0);
 
+/****************************************************************************
+ * Name: lib_bscanf
+ *
+ * Description:
+ *  Convert data into a structure according to standard formatting protocols.
+ *  For string arrays, please use "%{length}s" or "%{length}c" to specify
+ *  the length.
+ *
+ ****************************************************************************/
+
+int lib_bscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
+               FAR const IPTR char *fmt, FAR void *data);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/libs/libc/stdio/CMakeLists.txt
+++ b/libs/libc/stdio/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRCS
     lib_sscanf.c
     lib_vsscanf.c
     lib_libvscanf.c
+    lib_libbsprintf.c
     lib_libvsprintf.c
     lib_remove.c
     lib_tempnam.c

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -28,7 +28,7 @@ CSRCS += lib_perror.c lib_putchar.c lib_getchar.c lib_puts.c
 CSRCS += lib_gets_s.c lib_gets.c lib_libdgets.c
 CSRCS += lib_sscanf.c lib_vsscanf.c lib_libvscanf.c lib_libvsprintf.c
 CSRCS += lib_remove.c lib_tempnam.c lib_tmpnam.c lib_ultoa_invert.c
-CSRCS += lib_renameat.c lib_putwchar.c
+CSRCS += lib_renameat.c lib_putwchar.c lib_libbsprintf.c
 
 ifeq ($(CONFIG_LIBC_FLOATINGPOINT),y)
 CSRCS += lib_dtoa_engine.c lib_dtoa_data.c

--- a/libs/libc/stdio/README.md
+++ b/libs/libc/stdio/README.md
@@ -1,0 +1,95 @@
+# lib_libbsprintf
+  This function is mainly used to output the contents of the input structure. Most standards follow the standards of printf and scanf.
+  For detailed parameters, see:
+  1. https://en.cppreference.com/w/c/io/fprintf
+  2. https://en.cppreference.com/w/c/io/fscanf
+
+- **special**:
+  1. Float use %hf, and double for all others.
+  2. The char array is specified with %.xs. for example: "char t[30]" is specified with "%.30s", char a [20] - " %.20s "
+  3. "%u" is unsigned int.
+  4. "%d" is int.
+  5. When using %f to format a double data type, the double is truncated to 6 decimal places by default.
+  6. It is recommended that the "char[]" array be placed at the end of the structure to prevent parameter configuration errors such as "%.20s" from causing problems in parsing the entire buffer.
+- **demo**
+  1. **struct**:
+  ~~~
+  begin_packed_struct
+  struct test
+  {
+    uint8_t a;
+    uint16_t b;
+    uint32_t c;
+    int8_t d;
+    int16_t e;
+    int32_t f;
+    float g;
+    double h;
+    char i[32];
+    uint64_t j;
+    int64_t k;
+    char l;
+    unsigned char m;
+    short int n;
+    unsigned short int o;
+    int p;
+    unsigned int q;
+    long r;
+    unsigned long s;
+    long long t;
+    unsigned long long u;
+    size_t v;
+    long double w;
+  }end_packed_struct;
+  ~~~
+  1. **format string**:
+  ~~~
+  const char* sg = "           uint8_t:[%hhu]\n" \
+                   "          uint16_t:[%hu]\n" \
+                   "          uint32_t:[%u]\n" \
+                   "            int8_t:[%hhd]\n" \
+                   "           int16_t:[%hd]\n" \
+                   "           int32_t:[%d]\n" \
+                   "             float:[%hf]\n" \
+                   "            double:[%f]\n" \
+                   "            char[]:[%.32s]\n" \
+                   "          uint64_t:[%lu]\n" \
+                   "           int64_t:[%ld]\n" \
+                   "              char:[%hhd]\n" \
+                   "     unsigned char:[%hhu]\n" \
+                   "         short int:[%hd]\n" \
+                   "unsigned short int:[%hu]\n" \
+                   "               int:[%d]\n" \
+                   "      unsigned int:[%u]\n" \
+                   "              long:[%ld]\n" \
+                   "     unsigned long:[%lu]\n" \
+                   "         long long:[%lld]\n" \
+                   "unsigned long long:[%llu]\n" \
+                   "            size_t:[%uz]\n" \
+                   "       long double:[%Lf]\n";
+  ~~~
+  1. **use**:
+    -  output to terminal:
+   ~~~
+  #ifdef CONFIG_FILE_STREAM
+    struct lib_stdoutstream_s stdoutstream;
+
+    lib_stdoutstream(&stdoutstream, stdout);
+
+    flockfile(stdout);
+    lib_bsprintf(&stdoutstream.common, sv, &test_v);
+    lib_bsprintf(&stdoutstream.common, sg, &test_g);
+    funlockfile(stdout);
+  #else
+    struct lib_rawoutstream_s rawoutstream;
+    struct lib_bufferedoutstream_s outstream;
+
+    lib_rawoutstream(&rawoutstream, STDOUT_FILENO);
+    lib_bufferedoutstream(&outstream, &rawoutstream.common);
+
+    lib_bsprintf(&outstream.common, sv, &test_v);
+    lib_bsprintf(&outstream.common, sg, &test_g);
+
+    lib_stream_flush(&outstream.common);
+  #endif
+   ~~~

--- a/libs/libc/stdio/README.md
+++ b/libs/libc/stdio/README.md
@@ -1,11 +1,11 @@
-# lib_libbsprintf
-  This function is mainly used to output the contents of the input structure. Most standards follow the standards of printf and scanf.
+# lib_bsprintf
+  This function is mainly used to output the contents of the input structure. Supports standard formats for printf and scanf.
   For detailed parameters, see:
   1. https://en.cppreference.com/w/c/io/fprintf
   2. https://en.cppreference.com/w/c/io/fscanf
 
 - **special**:
-  1. Float use %hf, and double for all others.
+  1. Float use %hf, "%f" or "%lf" is double, "%Lf" is long double.
   2. The char array is specified with %.xs. for example: "char t[30]" is specified with "%.30s", char a [20] - " %.20s "
   3. "%u" is unsigned int.
   4. "%d" is int.
@@ -93,3 +93,63 @@
     lib_stream_flush(&outstream.common);
   #endif
    ~~~
+
+# lib_bscanf
+  This function adds a formatted standard scanf string to the structure(lib_bscanf).
+  1. https://zh.cppreference.com/w/c/io/fscanf
+
+- **special**:
+  1. Please use %lf for double precision, "%hf" or "%f" for float, long double ("%Lf") is not supported.
+  2. Please use %hhd or %hhu for a single char or unsigned char.
+  3. Use %hd or %hu for short int or unsigned short int.
+  4. When using %s or %c, please specify the length of the char array, such as %32s, %32c.
+  5. %s will check the string for spaces. When there are spaces in the string, it will be truncated. If you want to use string with spaces, please use %{length}c, but make sure that the length of the string can fill the array, otherwise an error will occur.
+  6. %[] collection and %n are not supported.
+
+- **demo**
+  1. **struct**:
+  Same as above
+  1. **format string**:
+  ~~~
+  #define TOSTR(str)   #str
+  #define TONNAME(name) TOSTR(name)
+
+  #define v_uint8_t    97
+  #define v_uint16_t   19299
+  #define v_uint32_t   22155
+
+  ......
+
+  #define v_l_double   -9299.9299929912122464755474
+
+  char bflag[] = "%hhu%hu%u%hhd%hd%d%f%lf%32s%llu%lld%hhd%hhu%hd%hu%d%u%ld%lu%lld%llu%zu%ld";
+
+  char binput[] = TONNAME(v_uint8_t) \
+                 " " TONNAME(v_uint16_t) \
+                 " " TONNAME(v_uint32_t) \
+                 " " TONNAME(v_int8_t) \
+                 " " TONNAME(v_int16_t) \
+                 " " TONNAME(v_int32_t) \
+                 " " TONNAME(v_float) \
+                 " " TONNAME(v_double) \
+                 " " TONNAME(v_char_arr) \
+                 " " TONNAME(v_uint64_t) \
+                 " " TONNAME(v_int64_t) \
+                 " " TONNAME(v_char) \
+                 " " TONNAME(v_u_char) \
+                 " " TONNAME(v_s_int) \
+                 " " TONNAME(v_u_s_int) \
+                 " " TONNAME(v_int) \
+                 " " TONNAME(v_u_int) \
+                 " " TONNAME(v_long) \
+                 " " TONNAME(v_u_long) \
+                 " " TONNAME(v_l_l) \
+                 " " TONNAME(v_u_l_l) \
+                 " " TONNAME(v_size_t) \
+                 " " TONNAME(v_l_double);
+  ~~~
+  3. **use**:
+  ~~~
+  struct test vg;
+  ret = lib_bscanf(binput, bflag, &vg);
+  ~~~

--- a/libs/libc/stdio/lib_libbsprintf.c
+++ b/libs/libc/stdio/lib_libbsprintf.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_libbsprintf.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/streams.h>
+#include <nuttx/compiler.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
+                 FAR const void *buf)
+{
+  begin_packed_struct union
+    {
+      char c;
+      short int si;
+      int i;
+      long l;
+#ifdef CONFIG_HAVE_LONG_LONG
+      long long ll;
+#endif
+      intmax_t im;
+      size_t sz;
+      ptrdiff_t pd;
+      uintptr_t p;
+#ifdef CONFIG_HAVE_DOUBLE
+      float f;
+      double d;
+#  ifdef CONFIG_HAVE_LONG_DOUBLE
+      long double ld;
+#  endif
+#endif
+    }
+
+  end_packed_struct *var;
+  FAR const char *prec = NULL;
+  FAR const char *data = buf;
+  char fmtstr[64];
+  bool infmt = false;
+  size_t offset = 0;
+  size_t ret = 0;
+  size_t len = 0;
+  char c;
+
+  while ((c = *fmt++) != '\0')
+    {
+      if (c != '%' && !infmt)
+        {
+          lib_stream_putc(s, c);
+          ret++;
+          continue;
+        }
+
+      if (!infmt)
+        {
+          len = 0;
+          infmt = true;
+          memset(fmtstr, 0, sizeof(fmtstr));
+        }
+
+      var = (FAR void *)((char *)buf + offset);
+      fmtstr[len++] = c;
+
+      if (c == 'c' || c == 'd' || c == 'i' || c == 'u' ||
+          c == 'o' || c == 'x' || c == 'X')
+        {
+          if (*(fmt - 2) == 'j')
+            {
+              offset += sizeof(var->im);
+              ret += lib_sprintf(s, fmtstr, var->im);
+            }
+#ifdef CONFIG_HAVE_LONG_LONG
+          else if (*(fmt - 2) == 'l' && *(fmt - 3) == 'l')
+            {
+              offset += sizeof(var->ll);
+              ret += lib_sprintf(s, fmtstr, var->ll);
+            }
+#endif
+          else if (*(fmt - 2) == 'l')
+            {
+              offset += sizeof(var->l);
+              ret += lib_sprintf(s, fmtstr, var->l);
+            }
+          else if (*(fmt - 2) == 'z')
+            {
+              offset += sizeof(var->sz);
+              ret += lib_sprintf(s, fmtstr, var->sz);
+            }
+          else if (*(fmt - 2) == 't')
+            {
+              offset += sizeof(var->pd);
+              ret += lib_sprintf(s, fmtstr, var->pd);
+            }
+          else if (*(fmt - 2) == 'h' && *(fmt - 3) == 'h')
+            {
+              offset += sizeof(var->c);
+              ret += lib_sprintf(s, fmtstr, var->c);
+            }
+          else if (*(fmt - 2) == 'h')
+            {
+              offset += sizeof(var->si);
+              ret += lib_sprintf(s, fmtstr, var->si);
+            }
+          else
+            {
+              offset += sizeof(var->i);
+              ret += lib_sprintf(s, fmtstr, var->i);
+            }
+
+          infmt = false;
+        }
+      else if (c == 'e' || c == 'f' || c == 'g' || c == 'a' ||
+               c == 'A' || c == 'E' || c == 'F' || c == 'G')
+        {
+#ifdef CONFIG_HAVE_DOUBLE
+          if (*(fmt - 2) == 'h')
+            {
+              offset += sizeof(var->f);
+              ret += lib_sprintf(s, fmtstr, var->f);
+            }
+#  ifdef CONFIG_HAVE_LONG_DOUBLE
+          else if (*(fmt - 2) == 'L')
+            {
+              offset += sizeof(var->ld);
+              ret += lib_sprintf(s, fmtstr, var->ld);
+            }
+#  endif
+          else
+            {
+              offset += sizeof(var->d);
+              ret += lib_sprintf(s, fmtstr, var->d);
+            }
+
+          infmt = false;
+#endif
+        }
+      else if (c == '*')
+        {
+          itoa(var->i, fmtstr + len - 1, 10);
+          len = strlen(fmtstr);
+          offset += sizeof(var->i);
+        }
+      else if (c == 's')
+        {
+          FAR const char *value = data + offset;
+
+          if (prec != NULL)
+            {
+              offset += strtol(prec, NULL, 10);
+              prec = NULL;
+            }
+          else
+            {
+              offset += strlen(value) + 1;
+            }
+
+          ret += lib_sprintf(s, fmtstr, value);
+          infmt = false;
+        }
+      else if (c == 'p')
+        {
+          offset += sizeof(var->p);
+          ret += lib_sprintf(s, fmtstr, var->p);
+          infmt = false;
+        }
+      else if (c == '.')
+        {
+          prec = fmt;
+        }
+    }
+
+  if (*(fmt - 2) != '\n')
+    {
+      lib_stream_putc(s, '\n');
+      ret++;
+    }
+
+  return ret;
+}

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -66,6 +66,29 @@
 #  define fmt_char(fmt)   (*(fmt))
 #endif
 
+#define buf_arg(buf, type) \
+  ((buf) = (FAR char *)(buf) + sizeof(*(type)0), \
+  (type)((FAR char *)(buf) - sizeof(*(type)0)))
+
+#define next_arg(varg, vabuf, type) \
+  (varg) ? va_arg((vabuf).ap, type) : buf_arg((vabuf).buf, type)
+
+#define buf_arg_width(buf, type, width) \
+  ((buf) = (FAR char *)(buf) + (width), (type)((FAR char *)(buf) - (width)))
+
+#define next_arg_width(varg, vabuf, type, width) \
+  (varg) ? va_arg((vabuf).ap, type) : buf_arg_width((vabuf).buf, type, width)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+union vabuf_u
+{
+  FAR const void *buf;
+  va_list ap;
+};
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -190,20 +213,17 @@ doexit:
 #endif
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: lib_vscanf
+ * Name: vscanf_internal
  *
  * Description:
  *  Stream-oriented implementation that underlies scanf family:  scanf,
- *  fscanf, vfscanf, sscanf, and vsscanf
+ *  fscanf, vfscanf, sscanf, vsscanf and bscanf.
  *
  ****************************************************************************/
 
-int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
-               FAR const IPTR char *fmt, va_list ap)
+static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
+                           FAR const IPTR char *fmt, bool varg,
+                           union vabuf_u vabuf)
 {
   int c;
   FAR char *tv;
@@ -392,7 +412,7 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
               tv = NULL;        /* To avoid warnings about begin uninitialized */
               if (!noassign)
                 {
-                  tv = va_arg(ap, FAR char *);
+                  tv = next_arg_width(varg, vabuf, FAR char *, width);
                   tv[0] = '\0';
                 }
 
@@ -454,7 +474,7 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
               tv = NULL;        /* To avoid warnings about begin uninitialized */
               if (!noassign)
                 {
-                  tv = va_arg(ap, FAR char *);
+                  tv = next_arg_width(varg, vabuf, FAR char *, width);
                   tv[0] = '\0';
                 }
 
@@ -513,7 +533,7 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
               tv = NULL;        /* To avoid warnings about being uninitialized */
               if (!noassign)
                 {
-                  tv = va_arg(ap, FAR char *);
+                  tv = next_arg_width(varg, vabuf, FAR char *, width);
                   tv[0] = '\0';
                 }
 
@@ -583,29 +603,30 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                   switch (modifier)
                     {
                     case HH_MOD:
-                      pchar = va_arg(ap, FAR unsigned char *);
+                      pchar = next_arg(varg, vabuf, FAR unsigned char *);
                       *pchar = 0;
                       break;
 
                     case H_MOD:
-                      pshort = va_arg(ap, FAR unsigned short *);
+                      pshort = next_arg(varg, vabuf, FAR unsigned short *);
                       *pshort = 0;
                       break;
 
                     case NO_MOD:
-                      pint = va_arg(ap, FAR unsigned int *);
+                      pint = next_arg(varg, vabuf, FAR unsigned int *);
                       *pint = 0;
                       break;
 
                     default:
                     case L_MOD:
-                      plong = va_arg(ap, FAR unsigned long *);
+                      plong = next_arg(varg, vabuf, FAR unsigned long *);
                       *plong = 0;
                       break;
 
 #ifdef CONFIG_HAVE_LONG_LONG
                     case LL_MOD:
-                      plonglong = va_arg(ap, FAR unsigned long long *);
+                      plonglong = next_arg(varg, vabuf,
+                                           FAR unsigned long long *);
                       *plonglong = 0;
                       break;
 #endif
@@ -974,14 +995,14 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
 #ifdef CONFIG_HAVE_DOUBLE
                   if (modifier >= L_MOD)
                     {
-                      pd = va_arg(ap, FAR double *);
+                      pd = next_arg(varg, vabuf, FAR double *);
                       *pd = 0.0;
                     }
                   else
 #endif
 #ifdef CONFIG_HAVE_FLOAT
                     {
-                      pf = va_arg(ap, FAR float *);
+                      pf = next_arg(varg, vabuf, FAR float *);
                       *pf = 0.0;
                     }
 #endif
@@ -1177,29 +1198,30 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                   switch (modifier)
                     {
                     case HH_MOD:
-                      pchar = va_arg(ap, FAR unsigned char *);
+                      pchar = next_arg(varg, vabuf, FAR unsigned char *);
                       *pchar = (unsigned char)nchars;
                       break;
 
                     case H_MOD:
-                      pshort = va_arg(ap, FAR unsigned short *);
+                      pshort = next_arg(varg, vabuf, FAR unsigned short *);
                       *pshort = (unsigned short)nchars;
                       break;
 
                     case NO_MOD:
-                      pint = va_arg(ap, FAR unsigned int *);
+                      pint = next_arg(varg, vabuf, FAR unsigned int *);
                       *pint = (unsigned int)nchars;
                       break;
 
                     default:
                     case L_MOD:
-                      plong = va_arg(ap, FAR unsigned long *);
+                      plong = next_arg(varg, vabuf, FAR unsigned long *);
                       *plong = (unsigned long)nchars;
                       break;
 
 #ifdef CONFIG_HAVE_LONG_LONG
                     case LL_MOD:
-                      plonglong = va_arg(ap, FAR unsigned long long *);
+                      plonglong = next_arg(varg, vabuf,
+                                           FAR unsigned long long *);
                       *plonglong = (unsigned long long)nchars;
                       break;
 #endif
@@ -1266,4 +1288,51 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
 
   *lastc = c;
   return (count || !conv) ? assigncount : EOF;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_vscanf
+ *
+ * Description:
+ *  Stream-oriented implementation that underlies scanf family:  scanf,
+ *  fscanf, vfscanf, sscanf, and vsscanf
+ *
+ ****************************************************************************/
+
+int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
+               FAR const IPTR char *fmt, va_list ap)
+{
+  union vabuf_u vabuf;
+  int ret;
+
+  va_copy(vabuf.ap, ap);
+  ret = vscanf_internal(stream, lastc, fmt, true, vabuf);
+  va_end(vabuf.ap);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: lib_bscanf
+ *
+ * Description:
+ *  Convert data into a structure according to standard formatting protocols.
+ *  For string arrays, please use "%{length}s" or "%{length}c" to specify
+ *  the length.
+ *
+ ****************************************************************************/
+
+int lib_bscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
+               FAR const IPTR char *fmt, FAR void *data)
+{
+  union vabuf_u vabuf =
+    {
+      data
+    };
+
+  return vscanf_internal(stream, lastc, fmt, false, vabuf);
 }

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1117,6 +1117,14 @@ str_lpad:
               c = fmt_char(fmt);
               switch (c)
                 {
+                  case 'B':
+                    {
+                      FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;
+
+                      lib_bsprintf(stream, vaf->fmt, vaf->va);
+                      continue;
+                    }
+
                   case 'V':
                     {
                       FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;


### PR DESCRIPTION
## **Summary**
  lib_libvsprintf.c: add Add support for %pB parameter.
## **Impact**
None，Only uorb info call。
## Testing
      struct va_format vaf;
      vaf.fmt = "%d%hf%lf";
      vaf.va  = &ap;
      printf("%s:%pB", str, vaf);
