### PR TITLE
Pci fixbug

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -689,6 +689,8 @@ static void pci_setup_device(FAR struct pci_device_s *dev, int max_bar,
   pci_read_config_byte(dev, PCI_COMMAND, &cmd);
   pci_write_config_byte(dev, PCI_COMMAND,
                         cmd & ~PCI_COMMAND_IO & ~PCI_COMMAND_MEMORY);
+#else
+  uint32_t tmp;
 #endif
 
   for (bar = 0; bar < max_bar; bar++)
@@ -762,8 +764,6 @@ static void pci_setup_device(FAR struct pci_device_s *dev, int max_bar,
       res->start += size;
 #else
       UNUSED(res);
-      uint32_t tmp;
-
       pci_read_config_dword(dev, base_address_0, &tmp);
       if (mask & PCI_BASE_ADDRESS_SPACE_IO)
         {
@@ -1040,7 +1040,7 @@ static void pci_scan_bus(FAR struct pci_bus_s *bus)
           child_bus->parent_bus = bus;
 
 #ifdef CONFIG_PCI_ASSIGN_ALL_BUSES
-          child_bus->number = ctrl->busno++;
+          child_bus->number = bus->ctrl->busno++;
 #endif
 
           list_add_tail(&bus->children, &child_bus->node);

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1135,7 +1135,7 @@ static int pci_enable_msi(FAR struct pci_device_s *dev, FAR int *irq,
     {
       mme = mmc;
       num = 1 << mme;
-      pciinfo("Limit MME to %x, num to %d\n", mmc, num);
+      pciinfo("Limit MME to %"PRIx32", num to %d\n", mmc, num);
     }
 
   /* Configure MSI (arch-specific) */

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -2011,12 +2011,13 @@ int pci_register_device(FAR struct pci_device_s *dev)
               if (drv->probe(dev) >= 0)
                 {
                   dev->drv = drv;
-                  break;
+                  goto out;
                 }
             }
         }
     }
 
+out:
   nxmutex_unlock(&g_pci_lock);
   return ret;
 }

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1154,7 +1154,8 @@ static int pci_enable_msi(FAR struct pci_device_s *dev, FAR int *irq,
 
   if ((flags & PCI_MSI_FLAGS_64BIT) != 0)
     {
-      pci_write_config_dword(dev, msi + PCI_MSI_ADDRESS_HI, (mar >> 32));
+      pci_write_config_dword(dev, msi + PCI_MSI_ADDRESS_HI,
+                             ((uint64_t)mar >> 32));
       pci_write_config_dword(dev, msi + PCI_MSI_DATA_64, mdr);
     }
   else

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -959,7 +959,7 @@ static void pci_scan_bus(FAR struct pci_bus_s *bus)
 {
   FAR struct pci_device_s *dev;
   FAR struct pci_bus_s *child_bus;
-  uint32_t devfn;
+  unsigned int devfn;
   uint32_t l;
   uint32_t class;
   uint8_t hdr_type;

--- a/drivers/pci/pci_ecam.c
+++ b/drivers/pci/pci_ecam.c
@@ -47,11 +47,13 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int pci_ecam_read_config(FAR struct pci_bus_s *bus, uint32_t devfn,
-                                int where, int size, FAR uint32_t *val);
+static int pci_ecam_read_config(FAR struct pci_bus_s *bus,
+                                unsigned int devfn, int where, int size,
+                                FAR uint32_t *val);
 
-static int pci_ecam_write_config(FAR struct pci_bus_s *bus, uint32_t devfn,
-                                 int where, int size, uint32_t val);
+static int pci_ecam_write_config(FAR struct pci_bus_s *bus,
+                                 unsigned int devfn, int where, int size,
+                                 uint32_t val);
 
 /****************************************************************************
  * Private Types
@@ -168,8 +170,9 @@ static bool pci_ecam_addr_valid(FAR const struct pci_bus_s *bus,
  *
  ****************************************************************************/
 
-static int pci_ecam_read_config(FAR struct pci_bus_s *bus, uint32_t devfn,
-                                int where, int size, FAR uint32_t *val)
+static int pci_ecam_read_config(FAR struct pci_bus_s *bus,
+                                unsigned int devfn, int where, int size,
+                                FAR uint32_t *val)
 {
   FAR void *addr;
 
@@ -225,8 +228,9 @@ static int pci_ecam_read_config(FAR struct pci_bus_s *bus, uint32_t devfn,
  *
  ****************************************************************************/
 
-static int pci_ecam_write_config(FAR struct pci_bus_s *bus, uint32_t devfn,
-                                 int where, int size, uint32_t val)
+static int pci_ecam_write_config(FAR struct pci_bus_s *bus,
+                                 unsigned int devfn, int where, int size,
+                                 uint32_t val)
 {
   FAR void *addr;
 

--- a/drivers/pci/pci_qemu_test.c
+++ b/drivers/pci/pci_qemu_test.c
@@ -319,6 +319,10 @@ static int pci_qemu_test_probe(FAR struct pci_device_s *dev)
         {
           ops = &g_pci_qemu_test_io_ops;
         }
+      else
+        {
+          PANIC();
+        }
 
       for (test_cnt = 0; test_cnt < 0xff; test_cnt++)
         {

--- a/include/nuttx/pci/pci_regs.h
+++ b/include/nuttx/pci/pci_regs.h
@@ -267,13 +267,13 @@
 #define  PCI_PM_CTRL_STATE_MASK           0x0003  /* Current power state (D0 to D3) */
 #define  PCI_PM_CTRL_NO_SOFT_RESET        0x0008  /* No reset for D3hot->D0 */
 #define  PCI_PM_CTRL_PME_ENABLE           0x0100  /* PME pin enable */
-#define  PCI_PM_CTRL_DATA_SEL_MASK        0x1e00  /* Data select (??) */
-#define  PCI_PM_CTRL_DATA_SCALE_MASK      0x6000  /* Data scale (??) */
+#define  PCI_PM_CTRL_DATA_SEL_MASK        0x1e00  /* Data select (/?/?) */
+#define  PCI_PM_CTRL_DATA_SCALE_MASK      0x6000  /* Data scale (/?/?) */
 #define  PCI_PM_CTRL_PME_STATUS           0x8000  /* PME pin status */
-#define PCI_PM_PPB_EXTENSIONS             6       /* PPB support extensions (??) */
-#define  PCI_PM_PPB_B2_B3                 0x40    /* Stop clock when in D3hot (??) */
-#define  PCI_PM_BPCC_ENABLE               0x80    /* Bus power/clock control enable (??) */
-#define PCI_PM_DATA_REGISTER              7       /* (??) */
+#define PCI_PM_PPB_EXTENSIONS             6       /* PPB support extensions (/?/?) */
+#define  PCI_PM_PPB_B2_B3                 0x40    /* Stop clock when in D3hot (/?/?) */
+#define  PCI_PM_BPCC_ENABLE               0x80    /* Bus power/clock control enable (/?/?) */
+#define PCI_PM_DATA_REGISTER              7       /* (/?/?) */
 #define PCI_PM_SIZEOF                     8
 
 /* AGP registers */

--- a/include/nuttx/pci/pci_regs.h
+++ b/include/nuttx/pci/pci_regs.h
@@ -26,6 +26,7 @@
  */
 
 #define PCI_STD_HEADER_SIZEOF             64
+#define PCI_STD_NUM_BARS                  6     /* Number of standard BARs */
 #define PCI_VENDOR_ID                     0x00  /* 16 bits */
 #define PCI_DEVICE_ID                     0x02  /* 16 bits */
 #define PCI_COMMAND                       0x04  /* 16 bits */


### PR DESCRIPTION
## Summary
1.pci.c: fix warning when CONFIG_PCI_ASSIGN_ALL_BUSES=n
2.pci.c: fix pci 32bit warning
3.toolchain/ghs: Fix ?? "trigraphs not allowed" warnings
4.pci_qemu_test.c: fix compiler warning
5.change all devfn type to unsigned int
6.one pci device should only associate with one driver
## Impact

## Testing

