### PR TITLE
smartfs: add partial support for FIOC_FILEPATH ioctl

### DIFF
--- a/fs/smartfs/smartfs.h
+++ b/fs/smartfs/smartfs.h
@@ -307,6 +307,7 @@ struct smartfs_ofile_s
                                              * a seek, or more data is written that
                                              * causes the sector to change.
                                              */
+  char                        path[1];      /* The full path to the file */
 };
 
 /* This structure represents the overall mountpoint state.  An instance of

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -44,6 +44,7 @@
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/smart.h>
 
+#include "inode/inode.h"
 #include "smartfs.h"
 
 /****************************************************************************
@@ -181,6 +182,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
   FAR struct smartfs_mountpt_s *fs;
   int                           ret;
   uint16_t                      parentdirsector;
+  size_t                        pathlen;
   FAR const char               *filename;
   FAR struct smartfs_ofile_s   *sf;
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
@@ -210,12 +212,19 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Locate the directory entry for this path */
 
-  sf = kmm_malloc(sizeof *sf);
+  pathlen = strlen(relpath) + 1;
+  sf = kmm_malloc(sizeof(*sf) + pathlen - 1);
   if (sf == NULL)
     {
       ret = -ENOMEM;
       goto errout_with_lock;
     }
+
+  /* Save the full path to smartfs_ofile_s stuctrue. This is needed
+   * to FIOC_FILEPATH ioctlc all support.
+   */
+
+  memcpy(sf->path, relpath, pathlen);
 
   /* Allocate a sector buffer if CRC enabled in the MTD layer */
 
@@ -997,9 +1006,39 @@ static off_t smartfs_seek(FAR struct file *filep, off_t offset, int whence)
 
 static int smartfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  /* We don't use any ioctls */
+  FAR struct smartfs_ofile_s *priv;
+  FAR struct inode *inode;
+  int ret;
 
-  return -ENOSYS;
+  /* Recover our private data from the struct file instance */
+
+  priv  = filep->f_priv;
+  inode = filep->f_inode;
+
+  switch (cmd)
+    {
+      case FIOC_FILEPATH:
+        {
+          FAR char *path = (FAR char *)(uintptr_t)arg;
+          ret = inode_getpath(inode, path, PATH_MAX);
+          if (ret >= 0)
+            {
+              size_t len = strlen(path);
+              if (path[len - 1] != '/')
+                {
+                  path[len++] = '/';
+                }
+
+              strlcat(path, priv->path, PATH_MAX - len);
+            }
+        }
+        break;
+      default:
+        ret = -ENOSYS;
+        break;
+    }
+
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The `FIOC_FILEPATH` ioctl call is required if smartfs is to be used together with inotify monitoring system. This partially implements the call support to smartfs file system.

The call currently does not work correctly if subdirectories are in the file's path. For example `/dir/file` will be returned correctly, but `/dir/subdir/file` will exclude the `subdir` part and return only `/dir/file`. The full support is complicated due to the SmartFS design.

The correct procedure would be to take the inode's path obtained by inode_getpath and let SmartFS recursively get the full path from the file. However, SmartFS entries do not keep the information about their parents and it is not possible to obtain the full path by going backwards. The file system currently takes the advantage of knowing the full path during the node creation/remove/rename/etc and does the forward search with node by node string comparison.

This possible solution would require the introduction of parent field in the entry structure and going backwards to obtain the full path. This would mean the modification of SmartFS structures including the ones stored in the NOR flash, most likely causing the incompatibility with previous versions.

## Impact
SmartFS now at least partially work with inotify for calls that do not have direct knowledge of the full file path.
