### PR TITLE
libxx:fix build error when enable LIBCXXTOOLCHAIN

### DIFF
--- a/libs/libxx/CMakeLists.txt
+++ b/libs/libxx/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_HAVE_CXX)
     include(uClibc++.cmake)
   elseif(CONFIG_LIBCXX)
     include(libcxx.cmake)
-  else()
+  elseif(CONFIG_LIBCXXMINI)
     include(libcxxmini.cmake)
   endif()
 

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -33,11 +33,12 @@ ifeq ($(CONFIG_UCLIBCXX),y)
 include uClibc++.defs
 else ifeq ($(CONFIG_LIBCXX),y)
 include libcxx.defs
-else
+else ifeq ($(CONFIG_LIBCXXMINI),y)
 include libcxxmini.defs
+endif
+
 ifeq ($(CONFIG_ETL),y)
 include etl.defs
-endif
 endif
 
 ifeq ($(CONFIG_LIBCXXABI),y)


### PR DESCRIPTION
## Summary
Fixed https://github.com/apache/nuttx/issues/13648

The problem is that when LIBCXXTOOLCHAIN ​​is enabled, LIBCXXMINI is included in the compilation. This causes a conflict between the void* operator new in the toolchain and the LIBCXXMINI.
When LIBCXXTOOLCHAIN ​​is enabled in the configuration, the version provided by the toolchain should be used.

```
  P:➜  nuttx git:(4cec713dbf) LC_ALL=C make
CC:  chip/stm32_gpio.c chip/stm32_gpio.c:41:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   41 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
CXX:  libcxxmini/libxx_new.cxx libcxxmini/libxx_new.cxx:72:11: error: redefinition of 'void* operator new(std::size_t, void*)'
   72 | FAR void *operator new(std::size_t nbytes, FAR void *ptr)
      |           ^~~~~~~~
In file included from /usr/include/newlib/c++/13.2.1/bits/atomic_base.h:36,
                 from /usr/include/newlib/c++/13.2.1/atomic:41,
                 from /home/leduc/wdc_workspace/src/autre/nuttx_dev/nuttx/include/nuttx/atomic.h:32,
                 from /home/leduc/wdc_workspace/src/autre/nuttx_dev/nuttx/include/nuttx/fs/fs.h:38,
                 from /home/leduc/wdc_workspace/src/autre/nuttx_dev/nuttx/include/nuttx/lib/lib.h:30,
                 from libcxxmini/libxx_new.cxx:29:
/usr/include/newlib/c++/13.2.1/new:174:33: note: 'void* operator new(std::size_t, void*)' previously defined here
  174 | _GLIBCXX_NODISCARD inline void* operator new(std::size_t, void* __p) _GLIBCXX_USE_NOEXCEPT
      |                                 ^~~~~~~~
make[1]: *** [Makefile:69: libxx_new.o] Error 1
make: *** [tools/LibTargets.mk:216: libs/libxx/libxx.a] Error 2
```

## Impact
**Is a new feature added?**: NO
**Impact on build**: NO
**Impact on hardware:**NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation**: NO,This patch does not introduce any new features
**Impact on compatibility**: This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): stm32f411e-disco:nsh
Build Success
```
make -j        
Create version.h
LN: platform/board to /home/crafcat7/SSD/apps/platform/dummy
Register: nsh
Register: sh
CC:  semaphore/sem_rw.c chip/stm32_gpio.c:41:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   41 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
CPP:  /home/crafcat7/SSD/nuttx/boards/arm/stm32/stm32f411e-disco/scripts/f411ve.ld-> /home/crafcat7/SSD/nuttx/boards/arm/stm32/stm32f411e-disco/scLD: nuttx
CP: nuttx.hex
CP: nuttx.bin
```

