### PR TITLE
File reference count bug fix

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -423,6 +423,7 @@ void files_dumplist(FAR struct filelist *list)
             , buf
 #endif
             );
+      fs_putfilep(filep);
     }
 }
 #endif

--- a/fs/mmap/Kconfig
+++ b/fs/mmap/Kconfig
@@ -6,6 +6,7 @@
 config FS_RAMMAP
 	bool "File mapping emulation"
 	default n
+	depends on FS_REFCOUNT
 	---help---
 		NuttX operates in a flat open address space and is focused on MCUs that do
 		support Memory Management Units (MMUs).  Therefore, NuttX generally does not

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -40,8 +40,6 @@
 #include "fs_rammap.h"
 #include "sched/sched.h"
 
-#ifdef CONFIG_FS_RAMMAP
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -347,5 +345,3 @@ errout_with_region:
 
   return ret;
 }
-
-#endif /* CONFIG_FS_RAMMAP */


### PR DESCRIPTION
## Summary
bug fix
1. Should call fs_putfilep put fs reference when call files_fget complete
2. FS_RAMMAP depends on FS_REFCOUNT and remove useless macro
## Impact
all CONFIG_FS_REFCOUNT and CONFIG_DUMP_ON_EXIT config, A reference count exception exists. Procedure
## Testing
open CONFIG_FS_REFCOUNT and CONFIG_DUMP_ON_EXIT，call files_dumplist 

