### PR TITLE
ci/platforms/msys2.sh: update esptool version and switch Wget to cURL tool

### DIFF
--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -54,7 +54,7 @@ arm_gcc_toolchain() {
     local basefile
     basefile=arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi
     cd "${NUTTXTOOLS}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.zip
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.zip
     unzip -qo ${basefile}.zip
     mv ${basefile} gcc-arm-none-eabi
     rm ${basefile}.zip
@@ -71,7 +71,7 @@ arm64_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf
     cd "${NUTTXTOOLS}"
     # Download the latest ARM64 GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.zip
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.zip
     unzip -qo ${basefile}.zip
     mv ${basefile} gcc-aarch64-none-elf
     rm ${basefile}.zip
@@ -95,9 +95,9 @@ esp_tool() {
 
   if ! type esptool > /dev/null 2>&1; then
     local basefile
-    basefile=esptool-v4.7.0-win64
+    basefile=esptool-v4.8.0-win64
     cd "${NUTTXTOOLS}"
-    curl -O -L -s https://github.com/espressif/esptool/releases/download/v4.7.0/${basefile}.zip
+    curl -O -L -s https://github.com/espressif/esptool/releases/download/v4.8.0/${basefile}.zip
     unzip -qo ${basefile}.zip
     mv esptool-win64 esp-tool
     rm ${basefile}.zip
@@ -109,7 +109,7 @@ gen_romfs() {
   add_path "${NUTTXTOOLS}"/genromfs/usr/bin
 
   if ! type genromfs > /dev/null 2>&1; then
-    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools
     tar zxf genromfs-0.5.2.tar.gz
     cd genromfs-0.5.2
@@ -123,7 +123,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \
@@ -156,7 +156,7 @@ riscv_gcc_toolchain() {
     basefile=xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.zip
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.zip
     unzip -qo ${basefile}.zip
     mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
     rm ${basefile}.zip
@@ -197,7 +197,7 @@ sparc_gcc_toolchain() {
     basefile=bcc-2.1.0-gcc-mingw64
     cd "${NUTTXTOOLS}"
     # Download the SPARC GCC toolchain prebuilt by Gaisler
-    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.zip
+    curl -O -L -s https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.zip
     unzip -qo ${basefile}.zip
     mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
     rm ${basefile}.zip
@@ -214,7 +214,7 @@ xtensa_esp32_gcc_toolchain() {
     basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-w64-mingw32
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
     unzip -qo ${basefile}.zip
     rm ${basefile}.zip
   fi
@@ -230,7 +230,7 @@ xtensa_esp32s2_gcc_toolchain() {
     basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-w64-mingw32
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
     unzip -qo ${basefile}.zip
     rm ${basefile}.zip
   fi
@@ -246,7 +246,7 @@ xtensa_esp32s3_gcc_toolchain() {
     basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-w64-mingw32
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.zip
     unzip -qo ${basefile}.zip
     rm ${basefile}.zip
   fi


### PR DESCRIPTION
## Summary

Bumps esptool from 4.7.0 to 4.8.0.

Switch wget to cURL tool for:
arm_gcc_toolchain()
arm64_gcc_toolchain()
riscv_gcc_toolchain()
sparc_gcc_toolchain()
xtensa_esp32_gcc_toolchain()
xtensa_esp32s2_gcc_toolchain()
xtensa_esp32s3_gcc_toolchain()

Used git clone --depth 1 a shallow clone with a history truncated to reduce the clone size for:
gen_romfs()
kconfig_frontends()

## Impact
There should be no impact.
Impact on user: No changes to user-facing functionality

## Testing
CI
[GitHUB](https://github.com/simbit18/nuttx-testing-ci/actions/runs/11033341894/job/30644357880)
local msys2