### PR TITLE
greenhills support: fix the pow() function calculate error

### DIFF
--- a/arch/arm/src/common/CMakeLists.txt
+++ b/arch/arm/src/common/CMakeLists.txt
@@ -91,4 +91,8 @@ if(CONFIG_ARCH_HAVE_FETCHADD)
   list(APPEND SRCS ${ARCH_TOOLCHAIN_PATH}/arm_fetchadd.S)
 endif()
 
+if(CONFIG_ARCH_TOOLCHAIN_GHS)
+  list(APPEND SRCS ghs/lib_dummy.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/common/ghs/lib_dummy.c
+++ b/arch/arm/src/common/ghs/lib_dummy.c
@@ -46,6 +46,6 @@ void __gh_fputs_stdout(void)
 {
 }
 
-void exp2(void)
+void __gh_set_errno(int errno)
 {
 }


### PR DESCRIPTION
## Summary
1. since the pow() function that defined in libmath_sd.a is depend on the
__gh_set_errno() function, and the __gh_set_errno() function provided in
libsys.a, in order to use the pow() function, we need to add dependency
of libsys.a
2. but the libsys.a will introduce an extra ".syscall" section, and the
".syscall" is mainly used for syscall actions that provided by
greenhills compiler. but since nuttx has syscall implementation, so we
choose to not depend on the greenhills's libsys.a lib. and the final implementation
are to add dummy "__gh_set_errno" implementation in arch/arm/src/common/ghs/lib_dummy.c
will work as we expect.

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on ghs/gcc compiler

