### PR TITLE
boards/qemu-rv: Correct tmpfs mount path to use CONFIG_LIBC_TMPDIR

### DIFF
--- a/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
+++ b/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
@@ -129,7 +129,7 @@ int board_app_initialize(uintptr_t arg)
 #endif
 
 #ifdef CONFIG_FS_TMPFS
-  mount(NULL, "/tmp", "tmpfs", 0, NULL);
+  mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
 #endif
 
 #endif


### PR DESCRIPTION


## Summary
Follow other boards, use CONFIG_LIBC_TMPDIR from Kconfig instead of hardcode it here.
## Impact
Minor
## Testing
CI
