### PR TITLE
 sensor:Fixed the problem of user information lag in cross-core communication "stublist".

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -456,9 +456,17 @@ static ssize_t sensor_do_samples(FAR struct sensor_upperhalf_s *upper,
 
   if (user->state.interval == UINT32_MAX)
     {
-      ret = circbuf_peekat(&upper->buffer,
-                           user->bufferpos * upper->state.esize,
-                           buffer, len);
+      if (buffer != NULL)
+        {
+          ret = circbuf_peekat(&upper->buffer,
+                               user->bufferpos * upper->state.esize,
+                               buffer, len);
+        }
+      else
+        {
+          ret = len;
+        }
+
       user->bufferpos += nums;
       circbuf_peekat(&upper->timing,
                      (user->bufferpos - 1) * TIMING_BUF_ESIZE,
@@ -506,9 +514,17 @@ static ssize_t sensor_do_samples(FAR struct sensor_upperhalf_s *upper,
               ((user->state.generation + user->state.interval) << 1);
       if (delta >= 0)
         {
-          ret += circbuf_peekat(&upper->buffer,
-                                (pos - 1) * upper->state.esize,
-                                buffer + ret, upper->state.esize);
+          if (buffer != NULL)
+            {
+              ret += circbuf_peekat(&upper->buffer,
+                                    (pos - 1) * upper->state.esize,
+                                    buffer + ret, upper->state.esize);
+            }
+          else
+            {
+              ret += upper->state.esize;
+            }
+
           user->bufferpos = pos;
           user->state.generation += user->state.interval;
           if (ret >= len)
@@ -701,7 +717,7 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
   FAR struct sensor_user_s *user = filep->f_priv;
   ssize_t ret;
 
-  if (!buffer || !len)
+  if (!len)
     {
       return -EINVAL;
     }
@@ -709,6 +725,11 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
   nxrmutex_lock(&upper->lock);
   if (lower->ops->fetch)
     {
+      if (buffer == NULL)
+        {
+          return -EINVAL;
+        }
+
       if (!(filep->f_oflags & O_NONBLOCK))
         {
           nxrmutex_unlock(&upper->lock);
@@ -738,11 +759,18 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
     }
   else if (lower->persist)
     {
-      /* Persistent device can get latest old data if not updated. */
+      if (buffer == NULL)
+        {
+          ret = upper->state.esize;
+        }
+      else
+        {
+          /* Persistent device can get latest old data if not updated. */
 
-      ret = circbuf_peekat(&upper->buffer,
-                           (user->bufferpos - 1) * upper->state.esize,
-                           buffer, upper->state.esize);
+          ret = circbuf_peekat(&upper->buffer,
+                               (user->bufferpos - 1) * upper->state.esize,
+                               buffer, upper->state.esize);
+        }
     }
   else
     {

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -1132,6 +1132,8 @@ static int sensor_rpmsg_publish_handler(FAR struct rpmsg_endpoint *ept,
 {
   FAR struct sensor_rpmsg_data_s *msg = data;
   FAR struct sensor_rpmsg_cell_s *cell;
+  FAR struct sensor_rpmsg_stub_s *stub;
+  FAR struct sensor_rpmsg_stub_s *stmp;
   FAR struct sensor_rpmsg_dev_s *dev;
   size_t written = sizeof(*msg);
 
@@ -1154,6 +1156,22 @@ static int sensor_rpmsg_publish_handler(FAR struct rpmsg_endpoint *ept,
         }
 
       dev->push_event(dev->upper, cell->data, cell->len);
+
+      /* When the remote core publishes a message, the subscribed cores will
+       * receive the message. When the subscribed core publishes a new
+       * message, it will take away the message published by the remote core,
+       * so all stublist information needs to be updated.
+       */
+
+      sensor_rpmsg_lock(dev);
+      list_for_every_entry_safe(&dev->stublist, stub, stmp,
+                                struct sensor_rpmsg_stub_s, node)
+        {
+          file_read(&stub->file, NULL, cell->len);
+        }
+
+      sensor_rpmsg_unlock(dev);
+
       written += sizeof(*cell) + cell->len + 0x7;
       written &= ~0x7;
     }


### PR DESCRIPTION
## Summary
- Bug fix. When the remote core publishes a message, the subscribed cores will receive the message. When the subscribed core publishes a new message, it will take away the message published by the remote core, so all stublist information needs to be updated.

## Impact
- Sensor cross-core communication.

## Testing
```
/****************************************************************************
 * apps/examples/hello/hello_main.c
 *
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.  The
 * ASF licenses this file to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance with the
 * License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 ****************************************************************************/

/****************************************************************************
 * Included Files
 ****************************************************************************/

#include <nuttx/config.h>
#include <stdio.h>
#include <errno.h>
#include <math.h>
#include <poll.h>
#include <string.h>
#include <stdarg.h>
#include <stdlib.h>
#include <unistd.h>
#include <inttypes.h>

#include <uORB/uORB.h>
#include <sensor/gps.h>
#include <uv.h>

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

 void cp_advertiser(void);
 void cp_subscriber(void);
 void sensor_adv_sub_er(void);

enum FakeCmd {
  FAKE_CONTROL_CMD,
  FAKE_DISTRIBUTE_CMD,
};

enum FakeAttribute {
  HELLO_QUEUE_SIZE = 5,
  HELLO_SLEEP_DURA = 20,
};

int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n");
  if (argc == 1) {
    cp_advertiser();
  } else if (argc == 2) {
    cp_subscriber();
  }else {
    sensor_adv_sub_er();
  }
  return 0;
}

 void cp_advertiser(void) {
  int instance = 0;
  int adv_fd = orb_advertise_multi_queue(ORB_ID(sensor_gps), NULL, &instance, HELLO_QUEUE_SIZE);
  syslog(3, "DEBUG_IN_HELLO, cp adv:%d\n", adv_fd);

  while(true) {
    sleep(HELLO_SLEEP_DURA);
    struct sensor_gps gps = {};
    gps.timestamp = (uint64_t)time(NULL);
    gps.time_utc = FAKE_CONTROL_CMD;
    int ret = orb_publish(ORB_ID(sensor_gps), adv_fd, &gps);
    syslog(3, "DEBUG_IN_HELLO, cp send ctl:%d,%" PRIu64 ",%" PRIu64 "\n",
           ret, gps.time_utc, gps.timestamp);
  }
}

static void cp_read_cb(uv_poll_t* handle, int status, int events) {
  struct sensor_gps gps = {};
  int* fd = (int*)(handle->data);
  read(*fd, &gps, sizeof(gps));
  syslog(3, "DEBUG_IN_HELLO, cp recv data:%" PRIu64 ",%" PRIu64 "\n",
         gps.time_utc, gps.timestamp);
}

void cp_subscriber(void) {
  int sub_fd = orb_subscribe(ORB_ID(sensor_gps));
  syslog(3, "DEBUG_IN_HELLO, cp sub:%d\n", sub_fd);

  uv_poll_t handle = {};
  handle.data = &sub_fd;
  uv_poll_init(uv_default_loop(), &handle, sub_fd);
  uv_poll_start(&handle, UV_READABLE, cp_read_cb);
  uv_run(uv_default_loop(), UV_RUN_DEFAULT);

}

struct TopicFD {
  int sub_fd;
  int adv_fd;
};

static void sensor_read_cb(uv_poll_t* handle, int status, int events) {
  struct sensor_gps gps = {};
  struct TopicFD* fds = (struct TopicFD*)handle->data;
  read(fds->sub_fd, &gps, sizeof(gps));

  syslog(3, "DEBUG_IN_HELLO, sen recv data:%" PRIu64 ",%" PRIu64 "\n",
         gps.time_utc, gps.timestamp);
  // need distribute
  if (gps.time_utc == FAKE_CONTROL_CMD) {
    gps.time_utc = FAKE_DISTRIBUTE_CMD;
    int ret = orb_publish(ORB_ID(sensor_gps), fds->adv_fd, &gps);
    syslog(3, "DEBUG_IN_HELLO, sen distribute ctl:%d,%" PRIu64 ",%" PRIu64 "\n",
           ret, gps.time_utc, gps.timestamp);
  }
}

void sensor_adv_sub_er(void) {
  int instance = 0;
  int adv_fd = orb_advertise_multi_queue(ORB_ID(sensor_gps), NULL, &instance, HELLO_QUEUE_SIZE);
  syslog(3, "DEBUG_IN_HELLO, sen adv:%d\n", adv_fd);
  int sub_fd = orb_subscribe(ORB_ID(sensor_gps));
  syslog(3, "DEBUG_IN_HELLO, sen sub:%d\n", sub_fd);

  uv_poll_t handle = {};
  struct TopicFD fds = {};
  fds.sub_fd = sub_fd;
  fds.adv_fd = adv_fd;
  handle.data = &fds;
  uv_poll_init(uv_default_loop(), &handle, sub_fd);
  uv_poll_start(&handle, UV_READABLE, sensor_read_cb);
  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
}
```
PC: ubuntu 2004,x86,SIM
1. rpserver and rpproxy open uorb config
2. build
```
./build.sh nuttx/boards/sim/sim/sim/configs/rpserver -j16
./build.sh nuttx/boards/sim/sim/sim/configs/rpproxy -j16
```
order:
rpserver:  hello &  and hello 1 &
rpproxy:  hello 1 1 &

