### PR TITLE
Pci ep 0926

### DIFF
--- a/drivers/pci/pci_epc.c
+++ b/drivers/pci/pci_epc.c
@@ -732,7 +732,7 @@ int pci_epc_add_epf(FAR struct pci_epc_ctrl_s *epc,
   epf->funcno = funcno;
   epf->epc = epc;
 
-  list_add_tail(&epc->epf, &epf->node);
+  list_add_tail(&epc->epf, &epf->epc_node);
 
 out:
   nxmutex_unlock(&epc->lock);
@@ -798,7 +798,7 @@ void pci_epc_linkup(FAR struct pci_epc_ctrl_s *epc)
     }
 
   nxmutex_lock(&epc->lock);
-  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, node)
+  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, epc_node)
     {
       nxmutex_lock(&epf->lock);
       if (epf->event_ops && epf->event_ops->link_up)
@@ -839,7 +839,7 @@ void pci_epc_linkdown(FAR struct pci_epc_ctrl_s *epc)
     }
 
   nxmutex_lock(&epc->lock);
-  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, node)
+  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, epc_node)
     {
       nxmutex_lock(&epf->lock);
       if (epf->event_ops && epf->event_ops->link_down)
@@ -880,7 +880,7 @@ void pci_epc_init_notify(FAR struct pci_epc_ctrl_s *epc)
     }
 
   nxmutex_lock(&epc->lock);
-  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, node)
+  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, epc_node)
     {
       nxmutex_lock(&epf->lock);
       if (epf->event_ops && epf->event_ops->core_init)
@@ -921,7 +921,7 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc)
     }
 
   nxmutex_lock(&epc->lock);
-  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, node)
+  list_for_every_entry(&epc->epf, epf, struct pci_epf_device_s, epc_node)
     {
       nxmutex_lock(&epf->lock);
       if (epf->event_ops && epf->event_ops->bme)

--- a/drivers/pci/pci_epc.c
+++ b/drivers/pci/pci_epc.c
@@ -945,13 +945,16 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc)
  *
  * Input Parameters:
  *   name        - EPC name strings
+ *   priv        - The epc priv data
  *   ops         - Function pointers for performing EPC operations
+ *
  * Returned Value:
  *   Return struct pci_epc_ctrl_s * if success, NULL if failed.
  ****************************************************************************/
 
 FAR struct pci_epc_ctrl_s *
-pci_epc_create(FAR const char *name, FAR const struct pci_epc_ops_s *ops)
+pci_epc_create(FAR const char *name, FAR void *priv,
+               FAR const struct pci_epc_ops_s *ops)
 {
   FAR struct pci_epc_ctrl_s *epc;
   size_t len;
@@ -968,6 +971,7 @@ pci_epc_create(FAR const char *name, FAR const struct pci_epc_ops_s *ops)
       return NULL;
     }
 
+  epc->priv = priv;
   memcpy(epc->name, name, len);
   nxmutex_init(&epc->lock);
   list_initialize(&epc->epf);

--- a/drivers/pci/pci_epc.c
+++ b/drivers/pci/pci_epc.c
@@ -380,14 +380,11 @@ int pci_epc_get_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno)
  * Description:
  *   Set the number of MSI interrupt numbers required.
  *
- *   Message Control Register for MSI:bit6-bit4:Multiple Message Enable
- *   Software writes to this field to indicate the number of allocate vectors
- *   Equal to or less than the number of requested vectors. The number of
- *   allocated vectors is aligned to a power of two. If a Function requests
- *   four vectors (indicated by a Multiple Message Capable encoding of
- *   010b), system software can allocate either four, two, or one vector
- *   by writing a 010b, 001b, or 000b to this field, respectively. When
- *   MSI Enable is Set, a Function will be allocated at least 1 vector
+ *   Message Control Register for MSI:bit3-bit1:System software reads this
+ *   field to determine the number of requested vectors. The number of
+ *   requested vectors must be aligned to a power of two (if a Function
+ *   requires three vectors, it requests four by initializing this field
+ *   to 010b).
  *
  *   Invoke to set the required number of MSI interrupts.
  *

--- a/drivers/pci/pci_epf.c
+++ b/drivers/pci/pci_epf.c
@@ -448,7 +448,7 @@ int pci_epf_register_driver(FAR struct pci_epf_driver_s *drv)
           continue;
         }
 
