### PR TITLE
greenhills support: Fix green hills build timer.h error

### DIFF
--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -33,6 +33,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <sys/types.h>
+#include <assert.h>
 
 #ifdef CONFIG_TIMER
 


### PR DESCRIPTION
## Summary
fix the nuttx/timers timer.h build error with greenhills compiler
the detailed error info are:
```
"/mnt/yang/qixinwei_commit/nuttx/include/nuttx/timers/timer.h", line 257: error #223-D:
          function DEBUGASSERT declared implicitly
    DEBUGASSERT(lower->ops->tick_getstatus);
```

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler

