### PR TITLE
boards: cxd56xx: Fix an issue not to enter cold sleep

### DIFF
--- a/arch/arm/include/cxd56xx/pm.h
+++ b/arch/arm/include/cxd56xx/pm.h
@@ -55,6 +55,10 @@
 #define PM_BOOT_COLD_USB_DETACH (0x40000000ul) /* In ColdSleep state, USB Disconnected */
 #define PM_BOOT_COLD_USB_ATTACH (0x80000000ul) /* In ColdSleep state, USB Connected */
 
+/* Get bootmask from GPIO IRQ number */
+
+#define PM_BOOT_GPIO_MASK(irq) (1 << ((irq) - CXD56_IRQ_EXDEVICE_0 + 16))
+
 /* SRAM power status definitions */
 
 #define PMCMD_RAM_OFF 0  /* Power off */

--- a/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
@@ -277,6 +277,9 @@ static int board_sdcard_detect_int(int irq, void *context, void *arg)
 int board_sdcard_initialize(void)
 {
   int ret = OK;
+#ifdef CONFIG_MMCSD_HAVE_CARDDETECT
+  int irq;
+#endif
 
 #ifdef CONFIG_SDCARD_TXS02612_PORT0
   /* Select port0 for SD-Card (default) */
@@ -296,8 +299,15 @@ int board_sdcard_initialize(void)
   /* Configure Interrupt pin with internal pull-up */
 
   cxd56_pin_config(PINCONF_SDIO_CD_GPIO);
-  cxd56_gpioint_config(PIN_SDIO_CD, GPIOINT_PSEUDO_EDGE_BOTH,
-                       board_sdcard_detect_int, NULL);
+  irq = cxd56_gpioint_config(PIN_SDIO_CD, GPIOINT_PSEUDO_EDGE_BOTH,
+                             board_sdcard_detect_int, NULL);
+
+  /* Disable wakeup from SD Card detect interrupt */
+
+  if ((CXD56_IRQ_EXDEVICE_0 <= irq) && (irq <= CXD56_IRQ_EXDEVICE_11))
+    {
+      up_pm_clr_bootmask(PM_BOOT_GPIO_MASK(irq));
+    }
 
   /* Handle the case when SD card is already inserted */
 


### PR DESCRIPTION
## Summary
Fix an issue not to enter cold sleep by SD Card detection interrupt.

## Impact
Only for spresense

## Testing