-      epc = pci_get_epc(epf->name);
+      epc = pci_get_epc(epf->epc_name);
       if (epc == NULL)
         {
           ret = -ENODEV;

--- a/include/nuttx/pci/pci_epc.h
+++ b/include/nuttx/pci/pci_epc.h
@@ -131,6 +131,7 @@ struct pci_epc_ops_s
 
 /* struct pci_epc_mem_window_s - Address window of the endpoint controller
  *
+ * virt_base: Virtual base address of the PCI address window
  * phys_base: Physical base address of the PCI address window
  * size: The size of the PCI address window
  * page_size: Size of each page
@@ -138,6 +139,7 @@ struct pci_epc_ops_s
 
 struct pci_epc_mem_window_s
 {
+  FAR void *virt_base;
   uintptr_t phys_base;
   size_t size;
   size_t page_size;
@@ -145,6 +147,7 @@ struct pci_epc_mem_window_s
 
 /* struct pci_epc_mem_s - Address space of the endpoint controller
  *
+ * virt_base: Virtual base address of the PCI address window
  * phys_base: Physical base address of the PCI address window
  * size: The size of the PCI address window
  * page_size: Size of each page
@@ -155,6 +158,7 @@ struct pci_epc_mem_window_s
 
 struct pci_epc_mem_s
 {
+  FAR void *virt_base;
   uintptr_t phys_base;
   size_t size;
   size_t page_size;
@@ -745,7 +749,8 @@ int pci_epc_mem_multi_init(FAR struct pci_epc_ctrl_s *epc,
  *
  * Input Parameters:
  *   epc       - PCI EPC device
- *   base      - The physical base address of the PCI address window
+ *   virt      - The virtual addr
+ *   phys      - The physical base address of the PCI address window
  *   size      - The PCI window size
  *   page_size - Size of each window page
  *
@@ -753,8 +758,8 @@ int pci_epc_mem_multi_init(FAR struct pci_epc_ctrl_s *epc,
  *   0 if success, negative if failed
  ****************************************************************************/
 
-int pci_epc_mem_init(FAR struct pci_epc_ctrl_s *epc, uintptr_t base,
-                     size_t size, size_t page_size);
+int pci_epc_mem_init(FAR struct pci_epc_ctrl_s *epc, FAR void *virt,
+                     uintptr_t phys, size_t size, size_t page_size);
 
 /****************************************************************************
  * Name: pci_epc_mem_exit
@@ -784,15 +789,16 @@ void pci_epc_mem_exit(FAR struct pci_epc_ctrl_s *epc);
  * is usually done to map the remote RC address into the local system.
  *
  * Input Parameters:
- *   epc  - The EPC device on which memory has to be allocated
- *   size - The size of the address space that has to be allocated
+ *   epc   - The EPC device on which memory has to be allocated
+ *   phys  - The Physical addr
+ *   size  - The size of the address space that has to be allocated
  *
  * Returned Value:
- *   The memory address alloced if success, 0 if failed
+ *   The memory address alloced if success, NULL if failed
  ****************************************************************************/
 
-uintptr_t pci_epc_mem_alloc_addr(FAR struct pci_epc_ctrl_s *epc,
-                                 size_t size);
+FAR void *pci_epc_mem_alloc_addr(FAR struct pci_epc_ctrl_s *epc,
+                                 FAR uintptr_t *phys, size_t size);
 
 /****************************************************************************
  * Name: pci_epc_mem_free_addr

--- a/include/nuttx/pci/pci_epc.h
+++ b/include/nuttx/pci/pci_epc.h
@@ -177,6 +177,7 @@ struct pci_epc_mem_s
  * node: The node of epc list
  * lock: Mutex to protect pci_epc ops
  * funcno_map: Bitmap to manage physical function number
+ * priv: The private data
  * name: The current epc structure name that used to bind the epf
  */
 
@@ -193,6 +194,7 @@ struct pci_epc_ctrl_s
 
   mutex_t lock;
   unsigned long funcno_map;
+  FAR void *priv;
   char name[0];
 };
 
@@ -684,6 +686,7 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc);
  *
  * Input Parameters:
  *   name - EPC name strings
+ *   priv - The epc priv data
  *   ops  - Function pointers for performing EPC operations
  *
  * Returned Value:
@@ -691,7 +694,8 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc);
  ****************************************************************************/
 
 FAR struct pci_epc_ctrl_s *
-pci_epc_create(FAR const char *name, FAR const struct pci_epc_ops_s *ops);
+pci_epc_create(FAR const char *name, FAR void *priv,
+               FAR const struct pci_epc_ops_s *ops);
 
 /****************************************************************************
  * Name: pci_epc_destroy

--- a/include/nuttx/pci/pci_epf.h
+++ b/include/nuttx/pci/pci_epf.h
@@ -128,6 +128,7 @@ struct pci_epf_device_s
   FAR struct pci_epf_driver_s *driver;
   FAR const struct pci_epf_device_id_s *id;
   struct list_node node;
+  struct list_node epc_node;
 
   /* Mutex to protect against concurrent access of pci_epf_ops_s */
 

--- a/include/nuttx/pci/pci_epf.h
+++ b/include/nuttx/pci/pci_epf.h
@@ -185,7 +185,7 @@ struct pci_epf_driver_s
   CODE void (*remove)(FAR struct pci_epf_device_s *epf);
 
   struct list_node node;
-  FAR struct pci_epf_ops_s *ops;
+  FAR const struct pci_epf_ops_s *ops;
   FAR const struct pci_epf_device_id_s *id_table;
 };
 

--- a/include/nuttx/pci/pci_epf.h
+++ b/include/nuttx/pci/pci_epf.h
@@ -111,6 +111,7 @@ struct pci_epf_device_id_s
  * is_bound: Indicates if bind notification to function driver has been
  *   invoked
  * event_ops: Callbacks for capturing the EPC events
+ * priv: The private data
  */
 
 struct pci_epf_device_s
@@ -133,6 +134,7 @@ struct pci_epf_device_s
   mutex_t lock;
   bool is_bound;
   FAR const struct pci_epc_event_ops_s *event_ops;
+  FAR void *priv;
 };
 
 /* struct pci_epf_ops_s - Set of function pointers for performing EPF


### PR DESCRIPTION
## Summary
1.pci_epf_device_s and pci_epc_ctrl_s add priv data
2.pci epf use epc_node link to epc
3.pci epc mem use virtual mem
4.pci_epf_driver_s use FAR const struct pci_epf_ops_s *ops
## Impact

## Testing

