### PR TITLE
mmcsd: fix a build error

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -164,8 +164,10 @@ static int     mmcsd_stoptransmission(FAR struct mmcsd_state_s *priv);
 #endif
 static int     mmcsd_setblocklen(FAR struct mmcsd_state_s *priv,
                                  uint32_t blocklen);
+#if MMCSD_MULTIBLOCK_LIMIT != 1
 static int     mmcsd_setblockcount(FAR struct mmcsd_state_s *priv,
                                    uint32_t nblocks);
+#endif
 static ssize_t mmcsd_readsingle(FAR struct mmcsd_state_s *priv,
                                 FAR uint8_t *buffer, off_t startblock);
 #if MMCSD_MULTIBLOCK_LIMIT != 1
@@ -1408,6 +1410,7 @@ static int mmcsd_setblocklen(FAR struct mmcsd_state_s *priv,
   return ret;
 }
 
+#if MMCSD_MULTIBLOCK_LIMIT != 1
 /****************************************************************************
  * Name: mmcsd_setblockcount
  *
@@ -1430,6 +1433,7 @@ static int mmcsd_setblockcount(FAR struct mmcsd_state_s *priv,
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: mmcsd_readsingle


### PR DESCRIPTION
## Summary
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
Error: mmcsd/mmcsd_sdio.c:1419:12: error: 'mmcsd_setblockcount' defined but not used [-Werror=unused-function]
 1419 | static int mmcsd_setblockcount(FAR struct mmcsd_state_s *priv,
      |            ^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:103: mmcsd_sdio.o] Error 1
make[1]: Target 'libdrivers.a' not remade because of errors.
make: *** [tools/LibTargets.mk:101: drivers/libdrivers.a] Error 2
make: Target 'all' not remade because of errors.
## Impact
  build break
## Testing
  ci test
