### PR TITLE
armv7/8-m/r: fix build warning

### DIFF
--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -208,7 +208,7 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  ****************************************************************************/
 
 #if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
-static void mpu_reset_internal()
+static void mpu_reset_internal(void)
 {
   int region;
   int regions;
@@ -647,7 +647,7 @@ void mpu_dump_region(void)
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_RESET)
-void mpu_reset()
+void mpu_reset(void)
 {
   mpu_reset_internal();
 }
@@ -668,7 +668,7 @@ void mpu_reset()
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_EARLY_RESET)
-void mpu_early_reset()
+void mpu_early_reset(void)
 {
   mpu_reset_internal();
 }

--- a/arch/arm/src/armv7-r/arm_mpu.c
+++ b/arch/arm/src/armv7-r/arm_mpu.c
@@ -207,7 +207,7 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  ****************************************************************************/
 
 #if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
-static void mpu_reset_internal()
+static void mpu_reset_internal(void)
 {
   int region;
   int regions;
@@ -570,7 +570,7 @@ void mpu_dump_region(void)
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_RESET)
-void mpu_reset()
+void mpu_reset(void)
 {
   mpu_reset_internal();
 }
@@ -591,7 +591,7 @@ void mpu_reset()
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_EARLY_RESET)
-void mpu_early_reset()
+void mpu_early_reset(void)
 {
   mpu_reset_internal();
 }

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -70,7 +70,7 @@ static unsigned int g_mpu_region;
  ****************************************************************************/
 
 #if defined(CONFIG_ARM_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
-static void mpu_reset_internal()
+static void mpu_reset_internal(void)
 {
   int region;
   int regions;
@@ -379,7 +379,7 @@ void mpu_dump_region(void)
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_RESET)
-void mpu_reset()
+void mpu_reset(void)
 {
   mpu_reset_internal();
 }
@@ -400,7 +400,7 @@ void mpu_reset()
  *
  ****************************************************************************/
 #if defined(CONFIG_ARM_MPU_EARLY_RESET)
-void mpu_early_reset()
+void mpu_early_reset(void)
 {
   mpu_reset_internal();
 }


### PR DESCRIPTION
## Summary

Error: armv7-m/arm_mpu.c:211:13: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  211 | static void mpu_reset_internal()
      |             ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:168: arm_mpu.o] Error 1

## Impact

mpu

## Testing

Compile only