### PR TITLE
arch/tricore: fix build error on tricore

### DIFF
--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -95,7 +95,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      __mtcr(CPU_PCXI, up_current_regs());
+      __mtcr(CPU_PCXI, (uintptr_t)up_current_regs());
       __isync();
     }
 

--- a/arch/tricore/src/common/tricore_svcall.c
+++ b/arch/tricore/src/common/tricore_svcall.c
@@ -120,7 +120,7 @@ void tricore_svcall(volatile void *trap)
 
       g_running_tasks[this_cpu()] = this_task();
 
-      regs[REG_UPCXI] = up_current_regs();
+      regs[REG_UPCXI] = (uintptr_t)up_current_regs();
 
       __isync();
     }


### PR DESCRIPTION
## Summary

arch/tricore: fix build error on tricore

ctc E333: ["arch/tricore/src/common/tricore_svcall.c" 123/23] incompatible types at assignment
ctc E333: ["arch/tricore/src/common/tricore_doirq.c" 98/39] incompatible types at argument #2

Regression by:
https://github.com/apache/nuttx/pull/13423

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check