### PR TITLE
greenhills support: fix the arch_interface archive error

### DIFF
--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -27,6 +27,8 @@ target_include_directories(arch PRIVATE ${CMAKE_SOURCE_DIR}/sched)
 
 if(CONFIG_BUILD_PROTECTED)
   nuttx_add_system_library(arch_interface)
+  file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/empty.c")
+  target_sources(arch_interface PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/empty.c")
   target_include_directories(arch_interface PRIVATE ${CMAKE_SOURCE_DIR}/sched)
 endif()
 


### PR DESCRIPTION
## Summary
fix the arch_interface archive error with greenhills cmake build
the detailed build error are:
```
: && cxarm cr arch/libarch_interface.a  arch/CMakeFiles/arch_interface.dir/arm/src/common/gnu/arm_signal_handler.S.obj  && echo arch/libarch_interface.a && : [elxr] (error #16) cannot find file cr
```

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs and gcc compiler

