### PR TITLE
char driver CAN: add tx_confirm ability in upperCAN driver.

### DIFF
--- a/arch/arm/src/at32/at32_can.c
+++ b/arch/arm/src/at32/at32_can.c
@@ -1586,7 +1586,7 @@ static int at32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 
@@ -1895,7 +1895,7 @@ static int at32can_sceinterrupt(int irq, void *context, void *arg)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
@@ -1356,7 +1356,7 @@ static void can_interrupt(struct lpc17_40_can_s *dev)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = ((rfs & CAN_RFS_FF) != 0);
 #else
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       if ((rfs & CAN_RFS_FF) != 0)
         {

--- a/arch/arm/src/sama5/sam_can.c
+++ b/arch/arm/src/sama5/sam_can.c
@@ -1318,7 +1318,7 @@ static inline void can_rxinterrupt(struct can_dev_s *dev, int mbndx,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* And provide the CAN message to the upper half logic */
 

--- a/arch/arm/src/sama5/sam_mcan.c
+++ b/arch/arm/src/sama5/sam_mcan.c
@@ -3459,14 +3459,14 @@ static void mcan_error(struct can_dev_s *dev, uint32_t status)
     {
       /* Format the CAN header for the error report. */
 
-      hdr.ch_id     = errbits;
-      hdr.ch_dlc    = CAN_ERROR_DLC;
-      hdr.ch_rtr    = 0;
-      hdr.ch_error  = 1;
+      hdr.ch_id    = errbits;
+      hdr.ch_dlc   = CAN_ERROR_DLC;
+      hdr.ch_rtr   = 0;
+      hdr.ch_error = 1;
 #ifdef CONFIG_CAN_EXTID
-      hdr.ch_extid  = 0;
+      hdr.ch_extid = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf   = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -3628,7 +3628,7 @@ static void mcan_receive(struct can_dev_s *dev, uint32_t *rxbuffer,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   if ((regval & BUFFER_R0_RTR) != 0)
     {

--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -3483,7 +3483,7 @@ static void mcan_error(struct can_dev_s *dev, uint32_t status)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -3535,9 +3535,9 @@ static void mcan_receive(struct can_dev_s *dev, uint32_t *rxbuffer,
   reginfo("R0: %08" PRIx32 "\n", regval);
 
 #ifdef CONFIG_CAN_ERRORS
-  hdr.ch_error  = 0;
+  hdr.ch_error = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf   = 0;
 
   if ((regval & BUFFER_R0_RTR) != 0)
     {

--- a/arch/arm/src/stm32/stm32_can.c
+++ b/arch/arm/src/stm32/stm32_can.c
@@ -1581,7 +1581,7 @@ static int stm32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 
@@ -1890,7 +1890,7 @@ static int stm32can_sceinterrupt(int irq, void *context, void *arg)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 

--- a/arch/arm/src/stm32/stm32_fdcan.c
+++ b/arch/arm/src/stm32/stm32_fdcan.c
@@ -2801,7 +2801,7 @@ static void fdcan_error(struct can_dev_s *dev, uint32_t status)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -2846,7 +2846,7 @@ static void fdcan_receive(struct can_dev_s *dev,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/arch/arm/src/stm32f7/stm32_can.c
+++ b/arch/arm/src/stm32f7/stm32_can.c
@@ -1518,7 +1518,7 @@ static int stm32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/arch/arm/src/stm32l4/stm32l4_can.c
+++ b/arch/arm/src/stm32l4/stm32l4_can.c
@@ -1445,7 +1445,7 @@ static int stm32l4can_rxinterrupt(int irq, void *context, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -51,6 +51,17 @@ config CAN_NPENDINGRTR
 	---help---
 		The size of the list of pending RTR requests. Default: 4
 
+config CAN_TXCONFIRM
+        bool "can txconfirm ability"
+        default n
+        ---help---
+                this section enables the can txconfirm ability.
+
+                Enabling this feature adds support for the can txconfirm
+                ability, the ability is used from CAN interrupt handler
+                when the transfer is complete, the ability will notify all
+                readers that the canid has been transferred.
+
 config CAN_TXREADY
 	bool "can_txready interface"
 	default n

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -408,7 +408,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 #ifdef CONFIG_CAN_EXTID
           msg->cm_hdr.ch_extid  = 0;
 #endif
-          msg->cm_hdr.ch_unused = 0;
+          msg->cm_hdr.ch_tcf    = 0;
           memset(&(msg->cm_data), 0, CAN_ERROR_DLC);
           msg->cm_data[5]       = fifo->rx_error;
 
@@ -1172,7 +1172,11 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
               memcpy(&waitmsg->cm_hdr, hdr, sizeof(struct can_hdr_s));
 
               nbytes = can_dlc2bytes(hdr->ch_dlc);
-              memcpy(waitmsg->cm_data, data, nbytes);
+              if (nbytes)
+                {
+                  memcpy(waitmsg->cm_data, data, nbytes);
+                }
+
               dev->cd_npendrtr--;
 
               /* Restart the waiting thread and mark the entry unused */
@@ -1213,7 +1217,10 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
                  sizeof(struct can_hdr_s));
 
           nbytes = can_dlc2bytes(hdr->ch_dlc);
-          memcpy(fifo->rx_buffer[fifo->rx_tail].cm_data, data, nbytes);
+          if (nbytes)
+            {
+              memcpy(fifo->rx_buffer[fifo->rx_tail].cm_data, data, nbytes);
+            }
 
           /* Increment the tail of the circular buffer */
 

--- a/drivers/can/mcp2515.c
+++ b/drivers/can/mcp2515.c
@@ -2031,7 +2031,7 @@ static void mcp2515_error(FAR struct can_dev_s *dev, uint8_t status,
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -2141,7 +2141,7 @@ static void mcp2515_receive(FAR struct can_dev_s *dev, uint8_t offset)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -510,7 +510,7 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_brs    : 1; /* Bit Rate Switch */
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
-  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
+  uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
 } end_packed_struct;
 
 #else
@@ -527,7 +527,7 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_brs    : 1; /* Bit Rate Switch */
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
-  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
+  uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
 } end_packed_struct;
 #endif
 


### PR DESCRIPTION
## Summary
add tx_confirm ability in upperCAN driver.

## Impact

need merge with https://github.com/apache/nuttx-apps/pull/2635
## Testing

test with flagchip