### PR TITLE
nuttx/libm: Fix powl wrong if first parameter is negative

### DIFF
--- a/libs/libm/libm/lib_pow.c
+++ b/libs/libm/libm/lib_pow.c
@@ -41,11 +41,11 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double pow(double b, double e)
 {
-  if (b > 0)
+  if (b > 0.0)
     {
       return exp(e * log(b));
     }
-  else if (b < 0 && e == (int)e)
+  else if (b < 0.0 && e == (int)e)
     {
       if ((int)e % 2 == 0)
         {
@@ -57,6 +57,6 @@ double pow(double b, double e)
         }
     }
 
-  return 0;
+  return 0.0;
 }
 #endif

--- a/libs/libm/libm/lib_powf.c
+++ b/libs/libm/libm/lib_powf.c
@@ -37,11 +37,11 @@
 
 float powf(float b, float e)
 {
-  if (b > 0.0)
+  if (b > 0.0f)
     {
       return expf(e * logf(b));
     }
-  else if (b < 0.0 && e == (int)e)
+  else if (b < 0.0f && e == (int)e)
     {
       if ((int)e % 2 == 0)
         {
@@ -53,5 +53,5 @@ float powf(float b, float e)
         }
     }
 
-  return 0.0;
+  return 0.0f;
 }

--- a/libs/libm/libm/lib_powl.c
+++ b/libs/libm/libm/lib_powl.c
@@ -41,6 +41,22 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double powl(long double b, long double e)
 {
-  return expl(e * logl(b));
+  if (b > 0.0)
+    {
+      return expl(e * logl(b));
+    }
+  else if (b < 0.0 && e == (int)e)
+    {
+      if ((int)e % 2 == 0)
+        {
+          return expl(e * logl(fabsl(b)));
+        }
+      else
+        {
+          return -expl(e * logl(fabsl(b)));
+        }
+    }
+
+  return 0.0;
 }
 #endif


### PR DESCRIPTION
## Summary
This PR applies the pattern of calculation used for `pow` and `powf` to `powl`

## Impact
Has no impact on current implementation

## Testing
Pass CI