### PR TITLE
pthread: add tls exit flags when pthread_exit()

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -66,6 +66,8 @@
 #  define TLS_INFO(sp)     ((FAR struct tls_info_s *)((sp) & ~TLS_STACK_MASK))
 #endif
 
+#define TLS_THREAD_EXIT_PROCESSING (1 << 0)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -218,6 +220,7 @@ struct tls_info_s
 
   uint16_t tl_size;                    /* Actual size with alignments */
   int tl_errno;                        /* Per-thread error number */
+  int flags;                           /* Per-thread flags */
 };
 
 /****************************************************************************

--- a/libs/libc/pthread/pthread_exit.c
+++ b/libs/libc/pthread/pthread_exit.c
@@ -55,6 +55,10 @@
 
 void pthread_exit(FAR void *exit_value)
 {
+  FAR struct tls_info_s *info = tls_get_info();
+
+  info->flags |= TLS_THREAD_EXIT_PROCESSING;
+
   /* Mark the pthread as non-cancelable to avoid additional calls to
    * pthread_exit() due to any cancellation point logic that might get
    * kicked off by actions taken during pthread_exit processing.

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -37,6 +37,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/signal.h>
+#include <nuttx/tls.h>
 
 #include "group/group.h"
 #include "sched/sched.h"
@@ -230,12 +231,17 @@ static void nxsig_abnormal_termination(int signo)
 
   if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD)
     {
+      FAR struct tls_info_s *info = tls_get_info();
+
       /* Exit the final thread of the task group.
        *
        * REVISIT:  This will not work if HAVE_GROUP_MEMBERS is not set.
        */
 
-      pthread_exit(NULL);
+      if ((info->flags & TLS_THREAD_EXIT_PROCESSING) == 0)
+        {
+          pthread_exit(NULL);
+        }
     }
   else
 #endif


### PR DESCRIPTION
## Summary

If receive SIGKILL during pthread_exit, tls_cleanup_popall and tls_destruct may be called twice, so add tls flags to prevent repeated calls.

## Impact

pthread_exit

## Testing

Test with BES board