### PR TITLE
nuttx/libm: Fix powf wrong if first parameter is negative

### DIFF
--- a/libs/libm/libm/lib_powf.c
+++ b/libs/libm/libm/lib_powf.c
@@ -37,5 +37,21 @@
 
 float powf(float b, float e)
 {
-  return expf(e * logf(b));
+  if (b > 0.0)
+    {
+      return expf(e * logf(b));
+    }
+  else if (b < 0.0 && e == (int)e)
+    {
+      if ((int)e % 2 == 0)
+        {
+          return expf(e * logf(fabsf(b)));
+        }
+      else
+        {
+          return -expf(e * logf(fabsf(b)));
+        }
+    }
+
+  return 0.0;
 }


### PR DESCRIPTION
## Summary
1. fix the powf function param incompatible error

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest

