### PR TITLE
can: Add g_ prefix to can_dlc_to_len and len_to_can_dlc.

### DIFF
--- a/Documentation/components/net/socketcan.rst
+++ b/Documentation/components/net/socketcan.rst
@@ -17,8 +17,8 @@ SocketCAN Device Drivers
 
   .. code-block:: c
 
-     extern const uint8_t can_dlc_to_len[16];
-     extern const uint8_t len_to_can_dlc[65];
+     extern const uint8_t g_can_dlc_to_len[16];
+     extern const uint8_t g_len_to_can_dlc[65];
 
 - **Initialization sequence is as follows**.
 


### PR DESCRIPTION

## Summary

can: Add g_ prefix to can_dlc_to_len and len_to_can_dlc.

continue work of f76c2ed83b2b5804ca1275363b954f925492c52d

detail: Add g_ prefix to can_dlc_to_len and len_to_can_dlc to
follow NuttX coding style conventions for global symbols,
improving code readability and maintainability.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check