### PR TITLE
fs_lock: fix cmake build error

### DIFF
--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -51,6 +51,8 @@ set(SRCS
 # File lock support
 
 if(NOT "${CONFIG_FS_LOCK_BUCKET_SIZE}" STREQUAL "0")
+  set_source_files_properties(fs_lock.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
+                              PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/sched)
   list(APPEND SRCS fs_lock.c)
 endif()
 


### PR DESCRIPTION
## Summary
nuttx/fs/vfs/fs_lock.c:39:10: fatal error: sched/sched.h: No such file or directory
   39 | #include "sched/sched.h"
      |          ^~~~~~~~~~~~~~~

## Impact

## Testing
cmake sim:local
