### PR TITLE
cmake: Fix some errors when using kasan

### DIFF
--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -138,15 +138,15 @@ if(CONFIG_MM_KASAN_ALL)
 endif()
 
 if(CONFIG_MM_KASAN_GLOBAL)
-  add_compile_options(--param asan-globals=1)
+  add_compile_options(--param=asan-globals=1)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
-  add_compile_options(--param asan-instrument-reads=0)
+  add_compile_options(--param=asan-instrument-reads=0)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
-  add_compile_options(--param asan-instrument-writes=0)
+  add_compile_options(--param=asan-instrument-writes=0)
 endif()
 
 # Instrumentation options

--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -150,15 +150,15 @@ if(CONFIG_MM_KASAN_ALL)
 endif()
 
 if(CONFIG_MM_KASAN_GLOBAL)
-  add_compile_options(--param asan-globals=1)
+  add_compile_options(--param=asan-globals=1)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
-  add_compile_options(--param asan-instrument-reads=0)
+  add_compile_options(--param=asan-instrument-reads=0)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
-  add_compile_options(--param asan-instrument-writes=0)
+  add_compile_options(--param=asan-instrument-writes=0)
 endif()
 
 # Instrumentation options

--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -109,15 +109,15 @@ if(CONFIG_MM_KASAN_ALL)
 endif()
 
 if(CONFIG_MM_KASAN_GLOBAL)
-  add_compile_options(--param asan-globals=1)
+  add_compile_options(--param=asan-globals=1)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
-  add_compile_options(--param asan-instrument-reads=0)
+  add_compile_options(--param=asan-instrument-reads=0)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
-  add_compile_options(--param asan-instrument-writes=0)
+  add_compile_options(--param=asan-instrument-writes=0)
 endif()
 
 # Instrumentation options

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -123,6 +123,18 @@ if(CONFIG_MM_KASAN_ALL)
   add_compile_options(-fsanitize=kernel-address)
 endif()
 
+if(CONFIG_MM_KASAN_GLOBAL)
+  add_compile_options(--param=asan-globals=1)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
+  add_compile_options(--param=asan-instrument-reads=0)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
+  add_compile_options(--param=asan-instrument-writes=0)
+endif()
+
 if(CONFIG_ARCH_INSTRUMENT_ALL)
   add_compile_options(-finstrument-functions)
 endif()

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -345,11 +345,11 @@ if(CONFIG_MM_KASAN_ALL)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
-  add_compile_options(--param asan-instrument-reads=0)
+  add_compile_options(--param=asan-instrument-reads=0)
 endif()
 
 if(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK)
-  add_compile_options(--param asan-instrument-writes=0)
+  add_compile_options(--param=asan-instrument-writes=0)
 endif()
 
 if(CONFIG_MM_UBSAN_ALL)

--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -104,7 +104,7 @@ elseif(CONFIG_MM_KASAN_ALL)
 endif()
 
 if(CONFIG_MM_KASAN_GLOBAL)
-  add_compile_options(--param asan-globals=1)
+  add_compile_options(--param=asan-globals=1)
 endif()
 
 if(CONFIG_SIM_UBSAN)


### PR DESCRIPTION
## Summary
1. cmake incorrectly identifies the --param xxx option and needs to be changed to --param=xxx
2. Add arm64 support kasan
## Impact
No
## Testing
No
