### PR TITLE
nuttx/uorb: Fix build error

### DIFF
--- a/drivers/sensors/adxl362_uorb.c
+++ b/drivers/sensors/adxl362_uorb.c
@@ -157,9 +157,11 @@ static const struct sensor_ops_s g_adxl362_accel_ops =
 #else
   adxl362_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   NULL,                 /* control */
 };
 

--- a/drivers/sensors/adxl362_uorb.c
+++ b/drivers/sensors/adxl362_uorb.c
@@ -107,7 +107,7 @@ struct adxl362_sensor_s
   float                      scale;
 #ifdef CONFIG_SENSORS_ADXL362_POLL
   bool                       enabled;
-  unsigned long              interval;
+  uint32_t                   interval;
   sem_t                      run;
 #endif
 };
@@ -134,7 +134,7 @@ static int adxl362_activate(FAR struct sensor_lowerhalf_s *lower,
                             bool enable);
 static int adxl362_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us);
+                                FAR uint32_t *period_us);
 #ifndef CONFIG_SENSORS_ADXL362_POLL
 static int adxl362_fetch(FAR struct sensor_lowerhalf_s *lower,
                          FAR struct file *filep,
@@ -447,7 +447,7 @@ static int adxl362_activate(FAR struct sensor_lowerhalf_s *lower,
 
 static int adxl362_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us)
+                                FAR uint32_t *period_us)
 {
 #ifdef CONFIG_SENSORS_ADXL362_POLL
   FAR struct adxl362_sensor_s *priv = (FAR struct adxl362_sensor_s *)lower;
@@ -460,7 +460,7 @@ static int adxl362_set_interval(FAR struct sensor_lowerhalf_s *lower,
 
 #ifndef CONFIG_SENSORS_ADXL362_POLL
 /****************************************************************************
- * Name: adxl362_set_interval
+ * Name: adxl362_fetch
  ****************************************************************************/
 
 static int adxl362_fetch(FAR struct sensor_lowerhalf_s *lower,

--- a/drivers/sensors/adxl372_uorb.c
+++ b/drivers/sensors/adxl372_uorb.c
@@ -105,9 +105,11 @@ static const struct sensor_ops_s g_adxl372_accel_ops =
 #else
   adxl372_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL                  /* get_info */
   NULL                  /* control */
 };
 

--- a/drivers/sensors/adxl372_uorb.c
+++ b/drivers/sensors/adxl372_uorb.c
@@ -55,7 +55,7 @@ struct adxl372_sensor_s
   int                        devno;
 #ifdef CONFIG_SENSORS_ADXL372_POLL
   bool                       enabled;
-  unsigned long              interval;
+  uint32_t                   interval;
   sem_t                      run;
 #endif
 };
@@ -82,7 +82,7 @@ static int adxl372_activate(FAR struct sensor_lowerhalf_s *lower,
                             bool enable);
 static int adxl372_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us);
+                                FAR uint32_t *period_us);
 #ifndef CONFIG_SENSORS_ADXL372_POLL
 static int adxl372_fetch(FAR struct sensor_lowerhalf_s *lower,
                          FAR struct file *filep,
@@ -412,7 +412,7 @@ static int adxl372_activate(FAR struct sensor_lowerhalf_s *lower,
 
 static int adxl372_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us)
+                                FAR uint32_t *period_us)
 {
 #ifdef CONFIG_SENSORS_ADXL372_POLL
   FAR struct adxl372_sensor_s *priv = (FAR struct adxl372_sensor_s *)lower;

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -60,7 +60,7 @@ struct bh1749nuc_sensor_s
   int                                gain;
   FAR struct bh1749nuc_sensor_dev_s *dev;
 #ifdef CONFIG_SENSORS_BH1749NUC_POLL
-  unsigned long                      interval;
+  uint32_t                           interval;
   uint64_t                           last_update;
 #endif
   bool                               enabled;
@@ -93,7 +93,7 @@ static int bh1749nuc_fetch(FAR struct sensor_lowerhalf_s *lower,
 #endif
 static int bh1749nuc_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                   FAR struct file *filep,
-                                  FAR unsigned long *period_us);
+                                  FAR uint32_t *period_us);
 static int bh1749nuc_control(FAR struct sensor_lowerhalf_s *lower,
                              FAR struct file *filep,
                              int cmd, unsigned long arg);
