### PR TITLE
include/sys/select.h: Define __SELECT_NUINT32 in generic way

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -49,25 +49,7 @@
  * many uint32_t's do we need to span all descriptors?
  */
 
-#if FD_SETSIZE <= 32
-#  define __SELECT_NUINT32 1
-#elif FD_SETSIZE <= 64
-#  define __SELECT_NUINT32 2
-#elif FD_SETSIZE <= 96
-#  define __SELECT_NUINT32 3
-#elif FD_SETSIZE <= 128
-#  define __SELECT_NUINT32 4
-#elif FD_SETSIZE <= 160
-#  define __SELECT_NUINT32 5
-#elif FD_SETSIZE <= 192
-#  define __SELECT_NUINT32 6
-#elif FD_SETSIZE <= 224
-#  define __SELECT_NUINT32 7
-#elif FD_SETSIZE <= 256
-#  define __SELECT_NUINT32 8
-#else
-#  warning "Larger fd_set needed"
-#endif
+#define __SELECT_NUINT32 ((FD_SETSIZE + 31) / 32)
 
 /* These macros map a file descriptor to an index and bit number */
 


### PR DESCRIPTION
Support defining OPEN_MAX freely to allow increasing it from 256

## Summary

This allows setting CONFIG_LIBC_OPEN_MAX into values greater than 256

## Impact

Simplifies the header file, makes it possible to configure higher maximum number of open FDs

## Testing

Tested on MPFS platform in CONFIG_BUILD_KERNEL configuration with more than 256 open file descriptors.
