### PR TITLE
nuttx/arch: Remove GCCVER and add compilation options directly.

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -305,19 +305,9 @@ else
     endif
   endif
 
-  # Workaround to skip -Warray-bounds check due to bug of GCC-12:
-  # Wrong warning array subscript [0] is outside array bounds:
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-
-  ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
-  endif
-
-  ifeq ($(GCCVER),12)
-    ARCHOPTIMIZATION += --param=min-pagesize=0
-    ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
-      LDFLAGS += --no-warn-rwx-segments
-    endif
+  ARCHOPTIMIZATION += --param=min-pagesize=0
+  ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
+    LDFLAGS += --no-warn-rwx-segments
   endif
 
   LDFLAGS += --entry=__start

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -31,3 +31,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
 endif
 
 include $(TOPDIR)/arch/arm/src/common/Toolchain.defs
+
+# tlsr82 can not recognize --param=min-pagesize=0, so remove it from ARCHOPTIMIZATION
+ARCHOPTIMIZATION := $(filter-out --param=min-pagesize=0,$(ARCHOPTIMIZATION))
+

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -180,16 +180,8 @@ ifeq ($(CONFIG_LTO_FULL),y)
   endif
 endif
 
-# Workaround for GCC-12.2 linker warning
-
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
-  ifeq ($(GCCVER),)
-    export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
-  endif
-
-  ifeq ($(GCCVER),12)
-    LDFLAGS += --no-warn-rwx-segments
-  endif
+  LDFLAGS += --no-warn-rwx-segments
 endif
 
 # Add the builtin library

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -176,17 +176,5 @@ if(CONFIG_DEBUG_SYMBOLS)
 endif()
 
 if(CONFIG_ARCH_TOOLCHAIN_GNU)
-  if(NOT GCCVER)
-
-    execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-                    OUTPUT_VARIABLE GCC_VERSION_INFO)
-
-    string(REGEX MATCH "[0-9]+\\.[0-9]+" GCC_VERSION ${GCC_VERSION_INFO})
-    string(REGEX REPLACE "\\..*" "" GCCVER ${GCC_VERSION})
-
-  endif()
-
-  if(GCCVER EQUAL 12)
-    add_link_options(-Wl,--no-warn-rwx-segments)
-  endif()
+  add_link_options(-Wl,--no-warn-rwx-segments)
 endif()

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -257,16 +257,7 @@ if(CONFIG_RISCV_TOOLCHAIN STREQUAL GNU_RVG)
   endif()
 
   if(CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI)
-    if(NOT DEFINED GCCVER)
-      execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version
-                      OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
-      string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
-                   "${GCC_VERSION_OUTPUT}")
-      set(GCCVER ${CMAKE_MATCH_1})
-    endif()
-    if(GCCVER GREATER_EQUAL 12 OR CONFIG_ARCH_TOOLCHAIN_CLANG)
-      set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}_zicsr_zifencei)
-    endif()
+    set(ARCHCPUEXTFLAGS ${ARCHCPUEXTFLAGS}_zicsr_zifencei)
   endif()
 
   if(CONFIG_ARCH_RV_EXPERIMENTAL_EXTENSIONS)

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -214,12 +214,7 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
   endif
 
   ifeq ($(CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI),y)
-    ifeq ($(GCCVER),)
-      export GCCVER = ${shell $(CROSSDEV)gcc --version | grep gcc | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n 1 | cut -d"." -f1 }
-    endif
-    ifeq ($(shell expr $(GCCVER) \>= 12), 1)
-      ARCHCPUEXTFLAGS := $(ARCHCPUEXTFLAGS)_zicsr_zifencei
-    endif
+    ARCHCPUEXTFLAGS := $(ARCHCPUEXTFLAGS)_zicsr_zifencei
   endif
 
   ARCH_RV_EXPERIMENTAL_EXTENSIONS = $(strip $(subst ",,$(CONFIG_ARCH_RV_EXPERIMENTAL_EXTENSIONS)))


### PR DESCRIPTION
## Summary
Remove the judgment of GCCVER and add compilation options directly. If there is a problem that the compiler cannot recognize the compilation options, add it separately.

## Impact

## Testing

