### PR TITLE
sched/group: replace the pthread interface used in the kernel

### DIFF
--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -68,7 +68,7 @@ static int group_kill_children_handler(pid_t pid, FAR void *arg)
 
   if (pid != (pid_t)((uintptr_t)arg))
     {
-      pthread_kill(pid, SIGTERM);
+      tkill(pid, SIGTERM);
     }
 
   return OK;


### PR DESCRIPTION
## Summary

In protected build, kernel cannot call usersapce interface, so change pthread_kill to tkill.

## Impact

pthread exit

## Testing

ostest passed on the sabre-6quad:knsh_smp board