### PR TITLE
arch/risc-v/src/common/riscv_internal.h: Change put/getreg address to uintptr_t

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -117,50 +117,50 @@
 
 /* Use ASM as rv64ilp32 compiler generated address is limited */
 
-static inline uint8_t getreg8(const volatile uintreg_t a)
+static inline uint8_t getreg8(const volatile uintptr_t a)
 {
   uint8_t v;
   __asm__ __volatile__("lb %0, 0(%1)" : "=r" (v) : "r" (a));
   return v;
 }
 
-static inline void putreg8(uint8_t v, const volatile uintreg_t a)
+static inline void putreg8(uint8_t v, const volatile uintptr_t a)
 {
   __asm__ __volatile__("sb %0, 0(%1)" : : "r" (v), "r" (a));
 }
 
-static inline uint16_t getreg16(const volatile uintreg_t a)
+static inline uint16_t getreg16(const volatile uintptr_t a)
 {
   uint16_t v;
   __asm__ __volatile__("lh %0, 0(%1)" : "=r" (v) : "r" (a));
   return v;
 }
 
-static inline void putreg16(uint16_t v, const volatile uintreg_t a)
+static inline void putreg16(uint16_t v, const volatile uintptr_t a)
 {
   __asm__ __volatile__("sh %0, 0(%1)" : : "r" (v), "r" (a));
 }
 
-static inline uint32_t getreg32(const volatile uintreg_t a)
+static inline uint32_t getreg32(const volatile uintptr_t a)
 {
   uint32_t v;
   __asm__ __volatile__("lw %0, 0(%1)" : "=r" (v) : "r" (a));
   return v;
 }
 
-static inline void putreg32(uint32_t v, const volatile uintreg_t a)
+static inline void putreg32(uint32_t v, const volatile uintptr_t a)
 {
   __asm__ __volatile__("sw %0, 0(%1)" : : "r" (v), "r" (a));
 }
 
-static inline uint64_t getreg64(const volatile uintreg_t a)
+static inline uint64_t getreg64(const volatile uintptr_t a)
 {
   uint64_t v;
   __asm__ __volatile__("ld %0, 0(%1)" : "=r" (v) : "r" (a));
   return v;
 }
 
-static inline void putreg64(uint64_t v, const volatile uintreg_t a)
+static inline void putreg64(uint64_t v, const volatile uintptr_t a)
 {
   __asm__ __volatile__("sd %0, 0(%1)" : : "r" (v), "r" (a));
 }
@@ -251,7 +251,7 @@ extern "C"
 #ifndef __ASSEMBLY__
 /* Atomic modification of registers */
 
-void modifyreg32(uintreg_t addr, uint32_t clearbits, uint32_t setbits);
+void modifyreg32(uintptr_t addr, uint32_t clearbits, uint32_t setbits);
 
 /* Memory allocation ********************************************************/
 

--- a/arch/risc-v/src/common/riscv_modifyreg32.c
+++ b/arch/risc-v/src/common/riscv_modifyreg32.c
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void modifyreg32(uintreg_t addr, uint32_t clearbits, uint32_t setbits)
+void modifyreg32(uintptr_t addr, uint32_t clearbits, uint32_t setbits)
 {
   irqstate_t flags;
   uint32_t   regval;


### PR DESCRIPTION
riscv putreg and getreg macros were changed into inline assembly function recently in 28ae3b38499.

But this changed the register addresses into "uintreg_t" type. This is clearly wrong. 

The register address *is* an adress, and the data type size should be able to address the whole addressable range. uintptr_t is the correct data type for the register address.
