### PR TITLE
chardriver upperCAN: support to independent set TX/RX FIFO size.

### DIFF
--- a/Documentation/platforms/arm/samv7/boards/same70-xplained/README.txt
+++ b/Documentation/platforms/arm/samv7/boards/same70-xplained/README.txt
@@ -695,7 +695,8 @@ MCAN1 Loopback Test
 
     Device Drivers -> CAN Driver support
        CONFIG_CAN=y                            # Enable the upper-half CAN driver
-       CONFIG_CAN_FIFOSIZE=8
+       CONFIG_CAN_TXFIFOSIZE=8
+       CONFIG_CAN_RXFIFOSIZE=8
        CONFIG_CAN_NPENDINGRTR=4
 
     System Type -> SAMV7 Peripheral Selections

--- a/Documentation/platforms/arm/samv7/boards/samv71-xult/README.txt
+++ b/Documentation/platforms/arm/samv7/boards/samv71-xult/README.txt
@@ -1288,7 +1288,8 @@ MCAN1 Loopback Test
 
     Device Drivers -> CAN Driver support
        CONFIG_CAN=y                            # Enable the upper-half CAN driver
-       CONFIG_CAN_FIFOSIZE=8
+       CONFIG_CAN_TXFIFOSIZE=8
+       CONFIG_CAN_RXFIFOSIZE=8
        CONFIG_CAN_NPENDINGRTR=4
 
     System Type -> SAMV7 Peripheral Selections

--- a/Documentation/platforms/arm/stm32f1/boards/cloudctrl/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/cloudctrl/index.rst
@@ -385,7 +385,11 @@ Cloudctrl-specific Configuration Options
 
    CONFIG_CAN - Enables CAN support (one or both of CONFIG_STM32_CAN1 or
    CONFIG_STM32_CAN2 must also be defined)
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/fire-stm32v2/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/fire-stm32v2/index.rst
@@ -501,7 +501,11 @@ M3 Wildfire-specific Configuration Options
    CONFIG_STM32_CAN2 must also be defined)
    CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
    Standard 11-bit IDs.
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/hymini-stm32/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/hymini-stm32/index.rst
@@ -282,7 +282,11 @@ HY-Mini specific Configuration Options
          CONFIG_STM32_CAN2 must also be defined)
        CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
          Standard 11-bit IDs.
-       CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+       CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+         of CAN messages.
+         Default: 8
+       CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+         of CAN messages.
          Default: 8
        CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
          Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/shenzhou/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/shenzhou/index.rst
@@ -395,7 +395,11 @@ Shenzhou-specific Configuration Options
 
    CONFIG_CAN - Enables CAN support (one or both of CONFIG_STM32_CAN1 or
    CONFIG_STM32_CAN2 must also be defined)
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm3210e-eval/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm3210e-eval/index.rst
@@ -444,7 +444,11 @@ STM3210E-EVAL-specific Configuration Options
    CONFIG_STM32_CAN2 must also be defined)
    CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
    Standard 11-bit IDs.
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm32_tiny/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm32_tiny/index.rst
@@ -231,7 +231,11 @@ STM32 Tiny - specific Configuration Options
          CONFIG_STM32_CAN2 must also be defined)
        CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
          Standard 11-bit IDs.
-       CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+       CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+         of CAN messages.
+         Default: 8
+       CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+         of CAN messages.
          Default: 8
        CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
          Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm32f103-minimum/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm32f103-minimum/index.rst
@@ -740,7 +740,11 @@ STM32F103 Minimum - specific Configuration Options
             CONFIG_STM32_CAN2 must also be defined)
           CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
             Standard 11-bit IDs.
-          CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+          CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+            of CAN messages.
+            Default: 8
+          CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+            of CAN messages.
             Default: 8
           CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
             Default: 4

--- a/Documentation/platforms/arm/stm32f2/index.rst
+++ b/Documentation/platforms/arm/stm32f2/index.rst
@@ -93,7 +93,12 @@ CAN
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.
   Default Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f3/index.rst
+++ b/Documentation/platforms/arm/stm32f3/index.rst
@@ -140,7 +140,12 @@ CAN character device
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
   Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f4/index.rst
+++ b/Documentation/platforms/arm/stm32f4/index.rst
@@ -144,7 +144,12 @@ CAN
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
   Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f7/index.rst
+++ b/Documentation/platforms/arm/stm32f7/index.rst
@@ -189,7 +189,13 @@ CAN
 
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.  Default: 8
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
+  Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.  Default: 4
 

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -39,11 +39,19 @@ config CAN_FD
 	---help---
 		Enables support for the CAN_FD mode.
 
-config CAN_FIFOSIZE
-	int "CAN driver I/O buffer size"
+config CAN_TXFIFOSIZE
+	int "CAN driver I/O tx buffer size"
 	default 8
+	range 1 255
 	---help---
-		The size of the circular buffer of CAN messages. Default: 8
+		The size of the circular tx buffer of CAN messages. Default: 8
+
+config CAN_RXFIFOSIZE
+	int "CAN driver I/O rx buffer size"
+	default 8
+	range 1 255
+	---help---
+		The size of the circular rx buffer of CAN messages. Default: 8
 
 config CAN_NPENDINGRTR
 	int "Number of pending RTRs"

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -465,7 +465,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 
           /* Increment the head of the circular message buffer */
 
