### PR TITLE
syslog/channel: rename syslog_channel() to syslog_channel_register()

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -149,14 +149,14 @@ defined in ``include/nuttx/syslog/syslog.h``:
   };
 
 The channel interface is instantiated by calling
-:c:func:`syslog_channel()`.
+:c:func:`syslog_channel_register()`.
 
-.. c:function:: int syslog_channel(FAR const struct syslog_channel_s *channel);
+.. c:function:: int syslog_channel_register(FAR const struct syslog_channel_s *channel);
 
   Configure the SYSLOG function to use the provided
   channel to generate SYSLOG output.
 
-  ``syslog_channel()`` is a non-standard, internal OS interface and
+  ``syslog_channel_register()`` is a non-standard, internal OS interface and
   is not available to applications. It may be called numerous times
   as necessary to change channel interfaces. By default, all system
   log output goes to console (``/dev/console``).
@@ -363,7 +363,7 @@ serial console is used and ``up_putc()`` is supported.
   device is used for a console -- such as a USB console or a Telnet
   console. The SYSLOG channel is not redirected as ``stdout`` is;
   the SYSLOG channel will stayed fixed (unless it is explicitly
-  changed via ``syslog_channel()``).
+  changed via ``syslog_channel_register()``).
 
 References: ``drivers/syslog/syslog_consolechannel.c`` and
 ``drivers/syslog/syslog_device.c``
@@ -415,9 +415,9 @@ SYSLOG file channel:
   at ``devpath`` as the SYSLOG channel.
 
   This tiny function is simply a wrapper around
-  ``syslog_dev_initialize()`` and ``syslog_channel()``. It calls
+  ``syslog_dev_initialize()`` and ``syslog_channel_register()``. It calls
   ``syslog_dev_initialize()`` to configure the character file at
-  ``devpath`` then calls ``syslog_channel()`` to use that device as
+  ``devpath`` then calls ``syslog_channel_register()`` to use that device as
   the SYSLOG output channel.
 
   File SYSLOG channels differ from other SYSLOG channels in that

--- a/arch/arm/src/armv7-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv7-m/arm_itm_syslog.c
@@ -180,7 +180,7 @@ void itm_syslog_initialize(void)
 
   /* Setup the SYSLOG channel */
 
-  syslog_channel(&g_itm_channel);
+  syslog_channel_register(&g_itm_channel);
 }
 
 #endif /* CONFIG_ARMV7M_ITMSYSLOG */

--- a/arch/arm/src/armv8-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv8-m/arm_itm_syslog.c
@@ -180,7 +180,7 @@ void itm_syslog_initialize(void)
 
   /* Setup the SYSLOG channel */
 
-  syslog_channel(&g_itm_channel);
+  syslog_channel_register(&g_itm_channel);
 }
 
 #endif /* CONFIG_ARMV8M_ITMSYSLOG */

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -110,9 +110,10 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel);
  *   CONFIG_SYSLOG_DEVPATH as the SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character device at CONFIG_SYSLOG_DEVPATH then calls
- *   syslog_channel() to use that device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character device at CONFIG_SYSLOG_DEVPATH then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   NOTE interrupt level SYSLOG output will be lost in this case unless
  *   the interrupt buffer is used.
@@ -137,9 +138,10 @@ FAR struct syslog_channel_s *syslog_dev_channel(void);
  *   SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character device at /dev/console then calls syslog_channel() to
- *   use that device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character device at /dev/console then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   NOTE interrupt level SYSLOG output will be lost in the general case
  *   unless the interrupt buffer is used.  As a special case:  If the serial

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -272,7 +272,7 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
  *
  ****************************************************************************/
 
-int syslog_channel(FAR struct syslog_channel_s *channel)
+int syslog_channel_register(FAR struct syslog_channel_s *channel)
 {
 #if (CONFIG_SYSLOG_MAX_CHANNELS != 1)
   int i;
@@ -313,7 +313,7 @@ int syslog_channel(FAR struct syslog_channel_s *channel)
 }
 
 /****************************************************************************
- * Name: syslog_channel_remove
+ * Name: syslog_channel_unregister
  *
  * Description:
  *   Removes an already configured SYSLOG channel from the list of used
@@ -328,7 +328,7 @@ int syslog_channel(FAR struct syslog_channel_s *channel)
  *
  ****************************************************************************/
 
