### PR TITLE
arch: cxd56xx: Fix gnss compile error

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2294,7 +2294,7 @@ cxd56_gnss_read_cep_file(struct file *fp, int32_t offset,
       if (offset + len > g_ceplen)
         {
           ret = -ENOENT;
-          goto _err0;
+          goto err0;
         }
 
       buf = &g_cepdata[offset];


### PR DESCRIPTION
## Summary
Fix a compile error when CONFIG_CXD56_GNSS_CEP_ON_SPIFLASH is enabled.

## Impact
Only for spresense

## Testing

