### PR TITLE
fix compile error:

### DIFF
--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -236,11 +236,7 @@ void xtensa_pause_handler(void)
       leave_critical_section(flags);
     }
 
-  tcb = current_task(cpu);
-  xtensa_savestate(tcb->xcp.regs);
   nxsched_process_delivered(cpu);
-  tcb = current_task(cpu);
-  xtensa_restorestate(tcb->xcp.regs);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Register: smp
Register: nsh
Register: sh
Register: getprime
Register: ostest
Espressif HAL for 3rd Party Platforms: b4c723a119344b4b71d69819019d55637fb570fd common/xtensa_cpupause.c: In function 'xtensa_pause_handler': common/xtensa_cpupause.c:240:3: warning: implicit declaration of function 'xtensa_savestate'; did you mean 'xtensa_setps'? [-Wimplicit-function-declaration]
  240 |   xtensa_savestate(tcb->xcp.regs);
      |   ^~~~~~~~~~~~~~~~
      |   xtensa_setps
common/xtensa_cpupause.c:243:3: warning: implicit declaration of function 'xtensa_restorestate'; did you mean 'xtensa_context_restore'? [-Wimplicit-function-declaration]
  243 |   xtensa_restorestate(tcb->xcp.regs);
      |   ^~~~~~~~~~~~~~~~~~~
      |   xtensa_context_restore


## Impact

## Testing

