### PR TITLE
Mpfs corepwm fixes

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -578,12 +578,6 @@ config MPFS_COREPWM0_BASE
 	default 0x44000000
 	depends on MPFS_COREPWM0
 
-config MPFS_COREPWM0_PWMCLK
-	int "Clock frequency of the CorePWM0 block (Hz)"
-	default 25000000
-	range 1000000 100000000
-	depends on MPFS_COREPWM0
-
 config MPFS_COREPWM0_REGWIDTH
 	int "Width of the PWM register (8, 16 or 32 bits)"
 	default 32
@@ -605,12 +599,6 @@ config MPFS_COREPWM1
 config MPFS_COREPWM1_BASE
 	hex "Base address for the instance"
 	default 0x45000000
-	depends on MPFS_COREPWM1
-
-config MPFS_COREPWM1_PWMCLK
-	int "Clock frequency of the CorePWM1 block (Hz)"
-	default 25000000
-	range 1000000 100000000
 	depends on MPFS_COREPWM1
 
 config MPFS_COREPWM1_REGWIDTH

--- a/arch/risc-v/src/mpfs/mpfs_corepwm.c
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.c
@@ -76,7 +76,6 @@ struct mpfs_pwmtimer_s
   struct mpfs_pwmchan_s channels[MPFS_MAX_PWM_CHANNELS];
   uint32_t frequency;          /* Current frequency setting */
   uintptr_t base;              /* The base address of the pwm block */
-  uint32_t pwmclk;             /* The frequency of the pwm clock */
 };
 
 /****************************************************************************
@@ -187,7 +186,6 @@ static struct mpfs_pwmtimer_s g_pwm0dev =
     }
   },
   .base        = CONFIG_MPFS_COREPWM0_BASE,
-  .pwmclk      = CONFIG_MPFS_COREPWM0_PWMCLK,
 };
 #endif
 
@@ -249,7 +247,6 @@ static struct mpfs_pwmtimer_s g_pwm1dev =
     }
   },
   .base        = CONFIG_MPFS_COREPWM1_BASE,
-  .pwmclk      = CONFIG_MPFS_COREPWM1_PWMCLK,
 };
 #endif
 
@@ -404,12 +401,12 @@ static int pwm_timer(struct mpfs_pwmtimer_s *priv,
    *    PERIOD = pwmclk / frequency = 25,000,000 / 50 = 500,000
    */
 
-  pwminfo("PWM%u frequency: %u PWMCLK: %u prescaler: %u\n",
-          priv->pwmid, info->frequency, priv->pwmclk, prescaler);
+  pwminfo("PWM%u frequency: %u PWMCLK: %lu prescaler: %u\n",
+          priv->pwmid, info->frequency, MPFS_FPGA_PERIPHERAL_CLK, prescaler);
 
   /* Set the reload and prescaler values */
 
-  period = priv->pwmclk / info->frequency;
+  period = MPFS_FPGA_PERIPHERAL_CLK / info->frequency;
 
   pwm_putreg(priv, MPFS_COREPWM_PERIOD_OFFSET, period);
   pwm_putreg(priv, MPFS_COREPWM_PRESCALE_OFFSET, prescaler);

--- a/arch/risc-v/src/mpfs/mpfs_corepwm.c
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.c
@@ -557,6 +557,13 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
   struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   pwminfo("PWMID%u\n", priv->pwmid);
+
+  /* Make sure that frequency is zero and channels has been disabled */
+
+  priv->frequency = 0;
+  pwm_putreg(priv, MPFS_COREPWM_PWM_ENABLE_0_7_OFFSET,  0x00);
+  pwm_putreg(priv, MPFS_COREPWM_PWM_ENABLE_8_15_OFFSET, 0x00);
+
   pwm_dumpregs(priv, "Initially");
 
   return OK;


### PR DESCRIPTION
## Summary

This adds small fixes for mpfs corepwm driver. The corepwm is a Microchip's IP block (freely usable), which can be instantiated on the FPGA of the MPFS chip.

## Impact

Only MPFS targets using CorePWM IP

## Testing

Tested on a custom MPFS hardware

