### PR TITLE
xtesa: fix lost save & restore states caused by merge code

### DIFF
--- a/arch/xtensa/src/common/xtensa_switchcontext.c
+++ b/arch/xtensa/src/common/xtensa_switchcontext.c
@@ -59,7 +59,24 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
   /* Are we in an interrupt handler? */
 
-  if (!up_current_regs())
+  if (up_current_regs())
+    {
+      /* Yes, then we have to do things differently.
+       * Just copy the current_regs into the OLD rtcb.
+       */
+
+      xtensa_savestate(rtcb->xcp.regs);
+
+      /* Then switch contexts.  Any necessary address environment
+       * changes will be made when the interrupt returns.
+       */
+
+      xtensa_restorestate(tcb->xcp.regs);
+    }
+
+  /* No, then we will need to perform the user context switch */
+
+  else
     {
       /* Switch context to the context of the task at the head of the
        * ready to run list.


### PR DESCRIPTION
## Summary

xtesa: fix lost save & restore states caused by merge code

this is caused by:
35c8c80a00a99ff0e19d51eaa74165bd830a36f8

https://github.com/apache/nuttx/pull/13651

## Impact

xtensa

## Testing

Test pass in QEMU:

./tools/configure.sh -E esp32-devkitc:nsh

qemu-system-xtensa -nographic -machine esp32 -drive file=nuttx.merged.bin,if=mtd,format=raw -drive file=qemu_efuse.bin,if=none,format=raw,id=efuse -global driver=nvram.esp32.efuse,property=drive,value=efuse
