### PR TITLE
arm64/SMP: Fix FPU and exception handling for ARM64

### DIFF
--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -292,6 +292,9 @@ struct regs_context
   uint64_t  spsr;
   uint64_t  sp_el0;
   uint64_t  exe_depth;
+#ifdef CONFIG_ARCH_FPU
+  struct fpu_reg fpu_regs;
+#endif
 };
 
 /****************************************************************************

--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -67,9 +67,6 @@ void up_exit(int status)
   enter_critical_section();
 
   /* Destroy the task at the head of the ready to run list. */
-#ifdef CONFIG_ARCH_FPU
-  arm64_destory_fpu(tcb);
-#endif
 
   nxtask_exit();
 

--- a/arch/arm64/src/common/arm64_fpu_func.S
+++ b/arch/arm64/src/common/arm64_fpu_func.S
@@ -66,10 +66,10 @@ SECTION_FUNC(text, arm64_fpu_save)
     stp    q28, q29, [x0, #(16 * FPU_REG_Q28)]
     stp    q30, q31, [x0, #(16 * FPU_REG_Q30)]
 
-    mrs    x1, fpsr
-    mrs    x2, fpcr
-    str    w1, [x0, #(16 * 32 + 0)]
-    str    w2, [x0, #(16 * 32 + 4)]
+    mrs    x10, fpsr
+    mrs    x11, fpcr
+    str    w10, [x0, #(16 * 32 + 0)]
+    str    w11, [x0, #(16 * 32 + 4)]
 
     ret
 
@@ -93,9 +93,9 @@ SECTION_FUNC(text, arm64_fpu_restore)
     ldp    q28, q29, [x0, #(16 * FPU_REG_Q28)]
     ldp    q30, q31, [x0, #(16 * FPU_REG_Q30)]
 
-    ldr    w1, [x0, #(16 * 32 + 0)]
-    ldr    w2, [x0, #(16 * 32 + 4)]
-    msr    fpsr, x1
-    msr    fpcr, x2
+    ldr    w10, [x0, #(16 * 32 + 0)]
+    ldr    w11, [x0, #(16 * 32 + 4)]
+    msr    fpsr, x10
+    msr    fpcr, x11
 
     ret

--- a/arch/arm64/src/common/arm64_initialstate.c
+++ b/arch/arm64/src/common/arm64_initialstate.c
@@ -47,10 +47,6 @@
 #include "chip.h"
 #include "arm64_fatal.h"
 
-#ifdef CONFIG_ARCH_FPU
-#include "arm64_fpu.h"
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -68,17 +64,6 @@ void arm64_new_task(struct tcb_s * tcb)
       tcb->xcp.ustkptr = (uintptr_t *)stack_ptr;
       stack_ptr        = (uintptr_t)tcb->xcp.kstack + ARCH_KERNEL_STACKSIZE;
     }
-#endif
-
-#ifdef CONFIG_ARCH_FPU
-  struct fpu_reg *pfpuctx;
-  pfpuctx = STACK_PTR_TO_FRAME(struct fpu_reg, stack_ptr);
-  tcb->xcp.fpu_regs   = (uint64_t *)pfpuctx;
-
-  /* set fpu context */
-
-  arm64_init_fpu(tcb);
-  stack_ptr  = (uintptr_t)pfpuctx;
 #endif
 
   pinitctx = STACK_PTR_TO_FRAME(struct regs_context, stack_ptr);
@@ -150,11 +135,6 @@ void up_initial_state(struct tcb_s *tcb)
       tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
 
-#ifdef CONFIG_ARCH_FPU
-      /* set fpu context */
-
-      arm64_init_fpu(tcb);
-#endif
       /* set initialize idle thread tcb and exception depth
        * core 0, idle0
        */

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -302,8 +302,7 @@ void arm64_pginitialize(void);
 #  define arm64_pginitialize()
 #endif /* CONFIG_LEGACY_PAGING */
 
-uint64_t * arm64_syscall_switch(uint64_t *regs);
-int arm64_syscall(uint64_t *regs);
+uint64_t *arm64_syscall(uint64_t *regs);
 
 /* Low level serial output **************************************************/
 

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -261,7 +261,7 @@ EXTERN uint8_t g_idle_topstack[];   /* End+1 of heap */
 
 void arm64_new_task(struct tcb_s *tak_new);
 void arm64_jump_to_user(uint64_t entry, uint64_t x0, uint64_t x1,
-                        uint64_t *regs) noreturn_function;
+                        uint64_t sp_el0, uint64_t *regs) noreturn_function;
 
 /* Low level initialization provided by chip logic */
 

--- a/arch/arm64/src/common/arm64_pthread_start.c
+++ b/arch/arm64/src/common/arm64_pthread_start.c
@@ -68,6 +68,8 @@
 void up_pthread_start(pthread_trampoline_t startup,
                       pthread_startroutine_t entrypt, pthread_addr_t arg)
 {
+  struct tcb_s *rtcb = this_task();
+
   /* Set up to enter the user-space pthread start-up function in
    * unprivileged mode. We need:
    *
@@ -78,7 +80,7 @@ void up_pthread_start(pthread_trampoline_t startup,
    */
 
   arm64_jump_to_user((uint64_t)startup, (uint64_t)entrypt, (uint64_t)arg,
-                     this_task()->xcp.initregs);
+                     (uint64_t)rtcb->xcp.ustkptr, rtcb->xcp.initregs);
 }
 
 #endif /* !CONFIG_BUILD_FLAT && __KERNEL__ && !CONFIG_DISABLE_PTHREAD */

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -38,10 +38,6 @@
 #include "irq/irq.h"
 #include "arm64_fatal.h"
 
-#ifdef CONFIG_ARCH_FPU
-#include "arm64_fpu.h"
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -58,16 +54,6 @@ void arm64_init_signal_process(struct tcb_s *tcb, struct regs_context *regs)
   struct regs_context  *psigctx;
   char *stack_ptr    = (char *)pctx->sp_elx - sizeof(struct regs_context);
 
-#ifdef CONFIG_ARCH_FPU
-  struct fpu_reg      *pfpuctx;
-  pfpuctx            = STACK_PTR_TO_FRAME(struct fpu_reg, stack_ptr);
-  tcb->xcp.fpu_regs  = (uint64_t *)pfpuctx;
-
-  /* set fpu context */
-
-  arm64_init_fpu(tcb);
-  stack_ptr          = (char *)pfpuctx;
-#endif
   psigctx            = STACK_PTR_TO_FRAME(struct regs_context, stack_ptr);
   memset(psigctx, 0, sizeof(struct regs_context));
   psigctx->elr       = (uint64_t)arm64_sigdeliver;
@@ -168,9 +154,6 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * have been delivered.
            */
 
-#ifdef CONFIG_ARCH_FPU
-          tcb->xcp.saved_fpu_regs = tcb->xcp.fpu_regs;
-#endif
           tcb->xcp.saved_reg = tcb->xcp.regs;
 
           /* create signal process context */

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -38,10 +38,6 @@
 #include "irq/irq.h"
 #include "arm64_fatal.h"
 
-#ifdef CONFIG_ARCH_FPU
-#include "arm64_fpu.h"
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -156,11 +152,6 @@ retry:
 
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
   rtcb->xcp.regs = rtcb->xcp.saved_reg;
-
-#ifdef CONFIG_ARCH_FPU
-  arm64_destory_fpu(rtcb);
-  rtcb->xcp.fpu_regs = rtcb->xcp.saved_fpu_regs;
-#endif
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -53,18 +53,18 @@ typedef uintptr_t (*syscall_t)(unsigned int, ...);
  ****************************************************************************/
 
 static void  arm64_dump_syscall(const char *tag, uint64_t cmd,
-                                const struct regs_context * f_regs)
+                                const uint64_t *regs)
 {
-  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId64 "\n", tag, f_regs, cmd);
+  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId64 "\n", tag, regs, cmd);
 
   svcinfo("x0:  0x%-16lx  x1:  0x%lx\n",
-          f_regs->regs[REG_X0], f_regs->regs[REG_X1]);
+          regs[REG_X0], regs[REG_X1]);
   svcinfo("x2:  0x%-16lx  x3:  0x%lx\n",
-          f_regs->regs[REG_X2], f_regs->regs[REG_X3]);
+          regs[REG_X2], regs[REG_X3]);
   svcinfo("x4:  0x%-16lx  x5:  0x%lx\n",
-          f_regs->regs[REG_X4], f_regs->regs[REG_X5]);
+          regs[REG_X4], regs[REG_X5]);
   svcinfo("x6:  0x%-16lx  x7:  0x%lx\n",
-          f_regs->regs[REG_X6], f_regs->regs[REG_X7]);
+          regs[REG_X6], regs[REG_X7]);
 }
 
 #ifdef CONFIG_LIB_SYSCALL
@@ -145,32 +145,32 @@ uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
 #endif
 
 /****************************************************************************
- * Name: arm64_syscall_switch
+ * Name: arm64_syscall
  *
  * Description:
  *   task switch syscall
  *
  ****************************************************************************/
 
-uint64_t *arm64_syscall_switch(uint64_t * regs)
+uint64_t *arm64_syscall(uint64_t *regs)
 {
+  uint64_t            *ret_regs = regs;
   uint64_t             cmd;
-  struct regs_context *f_regs;
-  uint64_t            *ret_regs;
   struct tcb_s        *tcb;
   int cpu;
+#ifdef CONFIG_BUILD_KERNEL
+  uint64_t             spsr;
+#endif
 
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(regs);
 
-  f_regs = (struct regs_context *)regs;
-
   /* The SYSCALL command is in x0 on entry.  Parameters follow in x1..x7 */
 
-  cmd = f_regs->regs[REG_X0];
+  cmd = regs[REG_X0];
 
-  arm64_dump_syscall(__func__, cmd, f_regs);
+  arm64_dump_syscall(__func__, cmd, regs);
 
   switch (cmd)
     {
@@ -192,8 +192,8 @@ uint64_t *arm64_syscall_switch(uint64_t * regs)
            * set will determine the restored context.
            */
 
-          ret_regs = (uint64_t *)f_regs->regs[REG_X1];
-          f_regs->regs[REG_X1] = 0; /* set the saveregs = 0 */
+          ret_regs = (uint64_t *)regs[REG_X1];
+          regs[REG_X1] = 0; /* set the saveregs = 0 */
 
           DEBUGASSERT(ret_regs);
         }
@@ -217,91 +217,13 @@ uint64_t *arm64_syscall_switch(uint64_t * regs)
 
       case SYS_switch_context:
         {
-          DEBUGASSERT(f_regs->regs[REG_X1] != 0 &&
-                      f_regs->regs[REG_X2] != 0);
-          *(uint64_t **)f_regs->regs[REG_X1] = regs;
+          DEBUGASSERT(regs[REG_X1] != 0 && regs[REG_X2] != 0);
+          *(uint64_t **)regs[REG_X1] = regs;
 
-          ret_regs = (uint64_t *) f_regs->regs[REG_X2];
+          ret_regs = (uint64_t *)regs[REG_X2];
         }
         break;
 
-      default:
-        {
-          svcerr("ERROR: Bad SYS call: 0x%" PRIx64 "\n", cmd);
-          ret_regs = 0;
-          return 0;
-        }
-        break;
-    }
-
-  if ((uint64_t *)f_regs != ret_regs)
-    {
-      cpu = this_cpu();
-      tcb = current_task(cpu);
-
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      addrenv_switch(NULL);
-#endif
-
-      /* Update scheduler parameters */
-
-      nxsched_suspend_scheduler(g_running_tasks[cpu]);
-      nxsched_resume_scheduler(tcb);
-
-      /* Record the new "running" task.  g_running_tasks[] is only used by
-       * assertion logic for reporting crashes.
-       */
-
-      g_running_tasks[cpu] = tcb;
-
-      /* Restore the cpu lock */
-
-      restore_critical_section(tcb, cpu);
-    }
-
-  return ret_regs;
-}
-
-/****************************************************************************
- * Name: arm64_syscall
- *
- * Description:
- *   SVC interrupts will vector here with insn=the SVC instruction and
- *   xcp=the interrupt context
- *
- *   The handler may get the SVC number be de-referencing the return
- *   address saved in the xcp and decoding the SVC instruction
- *
- ****************************************************************************/
-
-int arm64_syscall(uint64_t *regs)
-{
-  uint64_t             cmd;
-  struct regs_context *f_regs;
-#ifdef CONFIG_BUILD_KERNEL
-  uint64_t             spsr;
-#endif
-
-  /* Nested interrupts are not supported */
-
-  DEBUGASSERT(regs);
-
-  f_regs = (struct regs_context *)regs;
-
-  /* The SYSCALL command is in x0 on entry.  Parameters follow in x1..x7 */
-
-  cmd = f_regs->regs[REG_X0];
-
-  arm64_dump_syscall(__func__, cmd, f_regs);
-
-  switch (cmd)
-    {
 #ifdef CONFIG_BUILD_KERNEL
       /* R0=SYS_signal_handler:  This a user signal handler callback
        *
@@ -404,10 +326,44 @@ int arm64_syscall(uint64_t *regs)
 #endif
 
       default:
-
-          DEBUGPANIC();
-          break;
+        {
+          svcerr("ERROR: Bad SYS call: 0x%" PRIx64 "\n", cmd);
+          ret_regs = 0;
+          return 0;
+        }
+        break;
     }
 
-  return 0;
+  if ((uint64_t *)regs != ret_regs)
+    {
+      cpu = this_cpu();
+      tcb = current_task(cpu);
+
+#ifdef CONFIG_ARCH_ADDRENV
+      /* Make sure that the address environment for the previously
+       * running task is closed down gracefully (data caches dump,
+       * MMU flushed) and set up the address environment for the new
+       * thread at the head of the ready-to-run list.
+       */
+
+      addrenv_switch(NULL);
+#endif
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
+      /* Record the new "running" task.  g_running_tasks[] is only used by
+       * assertion logic for reporting crashes.
+       */
+
+      g_running_tasks[cpu] = tcb;
+
+      /* Restore the cpu lock */
+
+      restore_critical_section(tcb, cpu);
+    }
+
+  return ret_regs;
 }

--- a/arch/arm64/src/common/arm64_task_start.c
+++ b/arch/arm64/src/common/arm64_task_start.c
@@ -65,6 +65,8 @@
 
 void up_task_start(main_t taskentry, int argc, char *argv[])
 {
+  struct tcb_s *rtcb = this_task();
+
   /* Set up to return to the user-space _start function in
    * unprivileged mode.  We need:
    *
@@ -75,7 +77,7 @@ void up_task_start(main_t taskentry, int argc, char *argv[])
    */
 
   arm64_jump_to_user((uint64_t)taskentry, (uint64_t)argc, (uint64_t)argv,
-                     this_task()->xcp.initregs);
+                     (uint64_t)rtcb->xcp.ustkptr, rtcb->xcp.initregs);
 }
 
 #endif /* !CONFIG_BUILD_FLAT */

