### PR TITLE
fs/ioctl:add FIOC_XIPBASE to get file xip address

### DIFF
--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -604,6 +604,21 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       strlcat(ptr, rf->rf_path, PATH_MAX);
       return OK;
     }
+  else if (cmd == FIOC_XIPBASE)
+    {
+      FAR struct romfs_mountpt_s *rm = filep->f_inode->i_private;
+      FAR uintptr_t *ptr = (FAR uintptr_t *)arg;
+
+      if (rm->rm_xipbase != 0)
+        {
+          *ptr = (uintptr_t)rm->rm_xipbase + rf->rf_startoffset;
+          return OK;
+        }
+      else
+        {
+          return -ENXIO;
+        }
+    }
 
   return -ENOTTY;
 }

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1825,6 +1825,13 @@ static int tmpfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           return ret;
         }
     }
+  else if (cmd == FIOC_XIPBASE)
+    {
+      FAR uintptr_t *ptr = (FAR uintptr_t *)arg;
+
+      *ptr = (uintptr_t)tfo->tfo_data;
+      return OK;
+    }
 
   return ret;
 }

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -226,6 +226,9 @@
 #define FIOC_SETLKW         _FIOC(0x0014) /* IN:  Pointer to flock
                                            * OUT: None
                                            */
+#define FIOC_XIPBASE        _FIOC(0x0015) /* IN:  uinptr_t *
+                                           * OUT: Current file xip base address
+                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 


### PR DESCRIPTION
## Summary
in tmpfs/romfs, we can get file real xip address to execute program
## Impact
romfs & tmpfs
## Testing
qemu with mps3 an547
