### PR TITLE
net/usrsock: Clear usockid when USRSOCK_EVENT_ABORT is received

### DIFF
--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -50,6 +50,8 @@
 #define USRSOCK_EVENT_INTERNAL_MASK (USRSOCK_EVENT_CONNECT_READY | \
                                      USRSOCK_EVENT_REQ_COMPLETE)
 
+#define USRSOCK_USOCKID_INVALID     (-1)
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/usrsock/usrsock_close.c
+++ b/net/usrsock/usrsock_close.c
@@ -185,7 +185,7 @@ int usrsock_close(FAR struct usrsock_conn_s *conn)
 
 close_out:
   conn->state = USRSOCK_CONN_STATE_UNINITIALIZED;
-  conn->usockid = -1;
+  conn->usockid = USRSOCK_USOCKID_INVALID;
 
 errout:
   net_unlock();

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -117,7 +117,7 @@ FAR struct usrsock_conn_s *usrsock_alloc(void)
       /* Make sure that the connection is marked as uninitialized */
 
       nxsem_init(&conn->resp.sem, 0, 1);
-      conn->usockid = -1;
+      conn->usockid = USRSOCK_USOCKID_INVALID;
       conn->state = USRSOCK_CONN_STATE_UNINITIALIZED;
 
       /* Enqueue the connection into the active list */
@@ -344,7 +344,7 @@ void usrsock_initialize(void)
 
       /* Mark the connection closed and move it to the free list */
 
-      conn->usockid = -1;
+      conn->usockid = USRSOCK_USOCKID_INVALID;
       conn->state   = USRSOCK_CONN_STATE_UNINITIALIZED;
       dq_addlast(&conn->sconn.node, &g_free_usrsock_connections);
     }

--- a/net/usrsock/usrsock_event.c
+++ b/net/usrsock/usrsock_event.c
@@ -87,6 +87,7 @@ int usrsock_event(FAR struct usrsock_conn_s *conn)
   if (events & USRSOCK_EVENT_ABORT)
     {
       conn->state = USRSOCK_CONN_STATE_ABORTED;
+      conn->usockid = USRSOCK_USOCKID_INVALID;
     }
 
   if ((conn->state == USRSOCK_CONN_STATE_READY ||


### PR DESCRIPTION
## Summary
Clear usockid when USRSOCK_EVENT_ABORT is received.
When usrsock receives a USRSOCK_EVENT_ABORT, it determines that the usrsock daemon's socket is closed. Then usrsock clears the usockid.

## Impact
usrsock

## Testing
Test with Spresense LTE board.
