### PR TITLE
replace sync pause with async pause for nxsig_process

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -127,12 +127,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -152,12 +152,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -253,12 +253,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -212,12 +212,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -253,12 +253,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -223,12 +223,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -253,12 +253,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/arm/include/tlsr82/irq.h
+++ b/arch/arm/include/tlsr82/irq.h
@@ -158,12 +158,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved register array pointer used during
    * signal processing.
    */

--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -75,70 +75,61 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
+      /* In this case just deliver the signal now. */
 
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
+      /* Save the current register context location */
 
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
        */
 
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
+      tcb->xcp.regs            = (void *)
+                                 ((uint32_t)tcb->xcp.regs -
+                                            XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          /* Save the current register context location */
+      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                           XCPTCONTEXT_SIZE;
 
-          tcb->xcp.saved_regs      = tcb->xcp.regs;
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs            = (void *)
-                                     ((uint32_t)tcb->xcp.regs -
-                                                XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                               XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]  = PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT;
+      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_CPSR]  = PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT;
 #ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
-        }
     }
 }

--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -97,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* In this case just deliver the signal now. */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
 
       /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm/src/arm/arm_sigdeliver.c
+++ b/arch/arm/src/arm/arm_sigdeliver.c
@@ -59,8 +59,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always
@@ -72,7 +72,7 @@ void arm_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -92,7 +92,7 @@ void arm_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -85,9 +85,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -103,7 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -98,30 +98,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-      /* CASE 2:  The task that needs to receive the signal is running.
-       * This could happen if the task is running on another CPU OR if
-       * we are in an interrupt handler and the task is running on this
-       * CPU.  In the former case, we will have to PAUSE the other CPU
-       * first.  But in either case, we will have to modify the return
-       * state as well as the state in the TCB.
-       */
-
-      /* If we signaling a task running on the other CPU, we have
-       * to PAUSE the other CPU.
-       */
-
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
        * registers (and perhaps also the LR).  These will be restored
        * by the signal trampoline after the signal has been delivered.
@@ -156,15 +132,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
       tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
       tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
-#endif
-
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
 #endif
     }
 }

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -78,103 +78,93 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-  DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* In this case just deliver the signal now.
+       * REVISIT:  Signal handle will run in a critical section!
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+  else
+    {
+      /* CASE 2:  The task that needs to receive the signal is running.
+       * This could happen if the task is running on another CPU OR if
+       * we are in an interrupt handler and the task is running on this
+       * CPU.  In the former case, we will have to PAUSE the other CPU
+       * first.  But in either case, we will have to modify the return
+       * state as well as the state in the TCB.
+       */
 
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now.
-           * REVISIT:  Signal handle will run in a critical section!
-           */
-
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-      else
-        {
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          /* If we signaling a task running on the other CPU, we have
-           * to PAUSE the other CPU.
-           */
+      /* If we signaling a task running on the other CPU, we have
+       * to PAUSE the other CPU.
+       */
 
 #ifdef CONFIG_SMP
-          int cpu = tcb->cpu;
-          int me  = this_cpu();
+      int cpu = tcb->cpu;
+      int me  = this_cpu();
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              /* Pause the CPU */
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Pause the CPU */
 
-              up_cpu_pause(cpu);
-            }
+          up_cpu_pause(cpu);
+        }
 #endif
 
-          /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-           * registers (and perhaps also the LR).  These will be restored
-           * by the signal trampoline after the signal has been delivered.
-           */
+      /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
+       * registers (and perhaps also the LR).  These will be restored
+       * by the signal trampoline after the signal has been delivered.
+       */
 
-          /* Save the current register context location */
+      /* Save the current register context location */
 
-          tcb->xcp.saved_regs           = tcb->xcp.regs;
+      tcb->xcp.saved_regs           = tcb->xcp.regs;
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
+       */
 
-          tcb->xcp.regs                 = (void *)
-                                          ((uint32_t)tcb->xcp.regs -
-                                                     XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+      tcb->xcp.regs                 = (void *)
+                                      ((uint32_t)tcb->xcp.regs -
+                                                 XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
-                                                    XCPTCONTEXT_SIZE;
+      tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
+                                                XCPTCONTEXT_SIZE;
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled.  We must already be in privileged thread mode to be
+       * here.
+       */
 
-          tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_PRIMASK]    = 1;
-          tcb->xcp.regs[REG_XPSR]       = ARMV6M_XPSR_T;
+      tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_PRIMASK]    = 1;
+      tcb->xcp.regs[REG_XPSR]       = ARMV6M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+      tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
+      tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+      tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
 #endif
 
 #ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
+      /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              up_cpu_resume(cpu);
-            }
-#endif
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          up_cpu_resume(cpu);
         }
+#endif
     }
 }

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -123,7 +123,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -170,7 +170,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -101,7 +101,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -148,7 +148,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -121,7 +121,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -164,7 +164,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -83,9 +83,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on this CPU.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -101,7 +101,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -148,7 +148,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -430,7 +430,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->xcp.sigdeliver)
+              if (rtcb->sigdeliver)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -124,7 +124,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -175,7 +175,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -86,9 +86,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -104,7 +104,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -105,7 +105,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -156,7 +156,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -75,90 +75,81 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
+      /* In this case just deliver the signal now.
+       * REVISIT:  Signal handler will run in a critical section!
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
-
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now.
-           * REVISIT:  Signal handler will run in a critical section!
-           */
-
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-      else
-        {
-          /* If we signaling a task running on the other CPU, we have
-           * to PAUSE the other CPU.
-           */
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+  else
+    {
+      /* If we signaling a task running on the other CPU, we have
+       * to PAUSE the other CPU.
+       */
 
 #ifdef CONFIG_SMP
-          int cpu = tcb->cpu;
-          int me  = this_cpu();
+      int cpu = tcb->cpu;
+      int me  = this_cpu();
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              /* Pause the CPU */
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Pause the CPU */
 
-              up_cpu_pause(cpu);
-            }
+          up_cpu_pause(cpu);
+        }
 #endif
 
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
+      /* Save the return lr and cpsr and one scratch register.  These
+       * will be restored by the signal trampoline after the signals
+       * have been delivered.
+       */
 
-          /* Save the current register context location */
+      /* Save the current register context location */
 
-          tcb->xcp.saved_regs      = tcb->xcp.regs;
+      tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
+       */
 
-          tcb->xcp.regs            = (void *)
-                                     ((uint32_t)tcb->xcp.regs -
-                                                XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+      tcb->xcp.regs            = (void *)
+                                 ((uint32_t)tcb->xcp.regs -
+                                            XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                               XCPTCONTEXT_SIZE;
+      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                           XCPTCONTEXT_SIZE;
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
+      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
 
 #ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
+      /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              up_cpu_resume(cpu);
-            }
-#endif
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          up_cpu_resume(cpu);
         }
+#endif
     }
 }

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -95,22 +95,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-      /* If we signaling a task running on the other CPU, we have
-       * to PAUSE the other CPU.
-       */
-
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the return lr and cpsr and one scratch register.  These
        * will be restored by the signal trampoline after the signals
        * have been delivered.
@@ -141,15 +125,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
       tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
 #endif
     }
 }

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -111,7 +111,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -154,7 +154,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -101,7 +101,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -145,7 +145,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -427,7 +427,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->xcp.sigdeliver)
+              if (rtcb->sigdeliver)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -124,7 +124,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -175,7 +175,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -79,107 +79,97 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
-  DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* In this case just deliver the signal now.
+       * REVISIT:  Signal handle will run in a critical section!
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+  else
+    {
+      /* CASE 2:  The task that needs to receive the signal is running.
+       * This could happen if the task is running on another CPU OR if
+       * we are in an interrupt handler and the task is running on this
+       * CPU.  In the former case, we will have to PAUSE the other CPU
+       * first.  But in either case, we will have to modify the return
+       * state as well as the state in the TCB.
+       */
 
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now.
-           * REVISIT:  Signal handle will run in a critical section!
-           */
-
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-      else
-        {
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          /* If we signaling a task running on the other CPU, we have
-           * to PAUSE the other CPU.
-           */
+      /* If we signaling a task running on the other CPU, we have
+       * to PAUSE the other CPU.
+       */
 
 #ifdef CONFIG_SMP
-          int cpu = tcb->cpu;
-          int me  = this_cpu();
+      int cpu = tcb->cpu;
+      int me  = this_cpu();
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              /* Pause the CPU */
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Pause the CPU */
 
-              up_cpu_pause(cpu);
-            }
+          up_cpu_pause(cpu);
+        }
 #endif
 
-          /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-           * registers (and perhaps also the LR).  These will be restored
-           * by the signal trampoline after the signal has been delivered.
-           */
+      /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
+       * registers (and perhaps also the LR).  These will be restored
+       * by the signal trampoline after the signal has been delivered.
+       */
 
-          /* Save the current register context location */
+      /* Save the current register context location */
 
-          tcb->xcp.saved_regs           = tcb->xcp.regs;
+      tcb->xcp.saved_regs           = tcb->xcp.regs;
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
+       */
 
-          tcb->xcp.regs                 = (void *)
-                                          ((uint32_t)tcb->xcp.regs -
-                                                     XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+      tcb->xcp.regs                 = (void *)
+                                      ((uint32_t)tcb->xcp.regs -
+                                                 XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
-                                                    XCPTCONTEXT_SIZE;
+      tcb->xcp.regs[REG_SP]         = (uint32_t)tcb->xcp.regs +
+                                                XCPTCONTEXT_SIZE;
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled.  We must already be in privileged thread mode to be
+       * here.
+       */
 
-          tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_PC]         = (uint32_t)arm_sigdeliver;
 #ifdef CONFIG_ARMV8M_USEBASEPRI
-          tcb->xcp.regs[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
+      tcb->xcp.regs[REG_BASEPRI]    = NVIC_SYSH_DISABLE_PRIORITY;
 #else
-          tcb->xcp.regs[REG_PRIMASK]    = 1;
+      tcb->xcp.regs[REG_PRIMASK]    = 1;
 #endif
-          tcb->xcp.regs[REG_XPSR]       = ARMV8M_XPSR_T;
+      tcb->xcp.regs[REG_XPSR]       = ARMV8M_XPSR_T;
 #ifdef CONFIG_BUILD_PROTECTED
-          tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
-          tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
+      tcb->xcp.regs[REG_LR]         = EXC_RETURN_THREAD;
+      tcb->xcp.regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
+      tcb->xcp.regs[REG_CONTROL]    = getcontrol() & ~CONTROL_NPRIV;
 #endif
 
 #ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
+      /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              up_cpu_resume(cpu);
-            }
-#endif
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          up_cpu_resume(cpu);
         }
+#endif
     }
 }

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -86,9 +86,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -104,7 +104,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -105,7 +105,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -156,7 +156,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -75,90 +75,81 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
+      /* In this case just deliver the signal now.
+       * REVISIT:  Signal handler will run in a critical section!
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
-
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now.
-           * REVISIT:  Signal handler will run in a critical section!
-           */
-
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-      else
-        {
-          /* If we signaling a task running on the other CPU, we have
-           * to PAUSE the other CPU.
-           */
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+  else
+    {
+      /* If we signaling a task running on the other CPU, we have
+       * to PAUSE the other CPU.
+       */
 
 #ifdef CONFIG_SMP
-          int cpu = tcb->cpu;
-          int me  = this_cpu();
+      int cpu = tcb->cpu;
+      int me  = this_cpu();
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              /* Pause the CPU */
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Pause the CPU */
 
-              up_cpu_pause(cpu);
-            }
+          up_cpu_pause(cpu);
+        }
 #endif
 
