### PR TITLE
fs_heap: added support for initialization from a specified section

### DIFF
--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -17,6 +17,12 @@
 # the License.
 #
 # ##############################################################################
+
+if(NOT "${CONFIG_FS_HEAPBUF_SECTION}" STREQUAL "")
+  target_compile_definitions(
+    fs PRIVATE FS_HEAPBUF_SECTION=${CONFIG_FS_HEAPBUF_SECTION})
+endif()
+
 nuttx_add_kernel_library(fs fs_initialize.c fs_heap.c)
 nuttx_add_subdirectory()
 target_include_directories(fs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -112,12 +112,20 @@ config SENDFILE_BUFSIZE
 		Size of the I/O buffer to allocate in sendfile().  Default: 512b
 
 config FS_HEAPSIZE
-	int "Independent heap bytes used by shm/tmpfs/pseudofile"
+	int "Independent heap bytes"
 	default 0
 	depends on FS_SHMFS || FS_TMPFS || PSEUDOFS_FILE
 	---help---
 		Support for shm/tmpfs/fs_pseudofile.c ram based fs memory.
 		default 0 to use kmm directly. independent heap disabled
+
+config FS_HEAPBUF_SECTION
+	string "FS heap use Userheap section"
+	depends on FS_HEAPSIZE > 0
+	default ""
+	---help---
+		Allocated fs heap from the specified section. If not
+		specified, it will alloc from kernel heap.
 
 config FS_REFCOUNT
 	bool "File reference count"

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -22,6 +22,10 @@ include $(TOPDIR)/Make.defs
 
 CSRCS = fs_initialize.c fs_heap.c
 
+ifneq ($(CONFIG_FS_HEAPBUF_SECTION),"")
+  CFLAGS += ${DEFINE_PREFIX}FS_HEAPBUF_SECTION=CONFIG_FS_HEAPBUF_SECTION
+endif
+
 include inode/Make.defs
 include vfs/Make.defs
 include driver/Make.defs

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -41,6 +41,7 @@
 #include <nuttx/lib/builtin.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_BINFS)
 
@@ -305,7 +306,7 @@ static int binfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
       return -ENOENT;
     }
 
