### PR TITLE
greenhills support: fix the arc4random build error

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -55,11 +55,11 @@ if(CONFIG_CRYPTO)
   list(APPEND SRCS hmac.c)
   if(CONFIG_CRYPTO_RANDOM_POOL)
     list(APPEND SRCS idgen.c)
+    list(APPEND SRCS curve25519.c)
   endif()
   list(APPEND SRCS key_wrap.c)
   list(APPEND SRCS siphash.c)
   list(APPEND SRCS hmac_buff.c)
-  list(APPEND SRCS curve25519.c)
   list(APPEND SRCS bn.c)
 
   # Entropy pool random number generator

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -59,11 +59,11 @@ CRYPTO_CSRCS += cmac.c
 CRYPTO_CSRCS += hmac.c
 ifeq ($(CONFIG_CRYPTO_RANDOM_POOL),y)
   CRYPTO_CSRCS += idgen.c
+  CRYPTO_CSRCS += curve25519.c
 endif
 CRYPTO_CSRCS += key_wrap.c
 CRYPTO_CSRCS += siphash.c
 CRYPTO_CSRCS += hmac_buff.c
-CRYPTO_CSRCS += curve25519.c
 CRYPTO_CSRCS += bn.c
 
 # Entropy pool random number generator


### PR DESCRIPTION
## Summary
greenhills: fix the arc4random_buf implicit declaration build error

the detailed build error are:
    "nuttx/include/crypto/curve25519.h", line 44: error #223-D:
              function arc4random_buf declared implicitly
          arc4random_buf(secret, CURVE25519_KEY_SIZE);
          ^

## Impact

## Testing
1. has pass the ostest
2. has tested on gcc/ghs compiler