-          /* Save the return lr and cpsr and one scratch register.  These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
+      /* Save the return lr and cpsr and one scratch register.  These
+       * will be restored by the signal trampoline after the signals
+       * have been delivered.
+       */
 
-          /* Save the current register context location */
+      /* Save the current register context location */
 
-          tcb->xcp.saved_regs      = tcb->xcp.regs;
+      tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
+       */
 
-          tcb->xcp.regs            = (void *)
-                                     ((uint32_t)tcb->xcp.regs -
-                                                XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+      tcb->xcp.regs            = (void *)
+                                 ((uint32_t)tcb->xcp.regs -
+                                            XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                               XCPTCONTEXT_SIZE;
+      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                           XCPTCONTEXT_SIZE;
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
+      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-          tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
 
 #ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
+      /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              up_cpu_resume(cpu);
-            }
-#endif
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          up_cpu_resume(cpu);
         }
+#endif
     }
 }

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -95,22 +95,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-      /* If we signaling a task running on the other CPU, we have
-       * to PAUSE the other CPU.
-       */
-
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the return lr and cpsr and one scratch register.  These
        * will be restored by the signal trampoline after the signals
        * have been delivered.
@@ -141,15 +125,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
       tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
-#endif
-
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
 #endif
     }
 }

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -111,7 +111,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -154,7 +154,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm/src/armv8-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-r/arm_sigdeliver.c
@@ -68,8 +68,8 @@ void arm_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -101,7 +101,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -145,7 +145,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -426,7 +426,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->xcp.sigdeliver)
+              if (rtcb->sigdeliver)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -75,67 +75,58 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
+      /* In this case just deliver the signal now. */
 
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(),
-            this_task()->xcp.regs);
+      /* Save the current register context location */
 
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_regs     = tcb->xcp.regs;
 
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
        */
 
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
+      tcb->xcp.regs           = (void *)((uint32_t)tcb->xcp.regs -
+                                                   XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          /* Save the current register context location */
+      tcb->xcp.regs[REG_SP]   = (uint32_t)tcb->xcp.regs +
+                                          XCPTCONTEXT_SIZE;
 
-          tcb->xcp.saved_regs     = tcb->xcp.regs;
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
-
-          tcb->xcp.regs           = (void *)((uint32_t)tcb->xcp.regs -
-                                                       XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-          tcb->xcp.regs[REG_SP]   = (uint32_t)tcb->xcp.regs +
-                                              XCPTCONTEXT_SIZE;
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_LR]     = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]   = PSR_MODE_SVC | PSR_I_BIT;
-          tcb->xcp.regs[REG_IRQ_EN] = 0;
-        }
+      tcb->xcp.regs[REG_LR]     = (uint32_t)arm_sigdeliver;
+      tcb->xcp.regs[REG_CPSR]   = PSR_MODE_SVC | PSR_I_BIT;
+      tcb->xcp.regs[REG_IRQ_EN] = 0;
     }
 }

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -97,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* In this case just deliver the signal now. */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
 
       /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -243,12 +243,6 @@ extern "C"
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
 #ifdef CONFIG_BUILD_KERNEL
   /* This is the saved address to use when returning from a user-space
    * signal handler.

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -132,18 +132,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the return lr and cpsr and one scratch register.  These
        * will be restored by the signal trampoline after the signals
        * have been delivered.
@@ -154,14 +142,5 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       /* create signal process context */
 
       arm64_init_signal_process(tcb, NULL);
-
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
-#endif
     }
 }

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -118,9 +118,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -133,7 +133,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -141,7 +141,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -163,7 +163,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -70,8 +70,8 @@ void arm64_sigdeliver(void)
 #endif
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +103,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +150,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
   rtcb->xcp.regs = rtcb->xcp.saved_reg;
 
   /* Then restore the correct state for this thread of execution. */

--- a/arch/avr/include/avr/irq.h
+++ b/arch/avr/include/avr/irq.h
@@ -93,12 +93,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of PC and SR used during signal processing.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/avr/include/avr32/irq.h
+++ b/arch/avr/include/avr32/irq.h
@@ -93,12 +93,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of PC and SR used during signal processing.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -83,9 +83,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -104,7 +104,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -75,120 +75,112 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
   uintptr_t reg_ptr = (uintptr_t)avr_sigdeliver;
 
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * g_current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save registers that must be protected while the signal
-               * handler runs. These will be restored by the signal
-               * trampoline after the signal(s) have been delivered.
-               */
-
-              tcb->xcp.saved_pc0  = up_current_regs()[REG_PC0];
-              tcb->xcp.saved_pc1  = up_current_regs()[REG_PC1];
-#if defined(REG_PC2)
-              tcb->xcp.saved_pc2  = up_current_regs()[REG_PC2];
-#endif
-              tcb->xcp.saved_sreg = up_current_regs()[REG_SREG];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-#if !defined(REG_PC2)
-              up_current_regs()[REG_PC0] = (uint16_t)reg_ptr >> 8;
-              up_current_regs()[REG_PC1] = (uint16_t)reg_ptr & 0xff;
-#else
-              up_current_regs()[REG_PC0] = (uint32_t)reg_ptr >> 16;
-              up_current_regs()[REG_PC1] = (uint32_t)reg_ptr >> 8;
-              up_current_regs()[REG_PC2] = (uint32_t)reg_ptr & 0xff;
-#endif
-              up_current_regs()[REG_SREG] &= ~(1 << SREG_I);
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              avr_savestate(tcb->xcp.regs);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * g_current_regs does not refer to the thread of this_task()!
        */
 
       else
         {
-          /* Save registers that must be protected while the signal handler
-           * runs. These will be restored by the signal trampoline after
-           * the signals have been delivered.
+          /* Save registers that must be protected while the signal
+           * handler runs. These will be restored by the signal
+           * trampoline after the signal(s) have been delivered.
            */
 
-          tcb->xcp.saved_pc0     = tcb->xcp.regs[REG_PC0];
-          tcb->xcp.saved_pc1     = tcb->xcp.regs[REG_PC1];
+          tcb->xcp.saved_pc0  = up_current_regs()[REG_PC0];
+          tcb->xcp.saved_pc1  = up_current_regs()[REG_PC1];
 #if defined(REG_PC2)
-          tcb->xcp.saved_pc2     = tcb->xcp.regs[REG_PC2];
+          tcb->xcp.saved_pc2  = up_current_regs()[REG_PC2];
 #endif
-          tcb->xcp.saved_sreg    = tcb->xcp.regs[REG_SREG];
+          tcb->xcp.saved_sreg = up_current_regs()[REG_SREG];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
 #if !defined(REG_PC2)
-          tcb->xcp.regs[REG_PC0] = (uint16_t)reg_ptr >> 8;
-          tcb->xcp.regs[REG_PC1] = (uint16_t)reg_ptr & 0xff;
+          up_current_regs()[REG_PC0] = (uint16_t)reg_ptr >> 8;
+          up_current_regs()[REG_PC1] = (uint16_t)reg_ptr & 0xff;
 #else
-          tcb->xcp.regs[REG_PC0] = (uint32_t)reg_ptr >> 16;
-          tcb->xcp.regs[REG_PC1] = (uint32_t)reg_ptr >> 8;
-          tcb->xcp.regs[REG_PC2] = (uint32_t)reg_ptr & 0xff;
+          up_current_regs()[REG_PC0] = (uint32_t)reg_ptr >> 16;
+          up_current_regs()[REG_PC1] = (uint32_t)reg_ptr >> 8;
+          up_current_regs()[REG_PC2] = (uint32_t)reg_ptr & 0xff;
+#endif
+          up_current_regs()[REG_SREG] &= ~(1 << SREG_I);
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          avr_savestate(tcb->xcp.regs);
+        }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save registers that must be protected while the signal handler
+       * runs. These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc0     = tcb->xcp.regs[REG_PC0];
+      tcb->xcp.saved_pc1     = tcb->xcp.regs[REG_PC1];
+#if defined(REG_PC2)
+      tcb->xcp.saved_pc2     = tcb->xcp.regs[REG_PC2];
+#endif
+      tcb->xcp.saved_sreg    = tcb->xcp.regs[REG_SREG];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+#if !defined(REG_PC2)
+      tcb->xcp.regs[REG_PC0] = (uint16_t)reg_ptr >> 8;
+      tcb->xcp.regs[REG_PC1] = (uint16_t)reg_ptr & 0xff;
+#else
+      tcb->xcp.regs[REG_PC0] = (uint32_t)reg_ptr >> 16;
+      tcb->xcp.regs[REG_PC1] = (uint32_t)reg_ptr >> 8;
+      tcb->xcp.regs[REG_PC2] = (uint32_t)reg_ptr & 0xff;
 
 #endif
-          tcb->xcp.regs[REG_SREG] &= ~(1 << SREG_I);
-        }
+      tcb->xcp.regs[REG_SREG] &= ~(1 << SREG_I);
     }
 }

--- a/arch/avr/src/avr/avr_sigdeliver.c
+++ b/arch/avr/src/avr/avr_sigdeliver.c
@@ -59,8 +59,8 @@ void avr_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -76,7 +76,7 @@ void avr_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -96,13 +96,13 @@ void avr_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_PC0]        = rtcb->xcp.saved_pc0;
-  regs[REG_PC1]        = rtcb->xcp.saved_pc1;
+  regs[REG_PC0]    = rtcb->xcp.saved_pc0;
+  regs[REG_PC1]    = rtcb->xcp.saved_pc1;
 #if defined(REG_PC2)
-  regs[REG_PC2]        = rtcb->xcp.saved_pc2;
+  regs[REG_PC2]    = rtcb->xcp.saved_pc2;
 #endif
-  regs[REG_SREG]       = rtcb->xcp.saved_sreg;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_SREG]   = rtcb->xcp.saved_sreg;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. This is an
    * unusual case that must be handled by up_fullcontextresore. This case is

--- a/arch/avr/src/avr32/avr_initialstate.c
+++ b/arch/avr/src/avr32/avr_initialstate.c
@@ -87,7 +87,7 @@ void up_initial_state(struct tcb_s *tcb)
 #else
   /* No pending signal delivery */
 
-  xcp->sigdeliver   = NULL;
+  tcb->sigdeliver   = NULL;
 
   /* Clear the frame pointer and link register since this is the outermost
    * frame.

--- a/arch/avr/src/avr32/avr_schedulesigaction.c
+++ b/arch/avr/src/avr32/avr_schedulesigaction.c
@@ -75,95 +75,87 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * g_current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save registers that must be protected while the signal
-               * handler runs. These will be restored by the signal
-               * trampoline after the signal(s) have been delivered.
-               */
-
-              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
-              tcb->xcp.saved_sr = up_current_regs()[REG_SR];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]  = (uint32_t)avr_sigdeliver;
-              up_current_regs()[REG_SR] |= AVR32_SR_GM_MASK;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              avr_savestate(tcb->xcp.regs);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * g_current_regs does not refer to the thread of this_task()!
        */
 
       else
         {
-          /* Save registers that must be protected while the signal handler
-           * runs. These will be restored by the signal trampoline after
-           * the signals have been delivered.
+          /* Save registers that must be protected while the signal
+           * handler runs. These will be restored by the signal
+           * trampoline after the signal(s) have been delivered.
            */
 
-          tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_sr      = tcb->xcp.regs[REG_SR];
+          tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+          tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_PC]  = (uint32_t)avr_sigdeliver;
-          tcb->xcp.regs[REG_SR] |= AVR32_SR_GM_MASK;
+          up_current_regs()[REG_PC]  = (uint32_t)avr_sigdeliver;
+          up_current_regs()[REG_SR] |= AVR32_SR_GM_MASK;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          avr_savestate(tcb->xcp.regs);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save registers that must be protected while the signal handler
+       * runs. These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
+      tcb->xcp.saved_sr      = tcb->xcp.regs[REG_SR];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_PC]  = (uint32_t)avr_sigdeliver;
+      tcb->xcp.regs[REG_SR] |= AVR32_SR_GM_MASK;
     }
 }

