### PR TITLE
nuttx/sched: Disable RW_SPINLOCK by default

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -312,7 +312,7 @@ config TICKET_SPINLOCK
 
 config RW_SPINLOCK
 	bool "Support read-write Spinlocks"
-	default y
+	default n
 	---help---
 		Spinlocks are spilit into read and write lock.
 		Reader can take read lock simultaneously and only one writer


### PR DESCRIPTION
## Summary
1. disable RW_SPINLOCK by default

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest

