### PR TITLE
percpu reg store this_task

### DIFF
--- a/arch/arm64/include/arch.h
+++ b/arch/arm64/include/arch.h
@@ -55,7 +55,7 @@
 
 /****************************************************************************
  * Name:
- *   read_/write_/zero_ sysreg
+ *   read_/write_/zero_/modify_ sysreg
  *
  * Description:
  *
@@ -83,6 +83,10 @@
     __asm__ volatile ("msr " STRINGIFY(reg) ", xzr" \
                       ::: "memory");                \
   })
+
+#define modify_sysreg(v,m,a)                        \
+  write_sysreg((read_sysreg(a) & ~(m)) |            \
+               ((uintptr_t)(v) & (m)), a)
 
 /****************************************************************************
  * Inline functions

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -115,10 +115,6 @@ static void arm64_smp_init_top(void)
 {
   struct tcb_s *tcb = current_task(this_cpu());
 
-  /* Init idle task to percpu reg */
-
-  up_update_task(tcb);
-
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* And finally, enable interrupts */
 
@@ -226,6 +222,12 @@ int up_cpu_start(int cpu)
 
 void arm64_boot_secondary_c_routine(void)
 {
+  struct tcb_s *tcb = current_task(this_cpu());
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(tcb);
+
 #ifdef CONFIG_ARCH_HAVE_MPU
   arm64_mpu_init(false);
 #endif

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -113,7 +113,11 @@ static inline void local_delay(void)
 
 static void arm64_smp_init_top(void)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = current_task(this_cpu());
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(tcb);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* And finally, enable interrupts */

--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -544,13 +544,18 @@ static int arm64_exception_handler(struct regs_context *regs)
 
 void arm64_fatal_handler(struct regs_context *regs)
 {
+  struct tcb_s *tcb = this_task();
   int ret;
 
   /* Nested exception are not supported */
 
-  DEBUGASSERT(up_current_regs() == NULL);
+  DEBUGASSERT(!up_interrupt_context());
 
-  up_set_current_regs((uint64_t *)regs);
+  tcb->xcp.regs = (uint64_t *)regs;
+
+  /* Set irq flag */
+
+  write_sysreg((uintptr_t)tcb | 1, tpidr_el1);
 
   ret = arm64_exception_handler(regs);
 
@@ -561,11 +566,9 @@ void arm64_fatal_handler(struct regs_context *regs)
       PANIC_WITH_REGS("panic", regs);
     }
 
-  /* Set CURRENT_REGS to NULL to indicate that we are no longer in an
-   * Exception handler.
-   */
+  /* Clear irq flag */
 
-  up_set_current_regs(NULL);
+  write_sysreg((uintptr_t)tcb & ~1ul, tpidr_el1);
 }
 
 void arm64_register_debug_hook(int nr, fatal_handle_func_t fn)

--- a/arch/arm64/src/common/arm64_registerdump.c
+++ b/arch/arm64/src/common/arm64_registerdump.c
@@ -31,6 +31,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 
+#include "sched/sched.h"
 #include "arm64_arch.h"
 #include "arm64_internal.h"
 #include "chip.h"

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -41,6 +41,7 @@
 #include <nuttx/fs/procfs.h>
 
 #include "fs_heap.h"
+#include "sched/sched.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
     defined(CONFIG_ARCH_HAVE_TCBINFO) && !defined(CONFIG_FS_PROCFS_EXCLUDE_TCBINFO)

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -944,6 +944,43 @@ int up_copy_section(FAR void *dest, FAR const void *src, size_t n);
 #endif
 
 /****************************************************************************
+ * Percpu support
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_update_task
+ *
+ * Description:
+ *   We can utilize percpu storage to hold information about the
+ *   current running task. If we intend to implement this feature, we would
+ *   need to define two macros that help us manage this percpu information
+ *   effectively.
+ *
+ *   up_this_task: This macro is designed to read the contents of the percpu
+ *                 register to retrieve information about the current
+ *                 running task.This allows us to quickly access
+ *                 task-specific data without having to disable interrupts,
+ *                 access global variables and obtain the current cpu index.
+ *
+ *   up_update_task: This macro is responsible for updating the contents of
+ *                   the percpu register.It is typically called during
+ *                   initialization or when a context switch occurs to ensure
+ *                   that the percpu register reflects the information of the
+ *                   newly running task.
+ *
+ * Input Parameters:
+ *   current tcb
+ *
+ * Returned Value:
+ *   current tcb
+ *
+ ****************************************************************************/
+
+#ifndef up_update_task
+#  define up_update_task(t)
+#endif
+
+/****************************************************************************
  * Address Environment Interfaces
  *
  * Low-level interfaces used in binfmt/ to instantiate tasks with address

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -53,6 +53,7 @@
 
 #include <sys/param.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/clock.h>
 #include <nuttx/init.h>
 #include <nuttx/fs/fs.h>

--- a/net/utils/net_snoop.c
+++ b/net/utils/net_snoop.c
@@ -34,6 +34,7 @@
 
 #include <sys/param.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/net/snoop.h>
 
 /****************************************************************************

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -429,6 +429,11 @@ static void idle_task_initialize(void)
       /* Mark the idle task as the running task */
 
       g_running_tasks[i] = tcb;
