### PR TITLE
lib_libvsprintf.c: add Add support for %pB parameter.

### DIFF
--- a/libs/libc/misc/lib_err.c
+++ b/libs/libc/misc/lib_err.c
@@ -55,30 +55,38 @@ do                         \
 
 void vwarn(FAR const char *fmt, va_list ap)
 {
+#ifdef CONFIG_LIBC_PRINT_EXTENSION
   int error = get_errno();
   struct va_format vaf;
 
-#ifdef va_copy
+#  ifdef va_copy
   va_list copy;
 
   va_copy(copy, ap);
 
   vaf.fmt = fmt;
   vaf.va  = &copy;
-#else
+#  else
   vaf.fmt = fmt;
   vaf.va  = &ap;
-#endif
+#  endif
 
-#ifdef CONFIG_FILE_STREAM
+#  ifdef CONFIG_FILE_STREAM
   fprintf(stderr, "%d: %pV: %s\n", _SCHED_GETTID(), &vaf, strerror(error));
-#else
+#  else
   dprintf(STDERR_FILENO, "%d: %pV: %s\n", _SCHED_GETTID(),
                                           &vaf, strerror(error));
-#endif
+#  endif
 
-#ifdef va_copy
+#  ifdef va_copy
   va_end(copy);
+#  endif
+#else
+#  ifdef CONFIG_FILE_STREAM
+  vfprintf(stderr, fmt, ap);
+#  else
+  vdprintf(STDERR_FILENO, fmt, ap);
+#  endif
 #endif
 }
 
@@ -88,28 +96,36 @@ void vwarn(FAR const char *fmt, va_list ap)
 
 void vwarnx(FAR const char *fmt, va_list ap)
 {
+#ifdef CONFIG_LIBC_PRINT_EXTENSION
   struct va_format vaf;
 
-#ifdef va_copy
+#  ifdef va_copy
   va_list copy;
 
   va_copy(copy, ap);
 
   vaf.fmt = fmt;
   vaf.va  = &copy;
-#else
+#  else
   vaf.fmt = fmt;
   vaf.va  = &ap;
-#endif
+#  endif
 
-#ifdef CONFIG_FILE_STREAM
+#  ifdef CONFIG_FILE_STREAM
   fprintf(stderr, "%d: %pV\n", _SCHED_GETTID(), &vaf);
-#else
+#  else
   dprintf(STDERR_FILENO, "%d: %pV\n", _SCHED_GETTID(), &vaf);
-#endif
+#  endif
 
-#ifdef va_copy
+#  ifdef va_copy
   va_end(copy);
+#  endif
+#else
+#  ifdef CONFIG_FILE_STREAM
+  vfprintf(stderr, fmt, ap);
+#  else
+  vdprintf(STDERR_FILENO, fmt, ap);
+#  endif
 #endif
 }
 

--- a/libs/libc/stdio/Kconfig
+++ b/libs/libc/stdio/Kconfig
@@ -106,4 +106,10 @@ config LIBC_SCANSET
 	---help---
 		Add scanset support to sscanf().
 
+config LIBC_PRINT_EXTENSION
+	bool
+	default n
+	---help---
+		Enables vsprintf supports using "%p*" to print.
+
 endmenu #Standard C I/O

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1115,6 +1115,7 @@ str_lpad:
               break;
 
             case 'p':
+#ifdef CONFIG_LIBC_PRINT_EXTENSION
               c = fmt_char(fmt);
               switch (c)
                 {
@@ -1129,22 +1130,22 @@ str_lpad:
                   case 'V':
                     {
                       FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;
-#ifdef va_copy
+#  ifdef va_copy
                       va_list copy;
 
                       va_copy(copy, *vaf->va);
                       lib_vsprintf(stream, vaf->fmt, copy);
                       va_end(copy);
-#else
+#  else
                       lib_vsprintf(stream, vaf->fmt, *vaf->va);
-#endif
+#  endif
                       continue;
                     }
 
                   case 'S':
                   case 's':
                     {
-#ifdef CONFIG_ALLSYMS
+#  ifdef CONFIG_ALLSYMS
                       FAR const struct symtab_s *symbol;
                       FAR void *addr = (FAR void *)(uintptr_t)x;
                       size_t symbolsize;
@@ -1169,7 +1170,7 @@ str_lpad:
 
                           continue;
                         }
-#endif
+#  endif
                       break;
                     }
 
