### PR TITLE
drivers/syslog: compile syslog_device.c if console/char/file channel enabled

### DIFF
--- a/drivers/syslog/CMakeLists.txt
+++ b/drivers/syslog/CMakeLists.txt
@@ -41,7 +41,11 @@ endif()
 
 # System logging to a character device (or file)
 
-list(APPEND SRCS syslog_device.c)
+if(CONFIG_SYSLOG_CONSOLE
+   OR CONFIG_SYSLOG_CHAR
+   OR CONFIG_SYSLOG_FILE)
+  list(APPEND SRCS syslog_device.c)
+endif()
 
 if(CONFIG_SYSLOG_CHAR)
   list(APPEND SRCS syslog_devchannel.c)

--- a/drivers/syslog/Make.defs
+++ b/drivers/syslog/Make.defs
@@ -47,7 +47,9 @@ endif
 
 # System logging to a character device (or file)
 
+ifneq ($(CONFIG_SYSLOG_CONSOLE)$(CONFIG_SYSLOG_CHAR)$(CONFIG_SYSLOG_FILE),)
 CSRCS += syslog_device.c
+endif
 
 ifeq ($(CONFIG_SYSLOG_CHAR),y)
 CSRCS += syslog_devchannel.c


### PR DESCRIPTION
## Summary

drivers/syslog: compile syslog_device.c if console/char/file channel enabled

Add conditional compilation to syslog_device.c

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check