### PR TITLE
arm: we should use tcb->xcp.regs instead of up_current_regs()

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -474,7 +474,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #  endif
 #endif
 
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -483,7 +483,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #  endif
 #endif
 
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       restore_critical_section(this_task(), this_cpu());
     }

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -484,7 +484,7 @@ int arm_svcall(int irq, void *context, void *arg)
 #  endif
 #endif
 
-  if (regs != up_current_regs())
+  if (regs != tcb->xcp.regs)
     {
       restore_critical_section(this_task(), this_cpu());
     }


### PR DESCRIPTION
## Summary
we should use tcb->xcp.regs instead of up_current_regs() as the basis for judging whether to call restore_critical_section.
This commit fixes the regression from https://github.com/apache/nuttx/pull/13444

## Impact
arm6-m
arm7-m
arm8-m

## Testing
ostest

