### PR TITLE
arm64: exclude mpu from sanitize for SMP mode

### DIFF
--- a/arch/arm64/src/common/CMakeLists.txt
+++ b/arch/arm64/src/common/CMakeLists.txt
@@ -63,6 +63,10 @@ endif()
 
 if(CONFIG_ARCH_HAVE_MPU)
   list(APPEND SRCS arm64_mpu.c)
+  set_source_files_properties(
+    arm64_mpu.c TARGET_DIRECTORY arch
+    PROPERTIES COMPILE_FLAGS -fno-sanitize=kernel-hwaddress
+               -fno-sanitize=kernel-address)
 endif()
 
 if(CONFIG_ARM64_PSCI)

--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -76,6 +76,8 @@ endif
 
 ifeq ($(CONFIG_ARCH_HAVE_MPU),y)
 CMN_CSRCS += arm64_mpu.c
+common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-hwaddress
+common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-address
 endif
 
 ifeq ($(CONFIG_ARM64_PSCI),y)


### PR DESCRIPTION

## Summary

CPU0 boot -> mm_init() -> sanitizer on -> boot other CPUs 
                                                                          CPU1 boot -> mpu_init -> error

## Impact

No.

## Testing

CI build, local hardware test pass.

