### PR TITLE
Add support for smp_call from interrupt context

### DIFF
--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -137,6 +137,14 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
       ret = call_data->func(call_data->arg);
 
       flags = enter_critical_section();
+      if (spin_is_locked(&call_data->lock))
+        {
+          if (--call_data->refcount == 0)
+            {
+              spin_unlock(&call_data->lock);
+            }
+        }
+
       if (call_data->cookie != NULL)
         {
           if (ret < 0)
@@ -145,14 +153,6 @@ int nxsched_smp_call_handler(int irq, FAR void *context,
             }
 
           nxsem_post(&call_data->cookie->sem);
-        }
-
-      if (spin_is_locked(&call_data->lock))
-        {
-          if (--call_data->refcount == 0)
-            {
-              spin_unlock(&call_data->lock);
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

1. Fix the unlock order https://github.com/apache/nuttx/commit/f859c03325958de48f1c23c64adee538de07572a
2. Replace critical section with spinlock
3. Bypass sched_lock from interrupt context

## Impact

Now can call nxsched_smp_call from interrupt context. It's will be used to call function on all foreign CPUs from assert handler in order to stop all CPUs.

## Testing

arm64 qemu with ostest https://github.com/apache/nuttx-apps/pull/2628

1. Build
` cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm64/qemu/qemu-armv8a/configs/nsh_smp nuttx`
2. Launch
`qemu-system-aarch64 -smp 4 -cpu cortex-a53 -semihosting -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel build/nuttx -s`
3. Run ostest
`ostest &`
