### PR TITLE
arm/armv8-r: fix armv8 build error without neon

### DIFF
--- a/arch/arm/src/armv8-r/Toolchain.defs
+++ b/arch/arm/src/armv8-r/Toolchain.defs
@@ -23,10 +23,10 @@ ARCHCPUFLAGS += -march=armv8-r
 ifeq ($(CONFIG_ARCH_FPU),y)
   LLVM_ABITYPE := eabihf
 
-  ifeq ($(CONFIG_ARCH_CORTEXR52)$(CONFIG_ARM_NEON),yy)
+  ifeq ($(CONFIG_ARM_NEON),y)
     ARCHCPUFLAGS += -mfpu=neon-fp-armv8
   else
-    ARCHCPUFLAGS += -mfpu=fpv5-sp-d16
+    ARCHCPUFLAGS += -mfpu=fp-armv8
   endif
   ifeq ($(CONFIG_ARM_FPU_ABI_SOFT),y)
     ARCHCPUFLAGS += -mfloat-abi=softfp

--- a/arch/arm/src/cmake/armv8-r.cmake
+++ b/arch/arm/src/cmake/armv8-r.cmake
@@ -26,10 +26,10 @@ endif()
 
 if(CONFIG_ARCH_FPU)
 
-  if(CONFIG_ARCH_CORTEXR52 AND CONFIG_ARM_NEON)
+  if(CONFIG_ARM_NEON)
     list(APPEND PLATFORM_FLAGS -mfpu=neon-fp-armv8)
   else()
-    list(APPEND PLATFORM_FLAGS -mfpu=fpv5-sp-d16)
+    list(APPEND PLATFORM_FLAGS -mfpu=fp-armv8)
   endif()
   if(CONFIG_ARM_FPU_ABI_SOFT)
     list(APPEND PLATFORM_FLAGS -mfloat-abi=softfp)


### PR DESCRIPTION
Fix the build error:
armv8-r/arm_vectors.S:205:Error: VFP single precision register expected -- `vstmdb.64 sp!,{d16-d31}'
armv8-r/arm_vectors.S:242:Error: VFP single precision register expected -- `vldmia.64 r0!,{d16-d31}'

## Summary

## Impact

## Testing