--- a/arch/arm64/src/common/arm64_vector_table.S
+++ b/arch/arm64/src/common/arm64_vector_table.S
@@ -78,6 +78,10 @@
 #endif
     stp    \xreg0, \xreg1,  [sp, #8 * REG_ELR]
 
+    mrs    \xreg0, sp_el0
+    mrs    \xreg1, tpidrro_el0
+    stp    \xreg0, \xreg1,  [sp, #8 * REG_SP_EL0]
+
     /* Increment exception depth */
 
     mrs    \xreg0, tpidrro_el0
@@ -260,6 +264,10 @@ SECTION_FUNC(text, arm64_exit_exception)
     msr    elr_el1,   x0
     msr    spsr_el1,  x1
 #endif
+
+    ldp    x0, x1,   [sp, #8 * REG_SP_EL0]
+    msr    sp_el0,   x0
+    msr    tpidrro_el0,  x1
 
     /* decrement exception depth */
 

--- a/arch/arm64/src/common/arm64_vector_table.S
+++ b/arch/arm64/src/common/arm64_vector_table.S
@@ -46,7 +46,7 @@
  */
 
 .macro arm64_enter_exception xreg0, xreg1
-    sub    sp, sp, #8 * XCPTCONTEXT_GP_REGS
+    sub    sp, sp, #8 * XCPTCONTEXT_REGS
 
     stp    x0,  x1,  [sp, #8 * REG_X0]
     stp    x2,  x3,  [sp, #8 * REG_X2]
@@ -65,8 +65,8 @@
     stp    x28, x29, [sp, #8 * REG_X28]
 
     /* Save the current task's SP_ELx and x30 */
-    add    \xreg0, sp, #8 * XCPTCONTEXT_GP_REGS
-    stp    x30, \xreg0,  [sp, #8 * REG_X30]
+    add    \xreg0, sp,  #8 * XCPTCONTEXT_REGS
+    stp    x30, \xreg0, [sp, #8 * REG_X30]
 
     /* ELR and SPSR */
 #if CONFIG_ARCH_ARM64_EXCEPTION_LEVEL == 3
@@ -78,17 +78,20 @@
 #endif
     stp    \xreg0, \xreg1,  [sp, #8 * REG_ELR]
 
-    /* increment exception depth */
+    /* Increment exception depth */
 
     mrs    \xreg0, tpidrro_el0
     mov    \xreg1, #1
     add    \xreg0, \xreg0, \xreg1
     msr    tpidrro_el0, \xreg0
 
-#ifdef CONFIG_ARCH_FPU
-    bl    arm64_fpu_enter_exception
-#endif
+    /* Save the FPU registers */
 
+#ifdef CONFIG_ARCH_FPU
+    add    x0, sp, #8 * XCPTCONTEXT_GP_REGS
+    bl     arm64_fpu_save
+    ldr    x0, [sp, #8 * REG_X0]
+#endif
 .endm
 
 /****************************************************************************
@@ -243,9 +246,8 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 GTEXT(arm64_exit_exception)
 SECTION_FUNC(text, arm64_exit_exception)
 #ifdef CONFIG_ARCH_FPU
-    bl    arm64_fpu_exit_exception
-GTEXT(arm64_exit_exc_fpu_done)
-arm64_exit_exc_fpu_done:
+    add    x0, sp, #8 * XCPTCONTEXT_GP_REGS
+    bl     arm64_fpu_restore
 #endif
 
     /* restore spsr and elr at el1*/
@@ -283,6 +285,6 @@ arm64_exit_exc_fpu_done:
     ldp    x28, x29, [sp, #8 * REG_X28]
     ldp    x30, xzr, [sp, #8 * REG_X30]
 
-    add    sp, sp, #8 * XCPTCONTEXT_GP_REGS
+    add    sp, sp, #8 * XCPTCONTEXT_REGS
 
     eret

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -100,49 +100,6 @@ SECTION_FUNC(text, up_saveusercontext)
     ret
 
 /****************************************************************************
- * Function: arm64_context_switch
- *
- * Description:
- *  Routine to handle context switch
- *
- * arm64_context_switch( x0, x1)
- *     x0: restore thread stack context
- *     x1: save thread stack context
- * note:
- *     x1 = 0, only restore x0
- *
- ****************************************************************************/
-
-GTEXT(arm64_context_switch)
-SECTION_FUNC(text, arm64_context_switch)
-    cmp    x1, #0x0
-    beq    restore_new
-
-    /* Save the current SP_ELx */
-    add    x4, sp, #8 * XCPTCONTEXT_REGS
-    str    x4, [x1, #8 * REG_SP_ELX]
-
-    /* Save the current task's SP_EL0 and exception depth */
-    mrs    x4, sp_el0
-    mrs    x5, tpidrro_el0
-    stp    x4, x5, [x1, #8 * REG_SP_EL0]
-
-restore_new:
-
-    /* Restore SP_EL0 and thread's exception dept */
-    ldp    x4,  x5,  [x0, #8 * REG_SP_EL0]
-    msr    tpidrro_el0, x5
-    msr    sp_el0, x4
-
-    /* retrieve new thread's SP_ELx */
-    ldr    x4, [x0, #8 * REG_SP_ELX]
-    sub    sp, x4, #8 * XCPTCONTEXT_REGS
-
-    /* Return to arm64_sync_exc() or arm64_irq_handler() */
-
-    ret
-
-/****************************************************************************
  * Function: arm64_jump_to_user
  *
  * Description:
@@ -197,7 +154,7 @@ SECTION_FUNC(text, arm64_sync_exc)
 
     /* if this is a svc call ?*/
 
-    bne    exc_handle
+    bne    arm64_fatal_handler
 
 #ifdef CONFIG_LIB_SYSCALL
     /* Handle user system calls separately */
@@ -228,111 +185,23 @@ SECTION_FUNC(text, arm64_sync_exc)
 reserved_syscall:
 #endif
 
-    /* x0 = syscall_cmd
-     * if ( x0 <= SYS_switch_context ) {
-     *     call context_switch
-     *     it's a context switch syscall, so context need to be done
-     * }
-     * #define SYS_save_context          (0)
-     * #define SYS_restore_context       (1)
-     * #define SYS_switch_context        (2)
-     */
-
-    ldr    x0, [sp, #8 * REG_X0]
-    cmp    x0, #SYS_save_context
-    beq  save_context
-
-    cmp    x0, #SYS_switch_context
-    beq  context_switch
-
-    cmp    x0, #SYS_restore_context
-    beq  context_switch
-
-    /* Normal syscall, thread context will not switch
-     *
-     * call the SVC handler with interrupts disabled.
-     * void arm64_syscall(uint64_t *regs)
-     * in:
-     *      regs = pointer to struct reg_context allocating
-     *         from stack, esf_reg has put on it
-     *      regs[REG_X0]: syscall cmd
-     *      regs[REG_X1] ~ regs[REG_X6]: syscall parameter
-     * out:
-     *      x0: return by arm64_syscall
-     */
-
-    mov    x0, sp /* x0 = reg frame */
-
-    /* Call arm64_syscall() on the user stack */
-
-    bl    arm64_syscall        /* Call the handler */
-
-    /* Return from exception */
-
-    b    arm64_exit_exception
-
-context_switch:
-    /* Call arm64_syscall_switch() for context switch
-     *
-     * uint64_t * arm64_syscall_switch(uint64_t * regs)
-     * out:
-     *      x0: return by arm64_syscall_switch, restore task context
-     *      regs[REG_X1]: save task context, if x1 = 0, only restore x0
-     */
-
-    mov    x0, sp
-    bl    arm64_syscall_switch
-
-    /* get save task reg context pointer */
-
-    ldr    x1, [sp, #8 * REG_X1]
-    cmp    x1, #0x0
-
-    beq do_switch
-    ldr x1, [x1]
-
-do_switch:
+    /* Switch to IRQ stack and save current sp on it. */
 #ifdef CONFIG_SMP
-    /* Notes:
-     * Complete any pending TLB or cache maintenance on this CPU in case
-     * the thread migrates to a different CPU.
-     * This full barrier is also required by the membarrier system
-     * call.
-     */
-
-    dsb   ish
+    get_cpu_id x0
+    ldr    x1, =(g_cpu_int_stacktop)
+    lsl    x0, x0, #3
+    ldr    x1, [x1, x0]
+#else
+    ldr    x1, =(g_interrupt_stack + CONFIG_ARCH_INTERRUPTSTACK)
 #endif
 
-    bl    arm64_context_switch
-
-    b    arm64_exit_exception
-
-save_context:
-    arm64_exception_context_save x0 x1 sp
-
     mov    x0, sp
-    bl    arm64_syscall_save_context
+    mov    sp, x1
 
-    /* Save the return value into the ESF */
+    bl     arm64_syscall        /* Call the handler */
 
-    str    x0, [sp, #8 * REG_X0]
-
-    /* Return from exception */
-
-    b    arm64_exit_exception
-
-exc_handle:
-    mov    x0, sp
-
-    /* void arm64_fatal_handler(struct regs_context * reg);
-     * x0 = Exception stack frame
-     */
-
-    bl    arm64_fatal_handler
-
-    /* Return here only in case of recoverable error */
-
-    b    arm64_exit_exception
+    mov    sp, x0
+    b      arm64_exit_exception
 
 /****************************************************************************
  * Name: arm64_irq_handler
@@ -346,20 +215,16 @@ GTEXT(arm64_irq_handler)
 SECTION_FUNC(text, arm64_irq_handler)
     /* Switch to IRQ stack and save current sp on it. */
 #ifdef CONFIG_SMP
-    get_cpu_id x1
-    ldr    x0, =(g_cpu_int_stacktop)
-    lsl    x1, x1, #3
-    ldr    x0, [x0, x1]
+    get_cpu_id x0
+    ldr    x1, =(g_cpu_int_stacktop)
+    lsl    x0, x0, #3
+    ldr    x1, [x1, x0]
 #else
-    ldr    x0, =(g_interrupt_stack + CONFIG_ARCH_INTERRUPTSTACK)
+    ldr    x1, =(g_interrupt_stack + CONFIG_ARCH_INTERRUPTSTACK)
 #endif
-    /* Save the task's stack and switch irq stack */
 
-    mov    x1, sp
-    mov    sp, x0
-    str    x1, [sp, #-16]!
-
-    mov    x0, x1 /* x0 = reg frame */
+    mov    x0, sp
+    mov    sp, x1
 
     /* Call arm64_decodeirq() on the interrupt stack
      * with interrupts disabled
@@ -367,128 +232,79 @@ SECTION_FUNC(text, arm64_irq_handler)
 
     bl     arm64_decodeirq
 
-    /* Upon return from arm64_decodeirq, x0 holds the pointer to the
-     * call reg context area, which can be use to restore context.
-     * This may or may not be the same value that was passed to arm64_decodeirq:
-     * It will differ if a context switch is required.
-     */
+    mov    sp, x0
+    b      arm64_exit_exception
 
-    ldr    x1, [sp], #16
-
-    /* retrieve the task's stack. */
-
-    mov    sp, x1
-
-    cmp    x0, x1
-    beq    irq_exit
-
-irq_context_switch:
-#ifdef CONFIG_SMP
-    /* Notes:
-     * Complete any pending TLB or cache maintenance on this CPU in case
-     * the thread migrates to a different CPU.
-     * This full barrier is also required by the membarrier system
-     * call.
-     */
-    dsb   ish
-
-#endif
-
-    /*  Switch thread
-     *  - x0: restore task reg context, return by arm64_decodeirq,
-     *  - x1: save task reg context, save before call arm64_decodeirq
-     *    call arm64_context_switch(x0) to switch
-     */
-    bl    arm64_context_switch
-
-irq_exit:
-    b     arm64_exit_exception
-
-/* TODO: if the arm64_fatal_handler return success, maybe need context switch */
+/****************************************************************************
+ * Name: arm64_serror_handler
+ *
+ * Description:
+ *   SError exception handler
+ *
+ ****************************************************************************/
 
 GTEXT(arm64_serror_handler)
 SECTION_FUNC(text, arm64_serror_handler)
-    mov   x0, sp
-    bl    arm64_fatal_handler
+    mov    x0, sp
+    bl     arm64_fatal_handler
     /* Return here only in case of recoverable error */
 
-    b    arm64_exit_exception
+    b      arm64_exit_exception
+
+/****************************************************************************
+ * Name: arm64_mode32_handler
+ *
+ * Description:
+ *   Mode32 exception handler
+ *
+ ****************************************************************************/
 
 GTEXT(arm64_mode32_handler)
 SECTION_FUNC(text, arm64_mode32_handler)
-    mov   x0, sp
-    bl    arm64_fatal_handler
+    mov    x0, sp
+    bl     arm64_fatal_handler
     /* Return here only in case of recoverable error */
 
-    b    arm64_exit_exception
+    b      arm64_exit_exception
+
+/****************************************************************************
+ * Name: arm64_fiq_handler
+ *
+ * Description:
+ *   Interrupt exception handler
+ *
+ ****************************************************************************/
 
 GTEXT(arm64_fiq_handler)
 SECTION_FUNC(text, arm64_fiq_handler)
 #ifndef CONFIG_ARM64_DECODEFIQ
 
-    mov   x0, sp
-    bl    arm64_fatal_handler
+    mov    x0, sp
+    bl     arm64_fatal_handler
 
     /* Return here only in case of recoverable error */
 
-    b    arm64_exit_exception
+    b      arm64_exit_exception
 #else
    /* Switch to FIQ stack and save current sp on it. */
 #ifdef CONFIG_SMP
-    get_cpu_id x1
-    ldr    x0, =(g_cpu_int_fiq_stacktop)
-    lsl    x1, x1, #3
-    ldr    x0, [x0, x1]
+    get_cpu_id x0
+    ldr    x1, =(g_cpu_int_fiq_stacktop)
+    lsl    x0, x0, #3
+    ldr    x1, [x1, x0]
 #else
-    ldr    x0, =(g_interrupt_fiq_stack + CONFIG_ARCH_INTERRUPTSTACK)
+    ldr    x1, =(g_interrupt_fiq_stack + CONFIG_ARCH_INTERRUPTSTACK)
 #endif
-    /* Save the task's stack and switch fiq stack */
 
-    mov    x1, sp
-    mov    sp, x0
-    str    x1, [sp, #-16]!
+    mov    x0, sp
+    mov    sp, x1
 
-    mov    x0, x1 /* x0 = reg frame */
-
-    /* Call arm64_decodefiq() on the interrupt stack
+    /* Call arm64_decodeirq() on the interrupt stack
      * with interrupts disabled
      */
 
-    bl     arm64_decodefiq
+    bl     arm64_decodeirq
 
-    /* Upon return from arm64_decodefiq, x0 holds the pointer to the
-     * call reg context area, which can be use to restore context.
-     * This may or may not be the same value that was passed to arm64_decodefiq:
-     * It will differ if a context switch is required.
-     */
-
-    ldr    x1, [sp], #16
-
-    /* retrieve the task's stack. */
-
-    mov    sp, x1
-
-    cmp    x0, x1
-    beq    fiq_exit
-
-
-#ifdef CONFIG_SMP
-    /* Notes:
-     * Complete any pending TLB or cache maintenance on this CPU in case
-     * the thread migrates to a different CPU.
-     * This full barrier is also required by the membarrier system
-     * call.
-     */
-    dsb   ish
-
-#endif
-
-    /*  Switch thread
-     *  - x0: restore task reg context, return by arm64_decodefiq,
-     *  - x1: save task reg context, save before call arm64_decodefiq
-     *    call arm64_context_switch(x0) to switch
-     */
-    bl    arm64_context_switch
-fiq_exit:
-    b     arm64_exit_exception
+    mov    sp, x0
+    b      arm64_exit_exception
 #endif

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -118,16 +118,8 @@ SECTION_FUNC(text, arm64_context_switch)
     cmp    x1, #0x0
     beq    restore_new
 
-#if defined(CONFIG_ARCH_FPU) && defined(CONFIG_SMP)
-    stp    x0, x1, [sp, #-16]!
-    stp    xzr, x30, [sp, #-16]!
-    bl     arm64_fpu_context_save
-    ldp    xzr, x30, [sp], #16
-    ldp    x0, x1, [sp], #16
-#endif
-
     /* Save the current SP_ELx */
-    add    x4, sp, #8 * XCPTCONTEXT_GP_REGS
+    add    x4, sp, #8 * XCPTCONTEXT_REGS
     str    x4, [x1, #8 * REG_SP_ELX]
 
     /* Save the current task's SP_EL0 and exception depth */
@@ -144,13 +136,7 @@ restore_new:
 
     /* retrieve new thread's SP_ELx */
     ldr    x4, [x0, #8 * REG_SP_ELX]
-    sub    sp, x4, #8 * XCPTCONTEXT_GP_REGS
-
-#ifdef CONFIG_ARCH_FPU
-    stp    xzr, x30, [sp, #-16]!
-    bl     arm64_fpu_context_restore
-    ldp    xzr, x30, [sp], #16
-#endif
+    sub    sp, x4, #8 * XCPTCONTEXT_REGS
 
     /* Return to arm64_sync_exc() or arm64_irq_handler() */
 
@@ -205,19 +191,6 @@ SECTION_FUNC(text, arm64_sync_exc)
 #endif
     lsr    x10, x9, #26
 
-#ifdef CONFIG_ARCH_FPU
-    /* fpu trap */
-
-    cmp    x10, #0x07 /* Access to SIMD or floating-point */
-    bne    1f
-    mov    x0, sp     /* x0 = context */
-    bl     arm64_fpu_trap
-
-    /* when the fpu trap is handled */
-
-    b      arm64_exit_exc_fpu_done
-1:
-#endif
     /* 0x15 = SVC system call */
 
     cmp    x10, #0x15
@@ -332,13 +305,7 @@ do_switch:
 
     bl    arm64_context_switch
 
-#ifdef CONFIG_ARCH_FPU
-    /* when the fpu trap is handled */
-
-    b    arm64_exit_exc_fpu_done
-#else
     b    arm64_exit_exception
-#endif
 
 save_context:
     arm64_exception_context_save x0 x1 sp
@@ -433,11 +400,6 @@ irq_context_switch:
      *    call arm64_context_switch(x0) to switch
      */
     bl    arm64_context_switch
-#ifdef CONFIG_ARCH_FPU
-    /* when the fpu trap is handled */
-
-    b     arm64_exit_exc_fpu_done
-#endif
 
 irq_exit:
     b     arm64_exit_exception
@@ -527,11 +489,6 @@ SECTION_FUNC(text, arm64_fiq_handler)
      *    call arm64_context_switch(x0) to switch
      */
     bl    arm64_context_switch
-#ifdef CONFIG_ARCH_FPU
-    /* when the fpu trap is handled */
-
-    b     arm64_exit_exc_fpu_done
-#endif
 fiq_exit:
     b     arm64_exit_exception
 #endif

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -107,10 +107,11 @@ SECTION_FUNC(text, up_saveusercontext)
  *  the kernel is ready to give control to the user task in user space.
  *
  * arm64_jump_to_user(entry, x0, x1, regs)
- *     entry: process entry point
- *     x0:    parameter 0 for process
- *     x1:    parameter 1 for process
- *     regs:  integer register save area to use
+ *     entry:  process entry point
+ *     x0:     parameter 0 for process
+ *     x1:     parameter 1 for process
+ *     sp_el0: user stack pointer
+ *     regs:   integer register save area to use
  *
  ****************************************************************************/
 
@@ -118,10 +119,11 @@ SECTION_FUNC(text, up_saveusercontext)
 GTEXT(arm64_jump_to_user)
 SECTION_FUNC(text, arm64_jump_to_user)
     msr daifset, #IRQ_DAIF_MASK
-    mov sp,  x3
+    mov sp,  x4
     str x0,  [sp, #8 * REG_ELR]
     str x1,  [sp, #8 * REG_X0]
     str x2,  [sp, #8 * REG_X1]
+    str x3,  [sp, #8 * REG_SP_EL0]
     mrs x0,  spsr_el1
     and x0,  x0, #~SPSR_MODE_MASK
     #orr x0, x0, #SPSR_MODE_EL0T # EL0T=0x00, out of range for orr


### PR DESCRIPTION
## Summary
Fix FPU and exception handling for ARM64 by:
- Saving and restoring FPU state on every exception / interrupt
- Switching to the interrupt stack, when executing the exception handler / interrupt service routine

This is a continuation of: https://github.com/apache/nuttx/pull/13520
@GUIDINGLI and @lipengfei28 Did the initial patches, which are adapted for CONFIG_BUILD_KERNEL / CONFIG_LIB_SYSCALL, which were implemented by me. The goal is to merge this work without breaking either one.
## Impact
Impact is on ARM64 platform only. The impacted parts are the exception and ISR handling.
## Testing
qemu-armv8a:nsh
qemu-armv8a:nsh_smp
qemu-armv8a:knsh
