### PR TITLE
nuttx/arch: Fix the issue where the compiler cannot recognize min-pagesize=0.

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -305,10 +305,20 @@ else
     endif
   endif
 
-  ARCHOPTIMIZATION += --param=min-pagesize=0
-  ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
-    LDFLAGS += --no-warn-rwx-segments
-  endif
+  # Workaround to skip -Warray-bounds check due to bug of GCC-12:
+   # Wrong warning array subscript [0] is outside array bounds:
+   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+
+   ifeq ($(GCCVER),)
+     export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
+   endif
+
+   ifeq ($(GCCVER),12)
+     ARCHOPTIMIZATION += --param=min-pagesize=0
+     ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
+       LDFLAGS += --no-warn-rwx-segments
+     endif
+   endif
 
   LDFLAGS += --entry=__start
 

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -31,7 +31,3 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
 endif
 
 include $(TOPDIR)/arch/arm/src/common/Toolchain.defs
-
-# tlsr82 can not recognize --param=min-pagesize=0, so remove it from ARCHOPTIMIZATION
-ARCHOPTIMIZATION := $(filter-out --param=min-pagesize=0,$(ARCHOPTIMIZATION))
-


### PR DESCRIPTION
## Summary
[Bug fix]： https://github.com/apache/nuttx/issues/13776

Due to the https://github.com/apache/nuttx/commit/394a967263f35ba72363994ba03ae8929d5e4974, which directly added ARCHOPTIMIZATION += --param=min-pagesize=0, some compiler environments with lower versions could not recognize this compilation option. Therefore, I am submitting this current fix patch.

## Impact

## Testing

