### PR TITLE
greenhills support: fix the data type align build error

### DIFF
--- a/include/nuttx/crypto/blake2s.h
+++ b/include/nuttx/crypto/blake2s.h
@@ -88,8 +88,8 @@ typedef struct blake2s_param__
 
 #ifdef __GNUC__ > 3
 #define BLAKE2_UNALIGNED 1
-typedef uint32_t uint32_alias_t __attribute__((may_alias)) aligned_data(1);
-typedef uint16_t uint16_alias_t __attribute__((may_alias)) aligned_data(1);
+typedef uint32_t uint32_alias_t __attribute__((may_alias));
+typedef uint16_t uint16_alias_t __attribute__((may_alias));
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
fix the data type align build error with greenhills compiler

the detailed build error are:
```
"nuttx/include/nuttx/crypto/blake2s.h", line 91: error #2118-D:
          this attribute reduces the alignment of the typedef, and while that
          will be respected for struct/field layout, the compiler will not
          generate code to handle misaligned accesses for objects of this type
  typedef uint32_t uint32_alias_t __attribute__((may_alias)) aligned_data(1);
                                                             ^
```

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler
