### PR TITLE
BCH: Passing `BIOC_FLUSH` to block driver

### DIFF
--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -420,14 +420,6 @@ static int bch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      case BIOC_FLUSH:
-        {
-          /* Flush any dirty pages remaining in the cache */
-
-          ret = bchlib_flushsector(bch, false);
-        }
-        break;
-
 #ifdef CONFIG_BCH_ENCRYPTION
       /* This is a request to set the encryption key? */
 
@@ -439,9 +431,20 @@ static int bch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         break;
 #endif
 
-      /* Otherwise, pass the IOCTL command on to the contained block
-       * driver.
-       */
+      case BIOC_FLUSH:
+        {
+          /* Flush any dirty pages remaining in the cache */
+
+          ret = bchlib_flushsector(bch, false);
+          if (ret < 0)
+            {
+              break;
+            }
+
+          /* Go through */
+        }
+
+      /* Pass the IOCTL command on to the contained block driver. */
 
       default:
         {


### PR DESCRIPTION
## Summary
Passing `BIOC_FLUSH` to block driver to ensure that changes transfers ("flushes") to the block device.

**Background**
There was a problem when executing the `fastboot flash <PARTITION> <IMAGE>` command, if reset the device immediately after the flash is completed, there is a certain probability that the data is not written to the flash.
The patch([nuttx-apps/6ac7cbf4d263e8bf6fa39eb0e070b0bbb47fe3a0](https://github.com/apache/nuttx-apps/commit/6ac7cbf4d263e8bf6fa39eb0e070b0bbb47fe3a0))  call `fsync()` after flash completed to fix, but the problem still exists.

**About fsync() (glibc) FSYNC(2):**
fsync()  transfers  ("flushes")  all modified in-core data of (i.e., modified buffer cache pages for) the file referred to by the file descriptor fd to the disk device (or other permanent storage device) so that all changed information can be retrieved even if the system crashes or is rebooted.  This includes writing through or flushing a disk cache if present.  The call blocks until  the device reports that the transfer has completed.

**Kernel implementation of fsync():**
fs/vfs/fs_fsync.c: `fsync()` => `file_fsync()` => `inode->u.i_ops`->`ioctl(filep, BIOC_FLUSH, 0)`
=> `bch_ioctl()` => `BIOC_FLUSH` => `bchlib_flushsector()`

It seems that `fsync()`/`bchlib_flushsector()` does not transfers  ("flushes")  all modified in-core data to flash (calling write ops - `inode->u.i_bops->write` only, similar to `bchlib_write()`).

## Impact
BCH: `ioctl(filep, BIOC_FLUSH, 0)`: After this patch merged, when the block device driver corresponding to the BCH driver does not support `BIOC_FLUSH`, `bch_ioctl()` may return failure(determined by driver) even if `bchlib_flushsector()` returns successfully (currently the return value is only determined by `bchlib_flushsector()`)

## Testing
1. Local test
2. Github CI
