### PR TITLE
drivers/mmcsd/mmcsd_sdio.c: Fix setting SDIO_WIDEBUS for SD cards

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2690,8 +2690,9 @@ static int mmcsd_widebus(FAR struct mmcsd_state_s *priv)
 
   /* Configure the SDIO peripheral */
 
-  if ((IS_MMC(priv->type) && ((priv->caps & SDIO_CAPS_1BIT_ONLY) == 0)) &&
-      ((priv->buswidth & MMCSD_SCR_BUSWIDTH_4BIT) != 0))
+  if ((priv->caps & SDIO_CAPS_1BIT_ONLY) == 0 &&
+      (IS_MMC(priv->type) ||
+       (priv->buswidth & MMCSD_SCR_BUSWIDTH_4BIT) != 0))
     {
       /* JEDEC specs: A.8.3 Changing the data bus width: 'Bus testing
        * procedure' shows how mmc bus width may be detected.  This driver


### PR DESCRIPTION
## Summary

This corrects the setting widebus for SD cards, which was recently broken in 4f7f751d2adaa.

The if checking the priv->caps, priv->buswidth and IS_MMC has been wrong for some time. The proper logic is that for MMC only the priv->caps is checked. For SD card, both priv->caps and priv->buswidth need to be checked.

## Impact

SD-cards with 4-bit bus

## Testing

Tested on i.MX93 and MPFS platforms

