### PR TITLE
esp32s3: Fix faulty `esp32s3-devkit:stack` example

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -429,11 +429,12 @@ int up_cpu_index(void);
 #  define up_cpu_index() (0)
 #endif
 
-static inline_function uint32_t *up_current_regs(void)
+noinstrument_function static inline_function uint32_t *up_current_regs(void)
 {
   return (uint32_t *)g_current_regs[up_cpu_index()];
 }
 
+noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
   g_current_regs[up_cpu_index()] = regs;
@@ -449,7 +450,7 @@ static inline_function void up_set_current_regs(uint32_t *regs)
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
-noinstrument_function static inline bool up_interrupt_context(void)
+noinstrument_function static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -102,6 +102,7 @@ SECTIONS
     *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
     *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
+    *libsched.a:stack_record.*(.literal .text .literal.* .text.*)
 
     *libc.a:*lib_instrument.*(.literal .text .literal.* .text.*)
 

--- a/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld
@@ -210,6 +210,7 @@ SECTIONS
     *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
     *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
+    *libsched.a:stack_record.*(.literal .text .literal.* .text.*)
 
 #ifdef CONFIG_ESP32S3_SPEED_UP_ISR
     *libarch.a:xtensa_switchcontext.*(.literal.up_switch_context .text.up_switch_context)

--- a/boards/xtensa/esp32s3/common/scripts/simple_boot_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/simple_boot_sections.ld
@@ -104,6 +104,7 @@ SECTIONS
     *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
     *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
     *libsched.a:*sched_get_stackinfo.*(.literal .text .literal.* .text.*)
+    *libsched.a:stack_record.*(.literal .text .literal.* .text.*)
 
 #ifdef CONFIG_ESP32S3_SPEED_UP_ISR
     *libarch.a:xtensa_switchcontext.*(.literal.up_switch_context .text.up_switch_context)


### PR DESCRIPTION
Jira Task ID: _ NUT-1183_

## Summary

* esp32s3: Fix faulty `esp32s3-devkit:stack` example

This defconfig is an example of the recorded stack and it became faulty recently after the implementation of the `up_current_regs` functions (https://github.com/apache/nuttx/pull/13423). The `noinstrument_function` directive must be used to prevent it from being looped when instrumentation is enabled. Also, this commit places `sched/instrument/stack_record.c` in IRAM.

## Impact

Make `esp32s3-devkit:stack` example work again.

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.0

Just build it and run `cat /proc/0/stack`.