### PR TITLE
Documentation: improve command doc to run CI test locally

### DIFF
--- a/Documentation/guides/citests.rst
+++ b/Documentation/guides/citests.rst
@@ -60,7 +60,7 @@ by following command.
 
   .. code-block:: console
 
-      $ python3 -m pytest -m 'common or sim' ./ -B sim -P nuttx-path -L log-path -R sim -C --json=log-path/pytest.json
+      $ python3 -m pytest -m 'common or sim' ./ -B sim -P <nuttx-path> -L <log-path> -R sim -C --json=<log-path>/pytest.json
 
 Where nuttx-path is an absolute path to NuttX root directory and log-path is
 a user defined directory to which tests log are saved.


### PR DESCRIPTION
## Summary
Add `<>` for user defined variable in the command to run CI test locally. This makes it more obvious that the user needs to change those to execute the command.

## Impact
Update Documentation only

## Testing
local doc build
