### PR TITLE
drivers/modem/alt1250: Fix issue where the program would get stuck

### DIFF
--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -856,6 +856,24 @@ static int parse_altcompkt(FAR struct alt1250_dev_s *dev, FAR uint8_t *pkt,
       if (*container)
         {
           (*container)->result = -ENOSYS;
+          *bitmap = get_bitmap(dev, cid, get_altver(h));
+          if (LTE_IS_ASYNC_CMD((*container)->cmdid))
+            {
+              /* Asynchronous types need to call the callback corresponding
+               * to the received event, so the REPLY bit is added to the
+               * received event.
+               */
+
+              *bitmap |= ALT1250_EVTBIT_REPLY;
+            }
+          else
+            {
+              /* Synchronous types do not call a callback,
+               * so only the REPLY bit is needed.
+               */
+
+              *bitmap = ALT1250_EVTBIT_REPLY;
+            }
         }
 
       return *container == NULL ? ERROR: OK;


### PR DESCRIPTION
## Summary
Fix issue where the program would get stuck
if an unsupported ALTCOM packet was sent.

## Impact
Only ALT1250 driver.

## Testing
Test with Spresense LTE board.
