### PR TITLE
SAMA5 sam_mcan.c unitialized variable

### DIFF
--- a/arch/arm/src/sama5/sam_mcan.c
+++ b/arch/arm/src/sama5/sam_mcan.c
@@ -1425,7 +1425,7 @@ static void mcan_buffer_reserve(struct sam_mcan_s *priv)
   int tffl;
 #endif
   int sval;
-  int ret;
+  int ret = 0;
 
   /* Wait until we successfully get the semaphore.  EINTR is the only
    * expected 'failure' (meaning that the wait for the semaphore was


### PR DESCRIPTION
## Summary
Noted a compiler warning - perhaps as a result of moving to newer gcc version or changes to NuttX gcc compiler options:

```
chip/sam_mcan.c:1562:14: warning: 'ret' may be used uninitialized [-Wmaybe-uninitialized]
 1562 |   while (ret < 0);
```

## Impact
None - no detrimental effect as a result of the warning had been noted, but obviously needed to be cleaned up/fixed

## Testing
Custom board with SAMA5D27C-D1G

