### PR TITLE
drivers/usbdev: don't send setconfig response for xxxx_setup with composite

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1887,9 +1887,12 @@ static int cdcecm_setup(FAR struct usbdevclass_driver_s *driver,
       ctrlreq->len   = MIN(len, ret);
       ctrlreq->flags = USBDEV_REQFLAGS_NULLPKT;
 
+#ifndef CONFIG_CDCECM_COMPOSITE
       ret = EP_SUBMIT(dev->ep0, ctrlreq);
       uinfo("EP_SUBMIT ret: %d\n", ret);
-
+#else
+      ret = composite_ep0submit(driver, dev, ctrlreq, ctrl);
+#endif
       if (ret < 0)
         {
           ctrlreq->result = OK;

--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -2836,8 +2836,12 @@ static int cdcncm_setup(FAR struct usbdevclass_driver_s *driver,
       ctrlreq->len   = MIN(len, ret);
       ctrlreq->flags = USBDEV_REQFLAGS_NULLPKT;
 
+#ifndef CONFIG_CDCNCM_COMPOSITE
       ret = EP_SUBMIT(dev->ep0, ctrlreq);
       uinfo("EP_SUBMIT ret: %d\n", ret);
+#else
+      ret = composite_ep0submit(driver, dev, ctrlreq, ctrl);
+#endif
 
       if (ret < 0)
         {


### PR DESCRIPTION

## Summary
drivers/usbdev: don't send setconfig response for xxxx_setup with composite, so need call composite_ep0submit, like cdcacm and so on
## Impact
Bug fix
## Testing
Vela