@@ -301,7 +301,7 @@ static int bh1749nuc_control(FAR struct sensor_lowerhalf_s *lower,
 
 static int bh1749nuc_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                   FAR struct file *filep,
-                                  FAR unsigned long *interval)
+                                  FAR uint32_t *interval)
 {
 #ifdef CONFIG_SENSORS_BH1749NUC_POLL
   FAR struct bh1749nuc_sensor_s *priv = NULL;

--- a/drivers/sensors/bh1749nuc_uorb.c
+++ b/drivers/sensors/bh1749nuc_uorb.c
@@ -114,9 +114,11 @@ static const struct sensor_ops_s g_bh1749nuc_sensor_ops =
 #else
   bh1749nuc_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   bh1749nuc_control
 };
 

--- a/drivers/sensors/bme680_uorb.c
+++ b/drivers/sensors/bme680_uorb.c
@@ -422,9 +422,11 @@ static const struct sensor_ops_s g_sensor_ops =
   NULL,             /* set_interval */
   NULL,             /* batch */
   NULL,             /* fetch */
+  NULL,             /* flush */
   NULL,             /* selftest */
   NULL,             /* set_calibvalue */
   bme680_calibrate, /* calibrate */
+  NULL,             /* get_info */
   bme680_control    /* control */
 };
 

--- a/drivers/sensors/bmi270_uorb.c
+++ b/drivers/sensors/bmi270_uorb.c
@@ -126,9 +126,11 @@ static const struct sensor_ops_s g_sensor_ops =
 #else
   bmi270_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   bmi270_control
 };
 

--- a/drivers/sensors/bmi270_uorb.c
+++ b/drivers/sensors/bmi270_uorb.c
@@ -68,7 +68,7 @@ struct bmi270_sensor_s
   FAR void                  *dev;
   bool                       enabled;
 #ifdef CONFIG_SENSORS_BMI270_POLL
-  unsigned long              interval;
+  uint32_t                   interval;
 #endif
   struct bmi270_dev_s        base;
 };
