### PR TITLE
ci/platforms/darwin.sh: switch Wget to cURL tool

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -43,7 +43,7 @@ arm_gcc_toolchain() {
     local basefile
     basefile=arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi
     cd "${NUTTXTOOLS}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-arm-none-eabi
@@ -61,7 +61,7 @@ arm64_gcc_toolchain() {
     basefile=arm-gnu-toolchain-13.2.Rel1-darwin-x86_64-aarch64-none-elf
     cd "${NUTTXTOOLS}"
     # Download the latest ARM64 GCC toolchain prebuilt by ARM
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
+    curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     mv ${basefile} gcc-aarch64-none-elf
@@ -122,6 +122,7 @@ c_cache() {
   if ! type ccache > /dev/null 2>&1; then
     brew install ccache
   fi
+
   setup_links
   command ccache --version
 }
@@ -149,7 +150,7 @@ gperf() {
     basefile=gperf-3.1
 
     cd "${NUTTXTOOLS}"
-    wget --quiet http://ftp.gnu.org/pub/gnu/gperf/${basefile}.tar.gz
+    curl -O -L -s http://ftp.gnu.org/pub/gnu/gperf/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
     cd "${NUTTXTOOLS}"/${basefile}
     ./configure --prefix="${NUTTXTOOLS}"/gperf; make; make install
@@ -164,7 +165,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \
@@ -187,6 +188,14 @@ mips_gcc_toolchain() {
   fi
 
   command mips-elf-gcc --version
+}
+
+ninja_brew() {
+  if ! type ninja > /dev/null 2>&1; then
+    brew install ninja
+  fi
+
+  command ninja --version
 }
 
 python_tools() {
@@ -233,11 +242,12 @@ riscv_gcc_toolchain() {
     basefile=xpack-riscv-none-elf-gcc-13.2.0-2-darwin-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
     mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
+
   command riscv-none-elf-gcc --version
 }
 
@@ -270,7 +280,7 @@ xtensa_esp32_gcc_toolchain() {
     local basefile
     basefile=xtensa-esp32-elf-12.2.0_20230208-x86_64-apple-darwin
     cd "${NUTTXTOOLS}"
-    wget --quiet https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
+    curl -O -L -s https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
     rm ${basefile}.tar
@@ -304,12 +314,12 @@ wasi_sdk() {
     wasmbasefile=wamrc-1.1.2-x86_64-macos-latest
     cd "${NUTTXTOOLS}"
     mkdir -p wamrc
-    wget --quiet https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
+    curl -O -L -s https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/${wasibasefile}.tar.gz
     tar xzf ${wasibasefile}.tar.gz
     mv wasi-sdk-19.0 wasi-sdk
     rm ${wasibasefile}.tar.gz
     cd wamrc
-    wget --quiet https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
+    curl -O -L -s https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/${wasmbasefile}.tar.gz
     tar xzf ${wasmbasefile}.tar.gz
     rm ${wasmbasefile}.tar.gz
   fi
@@ -350,7 +360,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain ninja_brew python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   mkdir -p "${NUTTXTOOLS}"/homebrew
   export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew


### PR DESCRIPTION
## Summary
Switch wget to cURL tool for:

arm_gcc_toolchain()
arm64_gcc_toolchain()
gperf()
riscv_gcc_toolchain()
sparc_gcc_toolchain()
xtensa_esp32_gcc_toolchain()
wasi_sdk()

Used git clone --depth 1 a shallow clone with a history truncated to reduce the clone size for:

kconfig_frontends()

added ninja installation

## Impact
Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same
## Testing
CI
[my repository](https://github.com/simbit18/nuttx-testing-ci/actions/runs/11049176986/job/30694258680)
