### PR TITLE
syslog/channel: add constant attribute if SYSLOG_IOCTL is not enabled

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -151,7 +151,7 @@ defined in ``include/nuttx/syslog/syslog.h``:
 The channel interface is instantiated by calling
 :c:func:`syslog_channel_register()`.
 
-.. c:function:: int syslog_channel_register(FAR const struct syslog_channel_s *channel);
+.. c:function:: int syslog_channel_register(FAR syslog_channel_t *channel);
 
   Configure the SYSLOG function to use the provided
   channel to generate SYSLOG output.
@@ -408,7 +408,7 @@ mounting of the file systems.
 The interface ``syslog_file_channel()`` is used to configure the
 SYSLOG file channel:
 
-.. c:function:: FAR struct syslog_channel_s * \
+.. c:function:: FAR syslog_channel_t * \
                     syslog_file_channel(FAR const char *devpath);
 
   Configure to use a file in a mounted file system

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1374,6 +1374,7 @@ config DEBUG_SECUREFAULT
 config ARM_SEMIHOSTING_SYSLOG
 	bool "Semihosting SYSLOG support"
 	select ARCH_SYSLOG
+	select SYSLOG_REGISTER
 	---help---
 		Enable hooks to support semihosting syslog output.
 

--- a/arch/arm/src/armv7-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv7-m/arm_itm_syslog.c
@@ -62,8 +62,8 @@
 
 /* SYSLOG channel methods */
 
-static int itm_putc(struct syslog_channel_s *channel, int ch);
-static int itm_flush(struct syslog_channel_s *channel);
+static int itm_putc(syslog_channel_t *channel, int ch);
+static int itm_flush(syslog_channel_t *channel);
 
 /****************************************************************************
  * Private Data
@@ -80,7 +80,7 @@ static const struct syslog_channel_ops_s g_itm_channel_ops =
 
 /* This structure describes the ITM SYSLOG channel */
 
-static struct syslog_channel_s g_itm_channel =
+static syslog_channel_t g_itm_channel =
 {
   .sc_ops   = &g_itm_channel_ops
 };
@@ -97,7 +97,7 @@ static struct syslog_channel_s g_itm_channel =
  *
  ****************************************************************************/
 
