### PR TITLE
nuttx/libxx: Simplify compilation warnings for passing CXXFLAGS.

### DIFF
--- a/libs/libxx/libcxx.cmake
+++ b/libs/libxx/libcxx.cmake
@@ -88,6 +88,9 @@ list(APPEND SRCS ${SRCSTMP})
 file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/ryu/*.cpp)
 list(APPEND SRCS ${SRCSTMP})
 
+set(FLAGS -Wno-attributes -Wno-deprecated-declarations -Wno-shadow
+          -Wno-sign-compare)
+
 if(NOT DEFINED GCCVER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version
                   OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
@@ -97,43 +100,12 @@ if(NOT DEFINED GCCVER)
 endif()
 
 if(GCCVER EQUAL 12)
-  nuttx_append_source_file_properties(libcxx/src/filesystem/operations.cpp
-                                      COMPILE_FLAGS -Wno-maybe-uninitialized)
-  nuttx_append_source_file_properties(libcxx/src/locale.cpp COMPILE_FLAGS
-                                      -Wno-maybe-uninitialized)
-  nuttx_append_source_file_properties(libcxx/src/string.cpp COMPILE_FLAGS
-                                      -Wno-alloc-size-larger-than)
-  nuttx_append_source_file_properties(libcxx/src/charconv.cpp COMPILE_FLAGS
-                                      -Wno-attributes)
-  nuttx_append_source_file_properties(libcxx/src/locale.cpp COMPILE_FLAGS
-                                      -Wno-attributes)
+  list(APPEND FLAGS -Wno-maybe-uninitialized -Wno-alloc-size-larger-than)
 endif()
-
-if(GCCVER GREATER_EQUAL 12)
-  nuttx_append_source_file_properties(libcxx/src/string.cpp COMPILE_FLAGS
-                                      -Wno-deprecated-declarations)
-  nuttx_append_source_file_properties(libcxx/src/filesystem/path.cpp
-                                      COMPILE_FLAGS -Wno-shadow)
-  nuttx_append_source_file_properties(libcxx/src/ryu/d2s.cpp COMPILE_FLAGS
-                                      -Wno-maybe-uninitialized)
-endif()
-
-if(GCCVER GREATER_EQUAL 13)
-  nuttx_append_source_file_properties(libcxx/src/string.cpp COMPILE_FLAGS
-                                      -Wno-alloc-size-larger-than)
-endif()
-
-nuttx_append_source_file_properties(libcxx/src/barrier.cpp COMPILE_FLAGS
-                                    -Wno-shadow)
-nuttx_append_source_file_properties(libcxx/src/locale.cpp COMPILE_FLAGS
-                                    -Wno-shadow)
-nuttx_append_source_file_properties(libcxx/src/filesystem/operations.cpp
-                                    COMPILE_FLAGS -Wno-shadow)
-nuttx_append_source_file_properties(libcxx/src/condition_variable.cpp
-                                    COMPILE_FLAGS -Wno-sign-compare)
 
 nuttx_add_system_library(libcxx)
 target_sources(libcxx PRIVATE ${SRCS})
+target_compile_options(libcxx PRIVATE ${FLAGS})
 if(CONFIG_LIBCXXABI)
   target_include_directories(
     libcxx BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR}/libcxxabi/include)

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -55,137 +55,16 @@ ifeq ($(CONFIG_LIBSUPCXX), y)
 CXXFLAGS += ${DEFINE_PREFIX}__GLIBCXX__
 endif
 
-# Workaround the following warning with "c++ (Ubuntu 9.3.0-10ubuntu2) 9.3.0"
-#
-# libcxx/src/barrier.cpp: In constructor 'std::__1::__barrier_algorithm_base::__barrier_algorithm_base(ptrdiff_t&)':
-# libcxx/src/barrier.cpp:35:9: warning: declaration of '__expected' shadows a member of 'std::__1::__barrier_algorithm_base' [-Wshadow]
-#    35 |         : __expected(__expected)
-#       |         ^
-# libcxx/src/barrier.cpp:29:24: note: shadowed declaration is here
-#    29 |     ptrdiff_t&         __expected;
-#       |                        ^~~~~~~~~~
-libcxx/src/barrier.cpp_CXXFLAGS += -Wno-shadow
-libcxx/src/locale.cpp_CXXFLAGS += -Wno-shadow
-libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
-
-# Workaround the following warning with "GCC 12"
-#
-# ...
-# include/libcxx/string:2156:35: warning: '__temp' may be used uninitialized [-Wmaybe-uninitialized]
-#  2156 |         this->__throw_length_error();
-#       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
-# include/libcxx/string:614:1: note: by argument 1 of type 'const std::__1::__basic_string_common<true>*' to 'void std::__1::__basic_string_common<<anonymous> >::__throw_length_error() const [with bool <anonymous> = true]' declared here
-#   614 | __basic_string_common<__b>::__throw_length_error() const
-#       | ^~~~~~~~~~~~~~~~~~~~~~~~~~
-# include/libcxx/string:2676:32: note: '__temp' declared here
-#  2676 |             const basic_string __temp (__first, __last, __alloc());
-#       |                                ^~~~~~
+CXXFLAGS += -Wno-shadow -Wno-sign-compare
+CXXFLAGS += -Wno-attributes -Wno-deprecated-declarations
 
 ifeq ($(GCCVER),)
   export GCCVER = $(shell $(CXX) --version | grep ++ | sed -E 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
 endif
 
-ifeq ($(GCCVER),12)
-  libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-maybe-uninitialized
-  libcxx/src/locale.cpp_CXXFLAGS += -Wno-maybe-uninitialized
-endif
-
-# Workaround the following warning with "GCC 12"
-#
-# ...
-# include/libcxx/new:237:24: warning: argument 1 value '18446744073709551599' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
-#  237 |   return ::operator new(__args...);
-#      |          ~~~~~~~~~~~~~~^~~~~~~~~~~
-
-ifeq ($(GCCVER),12)
-  libcxx/src/string.cpp_CXXFLAGS += -Wno-alloc-size-larger-than
-endif
-
-# The following warning was observed with icicle:knsh config.
-# Looking at the code in question, it seems harmless to ignore.
-#
-# Note: For some reasons, GCC -Wall enables a different set of warnings
-# for C and C++.
-#
-# References:
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10604
-# https://github.com/gcc-mirror/gcc/blob/e54375d85d4aa5889869c2672158083b2106b623/gcc/c-family/c.opt#L1285-L1287
-#
-# CXX:  libcxx/src/condition_variable.cpp
-# libcxx/src/condition_variable.cpp: In member function 'void std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long int, std::__1::ratio<1, 1000000000> > >)':
-# libcxx/src/condition_variable.cpp:64:19: error: comparison of integer expressions of different signedness: 'std::__1::chrono::duration<long long int>::rep' {aka 'long long int'} and 'std::__1::__libcpp_numeric_limits<long unsigned int, true>::type' {aka 'long unsigned int'} [-Werror=sign-compare]
-#      if (s.count() < ts_sec_max)
-#          ~~~~~~~~~~^~~~~~~~~~~~
-libcxx/src/condition_variable.cpp_CXXFLAGS += -Wno-sign-compare
-
-# When building with GCC 12.2.0
-# libcxx has a fallback to use __always_inline__ when the (clang) exclude_from_explicit_instantiation isn't available.
-# This causes: `always_inline` function might not be inlinable [-Wattributes] warnings in some modules.
-# For example:
-# libcxx/src/include/to_chars_floating_point.h:988:17: warning: ‘always_inline’ function might not be inlinable [-Wattributes]
-# Should be OK to ignore these
-ifeq ($(GCCVER),12)
-	libcxx/src/charconv.cpp_CXXFLAGS += -Wno-attributes
-endif
-
-# Another warning on gcc 12.2.0
-# libcxx/src/locale.cpp:6604:85: warning: type attributes ignored after type is already defined [-Wattributes]
-# 6604 | template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char16_t, char, mbstate_t>;
-#      |                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# libcxx/src/locale.cpp:6605:85: warning: type attributes ignored after type is already defined [-Wattributes]
-# 6605 | template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char32_t, char, mbstate_t>;
-ifeq ($(GCCVER),12)
-	libcxx/src/locale.cpp_CXXFLAGS += -Wno-attributes
-endif
-
-# warning on gcc >= 12.3.Rel1
-# libcxx/src/string.cpp:58:33: warning: 'template<class _CharT> struct std::__1::char_traits' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it. [-Wdeprecated-declarations]
-#    58 | template string operator+<char, char_traits<char>, allocator<char>>(char const*, string const&);
-ifneq ($(GCCVER),)
 ifeq ($(shell expr $(GCCVER) \>= 12), 1)
-	libcxx/src/string.cpp_CXXFLAGS += -Wno-deprecated-declarations
+  CXXFLAGS += -Wno-maybe-uninitialized -Wno-alloc-size-larger-than
 endif
-endif
-
-# warning on gcc >= 12.3.Rel1
-# libcxx/src/filesystem/path.cpp:14:
-# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
-# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
-#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
-#       |                               ~~~~~~~~~~~~^~~~~
-# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
-#    55 |   ParserState State;
-#       |               ^~~~~
-# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
-# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
-#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
-#       |                               ~~~~~~~~~~~~^~~~~
-# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
-#    55 |   ParserState State;
-#       |               ^~~~~
-# libcxx/src/filesystem/path_parser.h: In constructor 'std::__1::__fs::filesystem::parser::PathParser::PathParser(std::__1::__fs::filesystem::parser::string_view_t, ParserState)':
-# libcxx/src/filesystem/path_parser.h:58:43: warning: declaration of 'State' shadows a member of 'std::__1::__fs::filesystem::parser::PathParser' [-Wshadow]
-#    58 |   PathParser(string_view_t P, ParserState State) noexcept : Path(P),
-#       |                               ~~~~~~~~~~~~^~~~~
-# libcxx/src/filesystem/path_parser.h:55:15: note: shadowed declaration is here
-#    55 |   ParserState State;
-#       |               ^~~~~
-ifneq ($(GCCVER),)
-ifeq ($(shell expr $(GCCVER) \>= 12), 1)
-	libcxx/src/filesystem/path.cpp_CXXFLAGS += -Wno-shadow
-endif
-endif
-
-# warning on gcc >= 12.3.Rel1
-# libcxx/src/ryu/d2s.cpp:490:31: warning: '_Trailing_zero_bits' may be used uninitialized [-Wmaybe-uninitialized]
-#   490 |           _Trailing_zero_bits += 32;
-#       |           ~~~~~~~~~~~~~~~~~~~~^~~~~
-ifneq ($(GCCVER),)
-ifeq ($(shell expr $(GCCVER) \>= 12), 1)
-	libcxx/src/ryu/d2s.cpp_CXXFLAGS += -Wno-maybe-uninitialized
-endif
-endif
-
 
 CPPSRCS += $(wildcard libcxx/src/*.cpp)
 CPPSRCS += $(wildcard libcxx/src/experimental/*.cpp)

--- a/libs/libxx/libcxxmini.cmake
+++ b/libs/libxx/libcxxmini.cmake
@@ -20,11 +20,9 @@
 
 nuttx_add_system_library(libcxxmini)
 
-set_source_files_properties(
-  libcxxmini/libxx_new.cxx PROPERTIES COMPILE_FLAGS -Wno-missing-exception-spec)
-set_source_files_properties(
-  libcxxmini/libxx_newa.cxx PROPERTIES COMPILE_FLAGS
-                                       -Wno-missing-exception-spec)
+if(NOT CONFIG_XTENSA_TOOLCHAIN_XCC)
+  add_compile_options(-Wno-missing-exception-spec)
+endif()
 
 target_sources(
   libcxxmini

--- a/libs/libxx/libcxxmini.defs
+++ b/libs/libxx/libcxxmini.defs
@@ -22,17 +22,8 @@ CXXSRCS += libxx_cxa_guard.cxx libxx_cxapurevirtual.cxx
 CXXSRCS += libxx_delete.cxx libxx_delete_sized.cxx libxx_deletea.cxx
 CXXSRCS += libxx_deletea_sized.cxx libxx_new.cxx libxx_newa.cxx
 
-# Note: Our implementations of operator new are not conforming to
-# the standard. (no bad_alloc implementation)
-#
-# libxx_new.cxx:64:11: error: 'operator new' is missing exception specification
-#       'throw(std::bad_alloc)' [-Werror,-Wmissing-exception-spec]
-# FAR void *operator new(std::size_t nbytes)
-#           ^
-#                                            throw(std::bad_alloc)
 ifneq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
-  libxx_new.cxx_CXXFLAGS += -Wno-missing-exception-spec
-  libxx_newa.cxx_CXXFLAGS += -Wno-missing-exception-spec
+  CXXFLAGS += -Wno-missing-exception-spec
 endif
 
 DEPPATH += --dep-path libcxxmini


### PR DESCRIPTION
## Summary
Remove the judgment of GCCVER and add CXXFLAGS directly. If there is a problem that the compiler cannot recognize the compilation options, add it separately.

## Impact

## Testing

