### PR TITLE
procfs:fix cat dir cause crash

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -421,6 +421,11 @@ static int procfs_open(FAR struct file *filep, FAR const char *relpath,
 
       if (fnmatch(g_procfs_entries[x].pathpattern, relpath, 0) == 0)
         {
+          if (g_procfs_entries[x].type == PROCFS_DIR_TYPE)
+            {
+              return -EISDIR;
+            }
+
           /* Match found!  Stat using this procfs entry */
 
           DEBUGASSERT(g_procfs_entries[x].ops &&


### PR DESCRIPTION
## Summary
when try to cat a dirctory, will cause a crash.

ap> cat pm
================================================================= ==30235==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf436edd9 at pc 0x03338a48 bp 0x9d1b6ca8 sp 0x9d1b6c98 READ of size 1 at 0xf436edd9 thread T0
    #0 0x3338a47 in strncmp string/lib_strncmp.c:42
    #1 0x371af87 in pm_get_file_index power/pm/pm_procfs.c:174
    #2 0x371b066 in pm_open power/pm/pm_procfs.c:207
    #3 0x3640d20 in procfs_open procfs/fs_procfs.c:419
    #4 0x359bce2 in file_vopen vfs/fs_open.c:240
    #5 0x359c431 in nx_vopen vfs/fs_open.c:312
    #6 0x359cb53 in open vfs/fs_open.c:465
    #7 0x33bccc9 in nsh_catfile /apps/nshlib/nsh_fsutils.c:140
    #8 0x33b28cc in cmd_cat /apps/nshlib/nsh_fscmds.c:556
    #9 0x33a434f in nsh_command /apps/nshlib/nsh_command.c:1164
    #10 0x3381b8f in nsh_execute /apps/nshlib/nsh_parse.c:845
    #11 0x338dc17 in nsh_parse_command /apps/nshlib/nsh_parse.c:2744
    #12 0x338e273 in nsh_parse /apps/nshlib/nsh_parse.c:2828
    #13 0x3390b47 in nsh_session /apps/nshlib/nsh_session.c:245
    #14 0x337e90a in nsh_consolemain /apps/nshlib/nsh_consolemain.c:75
    #15 0x337e7f7 in nsh_main /apps/system/nsh/nsh_main.c:74
    #16 0x332b6e6 in nxtask_startup sched/task_startup.c:70
    #17 0x323ec3f in nxtask_start task/task_start.c:134
    #18 0x33636ea in pre_start sim/sim_initialstate.c:52

ap> cat net
================================================================= ==30303==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf4479a5a at pc 0x03338a48 bp 0x9d2b6ce8 sp 0x9d2b6cd8 READ of size 1 at 0xf4479a5a thread T0
    #0 0x3338a47 in strncmp string/lib_strncmp.c:42
    #1 0x5395d62 in netprocfs_open procfs/net_procfs.c:215
    #2 0x3640d20 in procfs_open procfs/fs_procfs.c:419
    #3 0x359bce2 in file_vopen vfs/fs_open.c:240
    #4 0x359c431 in nx_vopen vfs/fs_open.c:312
    #5 0x359cb53 in open vfs/fs_open.c:465
    #6 0x33bccc9 in nsh_catfile /apps/nshlib/nsh_fsutils.c:140
    #7 0x33b28cc in cmd_cat /apps/nshlib/nsh_fscmds.c:556
    #8 0x33a434f in nsh_command /apps/nshlib/nsh_command.c:1164
    #9 0x3381b8f in nsh_execute /apps/nshlib/nsh_parse.c:845
    #10 0x338dc17 in nsh_parse_command /apps/nshlib/nsh_parse.c:2744
    #11 0x338e273 in nsh_parse /apps/nshlib/nsh_parse.c:2828
    #12 0x3390b47 in nsh_session /apps/nshlib/nsh_session.c:245
    #13 0x337e90a in nsh_consolemain /apps/nshlib/nsh_consolemain.c:75
    #14 0x337e7f7 in nsh_main /apps/system/nsh/nsh_main.c:74
    #15 0x332b6e6 in nxtask_startup sched/task_startup.c:70
    #16 0x323ec3f in nxtask_start task/task_start.c:134
    #17 0x33636ea in pre_start sim/sim_initialstate.c:52

## Impact
No impact for common usage.

## Testing
CI-test
