### PR TITLE
task: use get_task_name where possible

### DIFF
--- a/arch/arm/include/cxd56xx/crashdump.h
+++ b/arch/arm/include/cxd56xx/crashdump.h
@@ -100,19 +100,17 @@ typedef enum
 
 typedef struct
 {
-  struct timespec ts;                   /* timestamp */
-  fault_flags_t flags;                  /* What is in the dump */
-  uintptr_t     current_regs;           /* Used to validate the dump */
-  int           lineno;                 /* __LINE__ to up_assert */
-  pid_t         pid;                    /* Process ID */
-  uint32_t      regs[XCPTCONTEXT_REGS]; /* Interrupt register save area */
-  crash_stack_t stacks;                 /* Stack info */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char          name[CONFIG_TASK_NAME_SIZE + 1]; /* Task name (with NULL
-                                                  * terminator) */
-#endif
-  char          filename[MAX_FILE_PATH_LENGTH];  /* the Last of chars in
-                                                  * __FILE__ to up_assert */
+  struct timespec ts;                             /* timestamp */
+  fault_flags_t flags;                            /* What is in the dump */
+  uintptr_t     current_regs;                     /* Used to validate the dump */
+  int           lineno;                           /* __LINE__ to up_assert */
+  pid_t         pid;                              /* Process ID */
+  uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
+  crash_stack_t stacks;                           /* Stack info */
+  char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
+                                                   * terminator) */
+  char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
+                                                   * __FILE__ to up_assert */
 } info_t;
 
 typedef struct

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -99,28 +99,21 @@ __cyg_profile_func_enter(void *this_fn, void *call_site)
 
   if (sp < stack_base)
     {
-#if CONFIG_TASK_NAME_SIZE > 0
       struct tcb_s *rtcb;
-#endif
+
       __asm volatile("csrc mstatus, 8");
       __asm__("li s11, 0");
 
-#if CONFIG_TASK_NAME_SIZE > 0
       /* get current task */
 
       rtcb = running_task();
 
       syslog(LOG_EMERG,
              "task %s stack overflow detected! base:0x%x >= sp:0x%x\n",
-             rtcb->name,
+             get_task_name(rtcb),
              stack_base,
              sp);
-#else
-      syslog(LOG_EMERG,
-             "stack overflow detected! base:0x%x >= sp:0x%x\n",
-             stack_base,
-             sp);
-#endif
+
       /* PANIC(); */
 
       while (1)

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -103,11 +103,8 @@ int riscv_exception(int mcause, void *regs, void *args)
 #ifdef CONFIG_ARCH_KERNEL_STACK
   if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
-#  if CONFIG_TASK_NAME_SIZE > 0
-      _alert("Segmentation fault in PID %d: %s\n", tcb->pid, tcb->name);
-#  else
-      _alert("Segmentation fault in PID %d\n", tcb->pid);
-#  endif
+      _alert("Segmentation fault in PID %d: %s\n",
+             tcb->pid, get_task_name(tcb));
 
       tcb->flags |= TCB_FLAG_FORCED_CANCEL;
 

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -75,11 +75,8 @@ void xtensa_panic(int xptcode, uint32_t *regs)
 
   syslog_flush();
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Unhandled Exception %d task: %s\n", xptcode, running_task()->name);
-#else
-  _alert("Unhandled Exception %d\n", xptcode);
-#endif
+  _alert("Unhandled Exception %d task: %s\n", xptcode,
+         get_task_name(running_task()));
 
   PANIC_WITH_REGS("panic", regs);  /* Should not return */
   for (; ; );
@@ -177,12 +174,8 @@ void xtensa_user_panic(int exccause, uint32_t *regs)
 
   syslog_flush();
 
-#if CONFIG_TASK_NAME_SIZE > 0
   _alert("User Exception: EXCCAUSE=%04x task: %s\n",
-         exccause, running_task()->name);
-#else
-  _alert("User Exception: EXCCAUSE=%04x\n", exccause);
-#endif
+         exccause, get_task_name(running_task()));
 
   PANIC_WITH_REGS("user panic", regs); /* Should not return */
   for (; ; );

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -248,11 +248,11 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
 
   elf_emit(cinfo, &nhdr, sizeof(nhdr));
 
-  strlcpy(name, tcb->name, sizeof(name));
+  strlcpy(name, get_task_name(tcb), sizeof(name));
   elf_emit(cinfo, name, sizeof(name));
 
   info.pr_pid   = tcb->pid;