@@ -93,7 +93,7 @@ static int bmi270_activate(FAR struct sensor_lowerhalf_s *lower,
                            bool enable);
 static int bmi270_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 #ifndef CONFIG_SENSORS_BMI270_POLL
 static int bmi270_fetch(FAR struct sensor_lowerhalf_s *lower,
                         FAR struct file *filep,
@@ -209,7 +209,7 @@ static int bmi270_activate(FAR struct sensor_lowerhalf_s *lower,
 
 static int bmi270_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *interval)
+                               FAR uint32_t *interval)
 {
 #ifdef CONFIG_SENSORS_BMI270_POLL
   FAR struct bmi270_sensor_s *priv = NULL;
@@ -224,7 +224,7 @@ static int bmi270_set_interval(FAR struct sensor_lowerhalf_s *lower,
 
 #ifndef CONFIG_SENSORS_BMI270_POLL
 /****************************************************************************
- * Name: bmi270_set_interval
+ * Name: bmi270_fetch
  ****************************************************************************/
 
 static int bmi270_fetch(FAR struct sensor_lowerhalf_s *lower,

--- a/drivers/sensors/bmm150_uorb.c
+++ b/drivers/sensors/bmm150_uorb.c
@@ -134,7 +134,7 @@ struct bmm150_sensor_dev_s
   uint32_t                        freq;
   mutex_t                         lock;
 #ifdef CONFIG_SENSORS_BMM150_POLL
-  unsigned long                   interval;
+  uint32_t                        interval;
   uint64_t                        last_update;
   sem_t                           run;
 #endif
@@ -153,7 +153,7 @@ static int bmm150_fetch(FAR struct sensor_lowerhalf_s *lower,
 #endif
 static int bmm150_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 
 /* Helpers */
 
@@ -579,7 +579,7 @@ errout:
 
 static int bmm150_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                   FAR struct file *filep,
-                                  FAR unsigned long *interval)
+                                  FAR uint32_t *interval)
 {
 #ifdef CONFIG_SENSORS_BMM150_POLL
   FAR struct bmm150_sensor_dev_s *dev =

--- a/drivers/sensors/bmm150_uorb.c
+++ b/drivers/sensors/bmm150_uorb.c
@@ -180,9 +180,11 @@ static const struct sensor_ops_s g_bmm150_sensor_ops =
 #else
   bmm150_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   NULL,                 /* control */
 };
 

--- a/drivers/sensors/bmp180_uorb.c
+++ b/drivers/sensors/bmp180_uorb.c
@@ -47,7 +47,7 @@ struct bmp180_dev_uorb_s
 
   struct sensor_lowerhalf_s lower; /* Lower half sensor driver. */
   struct work_s work;              /* Interrupt handler worker. */
-  unsigned long interval;          /* Sensor acquisition interval. */
+  uint32_t interval;               /* Sensor acquisition interval. */
   struct bmp180_dev_s dev;
 };
 /****************************************************************************
@@ -57,7 +57,7 @@ struct bmp180_dev_uorb_s
 static void bmp180_worker(FAR void *arg);
 static int bmp180_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 static int bmp180_activate(FAR struct sensor_lowerhalf_s *lower,
                            FAR struct file *filep,
                            bool enable);
@@ -101,7 +101,7 @@ static const struct sensor_ops_s g_bmp180_ops =
 
 static int bmp180_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us)
+                               FAR uint32_t *period_us)
 {
   FAR struct bmp180_dev_uorb_s *priv = (FAR struct bmp180_dev_uorb_s *)lower;
 

--- a/drivers/sensors/bmp280_uorb.c
+++ b/drivers/sensors/bmp280_uorb.c
@@ -165,7 +165,7 @@ static int bmp280_putreg8(FAR struct bmp280_dev_s *priv, uint8_t regaddr,
 
 static int bmp280_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 static int bmp280_activate(FAR struct sensor_lowerhalf_s *lower,
                            FAR struct file *filep,
                            bool enable);
@@ -512,7 +512,7 @@ static uint32_t bmp280_compensate_press(FAR struct bmp280_dev_s *priv,
 
 static int bmp280_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us)
+                               FAR uint32_t *period_us)
 {
   FAR struct bmp280_dev_s *priv = container_of(lower,
                                                FAR struct bmp280_dev_s,

--- a/drivers/sensors/ds18b20_uorb.c
+++ b/drivers/sensors/ds18b20_uorb.c
@@ -146,7 +146,7 @@ struct ds18b20_dev_s
   struct onewire_config_s     config;         /* 1wire device configuration */
   struct ds18b20_config_s     reg;            /* Sensor resolution */
 #ifdef CONFIG_SENSORS_DS18B20_POLL
-  unsigned long               interval;       /* Polling interval */
+  uint32_t                    interval;       /* Polling interval */
   sem_t                       run;            /* Locks sensor thread */
 #endif
 };
@@ -172,7 +172,7 @@ static int ds18b20_control(FAR struct sensor_lowerhalf_s *lower,
 #ifdef CONFIG_SENSORS_DS18B20_POLL
 static int ds18b20_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us);
+                                FAR uint32_t *period_us);
 #endif
 
 /****************************************************************************
@@ -787,7 +787,7 @@ static int ds18b20_active(FAR struct sensor_lowerhalf_s *lower,
 #ifdef CONFIG_SENSORS_DS18B20_POLL
 static int ds18b20_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us)
+                                FAR uint32_t *period_us)
 {
   FAR struct ds18b20_dev_s *priv = (FAR struct ds18b20_dev_s *)lower;
   priv->interval = *period_us;

--- a/drivers/sensors/hyt271_uorb.c
+++ b/drivers/sensors/hyt271_uorb.c
@@ -96,7 +96,7 @@ struct hyt271_dev_s
   mutex_t                 lock_measure_cycle;       /* Locks measure cycle */
   uint32_t                freq;                     /* I2C Frequency */
 #ifdef CONFIG_SENSORS_HYT271_POLL
-  unsigned long           interval;                 /* Polling interval */
+  uint32_t                interval;                 /* Polling interval */
   sem_t                   run;                      /* Locks sensor thread */
   bool                    initial_read;             /* Already read */
 #endif
