### PR TITLE
x86_64: we should call x86_64_restorestate/x86_64_savestate

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpupause.c
+++ b/arch/x86_64/src/intel64/intel64_cpupause.c
@@ -286,9 +286,16 @@ int up_pause_handler(int irq, void *c, void *arg)
 
 int up_pause_async_handler(int irq, void *c, void *arg)
 {
+  struct tcb_s *tcb;
   int cpu = this_cpu();
 
+  tcb = current_task(cpu);
+  nxsched_suspend_scheduler(tcb);
+  x86_64_savestate(tcb->xcp.regs);
   nxsched_process_delivered(cpu);
+  tcb = current_task(cpu);
+  nxsched_resume_scheduler(tcb);
+  x86_64_restorestate(tcb->xcp.regs);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
In x86_64, g_current_regs is still used for context switching.

This commit fixes the regression from https://github.com/apache/nuttx/pull/13616
## Impact
x86_64

## Testing
qemu-intel64:smp (signest_test will Occasional failure not caused by https://github.com/apache/nuttx/pull/13616)