### PR TITLE
fs_rammap:Check last fileseek restore fpos

### DIFF
--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -78,7 +78,7 @@ static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
   fpos = file_seek(filep, entry->offset + offset, SEEK_SET);
   if (fpos < 0)
     {
-      ferr("ERRORL Seek to position %"PRIdOFF" failed\n", fpos);
+      ferr("ERROR: Seek to position %"PRIdOFF" failed\n", fpos);
       return fpos;
     }
 
@@ -109,7 +109,15 @@ static int msync_rammap(FAR struct mm_map_entry_s *entry, FAR void *start,
 
   /* Restore file pos */
 
-  file_seek(filep, opos, SEEK_SET);
+  fpos = file_seek(filep, opos, SEEK_SET);
+  if (fpos < 0)
+    {
+      /* Ensure that we finally seek back to the current file pos */
+
+      ferr("ERROR: Seek back to position %"PRIdOFF" failed\n", fpos);
+      return fpos;
+    }
+
   return nwrite >= 0 ? 0 : nwrite;
 }
 


### PR DESCRIPTION
## Summary
**Why is this change necessary**
  When restoring rammap fpos, we check the return value to avoid potential problems caused by no error return if the restore fails.

**Changes**
Check when restoring fpos to ensure the restoration is correct

## Impact
**Is a new feature added?**: NO
**Impact on build**: NO
**Impact on hardware**:NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation**: NO,This patch does not introduce any new features
**Impact on compatibility**: This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh
ostest OK
```
End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         4        4
mxordblk  3e052c0  3df4ab0
uordblks   1e8d08   1f96a8
fordblks  3e172f0  3e06950

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         1        4
mxordblk  3e28bd0  3df4ab0
uordblks   1d7428   1f96a8
fordblks  3e28bd0  3e06950
user_main: Exiting
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
```
