### PR TITLE
imx8qm-mek: Fix early print

### DIFF
--- a/arch/arm64/src/imx8/imx8qm_lowputc.S
+++ b/arch/arm64/src/imx8/imx8qm_lowputc.S
@@ -84,6 +84,6 @@ SECTION_FUNC(text, arm64_earlyprintinit)
 GTEXT(arm64_lowputc)
 SECTION_FUNC(text, arm64_lowputc)
     ldr   x15, =UART1_BASE_ADDRESS
-    early_uart_ready x15, 1
+    early_uart_ready x15, 2
     early_uart_transmit x15, w0
     ret


### PR DESCRIPTION
## Summary
Function `arm64_lowputc` corrupted the x1 register which is used in function `boot_stage_puts`.

## Impact
System hangs when early print is enabled.

## Testing
`imx8qm-mek` board.