-          if (++fifo->rx_head >= CONFIG_CAN_FIFOSIZE)
+          if (++fifo->rx_head >= CONFIG_CAN_RXFIFOSIZE)
             {
               fifo->rx_head = 0;
             }
@@ -549,7 +549,7 @@ static int can_xmit(FAR struct can_dev_s *dev)
        */
 
       tmpndx = dev->cd_xmit.tx_queue;
-      if (++dev->cd_xmit.tx_queue >= CONFIG_CAN_FIFOSIZE)
+      if (++dev->cd_xmit.tx_queue >= CONFIG_CAN_TXFIFOSIZE)
         {
           dev->cd_xmit.tx_queue = 0;
         }
@@ -615,7 +615,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
        */
 
       nexttail = fifo->tx_tail + 1;
-      if (nexttail >= CONFIG_CAN_FIFOSIZE)
+      if (nexttail >= CONFIG_CAN_TXFIFOSIZE)
         {
           nexttail = 0;
         }
@@ -885,7 +885,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case FIONWRITE:
         {
-          *(FAR uint8_t *)arg = CONFIG_CAN_FIFOSIZE - 1 -
+          *(FAR uint8_t *)arg = CONFIG_CAN_TXFIFOSIZE - 1 -
                             (dev->cd_xmit.tx_tail - dev->cd_xmit.tx_head);
         }
         break;
@@ -997,7 +997,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
        */
 
       ndx = dev->cd_xmit.tx_tail + 1;
-      if (ndx >= CONFIG_CAN_FIFOSIZE)
+      if (ndx >= CONFIG_CAN_TXFIFOSIZE)
         {
           ndx = 0;
         }
@@ -1188,7 +1188,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
       fifo = &reader->fifo;
 
       nexttail = fifo->rx_tail + 1;
-      if (nexttail >= CONFIG_CAN_FIFOSIZE)
+      if (nexttail >= CONFIG_CAN_RXFIFOSIZE)
         {
           nexttail = 0;
         }
@@ -1358,7 +1358,7 @@ int can_txdone(FAR struct can_dev_s *dev)
 
       /* Remove the message at the head of the xmit FIFO */
 
-      if (++dev->cd_xmit.tx_head >= CONFIG_CAN_FIFOSIZE)
+      if (++dev->cd_xmit.tx_head >= CONFIG_CAN_TXFIFOSIZE)
         {
           dev->cd_xmit.tx_head = 0;
         }

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -59,7 +59,11 @@
  * CONFIG_CAN_FD - Enable support for CAN FD mode.
  *   For the upper half driver, this just means handling encoded DLC values
  *   (for values of DLC > 9).
- * CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+ * CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+ *   of CAN messages.
+ *   Default: 8
+ * CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+ *   of CAN messages.
  *   Default: 8
  * CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
  *   Default: 4
@@ -81,11 +85,18 @@
  * The configured size is limited to 255 to fit into a uint8_t.
  */
 
-#if !defined(CONFIG_CAN_FIFOSIZE)
-#  define CONFIG_CAN_FIFOSIZE 8
-#elif CONFIG_CAN_FIFOSIZE > 255
-#  undef  CONFIG_CAN_FIFOSIZE
-#  define CONFIG_CAN_FIFOSIZE 255
+#if !defined(CONFIG_CAN_TXFIFOSIZE)
+#  define CONFIG_CAN_TXFIFOSIZE 8
+#elif CONFIG_CAN_TXFIFOSIZE > 255
+#  undef  CONFIG_CAN_TXFIFOSIZE
+#  define CONFIG_CAN_TXFIFOSIZE 255
+#endif
+
+#if !defined(CONFIG_CAN_RXFIFOSIZE)
+#  define CONFIG_CAN_RXFIFOSIZE 8
+#elif CONFIG_CAN_RXFIFOSIZE > 255
+#  undef  CONFIG_CAN_RXFIFOSIZE
+#  define CONFIG_CAN_RXFIFOSIZE 255
 #endif
 
 #if !defined(CONFIG_CAN_NPENDINGRTR)
@@ -554,7 +565,7 @@ struct can_rxfifo_s
   uint8_t       rx_head;                 /* Index to the head [IN] in the circular buffer */
   uint8_t       rx_tail;                 /* Index to the tail [OUT] in the circular buffer */
                                          /* Circular buffer of CAN messages */
-  struct can_msg_s rx_buffer[CONFIG_CAN_FIFOSIZE];
+  struct can_msg_s rx_buffer[CONFIG_CAN_RXFIFOSIZE];
 };
 
 struct can_txfifo_s
@@ -564,7 +575,7 @@ struct can_txfifo_s
   uint8_t       tx_queue;                /* Index to next message to send */
   uint8_t       tx_tail;                 /* Index to the tail [OUT] in the circular buffer */
                                          /* Circular buffer of CAN messages */
-  struct can_msg_s tx_buffer[CONFIG_CAN_FIFOSIZE];
+  struct can_msg_s tx_buffer[CONFIG_CAN_TXFIFOSIZE];
 };
 
 /* The following structure define the logic to handle


### PR DESCRIPTION
## Summary
support to independent set TX/RX FIFO size
## Impact

## Testing

