### PR TITLE
sim: add NXSYMBOLS for  pthread_gettid_np pthread_self

### DIFF
--- a/arch/sim/src/nuttx-names.in
+++ b/arch/sim/src/nuttx-names.in
@@ -99,6 +99,7 @@ NXSYMBOLS(pthread_cond_init)
 NXSYMBOLS(pthread_cond_signal)
 NXSYMBOLS(pthread_cond_wait)
 NXSYMBOLS(pthread_create)
+NXSYMBOLS(pthread_gettid_np)
 #if defined(CONFIG_TLS_NELEM) && CONFIG_TLS_NELEM > 0
 NXSYMBOLS(pthread_getspecific)
 NXSYMBOLS(pthread_key_create)
@@ -111,6 +112,7 @@ NXSYMBOLS(pthread_mutex_unlock)
 #if defined(CONFIG_TLS_NELEM) && CONFIG_TLS_NELEM > 0
 NXSYMBOLS(pthread_setspecific)
 #endif
+NXSYMBOLS(pthread_self)
 NXSYMBOLS(pthread_sigmask)
 NXSYMBOLS(puts)
 NXSYMBOLS(read)


### PR DESCRIPTION

## Summary
add NXSYMBOLS for  pthread_gettid_np pthread_self
enable sim:smp can boot

This commit fixes the regression from https://github.com/apache/nuttx/pull/12561
## Impact
sim

## Testing
ostest (but signest_test can still fail for other reason not cause by https://github.com/apache/nuttx/pull/13616)