@@ -1177,6 +1178,7 @@ str_lpad:
                     fmt_ungetc(fmt);
                     break;
                 }
+#endif
 
               flags |= FL_ALT;
 

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1118,6 +1118,14 @@ str_lpad:
               c = fmt_char(fmt);
               switch (c)
                 {
+                  case 'B':
+                    {
+                      FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;
+
+                      lib_bsprintf(stream, vaf->fmt, vaf->va);
+                      continue;
+                    }
+
                   case 'V':
                     {
                       FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;

--- a/libs/libc/symtab/Kconfig
+++ b/libs/libc/symtab/Kconfig
@@ -5,6 +5,7 @@
 
 config ALLSYMS
 	bool "Load all symbols for debugging"
+	select LIBC_PRINT_EXTENSION
 	default n
 	---help---
 		Say Y here to let the nuttx print out symbolic crash information and


### PR DESCRIPTION
## Summary

1. This is a new function that implements the method of printing the serialized data of the structure in a similar way to %pV %pS.
2. Add LIBC_PRINT_EXTENSION option to control the opening of %p*, which is closed by default

## Impact
  None. This is a new parameter parsing and does not affect existing parameters.
## Testing
```
pc: ubuntu 20.04,x86, SIM

void orb_info(FAR const char *format, FAR const char *name,
              FAR const void *data)
{
  struct lib_stdoutstream_s stdoutstream;
  struct va_format vaf;

  vaf.fmt = format;
  vaf.va  = (va_list *)data;

  lib_stdoutstream(&stdoutstream, stdout);
  lib_sprintf(&stdoutstream.common, "%s(now:%" PRIu64 "):%pB\n",
              name, orb_absolute_time(), &vaf);
}
```
order: `uorb_listener -n 10 sensor_accel_uncal`
out:
```
Mointor objects num:1
object_name:sensor_accel_uncal, object_instance:0
sensor_accel_uncal(now:57777592500):timestamp:57777591900,x:0.081402,y:0.689530,z:9.897630,temperature:31.253906
sensor_accel_uncal(now:57777632700):timestamp:57777632300,x:0.126893,y:0.792481,z:9.911995,temperature:31.253906
sensor_accel_uncal(now:57777672800):timestamp:57777672500,x:0.055066,y:0.708684,z:9.892841,temperature:31.253906
sensor_accel_uncal(now:57777713500):timestamp:57777713200,x:0.107739,y:0.682347,z:9.861717,temperature:31.253906
sensor_accel_uncal(now:57777754000):timestamp:57777753500,x:-0.040701,y:0.677559,z:9.751583,temperature:31.253906
sensor_accel_uncal(now:57777794200):timestamp:57777793800,x:0.117316,y:0.751779,z:9.797073,temperature:31.253906
sensor_accel_uncal(now:57777834600):timestamp:57777834100,x:0.081402,y:0.732626,z:9.734824,temperature:31.253906
sensor_accel_uncal(now:57777874700):timestamp:57777874400,x:0.062249,y:0.711078,z:9.732430,temperature:31.253906
sensor_accel_uncal(now:57777915000):timestamp:57777914700,x:0.114922,y:0.826000,z:9.742006,temperature:31.253906
sensor_accel_uncal(now:57777955600):timestamp:57777955000,x:0.098162,y:0.756568,z:9.809045,temperature:31.253906

```

`timestamp:57777591900,x:0.081402,y:0.689530,z:9.897630,temperature:31.253906` is B parameter output results