### PR TITLE
drivers/pipes: using rmutex to protect pipe and avoid deadlock

### DIFF
--- a/drivers/pipes/pipe_common.h
+++ b/drivers/pipes/pipe_common.h
@@ -115,7 +115,7 @@ typedef uint8_t pipe_ndx_t;   /*  8-bit index */
 
 struct pipe_dev_s
 {
-  mutex_t          d_bflock;      /* Used to serialize access to d_buffer and indices */
+  rmutex_t         d_bflock;      /* Used to serialize access to d_buffer and indices */
   sem_t            d_rdsem;       /* Empty buffer - Reader waits for data write AND
                                    * block O_RDONLY open until there is at least one writer */
   sem_t            d_wrsem;       /* Full buffer - Writer waits for data read AND


### PR DESCRIPTION


## Summary
drivers/pipes: using rmutex to protect pipe and avoid deadlock

The backtrace when bug occurs:(signal break current stack, and write pipe in signal handler)
```
nxsem_wait
nuttx/sched/semaphore/sem_wait.c:176
nxmutex_lock
nuttx/libs/libc/misc/lib_mutex.c:204 (discriminator 2) pipecommon_write
nuttx/drivers/pipes/pipe_common.c:538 (discriminator 2) file_write
nuttx/fs/vfs/fs_write.c:91
write
nuttx/include/unistd.h:523 (discriminator 2)
nxsig_deliver
nuttx/sched/signal/sig_deliver.c:170 (discriminator 4) arm_sigdeliver
nuttx/arch/arm/src/armv7-a/arm_sigdeliver.c:107
irq_waitlock
nuttx/sched/irq/irq_csection.c:204
nxsem_post
nuttx/sched/semaphore/sem_post.c:86 (discriminator 2) nxmutex_unlock
nuttx/libs/libc/misc/lib_mutex.c:339 (discriminator 2) pipecommon_poll
nuttx/drivers/pipes/pipe_common.c:769
file_poll
nuttx/fs/vfs/fs_poll.c:321
poll_fdsetup
nuttx/fs/vfs/fs_poll.c:194
poll
nuttx/include/sys/poll.h:164
uv_run
apps/system/libuv/libuv/src/unix/core.c:449
adb_hal_run
apps/system/adb/microADB/hal/hal_uv.c:76
adbd_main
apps/system/adb/adb_main.c:157
nxtask_startup
nuttx/libs/libc/sched/task_startup.c:70 (discriminator 2) nxtask_start
nuttx/sched/task/task_start.c:134
```
## Impact
using rmutex protect pipe
## Testing
Vela 
