### PR TITLE
mmcsd: move block driver register to probe stage in order to read ext_csd reg

### DIFF
--- a/drivers/mmcsd/mmcsd.h
+++ b/drivers/mmcsd/mmcsd.h
@@ -67,6 +67,7 @@ struct mmcsd_state_s
   FAR struct sdio_dev_s *dev;      /* The SDIO device bound to this instance */
   uint8_t  crefs;                  /* Open references on the driver */
   mutex_t  lock;                   /* Assures mutually exclusive access to the slot */
+  int      minor;                  /* Device number */
 
   /* Status flags */
 

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -214,7 +214,6 @@ static int     mmcsd_cardidentify(FAR struct mmcsd_state_s *priv);
 static int     mmcsd_probe(FAR struct mmcsd_state_s *priv);
 static int     mmcsd_removed(FAR struct mmcsd_state_s *priv);
 static int     mmcsd_hwinitialize(FAR struct mmcsd_state_s *priv);
-static void    mmcsd_hwuninitialize(FAR struct mmcsd_state_s *priv);
 #ifdef CONFIG_MMCSD_IOCSUPPORT
 static int     mmcsd_iocmd(FAR struct mmcsd_state_s *priv,
                            FAR struct mmc_ioc_cmd *ic_ptr);
@@ -1037,7 +1036,7 @@ static void mmcsd_decode_scr(FAR struct mmcsd_state_s *priv, uint32_t scr[2])
  *
  * Description:
  *   Execute CMD6 to switch the mode of operation of the selected device or
- * modify the EXT_CSD registers.
+ *   modify the EXT_CSD registers.
  *
  ****************************************************************************/
 
@@ -3008,7 +3007,7 @@ static int mmcsd_read_csd(FAR struct mmcsd_state_s *priv, FAR uint8_t *data)
       ret = SDIO_DMARECVSETUP(priv->dev, buffer, 512);
       if (ret != OK)
         {
-          finfo("SDIO_DMARECVSETUP: error %d\n", ret);
+          ferr("SDIO_DMARECVSETUP: error %d\n", ret);
           SDIO_CANCEL(priv->dev);
           return ret;
         }
@@ -3980,6 +3979,7 @@ static int mmcsd_cardidentify(FAR struct mmcsd_state_s *priv)
 
 static int mmcsd_probe(FAR struct mmcsd_state_s *priv)
 {
+  char devname[16];
   int ret;
 
   finfo("type: %d probed: %d\n", priv->type, priv->probed);
@@ -4082,6 +4082,14 @@ static int mmcsd_probe(FAR struct mmcsd_state_s *priv)
           /* When the card is identified, we have probed this card */
 
           priv->probed = true;
+
+          /* Create a MMCSD device name */
+
+          snprintf(devname, sizeof(devname), "/dev/mmcsd%d", priv->minor);
+
+          /* Inode private data is a reference to the MMCSD state structure */
+
+          register_blockdriver(devname, &g_bops, 0666, priv);
         }
 
       /* Regardless of whether or not a card was successfully initialized,
@@ -4123,7 +4131,12 @@ static int mmcsd_probe(FAR struct mmcsd_state_s *priv)
 
 static int mmcsd_removed(FAR struct mmcsd_state_s *priv)
 {
+  char devname[16];
+
   finfo("type: %d present: %d\n", priv->type, SDIO_PRESENT(priv->dev));
+
+  snprintf(devname, sizeof(devname), "/dev/mmcsd%d", priv->minor);
+  unregister_blockdriver(devname);
 
   /* Forget the card geometry, pretend the slot is empty (it might not
    * be), and that the card has never been initialized.
@@ -4213,7 +4226,7 @@ static int mmcsd_hwinitialize(FAR struct mmcsd_state_s *priv)
       ret = mmcsd_probe(priv);
       if (ret != OK)
         {
-          finfo("Slot not empty, but initialization failed: %d\n", ret);
+          ferr("Slot not empty, but initialization failed: %d\n", ret);
 
           /* NOTE: The failure to initialize a card does not mean that
            * initialization has failed! A card could be installed in the slot
@@ -4241,21 +4254,6 @@ static int mmcsd_hwinitialize(FAR struct mmcsd_state_s *priv)
 
   mmcsd_unlock(priv);
   return ret;
-}
-
-/****************************************************************************
- * Name: mmcsd_hwuninitialize
- *
- * Description:
- *   Restore the MMC/SD slot to the uninitialized state.  Called only from
- *   sdio_slotinitialize on a failure to initialize.
- *
- ****************************************************************************/
-
-static void mmcsd_hwuninitialize(FAR struct mmcsd_state_s *priv)
-{
-  mmcsd_removed(priv);
-  SDIO_RESET(priv->dev);
 }
 
 static FAR const char *mmc_get_mode_name(uint8_t mode)
@@ -4328,6 +4326,7 @@ int mmcsd_slotinitialize(int minor, FAR struct sdio_dev_s *dev)
   /* Bind the MMCSD driver to the MMCSD state structure */
 
   priv->dev = dev;
+  priv->minor = minor;
 
   /* Initialize the hardware associated with the slot */
 
@@ -4362,22 +4361,13 @@ int mmcsd_slotinitialize(int minor, FAR struct sdio_dev_s *dev)
         }
     }
 
-  /* Create a MMCSD device name */
-
-  snprintf(devname, sizeof(devname), "/dev/mmcsd%d", minor);
-
-  /* Inode private data is a reference to the MMCSD state structure */
-
-  ret = register_blockdriver(devname, &g_bops, 0, priv);
-  if (ret < 0)
-    {
-      ferr("ERROR: register_blockdriver failed: %d\n", ret);
-      goto errout_with_hwinit;
-    }
-
 #ifdef CONFIG_MMCSD_PROCFS
   mmcsd_initialize_procfs();
 #endif
+
+  /* Create a MMCSD device name */
+
+  snprintf(devname, sizeof(devname), "/dev/mmcsd%d", minor);
 
   finfo("MMC: %s %" PRIu64 "KB %s %s mode\n", devname,
          ((uint64_t)priv->nblocks << priv->blockshift) >> 10,
@@ -4386,8 +4376,6 @@ int mmcsd_slotinitialize(int minor, FAR struct sdio_dev_s *dev)
 
   return OK;
 
-errout_with_hwinit:
-  mmcsd_hwuninitialize(priv);
 errout_with_alloc:
   nxmutex_destroy(&priv->lock);
   kmm_free(priv);


### PR DESCRIPTION
## Summary
  mmcsd: move block driver register to probe stage in order to read ext_csd reg
## Impact
  mmcsd
## Testing
 cortext M55
