### PR TITLE
fs/chmod/fchmod/lchmod: only set permissions by mode_t and ignore othjer bits

### DIFF
--- a/fs/vfs/fs_chstat.c
+++ b/fs/vfs/fs_chstat.c
@@ -118,11 +118,6 @@ static int chstat(FAR const char *path,
 
   /* Adjust and check buf and flags */
 
-  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~0177777))
-    {
-      goto errout;
-    }
-
   if ((flags & CH_STAT_UID) && buf->st_uid == -1)
     {
       flags &= ~CH_STAT_UID;
@@ -210,7 +205,7 @@ int chmod(FAR const char *path, mode_t mode)
 {
   struct stat buf;
 
-  buf.st_mode = mode;
+  buf.st_mode = mode & 0777;
 
   return chstat(path, &buf, CH_STAT_MODE, 1);
 }
@@ -236,7 +231,7 @@ int lchmod(FAR const char *path, mode_t mode)
 {
   struct stat buf;
 
-  buf.st_mode = mode;
+  buf.st_mode = mode & 0777;
 
   return chstat(path, &buf, CH_STAT_MODE, 0);
 }

--- a/fs/vfs/fs_fchstat.c
+++ b/fs/vfs/fs_fchstat.c
@@ -114,11 +114,6 @@ int file_fchstat(FAR struct file *filep, FAR struct stat *buf, int flags)
 
   /* Adjust and check buf and flags */
 
-  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~0177777))
-    {
-      return -EINVAL;
-    }
-
   if ((flags & CH_STAT_UID) && buf->st_uid == -1)
     {
       flags &= ~CH_STAT_UID;
@@ -224,7 +219,7 @@ int fchmod(int fd, mode_t mode)
 {
   struct stat buf;
 
-  buf.st_mode = mode;
+  buf.st_mode = mode & 0777;
 
   return fchstat(fd, &buf, CH_STAT_MODE);
 }


### PR DESCRIPTION

## Summary
fs/chmod/fchmod/lchmod: only set permissions by mode_t and ignore othjer bits
## Impact

## Testing
test case:

int main(void)
{
  struct stat buf;
  int ret;

  stat("test1.t", &buf);
  printf("test1.t st.mode:%x\n", buf.st_mode);
  stat("test.t", &buf);
  printf("test.t st.mode:%x\n", buf.st_mode);
  ret = chmod("test1.t", buf.st_mode);
  if (ret == 0)
    {
      stat("test1.t", &buf);
      printf("test1.t st.mode:%x\n", buf.st_mode);
    }

  return 0;
}

>>
test1.t st.mode:81b4
test.t st.mode:81fd
test1.t st.mode:81fd