--- a/arch/avr/src/avr32/avr_schedulesigaction.c
+++ b/arch/avr/src/avr32/avr_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -102,7 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/avr/src/avr32/avr_sigdeliver.c
+++ b/arch/avr/src/avr32/avr_sigdeliver.c
@@ -63,8 +63,8 @@ void avr_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -80,7 +80,7 @@ void avr_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -100,9 +100,9 @@ void avr_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_PC]         = rtcb->xcp.saved_pc;
-  regs[REG_SR]         = rtcb->xcp.saved_sr;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_PC]     = rtcb->xcp.saved_pc;
+  regs[REG_SR]     = rtcb->xcp.saved_sr;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. This is an
    * unusual case that must be handled by up_fullcontextresore. This case is

--- a/arch/ceva/include/xc5/irq.h
+++ b/arch/ceva/include/xc5/irq.h
@@ -127,12 +127,6 @@ struct xcpt_syscall_s
 struct xcptcontext
 {
 #ifndef CONFIG_DISABLE_SIGNALS
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/ceva/include/xm6/irq.h
+++ b/arch/ceva/include/xm6/irq.h
@@ -130,12 +130,6 @@ struct xcpt_syscall_s
 struct xcptcontext
 {
 #ifndef CONFIG_DISABLE_SIGNALS
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -112,21 +112,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
       else
         {
-#ifdef CONFIG_SMP
-          /* If we signaling a task running on the other CPU, we have
-           * to PAUSE the other CPU.
-           */
-
-          if (cpu != me)
-            {
-              /* Pause the CPU */
-
-              up_cpu_pause(cpu);
-            }
-
-          /* Now tcb on the other CPU can be accessed safely */
-#endif
-
           /* Save the current register context location */
 
           tcb->xcp.saved_regs = up_current_regs();
@@ -151,15 +136,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 #ifdef REG_OM
           up_current_regs()[REG_OM] &= ~REG_OM_MASK;
           up_current_regs()[REG_OM] |=  REG_OM_KERNEL;
-#endif
-
-#ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
-
-          if (cpu != me)
-            {
-              up_cpu_resume(cpu);
-            }
 #endif
         }
     }

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -79,9 +79,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -107,7 +107,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.

--- a/arch/ceva/src/common/ceva_sigdeliver.c
+++ b/arch/ceva/src/common/ceva_sigdeliver.c
@@ -62,16 +62,16 @@ void ceva_sigdeliver(void)
   int saved_errno = rtcb->pterrno;
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Get a local copy of the sigdeliver function pointer. We do this so that
    * we can nullify the sigdeliver function pointer in the TCB and accept
    * more signal deliveries while processing the current pending signals.
    */
 
-  sigdeliver           = (sig_deliver_t)rtcb->xcp.sigdeliver;
-  rtcb->xcp.sigdeliver = NULL;
+  sigdeliver       = rtcb->sigdeliver;
+  rtcb->sigdeliver = NULL;
 
   /* Deliver the signal */
 

--- a/arch/mips/include/mips32/irq.h
+++ b/arch/mips/include/mips32/irq.h
@@ -321,12 +321,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-NULL if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    *

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -76,88 +76,41 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
   uint32_t status;
 
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * g_current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return EPC and STATUS registers.  These will be
-               * restored by the signal trampoline after the signals have
-               * been delivered.
-               */
-
-              tcb->xcp.saved_epc    = up_current_regs()[REG_EPC];
-              tcb->xcp.saved_status = up_current_regs()[REG_STATUS];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
-              status  = up_current_regs()[REG_STATUS];
-              status &= ~CP0_STATUS_INT_MASK;
-              status |= CP0_STATUS_INT_SW0;
-              up_current_regs()[REG_STATUS]  = status;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              mips_savestate(tcb->xcp.regs);
-
-              sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
-                    " New: %08" PRIx32 "/%08" PRIx32 "\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    up_current_regs()[REG_EPC],
-                    up_current_regs()[REG_STATUS]);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * g_current_regs does not refer to the thread of this_task()!
        */
 
       else
@@ -167,23 +120,62 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * been delivered.
            */
 
-          tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
-          tcb->xcp.saved_status      = tcb->xcp.regs[REG_STATUS];
+          tcb->xcp.saved_epc    = up_current_regs()[REG_EPC];
+          tcb->xcp.saved_status = up_current_regs()[REG_STATUS];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_EPC]     = (uint32_t)mips_sigdeliver;
-          status                     = tcb->xcp.regs[REG_STATUS];
-          status                    &= ~CP0_STATUS_INT_MASK;
-          status                    |= CP0_STATUS_INT_SW0;
-          tcb->xcp.regs[REG_STATUS]  = status;
+          up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
+          status  = up_current_regs()[REG_STATUS];
+          status &= ~CP0_STATUS_INT_MASK;
+          status |= CP0_STATUS_INT_SW0;
+          up_current_regs()[REG_STATUS]  = status;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          mips_savestate(tcb->xcp.regs);
 
           sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
                 " New: %08" PRIx32 "/%08" PRIx32 "\n",
                 tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
+                up_current_regs()[REG_EPC],
+                up_current_regs()[REG_STATUS]);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
+       */
+
+      tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
+      tcb->xcp.saved_status      = tcb->xcp.regs[REG_STATUS];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_EPC]     = (uint32_t)mips_sigdeliver;
+      status                     = tcb->xcp.regs[REG_STATUS];
+      status                    &= ~CP0_STATUS_INT_MASK;
+      status                    |= CP0_STATUS_INT_SW0;
+      tcb->xcp.regs[REG_STATUS]  = status;
+
+      sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
+            " New: %08" PRIx32 "/%08" PRIx32 "\n",
+            tcb->xcp.saved_epc, tcb->xcp.saved_status,
+            tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
     }
 }

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -84,9 +84,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -105,7 +105,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/mips/src/mips32/mips_sigdeliver.c
+++ b/arch/mips/src/mips32/mips_sigdeliver.c
@@ -61,8 +61,8 @@ void mips_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -78,7 +78,7 @@ void mips_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -100,9 +100,9 @@ void mips_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_EPC]        = rtcb->xcp.saved_epc;
-  regs[REG_STATUS]     = rtcb->xcp.saved_status;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_EPC]    = rtcb->xcp.saved_epc;
+  regs[REG_STATUS] = rtcb->xcp.saved_status;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/misoc/include/lm32/irq.h
+++ b/arch/misoc/include/lm32/irq.h
@@ -179,12 +179,6 @@
 
 struct xcptcontext
 {
-  /* The following function pointer is non-NULL if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver;       /* Actual type is sig_deliver_t */
-
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    *

--- a/arch/misoc/include/minerva/irq.h
+++ b/arch/misoc/include/minerva/irq.h
@@ -261,12 +261,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-NULL if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver;           /* Actual type is sig_deliver_t */
-
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    */

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -81,9 +81,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -102,7 +102,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -75,81 +75,39 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * g_current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return EPC and STATUS registers.  These will be
-               * restored by the signal trampoline after the signals have
-               * been delivered.
-               */
-
-             tcb->xcp.saved_epc = up_current_regs()[REG_EPC];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_EPC]     = (uint32_t)lm32_sigdeliver;
-              up_current_regs()[REG_INT_CTX] = 0;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              misoc_savestate(tcb->xcp.regs);
-
-              sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    up_current_regs()[REG_EPC],
-                    up_current_regs()[REG_STATUS]);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * g_current_regs does not refer to the thread of this_task()!
        */
 
       else
@@ -159,19 +117,53 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * been delivered.
            */
 
-          tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
-          tcb->xcp.saved_int_ctx     = tcb->xcp.regs[REG_INT_CTX];
+          tcb->xcp.saved_epc = up_current_regs()[REG_EPC];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_EPC]     = (uint32_t)lm32_sigdeliver;
-          tcb->xcp.regs[REG_INT_CTX] = 0;
+          up_current_regs()[REG_EPC]     = (uint32_t)lm32_sigdeliver;
+          up_current_regs()[REG_INT_CTX] = 0;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          misoc_savestate(tcb->xcp.regs);
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
                 tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
+                up_current_regs()[REG_EPC],
+                up_current_regs()[REG_STATUS]);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
+       */
+
+      tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
+      tcb->xcp.saved_int_ctx     = tcb->xcp.regs[REG_INT_CTX];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_EPC]     = (uint32_t)lm32_sigdeliver;
+      tcb->xcp.regs[REG_INT_CTX] = 0;
+
+      sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
+            tcb->xcp.saved_epc, tcb->xcp.saved_status,
+            tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
     }
 }

--- a/arch/misoc/src/lm32/lm32_sigdeliver.c
+++ b/arch/misoc/src/lm32/lm32_sigdeliver.c
@@ -60,8 +60,8 @@ void lm32_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +77,7 @@ void lm32_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -99,9 +99,9 @@ void lm32_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_EPC]        = rtcb->xcp.saved_epc;
-  regs[REG_INT_CTX]    = rtcb->xcp.saved_int_ctx;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_EPC]     = rtcb->xcp.saved_epc;
+  regs[REG_INT_CTX] = rtcb->xcp.saved_int_ctx;
+  rtcb->sigdeliver  = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -82,9 +82,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -103,7 +103,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2: We are in an interrupt handler AND the interrupted task

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -76,103 +76,95 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1: We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1: We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2: We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in
-           * the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that g_current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return EPC and STATUS registers.  These will be
-               * restored by the signal trampoline after the signals have
-               * been delivered.
-               */
-
-              tcb->xcp.saved_epc = up_current_regs()[REG_CSR_MEPC];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_CSR_MEPC] =
-                (uint32_t)minerva_sigdeliver;
-              up_current_regs()[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
-
-              /* And make sure that the saved context in the TCB is the same
-               * as the interrupt return context.
-               */
-
-              misoc_savestate(tcb->xcp.regs);
-
-              sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                    up_current_regs()[REG_CSR_MEPC],
-                    up_current_regs()[REG_CSR_MSTATUS]);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signalling some non-running task.
+      /* CASE 2: We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in
+       * the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following logic
+       * would fail in the strange case where we are in an interrupt
+       * handler, the thread is signalling itself, but a context switch
+       * to another task has occurred so that g_current_regs does not
+       * refer to the thread of this_task()!
        */
 
       else
         {
           /* Save the return EPC and STATUS registers.  These will be
-           * restored by the signal trampoline after the signals have been
-           * delivered.
+           * restored by the signal trampoline after the signals have
+           * been delivered.
            */
 
-          tcb->xcp.saved_epc = tcb->xcp.regs[REG_CSR_MEPC];
-          tcb->xcp.saved_int_ctx = tcb->xcp.regs[REG_CSR_MSTATUS];
+          tcb->xcp.saved_epc = up_current_regs()[REG_CSR_MEPC];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_CSR_MEPC] = (uint32_t) minerva_sigdeliver;
+          up_current_regs()[REG_CSR_MEPC] =
+            (uint32_t)minerva_sigdeliver;
           up_current_regs()[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
+
+          /* And make sure that the saved context in the TCB is the same
+           * as the interrupt return context.
+           */
+
+          misoc_savestate(tcb->xcp.regs);
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
                 tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                tcb->xcp.regs[REG_CSR_MEPC], tcb->xcp.regs[REG_CSR_MSTATUS]);
