### PR TITLE
nxstyle: Add NativeSymbol to white list

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -227,8 +227,14 @@ static const char *g_white_suffix[] =
 
 static const char *g_white_content_list[] =
 {
-  /* Ref:  wamr_custom_init.c */
+  /* Ref:
+   * nuttx-apps/examples/wamr_module/module_hello.c
+   * nuttx-apps/interpreters/wamr/wamr_custom_init.c
+   *
+   * They are from the WAMR project.
+   */
 
+  "NativeSymbol",
   "RuntimeInitArgs",
 
   /* Ref:  gnu_unwind_find_exidx.c */


### PR DESCRIPTION

## Summary
Add the new symbol `NativeSymbol` to the white list, and update the comments about the symbols that are from WAMR project.

## Impact
Minor
## Testing
CI, local
