### PR TITLE
rpmsg_virtio: move rpmsg virtio cmd definition before the resource table

### DIFF
--- a/arch/sim/src/sim/sim_rpmsg_virtio.c
+++ b/arch/sim/src/sim/sim_rpmsg_virtio.c
@@ -88,6 +88,7 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
   struct sim_rpmsg_virtio_dev_s *priv =
     container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
   struct rpmsg_virtio_rsc_s *rsc;
+  struct rpmsg_virtio_cmd_s *cmd;
 
   priv->shmem = host_allocshmem(priv->shmemname, sizeof(*priv->shmem));
   if (!priv->shmem)
@@ -96,6 +97,7 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
     }
 
   rsc = &priv->shmem->rsc;
+  cmd = RPMSG_VIRTIO_RSC2CMD(rsc);
 
   if (priv->master)
     {
@@ -113,8 +115,7 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
       rsc->rpmsg_vring1.num         = 8;
       rsc->config.r2h_buf_size      = 2048;
       rsc->config.h2r_buf_size      = 2048;
-      rsc->cmd_master               = 0;
-      rsc->cmd_slave                = 0;
+      cmd->cmd_slave                = 0;
 
       priv->shmem->base = (uintptr_t)priv->shmem;
     }
@@ -127,6 +128,7 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
+      cmd->cmd_master       = 0;
       priv->addrenv[0].va   = (uintptr_t)priv->shmem;
       priv->addrenv[0].pa   = priv->shmem->base;
       priv->addrenv[0].size = sizeof(*priv->shmem);

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -127,8 +127,10 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
   FAR struct rpmsg_virtio_ivshmem_dev_s *priv =
     (FAR struct rpmsg_virtio_ivshmem_dev_s *)dev;
   FAR struct rpmsg_virtio_rsc_s *rsc;
+  FAR struct rpmsg_virtio_cmd_s *cmd;
 
   rsc = &priv->shmem->rsc;
+  cmd = RPMSG_VIRTIO_RSC2CMD(rsc);
 
   if (priv->master)
     {
@@ -146,8 +148,7 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
       rsc->rpmsg_vring1.num         = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFNUM;
       rsc->config.r2h_buf_size      = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFSIZE;
       rsc->config.h2r_buf_size      = CONFIG_RPMSG_VIRTIO_IVSHMEM_BUFFSIZE;
-      rsc->cmd_master               = 0;
-      rsc->cmd_slave                = 0;
+      cmd->cmd_slave                = 0;
 
       priv->shmem->basem = (uint64_t)(uintptr_t)priv->shmem;
     }
@@ -162,6 +163,7 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
+      cmd->cmd_master       = 0;
       priv->addrenv[0].va   = (uint64_t)(uintptr_t)priv->shmem;
       priv->addrenv[0].pa   = priv->shmem->basem;
       priv->addrenv[0].size = priv->shmem_size;

--- a/include/nuttx/rpmsg/rpmsg_virtio.h
+++ b/include/nuttx/rpmsg/rpmsg_virtio.h
@@ -38,6 +38,18 @@
 
 #define RPMSG_VIRTIO_NOTIFY_ALL UINT32_MAX
 
+#define RPMSG_VIRTIO_CMD_PANIC  0x1
+#define RPMSG_VIRTIO_CMD_MASK   0xffff
+#define RPMSG_VIRTIO_CMD_SHIFT  16
+
+#define RPMSG_VIRTIO_CMD(c,v)   (((c) << RPMSG_VIRTIO_CMD_SHIFT) | \
+                                 ((v) & RPMSG_VIRTIO_CMD_MASK))
+#define RPMSG_VIRTIO_GET_CMD(c) ((c) >> RPMSG_VIRTIO_CMD_SHIFT)
+
+#define RPMSG_VIRTIO_RSC2CMD(r) \
+  ((FAR struct rpmsg_virtio_cmd_s *) \
+  &((FAR struct resource_table *)(r))->reserved[0])
+
 /* Access macros ************************************************************/
 
 /****************************************************************************
@@ -151,6 +163,12 @@
 
 typedef CODE int (*rpmsg_virtio_callback_t)(FAR void *arg, uint32_t vqid);
 
+begin_packed_struct struct rpmsg_virtio_cmd_s
+{
+  uint32_t cmd_master;
+  uint32_t cmd_slave;
+} end_packed_struct;
+
 struct aligned_data(8) rpmsg_virtio_rsc_s
 {
   struct resource_table    rsc_tbl_hdr;
@@ -160,8 +178,6 @@ struct aligned_data(8) rpmsg_virtio_rsc_s
   struct fw_rsc_vdev_vring rpmsg_vring0;
   struct fw_rsc_vdev_vring rpmsg_vring1;
   struct fw_rsc_config     config;
-  uint32_t                 cmd_master;
-  uint32_t                 cmd_slave;
 };
 
 struct rpmsg_virtio_s;


### PR DESCRIPTION
## Summary
use reserved[2] in struct resource_table as the command, avoid the resource table format do not follow the standard.

## Impact
rpmsg virtio

## Testing
qemu-armv7a with rpmsg_virtio enabled
