### PR TITLE
sched optimise for sim, CONFIG_SCHED_INSTRUMENTATION to CONFIG_SCHED_INSTRUMENTATION_SWITCH

### DIFF
--- a/arch/sim/src/sim/sim_smpsignal.c
+++ b/arch/sim/src/sim/sim_smpsignal.c
@@ -244,10 +244,6 @@ int up_cpu_paused_restore(void)
 
   nxsched_resume_scheduler(tcb);
 
-  /* Restore the cpu lock */
-
-  restore_critical_section(tcb, this_cpu());
-
   /* Then switch contexts.  Any necessary address environment changes
    * will be made when the interrupt returns.
    */
@@ -267,7 +263,7 @@ int up_cpu_paused_restore(void)
 
 void host_cpu_started(void)
 {
-#ifdef CONFIG_SCHED_INSTRUMENTATION
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
   struct tcb_s *tcb = this_task();
 
   /* Notify that this CPU has started */

--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -66,7 +66,7 @@
 
 void nx_idle_trampoline(void)
 {
-#ifdef CONFIG_SCHED_INSTRUMENTATION
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
   FAR struct tcb_s *tcb = this_task();
 
   /* Announce that the IDLE task has started */

--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -136,6 +136,7 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
 
       ret = call_data->func(call_data->arg);
 
+      flags = enter_critical_section();
       if (call_data->cookie != NULL)
         {
           if (ret < 0)
@@ -153,8 +154,6 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
               spin_unlock(&call_data->lock);
             }
         }
-
-      flags = enter_critical_section();
     }
 
   up_cpu_paused_restore();


### PR DESCRIPTION
## Summary
sched_smp:sync refcount before enqueue smp call queue
sched_smp:adjust the critical section to protect refcount from multi cores access

fix build error when sim SMP

CC:  sim/sim_smpsignal.c init/nx_smpstart.c: In function ‘nx_idle_trampoline’:
init/nx_smpstart.c:68:21: warning: unused variable ‘tcb’ [-Wunused-variable]
   68 |   FAR struct tcb_s *tcb = this_task_inirq();
      |                     ^~~
sim/sim_smpsignal.c: In function ‘host_cpu_started’:
sim/sim_smpsignal.c:271:17: warning: unused variable ‘tcb’ [-Wunused-variable]
  271 |   struct tcb_s *tcb = this_task();

sim/sim_smpsignal.c:249:33: error: ‘cpu’ undeclared (first use in this function)
  249 |   restore_critical_section(tcb, cpu);
      |                                 ^~~

## Impact
SMP call more safe,
SIM able to enable SMP

## Testing
CI test

