### PR TITLE
build.yml: Check out the correct branch of nuttx-apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           fi
 
           echo "name=$OS_REF" >> $GITHUB_OUTPUT
-          echo "app_ref=$APPS_REF" >> $GITHUB_OUTPUT
+          echo "apps_ref=$APPS_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout nuttx repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

When building a branch like `releases/12.7`, the CI Workflow incorrectly checks out the `master` branch of `nuttx-apps`, instead of `releases/12.7`. This PR fixes a typo in `apps_ref`, to check out the correct branch.

## Impact

This will fix the Apps Build for NuttX Releases.

## Testing

None
