### PR TITLE
misc/rpmsgdev: Fix invalid pointer error

### DIFF
--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -515,14 +515,14 @@ static void rpmsgdev_server_created(FAR struct rpmsg_device *rdev,
       snprintf(buf, sizeof(buf), "%s%s", RPMSGDEV_NAME_PREFIX,
                priv->localpath);
       rpmsgdev_ns_bind(rdev, NULL, buf, RPMSG_ADDR_ANY);
-    }
 
-  rpmsg_unregister_callback(priv,
-                            rpmsgdev_server_created,
-                            NULL,
-                            NULL,
-                            NULL);
-  kmm_free(priv);
+      rpmsg_unregister_callback(priv,
+                                rpmsgdev_server_created,
+                                NULL,
+                                NULL,
+                                NULL);
+      kmm_free(priv);
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix invalid pointer error when there are more than one remotes
- Log
```
  [ap] arm_busfault: PANIC!!! Bus Fault:
  [ap] arm_busfault:        IRQ: 5 regs: 0x3c434e44
  [ap] arm_busfault:        BASEPRI: 00000000 PRIMASK: 00000000 IPSR: 00000005 CONTROL: 00000004
  [ap] arm_busfault:        CFSR: 00008200 HFSR: 00000000 DFSR: 00000000 BFAR: 00000000 AFSR: 00040000
  [ap] arm_busfault: Bus Fault Reason:
  [ap] arm_busfault:        Precise data bus error
  [ap] dump_assert_info: Current Version: NuttX ****** ***** *** 12.3.0 ********** Sep 23 2024 18:35:50 arm
  [ap] dump_assert_info: Assertion failed panic: at file: armv8-m/arm_busfault.c:113 task: testdev process: testdev 0x2c86ca75
```
- Backtrace
```
  backtrace_unwind
  /workspace/nuttx/arch/arm/src/common/arm_backtrace_unwind.c:632
  sched_backtrace
  /workspace/nuttx/sched/sched/sched_backtrace.c:105
  sched_dumpstack
  /workspace/nuttx/libs/libc/sched/sched_dumpstack.c:69
  dump_running_task
  /workspace/nuttx/sched/misc/assert.c:629
  arm_busfault
  /workspace/nuttx/arch/arm/src/armv8-m/arm_busfault.c:113
  irq_dispatch
  /workspace/nuttx/sched/irq/irq_dispatch.c:142
  arm_doirq
  /workspace/nuttx/arch/arm/src/armv8-m/arm_doirq.c:95
  strcmp
  /workspace/nuttx/libs/libc/machine/arm/armv8-m/gnu/arch_strcmp.S:107
  rpmsgdev_server_created
  /workspace/nuttx/drivers/misc/rpmsgdev_server.c:520 (discriminator 1)
  rpmsg_register_callback
  /workspace/nuttx/drivers/rpmsg/rpmsg.c:245
  rpmsgdev_export
  /workspace/nuttx/drivers/misc/rpmsgdev_server.c:552
  _register_driver
  /workspace/tests/testcases/rpmsgdev/testdev.c:216
  nxtask_startup
  /workspace/nuttx/libs/libc/sched/task_startup.c:70
  nxtask_start
  /workspace/nuttx/sched/task/task_start.c:114
```
## Impact
- misc/rpmsgdev

## Testing
```
# see tests/testcases/rpmsgdev for details
# 1. Register dummy device
testdev -d 0 -r "/dev/ttyGNSS0"
# 2. Call rpmsgdev_export() to export the device to remote
testdev -d 2 -c "droid" -l "/dev/ttyGNSS0"
```