### PR TITLE
ci/platforms: linux.sh ubuntu.sh switch Wget to cURL tool

### DIFF
--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -56,7 +56,7 @@ arm_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi
     cd "${NUTTXTOOLS}"
     # Download the latest ARM GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-arm-none-eabi
@@ -74,7 +74,7 @@ arm64_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf
     cd "${NUTTXTOOLS}"
     # Download the latest ARM64 GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-aarch64-none-elf
@@ -106,7 +106,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \
@@ -240,7 +240,7 @@ sparc_gcc_toolchain() {
     basefile=bcc-2.1.0-gcc-linux64
     cd "${NUTTXTOOLS}"
     # Download the SPARC GCC toolchain prebuilt by Gaisler
-    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
+    curl -O -L -s https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
@@ -258,7 +258,7 @@ xtensa_esp32_gcc_toolchain() {
     basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -275,7 +275,7 @@ xtensa_esp32s2_gcc_toolchain() {
     basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -292,7 +292,7 @@ xtensa_esp32s3_gcc_toolchain() {
     basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -313,13 +313,13 @@ wasi_sdk() {
     mkdir -p wamrc
 
     # Download the latest WASI-enabled WebAssembly C/C++ toolchain prebuilt by WASM
-    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    curl -O -L -s https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
     tar xzf ${wasibasefile}.tar.gz
     mv wasi-sdk-19.0 wasi-sdk
     rm ${wasibasefile}.tar.gz
     cd wamrc
     # Download the latest "wamrc" AOT compiler prebuilt by WAMR
-    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    curl -O -L -s https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
     tar xzf ${wasmbasefile}.tar.gz
     rm ${wasmbasefile}.tar.gz
 

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -56,7 +56,7 @@ arm_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi
     cd "${NUTTXTOOLS}"
     # Download the latest ARM GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-arm-none-eabi
@@ -74,7 +74,7 @@ arm64_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf
     cd "${NUTTXTOOLS}"
     # Download the latest ARM64 GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-aarch64-none-elf
@@ -159,7 +159,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \
@@ -218,11 +218,12 @@ riscv_gcc_toolchain() {
     basefile=xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
     mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
+
   command riscv-none-elf-gcc --version
 }
 
@@ -313,7 +314,7 @@ sparc_gcc_toolchain() {
     basefile=bcc-2.1.0-gcc-linux64
     cd "${NUTTXTOOLS}"
     # Download the SPARC GCC toolchain prebuilt by Gaisler
-    wget --quiet https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
+    curl -O -L -s https://www.gaisler.com/anonftp/bcc2/bin/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv bcc-2.1.0-gcc sparc-gaisler-elf-gcc
@@ -331,7 +332,7 @@ xtensa_esp32_gcc_toolchain() {
     basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -348,7 +349,7 @@ xtensa_esp32s2_gcc_toolchain() {
     basefile=xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S2 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -365,7 +366,7 @@ xtensa_esp32s3_gcc_toolchain() {
     basefile=xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu
     cd "${NUTTXTOOLS}"
     # Download the latest ESP32 S3 GCC toolchain prebuilt by Espressif
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -392,13 +393,13 @@ wasi_sdk() {
     mkdir -p wamrc
 
     # Download the latest WASI-enabled WebAssembly C/C++ toolchain prebuilt by WASM
-    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    curl -O -L -s https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
     tar xzf ${wasibasefile}.tar.gz
     mv wasi-sdk-19.0 wasi-sdk
     rm ${wasibasefile}.tar.gz
     cd wamrc
     # Download the latest "wamrc" AOT compiler prebuilt by WAMR
-    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    curl -O -L -s https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
     tar xzf ${wasmbasefile}.tar.gz
     rm ${wasmbasefile}.tar.gz
 


### PR DESCRIPTION
## Summary

Switch wget to cURL tool for:
arm_gcc_toolchain()
arm64_gcc_toolchain()
riscv_gcc_toolchain()
sparc_gcc_toolchain()
xtensa_esp32_gcc_toolchain()
xtensa_esp32s2_gcc_toolchain()
xtensa_esp32s3_gcc_toolchain()
wasi_sdk()

Used git clone --depth 1 a shallow clone with a history truncated to reduce the clone size for:

 kconfig_frontends()

## Impact
Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
CI
