### PR TITLE
tools/nxstyle: Add RuntimeInitArgs to the white content list

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -227,6 +227,10 @@ static const char *g_white_suffix[] =
 
 static const char *g_white_content_list[] =
 {
+  /* Ref:  wamr_custom_init.c */
+
+  "RuntimeInitArgs",
+
   /* Ref:  gnu_unwind_find_exidx.c */
 
   "__EIT_entry",


### PR DESCRIPTION


## Summary
`RuntimeInitArgs` is used by WAMR, a popular WebAssembly runtime, it used in nuttx-apps side.
## Impact
Minor
## Testing
CI
