### PR TITLE
arch/risc-v/src/common/riscv_initialstate.c: Fix stack pointer in coloration

### DIFF
--- a/arch/risc-v/src/common/riscv_initialstate.c
+++ b/arch/risc-v/src/common/riscv_initialstate.c
@@ -97,7 +97,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == IDLE_PROCESS_ID)
     {
-      tcb->stack_alloc_ptr = (void *)g_cpux_idlestack(riscv_mhartid());
+      tcb->stack_alloc_ptr = (void *)g_cpux_idlestack(this_cpu());
       tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
       tcb->adj_stack_size  = SMP_STACK_SIZE;
 


### PR DESCRIPTION
## Summary

The logical CPU index should be retrieved with up_cpu_index(); the riscv_mhartid() returns the actual hart id of the SoC.

For mpfs target for example, NuttX can run on a single HART, for example on mhartid 2, but there is still just one logical CPU for the NuttX.

## Impact

risc-v target with more than 1 hart, NuttX running on some other than hartid 0

## Testing

Tested on mpfs platform, running NuttX on hart 2
