### PR TITLE
greenhills support: fix the arm_signal_handler.S build error

### DIFF
--- a/arch/arm/src/common/gnu/arm_signal_handler.S
+++ b/arch/arm/src/common/gnu/arm_signal_handler.S
@@ -32,7 +32,6 @@
  * File info
  ****************************************************************************/
 
-	.syntax		unified
 	.file		"arm_signal_handler.S"
 
 /****************************************************************************
@@ -67,9 +66,17 @@
  ****************************************************************************/
 
 	.text
+#ifdef __ghs__
+	.thumb
+#else
 	.thumb_func
+#endif
 	.globl	up_signal_handler
+#ifdef __ghs__
+	.type	up_signal_handler, $function
+#else
 	.type	up_signal_handler, function
+#endif
 up_signal_handler:
 
 	/* Save some register */


### PR DESCRIPTION
## Summary
fix the arm_signal_handler.S build error with greenhills compiler

the detailed build error are:
```
[asarm] (error #2067) 
nuttx/arch/arm/src/common/gnu/arm_signal_handler.S 35: unknown instruction
  .syntax unified
--^

[asarm] (error #2067) 
nuttx/arch/arm/src/common/gnu/arm_signal_handler.S 70: unknown instruction
  .thumb_func
--^

[asarm] (error #2230) 
nuttx/arch/arm/src/common/gnu/arm_signal_handler.S 72: bad directive
  .type up_signal_handler , function
----------------------------^
```

## Impact
has no impact on current implementation

## Testing
1. has passed the ostest
2. has tested on ghs and gcc compiler

