### PR TITLE
riscv: Remove some unnecessary macro guards

### DIFF
--- a/arch/risc-v/src/common/riscv_cpuindex.c
+++ b/arch/risc-v/src/common/riscv_cpuindex.c
@@ -51,9 +51,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void)
 {
   return (int)riscv_mhartid();
 }
-#endif

--- a/arch/risc-v/src/common/riscv_fpucmp.c
+++ b/arch/risc-v/src/common/riscv_fpucmp.c
@@ -34,8 +34,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_ARCH_FPU
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -63,4 +61,3 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   return memcmp(&regs1[INT_XCPT_REGS], &regs2[INT_XCPT_REGS],
                 INT_REG_SIZE * FPU_XCPT_REGS) == 0;
 }
-#endif /* CONFIG_ARCH_FPU */


### PR DESCRIPTION


## Summary
If CONFIG_SMP is not enabled, riscv_cpuindex.c will not be compiled anyway.

And for CONFIG_ARCH_FPU, if it's not enabled, riscv_fpucmp.c will not be compiled.

So we can remove the unnecessary macro guard for up_cpu_index() and up_fpucmp().
## Impact
Minor
## Testing
CI