### PR TITLE
ctype.h(bugfix):move locale macro define into lib_ctype file

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -34,23 +34,6 @@
 #include <langinfo.h>
 
 /****************************************************************************
- * Macro Definitions
- ****************************************************************************/
-
-/* GNU libstdc++ is expecting ctype.h to define a few macros for
- * locale related functions like C++ streams.
- */
-
-#define _U  01
-#define _L  02
-#define _N  04
-#define _S  010
-#define _P  020
-#define _C  040
-#define _X  0100
-#define _B  0200
-
-/****************************************************************************
  * Inline Functions
  ****************************************************************************/
 

--- a/libs/libc/ctype/lib_ctype.c
+++ b/libs/libc/ctype/lib_ctype.c
@@ -27,6 +27,23 @@
 #include <ctype.h>
 
 /****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+/* GNU libstdc++ is expecting ctype.h to define a few macros for
+ * locale related functions like C++ streams.
+ */
+
+#define _U  01
+#define _L  02
+#define _N  04
+#define _S  010
+#define _P  020
+#define _C  040
+#define _X  0100
+#define _B  0200
+
+/****************************************************************************
  * Private Types
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

When compiling `MSVC` after  https://github.com/apache/nuttx/pull/12230., a strange compilation error will occur.

```shell
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(36,112): error C2143: syntax error: 缺少“)”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(36,112): error C2143: syntax error: 缺少“{”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(36,112): error C2059: syntax error:“常数” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(36,154): error C2059: syntax error:“)” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(37,75): error C2143: syntax error: 缺少“)”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(37,75): error C2143: syntax error: 缺少“{”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(37,75): error C2059: syntax error:“常数” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(37,121): error C2059: syntax error:“)” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(39,112): error C2143: syntax error: 缺少“)”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(39,112): error C2143: syntax error: 缺少“{”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(39,112): error C2059: syntax error:“常数” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(39,154): error C2059: syntax error:“)” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(40,75): error C2143: syntax error: 缺少“)”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(40,75): error C2143: syntax error: 缺少“{”(在“常数”的前面) [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(40,75): error C2059: syntax error:“常数” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)

C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\uchar.h(40,121): error C2059: syntax error:“)” [D:\jenkins_home\github\nuttx\vs2022\sched\sched.vcxproj]
  (“../../sched/task/task_setup.c”)
``` 

This is caused by the following code of **MSVC's** **uchar.h** header file

```c
_Check_return_ _ACRTIMP size_t __cdecl mbrtoc16(_Out_opt_ char16_t *_Pc16, _In_reads_or_z_opt_(_N) const char *_S, _In_ size_t _N, _Inout_ mbstate_t *_Ps);
_Check_return_ _ACRTIMP size_t __cdecl c16rtomb(_Out_writes_opt_(4) char *_S, _In_ char16_t _C16, _Inout_ mbstate_t *_Ps);

_Check_return_ _ACRTIMP size_t __cdecl mbrtoc32(_Out_opt_ char32_t *_Pc32, _In_reads_or_z_opt_(_N) const char *_S, _In_ size_t _N, _Inout_ mbstate_t *_Ps);
_Check_return_ _ACRTIMP size_t __cdecl c32rtomb(_Out_writes_opt_(4) char *_S, _In_ char32_t _C32, _Inout_ mbstate_t *_Ps);
``` 
### root cause

Macro definitions such as **_S** in public header files can cause compilation problems under the **MSVC** compiler. 

so this patch move macro definitions that are not used in public locations to the corresponding files

## Impact

refator, no user awareness

## Testing

native windows
```shell
cmake -B vs2022 -DBOARD_CONFIG=sim/windows -G"Visual Studio 17 2022" -A Win32
cmake --build vs2022
``` 