+                up_current_regs()[REG_CSR_MEPC],
+                up_current_regs()[REG_CSR_MSTATUS]);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running from an
+   * interrupt handler or (2) we are not in an interrupt handler and the
+   * running task is signalling some non-running task.
+   */
+
+  else
+    {
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have been
+       * delivered.
+       */
+
+      tcb->xcp.saved_epc = tcb->xcp.regs[REG_CSR_MEPC];
+      tcb->xcp.saved_int_ctx = tcb->xcp.regs[REG_CSR_MSTATUS];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_CSR_MEPC] = (uint32_t) minerva_sigdeliver;
+      up_current_regs()[REG_CSR_MSTATUS] &= ~CSR_MSTATUS_MIE;
+
+      sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
+            tcb->xcp.saved_epc, tcb->xcp.saved_status,
+            tcb->xcp.regs[REG_CSR_MEPC], tcb->xcp.regs[REG_CSR_MSTATUS]);
     }
 }

--- a/arch/misoc/src/minerva/minerva_sigdeliver.c
+++ b/arch/misoc/src/minerva/minerva_sigdeliver.c
@@ -62,8 +62,8 @@ void minerva_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the real return state on the stack. */
 
@@ -76,8 +76,8 @@ void minerva_sigdeliver(void)
    * more signal deliveries while processing the current pending signals.
    */
 
-  sigdeliver = rtcb->xcp.sigdeliver;
-  rtcb->xcp.sigdeliver = NULL;
+  sigdeliver       = rtcb->sigdeliver;
+  rtcb->sigdeliver = NULL;
 
 #  ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/or1k/include/mor1kx/irq.h
+++ b/arch/or1k/include/mor1kx/irq.h
@@ -170,12 +170,6 @@ struct xcptcontext
 
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of LR and CPSR used during
    * signal processing.
    *

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -74,80 +74,39 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              /* tcb->xcp.saved_pc   = up_current_regs()[REG_PC];
-               * tcb->xcp.saved_cpsr = up_current_regs()[REG_CPSR];
-               */
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              /* up_current_regs()[REG_PC]   = (uint32_t)or1k_sigdeliver;
-               * up_current_regs()[REG_CPSR] = SVC_MODE | PSR_I_BIT |
-               *                          PSR_F_BIT;
-               */
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              or1k_savestate(tcb->xcp.regs);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * current_regs does not refer to the thread of this_task()!
        */
 
       else
@@ -157,17 +116,50 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.saved_pc          = tcb->xcp.regs[REG_PC];
-
-          /* tcb->xcp.saved_cpsr     = tcb->xcp.regs[REG_CPSR]; */
+          /* tcb->xcp.saved_pc   = up_current_regs()[REG_PC];
+           * tcb->xcp.saved_cpsr = up_current_regs()[REG_CPSR];
+           */
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          /* tcb->xcp.regs[REG_PC]   = (uint32_t)or1k_sigdeliver;
-           * tcb->xcp.regs[REG_CPSR] = SVC_MODE | PSR_I_BIT | PSR_F_BIT;
+          /* up_current_regs()[REG_PC]   = (uint32_t)or1k_sigdeliver;
+           * up_current_regs()[REG_CPSR] = SVC_MODE | PSR_I_BIT |
+           *                          PSR_F_BIT;
            */
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          or1k_savestate(tcb->xcp.regs);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc          = tcb->xcp.regs[REG_PC];
+
+      /* tcb->xcp.saved_cpsr     = tcb->xcp.regs[REG_CPSR]; */
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      /* tcb->xcp.regs[REG_PC]   = (uint32_t)or1k_sigdeliver;
+       * tcb->xcp.regs[REG_CPSR] = SVC_MODE | PSR_I_BIT | PSR_F_BIT;
+       */
     }
 }

--- a/arch/renesas/include/m16c/irq.h
+++ b/arch/renesas/include/m16c/irq.h
@@ -228,12 +228,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of LR and SR used during signal processing.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/renesas/include/rx65n/irq.h
+++ b/arch/renesas/include/rx65n/irq.h
@@ -986,12 +986,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of LR and SR used during signal processing. */
 
   uint32_t saved_pc;

--- a/arch/renesas/include/sh1/irq.h
+++ b/arch/renesas/include/sh1/irq.h
@@ -449,12 +449,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of LR and SR used during signal processing.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -74,73 +74,33 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC and SR and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              tcb->xcp.saved_pc[0] = up_current_regs()[REG_PC];
-              tcb->xcp.saved_pc[1] = up_current_regs()[REG_PC + 1];
-              tcb->xcp.saved_flg   = up_current_regs()[REG_FLG];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
-              up_current_regs()[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
-              up_current_regs()[REG_FLG] &= ~M16C_FLG_I;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              renesas_copystate(tcb->xcp.regs, up_current_regs());
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
        */
 
       else
@@ -150,17 +110,49 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.saved_pc[0]  = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_pc[1]  = tcb->xcp.regs[REG_PC + 1];
-          tcb->xcp.saved_flg    = tcb->xcp.regs[REG_FLG];
+          tcb->xcp.saved_pc[0] = up_current_regs()[REG_PC];
+          tcb->xcp.saved_pc[1] = up_current_regs()[REG_PC + 1];
+          tcb->xcp.saved_flg   = up_current_regs()[REG_FLG];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
-          tcb->xcp.regs[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
-          tcb->xcp.regs[REG_FLG] &= ~M16C_FLG_I;
+          up_current_regs()[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
+          up_current_regs()[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
+          up_current_regs()[REG_FLG] &= ~M16C_FLG_I;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          renesas_copystate(tcb->xcp.regs, up_current_regs());
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return PC and SR and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc[0]  = tcb->xcp.regs[REG_PC];
+      tcb->xcp.saved_pc[1]  = tcb->xcp.regs[REG_PC + 1];
+      tcb->xcp.saved_flg    = tcb->xcp.regs[REG_FLG];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
+      tcb->xcp.regs[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
+      tcb->xcp.regs[REG_FLG] &= ~M16C_FLG_I;
     }
 }

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/m16c/m16c_sigdeliver.c
+++ b/arch/renesas/src/m16c/m16c_sigdeliver.c
@@ -58,8 +58,8 @@ void renesas_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -75,7 +75,7 @@ void renesas_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)sig_rtcb->xcp.sigdeliver)(rtcb);
+  (sig_rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -95,10 +95,10 @@ void renesas_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_PC]         = rtcb->xcp.saved_pc[0];
-  regs[REG_PC + 1]     = rtcb->xcp.saved_pc[1];
-  regs[REG_FLG]        = rtcb->xcp.saved_flg;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_PC]     = rtcb->xcp.saved_pc[0];
+  regs[REG_PC + 1] = rtcb->xcp.saved_pc[1];
+  regs[REG_FLG]    = rtcb->xcp.saved_flg;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -74,71 +74,33 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC and SR and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
-              tcb->xcp.saved_sr = up_current_regs()[REG_PSW];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]   = (uint32_t)renesas_sigdeliver;
-              up_current_regs()[REG_PSW] |= 0x00030000;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              renesas_copystate(tcb->xcp.regs, up_current_regs());
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
        */
 
       else
@@ -148,15 +110,45 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.saved_pc       = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_sr       = tcb->xcp.regs[REG_PSW];
+          tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+          tcb->xcp.saved_sr = up_current_regs()[REG_PSW];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_PC]   = (uint32_t)renesas_sigdeliver;
-          tcb->xcp.regs[REG_PSW] |= 0x00030000;
+          up_current_regs()[REG_PC]   = (uint32_t)renesas_sigdeliver;
+          up_current_regs()[REG_PSW] |= 0x00030000;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          renesas_copystate(tcb->xcp.regs, up_current_regs());
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return PC and SR and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc       = tcb->xcp.regs[REG_PC];
+      tcb->xcp.saved_sr       = tcb->xcp.regs[REG_PSW];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_PC]   = (uint32_t)renesas_sigdeliver;
+      tcb->xcp.regs[REG_PSW] |= 0x00030000;
     }
 }

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/rx65n/rx65n_sigdeliver.c
+++ b/arch/renesas/src/rx65n/rx65n_sigdeliver.c
@@ -60,8 +60,8 @@ void renesas_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the real return state on the stack. */
 
@@ -75,8 +75,8 @@ void renesas_sigdeliver(void)
    * signals.
    */
 
-  sigdeliver           = rtcb->xcp.sigdeliver;
-  rtcb->xcp.sigdeliver = NULL;
+  sigdeliver       = rtcb->sigdeliver;
+  rtcb->sigdeliver = NULL;
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -74,71 +74,33 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* Save the return PC and SR and one scratch register
-               * These will be restored by the signal trampoline after
-               * the signals have been delivered.
-               */
-
-              tcb->xcp.saved_pc = up_current_regs()[REG_PC];
-              tcb->xcp.saved_sr = up_current_regs()[REG_SR];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]  = (uint32_t)renesas_sigdeliver;
-              up_current_regs()[REG_SR] |= 0x000000f0;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              renesas_copystate(tcb->xcp.regs, up_current_regs());
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
        */
 
       else
@@ -148,15 +110,45 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * the signals have been delivered.
            */
 
-          tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_sr      = tcb->xcp.regs[REG_SR];
+          tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+          tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_PC]  = (uint32_t)renesas_sigdeliver;
-          tcb->xcp.regs[REG_SR] |= 0x000000f0 ;
+          up_current_regs()[REG_PC]  = (uint32_t)renesas_sigdeliver;
+          up_current_regs()[REG_SR] |= 0x000000f0;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          renesas_copystate(tcb->xcp.regs, up_current_regs());
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return PC and SR and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc      = tcb->xcp.regs[REG_PC];
+      tcb->xcp.saved_sr      = tcb->xcp.regs[REG_SR];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_PC]  = (uint32_t)renesas_sigdeliver;
+      tcb->xcp.regs[REG_SR] |= 0x000000f0 ;
     }
 }

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/sh1/sh1_sigdeliver.c
+++ b/arch/renesas/src/sh1/sh1_sigdeliver.c
@@ -58,8 +58,8 @@ void renesas_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -75,7 +75,7 @@ void renesas_sigdeliver(void)
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -95,9 +95,9 @@ void renesas_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_PC]         = rtcb->xcp.saved_pc;
-  regs[REG_SR]         = rtcb->xcp.saved_sr;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_PC]     = rtcb->xcp.saved_pc;
+  regs[REG_SR]     = rtcb->xcp.saved_sr;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -567,12 +567,6 @@
 
 struct xcptcontext
 {
-  /* The following function pointer is non-NULL if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    *

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -84,9 +84,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -98,18 +98,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the return EPC and STATUS registers.  These will be
        * by the signal trampoline after the signal has been delivered.
        */
@@ -146,13 +134,5 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 #endif
 
       tcb->xcp.regs[REG_INT_CTX] = int_ctx;
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
-#endif
     }
 }

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -107,7 +107,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -154,7 +154,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -69,8 +69,8 @@ void riscv_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -102,7 +102,7 @@ retry:
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -147,7 +147,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -51,7 +51,6 @@
 
 struct xcptcontext
 {
-  void *sigdeliver; /* Actual type is sig_deliver_t */
   jmp_buf regs;
 };
 

