### PR TITLE
arch/xtensa/esp32s3: fix timer group 1 initialization

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_tim.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tim.c
@@ -37,6 +37,9 @@
 #include "esp32s3_irq.h"
 #include "esp32s3_gpio.h"
 
+#include "soc/periph_defs.h"
+#include "esp_private/periph_ctrl.h"
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -967,6 +970,15 @@ struct esp32s3_tim_dev_s *esp32s3_tim_init(int timer)
           tmrerr("Unsupported TIMER %d\n", timer);
           goto errout;
         }
+    }
+
+  if (tim->gid == ESP32S3_TIM_GROUP0)
+    {
+      periph_module_enable(PERIPH_TIMG0_MODULE);
+    }
+  else
+    {
+      periph_module_enable(PERIPH_TIMG1_MODULE);
     }
 
   /* Verify if it is in use */


### PR DESCRIPTION
## Summary
On ESP32S3, only timer group 0 is initialized.
This MR fixes timer group 1 initialization.

## Impact
Allows use of timers 3 and 4 on ESP32S3.

## Testing
Timer example with timers 1-4 using the `timers` defconfig.
Internal CI testing.