### PR TITLE
misc/rpmsgdev: add new cmd support for rpmsg device

### DIFF
--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -626,6 +626,8 @@ static ssize_t rpmsgdev_ioctl_arglen(int cmd)
       case TUNSETIFF:
       case TUNGETIFF:
         return sizeof(struct ifreq);
+      case FIOC_FILEPATH:
+        return PATH_MAX;
       default:
         return -ENOTTY;
     }

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -1160,6 +1160,9 @@ int rpmsgdev_register(FAR const char *remotecpu, FAR const char *remotepath,
       return -EINVAL;
     }
 
+  DEBUGASSERT(strlen(remotepath) + RPMSGDEV_NAME_PREFIX_LEN <=
+              RPMSG_NAME_SIZE);
+
   dev = kmm_zalloc(sizeof(*dev));
   if (dev == NULL)
     {

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -42,6 +42,7 @@
 #include <nuttx/rptun/openamp.h>
 #include <nuttx/net/ioctl.h>
 #include <nuttx/drivers/rpmsgdev.h>
+#include <nuttx/power/battery_ioctl.h>
 
 #include "rpmsgdev.h"
 
@@ -622,12 +623,16 @@ static ssize_t rpmsgdev_ioctl_arglen(int cmd)
       case FIONSPACE:
       case FBIOSET_POWER:
       case FBIOGET_POWER:
+      case BATIOC_STATE:
         return sizeof(int);
       case TUNSETIFF:
       case TUNGETIFF:
         return sizeof(struct ifreq);
       case FIOC_FILEPATH:
         return PATH_MAX;
+      case BATIOC_GET_PROTOCOL:
+      case BATIOC_OPERATE:
+        return sizeof(struct batio_operate_msg_s);
       default:
         return -ENOTTY;
     }

--- a/drivers/misc/rpmsgdev.h
+++ b/drivers/misc/rpmsgdev.h
@@ -33,8 +33,8 @@
  * Pre-processor definitions
  ****************************************************************************/
 
-#define RPMSGDEV_NAME_PREFIX     "rpmsgdev-"
-#define RPMSGDEV_NAME_PREFIX_LEN 9
+#define RPMSGDEV_NAME_PREFIX     "rpdev-"
+#define RPMSGDEV_NAME_PREFIX_LEN 6
 
 #define RPMSGDEV_OPEN            1
 #define RPMSGDEV_CLOSE           2


### PR DESCRIPTION
## Summary
misc/rpmsgdev: add new cmd support for rpmsg device.
FIOC_FILEPATH: get path from remote device
BATIOC_GET_PROTOCOL/BATIOC_OPERATE/BATIOC_STATE: get battery info from remote charger
## Impact
N/A
## Testing
Vela
