### PR TITLE
cmake(feat): Add support for etc files with absolute paths in romfs CMake module

### DIFF
--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -20,6 +20,20 @@
 #
 # ##############################################################################
 
+function(add_board_rcsrcs)
+  set_property(
+    TARGET board
+    APPEND
+    PROPERTY BOARD_RCSRCS ${ARGN})
+endfunction()
+
+function(add_board_rcraws)
+  set_property(
+    TARGET board
+    APPEND
+    PROPERTY BOARD_RCRAWS ${ARGN})
+endfunction()
+
 # ~~~
 # nuttx_add_romfs
 #
@@ -59,6 +73,19 @@ function(nuttx_add_romfs)
     message(FATAL_ERROR "Either PATH or FILES must be specified")
   endif()
 
+  if(TARGET board)
+    get_property(
+      board_rcsrcs
+      TARGET board
+      PROPERTY BOARD_RCSRCS)
+    get_property(
+      board_rcraws
+      TARGET board
+      PROPERTY BOARD_RCRAWS)
+    list(APPEND RCSRCS ${board_rcsrcs})
+    list(APPEND RCRAWS ${board_rcraws})
+  endif()
+
   get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
                                                        COMPILE_OPTIONS)
 
@@ -75,32 +102,55 @@ function(nuttx_add_romfs)
   endforeach()
 
   foreach(rcsrc ${RCSRCS})
-    get_filename_component(rcpath ${rcsrc} DIRECTORY)
+    if(IS_ABSOLUTE ${rcsrc})
+      string(REGEX REPLACE "^(.*)/etc(/.*)?$" "\\1" SOURCE_ETC_PREFIX
+                           "${rcsrc}")
+      string(REGEX REPLACE "^.*/(etc(/.*)?)$" "\\1" REMAINING_PATH "${rcsrc}")
+      string(REGEX REPLACE "^/" "" SOURCE_ETC_SUFFIX "${REMAINING_PATH}")
+    else()
+      set(SOURCE_ETC_PREFIX ${CMAKE_CURRENT_SOURCE_DIR})
+      set(SOURCE_ETC_SUFFIX ${rcsrc})
+    endif()
+
+    get_filename_component(rcpath ${SOURCE_ETC_SUFFIX} DIRECTORY)
     add_custom_command(
-      OUTPUT ${rcsrc}
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${rcpath}
       COMMAND
         ${CMAKE_C_COMPILER} ${ROMFS_CMAKE_C_FLAGS} -E -P -x c
-        -I${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/${rcsrc} >
-        ${rcsrc}
-      DEPENDS nuttx_context ${CMAKE_CURRENT_SOURCE_DIR}/${rcsrc})
-    list(APPEND DEPENDS ${rcsrc})
+        -I${CMAKE_BINARY_DIR}/include ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX}
+        > ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
+      DEPENDS nuttx_context ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
+    list(APPEND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})
   endforeach()
 
   foreach(rcraw ${RCRAWS})
-    get_filename_component(absrcraw ${rcraw} ABSOLUTE)
-    if(IS_DIRECTORY ${absrcraw})
+
+    if(IS_ABSOLUTE ${rcraw})
+      string(REGEX REPLACE "^(.*)/etc(/.*)?$" "\\1" SOURCE_ETC_PREFIX
+                           "${rcraw}")
+      string(REGEX REPLACE "^.*/(etc(/.*)?)$" "\\1" REMAINING_PATH "${rcraw}")
+      string(REGEX REPLACE "^/" "" SOURCE_ETC_SUFFIX "${REMAINING_PATH}")
+    else()
+      set(SOURCE_ETC_PREFIX ${CMAKE_CURRENT_SOURCE_DIR})
+      set(SOURCE_ETC_SUFFIX ${rcraw})
+    endif()
+
+    if(IS_DIRECTORY ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
       file(
-        GLOB subdir
+        GLOB subraws
         LIST_DIRECTORIES false
-        ${rcraws} ${rcraw})
-      foreach(rcraw ${rcraws})
-        list(APPEND DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${rcraw})
-        configure_file(${rcraw} ${CMAKE_CURRENT_BINARY_DIR}/${rcraw} COPYONLY)
+        RELATIVE ${SOURCE_ETC_PREFIX}
+        ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
+      foreach(subraw ${subraws})
+        list(APPEND DEPENDS ${SOURCE_ETC_PREFIX}/${subraw})
+        configure_file(${SOURCE_ETC_PREFIX}/${subraw}
+                       ${CMAKE_CURRENT_BINARY_DIR}/${subraw} COPYONLY)
       endforeach()
     else()
-      list(APPEND DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${rcraw})
-      configure_file(${rcraw} ${CMAKE_CURRENT_BINARY_DIR}/${rcraw} COPYONLY)
+      list(APPEND DEPENDS ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
+      configure_file(${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX}
+                     ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX} COPYONLY)
     endif()
   endforeach()
 


### PR DESCRIPTION
## Summary

The current romfs cmake method **only** supports adding relative paths to the etc path.
```cmake
# etc/ must be in the relative path of the current script directory
list(APPEND RCSRCS etc/init.d/rcS etc/init.d/rc.sysinit)
list(APPEND RCRAWS etc/media/media.conf)
  nuttx_add_romfs(
    NAME
    etc
    MOUNTPOINT
    etc
    RCSRCS
    ${RCSRCS}
    RCRAWS
    ${RCRAWS}
    PATH
    ${CMAKE_CURRENT_BINARY_DIR}/etc)
``` 

This patch supports adding romfs files with absolute paths at any location.
Because different boards on the same chip platform may have common board-level configurations, a common romfs file needs to be added

Usage after this patch:
```cmake
# in any CMakeLists.txt we can call
  add_board_rcsrcs(${CMAKE_CURRENT_SOURCE_DIR}/etc/build.prop)
  add_board_rcraws(${CMAKE_CURRENT_SOURCE_DIR}/etc/video_config.json)

# also compatible and supports the original call
# in board src CMakeLists.txt

  nuttx_add_romfs(
    NAME
    etc
    MOUNTPOINT
    etc
    RCSRCS
    etc/srcfile
    RCRAWS
    etc/rawfile
    PATH
    ${CMAKE_CURRENT_BINARY_DIR}/etc)

# The final romfs is a collection of all files

``` 

## Impact

`Forward compatibility`

## Testing

CI 

