### PR TITLE
espressif: add support for marking a ISR as running from IRAM.

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1200,6 +1200,19 @@ config ESPRESSIF_SPI_TEST_MODE
 
 endmenu # SPI configuration
 
+menu "Interrupt Configuration"
+
+config ESPRESSIF_IRAM_ISR_DEBUG
+	bool "Enable debugging of the IRAM-enabled interrupts"
+	default n
+	---help---
+		This option enables keeping track of the IRAM-enabled interrupts by
+		registering its execution when non-IRAM interrupts are disabled. It
+		keeps track of the IRQ executed and register how many times since
+		boot it was executed. Generally used for testing.
+
+endmenu
+
 menu "SPI Flash Configuration"
 
 choice ESPRESSIF_FLASH_MODE

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -78,6 +78,11 @@
 
 #define NO_CPUINT                     ETS_INVALID_INUM
 
+/* Masks for interrupt type used on esp_setup_irq */
+
+#define ESP_CPUINT_IRAM_MASK       (1 << 1)
+#define ESP_CPUINT_TRIGGER_MASK    (1 << 0)
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -129,6 +134,14 @@ static uint32_t non_iram_int_mask[CONFIG_ESPRESSIF_NUM_CPUS];
 
 static uint32_t non_iram_int_disabled[CONFIG_ESPRESSIF_NUM_CPUS];
 static bool non_iram_int_disabled_flag[CONFIG_ESPRESSIF_NUM_CPUS];
+
+#ifdef CONFIG_ESPRESSIF_IRAM_ISR_DEBUG
+/* The g_iram_count keeps track of how many times such an IRQ ran when the
+ * non-IRAM interrupts were disabled.
+ */
+
+static uint64_t g_iram_count[NR_IRQS];
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -272,6 +285,33 @@ static void esp_cpuint_initialize(void)
 
   memset(g_cpuint_map, 0, sizeof(g_cpuint_map));
 }
+
+#ifdef CONFIG_ESPRESSIF_IRAM_ISR_DEBUG
+
+/****************************************************************************
+ * Name:  esp_iram_interrupt_record
+ *
+ * Description:
+ *   This function keeps track of the IRQs that ran when non-IRAM interrupts
+ *   are disabled and enables debugging of the IRAM-enabled interrupts.
+ *
+ * Input Parameters:
+ *   irq - The IRQ associated with a CPU interrupt
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+IRAM_ATTR void esp_irq_iram_interrupt_record(int irq)
+{
+  irqstate_t flags = enter_critical_section();
+
+  g_iram_count[irq]++;
+
+  leave_critical_section(flags);
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -464,7 +504,7 @@ void esp_route_intr(int source, int cpuint, irq_priority_t priority,
  *
  ****************************************************************************/
 
-int esp_setup_irq(int source, irq_priority_t priority, irq_trigger_t type)
+int esp_setup_irq(int source, irq_priority_t priority, int type)
 {
   irqstate_t irqstate;
   int irq;
@@ -492,7 +532,17 @@ int esp_setup_irq(int source, irq_priority_t priority, irq_trigger_t type)
       PANIC();
     }
 
-  esp_route_intr(source, cpuint, priority, type);
+  esp_route_intr(source, cpuint, priority, (type & ESP_CPUINT_TRIGGER_MASK));
+
+  if ((type & ESP_CPUINT_IRAM_MASK) == ESP_IRQ_IRAM)
+    {
+      esp_irq_set_iram_isr(irq);
+      irqinfo("source %d marked IRAM (irq=%d)\n", source, irq);
+    }
+  else
+    {
+      esp_irq_unset_iram_isr(irq);
+    }
 
   leave_critical_section(irqstate);
 
@@ -557,6 +607,7 @@ IRAM_ATTR void *riscv_dispatch_irq(uintreg_t mcause, uintreg_t *regs)
   int irq;
   bool is_irq = (RISCV_IRQ_BIT & mcause) != 0;
   bool is_edge = false;
