### PR TITLE
coredump:Add a coreudmp api to watch custom variables

### DIFF
--- a/binfmt/binfmt_coredump.c
+++ b/binfmt/binfmt_coredump.c
@@ -45,7 +45,7 @@
  *
  ****************************************************************************/
 
-int core_dump(FAR struct memory_region_s *regions,
+int core_dump(FAR const struct memory_region_s *regions,
               FAR struct lib_outstream_s *stream,
               pid_t pid)
 {

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -70,7 +70,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
                           FAR const struct symtab_s *exports,
                           int nexports);
 #ifdef CONFIG_ELF_COREDUMP
-static int elf_dumpbinary(FAR struct memory_region_s *regions,
+static int elf_dumpbinary(FAR const struct memory_region_s *regions,
                           FAR struct lib_outstream_s *stream,
                           pid_t pid);
 #endif
@@ -382,7 +382,7 @@ errout_with_init:
  ****************************************************************************/
 
 #ifdef CONFIG_ELF_COREDUMP
-static int elf_dumpbinary(FAR struct memory_region_s *regions,
+static int elf_dumpbinary(FAR const struct memory_region_s *regions,
                           FAR struct lib_outstream_s *stream,
                           pid_t pid)
 {

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -139,7 +139,7 @@ struct binfmt_s
 
   /* Coredump callback */
 
-  CODE int (*coredump)(FAR struct memory_region_s *regions,
+  CODE int (*coredump)(FAR const struct memory_region_s *regions,
                        FAR struct lib_outstream_s *stream,
                        pid_t pid);
 };
@@ -220,7 +220,7 @@ int unregister_binfmt(FAR struct binfmt_s *binfmt);
  *
  ****************************************************************************/
 
-int core_dump(FAR struct memory_region_s *regions,
+int core_dump(FAR const struct memory_region_s *regions,
               FAR struct lib_outstream_s *stream,
               pid_t pid);
 

--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -134,7 +134,7 @@ struct elf_loadinfo_s
 #ifdef CONFIG_ELF_COREDUMP
 struct elf_dumpinfo_s
 {
-  FAR struct memory_region_s *regions;
+  FAR const struct memory_region_s *regions;
   FAR struct lib_outstream_s *stream;
   pid_t                       pid;
 };

--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -40,7 +40,7 @@
  *
  ****************************************************************************/
 
-int coredump_set_memory_region(FAR struct memory_region_s *region);
+int coredump_set_memory_region(FAR const struct memory_region_s *region);
 
 /****************************************************************************
  * Name: coredump_initialize

--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -43,6 +43,16 @@
 int coredump_set_memory_region(FAR const struct memory_region_s *region);
 
 /****************************************************************************
+ * Name: coredump_add_memory_region
+ *
+ * Description:
+ *   Use coredump to dump the memory of the specified area.
+ *
+ ****************************************************************************/
+
+int coredump_add_memory_region(FAR const void *ptr, size_t size);
+
+/****************************************************************************
  * Name: coredump_initialize
  *
  * Description:

--- a/include/nuttx/memoryregion.h
+++ b/include/nuttx/memoryregion.h
@@ -39,7 +39,6 @@ struct memory_region_s
   uintptr_t end;     /* End address of this region */
   uint32_t  flags;   /* Figure 5-3: Segment Flag Bits: PF_[X|W|R] */
 };
-
 /****************************************************************************
  * Public Function
  ****************************************************************************/
@@ -91,6 +90,6 @@ alloc_memory_region(FAR const char *format);
  *
  ****************************************************************************/
 
-void free_memory_region(FAR struct memory_region_s *region);
+void free_memory_region(FAR const struct memory_region_s *region);
 
 #endif /* __INCLUDE_MEMORYREGION_H */

--- a/libs/libc/misc/lib_memoryregion.c
+++ b/libs/libc/misc/lib_memoryregion.c
@@ -143,10 +143,10 @@ alloc_memory_region(FAR const char *format)
  *
  ****************************************************************************/
 
-void free_memory_region(FAR struct memory_region_s *region)
+void free_memory_region(FAR const struct memory_region_s *region)
 {
   if (region != NULL)
     {
-      lib_free(region);
+      lib_free((FAR void *)region);
     }
 }

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -47,7 +47,7 @@ static struct lib_blkoutstream_s  g_blockstream;
 static unsigned char *g_blockinfo;
 #endif
 
-static struct memory_region_s *g_regions;
+static const struct memory_region_s *g_regions;
 
 /****************************************************************************
  * Private Functions
@@ -173,7 +173,7 @@ static void coredump_dump_blkdev(pid_t pid)
  *
  ****************************************************************************/
 
-int coredump_set_memory_region(FAR struct memory_region_s *region)
+int coredump_set_memory_region(FAR const struct memory_region_s *region)
 {
   /* Not free g_regions, because allow call this fun when crash */
 


### PR DESCRIPTION
## Summary
Add a coreudmp api to watch custom variables
## Impact
coredump
## Testing
qemu with mps3 an547 syslog coredump

if we want add some variables in coredump
we can use `coredump_add_memory_region(&var, sizeof(var))`