-  bdir = kmm_zalloc(sizeof(*bdir));
+  bdir = fs_heap_zalloc(sizeof(*bdir));
   if (bdir == NULL)
     {
       return -ENOMEM;
@@ -330,7 +331,7 @@ static int binfs_closedir(FAR struct inode *mountpt,
                           FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return 0;
 }
 

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -43,6 +43,7 @@
 #include <nuttx/fs/ioctl.h>
 
 #include "cromfs.h"
+#include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_CROMFS)
 
@@ -785,7 +786,7 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  ff = kmm_zalloc(sizeof(struct cromfs_file_s));
+  ff = fs_heap_zalloc(sizeof(struct cromfs_file_s));
   if (ff == NULL)
     {
       return -ENOMEM;
@@ -793,10 +794,10 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Create a file buffer to support partial sector accesses */
 
-  ff->ff_buffer = kmm_malloc(fs->cv_bsize);
+  ff->ff_buffer = fs_heap_malloc(fs->cv_bsize);
   if (!ff->ff_buffer)
     {
-      kmm_free(ff);
+      fs_heap_free(ff);
       return -ENOMEM;
     }
 
@@ -829,8 +830,8 @@ static int cromfs_close(FAR struct file *filep)
 
   /* Free all resources consumed by the opened file */
 
-  kmm_free(ff->ff_buffer);
-  kmm_free(ff);
+  fs_heap_free(ff->ff_buffer);
+  fs_heap_free(ff);
 
   return OK;
 }
@@ -1118,7 +1119,7 @@ static int cromfs_dup(FAR const struct file *oldp, FAR struct file *newp)
    * same node.
    */
 
-  newff = kmm_zalloc(sizeof(struct cromfs_file_s));
+  newff = fs_heap_zalloc(sizeof(struct cromfs_file_s));
   if (newff == NULL)
     {
       return -ENOMEM;
@@ -1126,10 +1127,10 @@ static int cromfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Create a file buffer to support partial sector accesses */
 
-  newff->ff_buffer = kmm_malloc(fs->cv_bsize);
+  newff->ff_buffer = fs_heap_malloc(fs->cv_bsize);
   if (newff->ff_buffer == NULL)
     {
-      kmm_free(newff);
+      fs_heap_free(newff);
       return -ENOMEM;
     }
 
@@ -1236,7 +1237,7 @@ static int cromfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
       return -ENOTDIR;
     }
 
-  cdir = kmm_zalloc(sizeof(*cdir));
+  cdir = fs_heap_zalloc(sizeof(*cdir));
   if (cdir == NULL)
     {
       return -ENOMEM;
@@ -1261,7 +1262,7 @@ static int cromfs_closedir(FAR struct inode *mountpt,
                            FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(mountpt != NULL);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return 0;
 }
 

--- a/fs/driver/fs_blockpartition.c
+++ b/fs/driver/fs_blockpartition.c
@@ -35,6 +35,7 @@
 
 #include "driver/driver.h"
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -284,7 +285,7 @@ static int part_unlink(FAR struct inode *inode)
   FAR struct inode *parent = dev->parent;
 
   inode_release(parent);
-  kmm_free(dev);
+  fs_heap_free(dev);
 
   return OK;
 }
@@ -332,7 +333,7 @@ int register_partition_with_inode(FAR const char *partition,
 
   /* Allocate a partition device structure */
 
-  dev = kmm_zalloc(sizeof(*dev));
+  dev = fs_heap_zalloc(sizeof(*dev));
   if (dev == NULL)
     {
       return -ENOMEM;
@@ -365,7 +366,7 @@ int register_partition_with_inode(FAR const char *partition,
 
 errout_free:
   inode_release(parent);
-  kmm_free(dev);
+  fs_heap_free(dev);
   return ret;
 }
 

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -318,7 +318,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  ff = kmm_zalloc(sizeof(struct fat_file_s));
+  ff = fs_heap_zalloc(sizeof(struct fat_file_s));
   if (!ff)
     {
       ret = -ENOMEM;
@@ -379,7 +379,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
       off_t offset = fat_seek(filep, ff->ff_size, SEEK_SET);
       if (offset < 0)
         {
-          kmm_free(ff);
+          fs_heap_free(ff);
           return (int)offset;
         }
     }
@@ -391,7 +391,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
    */
 
 errout_with_struct:
-  kmm_free(ff);
+  fs_heap_free(ff);
 
 errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);
@@ -469,7 +469,7 @@ static int fat_close(FAR struct file *filep)
 
   /* Then free the file structure itself. */
 
-  kmm_free(ff);
+  fs_heap_free(ff);
   filep->f_priv = NULL;
   return ret;
 }
@@ -504,7 +504,7 @@ static int fat_zero_cluster(FAR struct fat_mountpt_s *fs, int cluster,
   off_t end_sec = sector + DIV_ROUND_UP(end, fs->fs_hwsectorsize);
   int ret;
 
-  buf = kmm_malloc(fs->fs_hwsectorsize);
+  buf = fs_heap_malloc(fs->fs_hwsectorsize);
   if (!buf)
     {
       return -ENOMEM;
@@ -543,7 +543,7 @@ static int fat_zero_cluster(FAR struct fat_mountpt_s *fs, int cluster,
   ret = OK;
 
 out:
-  kmm_free(buf);
+  fs_heap_free(buf);
 
   return ret;
 }
@@ -1549,7 +1549,7 @@ static int fat_dup(FAR const struct file *oldp, FAR struct file *newp)
    * dup'ed file.
    */
 
-  newff = kmm_malloc(sizeof(struct fat_file_s));
+  newff = fs_heap_malloc(sizeof(struct fat_file_s));
   if (!newff)
     {
       ret = -ENOMEM;
@@ -1616,7 +1616,7 @@ static int fat_dup(FAR const struct file *oldp, FAR struct file *newp)
    */
 
 errout_with_struct:
-  kmm_free(newff);
+  fs_heap_free(newff);
 
 errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);
@@ -1647,7 +1647,7 @@ static int fat_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
-  fdir = kmm_zalloc(sizeof(struct fat_dirent_s));
+  fdir = fs_heap_zalloc(sizeof(struct fat_dirent_s));
   if (fdir == NULL)
     {
       return -ENOMEM;
@@ -1725,7 +1725,7 @@ errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);
 
 errout_with_fdir:
-  kmm_free(fdir);
+  fs_heap_free(fdir);
   return ret;
 }
 
@@ -1740,7 +1740,7 @@ static int fat_closedir(FAR struct inode *mountpt,
                         FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return 0;
 }
 
@@ -2230,7 +2230,7 @@ static int fat_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  fs = kmm_zalloc(sizeof(struct fat_mountpt_s));
+  fs = fs_heap_zalloc(sizeof(struct fat_mountpt_s));
   if (!fs)
     {
       return -ENOMEM;
@@ -2252,7 +2252,7 @@ static int fat_bind(FAR struct inode *blkdriver, FAR const void *data,
   if (ret != 0)
     {
       nxmutex_destroy(&fs->fs_lock);
-      kmm_free(fs);
+      fs_heap_free(fs);
       return ret;
     }
 
@@ -2354,7 +2354,7 @@ static int fat_unbind(FAR void *handle, FAR struct inode **blkdriver,
     }
 
   nxmutex_destroy(&fs->fs_lock);
-  kmm_free(fs);
+  fs_heap_free(fs);
   return OK;
 }
 

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -35,6 +35,8 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
 
+#include "fs_heap.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -845,8 +847,8 @@
 #  define fat_io_alloc(s)  fat_dma_alloc(s)
 #  define fat_io_free(m,s) fat_dma_free(m,s)
 #else
-#  define fat_io_alloc(s)  kmm_malloc(s)
-#  define fat_io_free(m,s) kmm_free(m)
+#  define fat_io_alloc(s)  fs_heap_malloc(s)
+#  define fat_io_free(m,s) fs_heap_free(m)
 #endif
 
 /****************************************************************************

--- a/fs/fs_heap.c
+++ b/fs/fs_heap.c
@@ -38,7 +38,12 @@ static FAR struct mm_heap_s *g_fs_heap;
 
 void fs_heap_initialize(void)
 {
+#ifdef FS_HEAPBUF_SECTION
+  static uint8_t buf[CONFIG_FS_HEAPSIZE] locate_data(FS_HEAPBUF_SECTION);
+#else
   FAR void *buf = kmm_malloc(CONFIG_FS_HEAPSIZE);
+#endif
+
   DEBUGASSERT(buf != NULL);
   g_fs_heap = mm_initialize("heapfs", buf, CONFIG_FS_HEAPSIZE);
 }
@@ -46,6 +51,11 @@ void fs_heap_initialize(void)
 FAR void *fs_heap_zalloc(size_t size)
 {
   return mm_zalloc(g_fs_heap, size);
+}
+
+FAR void *fs_heap_malloc(size_t size)
+{
+  return mm_malloc(g_fs_heap, size);
 }
 
 size_t fs_heap_malloc_size(FAR void *mem)

--- a/fs/fs_heap.h
+++ b/fs/fs_heap.h
@@ -36,12 +36,14 @@
 #if defined(CONFIG_FS_HEAPSIZE) && CONFIG_FS_HEAPSIZE > 0
 void      fs_heap_initialize(void);
 FAR void *fs_heap_zalloc(size_t size);
+FAR void *fs_heap_malloc(size_t size);
 size_t    fs_heap_malloc_size(FAR void *mem);
 FAR void *fs_heap_realloc(FAR void *oldmem, size_t size);
 void      fs_heap_free(FAR void *mem);
 #else
 #  define fs_heap_initialize()
 #  define fs_heap_zalloc       kmm_zalloc
+#  define fs_heap_malloc       kmm_malloc
 #  define fs_heap_malloc_size  kmm_malloc_size
 #  define fs_heap_realloc      kmm_realloc
 #  define fs_heap_free         kmm_free

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -53,6 +53,7 @@
 
 #include "sched/sched.h"
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions
@@ -136,7 +137,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
       return -EMFILE;
     }
 
-  files = kmm_malloc(sizeof(FAR struct file *) * row);
+  files = fs_heap_malloc(sizeof(FAR struct file *) * row);
   DEBUGASSERT(files);
   if (files == NULL)
     {
@@ -146,16 +147,16 @@ static int files_extend(FAR struct filelist *list, size_t row)
   i = orig_rows;
   do
     {
-      files[i] = kmm_zalloc(sizeof(struct file) *
+      files[i] = fs_heap_zalloc(sizeof(struct file) *
                             CONFIG_NFILE_DESCRIPTORS_PER_BLOCK);
       if (files[i] == NULL)
         {
           while (--i >= orig_rows)
             {
-              kmm_free(files[i]);
+              fs_heap_free(files[i]);
             }
 
-          kmm_free(files);
+          fs_heap_free(files);
           return -ENFILE;
         }
     }
@@ -174,10 +175,10 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
       for (j = orig_rows; j < i; j++)
         {
-          kmm_free(files[j]);
+          fs_heap_free(files[j]);
         }
 
-      kmm_free(files);
+      fs_heap_free(files);
 
       return OK;
     }
@@ -196,7 +197,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   if (tmp != NULL && tmp != &list->fl_prefile)
     {
-      kmm_free(tmp);
+      fs_heap_free(tmp);
     }
 
   return OK;
@@ -485,13 +486,13 @@ void files_putlist(FAR struct filelist *list)
 
       if (i != 0)
         {
-          kmm_free(list->fl_files[i]);
+          fs_heap_free(list->fl_files[i]);
         }
     }
 
   if (list->fl_files != &list->fl_prefile)
     {
-      kmm_free(list->fl_files);
+      fs_heap_free(list->fl_files);
     }
 }
 

--- a/fs/inode/fs_foreachinode.c
+++ b/fs/inode/fs_foreachinode.c
@@ -33,6 +33,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -170,7 +171,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg)
 
   /* Allocate the mountpoint info structure */
 
-  info = kmm_malloc(sizeof(struct inode_path_s));
+  info = fs_heap_malloc(sizeof(struct inode_path_s));
   if (!info)
     {
       return -ENOMEM;
@@ -193,7 +194,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg)
 
   /* Free the info structure and return the result */
 
-  kmm_free(info);
+  fs_heap_free(info);
   return ret;
 
 #else

--- a/fs/inode/fs_inodefree.c
+++ b/fs/inode/fs_inodefree.c
@@ -31,6 +31,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Public Functions
@@ -69,10 +70,10 @@ void inode_free(FAR struct inode *node)
 
       if (INODE_IS_SOFTLINK(node) && node->u.i_link != NULL)
         {
-          kmm_free(node->u.i_link);
+          fs_heap_free(node->u.i_link);
         }
 #endif
 
-      kmm_free(node);
+      fs_heap_free(node);
     }
 }

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -31,6 +31,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Data
@@ -81,7 +82,7 @@ static FAR struct inode *inode_alloc(FAR const char *name, mode_t mode)
   int namelen;
 
   namelen = inode_namelen(name);
-  node    = kmm_zalloc(FSNODE_SIZE(namelen));
+  node    = fs_heap_zalloc(FSNODE_SIZE(namelen));
   if (node)
     {
       node->i_ino   = g_ino++;

--- a/fs/littlefs/lfs_util.patch
+++ b/fs/littlefs/lfs_util.patch
@@ -1,10 +1,11 @@
 --- ./littlefs/littlefs/lfs_util.h	2022-11-11 03:32:30.000000000 +1100
 +++ ./littlefs/littlefs/lfs_util.h	2023-04-21 12:25:27.987084276 +1000
-@@ -28,6 +28,7 @@
+@@ -28,6 +28,8 @@
 
  #ifndef LFS_NO_MALLOC
  #include <stdlib.h>
 +#include <nuttx/mm/mm.h>
++#include "fs_heap.h"
  #endif
  #ifndef LFS_NO_ASSERT
  #include <assert.h>
@@ -13,7 +14,7 @@
  static inline void *lfs_malloc(size_t size) {
  #ifndef LFS_NO_MALLOC
 -    return malloc(size);
-+    return kmm_malloc(size);
++    return fs_heap_malloc(size);
  #else
      (void)size;
      return NULL;
@@ -22,7 +23,7 @@
  static inline void lfs_free(void *p) {
  #ifndef LFS_NO_MALLOC
 -    free(p);
-+    kmm_free(p);
++    fs_heap_free(p);
  #else
      (void)p;
  #endif

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -40,6 +40,7 @@
 #include "inode/inode.h"
 #include "littlefs/lfs.h"
 #include "littlefs/lfs_util.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -298,7 +299,7 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate memory for the open file */
 
-  priv = kmm_malloc(sizeof(*priv));
+  priv = fs_heap_malloc(sizeof(*priv));
   if (priv == NULL)
     {
       return -ENOMEM;
@@ -361,7 +362,7 @@ errout_with_file:
 errout:
   nxmutex_unlock(&fs->lock);
 errlock:
-  kmm_free(priv);
+  fs_heap_free(priv);
   return ret;
 }
 
@@ -398,7 +399,7 @@ static int littlefs_close(FAR struct file *filep)
   nxmutex_unlock(&fs->lock);
   if (priv->refs <= 0)
     {
-      kmm_free(priv);
+      fs_heap_free(priv);
     }
 
   return ret;
@@ -780,7 +781,7 @@ static int littlefs_opendir(FAR struct inode *mountpt,
 
   /* Allocate memory for the open directory */
 
-  ldir = kmm_malloc(sizeof(*ldir));
+  ldir = fs_heap_malloc(sizeof(*ldir));
   if (ldir == NULL)
     {
       return -ENOMEM;
@@ -809,7 +810,7 @@ static int littlefs_opendir(FAR struct inode *mountpt,
 errout:
   nxmutex_unlock(&fs->lock);
 errlock:
-  kmm_free(ldir);
+  fs_heap_free(ldir);
   return ret;
 }
 
@@ -843,7 +844,7 @@ static int littlefs_closedir(FAR struct inode *mountpt,
   lfs_dir_close(&fs->lfs, &ldir->dir);
   nxmutex_unlock(&fs->lock);
 
-  kmm_free(ldir);
+  fs_heap_free(ldir);
   return OK;
 }
 
@@ -1070,7 +1071,7 @@ static int littlefs_bind(FAR struct inode *driver, FAR const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  fs = kmm_zalloc(sizeof(*fs));
+  fs = fs_heap_zalloc(sizeof(*fs));
   if (!fs)
     {
       ret = -ENOMEM;
@@ -1200,7 +1201,7 @@ static int littlefs_bind(FAR struct inode *driver, FAR const void *data,
 
 errout_with_fs:
   nxmutex_destroy(&fs->lock);
-  kmm_free(fs);
+  fs_heap_free(fs);
 errout_with_block:
   if (INODE_IS_BLOCK(driver) && driver->u.i_bops->close)
     {
@@ -1259,7 +1260,7 @@ static int littlefs_unbind(FAR void *handle, FAR struct inode **driver,
       /* Release the mountpoint private data */
 
       nxmutex_destroy(&fs->lock);
-      kmm_free(fs);
+      fs_heap_free(fs);
     }
 
   return ret;

--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -30,6 +30,7 @@
 
 #include "fs_anonmap.h"
 #include "sched/sched.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions
@@ -77,7 +78,7 @@ static int unmap_anonymous(FAR struct task_group_s *group,
 
       if (kernel)
         {
-          kmm_free(entry->vaddr);
+          fs_heap_free(entry->vaddr);
         }
       else
         {
@@ -97,7 +98,7 @@ static int unmap_anonymous(FAR struct task_group_s *group,
     {
       if (kernel)
         {
-          newaddr = kmm_realloc(entry->vaddr, length);
+          newaddr = fs_heap_realloc(entry->vaddr, length);
         }
       else
         {
@@ -127,7 +128,7 @@ int map_anonymous(FAR struct mm_map_entry_s *entry, bool kernel)
    */
 
   entry->vaddr = kernel ?
-    kmm_zalloc(entry->length) : kumm_zalloc(entry->length);
+    fs_heap_zalloc(entry->length) : kumm_zalloc(entry->length);
   if (entry->vaddr == NULL)
     {
       ferr("ERROR: kumm_alloc() failed, enable DEBUG_MM for info!\n");
@@ -142,7 +143,7 @@ int map_anonymous(FAR struct mm_map_entry_s *entry, bool kernel)
     {
       if (kernel)
         {
-          kmm_free(entry->vaddr);
+          fs_heap_free(entry->vaddr);
         }
       else
         {

--- a/fs/mmap/fs_anonmap.h
+++ b/fs/mmap/fs_anonmap.h
@@ -42,7 +42,7 @@
  *
  * Input Parameters:
  *   map     Input struct containing user request
- *   kernel  kmm_zalloc or kumm_zalloc
+ *   kernel  fs_heap_zalloc or kumm_zalloc
  *
  * Returned Value:
  *   On success returns 0. Otherwise negated errno is returned appropriately.

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -39,6 +39,7 @@
 
 #include "fs_rammap.h"
 #include "sched/sched.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Public Data
@@ -165,7 +166,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
 
       if (type == MAP_KERNEL)
         {
-          kmm_free(entry->vaddr);
+          fs_heap_free(entry->vaddr);
         }
       else if (type == MAP_USER)
         {
@@ -187,7 +188,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
     {
       if (type == MAP_KERNEL)
         {
-          newaddr = kmm_realloc(entry->vaddr, length);
+          newaddr = fs_heap_realloc(entry->vaddr, length);
         }
       else if (type == MAP_USER)
         {
@@ -216,7 +217,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
  *   filep   file descriptor of the backing file -- required.
  *   entry   mmap entry information.
  *           field offset and length must be initialized correctly.
- *   type    kmm_zalloc or kumm_zalloc or xip_base
+ *   type    fs_heap_zalloc or kumm_zalloc or xip_base
  *
  * Returned Value:
  *  On success, rammap returns 0 and entry->vaddr points to memory mapped.
@@ -262,7 +263,8 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
 
   /* Allocate a region of memory of the specified size */
 
-  rdbuffer = type == MAP_KERNEL ? kmm_malloc(length) : kumm_malloc(length);
+  rdbuffer = type == MAP_KERNEL ? fs_heap_malloc(length)
+                                : kumm_malloc(length);
   if (!rdbuffer)
     {
       ferr("ERROR: Region allocation failed, length: %zu\n", length);
@@ -344,7 +346,7 @@ out:
 errout_with_region:
   if (type == MAP_KERNEL)
     {
-      kmm_free(entry->vaddr);
+      fs_heap_free(entry->vaddr);
     }
   else if (type == MAP_USER)
     {

--- a/fs/mmap/fs_rammap.h
+++ b/fs/mmap/fs_rammap.h
@@ -81,7 +81,7 @@ enum mm_map_type_e
  *   length  The length of the mapping.  For exception #1 above, this length
  *           ignored:  The entire underlying media is always accessible.
  *   offset  The offset into the file to map
- *   type    kmm_zalloc or kumm_zalloc or xip_base
+ *   type    fs_heap_zalloc or kumm_zalloc or xip_base
  *
  * Returned Value:
  *   On success rammmap returns 0. Otherwise errno is returned appropriately.

--- a/fs/mnemofs/mnemofs_blkalloc.c
+++ b/fs/mnemofs/mnemofs_blkalloc.c
@@ -86,6 +86,7 @@
 #include <stdlib.h>
 
 #include "mnemofs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -307,7 +308,7 @@ int mfs_ba_fmt(FAR struct mfs_sb_s * const sb)
 
   /* MFS_BA(sb).k_del_elemsz = ((log + 7) & (-8)) / 8; */
 
-  MFS_BA(sb).k_del = kmm_zalloc(sizeof(size_t) * MFS_NBLKS(sb));
+  MFS_BA(sb).k_del = fs_heap_zalloc(sizeof(size_t) * MFS_NBLKS(sb));
   if (predict_false(MFS_BA(sb).k_del == NULL))
     {
       ret = -ENOMEM;
@@ -316,7 +317,7 @@ int mfs_ba_fmt(FAR struct mfs_sb_s * const sb)
 
   MFS_BA(sb).n_bmap_upgs = MFS_UPPER8(MFS_NPGS(sb));
 
-  MFS_BA(sb).bmap_upgs = kmm_zalloc(MFS_BA(sb).n_bmap_upgs);
+  MFS_BA(sb).bmap_upgs = fs_heap_zalloc(MFS_BA(sb).n_bmap_upgs);
   if (predict_false(MFS_BA(sb).bmap_upgs == NULL))
     {
       ret = -ENOMEM;
@@ -330,7 +331,7 @@ int mfs_ba_fmt(FAR struct mfs_sb_s * const sb)
   return ret;
 
 errout_with_k_del:
-  kmm_free(MFS_BA(sb).k_del);
+  fs_heap_free(MFS_BA(sb).k_del);
 
 errout:
   return ret;
@@ -367,8 +368,8 @@ errout:
 
 void mfs_ba_free(FAR struct mfs_sb_s * const sb)
 {
-  kmm_free(MFS_BA(sb).k_del);
-  kmm_free(MFS_BA(sb).bmap_upgs);
+  fs_heap_free(MFS_BA(sb).k_del);
+  fs_heap_free(MFS_BA(sb).bmap_upgs);
 
   finfo("Block Allocator Freed.");
 }

--- a/fs/mnemofs/mnemofs_ctz.c
+++ b/fs/mnemofs/mnemofs_ctz.c
@@ -102,6 +102,7 @@
 #include <sys/stat.h>
 
 #include "mnemofs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -452,7 +453,7 @@ int mfs_ctz_wrtnode(FAR struct mfs_sb_s * const sb,
 
   /* So, till cur_idx - 1, the CTZ blocks are common. */
 
-  buf = kmm_zalloc(MFS_PGSZ(sb));
+  buf = fs_heap_zalloc(MFS_PGSZ(sb));
   if (predict_false(buf == NULL))
     {
       ret = -ENOMEM;
@@ -595,7 +596,7 @@ int mfs_ctz_wrtnode(FAR struct mfs_sb_s * const sb,
     }
 
 errout_with_buf:
-  kmm_free(buf);
+  fs_heap_free(buf);
 
 errout:
   return ret;

--- a/fs/mnemofs/mnemofs_fsobj.c
+++ b/fs/mnemofs/mnemofs_fsobj.c
@@ -67,6 +67,7 @@
 #include <sys/stat.h>
 
 #include "mnemofs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -324,7 +325,7 @@ int pitr_traverse(FAR struct mfs_sb_s *sb, FAR struct mfs_path_s *path,
     {
       *cap = (*cap * 3) / 2; /* Don't want to double it for memory. */
 
-      path = kmm_realloc(path, (*cap) * sizeof(struct mfs_path_s));
+      path = fs_heap_realloc(path, (*cap) * sizeof(struct mfs_path_s));
       if (predict_false(path == NULL))
         {
           ret = -ENOMEM;
@@ -421,7 +422,7 @@ bool mfs_obj_isempty(FAR struct mfs_sb_s * const sb,
 
 void mfs_free_dirent(FAR struct mfs_dirent_s *dirent)
 {
-  kmm_free(dirent);
+  fs_heap_free(dirent);
 
   finfo("Dirent freed.");
 }
@@ -601,7 +602,7 @@ int mfs_pitr_readdirent(FAR const struct mfs_sb_s * const sb,
   *dirent = NULL;
   memset(rd, 0, len);
 
-  d = kmm_zalloc(len);
+  d = fs_heap_zalloc(len);
   if (predict_false(d == NULL))
     {
       ret = -ENOMEM;
@@ -637,7 +638,7 @@ int mfs_pitr_readdirent(FAR const struct mfs_sb_s * const sb,
     }
 
   sz  = MFS_DIRENTSZ(d);
-  tmp = kmm_realloc(d, sz);
+  tmp = fs_heap_realloc(d, sz);
   if (predict_true(tmp != NULL))
     {
       d = tmp;
@@ -653,7 +654,7 @@ int mfs_pitr_readdirent(FAR const struct mfs_sb_s * const sb,
   return ret;
 
 errout_with_d:
-  kmm_free(d);
+  fs_heap_free(d);
 
   if (ret < 0)
     {
@@ -713,7 +714,7 @@ static int search_ctz_by_name(FAR const struct mfs_sb_s * const sb,
     {
       DEBUGASSERT(namelen == 0);
 
-      nd = kmm_zalloc(sizeof(struct mfs_dirent_s));
+      nd = fs_heap_zalloc(sizeof(struct mfs_dirent_s));
       if (predict_false(nd == NULL))
         {
           ret = -ENOMEM;
@@ -810,7 +811,7 @@ int mfs_get_patharr(FAR const struct mfs_sb_s * const sb,
 
   *path  = NULL;
   n_objs = nobjs_in_path(relpath);
-  np     = kmm_zalloc(n_objs * sizeof(struct mfs_path_s));
+  np     = fs_heap_zalloc(n_objs * sizeof(struct mfs_path_s));
   if (predict_false(np == NULL))
     {
       ret = -ENOMEM;
@@ -921,7 +922,7 @@ errout:
 
 void mfs_free_patharr(FAR struct mfs_path_s *path)
 {
-  kmm_free(path);
+  fs_heap_free(path);
 }
 
 void mfs_pitr_reset(FAR struct mfs_pitr_s * const pitr)
@@ -988,7 +989,7 @@ int mfs_pitr_appendnew(FAR struct mfs_sb_s * const sb,
 
   DEBUGASSERT(depth > 0);
 
-  d = kmm_zalloc(sizeof(struct mfs_dirent_s) + len);
+  d = fs_heap_zalloc(sizeof(struct mfs_dirent_s) + len);
   if (predict_false(d == NULL))
     {
       ret = -ENOMEM;
@@ -1043,7 +1044,7 @@ int mfs_pitr_traversefs(FAR struct mfs_sb_s * sb, const struct mfs_ctz_s ctz,
   FAR struct mfs_path_s *path     = NULL;
 
   capacity = MFS_TRAVERSE_INITSZ;
-  path = kmm_zalloc(capacity * sizeof(struct mfs_path_s));
+  path = fs_heap_zalloc(capacity * sizeof(struct mfs_path_s));
   if (predict_false(path == NULL))
     {
       ret = -ENOMEM;

--- a/fs/mnemofs/mnemofs_journal.c
+++ b/fs/mnemofs/mnemofs_journal.c
@@ -82,6 +82,7 @@
 #include <sys/param.h>
 
 #include "mnemofs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -185,7 +186,7 @@ int mfs_jrnl_rdlog(FAR const struct mfs_sb_s *const sb,
       goto errout;
     }
 
-  buf = kmm_zalloc(log_sz);
+  buf = fs_heap_zalloc(log_sz);
   if (predict_false(buf == NULL))
     {
       ret = -ENOMEM;
@@ -215,7 +216,7 @@ int mfs_jrnl_rdlog(FAR const struct mfs_sb_s *const sb,
     }
 
 errout_with_buf:
-  kmm_free(buf);
+  fs_heap_free(buf);
 
 errout:
   return ret;
@@ -297,7 +298,7 @@ FAR static const char *deser_log(FAR const char * const in,
 
   /* Allocates path. Deallocate using mfs_jrnl_log_free. */
 
-  x->path = kmm_zalloc(sizeof(struct mfs_jrnl_log_s) * x->depth);
+  x->path = fs_heap_zalloc(sizeof(struct mfs_jrnl_log_s) * x->depth);
   if (predict_false(x->path == NULL))
     {
       return NULL;
@@ -328,7 +329,7 @@ FAR static const char *deser_log(FAR const char * const in,
 
 void mfs_jrnl_log_free(FAR const struct mfs_jrnl_log_s * const log)
 {
-  free(log->path);
+  fs_heap_free(log->path);
 }
 
 /****************************************************************************
@@ -430,7 +431,7 @@ int mfs_jrnl_fmt(FAR struct mfs_sb_s * const sb, FAR mfs_t *blk1,
 
   sz = MFS_JRNL_SUFFIXSZ + ((CONFIG_MNEMOFS_JOURNAL_NBLKS + 2) * 4);
 
-  buf = kmm_zalloc(sz);
+  buf = fs_heap_zalloc(sz);
   if (predict_false(buf == NULL))
     {
       ret = -ENOMEM;
@@ -508,7 +509,7 @@ int mfs_jrnl_fmt(FAR struct mfs_sb_s * const sb, FAR mfs_t *blk1,
   MFS_JRNL(sb).mblk2         = *blk2;
 
 errout_with_buf:
-  kmm_free(buf);
+  fs_heap_free(buf);
 
 errout:
   return ret;
@@ -631,7 +632,7 @@ int mfs_jrnl_wrlog(FAR struct mfs_sb_s * const sb,
   const mfs_t            log_sz   = sizeof(mfs_t) + MFS_LOGSZ(node->depth);
   struct mfs_jrnl_log_s  log;
 
-  buf = kmm_zalloc(log_sz); /* For size before log. */
+  buf = fs_heap_zalloc(log_sz); /* For size before log. */
   if (predict_false(buf == NULL))
     {
       ret = -ENOMEM;
@@ -677,7 +678,7 @@ int mfs_jrnl_wrlog(FAR struct mfs_sb_s * const sb,
   MFS_JRNL(sb).n_logs++;
 
 errout_with_buf:
-  kmm_free(buf);
+  fs_heap_free(buf);
 
 errout:
   return ret;
@@ -753,7 +754,7 @@ int mfs_jrnl_flush(FAR struct mfs_sb_s * const sb)
       tmp_blkidx    = blkidx;
       tmp_pg_in_blk = pg_in_blk;
 
-      path = kmm_zalloc(log.depth * sizeof(struct mfs_path_s));
+      path = fs_heap_zalloc(log.depth * sizeof(struct mfs_path_s));
       if (predict_false(path == NULL))
         {
           goto errout;

--- a/fs/mnemofs/mnemofs_lru.c
+++ b/fs/mnemofs/mnemofs_lru.c
@@ -74,6 +74,7 @@
 #include <sys/param.h>
 
 #include "mnemofs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -265,8 +266,8 @@ static bool lru_isnodefull(FAR struct mfs_sb_s * const sb,
 
 static void lru_free_delta(FAR struct mfs_delta_s *delta)
 {
-  kmm_free(delta->upd);
-  kmm_free(delta);
+  fs_heap_free(delta->upd);
+  fs_heap_free(delta);
 }
 
 /****************************************************************************
@@ -391,7 +392,7 @@ static int lru_wrtooff(FAR struct mfs_sb_s * const sb, const mfs_t data_off,
 
   if (node == NULL)
     {
-      node = kmm_zalloc(sizeof(*node));
+      node = fs_heap_zalloc(sizeof(*node));
       if (predict_false(node == NULL))
         {
           found = false;
@@ -399,7 +400,7 @@ static int lru_wrtooff(FAR struct mfs_sb_s * const sb, const mfs_t data_off,
           goto errout;
         }
 
-      node->path = kmm_zalloc(depth * sizeof(struct mfs_path_s));
+      node->path = fs_heap_zalloc(depth * sizeof(struct mfs_path_s));
       if (predict_false(node->path == NULL))
         {
           found = false;
@@ -455,7 +456,7 @@ static int lru_wrtooff(FAR struct mfs_sb_s * const sb, const mfs_t data_off,
   /* Add delta to node. */
 
   finfo("Adding delta to the node.");
-  delta = kmm_zalloc(sizeof(*delta));
+  delta = fs_heap_zalloc(sizeof(*delta));
   if (predict_false(delta == NULL))
     {
       ret = -ENOMEM;
@@ -466,7 +467,7 @@ static int lru_wrtooff(FAR struct mfs_sb_s * const sb, const mfs_t data_off,
 
   if (op == MFS_LRU_UPD)
     {
-      delta->upd = kmm_zalloc(bytes);
+      delta->upd = fs_heap_zalloc(bytes);
       if (predict_false(delta->upd == NULL))
         {
           ret = -ENOMEM;
@@ -511,13 +512,13 @@ static int lru_wrtooff(FAR struct mfs_sb_s * const sb, const mfs_t data_off,
 
 errout_with_delta:
   list_delete(&delta->list);
-  kmm_free(delta);
+  fs_heap_free(delta);
 
 errout_with_node:
   if (!found && node != NULL)
     {
       list_delete(&node->list);
-      kmm_free(node);
+      fs_heap_free(node);
     }
 
 errout:
@@ -622,7 +623,7 @@ errout:
 static void lru_node_free(FAR struct mfs_node_s *node)
 {
   mfs_free_patharr(node->path);
-  kmm_free(node);
+  fs_heap_free(node);
 }
 
 static bool lru_sort_cmp(FAR struct mfs_node_s * const node,
@@ -761,7 +762,7 @@ int mfs_lru_flush(FAR struct mfs_sb_s * const sb)
             {
               finfo("Adding parent to LRU");
 
-              tmp = kmm_zalloc(sizeof(struct mfs_node_s));
+              tmp = fs_heap_zalloc(sizeof(struct mfs_node_s));
               if (predict_false(tmp == NULL))
                 {
                   ret = -ENOMEM;
@@ -774,7 +775,7 @@ int mfs_lru_flush(FAR struct mfs_sb_s * const sb)
               /* TODO: Time fields. in tmp. */
 
               tmp->depth = node->depth - 1;
-              tmp->path  = kmm_zalloc((node->depth - 1)
+              tmp->path  = fs_heap_zalloc((node->depth - 1)
                                       * sizeof(struct mfs_path_s));
               if (predict_false(tmp->path == NULL))
                 {

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -49,6 +49,7 @@
 #endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -213,7 +214,7 @@ static int automount_open(FAR struct file *filep)
 
   /* Allocate a new open structure */
 
-  opriv = kmm_zalloc(sizeof(struct automounter_open_s));
+  opriv = fs_heap_zalloc(sizeof(struct automounter_open_s));
   if (opriv == NULL)
     {
       ferr("ERROR: Failed to allocate open structure\n");
@@ -295,7 +296,7 @@ static int automount_close(FAR struct file *filep)
 
   /* And free the open structure */
 
-  kmm_free(opriv);
+  fs_heap_free(opriv);
 
   ret = OK;
 
@@ -818,7 +819,7 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
 
   /* Allocate an auto-mounter state structure */
 
-  priv = kmm_zalloc(sizeof(struct automounter_state_s));
+  priv = fs_heap_zalloc(sizeof(struct automounter_state_s));
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
@@ -931,5 +932,5 @@ void automount_uninitialize(FAR void *handle)
 
   /* And free the state structure */
 
-  kmm_free(priv);
+  fs_heap_free(priv);
 }

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -46,6 +46,7 @@
 #include <nuttx/fs/procfs.h>
 
 #include "mount/mount.h"
+#include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #if !defined(CONFIG_FS_PROCFS_EXCLUDE_MOUNT) || \
@@ -409,7 +410,7 @@ static int mount_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the task and node selection */
 
   procfile = (FAR struct mount_file_s *)
-    kmm_zalloc(sizeof(struct mount_file_s));
+    fs_heap_zalloc(sizeof(struct mount_file_s));
   if (!procfile)
     {
       ferr("ERROR: Failed to allocate file container\n");
@@ -441,7 +442,7 @@ static int mount_close(FAR struct file *filep)
 
   /* Release the file container structure */
 
-  kmm_free(procfile);
+  fs_heap_free(procfile);
   filep->f_priv = NULL;
   return OK;
 }
@@ -539,7 +540,7 @@ static int mount_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container to hold the task and node selection */
 
   newfile = (FAR struct mount_file_s *)
-    kmm_malloc(sizeof(struct mount_file_s));
+    fs_heap_malloc(sizeof(struct mount_file_s));
   if (!newfile)
     {
       ferr("ERROR: Failed to allocate file container\n");

--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -41,6 +41,7 @@
 
 #include "inode/inode.h"
 #include "sched/sched.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -210,7 +211,7 @@ inotify_alloc_event(int wd, uint32_t mask, uint32_t cookie,
       len = ROUND_UP(strlen(name) + 1, sizeof(struct inotify_event));
     }
 
-  event = kmm_malloc(sizeof(struct inotify_event_s) + len);
+  event = fs_heap_malloc(sizeof(struct inotify_event_s) + len);
   if (event == NULL)
     {
       return NULL;
@@ -308,7 +309,7 @@ inotify_remove_watch_no_event(FAR struct inotify_watch_s *watch)
   list_delete(&watch->d_node);
   list_delete(&watch->l_node);
   inotify_sub_count(watch->mask);
-  kmm_free(watch);
+  fs_heap_free(watch);
 
   if (list_is_empty(&list->watches))
     {
@@ -347,7 +348,7 @@ static void inotify_remove_event(FAR struct inotify_device_s *dev,
   list_delete(&event->node);
   dev->event_size -= sizeof(struct inotify_event) + event->event.len;
   dev->event_count--;
-  kmm_free(event);
+  fs_heap_free(event);
 }
 
 /****************************************************************************
@@ -362,7 +363,7 @@ static FAR struct inotify_device_s *inotify_alloc_device(void)
 {
   FAR struct inotify_device_s *dev;
 
-  dev = kmm_zalloc(sizeof(struct inotify_device_s));
+  dev = fs_heap_zalloc(sizeof(struct inotify_device_s));
   if (dev == NULL)
     {
       return dev;
@@ -584,7 +585,7 @@ static int inotify_close(FAR struct file *filep)
   nxmutex_unlock(&g_inotify.lock);
   nxmutex_destroy(&dev->lock);
   nxsem_destroy(&dev->sem);
-  kmm_free(dev);
+  fs_heap_free(dev);
   return OK;
 }
 
@@ -653,7 +654,7 @@ inotify_alloc_watch(FAR struct inotify_device_s *dev,
 {
   FAR struct inotify_watch_s *watch;
 
-  watch = kmm_zalloc(sizeof(struct inotify_watch_s));
+  watch = fs_heap_zalloc(sizeof(struct inotify_watch_s));
   if (watch == NULL)
     {
       return NULL;
@@ -738,7 +739,7 @@ inotify_alloc_watch_list(FAR const char *path)
   FAR ENTRY *result;
   ENTRY item;
 
-  list = kmm_zalloc(sizeof(struct inotify_watch_list_s));
+  list = fs_heap_zalloc(sizeof(struct inotify_watch_list_s));
   if (list == NULL)
     {
       return NULL;
@@ -748,7 +749,7 @@ inotify_alloc_watch_list(FAR const char *path)
   list->path = strdup(path);
   if (list->path == NULL)
     {
-      kmm_free(list);
+      fs_heap_free(list);
       return NULL;
     }
 
@@ -757,7 +758,7 @@ inotify_alloc_watch_list(FAR const char *path)
   if (hsearch_r(item, ENTER, &result, &g_inotify.hash) == 0)
     {
       lib_free(list->path);
-      kmm_free(list);
+      fs_heap_free(list);
       return NULL;
     }
 
@@ -1019,10 +1020,10 @@ static inline void notify_queue_filep_event(FAR struct file *filep,
 
 static void notify_free_entry(FAR ENTRY *entry)
 {
-  /* Key is alloced by lib_malloc, value is alloced by kmm_malloc */
+  /* Key is alloced by lib_malloc, value is alloced by fs_heap_malloc */
 
   lib_free(entry->key);
-  kmm_free(entry->data);
+  fs_heap_free(entry->data);
 }
 
 /****************************************************************************
@@ -1262,7 +1263,7 @@ int inotify_init1(int flags)
 exit_with_dev:
   nxmutex_destroy(&dev->lock);
   nxsem_destroy(&dev->sem);
-  kmm_free(dev);
+  fs_heap_free(dev);
 exit_set_errno:
   set_errno(-ret);
   return ERROR;

--- a/fs/nxffs/nxffs.h
+++ b/fs/nxffs/nxffs.h
@@ -555,8 +555,8 @@ int nxffs_getc(FAR struct nxffs_volume_s *volume, uint16_t reserve);
  *   to dispose of that memory when the inode entry is no longer needed.
  *
  *   Note that the nxffs_entry_s containing structure is not freed.  The
- *   caller may call kmm_free upon return of this function if necessary to
- *   free the entry container.
+ *   caller may call fs_heap_free upon return of this function if necessary
+ *   to free the entry container.
  *
  * Input Parameters:
  *   entry  - The entry to be freed.

--- a/fs/nxffs/nxffs_dirent.c
+++ b/fs/nxffs/nxffs_dirent.c
@@ -35,6 +35,7 @@
 #include <nuttx/kmalloc.h>
 
 #include "nxffs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -74,7 +75,7 @@ int nxffs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
   /* Recover the file system state from the NuttX inode instance */
 
   volume = mountpt->i_private;
-  ndir = kmm_zalloc(sizeof(*ndir));
+  ndir = fs_heap_zalloc(sizeof(*ndir));
   if (ndir == NULL)
     {
       return -ENOMEM;
@@ -105,7 +106,7 @@ errout_with_lock:
   nxmutex_unlock(&volume->lock);
 
 errout_with_ndir:
-  kmm_free(ndir);
+  fs_heap_free(ndir);
   return ret;
 }
 
@@ -121,7 +122,7 @@ int nxffs_closedir(FAR struct inode *mountpt,
                    FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return 0;
 }
 

--- a/fs/nxffs/nxffs_dump.c
+++ b/fs/nxffs/nxffs_dump.c
@@ -34,6 +34,7 @@
 #include <nuttx/mtd/mtd.h>
 
 #include "nxffs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -443,7 +444,7 @@ int nxffs_dump(FAR struct mtd_dev_s *mtd, bool verbose)
 
   /* Allocate a buffer to hold one block */
 
-  blkinfo.buffer = kmm_malloc(blkinfo.geo.blocksize);
+  blkinfo.buffer = fs_heap_malloc(blkinfo.geo.blocksize);
   if (!blkinfo.buffer)
     {
       ferr("ERROR: Failed to allocate block cache\n");
@@ -470,7 +471,7 @@ int nxffs_dump(FAR struct mtd_dev_s *mtd, bool verbose)
           /* Read errors are fatal */
 
           ferr("ERROR: Failed to read block %d\n", blkinfo.block);
-          kmm_free(blkinfo.buffer);
+          fs_heap_free(blkinfo.buffer);
           return ret;
 #else
           /* A read error is probably fatal on all media but NAND.
@@ -493,7 +494,7 @@ int nxffs_dump(FAR struct mtd_dev_s *mtd, bool verbose)
 
   syslog(LOG_NOTICE, "%" PRIi32 " blocks analyzed\n", blkinfo.nblocks);
 
-  kmm_free(blkinfo.buffer);
+  fs_heap_free(blkinfo.buffer);
   return OK;
 
 #else

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -36,6 +36,7 @@
 #include <nuttx/fs/ioctl.h>
 
 #include "nxffs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Data
@@ -162,7 +163,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
 
   /* Allocate a NXFFS volume structure */
 
-  volume = kmm_zalloc(sizeof(struct nxffs_volume_s));
+  volume = fs_heap_zalloc(sizeof(struct nxffs_volume_s));
   if (!volume)
     {
       return -ENOMEM;
@@ -191,7 +192,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
 
   /* Allocate one I/O block buffer to general files system access */
 
-  volume->cache = kmm_malloc(volume->geo.blocksize);
+  volume->cache = fs_heap_malloc(volume->geo.blocksize);
   if (!volume->cache)
     {
       ferr("ERROR: Failed to allocate an erase block buffer\n");
@@ -204,7 +205,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
    * is not needed often, but is best to have pre-allocated and in-place.
    */
 
-  volume->pack = kmm_malloc(volume->geo.erasesize);
+  volume->pack = fs_heap_malloc(volume->geo.erasesize);
   if (!volume->pack)
     {
       ferr("ERROR: Failed to allocate an I/O block buffer\n");
@@ -302,14 +303,14 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
   ferr("ERROR: Failed to calculate file system limits: %d\n", -ret);
 
 errout_with_buffer:
-  kmm_free(volume->pack);
+  fs_heap_free(volume->pack);
 errout_with_cache:
-  kmm_free(volume->cache);
+  fs_heap_free(volume->cache);
 errout_with_volume:
   nxmutex_destroy(&volume->lock);
   nxsem_destroy(&volume->wrsem);
 #ifndef CONFIG_NXFFS_PREALLOCATED
-  kmm_free(volume);
+  fs_heap_free(volume);
 #endif
   return ret;
 }

--- a/fs/nxffs/nxffs_inode.c
+++ b/fs/nxffs/nxffs_inode.c
@@ -35,6 +35,7 @@
 #include <nuttx/mtd/mtd.h>
 
 #include "nxffs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions
@@ -108,7 +109,7 @@ static int nxffs_rdentry(FAR struct nxffs_volume_s *volume, off_t offset,
   /* Allocate memory to hold the variable-length file name */
 
   namlen = inode.namlen;
-  entry->name = kmm_malloc(namlen + 1);
+  entry->name = fs_heap_malloc(namlen + 1);
   if (!entry->name)
     {
       ferr("ERROR: Failed to allocate name, namlen: %d\n", namlen);
@@ -197,8 +198,8 @@ errout:
  *   to dispose of that memory when the inode entry is no longer needed.
  *
  *   Note that the nxffs_entry_s containing structure is not freed.  The
- *   caller may call kmm_free upon return of this function if necessary to
- *   free the entry container.
+ *   caller may call fs_heap_free upon return of this function if necessary
+ *   to free the entry container.
  *
  * Input Parameters:
  *   entry  - The entry to be freed.

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -38,6 +38,7 @@
 #include <nuttx/mtd/mtd.h>
 
 #include "nxffs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Data
@@ -490,7 +491,7 @@ static inline int nxffs_wropen(FAR struct nxffs_volume_s *volume,
   memset(wrfile, 0, sizeof(struct nxffs_wrfile_s));
 #else
   wrfile = (FAR struct nxffs_wrfile_s *)
-           kmm_zalloc(sizeof(struct nxffs_wrfile_s));
+           fs_heap_zalloc(sizeof(struct nxffs_wrfile_s));
   if (!wrfile)
     {
       ret = -ENOMEM;
@@ -657,7 +658,7 @@ errout_with_name:
   lib_free(wrfile->ofile.entry.name);
 errout_with_ofile:
 #ifndef CONFIG_NXFFS_PREALLOCATED
-  kmm_free(wrfile);
+  fs_heap_free(wrfile);
 #endif
 
 errout_with_lock:
@@ -726,7 +727,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
       /* Not already open.. create a new open structure */
 
       ofile = (FAR struct nxffs_ofile_s *)
-              kmm_zalloc(sizeof(struct nxffs_ofile_s));
+              fs_heap_zalloc(sizeof(struct nxffs_ofile_s));
       if (!ofile)
         {
           ferr("ERROR: ofile allocation failed\n");
@@ -761,7 +762,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
   return OK;
 
 errout_with_ofile:
-  kmm_free(ofile);
+  fs_heap_free(ofile);
 errout_with_lock:
   nxmutex_unlock(&volume->lock);
 errout:
@@ -832,7 +833,7 @@ static inline void nxffs_freeofile(FAR struct nxffs_volume_s *volume,
   if ((FAR struct nxffs_wrfile_s *)ofile != &g_wrfile)
 #endif
     {
-      kmm_free(ofile);
+      fs_heap_free(ofile);
     }
 }
 

--- a/fs/partition/fs_gpt.c
+++ b/fs/partition/fs_gpt.c
@@ -32,6 +32,7 @@
 #include <nuttx/kmalloc.h>
 
 #include "partition.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -205,7 +206,7 @@ gpt_alloc_verify_entries(FAR struct partition_state_s *state,
     }
 
   blk = (size + (state->blocksize - 1)) / state->blocksize;
-  pte = kmm_zalloc(blk * state->blocksize);
+  pte = fs_heap_zalloc(blk * state->blocksize);
   if (!pte)
     {
       return NULL;
@@ -216,7 +217,7 @@ gpt_alloc_verify_entries(FAR struct partition_state_s *state,
   ret = read_partition_block(state, pte, from, blk);
   if (ret < 0)
     {
-      kmm_free(pte);
+      fs_heap_free(pte);
       ferr("Read ptr from block failed:%d.\n", ret);
       return NULL;
     }
@@ -227,7 +228,7 @@ gpt_alloc_verify_entries(FAR struct partition_state_s *state,
   if (crc != le32toh(gpt->partition_entry_array_crc32))
     {
       ferr("GUID Partitition Entry Array CRC check failed.\n");
-      kmm_free(pte);
+      fs_heap_free(pte);
       return NULL;
     }
 
@@ -399,7 +400,7 @@ int parse_gpt_partition(FAR struct partition_state_s *state,
 
   count = (sizeof(struct gpt_ptable_s) + (state->blocksize - 1)) /
           state->blocksize;
-  ptbl = kmm_malloc(count * state->blocksize);
+  ptbl = fs_heap_malloc(count * state->blocksize);
   if (!ptbl)
     {
       return -ENOMEM;
@@ -485,8 +486,8 @@ int parse_gpt_partition(FAR struct partition_state_s *state,
       handler(&pentry, arg);
     }
 
-  kmm_free(ptes);
+  fs_heap_free(ptes);
 err:
-  kmm_free(ptbl);
+  fs_heap_free(ptbl);
   return ret;
 }

--- a/fs/partition/fs_mbr.c
+++ b/fs/partition/fs_mbr.c
@@ -30,6 +30,7 @@
 #include <nuttx/kmalloc.h>
 
 #include "partition.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -109,7 +110,7 @@ int parse_mbr_partition(FAR struct partition_state_s *state,
   int i;
 
   num = (MBR_SIZE + state->blocksize - 1) / state->blocksize;
-  buffer = kmm_malloc(num * state->blocksize);
+  buffer = fs_heap_malloc(num * state->blocksize);
   if (!buffer)
     {
       return -ENOMEM;
@@ -118,13 +119,13 @@ int parse_mbr_partition(FAR struct partition_state_s *state,
   ret = read_partition_block(state, buffer, 0, num);
   if (ret < 0)
     {
-      kmm_free(buffer);
+      fs_heap_free(buffer);
       return ret;
     }
 
   if (buffer[0x1fe] != 0x55 || buffer[0x1ff] != 0xaa)
     {
-      kmm_free(buffer);
+      fs_heap_free(buffer);
       return -EINVAL;
     }
 
@@ -211,6 +212,6 @@ int parse_mbr_partition(FAR struct partition_state_s *state,
     }
 
 out:
-  kmm_free(buffer);
+  fs_heap_free(buffer);
   return ret;
 }

--- a/fs/partition/fs_ptable.c
+++ b/fs/partition/fs_ptable.c
@@ -27,6 +27,7 @@
 #include <nuttx/kmalloc.h>
 
 #include "partition.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -91,7 +92,7 @@ int parse_ptable_partition(FAR struct partition_state_s *state,
 
   /* Allocate one erase block memory */
 
-  ptable = kmm_malloc(state->erasesize);
+  ptable = fs_heap_malloc(state->erasesize);
   if (ptable == NULL)
     {
       return -ENOMEM;
@@ -149,6 +150,6 @@ int parse_ptable_partition(FAR struct partition_state_s *state,
     }
 
 out:
-  kmm_free(ptable);
+  fs_heap_free(ptable);
   return ret;
 }

--- a/fs/partition/fs_txtable.c
+++ b/fs/partition/fs_txtable.c
@@ -30,6 +30,7 @@
 #include <nuttx/kmalloc.h>
 
 #include "partition.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -77,7 +78,7 @@ int parse_txtable_partition(FAR struct partition_state_s *state,
 
   /* Allocate memory for table of parsed and raw */
 
-  part = kmm_malloc(CONFIG_TXTABLE_PARTITION_MAX_NUM *
+  part = fs_heap_malloc(CONFIG_TXTABLE_PARTITION_MAX_NUM *
                     sizeof(struct partition_s) +
                     TXTABLE_LENGTH);
   if (part == NULL)
@@ -217,6 +218,6 @@ int parse_txtable_partition(FAR struct partition_state_s *state,
   handler(&part[j], arg);
 
 out:
-  kmm_free(part);
+  fs_heap_free(part);
   return ret;
 }

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -48,6 +48,7 @@
 
 #include "mount/mount.h"
 #include "sched/sched.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * External Definitions
@@ -468,7 +469,7 @@ static int procfs_close(FAR struct file *filep)
     }
   else
     {
-      kmm_free(attr);
+      fs_heap_free(attr);
     }
 
   filep->f_priv = NULL;
@@ -656,7 +657,7 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 #endif
 
       level0 = (FAR struct procfs_level0_s *)
-         kmm_zalloc(sizeof(struct procfs_level0_s) + sizeof(pid_t) * num) ;
+      fs_heap_zalloc(sizeof(struct procfs_level0_s) + sizeof(pid_t) * num);
       if (!level0)
         {
           ferr("ERROR: Failed to allocate the level0 directory structure\n");
@@ -742,7 +743,7 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
                */
 
               level1 = (FAR struct procfs_level1_s *)
-                 kmm_zalloc(sizeof(struct procfs_level1_s));
+                 fs_heap_zalloc(sizeof(struct procfs_level1_s));
               if (!level1)
                 {
                   ferr("ERROR: Failed to allocate the level0 directory "
@@ -783,7 +784,7 @@ static int procfs_closedir(FAR struct inode *mountpt,
                            FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(mountpt && dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 
@@ -1180,7 +1181,7 @@ int procfs_initialize(void)
       /* No.. allocate a modifiable list of entries */
 
       g_procfs_entries = (FAR struct procfs_entry_s *)
-        kmm_malloc(sizeof(g_base_entries));
+        fs_heap_malloc(sizeof(g_base_entries));
       if (g_procfs_entries == NULL)
         {
           return -ENOMEM;
@@ -1246,7 +1247,7 @@ int procfs_register(FAR const struct procfs_entry_s *entry)
   newsize  = newcount * sizeof(struct procfs_entry_s);
 
   newtable = (FAR struct procfs_entry_s *)
-    kmm_realloc(g_procfs_entries, newsize);
+    fs_heap_realloc(g_procfs_entries, newsize);
   if (newtable != NULL)
     {
       /* Copy the new entry at the end of the reallocated table */

--- a/fs/procfs/fs_procfscpuinfo.c
+++ b/fs/procfs/fs_procfscpuinfo.c
@@ -36,6 +36,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if defined(CONFIG_ARCH_HAVE_CPUINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_CPUINFO)
 
 /****************************************************************************
@@ -105,7 +107,7 @@ static int cpuinfo_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  procfile = kmm_zalloc(sizeof(struct cpuinfo_file_s));
+  procfile = fs_heap_zalloc(sizeof(struct cpuinfo_file_s));
   if (procfile == NULL)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -133,7 +135,7 @@ static int cpuinfo_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(procfile);
+  fs_heap_free(procfile);
   filep->f_priv = NULL;
   return OK;
 }
@@ -188,7 +190,7 @@ static int cpuinfo_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = kmm_malloc(sizeof(struct cpuinfo_file_s));
+  newattr = fs_heap_malloc(sizeof(struct cpuinfo_file_s));
   if (newattr == NULL)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -44,6 +44,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #if !defined(CONFIG_SCHED_CPULOAD_NONE) && \
     !defined(CONFIG_FS_PROCFS_EXCLUDE_CPULOAD)
@@ -142,7 +144,7 @@ static int cpuload_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = kmm_zalloc(sizeof(struct cpuload_file_s));
+  attr = fs_heap_zalloc(sizeof(struct cpuload_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -170,7 +172,7 @@ static int cpuload_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -300,7 +302,7 @@ static int cpuload_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = kmm_malloc(sizeof(struct cpuload_file_s));
+  newattr = fs_heap_malloc(sizeof(struct cpuload_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -43,6 +43,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
      defined(CONFIG_SCHED_CRITMONITOR)
 
@@ -140,7 +142,7 @@ static int critmon_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = kmm_zalloc(sizeof(struct critmon_file_s));
+  attr = fs_heap_zalloc(sizeof(struct critmon_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -168,7 +170,7 @@ static int critmon_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -348,7 +350,7 @@ static int critmon_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = kmm_malloc(sizeof(struct critmon_file_s));
+  newattr = fs_heap_malloc(sizeof(struct critmon_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfsfdt.c
+++ b/fs/procfs/fs_procfsfdt.c
@@ -42,6 +42,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if defined(CONFIG_DEVICE_TREE) && !defined(CONFIG_FS_PROCFS_EXCLUDE_FDT)
 
 /****************************************************************************
@@ -123,7 +125,7 @@ static int fdt_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = kmm_zalloc(sizeof(struct fdt_file_s));
+  attr = fs_heap_zalloc(sizeof(struct fdt_file_s));
   if (attr == NULL)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -151,7 +153,7 @@ static int fdt_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -219,7 +221,7 @@ static int fdt_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = kmm_malloc(sizeof(struct fdt_file_s));
+  newattr = fs_heap_malloc(sizeof(struct fdt_file_s));
   if (newattr == NULL)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -42,6 +42,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
     defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
 
@@ -137,7 +139,7 @@ static int iobinfo_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the file attributes */
 
   procfile = (FAR struct iobinfo_file_s *)
-    kmm_zalloc(sizeof(struct iobinfo_file_s));
+    fs_heap_zalloc(sizeof(struct iobinfo_file_s));
   if (!procfile)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -165,7 +167,7 @@ static int iobinfo_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(procfile);
+  fs_heap_free(procfile);
   filep->f_priv = NULL;
   return OK;
 }
@@ -248,7 +250,7 @@ static int iobinfo_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container to hold the task and attribute selection */
 
   newattr = (FAR struct iobinfo_file_s *)
-    kmm_malloc(sizeof(struct iobinfo_file_s));
+    fs_heap_malloc(sizeof(struct iobinfo_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -46,6 +46,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
 
 /****************************************************************************
@@ -234,7 +236,7 @@ static int meminfo_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  procfile = kmm_zalloc(sizeof(struct meminfo_file_s));
+  procfile = fs_heap_zalloc(sizeof(struct meminfo_file_s));
   if (!procfile)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -262,7 +264,7 @@ static int meminfo_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(procfile);
+  fs_heap_free(procfile);
   filep->f_priv = NULL;
   return OK;
 }
@@ -617,7 +619,7 @@ static int meminfo_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container to hold the task and attribute selection */
 
   newattr = (FAR struct meminfo_file_s *)
-    kmm_malloc(sizeof(struct meminfo_file_s));
+    fs_heap_malloc(sizeof(struct meminfo_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfspressure.c
+++ b/fs/procfs/fs_procfspressure.c
@@ -36,6 +36,8 @@
 #include <nuttx/queue.h>
 #include <nuttx/spinlock.h>
 
+#include "fs_heap.h"
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -121,7 +123,7 @@ static int pressure_open(FAR struct file *filep, FAR const char *relpath,
       return -ENOENT;
     }
 
-  priv = kmm_zalloc(sizeof(struct pressure_file_s));
+  priv = fs_heap_zalloc(sizeof(struct pressure_file_s));
   if (!priv)
     {
       return -ENOMEM;
@@ -147,7 +149,7 @@ static int pressure_close(FAR struct file *filep)
   flags = spin_lock_irqsave(&g_pressure_lock);
   dq_rem(&priv->entry, &g_pressure_memory_queue);
   spin_unlock_irqrestore(&g_pressure_lock, flags);
-  free(priv);
+  fs_heap_free(priv);
   return OK;
 }
 
@@ -292,7 +294,7 @@ static int pressure_dup(FAR const struct file *oldp, FAR struct file *newp)
   FAR struct pressure_file_s *newpriv;
   uint32_t flags;
 
-  newpriv = kmm_zalloc(sizeof(struct pressure_file_s));
+  newpriv = fs_heap_zalloc(sizeof(struct pressure_file_s));
   if (newpriv == NULL)
     {
       return -ENOMEM;
@@ -319,7 +321,7 @@ static int pressure_opendir(FAR const char *relpath,
   finfo("relpath: \"%s\"\n", relpath ? relpath : "NULL");
   DEBUGASSERT(relpath);
 
-  level = kmm_zalloc(sizeof(struct procfs_dir_priv_s));
+  level = fs_heap_zalloc(sizeof(struct procfs_dir_priv_s));
   if (level == NULL)
     {
       return -ENOMEM;
@@ -339,7 +341,7 @@ static int pressure_opendir(FAR const char *relpath,
 static int pressure_closedir(FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -57,6 +57,8 @@
 #include <nuttx/mm/mm.h>
 #include <nuttx/queue.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_SCHED_CPULOAD_NONE) || defined(CONFIG_SCHED_CRITMONITOR)
 #  include <nuttx/clock.h>
 #endif
@@ -904,7 +906,7 @@ static ssize_t proc_heap(FAR struct proc_file_s *procfile,
 #ifdef CONFIG_MM_KERNEL_HEAP
   if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
-      info = kmm_mallinfo_task(&task);
+      info = fs_heap_mallinfo_task(&task);
     }
   else
 #endif
@@ -1530,7 +1532,7 @@ static int proc_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the task and node selection */
 
   procfile = (FAR struct proc_file_s *)
-    kmm_zalloc(sizeof(struct proc_file_s));
+    fs_heap_zalloc(sizeof(struct proc_file_s));
   if (procfile == NULL)
     {
       ferr("ERROR: Failed to allocate file container\n");
@@ -1563,7 +1565,7 @@ static int proc_close(FAR struct file *filep)
 
   /* Release the file container structure */
 
-  kmm_free(procfile);
+  fs_heap_free(procfile);
   filep->f_priv = NULL;
   return OK;
 }
@@ -1726,7 +1728,7 @@ static int proc_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and node selection */
 
-  newfile = kmm_malloc(sizeof(struct proc_file_s));
+  newfile = fs_heap_malloc(sizeof(struct proc_file_s));
   if (newfile == NULL)
     {
       ferr("ERROR: Failed to allocate file container\n");
@@ -1815,11 +1817,11 @@ static int proc_opendir(FAR const char *relpath,
     }
 
   /* Allocate the directory structure.  Note that the index and procentry
-   * pointer are implicitly nullified by kmm_zalloc().  Only the remaining,
-   * non-zero entries will need be initialized.
+   * pointer are implicitly nullified by fs_heap_zalloc().
+   * Only the remaining, non-zero entries will need be initialized.
    */
 
-  procdir = kmm_zalloc(sizeof(struct proc_dir_s));
+  procdir = fs_heap_zalloc(sizeof(struct proc_dir_s));
   if (procdir == NULL)
     {
       ferr("ERROR: Failed to allocate the directory structure\n");
@@ -1839,7 +1841,7 @@ static int proc_opendir(FAR const char *relpath,
       if (node == NULL)
         {
           ferr("ERROR: Invalid path \"%s\"\n", relpath);
-          kmm_free(procdir);
+          fs_heap_free(procdir);
           return -ENOENT;
         }
 
@@ -1848,7 +1850,7 @@ static int proc_opendir(FAR const char *relpath,
       if (!DIRENT_ISDIRECTORY(node->dtype))
         {
           ferr("ERROR: Path \"%s\" is not a directory\n", relpath);
-          kmm_free(procdir);
+          fs_heap_free(procdir);
           return -ENOTDIR;
         }
 
@@ -1882,7 +1884,7 @@ static int proc_opendir(FAR const char *relpath,
 static int proc_closedir(FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir != NULL);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -40,6 +40,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
     defined(CONFIG_ARCH_HAVE_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)
 
@@ -140,7 +142,7 @@ static int tcbinfo_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the file attributes */
 
   attr = (FAR struct tcbinfo_file_s *)
-    kmm_zalloc(sizeof(struct tcbinfo_file_s));
+    fs_heap_zalloc(sizeof(struct tcbinfo_file_s));
 
   if (attr == NULL)
     {
@@ -169,7 +171,7 @@ static int tcbinfo_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -240,7 +242,7 @@ static int tcbinfo_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container to hold the task and attribute selection */
 
   newattr = (FAR struct tcbinfo_file_s *)
-    kmm_malloc(sizeof(struct tcbinfo_file_s));
+    fs_heap_malloc(sizeof(struct tcbinfo_file_s));
 
   if (!newattr)
     {

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -43,6 +43,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_UPTIME
 
@@ -142,7 +144,7 @@ static int uptime_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = kmm_zalloc(sizeof(struct uptime_file_s));
+  attr = fs_heap_zalloc(sizeof(struct uptime_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -170,7 +172,7 @@ static int uptime_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -297,7 +299,7 @@ static int uptime_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = kmm_malloc(sizeof(struct uptime_file_s));
+  newattr = fs_heap_malloc(sizeof(struct uptime_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -43,6 +43,8 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
 
+#include "fs_heap.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
 
@@ -143,7 +145,7 @@ static int version_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the file attributes */
 
   attr = (FAR struct version_file_s *)
-    kmm_zalloc(sizeof(struct version_file_s));
+    fs_heap_zalloc(sizeof(struct version_file_s));
 
   if (attr == NULL)
     {
@@ -172,7 +174,7 @@ static int version_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(attr);
+  fs_heap_free(attr);
   filep->f_priv = NULL;
   return OK;
 }
@@ -246,7 +248,7 @@ static int version_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container to hold the task and attribute selection */
 
   newattr = (FAR struct version_file_s *)
-    kmm_malloc(sizeof(struct version_file_s));
+    fs_heap_malloc(sizeof(struct version_file_s));
 
   if (!newattr)
     {

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -44,6 +44,7 @@
 #include <nuttx/fs/procfs.h>
 
 #include <arch/irq.h>
+#include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
 
@@ -174,7 +175,7 @@ static int skel_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate the open file structure */
 
-  priv = kmm_zalloc(sizeof(struct skel_file_s));
+  priv = fs_heap_zalloc(sizeof(struct skel_file_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -206,7 +207,7 @@ static int skel_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(priv);
+  fs_heap_free(priv);
   filep->f_priv = NULL;
   return OK;
 }
@@ -313,7 +314,7 @@ static int skel_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newpriv = kmm_zalloc(sizeof(struct skel_file_s));
+  newpriv = fs_heap_zalloc(sizeof(struct skel_file_s));
   if (!newpriv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -351,7 +352,7 @@ static int skel_opendir(FAR const char *relpath,
    */
 
   level1 = (FAR struct skel_level1_s *)
-     kmm_zalloc(sizeof(struct skel_level1_s));
+     fs_heap_zalloc(sizeof(struct skel_level1_s));
 
   if (!level1)
     {
@@ -381,7 +382,7 @@ static int skel_opendir(FAR const char *relpath,
 static int skel_closedir(FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -39,6 +39,7 @@
 #include <nuttx/fs/ioctl.h>
 
 #include "fs_romfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -418,7 +419,7 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
   int ret;
 
   nsize = strlen(name);
-  nodeinfo = kmm_zalloc(sizeof(struct romfs_nodeinfo_s) + nsize);
+  nodeinfo = fs_heap_zalloc(sizeof(struct romfs_nodeinfo_s) + nsize);
   if (nodeinfo == NULL)
     {
       return -ENOMEM;
@@ -461,8 +462,8 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
             {
               FAR void *tmp;
 
-              tmp = kmm_realloc(nodeinfo->rn_child, (num + NODEINFO_NINCR) *
-                                sizeof(*nodeinfo->rn_child));
+              tmp = fs_heap_realloc(nodeinfo->rn_child,
+                    (num + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
               if (tmp == NULL)
                 {
                   return -ENOMEM;
@@ -680,7 +681,7 @@ int romfs_hwconfigure(FAR struct romfs_mountpt_s *rm)
 
   /* Allocate the device cache buffer for normal sector accesses */
 
-  rm->rm_buffer = kmm_malloc(rm->rm_hwsectorsize);
+  rm->rm_buffer = fs_heap_malloc(rm->rm_hwsectorsize);
   if (!rm->rm_buffer)
     {
       return -ENOMEM;
@@ -791,7 +792,8 @@ int romfs_fileconfigure(FAR struct romfs_mountpt_s *rm,
 
       /* Create a file buffer to support partial sector accesses */
 
-      rf->rf_buffer = kmm_malloc(rm->rm_hwsectorsize * rf->rf_ncachesector);
+      rf->rf_buffer = fs_heap_malloc(rm->rm_hwsectorsize *
+                      rf->rf_ncachesector);
       if (!rf->rf_buffer)
         {
           return -ENOMEM;
@@ -865,10 +867,10 @@ void romfs_freenode(FAR struct romfs_nodeinfo_s *nodeinfo)
           romfs_freenode(nodeinfo->rn_child[i]);
         }
 
-      kmm_free(nodeinfo->rn_child);
+      fs_heap_free(nodeinfo->rn_child);
     }
 
-  kmm_free(nodeinfo);
+  fs_heap_free(nodeinfo);
 }
 #endif
 

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -35,6 +35,7 @@
 #include <nuttx/semaphore.h>
 
 #include "rpmsgfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -730,7 +731,7 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
       return -EINVAL;
     }
 
-  priv = kmm_zalloc(sizeof(struct rpmsgfs_s));
+  priv = fs_heap_zalloc(sizeof(struct rpmsgfs_s));
   if (!priv)
     {
       return -ENOMEM;
@@ -744,7 +745,7 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
                                 NULL);
   if (ret < 0)
     {
-      kmm_free(priv);
+      fs_heap_free(priv);
       return ret;
     }
 
@@ -765,7 +766,7 @@ int rpmsgfs_client_unbind(FAR void *handle)
                             NULL);
 
   nxsem_destroy(&priv->wait);
-  kmm_free(priv);
+  fs_heap_free(priv);
   return 0;
 }
 

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -37,6 +37,7 @@
 #include <nuttx/rptun/openamp.h>
 
 #include "rpmsgfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -191,7 +192,7 @@ static int rpmsgfs_attach_file(FAR struct rpmsgfs_server_s *priv,
         }
     }
 
-  tmp = kmm_realloc(priv->files, sizeof(FAR struct file *) * (i + 1));
+  tmp = fs_heap_realloc(priv->files, sizeof(FAR struct file *) * (i + 1));
   DEBUGASSERT(tmp);
   if (tmp == NULL)
     {
@@ -199,12 +200,12 @@ static int rpmsgfs_attach_file(FAR struct rpmsgfs_server_s *priv,
       goto out;
     }
 
-  tmp[i] = kmm_zalloc(sizeof(struct file) *
+  tmp[i] = fs_heap_zalloc(sizeof(struct file) *
                       CONFIG_NFILE_DESCRIPTORS_PER_BLOCK);
   DEBUGASSERT(tmp[i]);
   if (tmp[i] == NULL)
     {
-      kmm_free(tmp);
+      fs_heap_free(tmp);
       ret = -ENFILE;
       goto out;
     }
@@ -276,7 +277,7 @@ static int rpmsgfs_attach_dir(FAR struct rpmsgfs_server_s *priv,
         }
     }
 
-  tmp = kmm_realloc(priv->dirs, sizeof(FAR void *) *
+  tmp = fs_heap_realloc(priv->dirs, sizeof(FAR void *) *
                     (priv->dir_nums + CONFIG_NFILE_DESCRIPTORS_PER_BLOCK));
   DEBUGASSERT(tmp);
   if (tmp == NULL)
@@ -905,7 +906,7 @@ static void rpmsgfs_ns_bind(FAR struct rpmsg_device *rdev,
   FAR struct rpmsgfs_server_s *priv;
   int ret;
 
-  priv = kmm_zalloc(sizeof(*priv));
+  priv = fs_heap_zalloc(sizeof(*priv));
   if (!priv)
     {
       return;
@@ -920,7 +921,7 @@ static void rpmsgfs_ns_bind(FAR struct rpmsg_device *rdev,
   if (ret)
     {
       nxmutex_destroy(&priv->lock);
-      kmm_free(priv);
+      fs_heap_free(priv);
     }
 }
 
@@ -940,7 +941,7 @@ static void rpmsgfs_ns_unbind(FAR struct rpmsg_endpoint *ept)
             }
         }
 
-      kmm_free(priv->files[i]);
+      fs_heap_free(priv->files[i]);
     }
 
   for (i = 0; i < priv->dir_nums; i++)
@@ -954,9 +955,9 @@ static void rpmsgfs_ns_unbind(FAR struct rpmsg_endpoint *ept)
   rpmsg_destroy_ept(&priv->ept);
   nxmutex_destroy(&priv->lock);
 
-  kmm_free(priv->files);
-  kmm_free(priv->dirs);
-  kmm_free(priv);
+  fs_heap_free(priv->files);
+  fs_heap_free(priv->dirs);
+  fs_heap_free(priv);
 }
 
 static int rpmsgfs_ept_cb(FAR struct rpmsg_endpoint *ept,

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -67,7 +67,7 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
    * memory in user heap
    */
 
-  object = kmm_zalloc(sizeof(struct shmfs_object_s));
+  object = fs_heap_zalloc(sizeof(struct shmfs_object_s));
   if (object)
     {
       object->paddr = kumm_zalloc(length);
@@ -87,7 +87,7 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
   FAR void **pages;
   size_t n_pages = MM_NPAGES(length);
 
-  object = kmm_zalloc(sizeof(struct shmfs_object_s) +
+  object = fs_heap_zalloc(sizeof(struct shmfs_object_s) +
                       (n_pages - 1) * sizeof(object->paddr));
 
   if (object)

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -47,6 +47,7 @@
 
 #include <arch/irq.h>
 #include "smartfs.h"
+#include "fs_heap.h"
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
 
@@ -357,7 +358,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the task and attribute selection */
 
-  priv = kmm_malloc(sizeof(struct smartfs_file_s));
+  priv = fs_heap_malloc(sizeof(struct smartfs_file_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -371,7 +372,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       /* Entry not found */
 
-      kmm_free(priv);
+      fs_heap_free(priv);
       return ret;
     }
 
@@ -398,7 +399,7 @@ static int smartfs_close(FAR struct file *filep)
 
   /* Release the file attributes structure */
 
-  kmm_free(priv);
+  fs_heap_free(priv);
   filep->f_priv = NULL;
   return OK;
 }
@@ -509,7 +510,7 @@ static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newpriv = kmm_malloc(sizeof(struct smartfs_file_s));
+  newpriv = fs_heap_malloc(sizeof(struct smartfs_file_s));
   if (!newpriv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -548,7 +549,7 @@ static int smartfs_opendir(FAR const char *relpath,
    */
 
   level1 = (FAR struct smartfs_level1_s *)
-     kmm_malloc(sizeof(struct smartfs_level1_s));
+     fs_heap_malloc(sizeof(struct smartfs_level1_s));
 
   if (!level1)
     {
@@ -566,7 +567,7 @@ static int smartfs_opendir(FAR const char *relpath,
     }
   else
     {
-      kmm_free(level1);
+      fs_heap_free(level1);
     }
 
   return ret;
@@ -582,7 +583,7 @@ static int smartfs_opendir(FAR const char *relpath,
 static int smartfs_closedir(FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -46,6 +46,7 @@
 
 #include "inode/inode.h"
 #include "smartfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -213,7 +214,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
   /* Locate the directory entry for this path */
 
   pathlen = strlen(relpath) + 1;
-  sf = kmm_malloc(sizeof(*sf) + pathlen - 1);
+  sf = fs_heap_malloc(sizeof(*sf) + pathlen - 1);
   if (sf == NULL)
     {
       ret = -ENOMEM;
@@ -229,12 +230,12 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a sector buffer if CRC enabled in the MTD layer */
 
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  sf->buffer = kmm_malloc(fs->fs_llformat.availbytes);
+  sf->buffer = fs_heap_malloc(fs->fs_llformat.availbytes);
   if (sf->buffer == NULL)
     {
       /* Error ... no memory */
 
-      kmm_free(sf);
+      fs_heap_free(sf);
       ret = -ENOMEM;
       goto errout_with_lock;
     }
@@ -395,14 +396,14 @@ errout_with_buffer:
     {
       /* Free the space for the name too */
 
-      kmm_free(sf->entry.name);
+      fs_heap_free(sf->entry.name);
       sf->entry.name = NULL;
     }
 
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  kmm_free(sf->buffer);
+  fs_heap_free(sf->buffer);
 #endif /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
-  kmm_free(sf);
+  fs_heap_free(sf);
 
 errout_with_lock:
   nxmutex_unlock(&g_lock);
@@ -500,18 +501,18 @@ static int smartfs_close(FAR struct file *filep)
     {
       /* Free the space for the name too */
 
-      kmm_free(sf->entry.name);
+      fs_heap_free(sf->entry.name);
       sf->entry.name = NULL;
     }
 
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
   if (sf->buffer)
     {
-      kmm_free(sf->buffer);
+      fs_heap_free(sf->buffer);
     }
 #endif
 
-  kmm_free(sf);
+  fs_heap_free(sf);
 
 okout:
   nxmutex_unlock(&g_lock);
@@ -1260,7 +1261,7 @@ static int smartfs_opendir(FAR struct inode *mountpt,
   /* Recover our private data from the inode instance */
 
   fs = mountpt->i_private;
-  sdir = kmm_zalloc(sizeof(*sdir));
+  sdir = fs_heap_zalloc(sizeof(*sdir));
   if (sdir == NULL)
     {
       return -ENOMEM;
@@ -1300,14 +1301,14 @@ errout_with_lock:
 
   if (entry.name != NULL)
     {
-      kmm_free(entry.name);
+      fs_heap_free(entry.name);
       entry.name = NULL;
     }
 
   nxmutex_unlock(&g_lock);
 
 errout_with_sdir:
-  kmm_free(sdir);
+  fs_heap_free(sdir);
   return ret;
 }
 
@@ -1322,7 +1323,7 @@ static int smartfs_closedir(FAR struct inode *mountpt,
                             FAR struct fs_dirent_s *dir)
 {
   DEBUGASSERT(dir);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return 0;
 }
 
@@ -1533,7 +1534,7 @@ static int smartfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Create an instance of the mountpt state structure */
 
   fs = (FAR struct smartfs_mountpt_s *)
-    kmm_zalloc(sizeof(struct smartfs_mountpt_s));
+    fs_heap_zalloc(sizeof(struct smartfs_mountpt_s));
   if (!fs)
     {
       return -ENOMEM;
@@ -1542,7 +1543,7 @@ static int smartfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   ret = nxmutex_lock(&g_lock);
   if (ret < 0)
     {
-      kmm_free(fs);
+      fs_heap_free(fs);
       return ret;
     }
 
@@ -1560,7 +1561,7 @@ static int smartfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   if (ret != 0)
     {
       nxmutex_unlock(&g_lock);
-      kmm_free(fs);
+      fs_heap_free(fs);
       return ret;
     }
 
@@ -1618,7 +1619,7 @@ static int smartfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
     }
 
   nxmutex_unlock(&g_lock);
-  kmm_free(fs);
+  fs_heap_free(fs);
   return ret;
 }
 
@@ -1738,7 +1739,7 @@ static int smartfs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 errout_with_lock:
   if (entry.name != NULL)
     {
-      kmm_free(entry.name);
+      fs_heap_free(entry.name);
     }
 
   nxmutex_unlock(&g_lock);
@@ -1825,7 +1826,7 @@ errout_with_lock:
     {
       /* Free the filename space allocation */
 
-      kmm_free(entry.name);
+      fs_heap_free(entry.name);
       entry.name = NULL;
     }
 
@@ -1920,7 +1921,7 @@ int smartfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 errout_with_lock:
   if (entry.name != NULL)
     {
-      kmm_free(entry.name);
+      fs_heap_free(entry.name);
     }
 
   nxmutex_unlock(&g_lock);
@@ -2066,13 +2067,13 @@ int smartfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 errout_with_lock:
   if (oldentry.name != NULL)
     {
-      kmm_free(oldentry.name);
+      fs_heap_free(oldentry.name);
       oldentry.name = NULL;
     }
 
   if (newentry.name != NULL)
     {
-      kmm_free(newentry.name);
+      fs_heap_free(newentry.name);
       newentry.name = NULL;
     }
 
@@ -2175,7 +2176,7 @@ static int smartfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 errout_with_lock:
   if (entry.name != NULL)
     {
-      kmm_free(entry.name);
+      fs_heap_free(entry.name);
       entry.name = NULL;
     }
 

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -39,6 +39,7 @@
 #include <nuttx/fs/ioctl.h>
 
 #include "smartfs.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -242,8 +243,8 @@ int smartfs_mount(FAR struct smartfs_mountpt_s *fs, bool writeable)
 
   if (nextfs == NULL)
     {
-      fs->fs_rwbuffer = kmm_malloc(fs->fs_llformat.availbytes);
-      fs->fs_workbuffer = kmm_malloc(WORKBUFFER_SIZE);
+      fs->fs_rwbuffer = fs_heap_malloc(fs->fs_llformat.availbytes);
+      fs->fs_workbuffer = fs_heap_malloc(WORKBUFFER_SIZE);
     }
 
   /* Now add ourselves to the linked list of SMART mounts */
@@ -266,8 +267,8 @@ int smartfs_mount(FAR struct smartfs_mountpt_s *fs, bool writeable)
   g_mounthead = fs;
 #endif
 
-  fs->fs_rwbuffer = kmm_malloc(fs->fs_llformat.availbytes);
-  fs->fs_workbuffer = kmm_malloc(WORKBUFFER_SIZE);
+  fs->fs_rwbuffer = fs_heap_malloc(fs->fs_llformat.availbytes);
+  fs->fs_workbuffer = fs_heap_malloc(WORKBUFFER_SIZE);
   fs->fs_rootsector = SMARTFS_ROOT_DIR_SECTOR;
 
 #endif /* CONFIG_SMARTFS_MULTI_ROOT_DIRS */
@@ -382,8 +383,8 @@ int smartfs_unmount(FAR struct smartfs_mountpt_s *fs)
 
       /* Free the buffers */
 
-      kmm_free(fs->fs_rwbuffer);
-      kmm_free(fs->fs_workbuffer);
+      fs_heap_free(fs->fs_rwbuffer);
+      fs_heap_free(fs->fs_workbuffer);
 
       /* Set the buffer's to invalid value to catch program bugs */
 
@@ -420,8 +421,8 @@ int smartfs_unmount(FAR struct smartfs_mountpt_s *fs)
 
   /* Release the mountpoint private data */
 
-  kmm_free(fs->fs_rwbuffer);
-  kmm_free(fs->fs_workbuffer);
+  fs_heap_free(fs->fs_rwbuffer);
+  fs_heap_free(fs->fs_workbuffer);
 #endif
 
   return ret;
@@ -649,7 +650,7 @@ int smartfs_finddirentry(FAR struct smartfs_mountpt_s *fs,
                           if (direntry->name == NULL)
                             {
                               direntry->name = (FAR char *)
-                                kmm_malloc(fs->fs_llformat.namesize + 1);
+                                fs_heap_malloc(fs->fs_llformat.namesize + 1);
                             }
 
                           strlcpy(direntry->name, entry->name,
@@ -1079,7 +1080,7 @@ int smartfs_createentry(FAR struct smartfs_mountpt_s *fs,
   direntry->datlen = 0;
   if (direntry->name == NULL)
     {
-      direntry->name = kmm_malloc(fs->fs_llformat.namesize + 1);
+      direntry->name = fs_heap_malloc(fs->fs_llformat.namesize + 1);
     }
 
   memset(direntry->name, 0, fs->fs_llformat.namesize + 1);
@@ -1915,7 +1916,7 @@ int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs,
    * will, unfortunately, need to allocate one.
    */
 
-  buffer = kmm_malloc(SMARTFS_TRUNCBUFFER_SIZE);
+  buffer = fs_heap_malloc(SMARTFS_TRUNCBUFFER_SIZE);
   if (buffer == NULL)
     {
       return -ENOMEM;
@@ -2112,7 +2113,7 @@ errout_with_buffer:
 #ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
   /* Release the allocated buffer */
 
-  kmm_free(buffer);
+  fs_heap_free(buffer);
 #endif
   /* Restore the original file position */
 

--- a/fs/socket/CMakeLists.txt
+++ b/fs/socket/CMakeLists.txt
@@ -18,5 +18,5 @@
 #
 # ##############################################################################
 if(CONFIG_NET)
-  target_sources(fs PRIVATE socket.c)
+  target_sources(fs PRIVATE socket.c accept.c)
 endif()

--- a/fs/socket/Make.defs
+++ b/fs/socket/Make.defs
@@ -22,7 +22,7 @@
 
 ifeq ($(CONFIG_NET),y)
 
-CSRCS += socket.c
+CSRCS += socket.c accept.c
 
 # Include socket build support
 

--- a/fs/socket/accept.c
+++ b/fs/socket/accept.c
@@ -1,7 +1,5 @@
 /****************************************************************************
- * net/socket/accept.c
- *
- * SPDX-License-Identifier: Apache-2.0
+ * fs/socket/accept.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -36,28 +34,28 @@
 #include <fcntl.h>
 
 #include <nuttx/cancelpt.h>
+#include <nuttx/net/net.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/kmalloc.h>
 #include <arch/irq.h>
 
-#include "socket/socket.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: psock_accept
+ * Name: accept4
  *
  * Description:
- *   The psock_accept function is used with connection-based socket types
+ *   The accept4 function is used with connection-based socket types
  *   (SOCK_STREAM, SOCK_SEQPACKET and SOCK_RDM). It extracts the first
  *   connection request on the queue of pending connections, creates a new
  *   connected socket with mostly the same properties as 'sockfd', and
  *   allocates a new socket descriptor for the socket, which is returned. The
  *   newly created socket is no longer in the listening state. The original
  *   socket 'sockfd' is unaffected by this call.  Per file descriptor flags
- *   are not inherited across an psock_accept.
+ *   are not inherited across an accept.
  *
  *   The 'sockfd' argument is a socket descriptor that has been created with
  *   socket(), bound to a local address with bind(), and is listening for
@@ -69,26 +67,28 @@
  *   actual length of the address returned.
  *
  *   If no pending connections are present on the queue, and the socket is
- *   not marked as non-blocking, psock_accept blocks the caller until a
- *   connection is present. If the socket is marked non-blocking and no
- *   pending connections are present on the queue, psock_accept returns
- *   EAGAIN.
+ *   not marked as non-blocking, accept blocks the caller until a connection
+ *   is present. If the socket is marked non-blocking and no pending
+ *   connections are present on the queue, accept returns EAGAIN.
  *
  * Input Parameters:
- *   psock    Reference to the listening socket structure
+ *   sockfd   The listening socket descriptor
  *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr', Return: returned size
- *            of 'addr'
- *   newsock  Location to return the accepted socket information.
+ *   addrlen  Input: allocated size of 'addr',
+ *            Return: returned size of 'addr'
  *   flags    The flags used for initialization
  *
  * Returned Value:
- *  Returns 0 (OK) on success.  On failure, it returns a negated errno value
- *  to indicate the nature of the error.
+ *  Returns -1 on error. If it succeeds, it returns a non-negative integer
+ *  that is a descriptor for the accepted socket.
  *
  * EAGAIN or EWOULDBLOCK
  *   The socket is marked non-blocking and no connections are present to
  *   be accepted.
+ * EBADF
+ *   The descriptor is invalid.
+ * ENOTSOCK
+ *  The descriptor references a file, not a socket.
  * EOPNOTSUPP
  *   The referenced socket is not of type SOCK_STREAM.
  * EINTR
@@ -103,7 +103,8 @@
  * ENFILE
  *   The system maximum for file descriptors has been reached.
  * EFAULT
- *   The addr parameter is not in a writable part of the user address space.
+ *   The addr parameter is not in a writable part of the user address
+ *   space.
  * ENOBUFS or ENOMEM
  *   Not enough free memory.
  * EPROTO
@@ -113,59 +114,90 @@
  *
  ****************************************************************************/
 
-int psock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                 FAR socklen_t *addrlen, FAR struct socket *newsock,
-                 int flags)
+int accept4(int sockfd, FAR struct sockaddr *addr, FAR socklen_t *addrlen,
+            int flags)
 {
-  FAR struct socket_conn_s *conn;
+  FAR struct socket *psock = NULL;
+  FAR struct socket *newsock;
+  FAR struct file *filep;
+  int oflags = O_RDWR;
+  int errcode;
+  int newfd;
   int ret;
 
-  DEBUGASSERT(psock != NULL && psock->s_conn != NULL && newsock != NULL);
+  /* accept4() is a cancellation point */
 
-  /* May sure that the socket has been opened with socket() */
+  enter_cancellation_point();
 
-  if (psock == NULL || psock->s_conn == NULL)
+  if (flags & ~(SOCK_NONBLOCK | SOCK_CLOEXEC))
     {
-      nerr("ERROR: Socket invalid or not opened\n");
-      return -EINVAL;
+      errcode = EINVAL;
+      goto errout;
     }
 
-  /* Is the socket listening for a connection? */
+  /* Get the underlying socket structure */
 
-  conn = psock->s_conn;
-  if (!_SS_ISLISTENING(conn->s_flags))
+  ret = sockfd_socket(sockfd, &filep, &psock);
+
+  /* Verify that the sockfd corresponds to valid, allocated socket */
+
+  if (ret < 0)
     {
-      nerr("ERROR: Socket is not listening for a connection.\n");
-      return -EINVAL;
+      errcode = -ret;
+      goto errout;
     }
 
-  /* Let the address family's accept() method handle the operation */
-
-  DEBUGASSERT(psock->s_sockif != NULL);
-  if (psock->s_sockif->si_accept == NULL)
+  newsock = fs_heap_zalloc(sizeof(*newsock));
+  if (newsock == NULL)
     {
-      return -EOPNOTSUPP;
+      errcode = ENOMEM;
+      goto errout_with_filep;
     }
 
-  net_lock();
-  ret = psock->s_sockif->si_accept(psock, addr, addrlen, newsock, flags);
-  if (ret >= 0)
+  ret = psock_accept(psock, addr, addrlen, newsock, flags);
+  if (ret < 0)
     {
-      /* Mark the new socket as connected. */
-
-      conn = newsock->s_conn;
-      conn->s_flags |= _SF_CONNECTED;
-      conn->s_flags &= ~_SF_CLOSED;
-      if (flags & SOCK_NONBLOCK)
-        {
-          conn->s_flags |= _SF_NONBLOCK;
-        }
-    }
-  else
-    {
-      nerr("ERROR: si_accept failed: %d\n", ret);
+      errcode = -ret;
+      goto errout_with_alloc;
     }
 
-  net_unlock();
-  return ret;
+  /* Allocate a socket descriptor for the new connection now (so that it
+   * cannot fail later)
+   */
+
+  if (flags & SOCK_CLOEXEC)
+    {
+      oflags |= O_CLOEXEC;
+    }
+
+  if (flags & SOCK_NONBLOCK)
+    {
+      oflags |= O_NONBLOCK;
+    }
+
+  newfd = sockfd_allocate(newsock, oflags);
+  if (newfd < 0)
+    {
+      errcode = ENFILE;
+      goto errout_with_psock;
+    }
+
+  fs_putfilep(filep);
+  leave_cancellation_point();
+  return newfd;
+
+errout_with_psock:
+  psock_close(newsock);
+
+errout_with_alloc:
+  fs_heap_free(newsock);
+
+errout_with_filep:
+  fs_putfilep(filep);
+
+errout:
+  leave_cancellation_point();
+
+  set_errno(errcode);
+  return ERROR;
 }

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -36,6 +36,7 @@
 #include <debug.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions Prototypes
@@ -91,7 +92,7 @@ static int sock_file_open(FAR struct file *filep)
   FAR struct socket *psock;
   int ret;
 
-  psock = kmm_zalloc(sizeof(*psock));
+  psock = fs_heap_zalloc(sizeof(*psock));
   if (psock == NULL)
     {
       return -ENOMEM;
@@ -104,7 +105,7 @@ static int sock_file_open(FAR struct file *filep)
     }
   else
     {
-      kmm_free(psock);
+      fs_heap_free(psock);
     }
 
   return ret;
@@ -113,7 +114,7 @@ static int sock_file_open(FAR struct file *filep)
 static int sock_file_close(FAR struct file *filep)
 {
   psock_close(filep->f_priv);
-  kmm_free(filep->f_priv);
+  fs_heap_free(filep->f_priv);
   return 0;
 }
 
@@ -272,7 +273,7 @@ int socket(int domain, int type, int protocol)
       oflags |= O_NONBLOCK;
     }
 
-  psock = kmm_zalloc(sizeof(*psock));
+  psock = fs_heap_zalloc(sizeof(*psock));
   if (psock == NULL)
     {
       ret = -ENOMEM;
@@ -304,7 +305,7 @@ errout_with_psock:
   psock_close(psock);
 
 errout_with_alloc:
-  kmm_free(psock);
+  fs_heap_free(psock);
 
 errout:
   set_errno(-ret);

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -60,6 +60,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
 
+#include "fs_heap.h"
 #include "spiffs.h"
 #include "spiffs_core.h"
 #include "spiffs_cache.h"
@@ -333,7 +334,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a new file object with a reference count of one. */
 
   fobj = (FAR struct spiffs_file_s *)
-    kmm_zalloc(sizeof(struct spiffs_file_s));
+    fs_heap_zalloc(sizeof(struct spiffs_file_s));
   if (fobj == NULL)
     {
       ferr("ERROR: Failed to allocate fail object\n");
@@ -348,7 +349,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
   ret = spiffs_lock_volume(fs);
   if (ret < 0)
     {
-      kmm_free(fobj);
+      fs_heap_free(fobj);
       return ret;
     }
 
@@ -449,7 +450,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
   return OK;
 
 errout_with_fileobject:
-  kmm_free(fobj);
+  fs_heap_free(fobj);
   spiffs_unlock_volume(fs);
   return spiffs_map_errno(ret);
 }
@@ -1265,7 +1266,7 @@ static int spiffs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   DEBUGASSERT(mountpt != NULL && relpath != NULL && dir != NULL);
 
-  sdir = kmm_zalloc(sizeof(*sdir));
+  sdir = fs_heap_zalloc(sizeof(*sdir));
   if (sdir == NULL)
     {
       return -ENOMEM;
@@ -1288,7 +1289,7 @@ static int spiffs_closedir(FAR struct inode *mountpt,
 {
   finfo("mountpt=%p dir=%p\n",  mountpt, dir);
   DEBUGASSERT(mountpt != NULL && dir != NULL);
-  kmm_free(dir);
+  fs_heap_free(dir);
   return OK;
 }
 
@@ -1385,7 +1386,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
 
   /* Create an instance of the SPIFFS file system */
 
-  fs = kmm_zalloc(sizeof(struct spiffs_s));
+  fs = fs_heap_zalloc(sizeof(struct spiffs_s));
   if (fs == NULL)
     {
       ferr("ERROR: Failed to allocate volume structure\n");
@@ -1427,7 +1428,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
   /* Allocate the cache */
 
   fs->cache_size = cache_size;
-  fs->cache      = kmm_malloc(cache_size);
+  fs->cache      = fs_heap_malloc(cache_size);
 
   if (fs->cache == NULL)
     {
@@ -1448,7 +1449,7 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
    */
 
   work_size = 3 * SPIFFS_GEO_PAGE_SIZE(fs);
-  work      = kmm_malloc(work_size);
+  work      = fs_heap_malloc(work_size);
 
   if (work == NULL)
     {
@@ -1503,13 +1504,13 @@ static int spiffs_bind(FAR struct inode *mtdinode, FAR const void *data,
   return OK;
 
 errout_with_work:
-  kmm_free(fs->work);
+  fs_heap_free(fs->work);
 
 errout_with_cache:
-  kmm_free(fs->cache);
+  fs_heap_free(fs->cache);
 
 errout_with_volume:
-  kmm_free(fs);
+  fs_heap_free(fs);
   return spiffs_map_errno(ret);
 }
 
@@ -1553,19 +1554,19 @@ static int spiffs_unbind(FAR void *handle, FAR struct inode **mtdinode,
 
   if (fs->work != NULL)
     {
-      kmm_free(fs->work);
+      fs_heap_free(fs->work);
     }
 
   if (fs->cache != NULL)
     {
-      kmm_free(fs->cache);
+      fs_heap_free(fs->cache);
     }
 
   /* Free the volume memory (note that the mutex is now stale!) */
 
   spiffs_unlock_volume(fs);
   nxrmutex_destroy(&fs->lock);
-  kmm_free(fs);
+  fs_heap_free(fs);
 
   return spiffs_map_errno(OK);
 }
@@ -1698,7 +1699,7 @@ static int spiffs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
        */
 
       fobj = (FAR struct spiffs_file_s *)
-        kmm_zalloc(sizeof(struct spiffs_file_s));
+        fs_heap_zalloc(sizeof(struct spiffs_file_s));
       if (fobj == NULL)
         {
           fwarn("WARNING: Failed to allocate fobj\n");
@@ -1712,14 +1713,14 @@ static int spiffs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
       if (ret < 0)
         {
           ferr("ERROR: spiffs_fobj_open_bypage failed: %d\n", ret);
-          kmm_free(fobj);
+          fs_heap_free(fobj);
           goto errout_with_lock;
         }
 
       /* Now we can remove the file by truncating it to zero length */
 
       ret = spiffs_fobj_truncate(fs, fobj, 0, true);
-      kmm_free(fobj);
+      fs_heap_free(fobj);
 
       if (ret < 0)
         {
@@ -1831,7 +1832,7 @@ static int spiffs_rename(FAR struct inode *mountpt,
   /* Allocate new file object.  NOTE:  The file could already be open. */
 
   fobj = (FAR struct spiffs_file_s *)
-    kmm_zalloc(sizeof(struct spiffs_file_s));
+    fs_heap_zalloc(sizeof(struct spiffs_file_s));
   if (fobj == NULL)
     {
       ret = -ENOMEM;
@@ -1854,7 +1855,7 @@ static int spiffs_rename(FAR struct inode *mountpt,
                                   &newpgndx);
 
 errout_with_fobj:
-  kmm_free(fobj);
+  fs_heap_free(fobj);
 
 errout_with_lock:
   spiffs_unlock_volume(fs);

--- a/fs/spiffs/src/spiffs_volume.c
+++ b/fs/spiffs/src/spiffs_volume.c
@@ -54,6 +54,7 @@
 
 #include <nuttx/kmalloc.h>
 
+#include "fs_heap.h"
 #include "spiffs.h"
 #include "spiffs_core.h"
 #include "spiffs_cache.h"
@@ -489,5 +490,5 @@ void spiffs_fobj_free(FAR struct spiffs_s *fs,
 
   /* Then free the file object itself (which contains the lock we hold) */
 
-  kmm_free(fobj);
+  fs_heap_free(fobj);
 }

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -46,6 +46,7 @@
 #include <nuttx/mutex.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_UNIONFS)
 
@@ -748,7 +749,7 @@ static FAR char *unionfs_relpath(FAR const char *path, FAR const char *name)
     }
   else
     {
-      /* There is no path... just duplicate the name (so that kmm_free()
+      /* There is no path... just duplicate the name (so that fs_heap_free()
        * will work later).
        */
 
@@ -850,7 +851,7 @@ static void unionfs_destroy(FAR struct unionfs_inode_s *ui)
   /* And finally free the allocated unionfs state structure as well */
 
   nxmutex_destroy(&ui->ui_lock);
-  kmm_free(ui);
+  fs_heap_free(ui);
 }
 
 /****************************************************************************
@@ -882,7 +883,7 @@ static int unionfs_open(FAR struct file *filep, FAR const char *relpath,
   /* Allocate a container to hold the open file system information */
 
   uf = (FAR struct unionfs_file_s *)
-    kmm_zalloc(sizeof(struct unionfs_file_s));
+    fs_heap_zalloc(sizeof(struct unionfs_file_s));
   if (uf == NULL)
     {
       ret = -ENOMEM;
@@ -1000,7 +1001,7 @@ static int unionfs_close(FAR struct file *filep)
 
   /* Free the open file container */
 
-  kmm_free(uf);
+  fs_heap_free(uf);
   filep->f_priv = NULL;
   return ret;
 }
@@ -1248,7 +1249,7 @@ static int unionfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Allocate a new container for the union FS open file */
 
   newpriv = (FAR struct unionfs_file_s *)
-    kmm_malloc(sizeof(struct unionfs_file_s));
+    fs_heap_malloc(sizeof(struct unionfs_file_s));
   if (newpriv != NULL)
     {
       /* Clone the old file structure into the newly allocated one */
@@ -1264,7 +1265,7 @@ static int unionfs_dup(FAR const struct file *oldp, FAR struct file *newp)
           ret = ops->dup(&oldpriv->uf_file, &newpriv->uf_file);
           if (ret < 0)
             {
-              kmm_free(newpriv);
+              fs_heap_free(newpriv);
               newpriv = NULL;
             }
         }
@@ -1413,7 +1414,7 @@ static int unionfs_opendir(FAR struct inode *mountpt,
   DEBUGASSERT(mountpt != NULL && mountpt->i_private != NULL);
   ui = mountpt->i_private;
 
-  udir = kmm_zalloc(sizeof(*udir));
+  udir = fs_heap_zalloc(sizeof(*udir));
   if (udir == NULL)
     {
       return -ENOMEM;
@@ -1528,7 +1529,7 @@ errout_with_lock:
   nxmutex_unlock(&ui->ui_lock);
 
 errout_with_udir:
-  kmm_free(udir);
+  fs_heap_free(udir);
   return ret;
 }
 
@@ -1591,10 +1592,10 @@ static int unionfs_closedir(FAR struct inode *mountpt,
 
   if (udir->fu_relpath != NULL)
     {
-      kmm_free(udir->fu_relpath);
+      fs_heap_free(udir->fu_relpath);
     }
 
-  kmm_free(udir);
+  fs_heap_free(udir);
 
   /* Decrement the count of open reference.  If that count would go to zero
    * and if the file system has been unmounted, then destroy the file system
@@ -2595,7 +2596,7 @@ static int unionfs_dobind(FAR const char *fspath1, FAR const char *prefix1,
    */
 
   ui = (FAR struct unionfs_inode_s *)
-    kmm_zalloc(sizeof(struct unionfs_inode_s));
+    fs_heap_zalloc(sizeof(struct unionfs_inode_s));
   if (!ui)
     {
       ferr("ERROR: Failed to allocated union FS state structure\n");
@@ -2671,7 +2672,7 @@ errout_with_fs1:
 
 errout_with_uinode:
   nxmutex_destroy(&ui->ui_lock);
-  kmm_free(ui);
+  fs_heap_free(ui);
   return ret;
 }
 

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -47,6 +47,8 @@
 #include <nuttx/net/net.h>
 #include <nuttx/mutex.h>
 
+#include "fs_heap.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -1158,7 +1160,7 @@ static int userfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
   /* Save the opaque dir reference in struct fs_dirent_s */
 
   DEBUGASSERT(dir != NULL);
-  udir = kmm_zalloc(sizeof(struct userfs_dir_s));
+  udir = fs_heap_zalloc(sizeof(struct userfs_dir_s));
   if (udir == NULL)
     {
       return -ENOMEM;
@@ -1243,7 +1245,7 @@ static int userfs_closedir(FAR struct inode *mountpt,
       return -EIO;
     }
 
-  kmm_free(udir);
+  fs_heap_free(udir);
   return resp->ret;
 }
 
@@ -1430,7 +1432,7 @@ static int userfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Allocate an instance of the UserFS state structure */
 
   iolen = USERFS_REQ_MAXSIZE + config->mxwrite;
-  priv  = kmm_malloc(SIZEOF_USERFS_STATE_S(iolen));
+  priv  = fs_heap_malloc(SIZEOF_USERFS_STATE_S(iolen));
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
@@ -1490,7 +1492,7 @@ errout_with_psock:
 
 errout_with_alloc:
   nxmutex_destroy(&priv->lock);
-  kmm_free(priv);
+  fs_heap_free(priv);
   return ret;
 }
 
@@ -1574,7 +1576,7 @@ static int userfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
   psock_close(&priv->psock);
   nxmutex_destroy(&priv->lock);
-  kmm_free(priv);
+  fs_heap_free(priv);
   return OK;
 }
 

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -31,6 +31,7 @@
 #include <nuttx/lib/lib.h>
 
 #include "client.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -490,7 +491,7 @@ static int v9fs_fid_create(FAR struct v9fs_client_s *client,
   int ret;
 
   len = strlen(relpath);
-  fid = kmm_zalloc(sizeof(struct v9fs_fid_s) + len);
+  fid = fs_heap_zalloc(sizeof(struct v9fs_fid_s) + len);
   if (fid == NULL)
     {
       return -ENOMEM;
@@ -508,7 +509,7 @@ static int v9fs_fid_create(FAR struct v9fs_client_s *client,
 
   /* Failed to initialize fid */
 
-  kmm_free(fid);
+  fs_heap_free(fid);
   return ret;
 }
 
@@ -531,7 +532,7 @@ static void v9fs_fid_destroy(FAR struct v9fs_client_s *client,
 
   idr_remove(client->fids, fid);
   nxmutex_unlock(&client->lock);
-  kmm_free(fidp);
+  fs_heap_free(fidp);
 }
 
 /****************************************************************************

--- a/fs/v9fs/v9fs.c
+++ b/fs/v9fs/v9fs.c
@@ -35,6 +35,7 @@
 
 #include "inode/inode.h"
 #include "client.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Type
@@ -171,7 +172,7 @@ static int v9fs_vfs_open(FAR struct file *filep, FAR const char *relpath,
 
   client = filep->f_inode->i_private;
 
-  file = kmm_zalloc(sizeof(struct v9fs_vfs_file_s));
+  file = fs_heap_zalloc(sizeof(struct v9fs_vfs_file_s));
   if (file == NULL)
     {
       return -ENOMEM;
@@ -234,7 +235,7 @@ static int v9fs_vfs_open(FAR struct file *filep, FAR const char *relpath,
 err_put:
   v9fs_fid_put(client, file->fid);
 err_free:
-  kmm_free(file);
+  fs_heap_free(file);
   return ret;
 }
 
@@ -258,7 +259,7 @@ static int v9fs_vfs_close(FAR struct file *filep)
 
   v9fs_fid_put(client, file->fid);
   nxmutex_destroy(&file->lock);
-  kmm_free(file);
+  fs_heap_free(file);
   return 0;
 }
 
@@ -434,7 +435,7 @@ static int v9fs_vfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   client = oldp->f_inode->i_private;
   file = oldp->f_priv;
 
-  newfile = kmm_zalloc(sizeof(struct v9fs_vfs_file_s));
+  newfile = fs_heap_zalloc(sizeof(struct v9fs_vfs_file_s));
   if (newfile == NULL)
     {
       return -ENOMEM;
@@ -443,7 +444,7 @@ static int v9fs_vfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   ret = v9fs_fid_get(client, file->fid);
   if (ret < 0)
     {
-      kmm_free(newfile);
+      fs_heap_free(newfile);
       return ret;
     }
 
@@ -531,7 +532,7 @@ static int v9fs_vfs_opendir(FAR struct inode *mountpt,
 
   client = mountpt->i_private;
 
-  fsdir = kmm_zalloc(sizeof(struct v9fs_vfs_dirent_s) + client->msize);
+  fsdir = fs_heap_zalloc(sizeof(struct v9fs_vfs_dirent_s) + client->msize);
   if (fsdir == NULL)
     {
       return -ENOMEM;
@@ -559,7 +560,7 @@ static int v9fs_vfs_opendir(FAR struct inode *mountpt,
   return 0;
 
 err:
-  kmm_free(fsdir);
+  fs_heap_free(fsdir);
   return ret;
 }
 
@@ -584,7 +585,7 @@ static int v9fs_vfs_closedir(FAR struct inode *mountpt,
 
   v9fs_fid_put(client, fsdir->fid);
   nxmutex_destroy(&fsdir->lock);
-  kmm_free(fsdir);
+  fs_heap_free(fsdir);
   return 0;
 }
 
@@ -954,7 +955,7 @@ static int v9fs_vfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
       return ret;
     }
 
-  kmm_free(client);
+  fs_heap_free(client);
   return ret;
 }
 
@@ -968,7 +969,7 @@ static int v9fs_vfs_bind(FAR struct inode *driver, FAR const void *data,
   FAR struct v9fs_client_s *client;
   int ret;
 
-  client = kmm_zalloc(sizeof(struct v9fs_client_s));
+  client = fs_heap_zalloc(sizeof(struct v9fs_client_s));
   if (client == NULL)
     {
       return -ENOMEM;
@@ -978,7 +979,7 @@ static int v9fs_vfs_bind(FAR struct inode *driver, FAR const void *data,
   if (ret < 0)
     {
       ferr("ERROR: Failed to initialize for client: %d\n", ret);
-      kmm_free(client);
+      fs_heap_free(client);
       return ret;
     }
 

--- a/fs/v9fs/virtio_9p.c
+++ b/fs/v9fs/virtio_9p.c
@@ -29,6 +29,7 @@
 #include <nuttx/virtio/virtio.h>
 
 #include "client.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -109,7 +110,7 @@ static int virtio_9p_create(FAR struct v9fs_transport_s **transport,
   start += 4;
   end = strchr(start, ',');
   length = end ? end - start + 1 : strlen(start) + 1;
-  priv = kmm_zalloc(sizeof(struct virtio_9p_priv_s) + length);
+  priv = fs_heap_zalloc(sizeof(struct virtio_9p_priv_s) + length);
   if (priv == NULL)
     {
       return -ENOMEM;
@@ -125,7 +126,7 @@ static int virtio_9p_create(FAR struct v9fs_transport_s **transport,
   ret = virtio_register_driver(&priv->vdrv);
   if (ret < 0)
     {
-      kmm_free(priv);
+      fs_heap_free(priv);
     }
 
   return ret;
@@ -140,7 +141,7 @@ static void virtio_9p_destroy(FAR struct v9fs_transport_s *transport)
   FAR struct virtio_9p_priv_s *priv =
             container_of(transport, struct virtio_9p_priv_s, transport);
   virtio_unregister_driver(&priv->vdrv);
-  kmm_free(priv);
+  fs_heap_free(priv);
 }
 
 /****************************************************************************

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -34,6 +34,7 @@
 #include <nuttx/fs/ioctl.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -154,7 +155,7 @@ static int open_pseudodir(FAR struct inode *inode,
 {
   FAR struct fs_pseudodir_s *pdir;
 
-  pdir = kmm_zalloc(sizeof(*pdir));
+  pdir = fs_heap_zalloc(sizeof(*pdir));
   if (pdir == NULL)
     {
       return -ENOMEM;
@@ -447,7 +448,7 @@ static int dir_close(FAR struct file *filep)
 
       /* Then release the container */
 
-      kmm_free(dir);
+      fs_heap_free(dir);
     }
 
   /* Release our references on the contained 'root' inode */

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -42,6 +42,7 @@
 #include <nuttx/signal.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -201,10 +202,10 @@ static int epoll_do_close(FAR struct file *filep)
       list_for_every_entry_safe(&eph->extend, epn, tmp, epoll_node_t, node)
         {
           list_delete(&epn->node);
-          kmm_free(epn);
+          fs_heap_free(epn);
         }
 
-      kmm_free(eph);
+      fs_heap_free(eph);
     }
 
   return ret;
@@ -224,7 +225,7 @@ static int epoll_do_create(int size, int flags)
   int i;
 
   size = size <= 0 ? 1 : size;
-  eph = kmm_zalloc(sizeof(epoll_head_t) + sizeof(epoll_node_t) * size);
+  eph = fs_heap_zalloc(sizeof(epoll_head_t) + sizeof(epoll_node_t) * size);
   if (eph == NULL)
     {
       set_errno(ENOMEM);
@@ -257,7 +258,7 @@ static int epoll_do_create(int size, int flags)
   if (fd < 0)
     {
       nxmutex_destroy(&eph->lock);
-      kmm_free(eph);
+      fs_heap_free(eph);
       set_errno(-fd);
       return ERROR;
     }
@@ -535,7 +536,7 @@ int epoll_ctl(int epfd, int op, int fd, FAR struct epoll_event *ev)
              * list.
              */
 
-            extend = kmm_zalloc(sizeof(*extend) +
+            extend = fs_heap_zalloc(sizeof(*extend) +
                                 2 * sizeof(epoll_node_t) * eph->size);
             if (extend == NULL)
               {

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -35,6 +35,7 @@
 #include <sys/eventfd.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -128,7 +129,7 @@ static FAR struct eventfd_priv_s *eventfd_allocdev(void)
   FAR struct eventfd_priv_s *dev;
 
   dev = (FAR struct eventfd_priv_s *)
-    kmm_zalloc(sizeof(struct eventfd_priv_s));
+    fs_heap_zalloc(sizeof(struct eventfd_priv_s));
   if (dev)
     {
       /* Initialize the private structure */
@@ -145,7 +146,7 @@ static void eventfd_destroy(FAR struct eventfd_priv_s *dev)
 {
   nxmutex_unlock(&dev->lock);
   nxmutex_destroy(&dev->lock);
-  kmm_free(dev);
+  fs_heap_free(dev);
 }
 
 static int eventfd_do_open(FAR struct file *filep)

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -36,8 +36,9 @@
 #include <nuttx/mutex.h>
 #include <nuttx/list.h>
 
-#include "sched/sched.h"
 #include "lock.h"
+#include "sched/sched.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -219,7 +220,7 @@ static int file_lock_normalize(FAR struct file *filep,
 static void file_lock_delete(FAR struct file_lock_s *file_lock)
 {
   list_delete(&file_lock->fl_node);
-  kmm_free(file_lock);
+  fs_heap_free(file_lock);
 }
 
 /****************************************************************************
@@ -300,7 +301,7 @@ file_lock_find_bucket(FAR const char *filepath)
 static void file_lock_free_entry(FAR ENTRY *entry)
 {
   lib_free(entry->key);
-  kmm_free(entry->data);
+  fs_heap_free(entry->data);
 }
 
 /****************************************************************************
@@ -314,7 +315,7 @@ file_lock_create_bucket(FAR const char *filepath)
   FAR ENTRY *hretvalue;
   ENTRY item;
 
-  bucket = kmm_zalloc(sizeof(*bucket));
+  bucket = fs_heap_zalloc(sizeof(*bucket));
   if (bucket == NULL)
     {
       return NULL;
@@ -325,7 +326,7 @@ file_lock_create_bucket(FAR const char *filepath)
   item.key = strdup(filepath);
   if (item.key == NULL)
     {
-      kmm_free(bucket);
+      fs_heap_free(bucket);
       return NULL;
     }
 
@@ -334,7 +335,7 @@ file_lock_create_bucket(FAR const char *filepath)
   if (hsearch_r(item, ENTER, &hretvalue, &g_file_lock_table) == 0)
     {
       lib_free(item.key);
-      kmm_free(bucket);
+      fs_heap_free(bucket);
       return NULL;
     }
 
@@ -496,7 +497,7 @@ static int file_lock_modify(FAR struct file *filep,
 
       /* insert a new lock */
 
-      new_file_lock = kmm_zalloc(sizeof(struct file_lock_s));
+      new_file_lock = fs_heap_zalloc(sizeof(struct file_lock_s));
       if (new_file_lock == NULL)
         {
           return -ENOMEM;
@@ -514,7 +515,7 @@ static int file_lock_modify(FAR struct file *filep,
         {
           /* Splitting old locks */
 
-          new_file_lock = kmm_zalloc(sizeof(struct file_lock_s));
+          new_file_lock = fs_heap_zalloc(sizeof(struct file_lock_s));
           if (new_file_lock == NULL)
             {
               return -ENOMEM;

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -40,6 +40,7 @@
 #include <arch/irq.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Types
@@ -435,7 +436,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
 #ifdef CONFIG_BUILD_KERNEL
   /* Allocate kernel memory for the fds */
 
-  kfds = kmm_malloc(nfds * sizeof(struct pollfd));
+  kfds = fs_heap_malloc(nfds * sizeof(struct pollfd));
   if (!kfds)
     {
       /* Out of memory */
@@ -547,7 +548,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
 
   /* Free the temporary buffer */
 
-  kmm_free(kfds);
+  fs_heap_free(kfds);
 
 out_with_cancelpt:
 #endif

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -37,6 +37,7 @@
 
 #include "notify/notify.h"
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -38,6 +38,7 @@
 #include <nuttx/fs/fs.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -128,7 +129,7 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
   if (npfds > 0)
     {
       pollset = (FAR struct pollfd *)
-        kmm_zalloc(npfds * sizeof(struct pollfd));
+        fs_heap_zalloc(npfds * sizeof(struct pollfd));
 
       if (pollset == NULL)
         {
@@ -277,6 +278,6 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
         }
     }
 
-  kmm_free(pollset);
+  fs_heap_free(pollset);
   return ret;
 }

--- a/fs/vfs/fs_sendfile.c
+++ b/fs/vfs/fs_sendfile.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/net/net.h>
+#include "fs_heap.h"
 
 /****************************************************************************
  * Private Functions
@@ -72,7 +73,7 @@ static ssize_t copyfile(FAR struct file *outfile, FAR struct file *infile,
 
   /* Allocate an I/O buffer */
 
-  iobuffer = kmm_malloc(CONFIG_SENDFILE_BUFSIZE);
+  iobuffer = fs_heap_malloc(CONFIG_SENDFILE_BUFSIZE);
   if (!iobuffer)
     {
       return -ENOMEM;
@@ -195,7 +196,7 @@ static ssize_t copyfile(FAR struct file *outfile, FAR struct file *infile,
 
   /* Release the I/O buffer */
 
-  kmm_free(iobuffer);
+  fs_heap_free(iobuffer);
 
   /* Return the current file position */
 

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -37,6 +37,7 @@
 #include <sys/signalfd.h>
 
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -154,7 +155,7 @@ static int signalfd_file_close(FAR struct file *filep)
 
   nxmutex_unlock(&dev->mutex);
   nxmutex_destroy(&dev->mutex);
-  kmm_free(dev);
+  fs_heap_free(dev);
 
   return OK;
 }
@@ -340,7 +341,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
   if (fd == -1)
     {
-      dev = kmm_zalloc(sizeof(*dev));
+      dev = fs_heap_zalloc(sizeof(*dev));
       if (dev == NULL)
         {
           ret = ENOMEM;
@@ -406,7 +407,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
 errout_with_dev:
   nxmutex_destroy(&dev->mutex);
-  kmm_free(dev);
+  fs_heap_free(dev);
 
 errout:
   set_errno(ret);

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -39,6 +39,7 @@
 
 #include "clock/clock.h"
 #include "inode/inode.h"
+#include "fs_heap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -139,7 +140,7 @@ static FAR struct timerfd_priv_s *timerfd_allocdev(void)
   FAR struct timerfd_priv_s *dev;
 
   dev = (FAR struct timerfd_priv_s *)
-    kmm_zalloc(sizeof(struct timerfd_priv_s));
+    fs_heap_zalloc(sizeof(struct timerfd_priv_s));
   if (dev)
     {
       /* Initialize the private structure */
@@ -157,7 +158,7 @@ static void timerfd_destroy(FAR struct timerfd_priv_s *dev)
   wd_cancel(&dev->wdog);
   nxmutex_unlock(&dev->lock);
   nxmutex_destroy(&dev->lock);
-  kmm_free(dev);
+  fs_heap_free(dev);
 }
 
 static int timerfd_open(FAR struct file *filep)

--- a/fs/zipfs/zip_vfs.c
+++ b/fs/zipfs/zip_vfs.c
@@ -35,6 +35,8 @@
 
 #include <unzip.h>
 
+#include "fs_heap.h"
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -168,7 +170,7 @@ static voidpf zipfs_real_open(voidpf opaque, FAR const void *filename,
   FAR struct file *filep;
   int ret;
 
-  filep = kmm_malloc(sizeof(struct file));
+  filep = fs_heap_malloc(sizeof(struct file));
   if (filep == NULL)
     {
       return NULL;
@@ -177,7 +179,7 @@ static voidpf zipfs_real_open(voidpf opaque, FAR const void *filename,
   ret = file_open(filep, filename, O_RDONLY);
   if (ret < 0)
     {
-      kmm_free(filep);
+      fs_heap_free(filep);
       return NULL;
     }
 
@@ -209,7 +211,7 @@ static int zipfs_real_close(voidpf opaque, voidpf stream)
   int ret;
 
   ret = file_close(stream);
-  kmm_free(stream);
+  fs_heap_free(stream);
   return ret;
 }
 
@@ -246,7 +248,7 @@ static int zipfs_open(FAR struct file *filep, FAR const char *relpath,
 
   DEBUGASSERT(fs != NULL);
 
-  fp = kmm_malloc(sizeof(*fp) + strlen(relpath));
+  fp = fs_heap_malloc(sizeof(*fp) + strlen(relpath));
   if (fp == NULL)
     {
       return -ENOMEM;
@@ -290,7 +292,7 @@ err_with_zip:
 err_with_mutex:
       nxmutex_destroy(&fp->lock);
 err_with_fp:
-      kmm_free(fp);
+      fs_heap_free(fp);
     }
 
   return ret;
@@ -303,8 +305,8 @@ static int zipfs_close(FAR struct file *filep)
 
   ret = zipfs_convert_result(unzClose(fp->uf));
   nxmutex_destroy(&fp->lock);
-  kmm_free(fp->seekbuf);
-  kmm_free(fp);
+  fs_heap_free(fp->seekbuf);
+  fs_heap_free(fp);
   return ret;
 }
 
@@ -331,7 +333,7 @@ static off_t zipfs_skip(FAR struct zipfs_file_s *fp, off_t amount)
 
   if (fp->seekbuf == NULL)
     {
-      fp->seekbuf = kmm_malloc(CONFIG_ZIPFS_SEEK_BUFSIZE);
+      fp->seekbuf = fs_heap_malloc(CONFIG_ZIPFS_SEEK_BUFSIZE);
       if (fp->seekbuf == NULL)
         {
           return -ENOMEM;
@@ -486,7 +488,7 @@ static int zipfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   DEBUGASSERT(fs != NULL);
 
-  zdir = kmm_malloc(sizeof(*zdir));
+  zdir = fs_heap_malloc(sizeof(*zdir));
   if (zdir == NULL)
     {
       return -ENOMEM;
@@ -495,7 +497,7 @@ static int zipfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
   ret = nxmutex_init(&zdir->lock);
   if (ret < 0)
     {
-      kmm_free(zdir);
+      fs_heap_free(zdir);
       return ret;
     }
 
@@ -503,7 +505,7 @@ static int zipfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
   if (zdir->uf == NULL)
     {
       nxmutex_destroy(&zdir->lock);
-      kmm_free(zdir);
+      fs_heap_free(zdir);
       return -EINVAL;
     }
 
@@ -521,7 +523,7 @@ static int zipfs_closedir(FAR struct inode *mountpt,
   zdir = (FAR struct zipfs_dir_s *)dir;
   ret = zipfs_convert_result(unzClose(zdir->uf));
   nxmutex_destroy(&zdir->lock);
-  kmm_free(zdir);
+  fs_heap_free(zdir);
   return ret;
 }
 
@@ -584,7 +586,7 @@ static int zipfs_bind(FAR struct inode *driver, FAR const void *data,
       return -ENODEV;
     }
 
-  fs = kmm_zalloc(sizeof(struct zipfs_mountpt_s) + strlen(data));
+  fs = fs_heap_zalloc(sizeof(struct zipfs_mountpt_s) + strlen(data));
   if (fs == NULL)
     {
       return -ENOMEM;
@@ -593,7 +595,7 @@ static int zipfs_bind(FAR struct inode *driver, FAR const void *data,
   uf = unzOpen2_64(data, &zipfs_real_ops);
   if (uf == NULL)
     {
-      kmm_free(fs);
+      fs_heap_free(fs);
       return -EINVAL;
     }
 
@@ -607,7 +609,7 @@ static int zipfs_bind(FAR struct inode *driver, FAR const void *data,
 static int zipfs_unbind(FAR void *handle, FAR struct inode **driver,
                         unsigned int flags)
 {
-  kmm_free(handle);
+  fs_heap_free(handle);
   return OK;
 }
 


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
This PR is to enhance the use of fs_heap.

**Changes**
1. Based on the changes in https://github.com/apache/nuttx/pull/13150, I added a new way to initialize fs_heap by allocating memory through the specified section. This method requires modifying the ld file to allocate a space for fs to use
2. Replace all kmm_ application codes in nuttx/fs with fs_heap. By default, it is equivalent to kmm_
3. Move accept4 from net to fs because it uses sockfd_allocate, which will cause its priv to be released in fs.

## Impact
**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh
Based on the relevant fs case is passed (Because fs_heap_ is equivalent to kmm_ by default, there is no impact on any existing configurations.)