--- a/arch/sim/src/sim/sim_schedulesigaction.c
+++ b/arch/sim/src/sim/sim_schedulesigaction.c
@@ -83,13 +83,13 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   flags = enter_critical_section();
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
       if (tcb == this_task())
         {
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
     }
 

--- a/arch/sim/src/sim/sim_schedulesigaction.c
+++ b/arch/sim/src/sim/sim_schedulesigaction.c
@@ -71,27 +71,15 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  irqstate_t flags;
-
   /* We don't have to anything complex for the simulated target */
 
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p\n", tcb);
 
-  /* Make sure that interrupts are disabled */
-
-  flags = enter_critical_section();
-
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-      if (tcb == this_task())
-        {
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
     }
-
-  leave_critical_section(flags);
 }

--- a/arch/sim/src/sim/sim_sigdeliver.c
+++ b/arch/sim/src/sim/sim_sigdeliver.c
@@ -61,7 +61,7 @@ void sim_sigdeliver(void)
   int16_t saved_irqcount;
   irqstate_t flags;
 #endif
-  if (NULL == (rtcb->xcp.sigdeliver))
+  if (NULL == (rtcb->sigdeliver))
     {
       return;
     }
@@ -75,8 +75,8 @@ void sim_sigdeliver(void)
 #endif
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* NOTE: we do not save the return state for sim */
 
@@ -103,7 +103,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -135,7 +135,7 @@ retry:
 
   /* Allows next handler to be scheduled */
 
-  rtcb->xcp.sigdeliver = NULL;
+  rtcb->sigdeliver = NULL;
 
   /* NOTE: we leave a critical section here for sim */
 

--- a/arch/sparc/include/sparc_v8/irq.h
+++ b/arch/sparc/include/sparc_v8/irq.h
@@ -427,12 +427,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-NULL if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    *

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -84,9 +84,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -105,7 +105,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the
@@ -193,9 +193,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -219,7 +219,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -72,245 +72,39 @@
  ****************************************************************************/
 
 #ifndef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  irqstate_t flags;
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  /* Make sure that interrupts are disabled */
-
-  flags = enter_critical_section();
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save registers that must be protected while the signal
-               * handler runs. These will be restored by the signal
-               * trampoline after the signal(s) have been delivered.
-               */
-
-              tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
-              tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
-              tcb->xcp.saved_status = up_current_regs()[REG_PSR];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
-              up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
-              up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              sparc_savestate(tcb->xcp.regs);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
-       */
-
-      else
-        {
-          /* Save registers that must be protected while the signal handler
-           * runs. These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
-
-          tcb->xcp.saved_pc         = tcb->xcp.regs[REG_PC];
-          tcb->xcp.saved_npc        = tcb->xcp.regs[REG_NPC];
-          tcb->xcp.saved_status     = tcb->xcp.regs[REG_PSR];
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          tcb->xcp.regs[REG_PC]     = (uint32_t)sparc_sigdeliver;
-          tcb->xcp.regs[REG_NPC]    = (uint32_t)sparc_sigdeliver + 4;
-          tcb->xcp.regs[REG_PSR]    |= SPARC_PSR_ET_MASK;
-        }
-    }
-
-  leave_critical_section(flags);
-}
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
-{
-  irqstate_t flags;
-  int cpu;
-  int me;
-
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
-
-  /* Make sure that interrupts are disabled */
-
-  flags = enter_critical_section();
-
-  /* Refuse to handle nested signal actions */
-
-  if (!tcb->sigdeliver)
-    {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
-       */
-
-      sinfo("rtcb=0x%p current_regs=0x%p\n", this_task(), up_current_regs());
-
-      if (tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          me  = this_cpu();
-          cpu = tcb->cpu;
-
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signaling itself for some reason.
-           */
-
-          if (cpu == me && !up_current_regs())
-            {
-              /* In this case just deliver the signal now.
-               * REVISIT:  Signal handler will run in a critical section!
-               */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  The task that needs to receive the signal is running.
-           * This could happen if the task is running on another CPU OR if
-           * we are in an interrupt handler and the task is running on this
-           * CPU.  In the former case, we will have to PAUSE the other CPU
-           * first.  But in either case, we will have to modify the return
-           * state as well as the state in the TCB.
-           */
-
-          else
-            {
-              /* If we signaling a task running on the other CPU, we have
-               * to PAUSE the other CPU.
-               */
-
-              if (cpu != me)
-                {
-                  /* Pause the CPU */
-
-                  up_cpu_pause(cpu);
-
-                  /* Now tcb on the other CPU can be accessed safely */
-
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
-                   * restored by the signal trampoline after the signal has
-                   * been delivered.
-                   */
-
-                  tcb->xcp.saved_pc     = tcb->xcp.regs[REG_PC];
-                  tcb->xcp.saved_npc    = tcb->xcp.regs[REG_NPC];
-                  tcb->xcp.saved_status = tcb->xcp.regs[REG_PSR];
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  We must already be in privileged thread mode
-                   * to be here.
-                   */
-
-                  tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
-                  tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
-                  tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
-                }
-              else
-                {
-                  /* tcb is running on the same CPU */
-
-                  /* Save registers that must be protected while the signal
-                   * handler runs. These will be restored by the signal
-                   * trampoline after the signal(s) have been delivered.
-                   */
-
-                  tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
-                  tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
-                  tcb->xcp.saved_status = up_current_regs()[REG_PSR];
-
-                  /* Then set up vector to the trampoline with interrupts
-                   * disabled.  The kernel-space trampoline must run in
-                   * privileged thread mode.
-                   */
-
-                  up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
-                  up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver
-                                                + 4;
-                  up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
-
-                  /* And make sure that the saved context in the TCB is the
-                   * same as the interrupt return context.
-                   */
-
-                  sparc_savestate(tcb->xcp.regs);
-                }
-
-              /* NOTE: If the task runs on another CPU(cpu), adjusting
-               * global IRQ controls will be done in the pause handler
-               * on the CPU(cpu) by taking a critical section.
-               * If the task is scheduled on this CPU(me), do nothing
-               * because this CPU already took a critical section
-               */
-
-              /* RESUME the other CPU if it was PAUSED */
-
-              if (cpu != me)
-                {
-                  up_cpu_resume(cpu);
-                }
-            }
-        }
-
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some other non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * current_regs does not refer to the thread of this_task()!
        */
 
       else
@@ -325,16 +119,191 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.saved_status = up_current_regs()[REG_PSR];
 
           /* Then set up to vector to the trampoline with interrupts
-           * disabled.  We must already be in privileged thread mode to be
-           * here.
+           * disabled
            */
 
-          tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
-          tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
-          tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
+          up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
+          up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+          up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          sparc_savestate(tcb->xcp.regs);
         }
     }
 
-  leave_critical_section(flags);
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save registers that must be protected while the signal handler
+       * runs. These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc         = tcb->xcp.regs[REG_PC];
+      tcb->xcp.saved_npc        = tcb->xcp.regs[REG_NPC];
+      tcb->xcp.saved_status     = tcb->xcp.regs[REG_PSR];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_PC]     = (uint32_t)sparc_sigdeliver;
+      tcb->xcp.regs[REG_NPC]    = (uint32_t)sparc_sigdeliver + 4;
+      tcb->xcp.regs[REG_PSR]    |= SPARC_PSR_ET_MASK;
+    }
+}
+#endif /* !CONFIG_SMP */
+
+#ifdef CONFIG_SMP
+void up_schedule_sigaction(struct tcb_s *tcb)
+{
+  int cpu;
+  int me;
+
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
+
+  /* First, handle some special cases when the signal is being delivered
+   * to task that is currently executing on any CPU.
+   */
+
+  if (tcb->task_state == TSTATE_TASK_RUNNING)
+    {
+      me  = this_cpu();
+      cpu = tcb->cpu;
+
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signaling itself for some reason.
+       */
+
+      if (cpu == me && !up_current_regs())
+        {
+          /* In this case just deliver the signal now.
+           * REVISIT:  Signal handler will run in a critical section!
+           */
+
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
+        }
+
+      /* CASE 2:  The task that needs to receive the signal is running.
+       * This could happen if the task is running on another CPU OR if
+       * we are in an interrupt handler and the task is running on this
+       * CPU.  In the former case, we will have to PAUSE the other CPU
+       * first.  But in either case, we will have to modify the return
+       * state as well as the state in the TCB.
+       */
+
+      else
+        {
+          /* If we signaling a task running on the other CPU, we have
+           * to PAUSE the other CPU.
+           */
+
+          if (cpu != me)
+            {
+              /* Pause the CPU */
+
+              up_cpu_pause(cpu);
+
+              /* Now tcb on the other CPU can be accessed safely */
+
+              /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
+               * restored by the signal trampoline after the signal has
+               * been delivered.
+               */
+
+              tcb->xcp.saved_pc     = tcb->xcp.regs[REG_PC];
+              tcb->xcp.saved_npc    = tcb->xcp.regs[REG_NPC];
+              tcb->xcp.saved_status = tcb->xcp.regs[REG_PSR];
+
+              /* Then set up vector to the trampoline with interrupts
+               * disabled.  We must already be in privileged thread mode
+               * to be here.
+               */
+
+              tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
+              tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+              tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
+            }
+          else
+            {
+              /* tcb is running on the same CPU */
+
+              /* Save registers that must be protected while the signal
+               * handler runs. These will be restored by the signal
+               * trampoline after the signal(s) have been delivered.
+               */
+
+              tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
+              tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
+              tcb->xcp.saved_status = up_current_regs()[REG_PSR];
+
+              /* Then set up vector to the trampoline with interrupts
+               * disabled.  The kernel-space trampoline must run in
+               * privileged thread mode.
+               */
+
+              up_current_regs()[REG_PC]  = (uint32_t)sparc_sigdeliver;
+              up_current_regs()[REG_NPC] = (uint32_t)sparc_sigdeliver
+                                            + 4;
+              up_current_regs()[REG_PSR] |= SPARC_PSR_ET_MASK;
+
+              /* And make sure that the saved context in the TCB is the
+               * same as the interrupt return context.
+               */
+
+              sparc_savestate(tcb->xcp.regs);
+            }
+
+          /* NOTE: If the task runs on another CPU(cpu), adjusting
+           * global IRQ controls will be done in the pause handler
+           * on the CPU(cpu) by taking a critical section.
+           * If the task is scheduled on this CPU(me), do nothing
+           * because this CPU already took a critical section
+           */
+
+          /* RESUME the other CPU if it was PAUSED */
+
+          if (cpu != me)
+            {
+              up_cpu_resume(cpu);
+            }
+        }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running from an
+   * interrupt handler or (2) we are not in an interrupt handler and the
+   * running task is signaling some other non-running task.
+   */
+
+  else
+    {
+      /* Save registers that must be protected while the signal
+       * handler runs. These will be restored by the signal
+       * trampoline after the signal(s) have been delivered.
+       */
+
+      tcb->xcp.saved_pc     = up_current_regs()[REG_PC];
+      tcb->xcp.saved_npc    = up_current_regs()[REG_NPC];
+      tcb->xcp.saved_status = up_current_regs()[REG_PSR];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled.  We must already be in privileged thread mode to be
+       * here.
+       */
+
+      tcb->xcp.regs[REG_PC]  = (uint32_t)sparc_sigdeliver;
+      tcb->xcp.regs[REG_NPC] = (uint32_t)sparc_sigdeliver + 4;
+      tcb->xcp.regs[REG_PSR] |= SPARC_PSR_ET_MASK;
+    }
 }
 #endif /* CONFIG_SMP */

--- a/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
@@ -77,8 +77,8 @@ void sparc_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -114,7 +114,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -163,10 +163,10 @@ retry:
    * could be modified by a hostile program.
    */
 
-  regs[REG_PC]         = rtcb->xcp.saved_pc;
-  regs[REG_NPC]        = rtcb->xcp.saved_npc;
-  regs[REG_PSR]        = rtcb->xcp.saved_status;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_PC]     = rtcb->xcp.saved_pc;
+  regs[REG_NPC]    = rtcb->xcp.saved_npc;
+  regs[REG_PSR]    = rtcb->xcp.saved_status;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
 #ifdef CONFIG_SMP
   /* Restore the saved 'irqcount' and recover the critical section

--- a/arch/tricore/include/tc3xx/irq.h
+++ b/arch/tricore/include/tc3xx/irq.h
@@ -116,12 +116,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of the context used during
    * signal processing.
    */

