### PR TITLE
arch/intel64: fix IRQ conflict with GOLDFISH

### DIFF
--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -346,10 +346,18 @@
 #define HPET0_IRQ    IRQ2
 #define HPET1_IRQ    IRQ8
 
-/* Use IRQ15 IRQ16 for SMP */
+/* NuttX custom interrupts configuration starts from here.
+ * IRQ16-IRQ23 are reserved for GOLDFISH so we start from IRQ24.
+ */
 
-#define SMP_IPI_IRQ  IRQ15
-#define SMP_IPI_ASYNC_IRQ  IRQ16
+/* Use IRQ24 IRQ25 for SMP */
+
+#define SMP_IPI_IRQ        IRQ24
+#define SMP_IPI_ASYNC_IRQ  IRQ25
+
+/* Use IRQ32 and above for MSI */
+
+#define IRQ_MSI_START      IRQ32
 
 /* Common register save structure created by up_saveusercontext() and by
  * ISR/IRQ interrupt processing.

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -48,7 +48,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IRQ_MSI_START        IRQ32
 #define X86_64_MAR_DEST      0xfee00000
 #define X86_64_MDR_TYPE      0x4000
 


### PR DESCRIPTION
## Summary
arch/intel64: fix IRQ conflict with GOLDFISH
Also move MSI IRQ definition to place where other IRQ definitions are.

## Impact
x86_64 can be used with android goldfish. No impact on user.

## Testing
CI