-static int itm_putc(struct syslog_channel_s *channel, int ch)
+static int itm_putc(syslog_channel_t *channel, int ch)
 {
   UNUSED(channel);
 
@@ -127,7 +127,7 @@ static int itm_putc(struct syslog_channel_s *channel, int ch)
  *
  ****************************************************************************/
 
-static int itm_flush(struct syslog_channel_s *channel)
+static int itm_flush(syslog_channel_t *channel)
 {
   UNUSED(channel);
   return OK;

--- a/arch/arm/src/armv8-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv8-m/arm_itm_syslog.c
@@ -62,8 +62,8 @@
 
 /* SYSLOG channel methods */
 
-static int itm_putc(struct syslog_channel_s *channel, int ch);
-static int itm_flush(struct syslog_channel_s *channel);
+static int itm_putc(syslog_channel_t *channel, int ch);
+static int itm_flush(syslog_channel_t *channel);
 
 /****************************************************************************
  * Private Data
@@ -80,7 +80,7 @@ static const struct syslog_channel_ops_s g_itm_channel_ops =
 
 /* This structure describes the ITM SYSLOG channel */
 
-static struct syslog_channel_s g_itm_channel =
+static syslog_channel_t g_itm_channel =
 {
   .sc_ops   = &g_itm_channel_ops
 };
@@ -97,7 +97,7 @@ static struct syslog_channel_s g_itm_channel =
  *
  ****************************************************************************/
 
-static int itm_putc(struct syslog_channel_s *channel, int ch)
+static int itm_putc(syslog_channel_t *channel, int ch)
 {
   UNUSED(channel);
 
@@ -127,7 +127,7 @@ static int itm_putc(struct syslog_channel_s *channel, int ch)
  *
  ****************************************************************************/
 
-static int itm_flush(struct syslog_channel_s *channel)
+static int itm_flush(syslog_channel_t *channel)
 {
   UNUSED(channel);
   return OK;

--- a/boards/arm/stm32/clicker2-stm32/src/stm32_appinit.c
+++ b/boards/arm/stm32/clicker2-stm32/src/stm32_appinit.c
@@ -96,7 +96,7 @@ int board_app_initialize(uintptr_t arg)
 
   nxsig_usleep(CONFIG_CLICKER2_STM32_SYSLOG_FILE_DELAY * 1000);
 
-  struct syslog_channel_s *channel;
+  syslog_channel_t *channel;
   channel = syslog_file_channel(CONFIG_CLICKER2_STM32_SYSLOG_FILE_PATH);
   if (channel == NULL)
     {

--- a/drivers/segger/syslog_rtt.c
+++ b/drivers/segger/syslog_rtt.c
@@ -30,14 +30,14 @@
  * Public Functions
  ****************************************************************************/
 
-int syslog_rtt_putc(FAR struct syslog_channel_s *channel, int ch)
+int syslog_rtt_putc(FAR syslog_channel_t *channel, int ch)
 {
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(CONFIG_SYSLOG_RTT_CHANNEL);
   SEGGER_RTT_PutChar(CONFIG_SYSLOG_RTT_CHANNEL, ch);
   return ch;
 }
 
-ssize_t syslog_rtt_write(FAR struct syslog_channel_s *channel,
+ssize_t syslog_rtt_write(FAR syslog_channel_t *channel,
                          FAR const char *buffer, size_t buflen)
 {
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(CONFIG_SYSLOG_RTT_CHANNEL);

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -196,6 +196,7 @@ if !ARCH_SYSLOG
 config SYSLOG_CHAR
 	bool "Log to a character device"
 	default n
+	select SYSLOG_REGISTER
 	---help---
 		Enable the generic character device for the SYSLOG. The full path to the
 		SYSLOG device is provided by SYSLOG_DEVPATH. A valid character device (or
@@ -231,6 +232,7 @@ config SYSLOG_CONSOLE
 	bool "Log to /dev/console"
 	default !ARCH_LOWPUTC && !SYSLOG_CHAR && !RAMLOG_SYSLOG && !SYSLOG_RPMSG && !SYSLOG_RTT
 	depends on DEV_CONSOLE
+	select SYSLOG_REGISTER
 	---help---
 		Use the system console as a SYSLOG output device.
 
@@ -291,6 +293,7 @@ config SYSLOG_RPMSG_SERVER_CHARDEV
 menuconfig SYSLOG_FILE
 	bool "Syslog file output"
 	default n
+	select SYSLOG_REGISTER
 	---help---
 		Build in support to use a file to collect SYSLOG output.  File SYSLOG
 		channels differ from other SYSLOG channels in that they cannot be
@@ -374,5 +377,10 @@ config SYSLOG_IOCTL
 		to control the behavior of the SYSLOG device. Currently, the supported
 		commands are SYSLOGIOC_SETFILTER/SYSLOGIOC_GETCHANNELS, which can be
 		used to set the enable status of different channels
+
+config SYSLOG_REGISTER
+	bool "Register syslog channel support"
+	---help---
+		This option will support register the syslog channel dynamically.
 
 endmenu # System logging

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -732,7 +732,7 @@ void ramlog_syslog_register(void)
  ****************************************************************************/
 
 #ifdef CONFIG_RAMLOG_SYSLOG
-int ramlog_putc(FAR struct syslog_channel_s *channel, int ch)
+int ramlog_putc(FAR syslog_channel_t *channel, int ch)
 {
   char cch = ch;
 
@@ -747,7 +747,7 @@ int ramlog_putc(FAR struct syslog_channel_s *channel, int ch)
   return ch;
 }
 
-ssize_t ramlog_write(FAR struct syslog_channel_s *channel,
+ssize_t ramlog_write(FAR syslog_channel_t *channel,
                      FAR const char *buffer, size_t buflen)
 {
   return ramlog_addbuf(&g_sysdev, buffer, buflen);

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -47,9 +47,7 @@ extern "C"
  * g_default_channel.
  */
 
-struct syslog_channel_s; /* Forward reference */
-EXTERN FAR struct syslog_channel_s *g_syslog_channel
-                                                [CONFIG_SYSLOG_MAX_CHANNELS];
+EXTERN FAR syslog_channel_t *g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS];
 
 /****************************************************************************
  * Public Function Prototypes
@@ -81,8 +79,8 @@ EXTERN FAR struct syslog_channel_s *g_syslog_channel
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
-                                                   int oflags, int mode);
+FAR syslog_channel_t *syslog_dev_initialize(FAR const char *devpath,
+                                            int oflags, int mode);
 
 /****************************************************************************
  * Name: syslog_dev_uninitialize
@@ -100,7 +98,7 @@ FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
  *
  ****************************************************************************/
 
-void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel);
+void syslog_dev_uninitialize(FAR syslog_channel_t *channel);
 
 /****************************************************************************
  * Name: syslog_dev_channel
@@ -127,7 +125,7 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_CHAR
-FAR struct syslog_channel_s *syslog_dev_channel(void);
+FAR syslog_channel_t *syslog_dev_channel(void);
 #endif
 
 /****************************************************************************
@@ -158,7 +156,7 @@ FAR struct syslog_channel_s *syslog_dev_channel(void);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_CONSOLE
-FAR struct syslog_channel_s *syslog_console_channel(void);
+FAR syslog_channel_t *syslog_console_channel(void);
 #endif
 
 /****************************************************************************

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -47,7 +47,11 @@ extern "C"
  * g_default_channel.
  */
 
-EXTERN FAR syslog_channel_t *g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS];
+EXTERN FAR syslog_channel_t *
+#ifndef CONFIG_SYSLOG_REGISTER
+const
+#endif
+g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS];
 
 /****************************************************************************
  * Public Function Prototypes

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -60,9 +60,9 @@
  ****************************************************************************/
 
 #if defined(CONFIG_SYSLOG_DEFAULT)
-static int syslog_default_putc(FAR struct syslog_channel_s *channel,
+static int syslog_default_putc(FAR syslog_channel_t *channel,
                                int ch);
-static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_default_write(FAR syslog_channel_t *channel,
                                     FAR const char *buffer, size_t buflen);
 #endif
 
@@ -83,7 +83,7 @@ static const struct syslog_channel_ops_s g_ramlog_channel_ops =
   ramlog_write
 };
 
-static struct syslog_channel_s g_ramlog_channel =
+static syslog_channel_t g_ramlog_channel =
 {
   &g_ramlog_channel_ops
 #  ifdef CONFIG_SYSLOG_IOCTL
@@ -103,7 +103,7 @@ static const struct syslog_channel_ops_s g_rpmsg_channel_ops =
   syslog_rpmsg_write
 };
 
-static struct syslog_channel_s g_rpmsg_channel =
+static syslog_channel_t g_rpmsg_channel =
 {
   &g_rpmsg_channel_ops
 #  ifdef CONFIG_SYSLOG_IOCTL
@@ -123,7 +123,7 @@ static const struct syslog_channel_ops_s g_rtt_channel_ops =
   syslog_rtt_write
 };
 
-static struct syslog_channel_s g_rtt_channel =
+static syslog_channel_t g_rtt_channel =
 {
   &g_rtt_channel_ops
 #  ifdef CONFIG_SYSLOG_IOCTL
@@ -142,7 +142,7 @@ static const struct syslog_channel_ops_s g_default_channel_ops =
   syslog_default_write
 };
 
-static struct syslog_channel_s g_default_channel =
+static syslog_channel_t g_default_channel =
 {
   &g_default_channel_ops
 #  ifdef CONFIG_SYSLOG_IOCTL
@@ -191,7 +191,7 @@ static struct syslog_channel_s g_default_channel =
 
 /* This is the current syslog channel in use */
 
-FAR struct syslog_channel_s
+FAR syslog_channel_t
 *g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS] =
 {
 #if defined(CONFIG_SYSLOG_DEFAULT)
@@ -225,7 +225,7 @@ FAR struct syslog_channel_s
  ****************************************************************************/
 
 #if defined(CONFIG_SYSLOG_DEFAULT)
-static int syslog_default_putc(FAR struct syslog_channel_s *channel, int ch)
+static int syslog_default_putc(FAR syslog_channel_t *channel, int ch)
 {
   UNUSED(channel);
 
@@ -236,7 +236,7 @@ static int syslog_default_putc(FAR struct syslog_channel_s *channel, int ch)
 #endif
 }
 
-static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_default_write(FAR syslog_channel_t *channel,
                                     FAR const char *buffer, size_t buflen)
 {
 #if defined(CONFIG_ARCH_LOWPUTC)
@@ -272,7 +272,7 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
  *
  ****************************************************************************/
 
-int syslog_channel_register(FAR struct syslog_channel_s *channel)
+int syslog_channel_register(FAR syslog_channel_t *channel)
 {
 #if (CONFIG_SYSLOG_MAX_CHANNELS != 1)
   int i;
@@ -328,7 +328,7 @@ int syslog_channel_register(FAR struct syslog_channel_s *channel)
  *
  ****************************************************************************/
 
-int syslog_channel_unregister(FAR struct syslog_channel_s *channel)
+int syslog_channel_unregister(FAR syslog_channel_t *channel)
 {
   int i;
 

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -191,8 +191,11 @@ static syslog_channel_t g_default_channel =
 
 /* This is the current syslog channel in use */
 
-FAR syslog_channel_t
-*g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS] =
+FAR syslog_channel_t *
+#ifndef CONFIG_SYSLOG_REGISTER
+const
+#endif
+g_syslog_channel[CONFIG_SYSLOG_MAX_CHANNELS] =
 {
 #if defined(CONFIG_SYSLOG_DEFAULT)
   &g_default_channel,
@@ -272,6 +275,7 @@ static ssize_t syslog_default_write(FAR syslog_channel_t *channel,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SYSLOG_REGISTER
 int syslog_channel_register(FAR syslog_channel_t *channel)
 {
 #if (CONFIG_SYSLOG_MAX_CHANNELS != 1)
@@ -369,3 +373,4 @@ int syslog_channel_unregister(FAR syslog_channel_t *channel)
 
   return -EINVAL;
 }
+#endif

--- a/drivers/syslog/syslog_chardev.c
+++ b/drivers/syslog/syslog_chardev.c
@@ -85,7 +85,7 @@ static int syslog_chardev_ioctl(FAR struct file *filep,
                                 int cmd, unsigned long arg)
 {
   FAR struct syslog_channel_info_s *info;
-  FAR struct syslog_channel_s *channel = NULL;
+  FAR syslog_channel_t *channel = NULL;
   int i;
 
   if (arg == 0)

--- a/drivers/syslog/syslog_consolechannel.c
+++ b/drivers/syslog/syslog_consolechannel.c
@@ -72,9 +72,9 @@
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *syslog_console_channel(void)
+FAR syslog_channel_t *syslog_console_channel(void)
 {
-  FAR struct syslog_channel_s *console_channel;
+  FAR syslog_channel_t *console_channel;
 
   /* Initialize the character driver interface */
 

--- a/drivers/syslog/syslog_devchannel.c
+++ b/drivers/syslog/syslog_devchannel.c
@@ -69,9 +69,9 @@
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *syslog_dev_channel(void)
+FAR syslog_channel_t *syslog_dev_channel(void)
 {
-  FAR struct syslog_channel_s *dev_channel;
+  FAR syslog_channel_t *dev_channel;
 
   /* Initialize the character driver interface */
 

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -74,7 +74,7 @@ enum syslog_dev_state
 
 struct syslog_dev_s
 {
-  struct syslog_channel_s channel;
+  syslog_channel_t channel;
 
   uint8_t      sl_state;    /* See enum syslog_dev_state */
   uint8_t      sl_oflags;   /* Saved open mode (for re-open) */
@@ -88,11 +88,11 @@ struct syslog_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t syslog_dev_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_dev_write(FAR syslog_channel_t *channel,
                                 FAR const char *buffer, size_t buflen);
-static int syslog_dev_putc(FAR struct syslog_channel_s *channel, int ch);
-static int syslog_dev_force(FAR struct syslog_channel_s *channel, int ch);
-static int syslog_dev_flush(FAR struct syslog_channel_s *channel);
+static int syslog_dev_putc(FAR syslog_channel_t *channel, int ch);
+static int syslog_dev_force(FAR syslog_channel_t *channel, int ch);
+static int syslog_dev_flush(FAR syslog_channel_t *channel);
 
 /****************************************************************************
  * Private Data
@@ -373,7 +373,7 @@ static int syslog_dev_outputready(FAR struct syslog_dev_s *syslog_dev)
  *
  ****************************************************************************/
 
-static ssize_t syslog_dev_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_dev_write(FAR syslog_channel_t *channel,
                                 FAR const char *buffer, size_t buflen)
 {
   FAR struct syslog_dev_s *syslog_dev = (FAR struct syslog_dev_s *)channel;
@@ -526,7 +526,7 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-static int syslog_dev_putc(FAR struct syslog_channel_s *channel, int ch)
+static int syslog_dev_putc(FAR syslog_channel_t *channel, int ch)
 {
   FAR struct syslog_dev_s *syslog_dev = (FAR struct syslog_dev_s *)channel;
   ssize_t nbytes;
@@ -619,7 +619,7 @@ static int syslog_dev_putc(FAR struct syslog_channel_s *channel, int ch)
  *
  ****************************************************************************/
 
-static int syslog_dev_force(FAR struct syslog_channel_s *channel, int ch)
+static int syslog_dev_force(FAR syslog_channel_t *channel, int ch)
 {
   UNUSED(channel);
   return ch;
@@ -639,7 +639,7 @@ static int syslog_dev_force(FAR struct syslog_channel_s *channel, int ch)
  *
  ****************************************************************************/
 
-static int syslog_dev_flush(FAR struct syslog_channel_s *channel)
+static int syslog_dev_flush(FAR syslog_channel_t *channel)
 {
 #if defined(CONFIG_SYSLOG_FILE) && !defined(CONFIG_DISABLE_MOUNTPOINT)
   FAR struct syslog_dev_s *syslog_dev = (FAR struct syslog_dev_s *)channel;
@@ -687,7 +687,7 @@ static int syslog_dev_flush(FAR struct syslog_channel_s *channel)
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
+FAR syslog_channel_t *syslog_dev_initialize(FAR const char *devpath,
                                                    int oflags, int mode)
 {
   FAR struct syslog_dev_s *syslog_dev;
@@ -703,7 +703,7 @@ FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
 
   syslog_dev->channel.sc_ops = &g_syslog_dev_ops;
 
-  return (FAR struct syslog_channel_s *)syslog_dev;
+  return (FAR syslog_channel_t *)syslog_dev;
 }
 
 /****************************************************************************
@@ -726,7 +726,7 @@ FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
  *
  ****************************************************************************/
 
-void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel)
+void syslog_dev_uninitialize(FAR syslog_channel_t *channel)
 {
   FAR struct syslog_dev_s *syslog_dev = (FAR struct syslog_dev_s *)channel;
 

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -165,9 +165,9 @@ end:
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
+FAR syslog_channel_t *syslog_file_channel(FAR const char *devpath)
 {
-  FAR struct syslog_channel_s *file_channel;
+  FAR syslog_channel_t *file_channel;
   irqstate_t flags;
 
   /* Reset the default SYSLOG channel so that we can safely modify the

--- a/drivers/syslog/syslog_flush.c
+++ b/drivers/syslog/syslog_flush.c
@@ -76,7 +76,7 @@ int syslog_flush(void)
 
   for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
     {
-      FAR struct syslog_channel_s *channel = g_syslog_channel[i];
+      FAR syslog_channel_t *channel = g_syslog_channel[i];
 
       if (channel == NULL)
         {

--- a/drivers/syslog/syslog_putc.c
+++ b/drivers/syslog/syslog_putc.c
@@ -83,7 +83,7 @@ int syslog_putc(int ch)
 
           for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
             {
-              FAR struct syslog_channel_s *channel = g_syslog_channel[i];
+              FAR syslog_channel_t *channel = g_syslog_channel[i];
 
               if (channel == NULL)
                 {
@@ -123,7 +123,7 @@ int syslog_putc(int ch)
 
       for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
         {
-          FAR struct syslog_channel_s *channel = g_syslog_channel[i];
+          FAR syslog_channel_t *channel = g_syslog_channel[i];
 
           if (channel == NULL)
             {

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -338,7 +338,7 @@ static ssize_t syslog_rpmsg_file_write(FAR struct file *filep,
  * Public Functions
  ****************************************************************************/
 
-int syslog_rpmsg_putc(FAR struct syslog_channel_s *channel, int ch)
+int syslog_rpmsg_putc(FAR syslog_channel_t *channel, int ch)
 {
   FAR struct syslog_rpmsg_s *priv = &g_syslog_rpmsg;
   irqstate_t flags;
@@ -350,7 +350,7 @@ int syslog_rpmsg_putc(FAR struct syslog_channel_s *channel, int ch)
   return ch;
 }
 
-int syslog_rpmsg_flush(FAR struct syslog_channel_s *channel)
+int syslog_rpmsg_flush(FAR syslog_channel_t *channel)
 {
   FAR struct syslog_rpmsg_s *priv = &g_syslog_rpmsg;
   irqstate_t flags;
@@ -376,7 +376,7 @@ int syslog_rpmsg_flush(FAR struct syslog_channel_s *channel)
   return OK;
 }
 
-ssize_t syslog_rpmsg_write(FAR struct syslog_channel_s *channel,
+ssize_t syslog_rpmsg_write(FAR syslog_channel_t *channel,
                            FAR const char *buffer, size_t buflen)
 {
   FAR struct syslog_rpmsg_s *priv = &g_syslog_rpmsg;

--- a/drivers/syslog/syslog_stream.c
+++ b/drivers/syslog/syslog_stream.c
@@ -41,7 +41,7 @@
 
 struct syslog_stream_s
 {
-  struct syslog_channel_s     channel;
+  syslog_channel_t     channel;
   FAR struct lib_outstream_s *stream;
 };
 
@@ -49,12 +49,12 @@ struct syslog_stream_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t syslog_stream_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_stream_write(FAR syslog_channel_t *channel,
                                    FAR const char *buffer, size_t buflen);
-static int syslog_stream_putc(FAR struct syslog_channel_s *channel, int ch);
-static int syslog_stream_force(FAR struct syslog_channel_s *channel, int ch);
-static int syslog_stream_flush(FAR struct syslog_channel_s *channel);
-void syslog_stream_uninit(FAR struct syslog_channel_s *channel);
+static int syslog_stream_putc(FAR syslog_channel_t *channel, int ch);
+static int syslog_stream_force(FAR syslog_channel_t *channel, int ch);
+static int syslog_stream_flush(FAR syslog_channel_t *channel);
+void syslog_stream_uninit(FAR syslog_channel_t *channel);
 
 /****************************************************************************
  * Private Data
@@ -92,7 +92,7 @@ static const struct syslog_channel_ops_s g_syslog_stream_ops =
  *
  ****************************************************************************/
 
-static ssize_t syslog_stream_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_stream_write(FAR syslog_channel_t *channel,
                                    FAR const char *buffer, size_t buflen)
 {
   FAR struct syslog_stream_s *chan =
@@ -123,7 +123,7 @@ static ssize_t syslog_stream_write(FAR struct syslog_channel_s *channel,
  *
  ****************************************************************************/
 
-static int syslog_stream_putc(FAR struct syslog_channel_s *channel, int ch)
+static int syslog_stream_putc(FAR syslog_channel_t *channel, int ch)
 {
   FAR struct syslog_stream_s *chan =
     (FAR struct syslog_stream_s *)channel;
@@ -150,7 +150,7 @@ static int syslog_stream_putc(FAR struct syslog_channel_s *channel, int ch)
  *
  ****************************************************************************/
 
-static int syslog_stream_flush(FAR struct syslog_channel_s *channel)
+static int syslog_stream_flush(FAR syslog_channel_t *channel)
 {
   FAR struct syslog_stream_s *chan =
     (FAR struct syslog_stream_s *)channel;
@@ -186,7 +186,7 @@ static int syslog_stream_flush(FAR struct syslog_channel_s *channel)
  *
  ****************************************************************************/
 
-void syslog_stream_uninit(FAR struct syslog_channel_s *channel)
+void syslog_stream_uninit(FAR syslog_channel_t *channel)
 {
   FAR struct syslog_stream_s *chan =
     (FAR struct syslog_stream_s *)channel;
@@ -220,7 +220,7 @@ void syslog_stream_uninit(FAR struct syslog_channel_s *channel)
  *
  ****************************************************************************/
 
-FAR struct syslog_channel_s *
+FAR syslog_channel_t *
 syslog_stream_channel(FAR struct lib_outstream_s *stream)
 {
   FAR struct syslog_stream_s *chan;
@@ -237,7 +237,7 @@ syslog_stream_channel(FAR struct lib_outstream_s *stream)
 
   chan->stream = stream;
   chan->channel.sc_ops = &g_syslog_stream_ops;
-  return (FAR struct syslog_channel_s *)chan;
+  return (FAR syslog_channel_t *)chan;
 }
 
 #endif /* CONFIG_SYSLOG_STREAM */

--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -75,7 +75,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
         {
           for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
             {
-              FAR struct syslog_channel_s *channel = g_syslog_channel[i];
+              FAR syslog_channel_t *channel = g_syslog_channel[i];
 
               if (channel == NULL)
                 {
@@ -109,7 +109,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
     {
       for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
         {
-          FAR struct syslog_channel_s *channel = g_syslog_channel[i];
+          FAR syslog_channel_t *channel = g_syslog_channel[i];
 
           if (channel == NULL)
             {

--- a/include/nuttx/segger/rtt.h
+++ b/include/nuttx/segger/rtt.h
@@ -93,8 +93,8 @@ void lib_rttinstream_close(FAR struct lib_rttinstream_s *stream);
 #endif
 
 #ifdef CONFIG_SYSLOG_RTT
-int syslog_rtt_putc(FAR struct syslog_channel_s *channel, int ch);
-ssize_t syslog_rtt_write(FAR struct syslog_channel_s *channel,
+int syslog_rtt_putc(FAR syslog_channel_t *channel, int ch);
+ssize_t syslog_rtt_write(FAR syslog_channel_t *channel,
                          FAR const char *buffer, size_t buflen);
 #endif
 

--- a/include/nuttx/syslog/ramlog.h
+++ b/include/nuttx/syslog/ramlog.h
@@ -133,7 +133,7 @@ void ramlog_syslog_register(void);
  ****************************************************************************/
 
 #ifdef CONFIG_RAMLOG_SYSLOG
-int ramlog_putc(FAR struct syslog_channel_s *channel, int ch);
+int ramlog_putc(FAR syslog_channel_t *channel, int ch);
 #endif
 
 /****************************************************************************
@@ -145,7 +145,7 @@ int ramlog_putc(FAR struct syslog_channel_s *channel, int ch);
  ****************************************************************************/
 
 #ifdef CONFIG_RAMLOG_SYSLOG
-ssize_t ramlog_write(FAR struct syslog_channel_s *channel,
+ssize_t ramlog_write(FAR syslog_channel_t *channel,
                      FAR const char *buffer, size_t buflen);
 #endif
 

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -95,16 +95,21 @@
 
 /* Forward declaration */
 
-struct syslog_channel_s;
+#if defined(CONFIG_SYSLOG_IOCTL) || defined(CONFIG_SYSLOG_CONSOLE) || \
+    defined(CONFIG_SYSLOG_CHAR) || defined(CONFIG_SYSLOG_FILE)
+typedef struct syslog_channel_s syslog_channel_t;
+#else
+typedef const struct syslog_channel_s syslog_channel_t;
+#endif
 
 /* SYSLOG I/O redirection methods */
 
-typedef CODE ssize_t (*syslog_write_t)(FAR struct syslog_channel_s *channel,
+typedef CODE ssize_t (*syslog_write_t)(FAR syslog_channel_t *channel,
                                        FAR const char *buf, size_t buflen);
-typedef CODE int (*syslog_putc_t)(FAR struct syslog_channel_s *channel,
+typedef CODE int (*syslog_putc_t)(FAR syslog_channel_t *channel,
                                   int ch);
-typedef CODE int (*syslog_flush_t)(FAR struct syslog_channel_s *channel);
-typedef CODE void (*syslog_close_t)(FAR struct syslog_channel_s *channel);
+typedef CODE int (*syslog_flush_t)(FAR syslog_channel_t *channel);
+typedef CODE void (*syslog_close_t)(FAR syslog_channel_t *channel);
 
 /* SYSLOG device operations */
 
@@ -179,7 +184,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int syslog_channel_register(FAR struct syslog_channel_s *channel);
+int syslog_channel_register(FAR syslog_channel_t *channel);
 
 /****************************************************************************
  * Name: syslog_channel_unregister
@@ -197,7 +202,7 @@ int syslog_channel_register(FAR struct syslog_channel_s *channel);
  *
  ****************************************************************************/
 
-int syslog_channel_unregister(FAR struct syslog_channel_s *channel);
+int syslog_channel_unregister(FAR syslog_channel_t *channel);
 
 /****************************************************************************
  * Name: syslog_initialize
@@ -269,7 +274,7 @@ int syslog_initialize(void);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_FILE
-FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath);
+FAR syslog_channel_t *syslog_file_channel(FAR const char *devpath);
 #endif
 
 /****************************************************************************
@@ -293,7 +298,7 @@ FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_STREAM
-FAR struct syslog_channel_s *
+FAR syslog_channel_t *
 syslog_stream_channel(FAR struct lib_outstream_s *stream);
 #endif
 

--- a/include/nuttx/syslog/syslog_rpmsg.h
+++ b/include/nuttx/syslog/syslog_rpmsg.h
@@ -44,9 +44,9 @@ extern "C"
 void syslog_rpmsg_init_early(FAR void *buffer, size_t size);
 int syslog_rpmsg_init(void);
 
-int syslog_rpmsg_putc(FAR struct syslog_channel_s *channel, int ch);
-int syslog_rpmsg_flush(FAR struct syslog_channel_s *channel);
-ssize_t syslog_rpmsg_write(FAR struct syslog_channel_s *channel,
+int syslog_rpmsg_putc(FAR syslog_channel_t *channel, int ch);
+int syslog_rpmsg_flush(FAR syslog_channel_t *channel);
+ssize_t syslog_rpmsg_write(FAR syslog_channel_t *channel,
                            FAR const char *buffer, size_t buflen);
 #endif
 


### PR DESCRIPTION
## Summary

syslog/channel: add constant attribute if SYSLOG_IOCTL is not enabled

move all private channel define from data to rodata

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check