### PR TITLE
serial: add message for FORCE_PANIC

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -2081,7 +2081,7 @@ int uart_check_special(FAR uart_dev_t *dev, FAR const char *buf, size_t size)
 #ifdef CONFIG_TTY_FORCE_PANIC
       if (buf[i] == CONFIG_TTY_FORCE_PANIC_CHAR)
         {
-          PANIC();
+          PANIC_WITH_REGS("Force panic by user.", NULL);
           return 0;
         }
 #endif


### PR DESCRIPTION
## Summary

Print a log when user manually force panic the board.

## Impact

No.

## Testing

Tested on qemu, log is correctly printed out.

```
nsh> [CPU0] _assert: Current Version: NuttX  12.6.0 216f535472-dirty Sep 30 2024 15:34:51 arm64
[CPU0] _assert: Assertion failed Force panic by user.: at file: /drivers/serial/serial.c:2084 task(CPU0): CPU0 IDLE process: Kernel 0x4028cdac

```
