### PR TITLE
riscv: g_current_regs is only used to determine if we are in irq

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -85,13 +85,6 @@
 /* Interrupt Stack macros */
 #define INT_STACK_SIZE  (STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK))
 
-/* In the RISC-V model, the state is saved in stack,
- * only a reference stored in TCB.
- */
-
-#define riscv_savestate(regs) (regs = up_current_regs())
-#define riscv_restorestate(regs) up_set_current_regs(regs)
-
 /* Determine which (if any) console driver to use.  If a console is enabled
  * and no other console device is specified, then a serial console is
  * assumed.
@@ -322,8 +315,6 @@ static inline uintptr_t *riscv_vpuregs(struct tcb_s *tcb)
 
 static inline void riscv_savecontext(struct tcb_s *tcb)
 {
-  tcb->xcp.regs = (uintreg_t *)up_current_regs();
-
 #ifdef CONFIG_ARCH_FPU
   /* Save current process FPU state to TCB */
 
@@ -339,8 +330,6 @@ static inline void riscv_savecontext(struct tcb_s *tcb)
 
 static inline void riscv_restorecontext(struct tcb_s *tcb)
 {
-  up_set_current_regs(tcb->xcp.regs);
-
 #ifdef CONFIG_ARCH_FPU
   /* Restore FPU state for next process */
 

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -199,8 +199,7 @@ uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
 int riscv_swint(int irq, void *context, void *arg)
 {
   uintreg_t *regs = (uintreg_t *)context;
-
-  DEBUGASSERT(regs && regs == up_current_regs());
+  uintreg_t *new_regs = regs;
 
   /* Software interrupt 0 is invoked with REG_A0 (REG_X10) = system call
    * command and REG_A1-6 = variable number of
@@ -225,11 +224,6 @@ int riscv_swint(int irq, void *context, void *arg)
        *
        *   A0 = SYS_restore_context
        *   A1 = next
-       *
-       * In this case, we simply need to set current_regs to restore register
-       * area referenced in the saved A1. context == current_regs is the
-       * normal exception return.  By setting current_regs = context[A1], we
-       * force the return to the saved context referenced in $a1.
        */
 
       case SYS_restore_context:
@@ -237,6 +231,7 @@ int riscv_swint(int irq, void *context, void *arg)
           struct tcb_s *next = (struct tcb_s *)(uintptr_t)regs[REG_A1];
 
           DEBUGASSERT(regs[REG_A1] != 0);
+          new_regs = next->xcp.regs;
           riscv_restorecontext(next);
         }
         break;
@@ -253,9 +248,7 @@ int riscv_swint(int irq, void *context, void *arg)
        *   A2 = next
        *
        * In this case, we save the context registers to the save register
-       * area referenced by the saved contents of R5 and then set
-       * current_regs to the save register area referenced by the saved
-       * contents of R6.
+       * area referenced by the saved contents of R5.
        */
 
       case SYS_switch_context:
@@ -264,7 +257,9 @@ int riscv_swint(int irq, void *context, void *arg)
           struct tcb_s *next = (struct tcb_s *)(uintptr_t)regs[REG_A2];
 
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
+          prev->xcp.regs = regs;
           riscv_savecontext(prev);
+          new_regs = next->xcp.regs;
           riscv_restorecontext(next);
         }
         break;
@@ -478,7 +473,6 @@ int riscv_swint(int irq, void *context, void *arg)
 #endif
 
       default:
-
         DEBUGPANIC();
         break;
     }
@@ -488,10 +482,10 @@ int riscv_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (regs != up_current_regs())
+  if (regs != new_regs)
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(up_current_regs());
+      up_dump_register(new_regs);
     }
   else
     {
@@ -499,7 +493,7 @@ int riscv_swint(int irq, void *context, void *arg)
     }
 #endif
 
-  if (regs != up_current_regs())
+  if (regs != new_regs)
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -47,10 +47,11 @@ void *riscv_perform_syscall(uintreg_t *regs)
   /* Run the system call handler (swint) */
 
   riscv_swint(0, regs, NULL);
+  tcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
+#ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
        * MMU flushed) and set up the address environment for the new
@@ -58,11 +59,8 @@ void *riscv_perform_syscall(uintreg_t *regs)
        */
 
       addrenv_switch(NULL);
-    }
 #endif
 
-  if (regs != up_current_regs())
-    {
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
@@ -81,7 +79,7 @@ void *riscv_perform_syscall(uintreg_t *regs)
        * that a context switch occurred during interrupt processing.
        */
 
-      regs = up_current_regs();
+      regs = tcb->xcp.regs;
     }
 
   up_set_current_regs(NULL);


### PR DESCRIPTION
Why

When a context switch occurs currently, the context before the interrupt is fetched from the global variable g_current_regs and then stored in the corresponding tcb->xcp.regs. Subsequently, the new context is assigned to g_current_regs. When returning from the interrupt context, the context is retrieved from g_current_regs and used.

In reality, we do not necessarily require this intermediate variable g_current_regs to accomplish a context switch. Eliminating it avoids multiple assignments, especially during multiple context switches within interrupts, which can lead to repeated assignments.

All we need is to work directly with the context of the currently running task. This approach enhances the speed of context switching, reduces the code base, and optimizes signal handling logic. By simply leveraging the context of the active task, we can streamline the process and improve overall efficiency.

reason:
by doing this we can reduce context switch time,
When we exit from an interrupt handler, we directly use tcb->xcp.regs
Missing Information:
Related Issues: none
NuttX Apps Impact: none

Impact
Is a new feature added? NO
Is an existing feature changed? yes
g_current_regs is only used to determine if we are in irq with other functionalities removed.
We need to use up_interrupt_context for interrupt identification instead of relying on up_current_regs for that purpose.

before
   text    data     bss     dec     hex filename
 138805     337   24256  163398   27e46 nuttx

after
   text    data     bss     dec     hex filename
 138499     337   24240  163076   27d04 nuttx

size -322

Testing
Build Host:

OS: Ubuntu 20.04
CPU: x86_64
Compiler: GCC 9.4.0
Target:

Arch: riscv
logs:
NO change