### PR TITLE
modlib:

### DIFF
--- a/include/elf.h
+++ b/include/elf.h
@@ -191,6 +191,7 @@
 #define SHF_WRITE          1
 #define SHF_ALLOC          2
 #define SHF_EXECINSTR      4
+#define SHF_INFO_LINK      0x40
 #define SHF_MASKPROC       0xf0000000
 
 /* Figure 4-16: Symbol Binding, ELF_ST_BIND */
@@ -210,6 +211,13 @@
 #define STT_FILE           4
 #define STT_LOPROC         13
 #define STT_HIPROC         15
+
+/* Table 7-21 ELF Symbol Visibility */
+
+#define STV_DEFAULT        0
+#define STV_INTERNAL       1
+#define STV_HIDDEN         2
+#define STV_PROTECTED      3
 
 /* Figure 5-2: Segment Types, p_type */
 

--- a/include/elf32.h
+++ b/include/elf32.h
@@ -36,25 +36,27 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ELF_CLASS          ELFCLASS32
+#define ELF_CLASS              ELFCLASS32
 
-#define ELF32_ST_BIND(i)   ((i) >> 4)
-#define ELF32_ST_TYPE(i)   ((i) & 0xf)
-#define ELF32_ST_INFO(b,t) (((b) << 4) | ((t) & 0xf))
+#define ELF32_ST_BIND(i)       ((i) >> 4)
+#define ELF32_ST_TYPE(i)       ((i) & 0xf)
+#define ELF32_ST_INFO(b,t)     (((b) << 4) | ((t) & 0xf))
+#define ELF32_ST_VISIBILITY(o) ((o) & 0x3)
 
 /* Generic macro to abstract ELF32/ELF64 type/bind */
 
-#define ELF_ST_TYPE(a)     ELF32_ST_TYPE(a)
-#define ELF_ST_BIND(a)     ELF32_ST_BIND(a)
+#define ELF_ST_TYPE(a)         ELF32_ST_TYPE(a)
+#define ELF_ST_BIND(a)         ELF32_ST_BIND(a)
+#define ELF_ST_VISIBILITY(o)   ELF32_ST_VISIBILITY(o)
 
 /* Definitions for Elf32_Rel*::r_info */
 
-#define ELF32_R_SYM(i)     ((i) >> 8)
-#define ELF32_R_TYPE(i)    ((i) & 0xff)
-#define ELF32_R_INFO(s,t)  (((s)<< 8) | ((t) & 0xff))
+#define ELF32_R_SYM(i)         ((i) >> 8)
+#define ELF32_R_TYPE(i)        ((i) & 0xff)
+#define ELF32_R_INFO(s,t)      (((s)<< 8) | ((t) & 0xff))
 
-#define ELF_R_SYM(i)       ELF32_R_SYM(i)
-#define ELF_R_TYPE(i)      ELF32_R_TYPE(i)
+#define ELF_R_SYM(i)           ELF32_R_SYM(i)
+#define ELF_R_TYPE(i)          ELF32_R_TYPE(i)
 
 /****************************************************************************
  * Public Type Definitions

--- a/include/elf64.h
+++ b/include/elf64.h
@@ -36,27 +36,29 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ELF_CLASS         ELFCLASS64
+#define ELF_CLASS              ELFCLASS64
 
 /* See ELF-64 Object File Format: Version 1.5 Draft 2 */
 
-#define ELF64_ST_BIND(i)     ((i) >> 4)
-#define ELF64_ST_TYPE(i)     ((i) & 0xf)
-#define ELF64_ST_INFO(b,t)   (((b) << 4) | ((t) & 0xf))
+#define ELF64_ST_BIND(i)       ((i) >> 4)
+#define ELF64_ST_TYPE(i)       ((i) & 0xf)
+#define ELF64_ST_INFO(b,t)     (((b) << 4) | ((t) & 0xf))
+#define ELF64_ST_VISIBILITY(o) ((o) & 0x3)
 
 /* Generic macro to abstract ELF32/ELF64 type/bind */
 
-#define ELF_ST_TYPE(a)       ELF64_ST_TYPE(a)
-#define ELF_ST_BIND(a)       ELF64_ST_BIND(a)
+#define ELF_ST_TYPE(a)         ELF64_ST_TYPE(a)
+#define ELF_ST_BIND(a)         ELF64_ST_BIND(a)
+#define ELF_ST_VISIBILITY(o)   ELF64_ST_VISIBILITY(o)
 
 /* Definitions for Elf64_Rel*::r_info */
 