-  strlcpy(info.pr_fname, tcb->name, sizeof(info.pr_fname));
+  strlcpy(info.pr_fname, get_task_name(tcb), sizeof(info.pr_fname));
   elf_emit(cinfo, &info, sizeof(info));
 
   /* Fill Process status */

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -149,9 +149,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   /* Save Context */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  strlcpy(pdump->info.name, tcb->name, sizeof(pdump->info.name));
-#endif
+  strlcpy(pdump->info.name, get_task_name(tcb), sizeof(pdump->info.name));
 
   pdump->info.pid = tcb->pid;
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -232,18 +232,16 @@ typedef enum
 
 typedef struct
 {
-  fault_flags_t flags;                  /* What is in the dump */
-  uintptr_t     current_regs;           /* Used to validate the dump */
-  int           lineno;                 /* __LINE__ to up_assert */
-  pid_t         pid;                    /* Process ID */
-  uint32_t      regs[XCPTCONTEXT_REGS]; /* Interrupt register save area */
-  stacks_t      stacks;                 /* Stack info */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char          name[CONFIG_TASK_NAME_SIZE + 1]; /* Task name (with NULL
-                                                  * terminator) */
-#endif
-  char          filename[MAX_FILE_PATH_LENGTH];  /* the Last of chars in
-                                                  * __FILE__ to up_assert */
+  fault_flags_t flags;                            /* What is in the dump */
+  uintptr_t     current_regs;                     /* Used to validate the dump */
+  int           lineno;                           /* __LINE__ to up_assert */
+  pid_t         pid;                              /* Process ID */
+  uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
+  stack_t       stacks;                           /* Stack info */
+  char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
+                                                   * terminator) */
+  char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
+                                                   * __FILE__ to up_assert */
 } info_t;
 
 typedef struct
@@ -420,9 +418,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   /* Save Context */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  strlcpy(pdump->info.name, tcb->name, sizeof(pdump->info.name));
-#endif
+  strlcpy(pdump->info.name, get_task_name(tcb), sizeof(pdump->info.name));
 
   pdump->info.pid = tcb->pid;
 

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -232,18 +232,16 @@ typedef enum
 
 typedef struct
 {
-  fault_flags_t flags;                  /* What is in the dump */
-  uintptr_t     current_regs;           /* Used to validate the dump */
-  int           lineno;                 /* __LINE__ to up_assert */
-  int           pid;                    /* Process ID */
-  uint32_t      regs[XCPTCONTEXT_REGS]; /* Interrupt register save area */
-  stacks_t      stacks;                 /* Stack info */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char          name[CONFIG_TASK_NAME_SIZE + 1]; /* Task name (with NULL
-                                                  * terminator) */
-#endif
-  char          filename[MAX_FILE_PATH_LENGTH];  /* the Last of chars in
-                                                  * __FILE__ to up_assert */
+  fault_flags_t flags;                            /* What is in the dump */
+  uintptr_t     current_regs;                     /* Used to validate the dump */
+  int           lineno;                           /* __LINE__ to up_assert */
+  int           pid;                              /* Process ID */
+  uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
+  stack_t       stacks;                           /* Stack info */
+  char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
+                                                   * terminator) */
+  char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
+                                                   * __FILE__ to up_assert */
 } info_t;
 
 typedef struct
@@ -420,9 +418,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   /* Save Context */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  strlcpy(pdump->info.name, tcb->name, sizeof(pdump->info.name));
-#endif
+  strlcpy(pdump->info.name, get_task_name(tcb), sizeof(pdump->info.name));
 
   pdump->info.pid = tcb->pid;
 

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -181,18 +181,16 @@ typedef enum
 
 typedef struct
 {
-  fault_flags_t flags;                  /* What is in the dump */
-  uintptr_t     current_regs;           /* Used to validate the dump */
-  int           lineno;                 /* __LINE__ to up_assert */
-  pid_t         pid;                    /* Process ID */
-  uint32_t      regs[XCPTCONTEXT_REGS]; /* Interrupt register save area */
-  stack_t       stacks;                 /* Stack info */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char          name[CONFIG_TASK_NAME_SIZE + 1]; /* Task name (with NULL
-                                                  * terminator) */
-#endif
-  char          filename[MAX_FILE_PATH_LENGTH];  /* the Last of chars in
-                                                  * __FILE__ to up_assert */
+  fault_flags_t flags;                            /* What is in the dump */
+  uintptr_t     current_regs;                     /* Used to validate the dump */
+  int           lineno;                           /* __LINE__ to up_assert */
+  pid_t         pid;                              /* Process ID */
+  uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
+  stack_t       stacks;                           /* Stack info */
+  char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
+                                                   * terminator) */
+  char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
+                                                   * __FILE__ to up_assert */
 } info_t;
 
 struct fullcontext
