### PR TITLE
drivers/serial/CMakeLists.txt: add missing files

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -69,4 +69,16 @@ if(CONFIG_16550_PCI_UART)
   list(APPEND SRCS uart_pci_16550.c)
 endif()
 
+# Bluetooth H:5 UART driver
+
+if(CONFIG_UART_BTH5)
+  list(APPEND SRCS uart_bth5.c)
+endif()
+
+# RAM uart support
+
+if(CONFIG_RAM_UART)
+  list(APPEND SRCS uart_ram.c)
+endif()
+
 target_sources(drivers PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

- drivers/serial/CMakeLists.txt: add missing files
add missing files: uart_bth5.c and uart_ram.c

## Impact
missing files for cmake build

## Testing
CI
