### PR TITLE
i2c: Optimize access to private data

### DIFF
--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -116,16 +116,16 @@ static const struct file_operations g_i2cdrvr_fops =
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int i2cdrvr_open(FAR struct file *filep)
 {
-  FAR struct inode *inode;
   FAR struct i2c_driver_s *priv;
   int ret;
 
+  /* Sanity check */
+
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
+
   /* Get our private data structure */
 
-  inode = filep->f_inode;
-
-  priv = inode->i_private;
-  DEBUGASSERT(priv);
+  priv = filep->f_inode->i_private;
 
   /* Get exclusive access to the I2C driver state structure */
 
@@ -164,16 +164,16 @@ out:
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int i2cdrvr_close(FAR struct file *filep)
 {
-  FAR struct inode *inode;
   FAR struct i2c_driver_s *priv;
   int ret;
 
+  /* Sanity check */
+
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
+
   /* Get our private data structure */
 
-  inode = filep->f_inode;
-
-  priv = inode->i_private;
-  DEBUGASSERT(priv);
+  priv = filep->f_inode->i_private;
 
   /* Get exclusive access to the I2C driver state structure */
 
@@ -207,6 +207,7 @@ static int i2cdrvr_close(FAR struct file *filep)
     {
       nxmutex_destroy(&priv->lock);
       kmm_free(priv);
+      filep->f_inode->i_private = NULL;
       return OK;
     }
 
@@ -242,19 +243,18 @@ static ssize_t i2cdrvr_write(FAR struct file *filep, FAR const char *buffer,
 
 static int i2cdrvr_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode *inode;
   FAR struct i2c_driver_s *priv;
   FAR struct i2c_transfer_s *transfer;
   int ret;
 
+  /* Sanity check */
+
+  DEBUGASSERT(filep->f_inode->i_private != NULL);
   i2cinfo("cmd=%x arg=%08lx\n", cmd, arg);
 
   /* Get our private data structure */
 
-  inode = filep->f_inode;
-
-  priv = inode->i_private;
-  DEBUGASSERT(priv);
+  priv = filep->f_inode->i_private;
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   /* Get exclusive access to the I2C driver state structure */
@@ -325,9 +325,12 @@ static int i2cdrvr_unlink(FAR struct inode *inode)
   FAR struct i2c_driver_s *priv;
   int ret;
 
-  /* Get our private data structure */
+  /* Sanity check */
 
   DEBUGASSERT(inode->i_private != NULL);
+
+  /* Get our private data structure */
+
   priv = inode->i_private;
 
   /* Get exclusive access to the I2C driver state structure */
@@ -344,6 +347,7 @@ static int i2cdrvr_unlink(FAR struct inode *inode)
     {
       nxmutex_destroy(&priv->lock);
       kmm_free(priv);
+      inode->i_private = NULL;
       return OK;
     }
 


### PR DESCRIPTION
## Summary
i2c: Optimize access to private data，this is code cleanup. Access to private data is optimized to remove unwanted variables
## Impact
NONE
## Testing
Local iic testing
