### PR TITLE
lcd/st7735: add option to invert display color

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -686,6 +686,10 @@ config LCD_ST7735_BGR
 	bool "Swap R & B channel"
 	default n
 
+config LCD_ST7735_INVCOLOR
+	bool "Invert display color"
+	default n
+
 config LCD_ST7735_BPP
 	int "Bit Per Pixel (12, 16 or 18)"
 	default 16

--- a/drivers/lcd/st7735.c
+++ b/drivers/lcd/st7735.c
@@ -333,6 +333,21 @@ static void st7735_sleep(FAR struct st7735_dev_s *dev, bool sleep)
 }
 
 /****************************************************************************
+ * Name: st7735_invon
+ *
+ * Description:
+ *   Display inversion on or off.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_LCD_ST7735_INVCOLOR
+static void st7735_invon(FAR struct st7735_dev_s *dev, bool on)
+{
+  st7735_sendcmd(dev, on ? ST7735_INVON : ST7735_INVOFF);
+}
+#endif
+
+/****************************************************************************
  * Name: st7735_display
  *
  * Description:
@@ -743,6 +758,9 @@ FAR struct lcd_dev_s *st7735_lcdinitialize(FAR struct spi_dev_s *spi)
   st7735_sleep(priv, false);
   st7735_bpp(priv, ST7735_BPP);
   st7735_setorientation(priv);
+#ifdef CONFIG_LCD_ST7735_INVCOLOR
+  st7735_invon(priv, true);
+#endif
   st7735_display(priv, true);
   st7735_fill(priv, 0xffff);
 
@@ -750,4 +768,3 @@ FAR struct lcd_dev_s *st7735_lcdinitialize(FAR struct spi_dev_s *spi)
 }
 
 #endif /* CONFIG_LCD_ST7735 */
-


### PR DESCRIPTION
## Summary

Add option to invert display as required by some panels.

## Impact

No.

## Testing

Chip 0.96inch 80x160 ips display with below configuration

```
CONFIG_LCD_ST7735=y
CONFIG_LCD_ST7735_XRES=80
CONFIG_LCD_ST7735_YRES=160
CONFIG_LCD_ST7735_XOFFSET=26
CONFIG_LCD_ST7735_YOFFSET=1
CONFIG_LCD_ST7735_BGR=y
CONFIG_LCD_ST7735_INVCOLOR=y
CONFIG_LCD_ST7735_BPP=16
CONFIG_LCD_ST7735_SPIMODE=0
```
