### PR TITLE
fix bugs about noteram about alignment, fix the tail of reader did not reset when flush.

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -585,10 +585,10 @@ static void note_record_taskname(pid_t pid, FAR const char *name)
 
   ti = (FAR struct note_taskname_info_s *)
         &g_note_taskname.buffer[g_note_taskname.head];
-  ti->size = tilen;
+  ti->size = NOTE_ALIGN(tilen);
   ti->pid = pid;
   strlcpy(ti->name, name, namelen + 1);
-  g_note_taskname.head += tilen;
+  g_note_taskname.head += ti->size;
 }
 #endif
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -295,7 +295,7 @@ static void noteram_remove(FAR struct noteram_driver_s *drv)
 
   /* Get the length of the note at the tail index */
 
-  length = drv->ni_buffer[tail];
+  length = NOTE_ALIGN(drv->ni_buffer[tail]);
   DEBUGASSERT(length <= noteram_length(drv));
 
   /* Increment the tail index to remove the entire note from the circular
@@ -387,7 +387,7 @@ static ssize_t noteram_get(FAR struct noteram_driver_s *drv,
       remaining--;
     }
 
-  drv->ni_read = read;
+  drv->ni_read = NOTE_ALIGN(read);
 
   return notelen;
 }
@@ -594,7 +594,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
   space = space < notelen ? space : notelen;
   memcpy(drv->ni_buffer + head, note, space);
   memcpy(drv->ni_buffer, buf + space, notelen - space);
-  drv->ni_head = noteram_next(drv, head, notelen);
+  drv->ni_head = noteram_next(drv, head, NOTE_ALIGN(notelen));
   spin_unlock_irqrestore_wo_note(&drv->lock, flags);
 }
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -365,7 +365,7 @@ static ssize_t noteram_get(FAR struct noteram_driver_s *drv,
     {
       /* Skip the large note so that we do not get constipated. */
 
-      drv->ni_read = noteram_next(drv, read, notelen);
+      drv->ni_read = noteram_next(drv, read, NOTE_ALIGN(notelen));
 
       /* and return an error */
 
@@ -387,7 +387,7 @@ static ssize_t noteram_get(FAR struct noteram_driver_s *drv,
       remaining--;
     }
 
-  drv->ni_read = NOTE_ALIGN(read);
+  drv->ni_read = noteram_next(drv, drv->ni_read, NOTE_ALIGN(notelen));
 
   return notelen;
 }

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -567,7 +567,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
   DEBUGASSERT(note != NULL && notelen < drv->ni_bufsize);
   remain = drv->ni_bufsize - noteram_length(drv);
 
-  if (remain < notelen)
+  if (remain <= NOTE_ALIGN(notelen))
     {
       if (drv->ni_overwrite == NOTERAM_MODE_OVERWRITE_DISABLE)
         {
@@ -586,7 +586,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
           noteram_remove(drv);
           remain = drv->ni_bufsize - noteram_length(drv);
         }
-      while (remain < notelen);
+      while (remain <= NOTE_ALIGN(notelen));
     }
 
   head = drv->ni_head;

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -235,6 +235,21 @@ static void ramlog_pollnotify(FAR struct ramlog_dev_s *priv)
 }
 
 /****************************************************************************
+ * Name: ramlog_flush
+ ****************************************************************************/
+
+static void ramlog_bufferflush(FAR struct ramlog_dev_s *priv)
+{
+  FAR struct ramlog_user_s *upriv;
+
+  priv->rl_header->rl_head = 0;
+  list_for_every_entry(&priv->rl_list, upriv, struct ramlog_user_s, rl_node)
+    {
+      upriv->rl_tail = 0;
+    }
+}
+
+/****************************************************************************
  * Name: ramlog_copybuf
  ****************************************************************************/
 
@@ -535,7 +550,7 @@ static int ramlog_file_ioctl(FAR struct file *filep, int cmd,
         upriv->rl_threashold = (uint32_t)arg;
         break;
       case BIOC_FLUSH:
-        priv->rl_header->rl_head = 0;
+        ramlog_bufferflush(priv);
         break;
       default:
         ret = -ENOTTY;

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -51,6 +51,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define NOTE_ALIGN(a) (((a) + sizeof(uintptr_t) - 1) & \
+                       ~(sizeof(uintptr_t) - 1))
+
 /* Provide defaults for some configuration settings (could be undefined with
  * old configuration files)
  */


### PR DESCRIPTION
## Summary
The noteram have bugs.
when ramnote flush, we should reset the tail of reader.
make noteram aligned, fix un-aligned write operation report by coverity.

## Impact
Bug fixed after patch

## Testing
CI-test
