### PR TITLE
Imx9 usb fixes

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -265,12 +265,18 @@ static const struct uart_ops_s g_uartops =
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   cdcuart_rxflowcontrol, /* rxflowcontrol */
 #endif
+#ifdef CONFIG_SERIAL_TXDMA
   cdcuart_dmasend,       /* dmasend */
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
   cdcuart_dmareceive,    /* dmareceive */
   NULL,                  /* dmarxfree */
+#endif
+#ifdef CONFIG_SERIAL_TXDMA
   NULL,                  /* dmatxavail */
+#endif
   NULL,                  /* send */
-  cdcuart_txint,         /* txinit */
+  cdcuart_txint,         /* txint */
   cdcuart_txready,       /* txready */
   cdcuart_txempty,       /* txempty */
   cdcuart_release,       /* release */

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -327,7 +327,7 @@ static ssize_t cdcuart_sendbuf(FAR struct uart_dev_s *dev,
 
   /* Get the maximum number of bytes that will fit into one bulk IN request */
 
-  reqlen = MAX(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
+  reqlen = MIN(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
 
   /* Peek at the request in the container at the head of the list */
 
@@ -500,7 +500,7 @@ static int cdcacm_requeue_rdrequest(FAR struct cdcacm_dev_s *priv,
   /* Requeue the read request */
 
   ep       = priv->epbulkout;
-  req->len = MAX(CONFIG_CDCACM_BULKOUT_REQLEN, ep->maxpacket);
+  req->len = MIN(CONFIG_CDCACM_BULKOUT_REQLEN, ep->maxpacket);
   ret      = EP_SUBMIT(ep, req);
   if (ret != OK)
     {
@@ -2664,7 +2664,7 @@ static void cdcuart_dmasend(FAR struct uart_dev_s *dev)
 
   /* Get the maximum number of bytes that will fit into one bulk IN request */
 
-  reqlen = MAX(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
+  reqlen = MIN(CONFIG_CDCACM_BULKIN_REQLEN, ep->maxpacket);
 
   /* Peek at the request in the container at the head of the list */
 

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -636,7 +636,7 @@ static int usbclass_sndpacket(FAR struct pl2303_dev_s *priv)
 
   /* Get the maximum number of bytes that will fit into one bulk IN request */
 
-  reqlen = MAX(CONFIG_PL2303_BULKIN_REQLEN, ep->maxpacket);
+  reqlen = MIN(CONFIG_PL2303_BULKIN_REQLEN, ep->maxpacket);
 
   while (!sq_empty(&priv->reqlist))
     {


### PR DESCRIPTION
## Summary

This corrects some USB cache operations on imx9 platform, as well as with some generic buffer overflow issues in cdcacm and pl2303

## Impact

Fixes random crashes / instability

## Testing

Tested on i.MX93 platform