@@ -374,9 +372,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   /* Save Context */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  strlcpy(pdump->info.name, tcb->name, sizeof(pdump->info.name));
-#endif
+  strlcpy(pdump->info.name, get_task_name(tcb), sizeof(pdump->info.name));
 
   pdump->info.pid = tcb->pid;
 

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -181,18 +181,16 @@ typedef enum
 
 typedef struct
 {
-  fault_flags_t flags;                  /* What is in the dump */
-  uintptr_t     current_regs;           /* Used to validate the dump */
-  int           lineno;                 /* __LINE__ to up_assert */
-  pid_t         pid;                    /* Process ID */
-  uint32_t      regs[XCPTCONTEXT_REGS]; /* Interrupt register save area */
-  stack_t       stacks;                 /* Stack info */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char          name[CONFIG_TASK_NAME_SIZE + 1]; /* Task name (with NULL
-                                                  * terminator) */
-#endif
-  char          filename[MAX_FILE_PATH_LENGTH];  /* the Last of chars in
-                                                  * __FILE__ to up_assert */
+  fault_flags_t flags;                            /* What is in the dump */
+  uintptr_t     current_regs;                     /* Used to validate the dump */
+  int           lineno;                           /* __LINE__ to up_assert */
+  pid_t         pid;                              /* Process ID */
+  uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
+  stack_t       stacks;                           /* Stack info */
+  char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
+                                                   * terminator) */
+  char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
+                                                   * __FILE__ to up_assert */
 } info_t;
 
 struct fullcontext
@@ -372,9 +370,7 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   /* Save Context */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  strlcpy(pdump->info.name, tcb->name, sizeof(pdump->info.name));
-#endif
+  strlcpy(pdump->info.name, get_task_name(tcb), sizeof(pdump->info.name));
 
   pdump->info.pid = tcb->pid;
 

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -2007,4 +2007,3 @@ int note_driver_register(FAR struct note_driver_s *driver)
 
   return -ENOMEM;
 }
-

--- a/drivers/note/notelog_driver.c
+++ b/drivers/note/notelog_driver.c
@@ -149,21 +149,11 @@ static void notelog_start(FAR struct note_driver_s *drv,
                           FAR struct tcb_s *tcb)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Start %s, TCB@%p, state=%d\n",
-         tcb->cpu, tcb->name, tcb, tcb->task_state);
+         tcb->cpu, get_task_name(tcb), tcb, tcb->task_state);
 #else
-  syslog(LOG_INFO, "CPU%d: Start TCB@%p, state=%d\n"
-         tcb->cpu, tcb, tcb->task_state);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Start %s, TCB@%p, state=%d\n",
-         tcb->name, tcb, tcb->task_state);
-#else
-  syslog(LOG_INFO, "Start TCB@%p, state=%d\n",
-         tcb, tcb->task_state);
-#endif
+         get_task_name(tcb), tcb, tcb->task_state);
 #endif
 }
 
@@ -171,21 +161,11 @@ static void notelog_stop(FAR struct note_driver_s *drv,
                          FAR struct tcb_s *tcb)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Stop %s, TCB@%p, state=%d\n",
-         tcb->cpu, tcb->name, tcb, tcb->task_state);
+         tcb->cpu, get_task_name(tcb), tcb, tcb->task_state);
 #else
-  syslog(LOG_INFO, "CPU%d: Stop TCB@%p, state=%d\n",
-         tcb->cpu, tcb, tcb->task_state);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Stop %s, TCB@%p, state=%d\n",
-         tcb->name, tcb, tcb->task_state);
-#else
-  syslog(LOG_INFO, "Stop TCB@%p, state=%d\n",
-         tcb, tcb->task_state);
-#endif
+         get_task_name(tcb), tcb, tcb->task_state);
 #endif
 }
 
