### PR TITLE
cdcacm: config to enable or disable interrupt endpoint

### DIFF
--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -446,9 +446,17 @@ config CDCACM_CONSOLE
 		Register the USB device as /dev/console so that is will be used
 		as the console device.
 
+config CDCACM_HAVE_EPINTIN
+	bool "CDC/ACM have interrupt IN endpoint"
+	default y
+	---help---
+		Using the interrupt endpoint as notification element to transmit
+		asynchronous event information from device to host.
+
 config CDCACM_IFLOWCONTROL
 	bool "CDC/ACM RTS flow control"
 	default n
+	depends on CDCACM_HAVE_EPINTIN
 	select SERIAL_IFLOWCONTROL
 	---help---
 		Enable CDC/ACM RTS flow control

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -753,7 +753,9 @@ static void cdcacm_resetconfig(FAR struct cdcacm_dev_s *priv)
        * transfers.
        */
 
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
       EP_DISABLE(priv->epintin);
+#endif
       EP_DISABLE(priv->epbulkin);
       EP_DISABLE(priv->epbulkout);
     }
@@ -828,6 +830,7 @@ static int cdcacm_setconfig(FAR struct cdcacm_dev_s *priv, uint8_t config)
       return -EINVAL;
     }
 
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
   /* Configure the IN interrupt endpoint */
 
   ret = cdcacm_epconfigure(priv->epintin, CDCACM_EPINTIN, false,
@@ -840,6 +843,7 @@ static int cdcacm_setconfig(FAR struct cdcacm_dev_s *priv, uint8_t config)
     }
 
   priv->epintin->priv = priv;
+#endif
 
   /* Configure the IN bulk endpoint */
 
@@ -1121,6 +1125,7 @@ static int cdcacm_bind(FAR struct usbdevclass_driver_s *driver,
    * logic where kmm_malloc calls will fail.
    */
 
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
   /* Pre-allocate the IN interrupt endpoint */
 
   priv->epintin = DEV_ALLOCEP(dev, CDCACM_MKEPINTIN(&priv->devinfo),
@@ -1133,6 +1138,7 @@ static int cdcacm_bind(FAR struct usbdevclass_driver_s *driver,
     }
 
   priv->epintin->priv = priv;
+#endif
 
   /* Pre-allocate the IN bulk endpoint */
 
@@ -1390,6 +1396,7 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
       DEBUGASSERT(priv->nwrq == 0);
       leave_critical_section(flags);
 
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
       /* Free the interrupt IN endpoint */
 
       if (priv->epintin)
@@ -1397,6 +1404,7 @@ static void cdcacm_unbind(FAR struct usbdevclass_driver_s *driver,
           DEV_FREEEP(dev, priv->epintin);
           priv->epintin = NULL;
         }
+#endif
 
       /* Free the bulk OUT endpoint */
 

--- a/drivers/usbdev/cdcacm_desc.c
+++ b/drivers/usbdev/cdcacm_desc.c
@@ -231,6 +231,7 @@ cdcacm_copy_epcompdesc(enum cdcacm_epdesc_e epid,
 {
   switch (epid)
     {
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
     case CDCACM_EPINTIN:  /* Interrupt IN endpoint */
       {
         epcompdesc->len  = USB_SIZEOF_SS_EPCOMPDESC;                      /* Descriptor length */
@@ -252,6 +253,7 @@ cdcacm_copy_epcompdesc(enum cdcacm_epdesc_e epid,
                                         CONFIG_CDCACM_EPINTIN_SSSIZE);
       }
       break;
+#endif
 
     case CDCACM_EPBULKOUT:  /* Bulk OUT endpoint */
       {
@@ -349,6 +351,7 @@ int cdcacm_copy_epdesc(enum cdcacm_epdesc_e epid,
 
   switch (epid)
     {
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
     case CDCACM_EPINTIN:  /* Interrupt IN endpoint */
       {
         epdesc->len  = USB_SIZEOF_EPDESC;            /* Descriptor length */
@@ -392,6 +395,7 @@ int cdcacm_copy_epdesc(enum cdcacm_epdesc_e epid,
         epdesc->interval = 10;                       /* Interval */
       }
       break;
+#endif
 
     case CDCACM_EPBULKOUT:  /* Bulk OUT endpoint */
       {
@@ -585,7 +589,11 @@ int16_t cdcacm_mkcfgdesc(FAR uint8_t *buf,
       dest->type     = USB_DESC_TYPE_INTERFACE;              /* Descriptor type */
       dest->ifno     = devinfo->ifnobase;                    /* Interface number */
       dest->alt      = CDCACM_NOTALTIFID;                    /* Alternate setting */
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
       dest->neps     = 1;                                    /* Number of endpoints */
+#else
+      dest->neps     = 0;                                    /* Number of endpoints */
+#endif
       dest->classid  = USB_CLASS_CDC;                        /* Interface class */
       dest->subclass = CDC_SUBCLASS_ACM;                     /* Interface sub-class */
       dest->protocol = CDC_PROTO_ATM;                        /* Interface protocol */
@@ -675,6 +683,7 @@ int16_t cdcacm_mkcfgdesc(FAR uint8_t *buf,
 
   length += sizeof(struct cdc_callmgmt_funcdesc_s);
 
+#ifdef CONFIG_CDCACM_HAVE_EPINTIN
   /* Interrupt IN endpoint descriptor */
 
   ret = cdcacm_copy_epdesc(CDCACM_EPINTIN,
@@ -687,6 +696,7 @@ int16_t cdcacm_mkcfgdesc(FAR uint8_t *buf,
     }
 
   length += ret;
+#endif
 
   /* Data interface descriptor */
 


### PR DESCRIPTION
## Summary
With CDCACM_HAVE_EPINTIN, you can configure whether cdcacm uses interrupt endpoint.

## Impact
Interrupt endpoint is enabled as default and can be disabled when hardware endpoint resources are stretched. 
PS: linux as a usbhost does not support disabling interrupt endpoints.

## Testing
windows as usb host, it works properly.
Linux as usb host, the interrupt endpoint must be enable
