### PR TITLE
arch: change nxsched_suspend/resume_scheduler() called position

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -103,6 +103,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -75,6 +75,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != tcb->xcp.regs)
         {
+          /* Update scheduler parameters */
+
+          nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+          nxsched_resume_scheduler(tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -98,6 +98,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -579,12 +579,18 @@ uint32_t *arm_syscall(uint32_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      cpu = this_cpu();
+      tcb = current_task(cpu);
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      cpu = this_cpu();
-      tcb = current_task(cpu);
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -75,6 +75,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != tcb->xcp.regs)
         {
+          /* Update scheduler parameters */
+
+          nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+          nxsched_resume_scheduler(tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -77,6 +77,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -566,11 +566,17 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      cpu = this_cpu();
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      cpu = this_cpu();
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -124,6 +124,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       if (regs != tcb->xcp.regs)
         {
+          /* Update scheduler parameters */
+
+          nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+          nxsched_resume_scheduler(tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -72,10 +72,16 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
-  tcb = this_task();
 
   if (regs != tcb->xcp.regs)
     {
+      tcb = this_task();
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -565,11 +565,17 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      cpu = this_cpu();
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      cpu = this_cpu();
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/arm/src/common/arm_switchcontext.c
+++ b/arch/arm/src/common/arm_switchcontext.c
@@ -55,27 +55,10 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
-  if (up_interrupt_context())
+  if (!up_interrupt_context())
     {
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-    }
-
-  /* No, then we will need to perform the user context switch */
-
-  else
-    {
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -96,6 +96,11 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/arm64/src/common/arm64_switchcontext.c
+++ b/arch/arm64/src/common/arm64_switchcontext.c
@@ -55,27 +55,10 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
-  if (up_interrupt_context())
+  if (!up_interrupt_context())
     {
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-    }
-
-  /* No, then we will need to perform the user context switch */
-
-  else
-    {
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -236,6 +236,9 @@ uint64_t *arm64_syscall_switch(uint64_t * regs)
 
   if ((uint64_t *)f_regs != ret_regs)
     {
+      cpu = this_cpu();
+      tcb = current_task(cpu);
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -246,12 +249,15 @@ uint64_t *arm64_syscall_switch(uint64_t * regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      cpu = this_cpu();
-      tcb = current_task(cpu);
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -78,6 +78,11 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
 
       if (regs != up_current_regs())
         {
+          /* Update scheduler parameters */
+
+          nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+          nxsched_resume_scheduler(this_task());
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/ceva/src/common/ceva_switchcontext.c
+++ b/arch/ceva/src/common/ceva_switchcontext.c
@@ -69,10 +69,6 @@ void ceva_switchcontext(uint32_t **saveregs, uint32_t *restoreregs)
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  sched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -83,10 +79,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       rtcb->xcp.regs = up_current_regs();
 
-      /* Update scheduler parameters */
-
-      sched_resume_scheduler(tcb);
-
       /* Then switch contexts */
 
       up_set_current_regs(tcb->xcp.regs);
@@ -96,10 +88,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else
     {
-      /* Update scheduler parameters */
-
-      sched_resume_scheduler(tcb);
-
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -109,6 +109,11 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/risc-v/src/common/riscv_switchcontext.c
+++ b/arch/risc-v/src/common/riscv_switchcontext.c
@@ -57,10 +57,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_interrupt_context())
@@ -70,10 +66,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       riscv_savecontext(rtcb);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -86,10 +78,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else
     {
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-
       /* Then switch contexts */
 
       riscv_switchcontext(rtcb, tcb);

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -116,6 +116,11 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(this_task());
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -97,6 +97,11 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(this_task());
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -82,6 +82,11 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
       addrenv_switch(NULL);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(this_task());
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/xtensa/src/common/xtensa_switchcontext.c
+++ b/arch/xtensa/src/common/xtensa_switchcontext.c
@@ -57,39 +57,10 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
-  if (up_current_regs())
+  if (!up_current_regs())
     {
-      /* Yes, then we have to do things differently.
-       * Just copy the current_regs into the OLD rtcb.
-       */
-
-      xtensa_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-
-      /* Then switch contexts.  Any necessary address environment
-       * changes will be made when the interrupt returns.
-       */
-
-      xtensa_restorestate(tcb->xcp.regs);
-    }
-
-  /* No, then we will need to perform the user context switch */
-
-  else
-    {
-      /* Reset scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
-
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */


### PR DESCRIPTION
## Summary

arch: change nxsched_suspend/resume_scheduler() called position

for the citimon stats:

```
thread 0:                     thread 1:
enter_critical (t0)
up_switch_context
note suspend thread0 (t1)

                              thread running
                              IRQ happen, in ISR:
                                post thread0
                                up_switch_context
                                note resume thread0 (t2)
                                ISR continue f1
                                ISR continue f2
                                ...
                                ISR continue fn

leave_critical (t3)
```

You will see, the thread 0, critical_section time is: (t1 - t0) + (t3 - t2)

BUT, this result contains f1 f2 .. fn time spent, it is wrong to tell user thead0 hold the critical lots of time but actually not belong to it.

Resolve:
change the nxsched_suspend/resume_scheduler to real hanppends


## Impact

critmon

## Testing

qemu

./tools/configure.sh mps2-an500:nsh -j8