--- a/arch/tricore/src/common/tricore_schedulesigaction.c
+++ b/arch/tricore/src/common/tricore_schedulesigaction.c
@@ -76,88 +76,81 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      if (tcb == this_task())
+      if (up_current_regs() == NULL)
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (up_current_regs() == NULL)
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the
-           * interrupted task is the same as the one that
-           * must receive the signal, then we will have to modify
-           * the return state as well as the state in the TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following
-           * logic would fail in the strange case where we are in an
-           * interrupt handler, the thread is signalling itself, but
-           * a context switch to another task has occurred so that
-           * g_current_regs does not refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the context registers.  These will be
-               * restored by the signal trampoline after the signals have
-               * been delivered.
-               */
-
-              tricore_savestate(tcb->xcp.saved_regs);
-
-              /* Create a new CSA for signal delivery. The new context
-               * will borrow the process stack of the current tcb.
-               */
-
-              up_set_current_regs(tricore_alloc_csa((uintptr_t)
-                  tricore_sigdeliver,
-                  STACK_ALIGN_DOWN(up_getusrsp(tcb->xcp.regs)),
-                  PSW_IO_SUPERVISOR | PSW_CDE, true));
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the
+       * interrupted task is the same as the one that
+       * must receive the signal, then we will have to modify
+       * the return state as well as the state in the TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following
+       * logic would fail in the strange case where we are in an
+       * interrupt handler, the thread is signalling itself, but
+       * a context switch to another task has occurred so that
+       * g_current_regs does not refer to the thread of this_task()!
        */
 
       else
         {
-          /* Save the return EPC and STATUS registers.  These will be
+          /* Save the context registers.  These will be
            * restored by the signal trampoline after the signals have
            * been delivered.
            */
 
-          /* Save the current register context location */
-
-          tcb->xcp.saved_regs = tcb->xcp.regs;
+          tricore_savestate(tcb->xcp.saved_regs);
 
           /* Create a new CSA for signal delivery. The new context
            * will borrow the process stack of the current tcb.
            */
 
-          tcb->xcp.regs = tricore_alloc_csa((uintptr_t)tricore_sigdeliver,
-              STACK_ALIGN_DOWN(up_getusrsp(tcb->xcp.regs)),
-              PSW_IO_SUPERVISOR | PSW_CDE, true);
+          up_set_current_regs(tricore_alloc_csa((uintptr_t)
+            tricore_sigdeliver,
+            STACK_ALIGN_DOWN(up_getusrsp(tcb->xcp.regs)),
+            PSW_IO_SUPERVISOR | PSW_CDE, true));
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
+       */
+
+      /* Save the current register context location */
+
+      tcb->xcp.saved_regs = tcb->xcp.regs;
+
+      /* Create a new CSA for signal delivery. The new context
+       * will borrow the process stack of the current tcb.
+       */
+
+      tcb->xcp.regs = tricore_alloc_csa((uintptr_t)tricore_sigdeliver,
+        STACK_ALIGN_DOWN(up_getusrsp(tcb->xcp.regs)),
+        PSW_IO_SUPERVISOR | PSW_CDE, true);
     }
 }

--- a/arch/tricore/src/common/tricore_schedulesigaction.c
+++ b/arch/tricore/src/common/tricore_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/tricore/src/common/tricore_sigdeliver.c
+++ b/arch/tricore/src/common/tricore_sigdeliver.c
@@ -59,8 +59,8 @@ void tricore_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 
@@ -74,7 +74,7 @@ retry:
 
   /* Deliver the signal */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -106,7 +106,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/x86/include/i486/irq.h
+++ b/arch/x86/include/i486/irq.h
@@ -151,12 +151,6 @@
 #ifndef __ASSEMBLY__
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of instruction pointer and EFLAGS used during
    * signal processing.
    *

--- a/arch/x86/src/i486/i486_schedulesigaction.c
+++ b/arch/x86/src/i486/i486_schedulesigaction.c
@@ -76,9 +76,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -97,7 +97,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/x86/src/i486/i486_schedulesigaction.c
+++ b/arch/x86/src/i486/i486_schedulesigaction.c
@@ -70,95 +70,87 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in the
-           * TCB.
-           *
-           * Hmmm... there looks like a latent bug here: The following logic
-           * would fail in the strange case where we are in an interrupt
-           * handler, the thread is signalling itself, but a context switch
-           * to another task has occurred so that g_current_regs does not
-           * refer to the thread of this_task()!
-           */
-
-          else
-            {
-              /* Save the return lr and cpsr and one scratch register. These
-               * will be restored by the signal trampoline after the signals
-               * have been delivered.
-               */
-
-              tcb->xcp.saved_eip    = up_current_regs()[REG_EIP];
-              tcb->xcp.saved_eflags = up_current_regs()[REG_EFLAGS];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              up_current_regs()[REG_EIP]    = (uint32_t)x86_sigdeliver;
-              up_current_regs()[REG_EFLAGS] = 0;
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              x86_savestate(tcb->xcp.regs);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in the
+       * TCB.
+       *
+       * Hmmm... there looks like a latent bug here: The following logic
+       * would fail in the strange case where we are in an interrupt
+       * handler, the thread is signalling itself, but a context switch
+       * to another task has occurred so that g_current_regs does not
+       * refer to the thread of this_task()!
        */
 
       else
         {
-          /* Save the return lr and cpsr and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
+          /* Save the return lr and cpsr and one scratch register. These
+           * will be restored by the signal trampoline after the signals
+           * have been delivered.
            */
 
-          tcb->xcp.saved_eip        = tcb->xcp.regs[REG_EIP];
-          tcb->xcp.saved_eflags     = tcb->xcp.regs[REG_EFLAGS];
+          tcb->xcp.saved_eip    = up_current_regs()[REG_EIP];
+          tcb->xcp.saved_eflags = up_current_regs()[REG_EFLAGS];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          tcb->xcp.regs[REG_EIP]    = (uint32_t)x86_sigdeliver;
-          tcb->xcp.regs[REG_EFLAGS] = 0;
+          up_current_regs()[REG_EIP]    = (uint32_t)x86_sigdeliver;
+          up_current_regs()[REG_EFLAGS] = 0;
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          x86_savestate(tcb->xcp.regs);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_eip        = tcb->xcp.regs[REG_EIP];
+      tcb->xcp.saved_eflags     = tcb->xcp.regs[REG_EFLAGS];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+      tcb->xcp.regs[REG_EIP]    = (uint32_t)x86_sigdeliver;
+      tcb->xcp.regs[REG_EFLAGS] = 0;
     }
 }

--- a/arch/x86/src/i486/i486_sigdeliver.c
+++ b/arch/x86/src/i486/i486_sigdeliver.c
@@ -59,8 +59,8 @@ void x86_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -76,7 +76,7 @@ void x86_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -96,9 +96,9 @@ void x86_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_EIP]        = rtcb->xcp.saved_eip;
-  regs[REG_EFLAGS]     = rtcb->xcp.saved_eflags;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_EIP]    = rtcb->xcp.saved_eip;
+  regs[REG_EFLAGS] = rtcb->xcp.saved_eflags;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -495,12 +495,6 @@ enum ioapic_trigger_mode
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of instruction pointer and EFLAGS used during
    * signal processing.
    */

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -78,9 +78,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task
@@ -178,9 +178,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -205,7 +205,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  The task that needs to receive the signal is running.

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -222,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * to PAUSE the other CPU.
                */
 
-              if (cpu != me)
+              if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
                 {
                   /* Pause the CPU */
 
@@ -286,7 +286,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               /* RESUME the other CPU if it was PAUSED */
 
-              if (cpu != me)
+              if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
                 {
                   up_cpu_resume(cpu);
                 }

--- a/arch/x86_64/src/intel64/intel64_sigdeliver.c
+++ b/arch/x86_64/src/intel64/intel64_sigdeliver.c
@@ -69,8 +69,8 @@ void x86_64_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Align regs to 64 byte boundary for XSAVE */
 
@@ -113,7 +113,7 @@ void x86_64_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -138,10 +138,10 @@ void x86_64_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[REG_RIP]        = rtcb->xcp.saved_rip;
-  regs[REG_RSP]        = rtcb->xcp.saved_rsp;
-  regs[REG_RFLAGS]     = rtcb->xcp.saved_rflags;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[REG_RIP]    = rtcb->xcp.saved_rip;
+  regs[REG_RSP]    = rtcb->xcp.saved_rsp;
+  regs[REG_RFLAGS] = rtcb->xcp.saved_rflags;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
 #ifdef CONFIG_SMP
   /* Restore the saved 'irqcount' and recover the critical section

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -178,12 +178,6 @@ struct xcpt_syscall_s
 
 struct xcptcontext
 {
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* These are saved copies of registers used during signal processing.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -107,7 +107,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           int cpu = tcb->cpu;
           int me  = this_cpu();
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               /* Pause the CPU */
 
@@ -161,7 +161,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 #ifdef CONFIG_SMP
           /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me)
+          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
             {
               up_cpu_resume(cpu);
             }

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -84,9 +84,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to task that is currently executing on any CPU.
@@ -99,7 +99,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           sigdeliver(tcb);
-          tcb->xcp.sigdeliver = NULL;
+          tcb->sigdeliver = NULL;
         }
       else
         {

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -98,18 +98,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     }
   else
     {
-#ifdef CONFIG_SMP
-      int cpu = tcb->cpu;
-      int me  = this_cpu();
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Pause the CPU */
-
-          up_cpu_pause(cpu);
-        }
-#endif
-
       /* Save the context registers.  These will be restored by the
        * signal trampoline after the signals have been delivered.
        *
@@ -151,15 +139,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 #endif
 #ifndef CONFIG_BUILD_FLAT
       xtensa_raiseprivilege(tcb->xcp.regs);
-#endif
-
-#ifdef CONFIG_SMP
-      /* RESUME the other CPU if it was PAUSED */
-
-      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          up_cpu_resume(cpu);
-        }
 #endif
     }
 }

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -78,94 +78,88 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
+        this_task()->xcp.regs);
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to task that is currently executing on any CPU.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task() && !up_interrupt_context())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to task that is currently executing on any CPU.
+      /* In this case just deliver the signal now.
+       * REVISIT:  Signal handler will run in a critical section!
        */
 
