### PR TITLE
sensor_rpmsg.c:Fix that "stub" will be created when local core only has subscribers.

### DIFF
--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -1049,7 +1049,7 @@ static int sensor_rpmsg_sub_handler(FAR struct rpmsg_endpoint *ept,
   int ret;
 
   dev = sensor_rpmsg_find_dev(msg->path);
-  if (!dev)
+  if (!dev || (dev->nadvertisers == 0 && !dev->lower.persist))
     {
       return 0;
     }


### PR DESCRIPTION
## Summary
Bug fix, After the ap core subscribes to the 25hz batch 120ms data of the sensor core, it switches to the cp core and subscribes to the 50hz batch 120ms sensor core data. At this time, the data subscribed by the AP will be abnormally lost (12.5hz). Mainly because ap subscribes to sensor core data earlier than cp. The subscription of cp will be broadcast to the ap core at the same time, and the corresponding "path" already exists under "/dev/uorb" of ap. Thus the ap will create a "stub".
There are some restrictions on the creation of "stub" to avoid this situation.
## Impact
Cross-core communication and persistent topics
## Testing

- build
PC:ubuntu2004, X86,SIM
rpserver and rpproxy open uorb config
```
./build.sh nuttx/boards/sim/sim/sim/configs/rpserver -j16
./build.sh nuttx/boards/sim/sim/sim/configs/rpproxy -j16
```

- order:
1. rpserver 
2. rpproxy
