### PR TITLE
drivers/rptun: add cmake support for rptun_secure

### DIFF
--- a/drivers/rptun/CMakeLists.txt
+++ b/drivers/rptun/CMakeLists.txt
@@ -22,6 +22,10 @@ if(CONFIG_RPTUN)
 
   list(APPEND SRCS rptun.c)
 
+  if(CONFIG_RPTUN_SECURE)
+    list(APPEND SRCS rptun_secure.c)
+  endif()
+
   if(CONFIG_RPTUN_IVSHMEM)
     list(APPEND SRCS rptun_ivshmem.c)
   endif()

--- a/drivers/rptun/Make.defs
+++ b/drivers/rptun/Make.defs
@@ -24,12 +24,12 @@ ifeq ($(CONFIG_RPTUN),y)
 
 CSRCS += rptun.c
 
-ifeq ($(CONFIG_RPTUN_IVSHMEM),y)
-CSRCS += rptun_ivshmem.c
-endif
-
 ifeq ($(CONFIG_RPTUN_SECURE),y)
 CSRCS += rptun_secure.c
+endif
+
+ifeq ($(CONFIG_RPTUN_IVSHMEM),y)
+CSRCS += rptun_ivshmem.c
 endif
 
 DEPPATH += --dep-path rptun


### PR DESCRIPTION
## Summary
1. Add cmake support for rptun_serure;
2. Move rptun_secure.c before rptun_ivshmem.c in Make.defs to follow the order in Kconfig.

## Impact
rptun secure support cmake

## Testing
CI