-      if (tcb == this_task() && !up_interrupt_context())
-        {
-          /* In this case just deliver the signal now.
-           * REVISIT:  Signal handler will run in a critical section!
-           */
-
-          sigdeliver(tcb);
-          tcb->sigdeliver = NULL;
-        }
-      else
-        {
+      (tcb->sigdeliver)(tcb);
+      tcb->sigdeliver = NULL;
+    }
+  else
+    {
 #ifdef CONFIG_SMP
-          int cpu = tcb->cpu;
-          int me  = this_cpu();
+      int cpu = tcb->cpu;
+      int me  = this_cpu();
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              /* Pause the CPU */
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Pause the CPU */
 
-              up_cpu_pause(cpu);
-            }
+          up_cpu_pause(cpu);
+        }
 #endif
 
-          /* Save the context registers.  These will be restored by the
-           * signal trampoline after the signals have been delivered.
-           *
-           * NOTE: that hi-priority interrupts are not disabled.
-           */
+      /* Save the context registers.  These will be restored by the
+       * signal trampoline after the signals have been delivered.
+       *
+       * NOTE: that hi-priority interrupts are not disabled.
+       */
 
-          tcb->xcp.saved_regs   = tcb->xcp.regs;
+      tcb->xcp.saved_regs   = tcb->xcp.regs;
 
-          if ((tcb->xcp.saved_regs[REG_PS] & PS_EXCM_MASK) != 0)
-            {
-              tcb->xcp.saved_regs[REG_PS] &= ~PS_EXCM_MASK;
-            }
+      if ((tcb->xcp.saved_regs[REG_PS] & PS_EXCM_MASK) != 0)
+        {
+          tcb->xcp.saved_regs[REG_PS] &= ~PS_EXCM_MASK;
+        }
 
-          /* Duplicate the register context.  These will be
-           * restored by the signal trampoline after the signal has been
-           * delivered.
-           */
+      /* Duplicate the register context.  These will be
+       * restored by the signal trampoline after the signal has been
+       * delivered.
+       */
 
-          tcb->xcp.regs         = (void *)
-                                  ((uint32_t)tcb->xcp.regs -
-                                             XCPTCONTEXT_SIZE);
-          memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+      tcb->xcp.regs         = (void *)
+                              ((uint32_t)tcb->xcp.regs -
+                                         XCPTCONTEXT_SIZE);
+      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-          tcb->xcp.regs[REG_A1] = (uint32_t)tcb->xcp.regs +
-                                            XCPTCONTEXT_SIZE;
+      tcb->xcp.regs[REG_A1] = (uint32_t)tcb->xcp.regs +
+                                        XCPTCONTEXT_SIZE;
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          tcb->xcp.regs[REG_PC] = (uint32_t)xtensa_sig_deliver;
+      tcb->xcp.regs[REG_PC] = (uint32_t)xtensa_sig_deliver;
 #ifdef __XTENSA_CALL0_ABI__
-          tcb->xcp.regs[REG_PS] = (uint32_t)
-              (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM);
+      tcb->xcp.regs[REG_PS] = (uint32_t)
+          (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM);
 #else
-          tcb->xcp.regs[REG_PS] = (uint32_t)
-              (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM |
-               PS_WOE | PS_CALLINC(1));
+      tcb->xcp.regs[REG_PS] = (uint32_t)
+          (PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM |
+            PS_WOE | PS_CALLINC(1));
 #endif
 #ifndef CONFIG_BUILD_FLAT
-          xtensa_raiseprivilege(tcb->xcp.regs);
+      xtensa_raiseprivilege(tcb->xcp.regs);
 #endif
 
 #ifdef CONFIG_SMP
-          /* RESUME the other CPU if it was PAUSED */
+      /* RESUME the other CPU if it was PAUSED */
 
-          if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
-            {
-              up_cpu_resume(cpu);
-            }
-#endif
+      if (cpu != me && tcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          up_cpu_resume(cpu);
         }
+#endif
     }
 }

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -68,8 +68,8 @@ void xtensa_sig_deliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
 retry:
 #ifdef CONFIG_SMP
@@ -102,7 +102,7 @@ retry:
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -146,7 +146,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution.
    */

--- a/arch/z16/include/z16f/irq.h
+++ b/arch/z16/include/z16f/irq.h
@@ -165,12 +165,6 @@ struct xcptcontext
 
   uint16_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  CODE void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* The following retains that state during signal execution.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -74,93 +74,85 @@
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(FAR struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=0x%06x\n", tcb, (uint32_t)sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is
+   * being delivered to the currently executing task.
+   */
 
-  if (!tcb->sigdeliver)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is
-       * being delivered to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and
+       * a task is signalling itself for some reason.
        */
 
-      sinfo("rtcb=%p current_regs=%p\n", this_task(), up_current_regs());
-
-      if (tcb == this_task())
+      if (!up_current_regs())
         {
-          /* CASE 1:  We are not in an interrupt handler and
-           * a task is signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!up_current_regs())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted
-           * task is the same as the one that must receive the signal, then
-           * we will have to modify the return state as well as the state
-           * in the TCB.
-           */
-
-          else
-            {
-              FAR uint32_t *current_pc  =
-                (FAR uint32_t *)&up_current_regs()[REG_PC];
-
-              /* Save the return address and interrupt state. These will be
-               * restored by the signal trampoline after the signals have
-               * been delivered.
-               */
-
-              tcb->xcp.saved_pc = *current_pc;
-              tcb->xcp.saved_i  = up_current_regs()[REG_FLAGS];
-
-              /* Then set up to vector to the trampoline with interrupts
-               * disabled
-               */
-
-              *current_pc = (uint32_t)z16_sigdeliver;
-              up_current_regs()[REG_FLAGS] = 0;
-
-              /* And make sure that the saved context in the TCB is the
-               * same as the interrupt return context.
-               */
-
-              z16_copystate(tcb->xcp.regs, up_current_regs());
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler
-       * and the running task is signalling some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted
+       * task is the same as the one that must receive the signal, then
+       * we will have to modify the return state as well as the state
+       * in the TCB.
        */
 
       else
         {
-          FAR uint32_t *saved_pc   = (FAR uint32_t *)&tcb->xcp.regs[REG_PC];
+          FAR uint32_t *current_pc  =
+            (FAR uint32_t *)&up_current_regs()[REG_PC];
 
-          /* Save the return lr and cpsr and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
+          /* Save the return address and interrupt state. These will be
+           * restored by the signal trampoline after the signals have
+           * been delivered.
            */
 
-          tcb->xcp.saved_pc        = *saved_pc;
-          tcb->xcp.saved_i         = tcb->xcp.regs[REG_FLAGS];
+          tcb->xcp.saved_pc = *current_pc;
+          tcb->xcp.saved_i  = up_current_regs()[REG_FLAGS];
 
           /* Then set up to vector to the trampoline with interrupts
            * disabled
            */
 
-          *saved_pc                = (uint32_t)z16_sigdeliver;
-          tcb->xcp.regs[REG_FLAGS] = 0;
+         *current_pc = (uint32_t)z16_sigdeliver;
+          up_current_regs()[REG_FLAGS] = 0;
+
+          /* And make sure that the saved context in the TCB is the
+           * same as the interrupt return context.
+           */
+
+          z16_copystate(tcb->xcp.regs, up_current_regs());
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running from an
+   * interrupt handler or (2) we are not in an interrupt handler
+   * and the running task is signalling some non-running task.
+   */
+
+  else
+    {
+      FAR uint32_t *saved_pc   = (FAR uint32_t *)&tcb->xcp.regs[REG_PC];
+
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
+       */
+
+      tcb->xcp.saved_pc        = *saved_pc;
+      tcb->xcp.saved_i         = tcb->xcp.regs[REG_FLAGS];
+
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
+
+     *saved_pc                = (uint32_t)z16_sigdeliver;
+      tcb->xcp.regs[REG_FLAGS] = 0;
     }
 }

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -80,9 +80,9 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (!tcb->xcp.sigdeliver)
+  if (!tcb->sigdeliver)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is
        * being delivered to the currently executing task.
@@ -101,7 +101,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted

--- a/arch/z16/src/common/z16_sigdeliver.c
+++ b/arch/z16/src/common/z16_sigdeliver.c
@@ -60,8 +60,8 @@ void z16_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +77,7 @@ void z16_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -97,9 +97,9 @@ void z16_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs32[REG_PC / 2]   = rtcb->xcp.saved_pc;
-  regs[REG_FLAGS]      = rtcb->xcp.saved_i;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs32[REG_PC / 2] = rtcb->xcp.saved_pc;
+  regs[REG_FLAGS]    = rtcb->xcp.saved_i;
+  rtcb->sigdeliver   = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/include/ez80/irq.h
+++ b/arch/z80/include/ez80/irq.h
@@ -246,12 +246,6 @@ struct xcptcontext
 
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  CODE void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* The following retains that state during signal execution
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/z80/include/z180/irq.h
+++ b/arch/z80/include/z180/irq.h
@@ -173,12 +173,6 @@ struct xcptcontext
 
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  CODE void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* The following retains that state during signal execution
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/z80/include/z8/irq.h
+++ b/arch/z80/include/z8/irq.h
@@ -304,12 +304,6 @@ struct xcptcontext
 
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  CODE void *sigdeliver;    /* Actual type is sig_deliver_t */
-
   /* The following retains that state during signal execution
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/z80/include/z80/irq.h
+++ b/arch/z80/include/z80/irq.h
@@ -88,12 +88,6 @@ struct xcptcontext
 
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* The following function pointer is non-zero if there
-   * are pending signals to be processed.
-   */
-
-  CODE void *sigdeliver; /* Actual type is sig_deliver_t */
-
   /* The following retains that state during signal execution.
    *
    * REVISIT:  Because there is only one copy of these save areas,

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -105,9 +105,9 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -124,7 +124,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -43,8 +43,7 @@
  * Name: ez80_sigsetup
  ****************************************************************************/
 
-static void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
-                          FAR chipreg_t *regs)
+static void ez80_sigsetup(FAR struct tcb_s *tcb, FAR chipreg_t *regs)
 {
   /* Save the return address and interrupt state. These will be restored by
    * the signal trampoline after the signals have been delivered.
@@ -99,66 +98,60 @@ static void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(FAR struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=0x%06" PRIx32 "\n", tcb, (uint32_t)sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      if (tcb == this_task())
+      if (!IN_INTERRUPT())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!IN_INTERRUPT())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Set up to vector to the trampoline with interrupts
-               * disabled.
-               */
-
-              ez80_sigsetup(tcb, sigdeliver, (chipreg_t *)IRQ_STATE());
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              SAVE_IRQCONTEXT(tcb);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running from an
-       * interrupt handler or (2) we are not in an interrupt handler and the
-       * running task is signaling some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in
+       * the TCB.
        */
 
       else
         {
-          /* Set up to vector to the trampoline with interrupts disabled. */
+          /* Set up to vector to the trampoline with interrupts
+           * disabled.
+           */
 
-          ez80_sigsetup(tcb, sigdeliver, tcb->xcp.regs);
+          ez80_sigsetup(tcb, (chipreg_t *)IRQ_STATE());
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          SAVE_IRQCONTEXT(tcb);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running from an
+   * interrupt handler or (2) we are not in an interrupt handler and the
+   * running task is signaling some non-running task.
+   */
+
+  else
+    {
+      /* Set up to vector to the trampoline with interrupts disabled. */
+
+      ez80_sigsetup(tcb, tcb->xcp.regs);
     }
 }

--- a/arch/z80/src/ez80/ez80_sigdeliver.c
+++ b/arch/z80/src/ez80/ez80_sigdeliver.c
@@ -61,8 +61,8 @@ void z80_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-         rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+         rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -78,7 +78,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -98,9 +98,9 @@ void z80_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[XCPT_PC]        = rtcb->xcp.saved_pc;
-  regs[XCPT_I]         = rtcb->xcp.saved_i;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[XCPT_PC]    = rtcb->xcp.saved_pc;
+  regs[XCPT_I]     = rtcb->xcp.saved_i;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -46,8 +46,7 @@
  * Name: z180_sigsetup
  ****************************************************************************/
 
-static void z180_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
-                          FAR chipreg_t *regs)
+static void z180_sigsetup(FAR struct tcb_s *tcb, FAR chipreg_t *regs)
 {
   /* Save the return address and interrupt state. These will be restored by
    * the signal trampoline after the signals have been delivered.
@@ -102,67 +101,61 @@ static void z180_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(FAR struct tcb_s *tcb)
 {
-  _info("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      if (tcb == this_task())
+      if (!IN_INTERRUPT())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!IN_INTERRUPT())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Set up to vector to the trampoline with interrupts
-               * disabled.
-               */
-
-              z180_sigsetup(tcb, sigdeliver, IRQ_STATE());
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              SAVE_IRQCONTEXT(tcb);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in
+       * the TCB.
        */
 
       else
         {
-          /* Set up to vector to the trampoline with interrupts disabled. */
+          /* Set up to vector to the trampoline with interrupts
+           * disabled.
+           */
 
-          z180_sigsetup(tcb, sigdeliver, tcb->xcp.regs);
+          z180_sigsetup(tcb, IRQ_STATE());
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          SAVE_IRQCONTEXT(tcb);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Set up to vector to the trampoline with interrupts disabled. */
+
+      z180_sigsetup(tcb, tcb->xcp.regs);
     }
 }

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -108,9 +108,9 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -127,7 +127,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z180/z180_sigdeliver.c
+++ b/arch/z80/src/z180/z180_sigdeliver.c
@@ -58,8 +58,8 @@ void z80_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -75,7 +75,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -95,9 +95,9 @@ void z80_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[XCPT_PC]        = rtcb->xcp.saved_pc;
-  regs[XCPT_I]         = rtcb->xcp.saved_i;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[XCPT_PC]    = rtcb->xcp.saved_pc;
+  regs[XCPT_I]     = rtcb->xcp.saved_i;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -43,8 +43,7 @@
  * Name: z8_sigsetup
  ****************************************************************************/
 
-static void z8_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
-                        FAR chipreg_t *regs)
+static void z8_sigsetup(FAR struct tcb_s *tcb, FAR chipreg_t *regs)
 {
   /* Save the return address and interrupt state. These will be restored by
    * the signal trampoline after the signals have been delivered.
@@ -99,60 +98,33 @@ static void z8_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(FAR struct tcb_s *tcb)
 {
-  sinfo("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      if (tcb == this_task())
+      if (!IN_INTERRUPT())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!IN_INTERRUPT())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Set up to vector to the trampoline with interrupts
-               * disabled.
-               */
-
-              z8_sigsetup(tcb, sigdeliver, IRQ_STATE());
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              SAVE_IRQCONTEXT(tcb);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in
+       * the TCB.
        */
 
       else
@@ -161,7 +133,28 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * disabled.
            */
 
-          z8_sigsetup(tcb, sigdeliver, tcb->xcp.regs);
+          z8_sigsetup(tcb, IRQ_STATE());
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          SAVE_IRQCONTEXT(tcb);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Set up to vector to the trampoline with interrupts
+       * disabled.
+       */
+
+      z8_sigsetup(tcb, tcb->xcp.regs);
     }
 }

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -105,9 +105,9 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -124,7 +124,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z8/z8_sigdeliver.c
+++ b/arch/z80/src/z8/z8_sigdeliver.c
@@ -77,8 +77,8 @@ void z80_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -94,7 +94,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -114,9 +114,9 @@ void z80_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[XCPT_PC]        = rtcb->xcp.saved_pc;
-  regs[XCPT_IRQCTL]    = rtcb->xcp.saved_irqctl;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[XCPT_PC]     = rtcb->xcp.saved_pc;
+  regs[XCPT_IRQCTL] = rtcb->xcp.saved_irqctl;
+  rtcb->sigdeliver  = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -44,8 +44,7 @@
  * Name: z80_sigsetup
  ****************************************************************************/
 
