### PR TITLE
arch/intel64: various fixes for stack alignment

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpuidlestack.c
+++ b/arch/x86_64/src/intel64/intel64_cpuidlestack.c
@@ -88,7 +88,8 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 
   /* Get the top of the stack */
 
-  stack_alloc          = (uintptr_t)g_idle_topstack[cpu];
+  stack_alloc          = (uintptr_t)g_idle_topstack[cpu] -
+                         CONFIG_IDLETHREAD_STACKSIZE;
   tcb->adj_stack_size  = stack_size - 8;
   tcb->stack_alloc_ptr = (void *)stack_alloc;
   tcb->stack_base_ptr  = tcb->stack_alloc_ptr;

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -392,6 +392,10 @@ ap_start:
 	add     %rax, %rbx
 	mov     (%rbx),   %rsp
 
+	/* Move initial RSP below IDLE TCB regs */
+	sub     $XCPTCONTEXT_SIZE, %rsp
+	and     $(~XCPTCONTEXT_SIZE), %rsp
+
 	/* Jump to ap_start routine */
 	movabs  $x86_64_ap_boot,   %rbx
 	jmp     *%rbx

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -130,6 +130,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               up_current_regs()[REG_RIP]    = (uint64_t)x86_64_sigdeliver;
+              up_current_regs()[REG_RSP]    = up_current_regs()[REG_RSP] - 8;
               up_current_regs()[REG_RFLAGS] = 0;
 
               /* And make sure that the saved context in the TCB
@@ -162,6 +163,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           tcb->xcp.regs[REG_RIP]    = (uint64_t)x86_64_sigdeliver;
+          tcb->xcp.regs[REG_RSP]    = tcb->xcp.regs[REG_RSP] - 8;
           tcb->xcp.regs[REG_RFLAGS] = 0;
         }
     }
@@ -242,6 +244,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    */
 
                   tcb->xcp.regs[REG_RIP]    = (uint64_t)x86_64_sigdeliver;
+                  tcb->xcp.regs[REG_RSP]    = tcb->xcp.regs[REG_RSP] - 8;
                   tcb->xcp.regs[REG_RFLAGS] = 0;
                 }
               else
@@ -261,7 +264,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * disabled
                    */
 
-                  up_current_regs()[REG_RIP]  = (uint64_t)x86_64_sigdeliver;
+                  up_current_regs()[REG_RIP]    =
+                    (uint64_t)x86_64_sigdeliver;
+                  up_current_regs()[REG_RSP]    =
+                    up_current_regs()[REG_RSP] - 8;
                   up_current_regs()[REG_RFLAGS] = 0;
 
                   /* And make sure that the saved context in the TCB
@@ -308,6 +314,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           tcb->xcp.regs[REG_RIP]    = (uint64_t)x86_64_sigdeliver;
+          tcb->xcp.regs[REG_RSP]    = tcb->xcp.regs[REG_RSP] - 8;
           tcb->xcp.regs[REG_RFLAGS] = 0;
         }
     }


### PR DESCRIPTION
## Summary
- arch/x86_64/intel64/intel64_head.S: move initial RSP for AP cores below regs area
    move initial RSP for AP cores below regs area.
    otherwise IDLE thread for AP cores can be corrupted.
    XCP region now match regs allocation in up_initial_state()
    
-  arch/intel64_cpuidlestack.c: stack_alloc should point to stack base not stack top

- arch/x86_64/intel64/intel64_schedulesigaction.c: properly align signal handler stack for vector operations

## Impact
various fixes for problems observed with high optimization enabled and SMP

## Testing
qemu with smp test and ostest
