### PR TITLE
tools/btdecode.sh: add optional elf file parameter

### DIFF
--- a/tools/btdecode.sh
+++ b/tools/btdecode.sh
@@ -36,7 +36,7 @@
 #    0x400e1a2a: function_name at file.c:line
 #    0x40082912: function_name at file.c:line
 
-USAGE="USAGE: ${0} chip|toolchain-addr2line backtrace_file
+USAGE="USAGE: ${0} chip|toolchain-addr2line backtrace_file [elf_file]
 If the first argument contains 'addr2line', it will be used as the toolchain's addr2line tool.
 Otherwise, the script will try to identify the toolchain based on the chip name."
 
@@ -57,6 +57,12 @@ if [ -z "$2" ]; then
   echo "No backtrace supplied!"
   echo "$USAGE"
   exit 1
+fi
+
+elf_file="nuttx"
+
+if [ -n "$3" ]; then
+  elf_file=$3
 fi
 
 # Check if the first argument is an addr2line tool or a chip
@@ -95,9 +101,9 @@ else
   esac
 fi
 
-# Make sure the project was built
+# Make sure the elf file is accessible
 
-if [ ! -f nuttx ]; then
+if [ ! -f ${elf_file} ]; then
   echo "NuttX binaries not found!"
   exit 2
 fi
@@ -142,7 +148,7 @@ done < "$2"
 for task_id in "${!backtraces_before[@]}"; do
   echo "Backtrace for task $task_id:"
   for bt in ${backtraces_before[$task_id]}; do
-    $ADDR2LINE_TOOL -pfiaCs -e nuttx $bt
+    $ADDR2LINE_TOOL -pfiaCs -e ${elf_file} $bt
   done
   echo ""
 done
@@ -153,7 +159,7 @@ if $in_dump_tasks_section; then
   for task_id in "${!backtraces_after[@]}"; do
     echo "Backtrace for task $task_id:"
     for bt in ${backtraces_after[$task_id]}; do
-      $ADDR2LINE_TOOL -pfiaCs -e nuttx $bt
+      $ADDR2LINE_TOOL -pfiaCs -e ${elf_file} $bt
     done
     echo ""
   done


### PR DESCRIPTION

## Summary

Allow to provide the path to elffile instead of hardcoding 'nuttx'.
E.g.
```
./nuttx/tools/btdecode.sh aarch64-none-elf-addr2line crash.log build/nuttx

```

## Impact
No
## Testing

Tested with crash log generated from arm64.

```
./nuttx/tools/btdecode.sh aarch64-none-elf-addr2line crash.log build/nuttx
Backtrace for task 5:
0x00000000402a1318: cmd_mw at nsh_dbgcmds.c:259
0x000000004029d47c: nsh_command at nsh_command.c:1259
0x000000004029c964: nsh_execute at nsh_parse.c:874
 (inlined by) nsh_parse_command at nsh_parse.c:2840
0x000000004029ca50: nsh_parse at nsh_parse.c:2996
0x000000004029b018: nsh_session at nsh_session.c:246
0x000000004029aabc: nsh_consolemain at nsh_consolemain.c:79
0x00000000402945ac: nsh_main at nsh_main.c:80
0x0000000040298104: nxtask_startup at task_startup.c:70 (discriminator 1)
0x0000000040292cb8: nxtask_start at task_start.c:75

Backtrace for task 4:
0x000000004028f524: nxsem_wait at sem_wait.c:213
0x000000004028f54c: nxsem_wait_uninterruptible at sem_wait.c:254 (discriminator 1)
0x0000000040290960: work_thread at kwork_thread.c:214
0x0000000040292ca4: nxtask_start at task_start.c:124

Backtrace for task 3:
0x0000000040294b9c: up_idle at arm64_idle.c:63
0x000000004028136c: arm64_boot_secondary_c_routine at arm64_cpustart.c:240

Backtrace for task 2:
0x0000000040294b9c: up_idle at arm64_idle.c:63
0x000000004028136c: arm64_boot_secondary_c_routine at arm64_cpustart.c:240

Backtrace for task 1:
0x0000000040294b9c: up_idle at arm64_idle.c:63
0x000000004028136c: arm64_boot_secondary_c_routine at arm64_cpustart.c:240

Backtrace for task 0:
0x0000000040294b9c: up_idle at arm64_idle.c:63
0x00000000402812a0: arm64_boot_primary_c_routine at arm64_boot.c:207
```
