### PR TITLE
Pci framework 0926

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -556,6 +556,10 @@ static FAR struct pci_bus_s *pci_alloc_bus(void)
   FAR struct pci_bus_s *bus;
 
   bus = kmm_zalloc(sizeof(*bus));
+  if (bus == NULL)
+    {
+      return NULL;
+    }
 
   list_initialize(&bus->node);
   list_initialize(&bus->children);
@@ -580,6 +584,10 @@ static FAR struct pci_device_s *pci_alloc_device(void)
   FAR struct pci_device_s *dev;
 
   dev = kmm_zalloc(sizeof(*dev));
+  if (dev == NULL)
+    {
+      return NULL;
+    }
 
   list_initialize(&dev->node);
   list_initialize(&dev->bus_list);
@@ -2069,6 +2077,11 @@ int pci_register_controller(FAR struct pci_controller_s *ctrl)
     }
 
   bus = pci_alloc_bus();
+  if (bus == NULL)
+    {
+      return -ENOMEM;
+    }
+
   bus->ctrl = ctrl;
 
   ctrl->bus = bus;

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1246,7 +1246,11 @@ static int pci_enable_msix(FAR struct pci_device_s *dev, FAR int *irq,
   /* Map MSI-X table */
 
   tblend = tbladdr + tblsize * PCI_MSIX_ENTRY_SIZE;
-  tbladdr = dev->bus->ctrl->ops->map(dev->bus, tbladdr, tblend);
+
+  if (dev->bus->ctrl->ops->map)
+    {
+      tbladdr = dev->bus->ctrl->ops->map(dev->bus, tbladdr, tblend);
+    }
 
   /* Limit tblsize */
 
@@ -1772,7 +1776,12 @@ int pci_get_irq(FAR struct pci_device_s *dev)
 
 int pci_alloc_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
 {
-  return dev->bus->ctrl->ops->alloc_irq(dev->bus, irq, num);
+  if (dev->bus->ctrl->ops->alloc_irq)
+    {
+      return dev->bus->ctrl->ops->alloc_irq(dev->bus, irq, num);
+    }
+
+  return -ENOTSUP;
 }
 
 /****************************************************************************
@@ -1793,7 +1802,10 @@ int pci_alloc_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
 
 void pci_release_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
 {
-  dev->bus->ctrl->ops->release_irq(dev->bus, irq, num);
+  if (dev->bus->ctrl->ops->release_irq)
+    {
+      dev->bus->ctrl->ops->release_irq(dev->bus, irq, num);
+    }
 }
 
 /****************************************************************************
@@ -1816,6 +1828,11 @@ int pci_connect_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
 {
   uint8_t msi = 0;
   uint8_t msix = 0;
+
+  if (dev->bus->ctrl->ops->connect_irq)
+    {
+      return -ENOTSUP;
+    }
 
   /* Get MSI base */
 

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1829,7 +1829,7 @@ int pci_connect_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
   uint8_t msi = 0;
   uint8_t msix = 0;
 
-  if (dev->bus->ctrl->ops->connect_irq)
+  if (dev->bus->ctrl->ops->connect_irq == NULL)
     {
       return -ENOTSUP;
     }


### PR DESCRIPTION
## Summary
1. pci.c：fix ops not implement after calling panic err
2. pci.c: fix judge err in pci_connect_irq
3. pci.c: add error handle for pci_alloc_bus/device
## Impact

## Testing

