### PR TITLE
lzf:Add macro judgment to header file reference.

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -27,7 +27,9 @@
 
 #include <nuttx/config.h>
 
+#ifdef CONFIG_LIBC_LZF
 #include <lzf.h>
+#endif
 #include <stdio.h>
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #include <nuttx/fs/fs.h>


### PR DESCRIPTION
## Summary

1. bug fix，lzf.h header file reference adds macro package

## Impact

1. Libc LZF Modules

## Testing
PC：Ubuntu 20.04，X86，SIM，GCC 13.1
Configure lzf 
```
 ./tools/configure.sh sim:nsh
 ./nuttx 
```
