### PR TITLE
sim:fix oneshot sim_cancel assert

### DIFF
--- a/arch/sim/src/sim/sim_oneshot.c
+++ b/arch/sim/src/sim/sim_oneshot.c
@@ -364,12 +364,15 @@ static int sim_cancel(struct oneshot_lowerhalf_s *lower,
   struct timespec current;
   irqstate_t flags;
 
-  DEBUGASSERT(priv != NULL && ts != NULL);
+  DEBUGASSERT(priv != NULL);
 
   flags = enter_critical_section();
 
-  sim_timer_current(&current);
-  clock_timespec_subtract(&priv->alarm, &current, ts);
+  if (ts != NULL)
+    {
+      sim_timer_current(&current);
+      clock_timespec_subtract(&priv->alarm, &current, ts);
+    }
 
   sim_reset_alarm(&priv->alarm);
   sim_update_hosttimer();


### PR DESCRIPTION
## Summary
when CONFIG_PM and CONFIG_CPULOAD_ONESHOT are defined sim_cancel may assert:
sim_cancel may assert:
[429492.185400] [ 0] [ EMERG] [ap] _assert: Current Version: NuttX ap 12.3.0 5ffeb16111-dirty Dec 4 2023 14:32:27 sim
[429492.185400] [ 0] [ EMERG] [ap] _assert: Assertion failed : at file: sim/sim_oneshot.c:367 task: Idle_Task process: Kernel 0x323254d
[429492.185400] [ 0] [ EMERG] [ap] backtrace:
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0xf7941ad5>] _fini+0xf0753010/0xf8e1155b
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x71def50>] host_backtrace+0x41/0x72
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x65b68bd>] up_backtrace+0x126/0x2f8
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x6554ceb>] sched_backtrace+0x70/0x8a
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x37585d2>] sched_dumpstack+0xed/0x494
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x3694d8e>] _assert+0x93b/0xa82
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x33223eb>] __assert+0x3e/0x4c
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x336b6d5>] sim_cancel+0xde/0x392
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x36a4301>] nxsched_oneshot_pmnotify+0x2aa/0x2ee
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x36bce77>] pm_changeall+0x478/0x526
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x36bd71f>] pm_changestate+0x380/0x82c
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x336297b>] up_idle+0x54/0xa6
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x32347b8>] nx_start+0x226b/0x226e
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x31d49f5>] main+0x54/0x70
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0xf6bbcfa1>] _fini+0xef9ce4dc/0xf8e1155b
[429492.185400] [ 0] [ EMERG] [ap] [ 0] [<0x31914ac>] _start+0x31/0x46

## Impact
ts NULL is allowed, and only do not do time operations.

## Testing
CI-test
