### PR TITLE
Revert "lzf: Add macro judgment to header file reference."

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIBC_LZF
 #include <lzf.h>
-#endif
 #include <stdio.h>
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #include <nuttx/fs/fs.h>


### PR DESCRIPTION
## Summary

Revert "lzf: Add macro judgment to header file reference."

Already checked in
https://github.com/apache/nuttx/blob/master/include/lzf.h#L46

This reverts commit 2b59a0a19b5db632fa3d8f217ebde48382dff9ca.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check