+  uint32_t cpu = esp_cpu_get_core_id();
 
   if (is_irq)
     {
@@ -568,7 +619,18 @@ IRAM_ATTR void *riscv_dispatch_irq(uintreg_t mcause, uintreg_t *regs)
 
       irq = g_cpuint_map[cpuint].irq;
 
-      is_edge = esprv_intc_int_get_type(cpuint) == INTR_TYPE_EDGE;
+#ifdef CONFIG_ESPRESSIF_IRAM_ISR_DEBUG
+      /* Check if non-IRAM interrupts are disabled */
+
+      if (esp_irq_noniram_status(cpu) == 0)
+        {
+          /* Sum-up the IRAM-enabled counter associated with the IRQ */
+
+          esp_irq_iram_interrupt_record(irq);
+        }
+#endif
+
+      is_edge = esprv_intc_int_get_type(cpuint) == INTR_TYPE_LEVEL;
       if (is_edge)
         {
           /* Clear edge interrupts. */
@@ -626,7 +688,7 @@ irqstate_t up_irq_enable(void)
  *
  ****************************************************************************/
 
-void IRAM_ATTR esp_intr_noniram_disable(void)
+void esp_intr_noniram_disable(void)
 {
   uint32_t oldint;
   irqstate_t irqstate;
@@ -666,7 +728,7 @@ void IRAM_ATTR esp_intr_noniram_disable(void)
  *
  ****************************************************************************/
 
-void IRAM_ATTR esp_intr_noniram_enable(void)
+void esp_intr_noniram_enable(void)
 {
   irqstate_t irqstate;
   uint32_t cpu;
@@ -684,6 +746,27 @@ void IRAM_ATTR esp_intr_noniram_enable(void)
   non_iram_int_disabled_flag[cpu] = false;
   esp_cpu_intr_enable(non_iram_ints);
   leave_critical_section(irqstate);
+}
+
+/****************************************************************************
+ * Name:  esp_irq_noniram_status
+ *
+ * Description:
+ *   Get the current status of non-IRAM interrupts on a specific CPU core
+ *
+ * Input Parameters:
+ *   cpu - The CPU to check the non-IRAM interrupts state
+ *
+ * Returned Value:
+ *   true if non-IRAM interrupts are enabled, false otherwise.
+ *
+ ****************************************************************************/
+
+bool esp_irq_noniram_status(int cpu)
+{
+  DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS);
+
+  return !non_iram_int_disabled_flag[cpu];
 }
 
 /****************************************************************************
@@ -731,3 +814,89 @@ void esp_set_irq(int irq, int cpuint)
   CPUINT_ASSIGN(g_cpuint_map[cpuint], irq);
   g_irq_map[irq] = cpuint;
 }
+
+/****************************************************************************
+ * Name:  esp_irq_set_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a IRAM-enabled ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp_irq_set_iram_isr(int irq)
+{
+  uint32_t cpu = esp_cpu_get_core_id();
+  int cpuint = g_irq_map[irq];
+
+  if (cpuint == IRQ_UNMAPPED)
+    {
+      return -EINVAL;
+    }
+
+  non_iram_int_mask[cpu] &= ~(1 << cpuint);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  esp_irq_unset_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a non-IRAM ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp_irq_unset_iram_isr(int irq)
+{
+  uint32_t cpu = esp_cpu_get_core_id();
+  int cpuint = g_irq_map[irq];
+
+  if (cpuint == IRQ_UNMAPPED)
+    {
+      return -EINVAL;
+    }
+
+  non_iram_int_mask[cpu] |= (1 << cpuint);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  esp_get_iram_interrupt_records
+ *
+ * Description:
+ *   This function copies the vector that keeps track of the IRQs that ran
+ *   when non-IRAM interrupts were disabled.
+ *
+ * Input Parameters:
+ *
+ *   irq_count - A previously allocated pointer to store the counter of the
+ *               interrupts that ran when non-IRAM interrupts were disabled.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESPRESSIF_IRAM_ISR_DEBUG
+void esp_get_iram_interrupt_records(uint64_t *irq_count)
+{
+  irqstate_t flags = enter_critical_section();
+
+  memcpy(irq_count, &g_iram_count, sizeof(uint64_t) * NR_IRQS);
+
+  leave_critical_section(flags);
+}
+#endif

--- a/arch/risc-v/src/common/espressif/esp_irq.h
+++ b/arch/risc-v/src/common/espressif/esp_irq.h
@@ -45,6 +45,15 @@ extern "C"
 #define EXTERN extern
 #endif
 
+/* CPU interrupt flags.
+ * esp_setup_irq() will check bit 1 for IRAM requirement and
+ * bit 0 for trigger type.
+ *
+ * OR'ed values of irq_trigger_e and irq_iram_e define interrupt type.
+ *      | IRAM | TRIGGER |
+ * Bits |   1  |    0    |
+ */
+
 /* CPU interrupt trigger types */
 
 typedef enum irq_trigger_e
@@ -52,6 +61,14 @@ typedef enum irq_trigger_e
   ESP_IRQ_TRIGGER_LEVEL    = 0, /* Level-triggered interrupts */
   ESP_IRQ_TRIGGER_EDGE     = 1, /* Edge-triggered interrupts */
 } irq_trigger_t;
+
+/* CPU interrupt IRAM enabled */
+
+typedef enum irq_iram_e
+{
+  ESP_IRQ_NON_IRAM    = (0 << 1), /* Non-IRAM interrupt */
+  ESP_IRQ_IRAM        = (1 << 1), /* IRAM interrupt */
+} irq_iram_t;
 
 /* CPU interrupt priority levels */
 
@@ -119,7 +136,7 @@ void esp_route_intr(int source, int cpuint, irq_priority_t priority,
  *
  ****************************************************************************/
 
-int esp_setup_irq(int source, irq_priority_t priority, irq_trigger_t type);
+int esp_setup_irq(int source, irq_priority_t priority, int type);
 
 /****************************************************************************
  * Name: esp_teardown_irq
@@ -212,6 +229,73 @@ int esp_get_irq(int cpuint);
  ****************************************************************************/
 
 void esp_set_irq(int irq, int cpuint);
+
+/****************************************************************************
+ * Name:  esp_irq_set_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a IRAM-enabled ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp_irq_set_iram_isr(int irq);
+
+/****************************************************************************
+ * Name:  esp32s3_irq_unset_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a non-IRAM ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp_irq_unset_iram_isr(int irq);
+
+/****************************************************************************
+ * Name:  esp_irq_noniram_status
+ *
+ * Description:
+ *   Get the current status of non-IRAM interrupts on a specific CPU core
+ *
+ * Input Parameters:
+ *   cpu - The CPU to check the non-IRAM interrupts state
+ *
+ * Returned Value:
+ *   true if non-IRAM interrupts are enabled, false otherwise.
+ *
+ ****************************************************************************/
+
+bool esp_irq_noniram_status(int cpu);
+
+/****************************************************************************
+ * Name:  esp_get_iram_interrupt_records
+ *
+ * Description:
+ *   This function copies the vector that keeps track of the IRQs that ran
+ *   when non-IRAM interrupts were disabled.
+ *
+ * Input Parameters:
+ *
+ *   irq_count - A previously allocated pointer to store the counter of the
+ *               interrupts that ran when non-IRAM interrupts were disabled.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp_get_iram_interrupt_records(uint64_t *irq_count);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/common/espressif/esp_spiflash.c
+++ b/arch/risc-v/src/common/espressif/esp_spiflash.c
@@ -132,8 +132,8 @@ spi_mem_dev_t *dev = spimem_flash_ll_get_hw(SPI1_HOST);
  * Private Functions Declaration
  ****************************************************************************/
 
-static void spiflash_start(void);
-static void spiflash_end(void);
+void spiflash_start(void);
+void spiflash_end(void);
 #ifndef CONFIG_ESPRESSIF_SPI_FLASH_USE_ROM_CODE
 extern bool spi_flash_check_and_flush_cache(size_t start_addr,
                                             size_t length);
@@ -175,7 +175,7 @@ static volatile bool s_sched_suspended[CONFIG_ESPRESSIF_NUM_CPUS];
  *
  ****************************************************************************/
 
-static IRAM_ATTR void spiflash_start(void)
+IRAM_ATTR void spiflash_start(void)
 {
   extern uint32_t cache_suspend_icache(void);
   int cpu;
@@ -208,7 +208,7 @@ static IRAM_ATTR void spiflash_start(void)
  *
  ****************************************************************************/
 
-static IRAM_ATTR void spiflash_end(void)
+IRAM_ATTR void spiflash_end(void)
 {
   extern void cache_resume_icache(uint32_t);
   extern void cache_invalidate_icache_all(void);

--- a/arch/xtensa/include/esp32/irq.h
+++ b/arch/xtensa/include/esp32/irq.h
@@ -45,6 +45,11 @@
 #define ESP32_CPUINT_FLAG_SHARED  (1 << 2) /* Interrupt can be shared between ISRs */
 #define ESP32_CPUINT_FLAG_IRAM    (1 << 3) /* ISR can be called if cache is disabled */
 
+/* Trigger mask useful on debug assertion */
+
+#define ESP32_CPUINT_TRIGGER_MASK (ESP32_CPUINT_FLAG_LEVEL | \
+                                   ESP32_CPUINT_FLAG_EDGE)
+
 /* Interrupt Matrix
  *
  * The Interrupt Matrix embedded in the ESP32 independently allocates

--- a/arch/xtensa/src/common/espressif/esp_spiflash.c
+++ b/arch/xtensa/src/common/espressif/esp_spiflash.c
@@ -137,8 +137,8 @@ spi_mem_dev_t *dev = spimem_flash_ll_get_hw(SPI1_HOST);
  * Private Functions Declaration
  ****************************************************************************/
 
-static void spiflash_start(void);
-static void spiflash_end(void);
+void spiflash_start(void);
+void spiflash_end(void);
 #if !CONFIG_ESPRESSIF_SPI_FLASH_USE_ROM_CODE && CONFIG_ARCH_CHIP_ESP32S3
 extern bool spi_flash_check_and_flush_cache(size_t start_addr,
                                             size_t length);
@@ -180,7 +180,7 @@ static volatile bool s_sched_suspended[CONFIG_ESPRESSIF_NUM_CPUS];
  *
  ****************************************************************************/
 
-static IRAM_ATTR void spiflash_start(void)
+IRAM_ATTR void spiflash_start(void)
 {
   extern uint32_t cache_suspend_icache(void);
   int cpu;
@@ -215,7 +215,7 @@ static IRAM_ATTR void spiflash_start(void)
  *
  ****************************************************************************/
 
-static IRAM_ATTR void spiflash_end(void)
+IRAM_ATTR void spiflash_end(void)
 {
   extern void cache_resume_icache(uint32_t);
   extern void cache_invalidate_icache_all(void);

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -393,8 +393,7 @@ static int esp32_alloc_cpuint(int cpu, int priority, int type)
 
   DEBUGASSERT(priority >= ESP32_MIN_PRIORITY &&
               priority <= ESP32_MAX_PRIORITY);
-  DEBUGASSERT(type == ESP32_CPUINT_LEVEL ||
-              type == ESP32_CPUINT_EDGE);
+  DEBUGASSERT(type & ESP32_CPUINT_TRIGGER_MASK);
 
   if ((type & (ESP32_CPUINT_LEVEL | ESP32_CPUINT_EDGE)) == 0)
     {

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -221,9 +221,9 @@ static inline void spi_reset_regbits(struct esp32_spiflash_s *priv,
 
 /* Misc. helpers */
 
-static inline void IRAM_ATTR
+inline void IRAM_ATTR
 esp32_spiflash_opstart(void);
-static inline void IRAM_ATTR
+inline void IRAM_ATTR
 esp32_spiflash_opdone(void);
 
 static bool IRAM_ATTR spiflash_pagecached(uint32_t phypage);
@@ -460,7 +460,7 @@ static inline void spi_reset_regbits(struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static void esp32_spiflash_opstart(void)
+void esp32_spiflash_opstart(void)
 {
   struct tcb_s *tcb = this_task();
   int saved_priority = tcb->sched_priority;
@@ -519,7 +519,7 @@ static void esp32_spiflash_opstart(void)
  *
  ****************************************************************************/
 
-static void esp32_spiflash_opdone(void)
+void esp32_spiflash_opdone(void)
 {
   const int cpu = this_cpu();
 #ifdef CONFIG_SMP

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
@@ -186,8 +186,8 @@
  * Private Functions Declaration
  ****************************************************************************/
 
-static void spiflash_start(void);
-static void spiflash_end(void);
+void spiflash_start(void);
+void spiflash_end(void);
 static void spi_flash_disable_cache(void);
 static void spi_flash_restore_cache(void);
 #ifdef CONFIG_SMP
@@ -279,7 +279,7 @@ static void spiflash_resume_cache(void)
  *
  ****************************************************************************/
 
-static void spiflash_start(void)
+void spiflash_start(void)
 {
   struct tcb_s *tcb = this_task();
   int saved_priority = tcb->sched_priority;
@@ -341,7 +341,7 @@ static void spiflash_start(void)
  *
  ****************************************************************************/
 
-static void spiflash_end(void)
+void spiflash_end(void)
 {
   const int cpu = this_cpu();
 #ifdef CONFIG_SMP

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
@@ -73,6 +73,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
 
+    *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
     *libarch.a:*brownout.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu.*(.text .text.* .literal .literal.*)
     *libarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
@@ -188,6 +190,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
 
+    *libarch.a:*(.rodata.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.rodata .rodata.*)
     *libarch.a:*brownout.*(.rodata .rodata.*)
     *libarch.a:*cpu.*(.rodata .rodata.*)
     *libarch.a:*gpio_hal.*(.rodata .rodata.*)

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
@@ -73,6 +73,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
 
+    *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
     *libarch.a:*brownout.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu.*(.text .text.* .literal .literal.*)
     *libarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
@@ -212,6 +214,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
 
+    *libarch.a:*(.rodata.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.rodata .rodata.*)
     *libarch.a:*brownout.*(.rodata .rodata.*)
     *libarch.a:*cpu.*(.rodata .rodata.*)
     *libarch.a:*gpio_hal.*(.rodata .rodata.*)
@@ -488,4 +492,3 @@ SECTIONS
           "RTC reserved segment data does not fit.")
 
 }
-

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
@@ -73,6 +73,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
 
+    *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
     *libarch.a:*brownout.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu.*(.text .text.* .literal .literal.*)
     *libarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
@@ -209,6 +211,8 @@ SECTIONS
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
 
+    *libarch.a:*(.rodata.esprv_intc_int_get_type)
+    *libarch.a:*riscv_doirq.*(.rodata .rodata.*)
     *libarch.a:*brownout.*(.rodata .rodata.*)
     *libarch.a:*cpu.*(.rodata .rodata.*)
     *libarch.a:*gpio_hal.*(.rodata .rodata.*)


### PR DESCRIPTION
## Summary
This MR adds support for marking a ISR as running from IRAM.

Also, fix a debug assertion on ESP32 related to interrupt trigger type and removes `static` from some spiflash operations to allow testing.

## Impact
Allows an interrupt to be marked as running from IRAM during IRQ setup by using the ESP_IRQ_IRAM flag (passed too type argument on `esp_setup_irq`).

## Testing
Internal CI testing.
