### PR TITLE
DOC: STM32F3 add example flashing information.

### DIFF
--- a/Documentation/platforms/arm/stm32f3/index.rst
+++ b/Documentation/platforms/arm/stm32f3/index.rst
@@ -215,6 +215,33 @@ There are two version of the FPU support built into the STM32 port.
 
      CONFIG_ARCH_FPU=y
 
+Flashing and Debugging
+======================
+
+NuttX firmware Flashing with STLink probe and OpenOCD::
+
+   openocd -f  interface/stlink.cfg -f target/stm32f3x.cfg -c 'program nuttx.bin 0x08000000; reset run; exit'
+
+Remote target Reset with STLink probe and OpenOCD::
+
+   openocd -f interface/stlink.cfg -f target/stm32f3x.cfg -c 'init; reset run; exit'
+
+Remote target Debug with STLink probe and OpenOCD:
+
+ 1. You need to have NuttX built with debug symbols, see :ref:`debugging`.
+
+ 2. Launch the OpenOCD GDB server::
+
+     openocd -f interface/stlink.cfg -f target/stm32f3x.cfg -c 'init; reset halt'
+
+ 3. You can now attach to remote OpenOCD GDB server with your favorite debugger,
+    for instance gdb::
+
+     arm-none-eabi-gdb --tui nuttx -ex 'target extended-remote localhost:3333'
+     (gdb) monitor reset halt
+     (gdb) breakpoint nsh_main
+     (gdb) continue
+
 Supported Boards
 ================
 

--- a/Documentation/platforms/arm/stm32f4/index.rst
+++ b/Documentation/platforms/arm/stm32f4/index.rst
@@ -519,6 +519,33 @@ Protected Mode Build
      If you do this a lot, you will probably want to invest a little time
      to develop a tool to automate these steps.
 
+Flashing and Debugging
+======================
+
+NuttX firmware Flashing with STLink probe and OpenOCD::
+
+   openocd -f  interface/stlink.cfg -f target/stm32f4x.cfg -c 'program nuttx.bin 0x08000000; reset run; exit'
+
+Remote target Reset with STLink probe and OpenOCD::
+
+   openocd -f interface/stlink.cfg -f target/stm32f4x.cfg -c 'init; reset run; exit'
+
+Remote target Debug with STLink probe and OpenOCD:
+
+ 1. You need to have NuttX built with debug symbols, see :ref:`debugging`.
+
+ 2. Launch the OpenOCD GDB server::
+
+     openocd -f interface/stlink.cfg -f target/stm32f4x.cfg -c 'init; reset halt'
+
+ 3. You can now attach to remote OpenOCD GDB server with your favorite debugger,
+    for instance gdb::
+
+     arm-none-eabi-gdb --tui nuttx -ex 'target extended-remote localhost:3333'
+     (gdb) monitor reset halt
+     (gdb) breakpoint nsh_main
+     (gdb) continue
+
 Supported Boards
 ================
 

--- a/Documentation/platforms/arm/stm32f7/index.rst
+++ b/Documentation/platforms/arm/stm32f7/index.rst
@@ -429,6 +429,33 @@ different from the default in your PATH variable).
 
      $ make
 
+Flashing and Debugging
+======================
+
+NuttX firmware Flashing with STLink probe and OpenOCD::
+
+   openocd -f  interface/stlink.cfg -f target/stm32f7x.cfg -c 'program nuttx.bin 0x08000000; reset run; exit'
+
+Remote target Reset with STLink probe and OpenOCD::
+
+   openocd -f interface/stlink.cfg -f target/stm32f7x.cfg -c 'init; reset run; exit'
+
+Remote target Debug with STLink probe and OpenOCD:
+
+ 1. You need to have NuttX built with debug symbols, see :ref:`debugging`.
+
+ 2. Launch the OpenOCD GDB server::
+
+     openocd -f interface/stlink.cfg -f target/stm32f7x.cfg -c 'init; reset halt'
+
+ 3. You can now attach to remote OpenOCD GDB server with your favorite debugger,
+    for instance gdb::
+
+     arm-none-eabi-gdb --tui nuttx -ex 'target extended-remote localhost:3333'
+     (gdb) monitor reset halt
+     (gdb) breakpoint nsh_main
+     (gdb) continue
+
 Supported Boards
 ================
 


### PR DESCRIPTION
## Summary

* Information on how to flash NuttX firmware to STM32F[3,4,7] target were missing and asked by new users.
* Example on how to flash/reset/debug is now added to the docs.

## Impact

* Documentation: added information on how to flash nuttx firmware to STM32F[3,4,7].

## Testing

Local Sphinx build: OK.