### PR TITLE
greenhills support: Fix ?? "trigraphs not allowed" warnings

### DIFF
--- a/include/nuttx/pci/pci_regs.h
+++ b/include/nuttx/pci/pci_regs.h
@@ -266,13 +266,13 @@
 #define  PCI_PM_CTRL_STATE_MASK           0x0003  /* Current power state (D0 to D3) */
 #define  PCI_PM_CTRL_NO_SOFT_RESET        0x0008  /* No reset for D3hot->D0 */
 #define  PCI_PM_CTRL_PME_ENABLE           0x0100  /* PME pin enable */
-#define  PCI_PM_CTRL_DATA_SEL_MASK        0x1e00  /* Data select (??) */
-#define  PCI_PM_CTRL_DATA_SCALE_MASK      0x6000  /* Data scale (??) */
+#define  PCI_PM_CTRL_DATA_SEL_MASK        0x1e00  /* Data select (/?/?) */
+#define  PCI_PM_CTRL_DATA_SCALE_MASK      0x6000  /* Data scale (/?/?) */
 #define  PCI_PM_CTRL_PME_STATUS           0x8000  /* PME pin status */
-#define PCI_PM_PPB_EXTENSIONS             6       /* PPB support extensions (??) */
-#define  PCI_PM_PPB_B2_B3                 0x40    /* Stop clock when in D3hot (??) */
-#define  PCI_PM_BPCC_ENABLE               0x80    /* Bus power/clock control enable (??) */
-#define PCI_PM_DATA_REGISTER              7       /* (??) */
+#define PCI_PM_PPB_EXTENSIONS             6       /* PPB support extensions (/?/?) */
+#define  PCI_PM_PPB_B2_B3                 0x40    /* Stop clock when in D3hot (/?/?) */
+#define  PCI_PM_BPCC_ENABLE               0x80    /* Bus power/clock control enable (/?/?) */
+#define PCI_PM_DATA_REGISTER              7       /* (/?/?) */
 #define PCI_PM_SIZEOF                     8
 
 /* AGP registers */


### PR DESCRIPTION
## Summary
fix the ?? "trigraphs not allowed" build warnings with greenhills compiler
the detailed build warning are:
```
"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 263: warning #1695-D:
          trigraphs not allowed
  #define  PCI_PM_CTRL_DATA_SEL_MASK        0x1e00  /* Data select (??) */
                                                                    ^

"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 264: warning #1695-D:
          trigraphs not allowed
  #define  PCI_PM_CTRL_DATA_SCALE_MASK      0x6000  /* Data scale (??) */
                                                                   ^

"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 266: warning #1695-D:
          trigraphs not allowed
  #define PCI_PM_PPB_EXTENSIONS             6       /* PPB support extensions (??) */
                                                                               ^

"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 267: warning #1695-D:
          trigraphs not allowed
  #define  PCI_PM_PPB_B2_B3                 0x40    /* Stop clock when in D3hot (??) */
                                                                                 ^

"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 268: warning #1695-D:
          trigraphs not allowed
  #define  PCI_PM_BPCC_ENABLE               0x80    /* Bus power/clock control enable (??) */
                                                                                       ^

"/mnt/yang/qixinwei_vela_warnings_04_23/nuttx/include/nuttx/pci/pci_regs.h", line 269: warning #1695-D:
          trigraphs not allowed
  #define PCI_PM_DATA_REGISTER              7       /* (??) */
```

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler

