### PR TITLE
libc/pathbuffer: fix build warning on tasking

### DIFF
--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -141,6 +141,6 @@ void lib_put_pathbuffer(FAR char *buffer)
   /* Free the buffer if it was dynamically allocated */
 
 #ifdef CONFIG_LIBC_PATHBUFFER_MALLOC
-  return lib_free(buffer);
+  lib_free(buffer);
 #endif
 }


### PR DESCRIPTION
## Summary

libc/pathbuffer: fix build warning on tasking

```
[263/1096] Building C object libs/libc/CMakeFiles/c.dir/misc/lib_pathbuffer.c.obj
ctc W574: ["libs/libc/misc/lib_pathbuffer.c" 144/3] 'return' with an expression in function returning void
```

Commit:
https://github.com/apache/nuttx/pull/12969/files#diff-6cd9ed22f42280c9ebc90642c0b44fbc0d1d90c7e58700110ceefd229d79b02aR144

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check