### PR TITLE
libcxxabi: Optimize cxx code size.

### DIFF
--- a/libs/libxx/0001-libcxx-fix-ld-errors.patch
+++ b/libs/libxx/0001-libcxx-fix-ld-errors.patch
@@ -1,0 +1,28 @@
+diff --git libcxx/include/ostream libcxx/include/ostream
+--- libcxx/include/ostream
++++ libcxx/include/ostream
+@@ -320,7 +320,10 @@ template <class _CharT, class _Traits>
+ basic_ostream<_CharT, _Traits>::sentry::~sentry()
+ {
+     if (__os_.rdbuf() && __os_.good() && (__os_.flags() & ios_base::unitbuf)
+-                      && !uncaught_exception())
++#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
++                      && !uncaught_exception()
++#endif
++       ) 
+     {
+ #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+         try
+diff --git libcxx/src/exception.cpp libcxx/src/exception.cpp
+--- libcxx/src/exception.cpp
++++ libcxx/src/exception.cpp
+@@ -19,6 +19,9 @@
+ #if defined(_LIBCPP_ABI_MICROSOFT)
+ #include "support/runtime/exception_msvc.ipp"
+ #include "support/runtime/exception_pointer_msvc.ipp"
++#elif defined(_LIBCPPABI_VERSION) && defined(_LIBCPP_HAS_NO_EXCEPTIONS)
++#include "include/atomic_support.h"
++#include "support/runtime/exception_pointer_unimplemented.ipp"
+ #elif defined(_LIBCPPABI_VERSION)
+ #include "support/runtime/exception_libcxxabi.ipp"
+ #include "support/runtime/exception_pointer_cxxabi.ipp"

--- a/libs/libxx/libcxx.cmake
+++ b/libs/libxx/libcxx.cmake
@@ -45,7 +45,9 @@ if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcxx)
       -p3 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
       ${CMAKE_CURRENT_LIST_DIR}/mbstate_t.patch && patch -p1 -d
       ${CMAKE_CURRENT_LIST_DIR}/libcxx <
-      ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-remove-mach-time-h.patch
+      ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-remove-mach-time-h.patch && patch
+      -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
+      ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-fix-ld-errors.patch
     DOWNLOAD_NO_PROGRESS true
     TIMEOUT 30)
 

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -32,6 +32,7 @@ libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(Q) patch -p0 < 0001_fix_stdatomic_h_miss_typedef.patch
 	$(Q) patch -p2 < mbstate_t.patch
 	$(Q) patch -p0 < 0001-libcxx-remove-mach-time-h.patch
+	$(Q) patch -p0 < 0001-libcxx-fix-ld-errors.patch
 	$(Q) touch $@
 endif
 

--- a/libs/libxx/libcxxabi.cmake
+++ b/libs/libxx/libcxxabi.cmake
@@ -75,9 +75,9 @@ list(APPEND SRCS stdlib_exception.cpp stdlib_new_delete.cpp
 # Internal files
 list(APPEND SRCS abort_message.cpp fallback_malloc.cpp private_typeinfo.cpp)
 
-# Always compile libcxxabi with exception
-list(APPEND SRCS cxa_exception.cpp cxa_personality.cpp)
-target_compile_options(libcxxabi PRIVATE -fexceptions)
+if(CONFIG_CXX_EXCEPTION)
+  list(APPEND SRCS cxa_exception.cpp cxa_personality.cpp)
+endif()
 
 if(CONFIG_LIBCXXABI)
   add_compile_definitions(LIBCXX_BUILDING_LIBCXXABI)
@@ -106,6 +106,8 @@ if(CONFIG_ARCH_ARM)
   target_compile_definitions(libcxxabi
                              PRIVATE _URC_FATAL_PHASE1_ERROR=_URC_FAILURE)
 endif()
+
+target_compile_definitions(libcxxabi PRIVATE LIBCXXABI_NON_DEMANGLING_TERMINATE)
 
 target_sources(libcxxabi PRIVATE ${TARGET_SRCS})
 target_compile_options(libcxxabi PRIVATE -frtti)

--- a/libs/libxx/libcxxabi.defs
+++ b/libs/libxx/libcxxabi.defs
@@ -67,9 +67,9 @@ CPPSRCS += stdlib_exception.cpp stdlib_new_delete.cpp stdlib_stdexcept.cpp stdli
 # Internal files
 CPPSRCS += abort_message.cpp fallback_malloc.cpp private_typeinfo.cpp
 
-# Always compile libcxxabi with exception
+ifeq ($(CONFIG_CXX_EXCEPTION),y)
 CPPSRCS += cxa_exception.cpp cxa_personality.cpp
-CXXFLAGS += -fexceptions
+endif
 
 # Fix compilation error on ARM32:
 # libcxxabi/src/cxa_personality.cpp:594:22: error: '_URC_FATAL_PHASE1_ERROR' was not declared in this scope
@@ -77,6 +77,8 @@ CXXFLAGS += -fexceptions
 ifeq ($(CONFIG_ARCH_ARM),y)
 CXXFLAGS += -D_URC_FATAL_PHASE2_ERROR=_URC_FAILURE -D_URC_FATAL_PHASE1_ERROR=_URC_FAILURE
 endif
+
+CXXFLAGS += -DLIBCXXABI_NON_DEMANGLING_TERMINATE
 
 # RTTI is required for building the libcxxabi library
 CXXFLAGS += -frtti


### PR DESCRIPTION
## Summary
enable LIBSUPCXX:
   text	   data	    bss	    dec	    hex	filename
  93080	    592	   5472	  99144	  18348	nuttx/nuttx

enable LIBCXXABI:
before:
   text	   data	    bss	    dec	    hex	filename
 126468	    352	   5960	 132780	  206ac	nuttx/nuttx

after:
   text	   data	    bss	    dec	    hex	filename
  68048	    352	   5960	  74360	  12278	nuttx/nuttx

## Impact

## Testing

