### PR TITLE
xtensa: fix up_saveusercontext in interrupt context

### DIFF
--- a/arch/xtensa/src/common/xtensa_saveusercontext.c
+++ b/arch/xtensa/src/common/xtensa_saveusercontext.c
@@ -24,9 +24,11 @@
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
+#include <nuttx/nuttx.h>
 
 #include <string.h>
 
+#include <arch/irq.h>
 #include <arch/syscall.h>
 
 /****************************************************************************
@@ -51,9 +53,47 @@ int up_saveusercontext(void *saveregs)
 {
   if (up_interrupt_context())
     {
-      /* TODO: save interrupt context */
-
-      memset(saveregs, 0x0, XCPTCONTEXT_SIZE);
+      __asm__ __volatile__
+        (
+          "   s32i a0, %0, (4 * " STRINGIFY(REG_A0) ")\n"
+          "   s32i a1, %0, (4 * " STRINGIFY(REG_A1) ")\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_A2) ")\n"
+          "   s32i a3, %0, (4 * " STRINGIFY(REG_A3) ")\n"
+          "   movi a2, 1f\n"
+          "1: s32i a2, %0, (4 * " STRINGIFY(REG_PC) ")\n"
+          "   rsr  a2, PS\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_PS) ")\n"
+          "   s32i a4, %0, (4 * " STRINGIFY(REG_A4) ")\n"
+          "   s32i a5, %0, (4 * " STRINGIFY(REG_A5) ")\n"
+          "   s32i a6, %0, (4 * " STRINGIFY(REG_A6) ")\n"
+          "   s32i a7, %0, (4 * " STRINGIFY(REG_A7) ")\n"
+          "   s32i a8, %0, (4 * " STRINGIFY(REG_A8) ")\n"
+          "   s32i a9, %0, (4 * " STRINGIFY(REG_A9) ")\n"
+          "   s32i a10, %0, (4 * " STRINGIFY(REG_A10) ")\n"
+          "   s32i a11, %0, (4 * " STRINGIFY(REG_A11) ")\n"
+#ifndef __XTENSA_CALL0_ABI__
+          "   s32i a12, %0, (4 * " STRINGIFY(REG_A12) ")\n"
+          "   s32i a13, %0, (4 * " STRINGIFY(REG_A13) ")\n"
+          "   s32i a14, %0, (4 * " STRINGIFY(REG_A14) ")\n"
+          "   s32i a15, %0, (4 * " STRINGIFY(REG_A15) ")\n"
+#endif
+          "   rsr  a2, SAR\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_SAR) ")\n"
+#if XCHAL_HAVE_S32C1I != 0
+          "   rsr  a2, SCOMPARE1\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_SCOMPARE1) ")\n"
+#endif
+#if XCHAL_HAVE_LOOPS != 0
+          "   rsr  a2, LBEG\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_LBEG) ")\n"
+          "   rsr  a2, LEND\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_LEND) ")\n"
+          "   rsr  a2, LCOUNT\n"
+          "   s32i a2, %0, (4 * " STRINGIFY(REG_LCOUNT) ")\n"
+#endif
+          :
+          : "a" (saveregs)
+        );
       return 0;
     }
 


### PR DESCRIPTION
## Summary
Currently, without the change, when assert in interrupt handler, it will show the registers are all zeros.
This PR tries to save these registers.

## Impact

## Testing
Try to trigger an __assert in interrupt handler.
