### PR TITLE
Fix esp spi bug

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_spi.c
+++ b/arch/risc-v/src/common/espressif/esp_spi.c
@@ -847,12 +847,12 @@ static void esp_spi_poll_exchange(struct esp_spi_priv_s *priv,
 
       if (rp != NULL)
         {
+          rp += transfer_size;
           spi_hal_fetch_result(priv->ctx);
         }
 
       bytes_remaining -= transfer_size;
       tp += transfer_size;
-      rp += transfer_size;
     }
 }
 

--- a/arch/risc-v/src/common/espressif/esp_spi.c
+++ b/arch/risc-v/src/common/espressif/esp_spi.c
@@ -752,6 +752,7 @@ static uint32_t esp_spi_poll_send(struct esp_spi_priv_s *priv, uint32_t wd)
 
   spi_ll_set_mosi_bitlen(priv->ctx->hw, priv->nbits);
   spi_hal_prepare_data(priv->ctx, priv->dev_cfg, &trans);
+  spi_hal_setup_trans(priv->ctx, priv->dev_cfg, &trans);
   spi_hal_user_start(priv->ctx);
 
   while (!spi_hal_usr_is_done(priv->ctx));


### PR DESCRIPTION
## Summary

1. Fix crash when rx buffer is NULL in `esp_spi_poll_exchange`
2. Add missing SPI setup in send one word.

## Impact

Now SPI is functional.

## Testing

Tested with a chip 0.96inch st7735 LCD with esp32c3.


