### PR TITLE
risc-v: Support customize idle loop

### DIFF
--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -25,14 +25,17 @@ list(APPEND SRCS riscv_saveusercontext.S)
 list(APPEND SRCS riscv_allocateheap.c riscv_cpuidlestack.c)
 list(APPEND SRCS riscv_cpuinfo.c riscv_createstack.c riscv_doirq.c
      riscv_exception.c)
-list(APPEND SRCS riscv_exit.c riscv_getintstack.c riscv_getnewintctx.c
-     riscv_idle.c)
+list(APPEND SRCS riscv_exit.c riscv_getintstack.c riscv_getnewintctx.c)
 list(APPEND SRCS riscv_initialize.c riscv_initialstate.c riscv_modifyreg32.c)
 list(APPEND SRCS riscv_mtimer.c riscv_nputs.c riscv_registerdump.c)
 list(APPEND SRCS riscv_releasestack.c riscv_schedulesigaction.c
      riscv_sigdeliver.c)
 list(APPEND SRCS riscv_stackframe.c riscv_tcbinfo.c riscv_swint.c)
 list(APPEND SRCS riscv_switchcontext.c riscv_usestack.c)
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS riscv_idle.c)
+endif()
 
 if(NOT CONFIG_ALARM_ARCH)
   if(NOT CONFIG_TIMER_ARCH)

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -31,10 +31,14 @@ CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_mtimer.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_cpuinfo.c
 CMN_CSRCS += riscv_cpuidlestack.c riscv_doirq.c riscv_exit.c riscv_exception.c
 CMN_CSRCS += riscv_getnewintctx.c riscv_getintstack.c riscv_initialstate.c
-CMN_CSRCS += riscv_idle.c riscv_modifyreg32.c riscv_nputs.c riscv_releasestack.c
+CMN_CSRCS += riscv_modifyreg32.c riscv_nputs.c riscv_releasestack.c
 CMN_CSRCS += riscv_registerdump.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_switchcontext.c
 CMN_CSRCS += riscv_usestack.c riscv_tcbinfo.c
+
+ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
+  CMN_CSRCS += riscv_idle.c
+endif
 
 ifneq ($(CONFIG_ALARM_ARCH),y)
   ifneq ($(CONFIG_TIMER_ARCH),y)


### PR DESCRIPTION


## Summary
Support customize idle loop by CONFIG_ARCH_IDLE_CUSTOM as other architectures.

Then user can provide their own `up_idle()` function with CONFIG_ARCH_IDLE_CUSTOM enabled.
## Impact
build system
## Testing
CI
