### PR TITLE
net/tcp: Fix TCP keepalive time unit misuse problem

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -107,11 +107,15 @@ static int tcp_get_timeout(FAR struct tcp_conn_s *conn)
 #ifdef CONFIG_NET_TCP_KEEPALIVE
   if (timeout == 0)
     {
-      timeout = conn->keeptimer;
+      /* The conn->keeptimer units is decisecond and the timeout
+       * units is half-seconds, therefore they need to be unified.
+       */
+
+      timeout = conn->keeptimer / DSEC_PER_HSEC;
     }
-  else if (conn->keeptimer > 0 && timeout > conn->keeptimer)
+  else if (conn->keeptimer > 0 && timeout > conn->keeptimer / DSEC_PER_HSEC)
     {
-      timeout = conn->keeptimer;
+      timeout = conn->keeptimer / DSEC_PER_HSEC;
     }
 #endif
 
@@ -699,11 +703,11 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
                * received from the remote peer?
                */
 
-              if (conn->keeptimer > hsec)
+              if (conn->keeptimer > hsec * DSEC_PER_HSEC)
                 {
                   /* Will not yet decrement to zero */
 
-                  conn->keeptimer -= hsec;
+                  conn->keeptimer -= hsec * DSEC_PER_HSEC;
                 }
               else
                 {


### PR DESCRIPTION
## Summary

The conn->keeptimer units is decisecond，but its unit is treated as half-second in the tcp_timer & tcp_get_timeout function.
This question was asked here:
https://github.com/apache/nuttx/issues/13493

## Impact

Only affects the TCP keepalive mechanism.

## Testing

Local packet capture verification.
