### PR TITLE
greenhills support: fix the register variable usage error

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -82,6 +82,7 @@
 #if defined(__ghs__)
 
 #  define __extension__
+#  define register
 
 #endif
 


### PR DESCRIPTION
## Summary
fix the armv7-m/irq register variable usage error
the detailed build error info are:
```
CXX:  libcxxmini/libxx_new.cxx "nuttx/include/arch/armv7-m/irq.h", line 594: error #3422:
          use of the "register" storage class specifier is not allowed
    register uint32_t sp;
    ^

"nuttx/include/arch/armv7-m/irq.h", line 594: error #3422:
          use of the "register" storage class specifier is not allowed
    register uint32_t sp;
    ^

"nuttx/include/arch/armv7-m/irq.h", line 594: error #3422:
          use of the "register" storage class specifier is not allowed
    register uint32_t sp;
    ^

make[1]: *** [Makefile:69: libxx_delete_sized.o] Error 1 make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:69: libxx_deletea_sized.o] Error 1 make[1]: *** [Makefile:69: libxx_new.o] Error 1
"nuttx/include/arch/armv7-m/irq.h", line 594: error #3422:
          use of the "register" storage class specifier is not allowed
    register uint32_t sp;
    ^

"nuttx/include/arch/armv7-m/irq.h", line 594: error #3422:
          use of the "register" storage class specifier is not allowed
    register uint32_t sp;
    ^
```

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler

