### PR TITLE
add function of allocating fifosize on adc separately

### DIFF
--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -793,6 +793,7 @@ int adc_register(FAR const char *path, FAR struct adc_dev_s *dev)
 
       nxsem_destroy(&dev->ad_recv.af_sem);
       nxmutex_destroy(&dev->ad_closelock);
+      return ret;
     }
 
   /* Initialize the af_channale */

--- a/include/nuttx/analog/adc.h
+++ b/include/nuttx/analog/adc.h
@@ -140,9 +140,9 @@ struct adc_fifo_s
   uint16_t     af_head;                  /* Index to the head [IN] index in the circular buffer */
   uint16_t     af_tail;                  /* Index to the tail [OUT] index in the circular buffer */
                                          /* Circular buffer of ADC messages */
-  uint8_t      af_channel[CONFIG_ADC_FIFOSIZE];
-  int32_t      af_data[CONFIG_ADC_FIFOSIZE];
-  struct adc_msg_s af_buffer[CONFIG_ADC_FIFOSIZE];
+  FAR uint8_t  *af_channel;
+  FAR uint32_t *af_data;
+  uint16_t     af_fifosize;
 };
 
 /* This structure defines all of the operations provided by the architecture


### PR DESCRIPTION
## Summary

allocating fifosize on demand to optimize memory ,no need to seting adc_fifosize unified

## Impact

Allocate fifosize on demand to optimize memory & Fix the situation where af_channel is still being read after it is released

## Testing

