### PR TITLE
drivers/gnss-uorb: bug fix about gnss data lost and deadlock

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -591,8 +591,15 @@ static void gnss_parse(FAR struct gnss_upperhalf_s *upper,
         {
           if (*buffer != '\r' && *buffer != '\n')
             {
-              upper->parsebuffer[upper->parsenext++] = *buffer;
-              continue;
+              if (upper->parsenext + 1 < GNSS_PARSE_BUFFERSIZE)
+                {
+                  upper->parsebuffer[upper->parsenext++] = *buffer;
+                  continue;
+                }
+
+              upper->parsebuffer[upper->parsenext] = '\0';
+              snerr("NMEA buffer overflow, invalid statement:%s\n",
+                    upper->parsebuffer);
             }
 
           upper->parsebuffer[upper->parsenext] = '\0';


### PR DESCRIPTION
## Summary
1. drivers/sensors/gnss: notify user when new data ready
2. drivers/sensors/gnss: using new buffer lock avoid 
3. drivers/sensors/gnss: check invalid nmea to avoid prasebuffer overflow
## Impact
Bug fix 
## Testing
Vela
