### PR TITLE
drivers/rpmsg: replace metal_list_for_each to safety version

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -354,7 +354,7 @@ void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
           FAR void *cb_priv = cb->priv;
 
           nxrmutex_unlock(&g_rpmsg_lock);
-          DEBUGASSERT(ns_bind != NULL);
+
           ns_bind(rdev, cb_priv, name, dest);
           return;
         }
@@ -448,7 +448,7 @@ void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg)
   /* Broadcast device_destroy to all registers */
 
   nxrmutex_lock(&g_rpmsg_lock);
-  metal_list_for_each(&g_rpmsg_cb, node)
+  metal_list_for_each_safe(&g_rpmsg_cb, tmp, node)
     {
       FAR struct rpmsg_cb_s *cb =
         metal_container_of(node, struct rpmsg_cb_s, node);


### PR DESCRIPTION
## Summary

drivers/rpmsg: replace metal_list_for_each to safety version

replace metal_list_for_each to safety version to avoid invalid access to deleted node in destory flow

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check