### PR TITLE
fix the misra check issues

### DIFF
--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -159,7 +159,7 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
 
               if ((filep->f_oflags & O_APPEND) != 0)
                 {
-                  file_seek(filep, 0, SEEK_END);
+                  ret = file_seek(filep, 0, SEEK_END);
                 }
             }
         }

--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -607,7 +607,7 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
 
   /* Assume DT_RELA to get maximum size required */
 
-  rels = lib_malloc(CONFIG_MODLIB_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rela));
+  rels = lib_zalloc(CONFIG_MODLIB_RELOCATION_BUFFERCOUNT * sizeof(Elf_Rela));
   if (!rels)
     {
       berr("Failed to allocate memory for elf relocation rels\n");
@@ -774,7 +774,10 @@ static int modlib_relocatedyn(FAR struct module_s *modp,
             }
           else
             {
-              Elf_Sym dynsym;
+              Elf_Sym dynsym =
+                {
+                  0
+                };
 
               addr = rel->r_offset - loadinfo->datasec + loadinfo->datastart;
 

--- a/libs/libc/pthread/pthread_mutexattr_setprotocol.c
+++ b/libs/libc/pthread/pthread_mutexattr_setprotocol.c
@@ -54,38 +54,33 @@ int pthread_mutexattr_setprotocol(FAR pthread_mutexattr_t *attr,
   linfo("attr=%p protocol=%d\n", attr, protocol);
   DEBUGASSERT(attr != NULL);
 
-  if (protocol >= PTHREAD_PRIO_NONE && protocol <= PTHREAD_PRIO_PROTECT)
+  switch (protocol)
     {
-      switch (protocol)
-        {
-          case PTHREAD_PRIO_NONE:
+      case PTHREAD_PRIO_NONE:
 #if defined(CONFIG_PRIORITY_INHERITANCE) || defined(CONFIG_PRIORITY_PROTECT)
-            attr->proto = PTHREAD_PRIO_INHERIT;
+        attr->proto = PTHREAD_PRIO_INHERIT;
 #endif
-            break;
+        break;
 
-          case PTHREAD_PRIO_INHERIT:
+      case PTHREAD_PRIO_INHERIT:
 #ifdef CONFIG_PRIORITY_INHERITANCE
-            attr->proto = PTHREAD_PRIO_INHERIT;
-            break;
+        attr->proto = PTHREAD_PRIO_INHERIT;
+        break;
 #else
-            return ENOTSUP;
+        return ENOTSUP;
 #endif /* CONFIG_PRIORITY_INHERITANCE */
 
-          case PTHREAD_PRIO_PROTECT:
+      case PTHREAD_PRIO_PROTECT:
 #ifdef CONFIG_PRIORITY_PROTECT
-            attr->proto = PTHREAD_PRIO_PROTECT;
-            break;
+        attr->proto = PTHREAD_PRIO_PROTECT;
+        break;
 #else
-            return ENOTSUP;
+        return ENOTSUP;
 #endif /* CONFIG_PRIORITY_PROTECT */
 
-          default:
-            return ENOTSUP;
-        }
-
-      return OK;
+      default:
+        return EINVAL;
     }
 
-  return EINVAL;
+  return OK;
 }

--- a/libs/libc/search/hcreate.c
+++ b/libs/libc/search/hcreate.c
@@ -132,7 +132,7 @@ void hdestroy(void)
 
 FAR ENTRY *hsearch(ENTRY item, ACTION action)
 {
-  FAR ENTRY *retval;
+  FAR ENTRY *retval = NULL;
 
   hsearch_r(item, action, &retval, &g_htab);
 


### PR DESCRIPTION
## Summary
1. fix the moblib_bind variable uninit misra issue
2. remove the unreached dead code in  pthread_mutexattr_setprotocol
3. fix using the uninit value misra issue in hcreate
4. fix the ret value not check erro on fs_fcntl

## Impact

## Testing
1. has pass the ostest
5. has checked on ghs and gcc compiler
