### PR TITLE
arm64_fpu: Remove fpu_regs from the TCB

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -268,11 +268,6 @@ struct xcptcontext
 
   uint64_t *saved_reg;
 
-#ifdef CONFIG_ARCH_FPU
-  uint64_t *fpu_regs;
-  uint64_t *saved_fpu_regs;
-#endif
-
   /* Extra fault address register saved for common paging logic.  In the
    * case of the pre-fetch abort, this value is the same as regs[REG_ELR];
    * For the case of the data abort, this value is the value of the fault

--- a/arch/arm64/src/common/arm64_copystate.c
+++ b/arch/arm64/src/common/arm64_copystate.c
@@ -102,14 +102,15 @@ int arm64_syscall_save_context(uint64_t * regs)
 
 #ifdef CONFIG_ARCH_FPU
   rtcb      = (struct tcb_s *)f_regs->regs[REG_X1];
-  p_save += XCPTCONTEXT_GP_SIZE;
+  p_save += XCPTCONTEXT_GP_REGS;
   if (rtcb_cur == rtcb)
     {
       arch_save_fpucontext(p_save);
     }
   else
     {
-      p_fpu = (uint64_t *)rtcb->xcp.fpu_regs;
+      p_fpu = (uint64_t *)rtcb->xcp.regs;
+      p_fpu += XCPTCONTEXT_GP_REGS;
       for (i = 0; i < XCPTCONTEXT_FPU_REGS; i++)
         {
           p_save[i] = p_fpu[i];


### PR DESCRIPTION

## Summary
Since FPU is now always saved into the current process stack location upon exception entry, there is no need to keep fpu_regs (or saved_fpu_regs) in the TCB.

## Impact
Removal of dead code from ARM64
## Testing
qemu-armv8a:knsh
qemu-armv8a:nsh
