### PR TITLE
{bp-13633} riscv_fork.c: Fix vfork() for kernel mode + SMP

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -613,6 +613,12 @@ struct xcptcontext
 
   uintreg_t *regs;
 
+#ifdef CONFIG_LIB_SYSCALL
+  /* User integer registers upon system call entry */
+
+  uintreg_t *sregs;
+#endif
+
   /* FPU register save area */
 
 #if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARCH_LAZYFPU)

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -161,7 +161,7 @@ uintptr_t dispatch_syscall(unsigned int nbr, uintptr_t parm1,
 
   /* Set the user register context to TCB */
 
-  rtcb->xcp.regs = context;
+  rtcb->xcp.sregs = context;
 
   /* Indicate that we are in a syscall handler */
 


### PR DESCRIPTION
Summary
There was an error in the fork() routine when system calls are in use: the child context is saved on the child's user stack, which is incorrect, the context must be saved on the kernel stack instead.

The result is a full system crash if (when) the child executes on a different CPU which does not have the same MMU mappings active.

Impact
RELEASE

Testing
CI
