### PR TITLE
net/arp: modify some flow of arp return failure

### DIFF
--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -91,6 +91,13 @@ struct arp_table_info_s
 
 static struct arp_entry_s g_arptable[CONFIG_NET_ARPTAB_SIZE];
 
+static const struct ether_addr g_zero_ethaddr =
+{
+  {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  }
+};
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -308,6 +315,11 @@ int arp_update(FAR struct net_driver_s *dev, in_addr_t ipaddr,
         }
     }
 
+  if (ethaddr == NULL)
+    {
+      ethaddr = g_zero_ethaddr.ether_addr_octet;
+    }
+
   /* When overwite old entry, notify old entry RTM_DELNEIGH */
 
 #ifdef CONFIG_NETLINK_ROUTE
@@ -407,6 +419,16 @@ int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
   tabptr = arp_lookup(ipaddr, dev);
   if (tabptr != NULL)
     {
+      /* Addresses that have failed to be searched will return a special
+       * error code so that the upper layer can return faster.
+       */
+
+      if (memcmp(&tabptr->at_ethaddr, &g_zero_ethaddr,
+                 sizeof(tabptr->at_ethaddr)) == 0)
+        {
+          return -ENETUNREACH;
+        }
+
       /* Yes.. return the Ethernet MAC address if the caller has provided a
        * non-NULL address in 'ethaddr'.
        */
@@ -416,8 +438,8 @@ int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
           memcpy(ethaddr, &tabptr->at_ethaddr, ETHER_ADDR_LEN);
         }
 
-      /* Return success in any case meaning that a valid Ethernet MAC
-       * address mapping is available for the IP address.
+      /* Return success meaning that a valid Ethernet MAC address mapping
+       * is available for the IP address.
        */
 
       return OK;


### PR DESCRIPTION
## Summary
If arp search fails once, subsequent searches for the ip will directly return failure, and sends an asynchronous arp request to try to update arp table in the future. In this way, the psock_sendmsg interface will not block for a long time each time because arp cannot be obtained.

This scenario is triggered when a udp socket frequently attempts to access an ip address that does not exist on the LAN.

## Impact

## Testing
sim:local
