### PR TITLE
dirent.h: Add missing field d_ino

### DIFF
--- a/arch/sim/src/sim/sim_checkhostfstypes.c
+++ b/arch/sim/src/sim/sim_checkhostfstypes.c
@@ -63,6 +63,7 @@
 /* dirent */
 
 STATIC_ASSERT_FILED(nuttx_dirent_s, dirent, d_type);
+STATIC_ASSERT_FILED(nuttx_dirent_s, dirent, d_ino);
 STATIC_ASSERT_FILED(nuttx_dirent_s, dirent, d_name);
 
 STATIC_ASSERT(sizeof(struct nuttx_dirent_s) == sizeof(struct dirent));

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -464,6 +464,7 @@ static ssize_t dir_read(FAR struct file *filep, FAR char *buffer,
 #ifndef CONFIG_DISABLE_MOUNTPOINT
   FAR struct inode *inode = dir->fd_root;
 #endif
+  FAR struct dirent *dirent = (FAR struct dirent *)buffer;
   int ret;
 
   /* Verify that we were provided with a valid directory structure */
@@ -480,15 +481,14 @@ static ssize_t dir_read(FAR struct file *filep, FAR char *buffer,
 #ifndef CONFIG_DISABLE_MOUNTPOINT
   if (INODE_IS_MOUNTPT(inode))
     {
-      ret = inode->u.i_mops->readdir(inode, dir,
-                                     (FAR struct dirent *)buffer);
+      ret = inode->u.i_mops->readdir(inode, dir, dirent);
     }
   else
 #endif
     {
       /* The node is part of the root pseudo file system */
 
-      ret = read_pseudodir(dir, (FAR struct dirent *)buffer);
+      ret = read_pseudodir(dir, dirent);
     }
 
   /* ret < 0 is an error. Special case: ret = -ENOENT is end of file */
@@ -503,6 +503,9 @@ static ssize_t dir_read(FAR struct file *filep, FAR char *buffer,
       return ret;
     }
 
+  /* REVISIT: Should we use i_ino for the d_ino field? */
+
+  dirent->d_ino = dir->fd_root->i_ino;
   filep->f_pos++;
   return sizeof(struct dirent);
 }

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -111,6 +111,7 @@
 struct dirent
 {
   uint8_t  d_type;                /* Type of file */
+  ino_t    d_ino;                 /* File serial number, not implemented */
   char     d_name[NAME_MAX + 1];  /* File name */
 };
 

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -151,6 +151,7 @@ struct nuttx_timespec
 struct nuttx_dirent_s
 {
   uint8_t      d_type;                      /* type of file */
+  nuttx_ino_t  d_ino;                       /* inode number */
   char         d_name[CONFIG_NAME_MAX + 1]; /* filename */
 };
 


### PR DESCRIPTION
## Summary
Currently implementations of dirent.h do not have a field for the inode number, but it is required by POSIX.

For better compatibility with POSIX based applications, it is should be added even if it is not actually implemented.

PR coupled with nuttx-apps PR https://github.com/apache/nuttx-apps/pull/2593.

## Impact

* `include/dirent.h`.
* `include/nuttx/fs/hostfs.h`.
* Makes implementation compatible with POSIX.

## Testing
CI and local machine
