### PR TITLE
drivers/rpmsg: Using safe list iterating in rpmsg_device_created() to fix list access after delete error

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -434,7 +434,7 @@ void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg)
 #endif
 
   nxrmutex_lock(&rpmsg->lock);
-  metal_list_for_each_safe(&rpmsg->bind, node, tmp)
+  metal_list_for_each_safe(&rpmsg->bind, tmp, node)
     {
       FAR struct rpmsg_bind_s *bind =
         metal_container_of(node, struct rpmsg_bind_s, node);

--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -402,9 +402,10 @@ void rpmsg_ns_unbind(FAR struct rpmsg_device *rdev,
 void rpmsg_device_created(FAR struct rpmsg_s *rpmsg)
 {
   FAR struct metal_list *node;
+  FAR struct metal_list *tmp;
 
   nxrmutex_lock(&g_rpmsg_lock);
-  metal_list_for_each(&g_rpmsg_cb, node)
+  metal_list_for_each_safe(&g_rpmsg_cb, tmp, node)
     {
       FAR struct rpmsg_cb_s *cb =
         metal_container_of(node, struct rpmsg_cb_s, node);


### PR DESCRIPTION
## Summary
1. Using safe list iterating in rpmsg_device_created()
2. Fix a typo error of rpmsg_device_destory()

- Log
```
  [ap] kasan_report: kasan detected a read access error, address at 0x40b7ae78,size is 8, return address: 0x402a3c50
  [ap] kasan_show_memory: Shadow bytes around the buggy address:
  [ap] kasan_show_memory:   0x40b7ae20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae50: 20 af b7 40 00 00 00 00 c0 17 2a 40 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae70: 00 00 00 00 00 00 00 00[b0 f7 b3 40 00 00 00 00]
  [ap] kasan_show_memory:   0x40b7ae80: c8 48 b8 40 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7ae90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7aea0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  [ap] kasan_show_memory:   0x40b7aeb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

  $ addr2line -fe nuttx/nuttx 0x402a3c50
  rpmsg_device_created
  /workspace/nuttx/drivers/rpmsg/rpmsg.c:395 (discriminator 2)

  # line 395 is local version, corresponds to metal_list_for_each() in rpmsg_device_created() of apache:nuttx version.

```
## Impact
- drivers/rpmsg

## Testing
1. Local test
```
  /* Export */
  rpmsgdev_export("SERVER", "/dev/DEVNAME");

  /* Register */
  rpmsgdev_register("CLIENT", "/dev/DEVNAME", "/dev/server-DEVNAME", 0);
```
2. Github CI
