### PR TITLE
pm & runtime pm bugfix 

### DIFF
--- a/drivers/power/pm/CMakeLists.txt
+++ b/drivers/power/pm/CMakeLists.txt
@@ -62,6 +62,12 @@ if(CONFIG_PM)
 
   endif()
 
+  if(CONFIG_PM_RUNTIME)
+
+    list(APPEND SRCS pm_runtime.c)
+
+  endif()
+
 endif()
 
 target_sources(drivers PRIVATE ${SRCS})

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1942,8 +1942,10 @@ void uart_datareceived(FAR uart_dev_t *dev)
 
   if (dev->isconsole)
     {
+#  if CONFIG_SERIAL_PM_ACTIVITY_PRIORITY > 0
       pm_activity(CONFIG_SERIAL_PM_ACTIVITY_DOMAIN,
                   CONFIG_SERIAL_PM_ACTIVITY_PRIORITY);
+#  endif
     }
 #endif
 }

--- a/include/nuttx/power/pm_runtime.h
+++ b/include/nuttx/power/pm_runtime.h
@@ -68,6 +68,15 @@ struct pm_runtime_ops_s
  * Public Function Prototypes
  ****************************************************************************/
 
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 void pm_runtime_init(FAR struct pm_runtime_s *rpm, rpm_state_e state,
                      FAR struct pm_runtime_ops_s *rops);
 int pm_runtime_get(FAR struct pm_runtime_s *rpm);
@@ -75,5 +84,11 @@ int pm_runtime_put(FAR struct pm_runtime_s *rpm);
 int pm_runtime_put_autosuspend(FAR struct pm_runtime_s *rpm);
 void pm_runtime_set_autosuspend_delay(FAR struct pm_runtime_s *rpm,
                                       unsigned int delay);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
 #endif /* CONFIG_PM_RUNTIME */
 #endif /* __INCLUDE_NUTTX_POWER_PM_RUNTIME_H */


### PR DESCRIPTION
## Summary
add runtimepm in cmake
when CONFIG_SERIAL_PM_ACTIVITY_PRIORITY == 0 disable pm_activity
add extern C for public api

## Impact
runtime pm able to use in cxx, runtimepm able to use in cmake

## Testing
CI-test