-int syslog_channel_remove(FAR struct syslog_channel_s *channel)
+int syslog_channel_unregister(FAR struct syslog_channel_s *channel)
 {
   int i;
 

--- a/drivers/syslog/syslog_consolechannel.c
+++ b/drivers/syslog/syslog_consolechannel.c
@@ -53,9 +53,10 @@
  *   SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character device at /dev/console then calls syslog_channel() to
- *   use that device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character device at /dev/console then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   NOTE interrupt level SYSLOG output will be lost in the general case
  *   unless the interrupt buffer is used.  As a special case:  If the serial
@@ -86,7 +87,7 @@ FAR struct syslog_channel_s *syslog_console_channel(void)
 
   /* Use the character driver as the SYSLOG channel */
 
-  if (syslog_channel(console_channel) != OK)
+  if (syslog_channel_register(console_channel) != OK)
     {
       syslog_dev_uninitialize(console_channel);
       console_channel = NULL;

--- a/drivers/syslog/syslog_devchannel.c
+++ b/drivers/syslog/syslog_devchannel.c
@@ -53,9 +53,10 @@
  *   SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character device at CONFIG_SYSLOG_DEVPATH then calls
- *   syslog_channel() to use that device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character device at CONFIG_SYSLOG_DEVPATH then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   NOTE interrupt level SYSLOG output will be lost in this case unless
  *   the interrupt buffer is used.
@@ -83,7 +84,7 @@ FAR struct syslog_channel_s *syslog_dev_channel(void)
 
   /* Use the character driver as the SYSLOG channel */
 
-  if (syslog_channel(dev_channel) != OK)
+  if (syslog_channel_register(dev_channel) != OK)
     {
       syslog_dev_uninitialize(dev_channel);
       dev_channel = NULL;

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -137,9 +137,10 @@ end:
  *   SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character file at 'devpath then calls syslog_channel() to use that
- *   device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character file at 'devpath then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   File SYSLOG channels differ from other SYSLOG channels in that they
  *   cannot be established until after fully booting and mounting the target
@@ -203,7 +204,7 @@ FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
    * screwed.
    */
 
-  if (syslog_channel(file_channel) != OK)
+  if (syslog_channel_register(file_channel) != OK)
     {
       syslog_dev_uninitialize(file_channel);
       file_channel = NULL;

--- a/drivers/syslog/syslog_initialize.c
+++ b/drivers/syslog/syslog_initialize.c
@@ -50,11 +50,11 @@
  *   This function performs these basic operations:
  *
  *   - Initialize the SYSLOG device
- *   - Call syslog_channel() to begin using that device.
+ *   - Call syslog_channel_register() to begin using that device.
  *
  *   If CONFIG_ARCH_SYSLOG is selected, then the architecture-specifica
  *   logic will provide its own SYSLOG device initialize which must include
- *   as a minimum a call to syslog_channel() to use the device.
+ *   as a minimum a call to syslog_channel_register() to use the device.
  *
  * Input Parameters:
  *  None

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -164,7 +164,7 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: syslog_channel
+ * Name: syslog_channel_register
  *
  * Description:
  *   Configure the SYSLOGging function to use the provided channel to
@@ -179,10 +179,10 @@ extern "C"
  *
  ****************************************************************************/
 
-int syslog_channel(FAR struct syslog_channel_s *channel);
+int syslog_channel_register(FAR struct syslog_channel_s *channel);
 
 /****************************************************************************
- * Name: syslog_channel_remove
+ * Name: syslog_channel_unregister
  *
  * Description:
  *   Removes an already configured SYSLOG channel from the list of used
@@ -197,7 +197,7 @@ int syslog_channel(FAR struct syslog_channel_s *channel);
  *
  ****************************************************************************/
 
-int syslog_channel_remove(FAR struct syslog_channel_s *channel);
+int syslog_channel_unregister(FAR struct syslog_channel_s *channel);
 
 /****************************************************************************
  * Name: syslog_initialize
@@ -211,11 +211,11 @@ int syslog_channel_remove(FAR struct syslog_channel_s *channel);
  *   This function performs these basic operations:
  *
  *   - Initialize the SYSLOG device
- *   - Call syslog_channel() to begin using that device.
+ *   - Call syslog_channel_register() to begin using that device.
  *
  *   If CONFIG_ARCH_SYSLOG is selected, then the architecture-specifica
  *   logic will provide its own SYSLOG device initialize which must include
- *   as a minimum a call to syslog_channel() to use the device.
+ *   as a minimum a call to syslog_channel_register() to use the device.
  *
  * Input Parameters:
  *   None
@@ -240,9 +240,10 @@ int syslog_initialize(void);
  *   SYSLOG channel.
  *
  *   This tiny function is simply a wrapper around syslog_dev_initialize()
- *   and syslog_channel().  It calls syslog_dev_initialize() to configure
- *   the character file at 'devpath then calls syslog_channel() to use that
- *   device as the SYSLOG output channel.
+ *   and syslog_channel_register().  It calls syslog_dev_initialize() to
+ *   configure the character file at 'devpath then calls
+ *   syslog_channel_register() to use that device as the SYSLOG output
+ *   channel.
  *
  *   File SYSLOG channels differ from other SYSLOG channels in that they
  *   cannot be established until after fully booting and mounting the target


### PR DESCRIPTION
## Summary

syslog/channel: rename syslog_channel() to syslog_channel_register()

Change syslog API naming more reasonable:

1. rename syslog_channel() to syslog_channel_register()
2. rename syslog_channel_remove() to syslog_channel_unregister()

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check
