### PR TITLE
arch/arm/nrf{52|53|91}: fix read GPIO state for outputs

### DIFF
--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -409,7 +409,14 @@ bool nrf52_gpio_read(nrf52_pinset_t pinset)
 
   /* Get register address */
 
-  offset = nrf52_gpio_regget(port, NRF52_GPIO_IN_OFFSET);
+  if ((pinset & GPIO_FUNC_MASK) == GPIO_OUTPUT)
+    {
+      offset = nrf52_gpio_regget(port, NRF52_GPIO_OUTSET_OFFSET);
+    }
+  else
+    {
+      offset = nrf52_gpio_regget(port, NRF52_GPIO_IN_OFFSET);
+    }
 
   /* Get register value */
 

--- a/arch/arm/src/nrf53/nrf53_gpio.c
+++ b/arch/arm/src/nrf53/nrf53_gpio.c
@@ -468,7 +468,14 @@ bool nrf53_gpio_read(nrf53_pinset_t pinset)
 
   /* Get register address */
 
-  offset = nrf53_gpio_regget(port, NRF53_GPIO_IN_OFFSET);
+  if ((pinset & GPIO_FUNC_MASK) == GPIO_OUTPUT)
+    {
+      offset = nrf53_gpio_regget(port, NRF53_GPIO_OUTSET_OFFSET);
+    }
+  else
+    {
+      offset = nrf53_gpio_regget(port, NRF53_GPIO_IN_OFFSET);
+    }
 
   /* Get register value */
 

--- a/arch/arm/src/nrf91/nrf91_gpio.c
+++ b/arch/arm/src/nrf91/nrf91_gpio.c
@@ -401,7 +401,14 @@ bool nrf91_gpio_read(nrf91_pinset_t pinset)
 
   /* Get register address */
 
-  offset = nrf91_gpio_regget(port, NRF91_GPIO_IN_OFFSET);
+  if ((pinset & GPIO_FUNC_MASK) == GPIO_OUTPUT)
+    {
+      offset = nrf91_gpio_regget(port, NRF91_GPIO_OUTSET_OFFSET);
+    }
+  else
+    {
+      offset = nrf91_gpio_regget(port, NRF91_GPIO_IN_OFFSET);
+    }
 
   /* Get register value */
 


### PR DESCRIPTION
## Summary
- arch/arm/nrf{52|53|91}: fix read GPIO state for outputs
when GPIO is configured as output, we have to read output state register instead of input register

## Impact
read GPIO state for outputs works correctly

## Testing
tested on nrf52840 but should work the same for all Nordic chips