@@ -123,7 +123,7 @@ static int hyt271_control(FAR struct sensor_lowerhalf_s *lower,
 #ifdef CONFIG_SENSORS_HYT271_POLL
 static int hyt271_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 #endif
 
 /****************************************************************************
@@ -758,7 +758,7 @@ static int hyt271_active(FAR struct sensor_lowerhalf_s *lower,
 #ifdef CONFIG_SENSORS_HYT271_POLL
 static int hyt271_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us)
+                               FAR uint32_t *period_us)
 {
   FAR struct hyt271_sensor_s *priv = (FAR struct hyt271_sensor_s *)lower;
   priv->dev->interval = *period_us;

--- a/drivers/sensors/lsm9ds1_uorb.c
+++ b/drivers/sensors/lsm9ds1_uorb.c
@@ -129,9 +129,11 @@ static const struct sensor_ops_s g_sensor_ops =
 #else
   .fetch        = lsm9ds1_fetch,
 #endif
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   .control      = lsm9ds1_control
 };
 

--- a/drivers/sensors/lsm9ds1_uorb.c
+++ b/drivers/sensors/lsm9ds1_uorb.c
@@ -69,7 +69,7 @@ struct lsm9ds1_sensor_s
   FAR void                  *dev;
 #ifdef CONFIG_SENSORS_LSM9DS1_POLL
   bool                       enabled;
-  unsigned long              interval;
+  uint32_t                   interval;
 #endif
   struct lsm9ds1_dev_s       base;
 };
@@ -94,7 +94,7 @@ static int lsm9ds1_activate(FAR struct sensor_lowerhalf_s *lower,
                            bool enable);
 static int lsm9ds1_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us);
+                                FAR uint32_t *period_us);
 #ifndef CONFIG_SENSORS_LSM9DS1_POLL
 static int lsm9ds1_fetch(FAR struct sensor_lowerhalf_s *lower,
                          FAR struct file *filep,
@@ -193,7 +193,7 @@ static int lsm9ds1_activate(FAR struct sensor_lowerhalf_s *lower,
 
 static int lsm9ds1_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *interval)
+                                FAR uint32_t *interval)
 {
 #ifdef CONFIG_SENSORS_LSM9DS1_POLL
   FAR struct lsm9ds1_sensor_s *priv = NULL;
@@ -242,7 +242,7 @@ static int16_t lsm9ds1_data(int16_t data)
 
 #ifndef CONFIG_SENSORS_LSM9DS1_POLL
 /****************************************************************************
- * Name: lsm9ds1_set_interval
+ * Name: lsm9ds1_fetch
  ****************************************************************************/
 
 static int lsm9ds1_fetch(FAR struct sensor_lowerhalf_s *lower,

--- a/drivers/sensors/ltr308_uorb.c
+++ b/drivers/sensors/ltr308_uorb.c
@@ -97,9 +97,11 @@ static const struct sensor_ops_s g_sensor_ops =
   NULL,               /* set_interval */
   NULL,               /* batch */
   NULL,               /* fetch */
+  NULL,               /* flush */
   NULL,               /* selftest */
   NULL,               /* set_calibvalue */
   ltr308_calibrate,   /* calibrate */
+  NULL,               /* get_info */
   NULL                /* control */
 };
 

--- a/drivers/sensors/mpu9250_uorb.c
+++ b/drivers/sensors/mpu9250_uorb.c
@@ -318,7 +318,7 @@ struct mpu9250_sensor_s
   bool                      enabled;
   float                     scale;
   float                     adj[3];
-  unsigned long             interval;
+  uint32_t                  interval;
   FAR void  *dev; /* The pointer to common device data of mpu9250 */
 };
 
@@ -340,7 +340,7 @@ struct mpu9250_dev_s
 
 static int mpu9250_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *period_us);
