### PR TITLE
arm64 fork: FORK_REG_LR,FORK_REG_SP should save the func local stack

### DIFF
--- a/arch/arm64/src/common/arm64_fork_func.S
+++ b/arch/arm64/src/common/arm64_fork_func.S
@@ -86,9 +86,8 @@ GTEXT(up_fork)
 SECTION_FUNC(text, up_fork)
     /* Create a stack frame */
 
-    mov    x0,  sp            /* Save the value of the stack on entry */
-    stp    x29, x30, [sp]
     sub    sp,  sp, #8 * FORK_REGS_SIZE    /* Allocate the structure on the stack */
+    stp    x29, x30, [sp, #8 * FORK_REG_FP] /* Save the FP, LR */
 
     /* CPU registers, save all register*/
 
@@ -106,11 +105,12 @@ SECTION_FUNC(text, up_fork)
     stp    x22, x23, [sp, #8 * FORK_REG_X22]
     stp    x24, x25, [sp, #8 * FORK_REG_X24]
     stp    x26, x27, [sp, #8 * FORK_REG_X26]
-    stp    x28, x29, [sp, #8 * FORK_REG_X28]
+    str    x28,      [sp, #8 * FORK_REG_X28]
 
-    /* Save the LR, stack pointer */
+    /* Save the stack pointer */
 
-    stp    x30, x0, [sp, #8 * FORK_REG_LR]
+    add    x0, sp, #8 * FORK_REGS_SIZE
+    str    x0, [sp, #8 * FORK_REG_SP]
 
     /* Floating point registers */
 #ifdef CONFIG_ARCH_FPU
@@ -128,7 +128,7 @@ SECTION_FUNC(text, up_fork)
 
     /* Release the stack data and return the value returned by arm64_fork */
 
+    ldp    x29, x30, [sp, #8 * FORK_REG_FP]
     add    sp, sp,  #8 * FORK_REGS_SIZE
-    ldp    x29, x30, [sp]
 
     ret


### PR DESCRIPTION
FORK_REG_LR,FORK_REG_SP should save the func local stack not the last func stack
not the last func stack
## Summary

## Impact

## Testing

