### PR TITLE
xtensa: add parameters to xtensa_pause_handler

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -234,7 +234,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs);
 
 #ifdef CONFIG_SMP
 int xtensa_intercpu_interrupt(int tocpu, int intcode);
-void xtensa_pause_handler(void);
+void xtensa_pause_handler(int irq, void *context, void *arg);
 #endif
 
 /* Signals */

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -208,10 +208,12 @@ int up_cpu_paused_restore(void)
  *
  ****************************************************************************/
 
-void xtensa_pause_handler(void)
+void xtensa_pause_handler(int irq, void *context, void *arg)
 {
   struct tcb_s *tcb;
   int cpu = this_cpu();
+
+  nxsched_smp_call_handler(irq, context, arg);
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the

--- a/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
@@ -49,7 +49,8 @@
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_fromcpu_interrupt(int fromcpu)
+static int IRAM_ATTR esp32_fromcpu_interrupt(int irq, void *context,
+                                             void *arg, int fromcpu)
 {
   uintptr_t regaddr;
 
@@ -64,7 +65,7 @@ static int IRAM_ATTR esp32_fromcpu_interrupt(int fromcpu)
 
   /* Call pause handler */
 
-  xtensa_pause_handler();
+  xtensa_pause_handler(irq, context, arg);
 
   return OK;
 }
@@ -83,14 +84,12 @@ static int IRAM_ATTR esp32_fromcpu_interrupt(int fromcpu)
 
 int IRAM_ATTR esp32_fromcpu0_interrupt(int irq, void *context, void *arg)
 {
-  nxsched_smp_call_handler(irq, context, arg);
-  return esp32_fromcpu_interrupt(0);
+  return esp32_fromcpu_interrupt(irq, context, arg, 0);
 }
 
 int IRAM_ATTR esp32_fromcpu1_interrupt(int irq, void *context, void *arg)
 {
-  nxsched_smp_call_handler(irq, context, arg);
-  return esp32_fromcpu_interrupt(1);
+  return esp32_fromcpu_interrupt(irq, context, arg, 1);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_intercpu_interrupt.c
@@ -50,7 +50,8 @@
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32s3_fromcpu_interrupt(int fromcpu)
+static int IRAM_ATTR esp32s3_fromcpu_interrupt(int irq, void *context,
+                                               void *arg, int fromcpu)
 {
   uintptr_t regaddr;
 
@@ -65,7 +66,7 @@ static int IRAM_ATTR esp32s3_fromcpu_interrupt(int fromcpu)
 
   /* Call pause handler */
 
-  xtensa_pause_handler();
+  xtensa_pause_handler(irq, context, arg);
 
   return OK;
 }
@@ -84,14 +85,12 @@ static int IRAM_ATTR esp32s3_fromcpu_interrupt(int fromcpu)
 
 int IRAM_ATTR esp32s3_fromcpu0_interrupt(int irq, void *context, void *arg)
 {
-  nxsched_smp_call_handler(irq, context, arg);
-  return esp32s3_fromcpu_interrupt(0);
+  return esp32s3_fromcpu_interrupt(irq, context, arg, 0);
 }
 
 int IRAM_ATTR esp32s3_fromcpu1_interrupt(int irq, void *context, void *arg)
 {
-  nxsched_smp_call_handler(irq, context, arg);
-  return esp32s3_fromcpu_interrupt(1);
+  return esp32s3_fromcpu_interrupt(irq, context, arg, 1);
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
add parameters to xtensa_pause_handler
nxsched_smp_call_handler need these parameters
## Impact
xtensa

## Testing

esp32s3-devkit:smp(ostest)
