### PR TITLE
nuttx/timers: Fix green hills build timer.h error

### DIFF
--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -33,6 +33,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <sys/types.h>
+#include <assert.h>
 
 #ifdef CONFIG_TIMER
 


### PR DESCRIPTION

## Summary
fix a small error in Non-Gnu compiler build
"/mnt/xxxx/nuttx/include/nuttx/timers/timer.h", line 257: error #223-D:
          function DEBUGASSERT declared implicitly
    DEBUGASSERT(lower->ops->tick_getstatus);

## Impact
None

## Testing
Green hills build