-static void z80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
-                         FAR chipreg_t *regs)
+static void z80_sigsetup(FAR struct tcb_s *tcb, FAR chipreg_t *regs)
 {
   /* Save the return address and interrupt state. These will be restored by
    * the signal trampoline after the signals have been delivered.
@@ -100,67 +99,61 @@ static void z80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
+void up_schedule_sigaction(FAR struct tcb_s *tcb)
 {
-  _info("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb,
+        this_task(), up_current_regs());
 
-  /* Refuse to handle nested signal actions */
+  /* First, handle some special cases when the signal is being delivered
+   * to the currently executing task.
+   */
 
-  if (tcb->sigdeliver == NULL)
+  if (tcb == this_task())
     {
-      tcb->sigdeliver = sigdeliver;
-
-      /* First, handle some special cases when the signal is being delivered
-       * to the currently executing task.
+      /* CASE 1:  We are not in an interrupt handler and a task is
+       * signalling itself for some reason.
        */
 
-      if (tcb == this_task())
+      if (!IN_INTERRUPT())
         {
-          /* CASE 1:  We are not in an interrupt handler and a task is
-           * signalling itself for some reason.
-           */
+          /* In this case just deliver the signal now. */
 
-          if (!IN_INTERRUPT())
-            {
-              /* In this case just deliver the signal now. */
-
-              sigdeliver(tcb);
-              tcb->sigdeliver = NULL;
-            }
-
-          /* CASE 2:  We are in an interrupt handler AND the interrupted task
-           * is the same as the one that must receive the signal, then we
-           * will have to modify the return state as well as the state in
-           * the TCB.
-           */
-
-          else
-            {
-              /* Set up to vector to the trampoline with interrupts
-               * disabled.
-               */
-
-              z80_sigsetup(tcb, sigdeliver, IRQ_STATE());
-
-              /* And make sure that the saved context in the TCB
-               * is the same as the interrupt return context.
-               */
-
-              SAVE_IRQCONTEXT(tcb);
-            }
+          (tcb->sigdeliver)(tcb);
+          tcb->sigdeliver = NULL;
         }
 
-      /* Otherwise, we are (1) signaling a task is not running
-       * from an interrupt handler or (2) we are not in an
-       * interrupt handler and the running task is signalling
-       * some non-running task.
+      /* CASE 2:  We are in an interrupt handler AND the interrupted task
+       * is the same as the one that must receive the signal, then we
+       * will have to modify the return state as well as the state in
+       * the TCB.
        */
 
       else
         {
-          /* Set up to vector to the trampoline with interrupts disabled. */
+          /* Set up to vector to the trampoline with interrupts
+           * disabled.
+           */
 
-          z80_sigsetup(tcb, sigdeliver, tcb->xcp.regs);
+          z80_sigsetup(tcb, IRQ_STATE());
+
+          /* And make sure that the saved context in the TCB
+           * is the same as the interrupt return context.
+           */
+
+          SAVE_IRQCONTEXT(tcb);
         }
+    }
+
+  /* Otherwise, we are (1) signaling a task is not running
+   * from an interrupt handler or (2) we are not in an
+   * interrupt handler and the running task is signalling
+   * some non-running task.
+   */
+
+  else
+    {
+      /* Set up to vector to the trampoline with interrupts disabled. */
+
+      z80_sigsetup(tcb, tcb->xcp.regs);
     }
 }

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -106,9 +106,9 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* Refuse to handle nested signal actions */
 
-  if (tcb->xcp.sigdeliver == NULL)
+  if (tcb->sigdeliver == NULL)
     {
-      tcb->xcp.sigdeliver = sigdeliver;
+      tcb->sigdeliver = sigdeliver;
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -125,7 +125,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* In this case just deliver the signal now. */
 
               sigdeliver(tcb);
-              tcb->xcp.sigdeliver = NULL;
+              tcb->sigdeliver = NULL;
             }
 
           /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z80/z80_sigdeliver.c
+++ b/arch/z80/src/z80/z80_sigdeliver.c
@@ -58,8 +58,8 @@ void z80_sigdeliver(void)
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->xcp.sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->xcp.sigdeliver != NULL);
+        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
+  DEBUGASSERT(rtcb->sigdeliver != NULL);
 
   /* Save the return state on the stack. */
 
@@ -75,7 +75,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+  (rtcb->sigdeliver)(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -95,9 +95,9 @@ void z80_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  regs[XCPT_PC]        = rtcb->xcp.saved_pc;
-  regs[XCPT_I]         = rtcb->xcp.saved_i;
-  rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  regs[XCPT_PC]    = rtcb->xcp.saved_pc;
+  regs[XCPT_I]     = rtcb->xcp.saved_i;
+  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -545,7 +545,7 @@ int up_backtrace(FAR struct tcb_s *tcb,
  *
  ****************************************************************************/
 
-void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver);
+void up_schedule_sigaction(FAR struct tcb_s *tcb);
 
 /****************************************************************************
  * Name: up_task_start

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -103,7 +103,6 @@
  * Public Types
  ****************************************************************************/
 
-typedef CODE void (*sig_deliver_t)(FAR struct tcb_s *tcb);
 typedef CODE void (*phy_enable_t)(bool enable);
 typedef CODE void (*initializer_t)(void);
 typedef CODE void (*debug_callback_t)(int type, FAR void *addr, size_t size,

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -299,6 +299,7 @@ typedef enum tstate_e tstate_t;
 /* The following is the form of a thread start-up function */
 
 typedef CODE void (*start_t)(void);
+typedef CODE void (*sig_deliver_t)(FAR struct tcb_s *tcb);
 
 /* This is the entry point into the main thread of the task or into a created
  * pthread within the task.
@@ -716,6 +717,11 @@ struct tcb_s
 
   struct xcptcontext xcp;                /* Interrupt register save area    */
 
+  /* The following function pointer is non-zero if there are pending signals
+   * to be processed.
+   */
+
+  sig_deliver_t sigdeliver;
 #if CONFIG_TASK_NAME_SIZE > 0
   char name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NUL terminator) */
 #endif

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -115,7 +115,12 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
            * up_schedule_sigaction()
            */
 
-          up_schedule_sigaction(stcb, nxsig_deliver);
+          if (!stcb->sigdeliver)
+            {
+              stcb->sigdeliver = nxsig_deliver;
+              up_schedule_sigaction(stcb);
+            }
+
           leave_critical_section(flags);
         }
     }


### PR DESCRIPTION
## Summary
In the kernel, we are planning to remove all occurrences of up_cpu_pause as one of the steps to simplify the implementation of critical sections. The goal is to enable spin_lock_irqsave to encapsulate critical sections, thereby facilitating the replacement of critical sections(big lock) with smaller spin_lock_irqsave(small lock)
## Impact
up_schedule_sigaction
## Testing
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3
-net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

