### PR TITLE
fs_lock:Check the nwaiter when deleting a bucket

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -237,7 +237,7 @@ static void file_lock_delete_bucket(FAR struct file_lock_bucket_s *bucket,
    * released
    */
 
-  if (list_is_empty(&bucket->list))
+  if (list_is_empty(&bucket->list) && bucket->nwaiter == 0)
     {
       /* At this point, the file has no lock information context, so we can
        * remove it from the hash table, and the return result is 0 or 1 means


### PR DESCRIPTION
## Summary

Fixed the problem of releasing the bucket prematurely in multi-threaded flock scenarios by https://github.com/apache/nuttx/issues/13821

**How to reproduce the problem**
A thread setlk
B thread setlk_wait
A thread releases lock but fails to determine if nwaiter causes the bucket to be released prematurely post B thread causes crash due to heap use after free

## Impact
**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh

We can through the two process USES case to verify the problem as follows
```
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <fcntl.h>
#include <sys/file.h>

#define FILENAME "/data/lockfile.txt"

int main() {
    int fd;

    fd = open(FILENAME, O_CREAT | O_RDWR, 0666);
    if (fd == -1) {
        perror("Failed to open file");
        exit(EXIT_FAILURE);
    }

    printf("Main thread: Trying to acquire write lock...\n");
    if (flock(fd, LOCK_EX) == -1) {
        perror("Failed to acquire write lock");
        close(fd);
        exit(EXIT_FAILURE);
    }
    printf("Main thread: Acquired write lock, holding for 5 seconds...\n");
    sleep(5);

    printf("Main thread: Releasing write lock...\n");
    if (flock(fd, LOCK_UN) == -1) {
        perror("Failed to release write lock");
        close(fd);
        exit(EXIT_FAILURE);
    }

    close(fd);
    printf("All locks released and file closed.\n");

    return 0;
}
```