@@ -194,21 +174,11 @@ static void notelog_suspend(FAR struct note_driver_s *drv,
                             FAR struct tcb_s *tcb)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Suspend %s, TCB@%p, state=%d\n",
-         tcb->cpu, tcb->name, tcb, tcb->task_state);
+         tcb->cpu, get_task_name(tcb), tcb, tcb->task_state);
 #else
-  syslog(LOG_INFO, "CPU%d: Suspend TCB@%p, state=%d\n",
-         tcb->cpu, tcb, tcb->task_state);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Suspend %s, TCB@%p, state=%d\n",
-         tcb->name, tcb, tcb->task_state);
-#else
-  syslog(LOG_INFO, "Suspend TCB@%p, state=%d\n",
-         tcb, tcb->task_state);
-#endif
+         get_task_name(tcb), tcb, tcb->task_state);
 #endif
 }
 
@@ -216,21 +186,11 @@ static void notelog_resume(FAR struct note_driver_s *drv,
                            FAR struct tcb_s *tcb)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Resume %s, TCB@%p, state=%d\n",
-         tcb->cpu, tcb->name, tcb, tcb->task_state);
+         tcb->cpu, get_task_name(tcb), tcb, tcb->task_state);
 #else
-  syslog(LOG_INFO, "CPU%d: Resume TCB@%p, state=%d\n",
-         tcb->cpu, tcb, tcb->task_state);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Resume %s, TCB@%p, state=%d\n",
-         tcb->name, tcb, tcb->task_state);
-#else
-  syslog(LOG_INFO, "Resume TCB@%p, state=%d\n",
-         tcb, tcb->task_state);
-#endif
+         get_task_name(tcb), tcb, tcb->task_state);
 #endif
 }
 #endif
@@ -239,74 +199,44 @@ static void notelog_resume(FAR struct note_driver_s *drv,
 static void notelog_cpu_start(FAR struct note_driver_s *drv,
                               FAR struct tcb_s *tcb, int cpu)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d START\n",
-         tcb->cpu, tcb->name, tcb, cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d START\n",
-         tcb->cpu, tcb, cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, cpu);
 }
 
 static void notelog_cpu_started(FAR struct note_driver_s *drv,
                                 FAR struct tcb_s *tcb)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d STARTED\n",
-         tcb->cpu, tcb->name, tcb, tcb->cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d STARTED\n",
-         tcb->cpu, tcb, tcb->cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, tcb->cpu);
 }
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
 static void notelog_cpu_pause(FAR struct note_driver_s *drv,
                               FAR struct tcb_s *tcb, int cpu)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d PAUSE\n",
-         tcb->cpu, tcb->name, tcb, cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d PAUSE\n",
-         tcb->cpu, tcb, cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, cpu);
 }
 
 static void notelog_cpu_paused(FAR struct note_driver_s *drv,
                                FAR struct tcb_s *tcb)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d PAUSED\n",
-         tcb->cpu, tcb->name, tcb, tcb->cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d PAUSED\n",
-         tcb->cpu, tcb, tcb->cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, tcb->cpu);
 }
 
 static void notelog_cpu_resume(FAR struct note_driver_s *drv,
                                FAR struct tcb_s *tcb, int cpu)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d RESUME\n",
-         tcb->cpu, tcb->name, tcb, cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d RESUME\n",
-         tcb->cpu, tcb, cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, cpu);
 }
 
 static void notelog_cpu_resumed(FAR struct note_driver_s *drv,
                                 FAR struct tcb_s *tcb)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p CPU%d RESUMED\n",
-         tcb->cpu, tcb->name, tcb, tcb->cpu);
-#else
-  syslog(LOG_INFO, "CPU%d: TCB@%p CPU%d RESUMED\n",
-         tcb->cpu, tcb, tcb->cpu);
-#endif
+         tcb->cpu, get_task_name(tcb), tcb, tcb->cpu);
 }
 #endif
 #endif
@@ -316,21 +246,11 @@ static void notelog_premption(FAR struct note_driver_s *drv,
                               FAR struct tcb_s *tcb, bool locked)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p preemption %s\n",
-         tcb->cpu, tcb->name, tcb, locked ? "LOCKED" : "UNLOCKED");
+         tcb->cpu, get_task_name(tcb), tcb, locked ? "LOCKED" : "UNLOCKED");
 #else
