### PR TITLE
libc.h:Fixed the problem of multiple define appearing in arch_xxx.S

### DIFF
--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #ifndef __ASSEMBLY__
 #  include <sys/types.h>
 #  include <stdbool.h>


### PR DESCRIPTION
## Summary
**Why is this change necessary**
Fixed the problem of multiple define appearing in arch_xxx.S after opening kasan
The reason is that libc.h needs to check whether CONFIG is enabled before the corresponding macro is enabled
Error scene:
```
arm-none-eabi-ld: /home/crafcat7/SSD/xxx/xxx-dev/nuttx/staging/libc.a(arch_libc.o): in function `memmove:
/home/crafcat7/SSD/xxx/xxx-dev/nuttx/libs/libc/machine/arch_libc.c:146: multiple definition of memmove`; /home/crafcat7/SSD/xxx/xxx-dev/nuttx/staging/libc.a(arch_memmove.o):/home/crafcat7/SSD/xxx/xxx-dev/nuttx/libs/libc/machine/arm/armv8-m/gnu/arch_memmove.S:56: first defined here
```

**Changes**
add `#include<nuttx/config.h>` in libc.h

## Impact
**Is a new feature added?**: NO
**Impact on build**: YES,This is a fix for compilation-related issues
**Impact on hardware**:NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation**: NO,This patch does not introduce any new features
**Impact on compatibility**: This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh
Build Success
```
Create version.h
LN: platform/board to /home/crafcat7/SSD/vela/vela-dev/apps/platform/dummy
Register: gpio
Register: hello
Register: dumpstack
Register: nsh
Register: sh
Register: ostest
CP:  /home/crafcat7/SSD/vela/vela-dev/nuttx/include/nuttx/config.h
CP:  /home/crafcat7/SSD/vela/vela-dev/nuttx/include/nuttx/fs/hostfs.h
LD:  nuttx
```
