### PR TITLE
lib_fdopendir.c:Fix crash in fdopendir caused by fdsan

### DIFF
--- a/libs/libc/dirent/lib_fdopendir.c
+++ b/libs/libc/dirent/lib_fdopendir.c
@@ -27,6 +27,10 @@
 #include <dirent.h>
 #include <errno.h>
 
+#ifdef CONFIG_FDSAN
+#  include <android/fdsan.h>
+#endif
+
 #include "libc.h"
 
 /****************************************************************************
@@ -83,5 +87,12 @@ FAR DIR *fdopendir(int fd)
     }
 
   dir->fd = fd;
+
+#ifdef CONFIG_FDSAN
+  android_fdsan_exchange_owner_tag(fd, 0,
+    android_fdsan_create_owner_tag(ANDROID_FDSAN_OWNER_TYPE_DIR,
+                                   (uintptr_t)dir));
+#endif
+
   return dir;
 }


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
When we enable fdsan and use the fdopendir interface, because we do not update the fdsan tag in the interface, this will cause a PANIC caused by fdsan

**Changes**
Update fdsan tag in lib_fdopendir.c
```
#ifdef CONFIG_FDSAN
  android_fdsan_exchange_owner_tag(fd, 0,
    android_fdsan_create_owner_tag(ANDROID_FDSAN_OWNER_TYPE_DIR,
                                   (uintptr_t)dir));
#endif
```

## Impact
**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh

We can verify this by using a simple fdopendir demo. and open the CONFIG_FDSAN. After this PR, it will not crash.
```
#include <stdio.h>
#include <stdlib.h>
#include <dirent.h>
#include <fcntl.h>
#include <unistd.h>

int main() {
    const char *dirpath = "/tmp";

    int dir_fd = open(dirpath, O_RDONLY | O_DIRECTORY);
    if (dir_fd == -1) {
        perror("open");
        return EXIT_FAILURE;
    }

    DIR *dir = fdopendir(dir_fd);
    if (dir == NULL) {
        perror("fdopendir");
        close(dir_fd);
        return EXIT_FAILURE;
    }

    struct dirent *entry;
    while ((entry = readdir(dir)) != NULL) {
        printf("Found: %s\n", entry->d_name);
    }

    if (closedir(dir) == -1) {
        perror("closedir");
        return EXIT_FAILURE;
    }

    return EXIT_SUCCESS;
}
```