-  syslog(LOG_INFO, "CPU%d: TCB@%p preemption %s\n",
-         tcb->cpu, tcb, locked ? "LOCKED" : "UNLOCKED");
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Task %s, TCB@%p preemption %s\n",
-         tcb->name, tcb, locked ? "LOCKED" : "UNLOCKED");
-#else
-  syslog(LOG_INFO, "TCB@%p preemption %s\n",
-         tcb, locked ? "LOCKED" : "UNLOCKED");
-#endif
+         get_task_name(tcb), tcb, locked ? "LOCKED" : "UNLOCKED");
 #endif
 }
 #endif
@@ -340,21 +260,11 @@ static void notelog_csection(FAR struct note_driver_s *drv,
                              FAR struct tcb_s *tcb, bool enter)
 {
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p critical section %s\n",
-         tcb->cpu, tcb->name, tcb, enter ? "ENTER" : "LEAVE");
+         tcb->cpu, get_task_name(tcb), tcb, enter ? "ENTER" : "LEAVE");
 #else
-  syslog(LOG_INFO, "CPU%d: TCB@%p critical section %s\n",
-         tcb->cpu, tcb, enter ? "ENTER" : "LEAVE");
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Task %s, TCB@%p critical section %s\n",
-         tcb->name, tcb, enter ? "ENTER" : "LEAVE");
-#else
-  syslog(LOG_INFO, "TCB@%p critical section %s\n",
-         tcb, enter ? "ENTER" : "LEAVE");
-#endif
+         get_task_name(tcb), tcb, enter ? "ENTER" : "LEAVE");
 #endif
 }
 #endif
@@ -376,21 +286,11 @@ static void note_spinlock(FAR struct note_driver_s *drv,
   FAR const char * msg = tmp[type - NOTE_SPINLOCK_LOCK];
 
 #ifdef CONFIG_SMP
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p spinlock@%p %s\n",
-         tcb->cpu, tcb->name, tcb, spinlock, msg);
+         tcb->cpu, get_task_name(tcb), tcb, spinlock, msg);
 #else
-  syslog(LOG_INFO, "CPU%d: TCB@%p spinlock@%p %s\n",
-         tcb->cpu, tcb, spinlock, msg);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
   syslog(LOG_INFO, "Task %s TCB@%p spinlock@%p %s\n",
-         tcb->name, tcb, spinlock, msg);
-#else
-  syslog(LOG_INFO, "TCB@%p spinlock@%p %s\n",
-         tcb, spinlock, msg);
-#endif
+         get_task_name(tcb), tcb, spinlock, msg);
 #endif
 }
 #endif

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -624,7 +624,7 @@ static void noteram_dump_init_context(FAR struct noteram_dump_context_s *ctx)
  * Name: get_task_name
  ****************************************************************************/
 
-static FAR const char *get_task_name(pid_t pid)
+static const char *get_taskname(pid_t pid)
 {
   FAR const char *taskname;
 
@@ -658,7 +658,7 @@ static int noteram_dump_header(FAR struct lib_outstream_s *s,
 #endif
 
   ret = lib_sprintf(s, "%8s-%-3u [%d] %3" PRIu32 ".%09" PRIu32 ": ",
-                    get_task_name(pid), get_pid(pid), cpu, sec, nsec);
+                    get_taskname(pid), get_pid(pid), cpu, sec, nsec);
   return ret;
 }
 
@@ -694,9 +694,9 @@ static int noteram_dump_sched_switch(FAR struct lib_outstream_s *s,
   ret = lib_sprintf(s, "sched_switch: prev_comm=%s prev_pid=%u "
                     "prev_prio=%u prev_state=%c ==> "
                     "next_comm=%s next_pid=%u next_prio=%u\n",
-                    get_task_name(current_pid), get_pid(current_pid),
+                    get_taskname(current_pid), get_pid(current_pid),
                     current_priority, get_task_state(cctx->current_state),
-                    get_task_name(next_pid), get_pid(next_pid),
+                    get_taskname(next_pid), get_pid(next_pid),
                     next_priority);
 
   cctx->current_pid = cctx->next_pid;
@@ -740,7 +740,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         ret += noteram_dump_header(s, note, ctx);
         ret += lib_sprintf(s, "sched_wakeup_new: comm=%s pid=%d "
                            "target_cpu=%d\n",
-                           get_task_name(pid), get_pid(pid), cpu);
+                           get_taskname(pid), get_pid(pid), cpu);
       }
       break;
 