+                                FAR uint32_t *period_us);
 static int mpu9250_activate(FAR struct sensor_lowerhalf_s *lower,
                             FAR struct file *filep, bool enable);
 static int mpu9250_control(FAR struct sensor_lowerhalf_s *lower,
@@ -434,7 +434,7 @@ static int mpu9250_activate(FAR struct sensor_lowerhalf_s *lower,
 
 static int mpu9250_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                 FAR struct file *filep,
-                                FAR unsigned long *interval)
+                                FAR uint32_t *interval)
 {
   FAR struct mpu9250_sensor_s *priv = (FAR struct mpu9250_sensor_s *)lower;
 

--- a/drivers/sensors/mpu9250_uorb.c
+++ b/drivers/sensors/mpu9250_uorb.c
@@ -374,9 +374,11 @@ static const struct sensor_ops_s g_mpu9250_ops =
   mpu9250_set_interval, /* set_interval */
   NULL,                 /* batch */
   NULL,                 /* fetch */
+  NULL,                 /* flush */
   NULL,                 /* selftest */
   NULL,                 /* set_calibvalue */
   NULL,                 /* calibrate */
+  NULL,                 /* get_info */
   mpu9250_control       /* control */
 };
 

--- a/drivers/sensors/ms56xx_uorb.c
+++ b/drivers/sensors/ms56xx_uorb.c
@@ -96,7 +96,7 @@ struct ms56xx_dev_s
   enum ms56xx_model_e      model;     /* Model of MS56XX */
   uint32_t                 freq;      /* Bus Frequency I2C/SPI */
   struct ms56xx_calib_s    calib;     /* Calib. params from ROM */
-  unsigned long            interval;  /* Polling interval */
+  uint32_t                 interval;  /* Polling interval */
   bool                     enabled;   /* Enable/Disable MS56XX */
   sem_t                    run;       /* Locks measure cycle */
   mutex_t                  lock;      /* Manages exclusive to device */
@@ -125,7 +125,7 @@ static unsigned long ms56xx_curtime(void);
 
 static int ms56xx_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us);
+                               FAR uint32_t *period_us);
 static int ms56xx_activate(FAR struct sensor_lowerhalf_s *lower,
                            FAR struct file *filep, bool enable);
 
@@ -614,7 +614,7 @@ static uint32_t ms56xx_compensate_press(FAR struct ms56xx_dev_s *priv,
 
 static int ms56xx_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR struct file *filep,
-                               FAR unsigned long *period_us)
+                               FAR uint32_t *period_us)
 {
   FAR struct ms56xx_dev_s *priv = container_of(lower,
                                                FAR struct ms56xx_dev_s,


### PR DESCRIPTION
## Summary
New member added to `struct sensor_ops_s`, and type changed, but not update all existed code, for details, please see "Related change" below.
- Error 1:
```
  1153  Building NuttX...
  1154Error: sensors/bme680_uorb.c:428:3: error: initialization of 'int (*)(struct sensor_lowerhalf_s *, struct file *, long unsigned int)' from incompatible pointer type 'int (*)(struct sensor_lowerhalf_s *, struct file *, int,  long unsigned int)' [-Werror=incompatible-pointer-types]
  1155  428 |   bme680_control    /* control */
  1156      |   ^~~~~~~~~~~~~~
```
- Error 2:
```
      Error: sensors/ms56xx_uorb.c:145:20: error: initialization of 'int (*)(struct sensor_lowerhalf_s *, struct file *, uint32_t *)' {aka 'int (*)(struct sensor_lowerhalf_s *, struct file *, unsigned int *)'} from incompatible pointer type 'int (*)(struct sensor_lowerhalf_s *, struct file *, long unsigned int *)' [-Werror=incompatible-pointer-types]
        145 |   .set_interval  = ms56xx_set_interval,
            |                    ^~~~~~~~~~~~~~~~~~~
      sensors/ms56xx_uorb.c:145:20: note: (near initialization for 'g_sensor_ops.set_interval')
      cc1: all warnings being treated as errors
```
- Related change:
  -   .flush    : 403469336f27568e64a04bbab8c9a1bb68e61f75
  -  .get_info : 703bb7e7b3a1207951bf4f10dfab34c263c18fd9
  - unsigned log => uint32_t : b17c074a18834f2f69e465b354948f04a4b80d78
## Impact
drivers/sensors

## Testing
```
./tools/configure.sh -l esp32-devkitc:ms5611
./tools/configure.sh -l esp32-sparrow-kit:nsh
```
`esp32-devkitc:ms5611` and `esp32-sparrow-kit:nsh` compiled ok, but failed in link stage(maybe because of abnormal local env), waiting for result of CI(xtensa-01).