### PR TITLE
nuttx/can: support to Send message priority sorting function

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -46,6 +46,12 @@ config CAN_TXFIFOSIZE
 	---help---
 		The size of the circular tx buffer of CAN messages. Default: 8
 
+config CAN_TXPRIORITY
+	bool "Prioritize sending based on canid"
+	default n
+	---help---
+		Prioritize sending based on canid.
+
 config CAN_RXFIFOSIZE
 	int "CAN driver I/O rx buffer size"
 	default 8

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -651,7 +651,6 @@ static int can_xmit(FAR struct can_dev_s *dev)
       if (ret < 0)
         {
           canerr("dev_send failed: %d\n", ret);
-          __can_add_sendnode(&dev->cd_xmit, msg_node);
           break;
         }
       else


### PR DESCRIPTION
## Summary
This PR introduces a new priority-based sending mechanism for the CAN protocol stack, addressing the need for deterministic message delivery in time-critical applications. The change modifies the CAN driver files to implement a linked list-based priority queue for outgoing CAN frames.

The priority of a CAN frame is determined by  CAN ID. This allows applications to prioritize critical messages, ensuring they are transmitted ahead of less important ones, even under high bus load.

## Impact

New Feature: Adds priority-based sending for CAN frames.
User Impact: YES. Users can now enable and configure priority sending using  Kconfig options.
Build Impact: YES. To enable priority sending, users must select the CAN_TXPRIORITY during build configuration.
Compatibility Impact:  Assess backward compatibility. 

## Testing

The application layer sends unordered CAN messages, constructs a scenario where the sending queue is full, and manually adds log information to record the frame order in the priority sending queue. Print the frame.can_id information for each frame as follows:

tx_list has full, and frame order is :  0x193 ， 0x198,  0x19B,  0x1b5,  0x1b9,  0x259,  0x268,  0x2a1, 0x311, 0x319


