### PR TITLE
cmake(bugfix):make sure the extra_lib only added once

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -201,8 +201,10 @@ function(nuttx_add_extra_library)
     # define the target name of the extra library
     string(REGEX REPLACE "[^a-zA-Z0-9]" "_" extra_target "${extra_lib}")
     # set the absolute path of the library for the import target
-    nuttx_library_import(${extra_target} ${extra_lib})
-    set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${extra_target})
+    if(NOT TARGET ${extra_target})
+      nuttx_library_import(${extra_target} ${extra_lib})
+      set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES ${extra_target})
+    endif()
   endforeach()
 endfunction()
 


### PR DESCRIPTION
## Summary

avoid duplicate definitions of target when
`nuttx_add_extra_library` is called between different models at the same time

```shell
CMake Error at cmake/nuttx_add_library.cmake:220 (add_library):
  add_library cannot create imported target
  "_home_data_prebuilts_gcc_linux_arm_bin____lib_gcc_arm_none_eabi_13_2_1_thumb_v7ve_simd_hard_libgcc_a"
  because another target with the same name already exists.
Call Stack (most recent call first):
  cmake/nuttx_add_library.cmake:208 (nuttx_library_import)
  cmake/nuttx_toolchain.cmake:103 (nuttx_add_extra_library)
  arch/arm/src/cmake/platform.cmake:76 (nuttx_find_toolchain_lib)
  CMakeLists.txt:416 (include)


CMake Error at cmake/nuttx_add_library.cmake:220 (add_library):
  add_library cannot create imported target
  "_home_data_prebuilts_gcc_linux_arm_bin____lib_gcc_arm_none_eabi_13_2_1_____________arm_none_eabi_lib_thumb_v7ve_simd_hard_libm_a"
  because another target with the same name already exists.
Call Stack (most recent call first):
  cmake/nuttx_add_library.cmake:208 (nuttx_library_import)
  cmake/nuttx_toolchain.cmake:103 (nuttx_add_extra_library)
  arch/arm/src/cmake/platform.cmake:79 (nuttx_find_toolchain_lib)
  CMakeLists.txt:416 (include)
``` 

## Impact
cmake build

## Testing
ci build
