### PR TITLE
smartfs: return -ENOTTY if ioctl command is not found

### DIFF
--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -1035,7 +1035,7 @@ static int smartfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
       default:
-        ret = -ENOSYS;
+        ret = -ENOTTY;
         break;
     }
 


### PR DESCRIPTION
## Summary
The upper layer expects -ENOTTY is returned if ioctl command is not found in file system specific implementation.

## Impact
Ioctl calls not implemented in SmartFS layer works now.

## Testing
Tested on SAMv7 EVK board.