@@ -794,7 +794,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
             ret += noteram_dump_header(s, note, ctx);
             ret += lib_sprintf(s, "sched_waking: comm=%s "
                                "pid=%d target_cpu=%d\n",
-                               get_task_name(cctx->next_pid),
+                               get_taskname(cctx->next_pid),
                                get_pid(cctx->next_pid), cpu);
             cctx->pendingswitch = true;
           }

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -135,11 +135,7 @@ static void note_sysview_send_taskinfo(FAR struct tcb_s *tcb)
   SEGGER_SYSVIEW_TASKINFO info;
 
   info.TaskID    = tcb->pid;
-#if CONFIG_TASK_NAME_SIZE > 0
-  info.sName     = tcb->name;
-#else
-  info.sName     = "<noname>";
-#endif
+  info.sName     = get_task_name(tcb);
   info.Prio      = tcb->sched_priority;
   info.StackBase = (uintptr_t)tcb->stack_base_ptr;
   info.StackSize = tcb->adj_stack_size;

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1804,9 +1804,9 @@ static int uart_unlink(FAR struct inode *inode)
 static void uart_launch_foreach(FAR struct tcb_s *tcb, FAR void *arg)
 {
 #ifdef CONFIG_TTY_LAUNCH_ENTRY
-  if (!strcmp(tcb->name, CONFIG_TTY_LAUNCH_ENTRYNAME))
+  if (!strcmp(get_task_name(tcb), CONFIG_TTY_LAUNCH_ENTRYNAME))
 #else
-  if (!strcmp(tcb->name, CONFIG_TTY_LAUNCH_FILEPATH))
+  if (!strcmp(get_task_name(tcb), CONFIG_TTY_LAUNCH_FILEPATH))
 #endif
     {
       *(FAR int *)arg = 1;

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -153,6 +153,7 @@ config SYSLOG_PRIORITY
 config SYSLOG_PROCESS_NAME
 	bool "Prepend process name to syslog message"
 	default n
+	depends on TASK_NAME_SIZE > 0
 	---help---
 		Prepend Process name to syslog message.
 

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -83,7 +83,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 {
   struct lib_syslograwstream_s stream;
   int ret = 0;
-#if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
+#ifdef CONFIG_SYSLOG_PROCESS_NAME
   FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid());
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
@@ -196,7 +196,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
                              "[%s] "
 #endif
-#if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
+#ifdef CONFIG_SYSLOG_PROCESS_NAME
   /* Prepend the thread name */
 
                              "%s: "
@@ -242,10 +242,10 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
                              , CONFIG_SYSLOG_PREFIX_STRING
 #endif
 
-#if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
+#ifdef CONFIG_SYSLOG_PROCESS_NAME
   /* Prepend the thread name */
 
-                             , tcb != NULL ? tcb->name : "(null)"
+                             , get_task_name(tcb)
 #endif
                     );
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -486,11 +486,7 @@ static ssize_t proc_status(FAR struct proc_file_s *procfile,
 
   /* Show the task name */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  name       = tcb->name;
-#else
-  name       = "<noname>";
-#endif
+  name       = get_task_name(tcb);
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
                                "%-12s%.18s\n", "Name:", name);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
@@ -670,11 +666,7 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
 
   /* Show the task name */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  name       = tcb->name;
-#else
-  name       = "<noname>";
-#endif
+  name       = get_task_name(tcb);
   linesize   = strlen(name);
   memcpy(procfile->line, name, linesize);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -222,6 +222,14 @@
 
 #define get_current_mm()             (get_group_mm(nxsched_self()->group))
 
+/* Get task name from tcb */
+
+#if CONFIG_TASK_NAME_SIZE > 0
+#  define get_task_name(tcb)         ((tcb)->name)
+#else
+#  define get_task_name(tcb)         "<noname>"
+#endif
+
 /* These are macros to access the current CPU and the current task on a CPU.
  * These macros are intended to support a future SMP implementation.
  */

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1249,17 +1249,10 @@ static int gdb_query(FAR struct gdb_state_s *state)
         }
 
       nxsched_get_stateinfo(tcb, thread_state, sizeof(thread_state));
-#if CONFIG_TASK_NAME_SIZE > 0
       snprintf(thread_info, sizeof(thread_info),
                "Name: %s, State: %s, Priority: %d, Stack: %zu",
-                tcb->name, thread_state, tcb->sched_priority,
+                get_task_name(tcb), thread_state, tcb->sched_priority,
                 tcb->adj_stack_size);
-#else
-      snprintf(thread_info, sizeof(thread_info),
-               "State: %s, Priority: %d, Stack: %zu",
-               thread_state, tcb->sched_priority,
-               tcb->adj_stack_size);
-#endif
 
       ret = gdb_bin2hex(state->pkt_buf, sizeof(state->pkt_buf),
                         thread_info, strlen(thread_info));
@@ -1966,4 +1959,3 @@ out:
   state->last_stopaddr = stopaddr;
   return ret;
 }
-

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -415,11 +415,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #ifndef CONFIG_SCHED_CPULOAD_NONE
          , intpart, fracpart
 #endif
-#if CONFIG_TASK_NAME_SIZE > 0
-         , tcb->name
-#else
-         , "<noname>"
-#endif
+         , get_task_name(tcb)
          , args
         );
 }
@@ -630,18 +626,14 @@ static void dump_assert_info(FAR struct tcb_s *rtcb,
                              FAR const char *filename, int linenum,
                              FAR const char *msg, FAR void *regs)
 {
-#if CONFIG_TASK_NAME_SIZE > 0
   FAR struct tcb_s *ptcb = NULL;
-#endif
   struct utsname name;
 
-#if CONFIG_TASK_NAME_SIZE > 0
   if (rtcb->group &&
       (rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
       ptcb = nxsched_get_tcb(rtcb->group->tg_pid);
     }
-#endif
 
   uname(&name);
   _alert("Current Version: %s %s %s %s %s\n",
@@ -653,20 +645,16 @@ static void dump_assert_info(FAR struct tcb_s *rtcb,
          "(CPU%d)"
 #endif
          ": "
-#if CONFIG_TASK_NAME_SIZE > 0
          "%s "
          "process: %s "
-#endif
          "%p\n",
          msg ? msg : "",
          filename ? filename : "", linenum,
 #ifdef CONFIG_SMP
          this_cpu(),
 #endif
-#if CONFIG_TASK_NAME_SIZE > 0
-         rtcb->name,
-         ptcb ? ptcb->name : "Kernel",
-#endif
+         get_task_name(rtcb),
+         ptcb ? get_task_name(ptcb) : "Kernel",
          rtcb->entry.main);
 
   /* Dump current CPU registers, running task stack and backtrace. */

--- a/sched/sched/sched_dumponexit.c
+++ b/sched/sched/sched_dumponexit.c
@@ -57,8 +57,8 @@ static void dumphandler(FAR struct tcb_s *tcb, FAR void *arg)
 
   syslog(LOG_INFO, "tcb=%p name=%s, pid:%d, priority=%d state=%d "
          "stack_alloc_ptr: %p, adj_stack_size: %zu\n",
-         tcb, tcb->name, tcb->pid, tcb->sched_priority, tcb->task_state,
-         tcb->stack_alloc_ptr, tcb->adj_stack_size);
+         tcb, get_task_name(tcb), tcb->pid, tcb->sched_priority,
+         tcb->task_state, tcb->stack_alloc_ptr, tcb->adj_stack_size);
 
   filelist = &tcb->group->tg_filelist;
   files_dumplist(filelist);

--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -86,11 +86,7 @@ void nxtask_activate(FAR struct tcb_s *tcb)
 
   nxsched_remove_blocked(tcb);
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  sinfo("%s pid=%d,TCB=%p\n", tcb->name,
-#else
-  sinfo("pid=%d,TCB=%p\n",
-#endif  
+  sinfo("%s pid=%d,TCB=%p\n", get_task_name(tcb),
         tcb->pid, tcb);
 
   /* Add the task to ready-to-run task list, and

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -91,11 +91,7 @@ int nxtask_exit(void)
   dtcb = this_task();
 #endif
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  sinfo("%s pid=%d,TCB=%p\n", dtcb->name,
-#else
-  sinfo("pid=%d,TCB=%p\n",
-#endif  
+  sinfo("%s pid=%d,TCB=%p\n", get_task_name(dtcb),
         dtcb->pid, dtcb);
 
   /* Update scheduler parameters */


### PR DESCRIPTION
## Summary

Introduce `get_task_name` to streamline code by replacing (#if #else #endif) with a cleaner implementation.

## Impact

For debug log, instead of printing nothing, now it will print "noname".

## Testing

CI test should be enough for this change.


