### PR TITLE
greenhills support: add cortex-m4 Makefile support for ghs compiler

### DIFF
--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -22,11 +22,22 @@
 
 ifeq ($(CONFIG_ARCH_CORTEXM4),y)
   TOOLCHAIN_ARM7EM   := y
-  TOOLCHAIN_MTUNE    := -mtune=cortex-m4
-  TOOLCHAIN_MARCH    := -march=armv7e-m
-  LLVM_CPUTYPE       := cortex-m4
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    TOOLCHAIN_MFLOAT := -mfpu=fpv4-sp-d16
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)
+    TOOLCHAIN_MTUNE  := -cpu=cortexm4
+    ifeq ($(CONFIG_ARCH_FPU),y)
+      ifeq ($(CONFIG_ARCH_DPFPU),y)
+        TOOLCHAIN_MFLOAT := -fpu=vfpv3
+      else
+        TOOLCHAIN_MFLOAT := -fpu=vfpv3_d16
+      endif
+    endif
+  else
+    TOOLCHAIN_MTUNE    := -mtune=cortex-m4
+    TOOLCHAIN_MARCH    := -march=armv7e-m
+    LLVM_CPUTYPE       := cortex-m4
+    ifeq ($(CONFIG_ARCH_FPU),y)
+      TOOLCHAIN_MFLOAT := -mfpu=fpv4-sp-d16
+    endif
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
   TOOLCHAIN_ARM7EM   := y

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -35,6 +35,8 @@ ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
 else ifeq ($(CONFIG_DEBUG_FULLOPT),y)
   ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
     ARCHOPTIMIZATION += -Oz
+  else ifeq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)
+    ARCHOPTIMIZATION += -Osize
   else
     ARCHOPTIMIZATION += -Os
   endif


### PR DESCRIPTION
## Summary
1. add cortex-m platform support in Makefile build for greenhills compiler
2. add greenhills specific compiler optimization build option: Osize

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler

