### PR TITLE
CMake/preprocess: fix typo PREPROCES -> PREPROCESS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,14 +593,14 @@ endif()
 get_property(ldscript GLOBAL PROPERTY LD_SCRIPT)
 
 # Pre-compile linker script
-if(DEFINED PREPROCES)
+if(DEFINED PREPROCESS)
   get_filename_component(LD_SCRIPT_NAME ${ldscript} NAME)
   set(LD_SCRIPT_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_NAME}.tmp")
 
   add_custom_command(
     OUTPUT ${LD_SCRIPT_TMP}
     DEPENDS ${ldscript}
-    COMMAND ${PREPROCES} -I${CMAKE_BINARY_DIR}/include -I${NUTTX_CHIP_ABS_DIR}
+    COMMAND ${PREPROCESS} -I${CMAKE_BINARY_DIR}/include -I${NUTTX_CHIP_ABS_DIR}
             ${ldscript} > ${LD_SCRIPT_TMP}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -752,14 +752,14 @@ if(CONFIG_BUILD_PROTECTED)
 
   get_property(user_ldscript GLOBAL PROPERTY LD_SCRIPT_USER)
 
-  if(DEFINED PREPROCES)
+  if(DEFINED PREPROCESS)
     get_filename_component(LD_SCRIPT_NAME ${user_ldscript} NAME)
     set(LD_SCRIPT_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_NAME}.tmp")
     add_custom_command(
       OUTPUT ${LD_SCRIPT_TMP}
       DEPENDS ${user_ldscript}
-      COMMAND ${PREPROCES} -I${CMAKE_BINARY_DIR}/include -I${NUTTX_CHIP_ABS_DIR}
-              ${user_ldscript} > ${LD_SCRIPT_TMP}
+      COMMAND ${PREPROCESS} -I${CMAKE_BINARY_DIR}/include
+              -I${NUTTX_CHIP_ABS_DIR} ${user_ldscript} > ${LD_SCRIPT_TMP}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     add_custom_target(user_ldscript_tmp DEPENDS ${LD_SCRIPT_TMP})
     add_dependencies(nuttx_user user_ldscript_tmp)

--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -119,4 +119,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
+set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/arm64/src/cmake/platform.cmake
+++ b/arch/arm64/src/cmake/platform.cmake
@@ -67,4 +67,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
+set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -72,4 +72,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
+set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/tricore/src/cmake/platform.cmake
+++ b/arch/tricore/src/cmake/platform.cmake
@@ -71,5 +71,5 @@ if(CONFIG_TRICORE_TOOLCHAIN_GNU)
 
   nuttx_add_extra_library(${EXTRA_LIB})
 
-  set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
+  set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
 endif()

--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -71,4 +71,4 @@ endif()
 nuttx_add_extra_library(${EXTRA_LIB})
 
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
-set(PREPROCES ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
+set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)


### PR DESCRIPTION
## Summary

CMake/preprocess: fix typo PREPROCES -> PREPROCESS

correct the marco define from PREPROCES to PREPROCESS

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check