### PR TITLE
Mpfs opensbi fixes

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.c
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.c
@@ -222,4 +222,28 @@ int mpfs_set_use_sbi(uint64_t hartid, bool use_sbi)
   return ERROR;
 }
 
+/****************************************************************************
+ * Name: mpfs_get_use_sbi
+ *
+ * Description:
+ *   Get if hart boots via SBI.
+ *
+ * Input Parameters:
+ *   hartid - hart id to check
+ *
+ * Returned value:
+ *   true if SBI is used, false otherwise
+ *
+ ****************************************************************************/
+
+bool mpfs_get_use_sbi(uint64_t hartid)
+{
+  if (hartid < ENTRYPT_CNT)
+    {
+      return (g_hart_use_sbi & (1 << hartid)) != 0;
+    }
+
+  return false;
+}
+
 #endif /* CONFIG_MPFS_BOOTLOADER */

--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.h
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.h
@@ -86,6 +86,22 @@ int mpfs_set_entrypt(uint64_t hartid, uintptr_t entry);
 
 int mpfs_set_use_sbi(uint64_t hartid, bool use_sbi);
 
+/****************************************************************************
+ * Name: mpfs_get_use_sbi
+ *
+ * Description:
+ *   Get if hart boots via SBI.
+ *
+ * Input Parameters:
+ *   hartid - hart id to check
+ *
+ * Returned value:
+ *   true if SBI is used, false otherwise
+ *
+ ****************************************************************************/
+
+bool mpfs_get_use_sbi(uint64_t hartid);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -45,6 +45,8 @@
 #include <mpfs_ihc.h>
 #endif
 
+#include <sys/param.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -184,30 +186,7 @@ static struct aclint_mswi_data mpfs_mswi =
  * Unused hart is marked with -1.  Mpfs will always have the hart0 unused.
  */
 
-static const u32 mpfs_hart_index2id[MPFS_HART_COUNT] =
-{
-  [0] = -1,
-#ifdef CONFIG_MPFS_HART1_SBI
-  [1] = 1,
-#else
-  [1] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART2_SBI
-  [2] = 2,
-#else
-  [2] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART3_SBI
-  [3] = 3,
-#else
-  [3] = -1,
-#endif
-#ifdef CONFIG_MPFS_HART4_SBI
-  [4] = 4,
-#else
-  [4] = -1,
-#endif
-};
+static u32 mpfs_hart_index2id[MPFS_HART_COUNT];
 
 static const struct sbi_platform platform =
 {
@@ -602,6 +581,12 @@ static int mpfs_opensbi_ecall_handler(long funcid,
 void __attribute__((noreturn)) mpfs_opensbi_setup(void)
 {
   uint32_t hartid = current_hartid();
+  size_t i;
+
+  for (i = 0; i < nitems(mpfs_hart_index2id); i++)
+    {
+      mpfs_hart_index2id[i] = mpfs_get_use_sbi(i) ? i : -1;
+    }
 
   sbi_console_set_device(&mpfs_console);
   mpfs_opensbi_scratch_setup(hartid);

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -28,8 +28,31 @@
 #include <hardware/mpfs_sysreg.h>
 #ifdef CONFIG_MPFS_IHC_SBI
 #include <hardware/mpfs_ihc_sbi.h>
+#include <mpfs_ihc.h>
+#endif
+#include "mpfs_entrypoints.h"
+
+/* Make sure that anything that intefraces with the SBI uses the same data
+ * types as the SBI code (e.g. same "bool")
+ */
+
+#ifdef bool
+#undef bool
 #endif
 
+#ifdef true
+#undef true
+#endif
+
+#ifdef false
+#undef false
+#endif
+
+#ifdef NULL
+#undef NULL
+#endif
+
+#include <sbi/sbi_types.h>
 #include <sbi/riscv_io.h>
 #include <sbi/riscv_encoding.h>
 #include <sbi/sbi_console.h>


### PR DESCRIPTION
## Summary

These are opensbi related fixes for MPFS platform, mainly to support custom bootloaders. 

- Provides a function which nuttx-based bootloader can call to obtain info whether the SW running on a hart is controlled by opensbi
- Uses sbi_types.h to have compatible types when initializing opensbi from within the mpfs.

## Impact

MPFS w. opensbi only

## Testing

Tested on custom mpfs hw
