### PR TITLE
xtensa/esp32s3: add setup rx dma after slave receive data

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -1732,19 +1732,28 @@ static size_t spislave_qpoll(struct spi_slave_ctrlr_s *ctrlr)
 
   tmp = SPIS_DEV_RECEIVE(priv->dev, priv->rx_buffer,
                          BYTES2WORDS(priv, priv->rx_length));
-  recv_n = WORDS2BYTES(priv, tmp);
-  if (recv_n < priv->rx_length)
+  if (tmp)
     {
-      /* If the upper layer does not receive all of the data from the receive
-       * buffer, move the remaining data to the head of the buffer.
-       */
+      recv_n = WORDS2BYTES(priv, tmp);
+      if (recv_n < priv->rx_length)
+        {
+          /* If the upper layer does not receive all of the data from the
+           * receive buffer, move the remaining data to the head of the
+           * buffer.
+           */
 
-      priv->rx_length -= recv_n;
-      memmove(priv->rx_buffer, priv->rx_buffer + recv_n, priv->rx_length);
-    }
-  else
-    {
-      priv->rx_length = 0;
+          priv->rx_length -= recv_n;
+          memmove(priv->rx_buffer, priv->rx_buffer + recv_n,
+                  priv->rx_length);
+        }
+      else
+        {
+          priv->rx_length = 0;
+        }
+
+  #ifdef CONFIG_ESP32S3_SPI_DMA
+      spislave_setup_rx_dma(priv);
+  #endif
     }
 
   remaining_words = BYTES2WORDS(priv, priv->rx_length);


### PR DESCRIPTION
## Summary
Slave receive more than half buffer size, for example, Master and Slave buffer size is 32K, Master send more than 16K data through DMA every time, the first 16K data received by Slave is correct, but the data received afterward is wrong .
This because after Slave receiving data, it update data offset in the buffer, but not update DMA buffer Link List.

## Impact
ESP32S3 SPI

## Testing
Test with two esp32s3-devkit, one as master, another as slave.
