### PR TITLE
arch/risc-v/src/litex_ticked: Set initial tick count to known value.

### DIFF
--- a/arch/risc-v/src/litex/litex_ticked.c
+++ b/arch/risc-v/src/litex/litex_ticked.c
@@ -81,6 +81,7 @@ void up_timer_initialize(void)
 
   /* Set the timer period */
 
+  putreg32(TICK_COUNT, LITEX_TIMER0_LOAD);
   putreg32(TICK_COUNT, LITEX_TIMER0_RELOAD);
 
   /* Attach timer interrupt handler */


### PR DESCRIPTION
## Summary

The tick count should be manually set as there is no guarantee that the previous boot stage hasn't modified this count since reset.

## Impact

The fist timer expiry is always set to the tick count.

## Testing

arty_a7:knsh


