### PR TITLE
arch/intel64: colorize IDLE stack for AP cores

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 
+#include "sched/sched.h"
 #include "init/init.h"
 
 #include "intel64_lowsetup.h"
@@ -128,7 +129,10 @@ static int x86_64_ap_startup(int cpu)
 
 void x86_64_ap_boot(void)
 {
+  struct tcb_s *tcb = this_task();
   uint8_t cpu = 0;
+
+  UNUSED(tcb);
 
   /* Do some checking on CPU compatibilities at the top of this function */
 
@@ -153,7 +157,7 @@ void x86_64_ap_boot(void)
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */
 
-  sched_note_cpu_started(this_task());
+  sched_note_cpu_started(tcb);
 #endif
 
   sinfo("cpu=%d\n", cpu);
@@ -164,6 +168,15 @@ void x86_64_ap_boot(void)
   irq_attach(SMP_IPI_ASYNC_IRQ, up_pause_async_handler, NULL);
   up_enable_irq(SMP_IPI_IRQ);
   up_enable_irq(SMP_IPI_ASYNC_IRQ);
+
+#ifdef CONFIG_STACK_COLORATION
+  /* If stack debug is enabled, then fill the stack with a
+   * recognizable value that we can use later to test for high
+   * water marks.
+   */
+
+  x86_64_stack_color(tcb->stack_alloc_ptr, 0);
+#endif
 
   /* CPU ready */
 


### PR DESCRIPTION
## Summary
colorize IDLE stack for AP cores in x86_64

## Impact
`CONFIG_STACK_COLORATION=y` works also for AP cores IDLE stack 

## Testing
qemu
