### PR TITLE
arch/x86_64/addrenv.h: fix MMU flags for USER region

### DIFF
--- a/arch/x86_64/src/common/addrenv.h
+++ b/arch/x86_64/src/common/addrenv.h
@@ -66,7 +66,7 @@
 
 /* Mark user memory if in kernel build */
 
-#ifndef CONFIG_BUILD_KERNEL
+#ifdef CONFIG_BUILD_KERNEL
 #  define MMU_USER_DEFAULT      (X86_PAGE_USER)
 #else
 #  define MMU_USER_DEFAULT      (0)


### PR DESCRIPTION
## Summary
arch/x86_64/addrenv.h: fix MMU flags for USER region

## Impact
fix typo

## Testing
kernel build with x86_64 (not yet upstream)