+
+      if (i == 0)
+        {
+          up_update_task(&g_idletcb[0]); /* Init idle task to percpu reg */
+        }
     }
 }
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -69,7 +69,6 @@
 #  define current_task(cpu)      ((FAR struct tcb_s *)list_assignedtasks(cpu)->head)
 #else
 #  define current_task(cpu)      ((FAR struct tcb_s *)list_readytorun()->head)
-#  define this_task()            (current_task(this_cpu()))
 #endif
 
 #define is_idle_task(t)          ((t)->pid < CONFIG_SMP_NCPUS)
@@ -375,7 +374,11 @@ void nxsched_sporadic_lowpriority(FAR struct tcb_s *tcb);
 void nxsched_suspend(FAR struct tcb_s *tcb);
 #endif
 
-#ifdef CONFIG_SMP
+#if defined(up_this_task)
+#  define this_task()            up_this_task()
+#elif !defined(CONFIG_SMP)
+#  define this_task()            ((FAR struct tcb_s *)g_readytorun.head)
+#else
 noinstrument_function
 static inline_function FAR struct tcb_s *this_task(void)
 {
@@ -389,7 +392,7 @@ static inline_function FAR struct tcb_s *this_task(void)
 
   flags = up_irq_save();
 
-  /* Obtain the TCB which is currently running on this CPU */
+  /* Obtain the TCB which is current running on this CPU */
 
   tcb = current_task(this_cpu());
 
@@ -398,7 +401,9 @@ static inline_function FAR struct tcb_s *this_task(void)
   up_irq_restore(flags);
   return tcb;
 }
+#endif
 
+#ifdef CONFIG_SMP
 void nxsched_process_delivered(int cpu);
 #else
 #  define nxsched_select_cpu(a)     (0)

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -100,6 +100,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
 
       btcb->task_state = TSTATE_TASK_RUNNING;
       btcb->flink->task_state = TSTATE_TASK_READYTORUN;
+      up_update_task(btcb);
       ret = true;
     }
   else
@@ -269,6 +270,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        */
 
       dq_addfirst_nonempty((FAR dq_entry_t *)btcb, tasklist);
+      up_update_task(btcb);
 
       DEBUGASSERT(task_state == TSTATE_TASK_RUNNING);
       btcb->cpu        = cpu;

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -134,6 +134,7 @@ bool nxsched_merge_pending(void)
                                 = (FAR dq_entry_t *)ptcb;
               rtcb->task_state  = TSTATE_TASK_READYTORUN;
               ptcb->task_state  = TSTATE_TASK_RUNNING;
+              up_update_task(ptcb);
               ret               = true;
             }
           else

--- a/sched/sched/sched_process_delivered.c
+++ b/sched/sched/sched_process_delivered.c
@@ -120,6 +120,7 @@ void nxsched_process_delivered(int cpu)
       dq_addfirst_nonempty((FAR dq_entry_t *)btcb, tasklist);
       btcb->cpu = cpu;
       btcb->task_state = TSTATE_TASK_RUNNING;
+      up_update_task(btcb);
 
       DEBUGASSERT(btcb->flink != NULL);
       DEBUGASSERT(next == btcb->flink);

--- a/sched/sched/sched_profil.c
+++ b/sched/sched/sched_profil.c
@@ -28,6 +28,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/wdog.h>
 #include <nuttx/spinlock.h>
+#include "sched/sched.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -85,6 +85,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
       DEBUGASSERT(nxttcb != NULL);
 
       nxttcb->task_state = TSTATE_TASK_RUNNING;
+      up_update_task(nxttcb);
       doswitch = true;
     }
 
@@ -270,6 +271,8 @@ void nxsched_remove_running(FAR struct tcb_s *tcb)
   /* Since the TCB is no longer in any list, it is now invalid */
 
   tcb->task_state = TSTATE_TASK_INVALID;
+
+  up_update_task(nxttcb);
 }
 
 void nxsched_remove_self(FAR struct tcb_s *tcb)


### PR DESCRIPTION
## Summary
We can utilize percpu storage to hold information about the             
current running task. If we intend to implement this feature, we would  
need to define two macros that help us manage this percpu information   
effectively.

up_this_task: This macro is designed to read the contents of the percpu 
              register to retrieve information about the current        
              running task.This allows us to quickly access             
              task-specific data without having to disable interrupts,  
              access global variables and obtain the current cpu index. 

up_update_task: This macro is responsible for updating the contents of  
                the percpu register.It is typically called during       
                initialization or when a context switch occurs to ensure
                that the percpu register reflects the information of the
                newly running task.
## Impact
arm64

## Testing
    Configuring NuttX and compile:
    $ ./tools/configure.sh -l qemu-armv8a:nsh_smp
    $ make
    Running with qemu
    $ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
       -machine virt,virtualization=on,gic-version=3 \
       -net none -chardev stdio,id=con,mux=on -serial chardev:con \
       -mon chardev=con,mode=readline -kernel ./nuttx

