### PR TITLE
Allow each chip to use its own timer

### DIFF
--- a/arch/arm64/src/a64/Make.defs
+++ b/arch/arm64/src/a64/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # Allwinner A64 specific C source files
-CHIP_CSRCS  = a64_boot.c a64_pio.c a64_serial.c a64_twi.c
+CHIP_CSRCS  = a64_boot.c a64_pio.c a64_serial.c a64_twi.c a64_timer.c
 
 ifeq ($(CONFIG_A64_DE),y)
 CHIP_CSRCS += a64_de.c

--- a/arch/arm64/src/a64/a64_timer.c
+++ b/arch/arm64/src/a64/a64_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/a64/a64_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -232,10 +232,7 @@ void arm64_boot_secondary_c_routine(void)
 
   arm64_gic_secondary_init();
 
-  arm64_arch_timer_secondary_init();
-
   up_perf_init(NULL);
 
   arm64_smp_init_top();
 }
-

--- a/arch/arm64/src/fvp-v8r/Make.defs
+++ b/arch/arm64/src/fvp-v8r/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # fvp-specific C source files
-CHIP_CSRCS  = fvp_boot.c fvp_serial.c
+CHIP_CSRCS  = fvp_boot.c fvp_serial.c fvp_timer.c
 
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS  += fvp_lowputc.S

--- a/arch/arm64/src/fvp-v8r/fvp_timer.c
+++ b/arch/arm64/src/fvp-v8r/fvp_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/fvp-v8r/fvp_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/goldfish/Make.defs
+++ b/arch/arm64/src/goldfish/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # qemu-specific C source files
-CHIP_CSRCS = goldfish_boot.c goldfish_serial.c
+CHIP_CSRCS = goldfish_boot.c goldfish_serial.c goldfish_timer.c
 
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS = goldfish_lowputc.S

--- a/arch/arm64/src/goldfish/goldfish_timer.c
+++ b/arch/arm64/src/goldfish/goldfish_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/goldfish/goldfish_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/imx8/Make.defs
+++ b/arch/arm64/src/imx8/Make.defs
@@ -22,7 +22,7 @@ include common/Make.defs
 
 # i.MX8-specific C source files
 
-CHIP_CSRCS  = imx8_boot.c
+CHIP_CSRCS  = imx8_boot.c imx8_timer.c
 
 ifeq ($(CONFIG_ARCH_CHIP_IMX8_QUADMAX),y)
   CHIP_CSRCS += imx8qm_serial.c

--- a/arch/arm64/src/imx8/imx8_timer.c
+++ b/arch/arm64/src/imx8/imx8_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/imx8/imx8_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -22,7 +22,8 @@ include common/Make.defs
 
 # i.MX9-specific C source files
 
-CHIP_CSRCS = imx9_boot.c imx9_ccm.c imx9_clockconfig.c imx9_gpio.c imx9_iomuxc.c
+CHIP_CSRCS  = imx9_boot.c imx9_ccm.c imx9_clockconfig.c imx9_gpio.c
+CHIP_CSRCS += imx9_iomuxc.c imx9_timer.c
 
 ifeq ($(CONFIG_ARCH_CHIP_IMX93),y)
   CHIP_CSRCS += imx9_lpuart.c imx9_lowputc.c

--- a/arch/arm64/src/imx9/imx9_timer.c
+++ b/arch/arm64/src/imx9/imx9_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/imx9/imx9_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/qemu/CMakeLists.txt
+++ b/arch/arm64/src/qemu/CMakeLists.txt
@@ -17,7 +17,7 @@
 # the License.
 #
 # ##############################################################################
-set(SRCS qemu_boot.c qemu_serial.c)
+set(SRCS qemu_boot.c qemu_serial.c qemu_timer.c)
 
 if(CONFIG_ARCH_EARLY_PRINT)
   list(APPEND SRCS qemu_lowputc.S)

--- a/arch/arm64/src/qemu/Make.defs
+++ b/arch/arm64/src/qemu/Make.defs
@@ -23,6 +23,8 @@ include common/Make.defs
 # qemu-specific C source files
 CHIP_CSRCS  = qemu_boot.c qemu_serial.c
 
+CHIP_CSRCS += qemu_timer.c
+
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS  = qemu_lowputc.S
 endif

--- a/arch/arm64/src/qemu/qemu_timer.c
+++ b/arch/arm64/src/qemu/qemu_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/qemu/qemu_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/rk3399/Make.defs
+++ b/arch/arm64/src/rk3399/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # Rockchip RK3399 specific C source files
-CHIP_CSRCS  = rk3399_boot.c rk3399_serial.c
+CHIP_CSRCS  = rk3399_boot.c rk3399_serial.c rk3399_timer.c
 
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS  = rk3399_lowputc.S

--- a/arch/arm64/src/rk3399/rk3399_timer.c
+++ b/arch/arm64/src/rk3399/rk3399_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/rk3399/rk3399_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}

--- a/arch/arm64/src/zynq-mpsoc/Make.defs
+++ b/arch/arm64/src/zynq-mpsoc/Make.defs
@@ -21,7 +21,7 @@
 include common/Make.defs
 
 # Rockchip zynq mpsoc specific C source files
-CHIP_CSRCS  = zynq_boot.c zynq_serial.c zynq_mio.c
+CHIP_CSRCS  = zynq_boot.c zynq_serial.c zynq_mio.c zynq_timer.c
 
 ifeq ($(CONFIG_ARCH_EARLY_PRINT),y)
 CHIP_ASRCS  = zynq_lowputc.S

--- a/arch/arm64/src/zynq-mpsoc/zynq_timer.c
+++ b/arch/arm64/src/zynq-mpsoc/zynq_timer.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/common/arm64_arch_timer.h
+ * arch/arm64/src/zynq-mpsoc/zynq_timer.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,33 +18,19 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-#define __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/arch_alarm.h>
+
+#include "arm64_arch_timer.h"
 
 /****************************************************************************
- * Public Function Prototypes
+ * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: arm64_oneshot_initialize
- *
- * Description:
- *   This function initialize generic timer hardware module
- *   and return an instance of a "lower half" timer interface.
- *
- * Returned Value:
- *   On success, a non-NULL oneshot_lowerhalf_s is returned to the caller.
- *   In the event of any failure, a NULL value is returned.
- *
- ****************************************************************************/
-
-struct oneshot_lowerhalf_s *arm64_oneshot_initialize(void);
-
-#endif /* __ARCH_ARM64_SRC_COMMON_ARM64_ARCH_TIMER_H */
+void up_timer_initialize(void)
+{
+  up_alarm_set_lowerhalf(arm64_oneshot_initialize());
+}


### PR DESCRIPTION
## Summary

Similar to arch/arm, let chip implement their own up_timer_initialize. By default the `arm64_oneshot_initialize` timer is used.

## Impact

There should be no impact. It simply move the timer to chip level code.

## Testing

Tested with qemu arm64

```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm64/qemu/qemu-armv8a/configs/nsh_smp nuttx

qemu-system-aarch64 -smp 2 -cpu cortex-a53 -semihosting -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel build/nuttx -s

ostest &
```