-#define ELF64_R_SYM(i)       ((i) >> 32)
-#define ELF64_R_TYPE(i)      ((i) & 0xffffffffL)
-#define ELF64_R_INFO(s,t)    (((s)<< 32) + ((t) & 0xffffffffL))
+#define ELF64_R_SYM(i)         ((i) >> 32)
+#define ELF64_R_TYPE(i)        ((i) & 0xffffffffL)
+#define ELF64_R_INFO(s,t)      (((s)<< 32) + ((t) & 0xffffffffL))
 
-#define ELF_R_SYM(i)         ELF64_R_SYM(i)
-#define ELF_R_TYPE(i)        ELF64_R_TYPE(i)
+#define ELF_R_SYM(i)           ELF64_R_SYM(i)
+#define ELF_R_TYPE(i)          ELF64_R_TYPE(i)
 
 /****************************************************************************
  * Public Type Definitions

--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -155,9 +155,6 @@ struct module_s
 #ifdef HAVE_MODLIB_NAMES
   char modname[MODLIB_NAMEMAX];        /* Module name */
 #endif
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
-  mod_initializer_t initializer;       /* Module initializer function */
-#endif
   struct mod_info_s modinfo;           /* Module information */
   FAR void *textalloc;                 /* Allocated kernel text memory */
   FAR void *dataalloc;                 /* Allocated kernel memory */

--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -563,6 +563,40 @@ int modlib_registry_foreach(mod_callback_t callback, FAR void *arg);
 void modlib_freesymtab(FAR struct module_s *modp);
 
 /****************************************************************************
+ * Name: modlib_dumploadinfo
+ *
+ * Description:
+ *  Dump the load information to debug output.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_BINFMT_INFO
+void modlib_dumploadinfo(FAR struct mod_loadinfo_s *loadinfo);
+#else
+#  define modlib_dumploadinfo(i)
+#endif
+
+/****************************************************************************
+ * Name: modlib_dumpmodule
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_BINFMT_INFO
+void modlib_dumpmodule(FAR struct module_s *modp);
+#else
+#  define modlib_dumpmodule(m)
+#endif
+
+/****************************************************************************
+ * Name: elf_dumpentrypt
+ ****************************************************************************/
+
+#ifdef CONFIG_MODLIB_DUMPBUFFER
+void modlib_dumpentrypt(FAR struct mod_loadinfo_s *loadinfo);
+#else
+#  define modlib_dumpentrypt(l)
+#endif
+
+/****************************************************************************
  * Name: modlib_insert
  *
  * Description:

--- a/libs/libc/modlib/gnu-elf.ld
+++ b/libs/libc/modlib/gnu-elf.ld
@@ -33,6 +33,16 @@ SECTIONS
       _etext = . ;
     }
 
+  .init_array :
+    {
+      *(.init_array)
+    }
+
+  .fini_array :
+    {
+      *(.fini_array)
+    }
+
   .rodata :
     {
       _srodata = . ;

--- a/sched/module/mod_procfs.c
+++ b/sched/module/mod_procfs.c
@@ -137,8 +137,8 @@ static int modprocfs_callback(FAR struct module_s *modp, FAR void *arg)
   priv = (FAR struct modprocfs_file_s *)arg;
 
   linesize = snprintf(priv->line, MOD_LINELEN,
-                      "%s,%p,%p,%p,%u,%p,%lu,%p,%lu\n",
-                      modp->modname, modp->initializer,
+                      "%s,%p,%p,%u,%p,%lu,%p,%lu\n",
+                      modp->modname,
                       modp->modinfo.uninitializer, modp->modinfo.arg,
                       modp->modinfo.nexports,
                       modp->textalloc,


### PR DESCRIPTION
## Summary
The loading method of modlib has been optimized to allow dynamic modules to be loaded using __attribute__((destructor)), eliminating the need for module_initialize.

    1. use '__attribute__((constructor))' mark initialize function
    2. use '__attribute__((destructor))' mark uninitialize function
    3. compile module with -fvisibility=hidden. use `__attribute__((visibility("default")))`
    mark is need export symbol.so not need module_initialize to initialize export symbol.

## Impact
modlib
## Testing

qemu with mps3 an547