### PR TITLE
Fix greater-than-or-equal-to-zero issue

### DIFF
--- a/libs/libc/tls/tls_cleanup.c
+++ b/libs/libc/tls/tls_cleanup.c
@@ -62,7 +62,7 @@ void tls_cleanup_pop(FAR struct tls_info_s *tls, int execute)
       /* Get the index to the last cleaner function pushed onto the stack */
 
       ndx = tls->tl_tos - 1;
-      DEBUGASSERT(ndx >= 0 && ndx < CONFIG_TLS_NCLEANUP);
+      DEBUGASSERT(ndx < CONFIG_TLS_NCLEANUP);
 
       /* Should we execute the cleanup routine at the top of the stack? */
 


### PR DESCRIPTION
## Summary
unsigned_compare: This greater-than-or-equal-to-zero comparison without a signed value is always true. ndx >= 0U
## Impact
NONE
## Testing
ci-check
