### PR TITLE
VirtIO/Vhost Drivers: bug fix and new feature support

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -95,6 +95,15 @@ config DRIVERS_VIRTIO_SERIAL_CONSOLE
 	---help---
 		This enables using first virtio serial device as console.
 
+config DRIVERS_VIRTIO_SERIAL_NAME
+	string "Virtio serial driver name"
+	default ""
+	---help---
+		Using this config to custom the virtio serial registered device name,
+		using ";" to split the names.
+		For example, if DRIVERS_VIRTIO_SERIAL_NAME = "ttyBT;ttyTEL" and pass
+		three virtio-serial devices to the qemu, we will get three uart devices
+		with names: "/dev/ttyBT", "/dev/ttyTEL", "/dev/ttyV2"
 endif
 
 config DRIVERS_VIRTIO_SOUND

--- a/drivers/virtio/virtio-blk.c
+++ b/drivers/virtio/virtio-blk.c
@@ -43,6 +43,7 @@
 
 /* Block feature bits */
 
+#define VIRTIO_BLK_F_RO             5  /* Disk is read-only */
 #define VIRTIO_BLK_F_FLUSH          9  /* Cache flush command support */
 
 /* Block request type */
@@ -360,6 +361,11 @@ static ssize_t virtio_blk_write(FAR struct inode *inode,
 
   DEBUGASSERT(inode->i_private);
   priv = inode->i_private;
+  if (virtio_has_feature(priv->vdev, VIRTIO_BLK_F_RO))
+    {
+      return -EPERM;
+    }
+
   return virtio_blk_rdwr(priv, (FAR void *)buffer, startsector, nsectors,
                          true);
 }
@@ -521,7 +527,8 @@ static int virtio_blk_init(FAR struct virtio_blk_priv_s *priv,
   /* Initialize the virtio device */
 
   virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_DRIVER);
-  virtio_negotiate_features(vdev, 1UL << VIRTIO_BLK_F_FLUSH);
+  virtio_negotiate_features(vdev, (1UL << VIRTIO_BLK_F_RO) |
+                                  (1UL << VIRTIO_BLK_F_FLUSH));
   virtio_set_status(vdev, VIRTIO_CONFIG_FEATURES_OK);
 
   vqname[0]   = "virtio_blk_vq";

--- a/drivers/virtio/virtio-blk.c
+++ b/drivers/virtio/virtio-blk.c
@@ -41,6 +41,10 @@
 #define VIRTIO_BLK_REQ_HEADER_SIZE  sizeof(struct virtio_blk_req_s)
 #define VIRTIO_BLK_RESP_HEADER_SIZE sizeof(struct virtio_blk_resp_s)
 
+/* Block feature bits */
+
+#define VIRTIO_BLK_F_FLUSH          9  /* Cache flush command support */
+
 /* Block request type */
 
 #define VIRTIO_BLK_T_IN             0  /* READ */
@@ -458,7 +462,10 @@ static int virtio_blk_ioctl(FAR struct inode *inode, int cmd,
   switch (cmd)
     {
       case BIOC_FLUSH:
-        ret = virtio_blk_flush(priv);
+        if (virtio_has_feature(priv->vdev, VIRTIO_BLK_F_FLUSH))
+          {
+            ret = virtio_blk_flush(priv);
+          }
         break;
     }
 
@@ -514,7 +521,7 @@ static int virtio_blk_init(FAR struct virtio_blk_priv_s *priv,
   /* Initialize the virtio device */
 
   virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_DRIVER);
-  virtio_set_features(vdev, 0);
+  virtio_negotiate_features(vdev, 1UL << VIRTIO_BLK_F_FLUSH);
   virtio_set_status(vdev, VIRTIO_CONFIG_FEATURES_OK);
 
   vqname[0]   = "virtio_blk_vq";

--- a/drivers/virtio/virtio-gpu.c
+++ b/drivers/virtio/virtio-gpu.c
@@ -63,6 +63,7 @@ struct virtio_gpu_priv_s
   fb_coord_t yres;                  /* Vertical resolution in pixel rows */
   fb_coord_t stride;                /* Width of a row in bytes */
   uint8_t display;                  /* Display number */
+  spinlock_t lock;                  /* Lock */
 };
 
 struct virtio_gpu_cookie_s
@@ -141,6 +142,8 @@ static int virtio_gpu_send_cmd(FAR struct virtqueue *vq,
                                FAR struct virtqueue_buf *buf_list,
                                int readable, int writable, FAR void *buf)
 {
+  FAR struct virtio_gpu_priv_s *priv = vq->vq_dev->priv;
+  irqstate_t flags;
   int ret;
 
   if (writable > 0)
@@ -152,11 +155,17 @@ static int virtio_gpu_send_cmd(FAR struct virtqueue *vq,
       nxsem_init(&sem, 0, 0);
       cookie.blocking = true;
       cookie.p = &sem;
+      flags = spin_lock_irqsave(&priv->lock);
       ret = virtqueue_add_buffer(vq, buf_list, readable, writable, &cookie);
       if (ret >= 0)
         {
           virtqueue_kick(vq);
+          spin_unlock_irqrestore(&priv->lock, flags);
           nxsem_wait(&sem);
+        }
+      else
+        {
+          spin_unlock_irqrestore(&priv->lock, flags);
         }
 
       nxsem_destroy(&sem);
@@ -175,14 +184,17 @@ static int virtio_gpu_send_cmd(FAR struct virtqueue *vq,
         {
           cookie->blocking = false;
           cookie->p = buf;
+          flags = spin_lock_irqsave(&priv->lock);
           ret = virtqueue_add_buffer(vq, buf_list, readable, writable,
                                      cookie);
           if (ret >= 0)
             {
               virtqueue_kick(vq);
+              spin_unlock_irqrestore(&priv->lock, flags);
             }
           else
             {
+              spin_unlock_irqrestore(&priv->lock, flags);
               kmm_free(cookie);
             }
         }
@@ -202,9 +214,11 @@ static int virtio_gpu_send_cmd(FAR struct virtqueue *vq,
 
 static void virtio_gpu_done(FAR struct virtqueue *vq)
 {
+  FAR struct virtio_gpu_priv_s *priv = vq->vq_dev->priv;
   FAR struct virtio_gpu_cookie_s *cookie;
 
-  while ((cookie = virtqueue_get_buffer(vq, NULL, NULL)) != NULL)
+  while ((cookie =
+          virtqueue_get_buffer_lock(vq, NULL, NULL, &priv->lock)) != NULL)
     {
       if (cookie->blocking)
         {
@@ -229,6 +243,7 @@ static int virtio_gpu_init(FAR struct virtio_gpu_priv_s *priv,
   vq_callback callbacks[VIRTIO_GPU_NUM];
   int ret;
 
+  spin_lock_init(&priv->lock);
   priv->vdev = vdev;
   vdev->priv = priv;
 

--- a/drivers/virtio/virtio-input.c
+++ b/drivers/virtio/virtio-input.c
@@ -62,6 +62,7 @@ struct virtio_input_priv
   struct virtio_input_event     evt[VIRTIO_INPUT_EVT_NUM];
   size_t                        evtnum;         /* Input event number */
   struct work_s                 work;           /* Supports the interrupt handling "bottom half" */
+  spinlock_t                    lock;           /* Lock */
   virtio_send_event_handler     eventhandler;
 
   union
@@ -253,7 +254,7 @@ static void virtio_input_worker(FAR void *arg)
   uint32_t len;
 
   while ((evt = (FAR struct virtio_input_event *)
-         virtqueue_get_buffer(vq, &len, NULL)) != NULL)
+         virtqueue_get_buffer_lock(vq, &len, NULL, &priv->lock)) != NULL)
     {
       vrtinfo("virtio_input_worker (type,code,value)-(%d,%d,%" PRIu32 ").\n",
               evt->type, evt->code, evt->value);
@@ -262,10 +263,10 @@ static void virtio_input_worker(FAR void *arg)
 
       vb.buf = evt;
       vb.len = len;
-      virtqueue_add_buffer(vq, &vb, 0, 1, vb.buf);
+      virtqueue_add_buffer_lock(vq, &vb, 0, 1, vb.buf, &priv->lock);
     }
 
-  virtqueue_kick(vq);
+  virtqueue_kick_lock(vq, &priv->lock);
 }
 
 /****************************************************************************
@@ -300,10 +301,10 @@ static void virtio_input_fill_event(FAR struct virtio_input_priv *priv)
     {
       vb.buf = &priv->evt[i];
       vb.len = sizeof(struct virtio_input_event);
-      virtqueue_add_buffer(vq, &vb, 0, 1, vb.buf);
+      virtqueue_add_buffer_lock(vq, &vb, 0, 1, vb.buf, &priv->lock);
     }
 
-    virtqueue_kick(vq);
+  virtqueue_kick_lock(vq, &priv->lock);
 }
 
 /****************************************************************************
@@ -377,6 +378,7 @@ static int virtio_input_probe(FAR struct virtio_device *vdev)
       return -ENOMEM;
     }
 
+  spin_lock_init(&priv->lock);
   priv->vdev = vdev;
   vdev->priv = priv;
 

--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -806,18 +806,14 @@ static int virtio_mmio_init_device(FAR struct virtio_mmio_device_s *vmdev,
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: virtio_register_mmio_device
+ * Name: virtio_register_mmio_device_
  *
  * Description:
- *   Register virtio mmio device to the virtio bus
+ *   Register secure or non-secure virtio mmio device to the virtio bus
  *
  ****************************************************************************/
 
-int virtio_register_mmio_device(FAR void *regs, int irq)
+static int virtio_register_mmio_device_(FAR void *regs, int irq, bool secure)
 {
   FAR struct virtio_mmio_device_s *vmdev;
   int ret;
@@ -842,6 +838,15 @@ int virtio_register_mmio_device(FAR void *regs, int irq)
       vrterr("virtio_mmio_device_init failed, ret=%d\n", ret);
       goto err;
     }
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+  if (secure)
+    {
+      up_secure_irq(irq, true);
+    }
+#else
+  UNUSED(secure);
+#endif
 
   /* Attach the intterupt before register the device driver */
 
@@ -868,3 +873,35 @@ err:
   kmm_free(vmdev);
   return ret;
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: virtio_register_mmio_device
+ *
+ * Description:
+ *   Register virtio mmio device to the virtio bus
+ *
+ ****************************************************************************/
+
+int virtio_register_mmio_device(FAR void *regs, int irq)
+{
+  return virtio_register_mmio_device_(regs, irq, false);
+}
+
+/****************************************************************************
+ * Name: virtio_register_mmio_device_secure
+ *
+ * Description:
+ *   Register secure virtio mmio device to the virtio bus
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+int virtio_register_mmio_device_secure(FAR void *regs, int irq)
+{
+  return virtio_register_mmio_device_(regs, irq, true);
+}
+#endif

--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -579,10 +579,10 @@ static int virtio_net_init(FAR struct virtio_net_priv_s *priv,
 
   priv->bufnum = CONFIG_IOB_NBUFFERS / VIRTIO_NET_MAX_NIOB / 4;
 #endif
-  priv->bufnum = MIN(vdev->vrings_info[VIRTIO_NET_RX].info.num_descs,
-                     priv->bufnum);
-  priv->bufnum = MIN(vdev->vrings_info[VIRTIO_NET_TX].info.num_descs,
-                     priv->bufnum);
+  priv->bufnum = MIN(vdev->vrings_info[VIRTIO_NET_RX].info.num_descs /
+                     (VIRTIO_NET_MAX_NIOB + 1), priv->bufnum);
+  priv->bufnum = MIN(vdev->vrings_info[VIRTIO_NET_TX].info.num_descs /
+                     (VIRTIO_NET_MAX_NIOB + 1), priv->bufnum);
   return OK;
 }
 

--- a/drivers/virtio/virtio-rng.c
+++ b/drivers/virtio/virtio-rng.c
@@ -110,18 +110,15 @@ static void virtio_rng_done(FAR struct virtqueue *vq)
 {
   FAR struct virtio_rng_priv_s *priv = vq->vq_dev->priv;
   FAR struct virtio_rng_cookie_s *cookie;
-  irqstate_t flags;
   uint32_t len;
 
-  /* Get the buffer, virtqueue_get_buffer() return the cookie added in
+  /* Get the buffer, virtqueue_get_buffer_lock() return the cookie added in
    * virtio_rng_read().
    */
 
   for (; ; )
     {
-      flags = spin_lock_irqsave(&priv->lock);
-      cookie = virtqueue_get_buffer(vq, &len, NULL);
-      spin_unlock_irqrestore(&priv->lock, flags);
+      cookie = virtqueue_get_buffer_lock(vq, &len, NULL, &priv->lock);
       if (cookie == NULL)
         {
           break;

--- a/drivers/virtio/virtio-rng.c
+++ b/drivers/virtio/virtio-rng.c
@@ -28,6 +28,7 @@
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/virtio/virtio.h>
 
 #include "virtio-rng.h"
@@ -50,6 +51,7 @@ struct virtio_rng_priv_s
 {
   FAR struct virtio_device *vdev;
   char                      name[NAME_MAX];
+  spinlock_t                lock;
 };
 
 /****************************************************************************
@@ -106,16 +108,25 @@ static int g_virtio_rng_idx = 0;
 
 static void virtio_rng_done(FAR struct virtqueue *vq)
 {
+  FAR struct virtio_rng_priv_s *priv = vq->vq_dev->priv;
   FAR struct virtio_rng_cookie_s *cookie;
+  irqstate_t flags;
   uint32_t len;
 
   /* Get the buffer, virtqueue_get_buffer() return the cookie added in
    * virtio_rng_read().
    */
 
-  cookie = virtqueue_get_buffer(vq, &len, NULL);
-  if (cookie != NULL)
+  for (; ; )
     {
+      flags = spin_lock_irqsave(&priv->lock);
+      cookie = virtqueue_get_buffer(vq, &len, NULL);
+      spin_unlock_irqrestore(&priv->lock, flags);
+      if (cookie == NULL)
+        {
+          break;
+        }
+
       /* Assign the return length */
 
       cookie->len = len;
@@ -137,6 +148,7 @@ static ssize_t virtio_rng_read(FAR struct file *filep, FAR char *buffer,
   FAR struct virtqueue *vq = priv->vdev->vrings_info[0].vq;
   struct virtio_rng_cookie_s cookie;
   struct virtqueue_buf vb;
+  irqstate_t flags;
   int ret;
 
   /* Init the cookie */
@@ -155,15 +167,18 @@ static ssize_t virtio_rng_read(FAR struct file *filep, FAR char *buffer,
       return -ENOMEM;
     }
 
+  flags = spin_lock_irqsave(&priv->lock);
   ret = virtqueue_add_buffer(vq, &vb, 0, 1, &cookie);
   if (ret < 0)
     {
+      spin_unlock_irqrestore(&priv->lock, flags);
       return ret;
     }
 
   /* Notify the other side to process the added virtqueue buffer */
 
   virtqueue_kick(vq);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   /* Wait fot completion */
 
@@ -191,6 +206,7 @@ static int virtio_rng_probe(FAR struct virtio_device *vdev)
       return -ENOMEM;
     }
 
+  spin_lock_init(&priv->lock);
   priv->vdev = vdev;
   vdev->priv = priv;
 

--- a/drivers/virtio/virtio-rpmb.c
+++ b/drivers/virtio/virtio-rpmb.c
@@ -105,14 +105,11 @@ static void virtio_rpmb_done(FAR struct virtqueue *vq)
 {
   FAR struct virtio_rpmb_priv_s *priv = vq->vq_dev->priv;
   FAR struct virtio_rpmb_cookie_s *cookie;
-  irqstate_t flags;
   uint32_t len;
 
   for (; ; )
     {
-      flags = spin_lock_irqsave(&priv->lock);
-      cookie = virtqueue_get_buffer(vq, &len, NULL);
-      spin_unlock_irqrestore(&priv->lock, flags);
+      cookie = virtqueue_get_buffer_lock(vq, &len, NULL, &priv->lock);
       if (cookie == NULL)
         {
           break;

--- a/drivers/virtio/virtio-serial.c
+++ b/drivers/virtio/virtio-serial.c
@@ -419,14 +419,11 @@ static void virtio_serial_rxready(FAR struct virtqueue *vq)
 {
   FAR struct virtio_serial_priv_s *priv = vq->vq_dev->priv;
   FAR struct uart_dmaxfer_s *xfer;
-  irqstate_t flags;
   uint32_t len;
 
   /* Received some data, call uart_recvchars_done() */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  xfer = virtqueue_get_buffer(vq, &len, NULL);
-  spin_unlock_irqrestore(&priv->lock, flags);
+  xfer = virtqueue_get_buffer_lock(vq, &len, NULL, &priv->lock);
   if (xfer == NULL)
     {
       return;
@@ -448,14 +445,11 @@ static void virtio_serial_rxready(FAR struct virtqueue *vq)
 static void virtio_serial_txdone(FAR struct virtqueue *vq)
 {
   FAR struct virtio_serial_priv_s *priv = vq->vq_dev->priv;
-  irqstate_t flags;
   uintptr_t len;
 
   /* Call uart_xmitchars_done to notify the upperhalf */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  len = (uintptr_t)virtqueue_get_buffer(vq, NULL, NULL);
-  spin_unlock_irqrestore(&priv->lock, flags);
+  len = (uintptr_t)virtqueue_get_buffer_lock(vq, NULL, NULL, &priv->lock);
 
   priv->udev.dmatx.nbytes = len;
   uart_xmitchars_done(&priv->udev);

--- a/drivers/virtio/virtio-serial.c
+++ b/drivers/virtio/virtio-serial.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 
 #include <nuttx/serial/serial.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/virtio/virtio.h>
 
 #include "virtio-serial.h"
@@ -55,6 +56,7 @@ struct virtio_serial_priv_s
 
   FAR struct uart_dev_s     udev;
   char                      name[NAME_MAX];
+  spinlock_t                lock;
 };
 
 /****************************************************************************
@@ -322,6 +324,7 @@ static void virtio_serial_dmasend(FAR struct uart_dev_s *dev)
   FAR struct virtqueue *vq = priv->vdev->vrings_info[VIRTIO_SERIAL_TX].vq;
   FAR struct uart_dmaxfer_s *xfer = &dev->dmatx;
   struct virtqueue_buf vb[2];
+  irqstate_t flags;
   uintptr_t len;
   int num = 1;
 
@@ -343,8 +346,10 @@ static void virtio_serial_dmasend(FAR struct uart_dev_s *dev)
 
   /* Add buffer to TX virtiqueue and notify the other size */
 
+  flags = spin_lock_irqsave(&priv->lock);
   virtqueue_add_buffer(vq, vb, num, 0, (FAR void *)len);
   virtqueue_kick(vq);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -369,6 +374,7 @@ static void virtio_serial_dmareceive(FAR struct uart_dev_s *dev)
   FAR struct virtqueue *vq = priv->vdev->vrings_info[VIRTIO_SERIAL_RX].vq;
   FAR struct uart_dmaxfer_s *xfer = &dev->dmarx;
   struct virtqueue_buf vb[2];
+  irqstate_t flags;
   int num = 1;
 
   vb[0].buf = xfer->buffer;
@@ -383,8 +389,10 @@ static void virtio_serial_dmareceive(FAR struct uart_dev_s *dev)
 
   /* Add buffer to the RX virtqueue and notify the device side */
 
+  flags = spin_lock_irqsave(&priv->lock);
   virtqueue_add_buffer(vq, vb, 0, num, xfer);
   virtqueue_kick(vq);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -411,11 +419,14 @@ static void virtio_serial_rxready(FAR struct virtqueue *vq)
 {
   FAR struct virtio_serial_priv_s *priv = vq->vq_dev->priv;
   FAR struct uart_dmaxfer_s *xfer;
+  irqstate_t flags;
   uint32_t len;
 
   /* Received some data, call uart_recvchars_done() */
 
+  flags = spin_lock_irqsave(&priv->lock);
   xfer = virtqueue_get_buffer(vq, &len, NULL);
+  spin_unlock_irqrestore(&priv->lock, flags);
   if (xfer == NULL)
     {
       return;
@@ -437,11 +448,15 @@ static void virtio_serial_rxready(FAR struct virtqueue *vq)
 static void virtio_serial_txdone(FAR struct virtqueue *vq)
 {
   FAR struct virtio_serial_priv_s *priv = vq->vq_dev->priv;
+  irqstate_t flags;
   uintptr_t len;
 
   /* Call uart_xmitchars_done to notify the upperhalf */
 
+  flags = spin_lock_irqsave(&priv->lock);
   len = (uintptr_t)virtqueue_get_buffer(vq, NULL, NULL);
+  spin_unlock_irqrestore(&priv->lock, flags);
+
   priv->udev.dmatx.nbytes = len;
   uart_xmitchars_done(&priv->udev);
   uart_dmatxavail(&priv->udev);
@@ -461,6 +476,7 @@ static int virtio_serial_init(FAR struct virtio_serial_priv_s *priv,
 
   priv->vdev = vdev;
   vdev->priv = priv;
+  spin_lock_init(&priv->lock);
 
   /* Uart device buffer and ops init */
 

--- a/drivers/virtio/virtio-serial.c
+++ b/drivers/virtio/virtio-serial.c
@@ -528,6 +528,61 @@ static void virtio_serial_uninit(FAR struct virtio_serial_priv_s *priv)
 }
 
 /****************************************************************************
+ * Name: virtio_serial_uart_register
+ ****************************************************************************/
+
+static int virtio_serial_uart_register(FAR struct virtio_serial_priv_s *priv)
+{
+  FAR const char *name = CONFIG_DRIVERS_VIRTIO_SERIAL_NAME;
+  bool found = false;
+  int start = 0;
+  int ret;
+  int i;
+  int j;
+
+  for (i = 0, j = 0; name[start] != '\0'; i++)
+    {
+      if (name[i] == ';' || name[i] == '\0')
+        {
+          if (j++ == g_virtio_serial_idx)
+            {
+              found = true;
+              break;
+            }
+
+          start = i + 1;
+        }
+    }
+
+  if (found)
+    {
+      snprintf(priv->name, NAME_MAX, "/dev/%.*s", i - start, &name[start]);
+    }
+  else
+    {
+      snprintf(priv->name, NAME_MAX, "/dev/ttyV%d", g_virtio_serial_idx);
+    }
+
+  ret = uart_register(priv->name, &priv->udev);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+#ifdef CONFIG_DRIVERS_VIRTIO_SERIAL_CONSOLE
+  if (g_virtio_console == NULL)
+    {
+      DEBUGVERIFY(uart_register("/dev/console", &priv->udev));
+      g_virtio_console = &priv->udev;
+      g_virtio_console->isconsole = true;
+    }
+#endif
+
+  g_virtio_serial_idx++;
+  return ret;
+}
+
+/****************************************************************************
  * Name: virtio_serial_probe
  ****************************************************************************/
 
@@ -554,25 +609,13 @@ static int virtio_serial_probe(FAR struct virtio_device *vdev)
 
   /* Uart driver register */
 
-  snprintf(priv->name, NAME_MAX, "/dev/ttyV%d", g_virtio_serial_idx);
-  ret = uart_register(priv->name, &priv->udev);
+  ret = virtio_serial_uart_register(priv);
   if (ret < 0)
     {
       vrterr("uart_register failed, ret=%d\n", ret);
       goto err_with_init;
     }
 
-#ifdef CONFIG_DRIVERS_VIRTIO_SERIAL_CONSOLE
-  if (g_virtio_console == NULL)
-    {
-      DEBUGVERIFY(uart_register("/dev/console", &priv->udev));
-      g_virtio_console = &priv->udev;
-      g_virtio_console->isconsole = true;
-    }
-
-#endif
-
-  g_virtio_serial_idx++;
   return ret;
 
 err_with_init:

--- a/include/nuttx/virtio/virtio-mmio.h
+++ b/include/nuttx/virtio/virtio-mmio.h
@@ -61,6 +61,18 @@ extern "C"
 
 int virtio_register_mmio_device(FAR void *regs, int irq);
 
+/****************************************************************************
+ * Name: virtio_register_mmio_device_secure
+ *
+ * Description:
+ *   Register secure virtio mmio device to the virtio bus
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+int virtio_register_mmio_device_secure(FAR void *regs, int irq);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
1.    virtio devices: update virtqueue operate buffer add lock API
    
    1. Use the virtqueue_xxx_lock() api;
    2. Add spinlock for some virtio and vhost drivers that do not
       use spinlock to protect the virtqueues;

2.    virtio/virtio-net: add spinlock for the virtqueue
    
    virtqueues are used in irq and thread, so add spinlock to protect
    them.

3.    virtio/virtio-net: calculate the correct buffer number
    
    Avoid exceed the virtqueue length limit when adding buffer to the
    virtqueue.

4.    virtio-rpmb.c: add spin lock for virtqueue add/get buffer
    
    Virtqueeus are used in both user thread and interrupt, so add spinlock
    to proetect them.

5.    virtio-serial.c: add spin lock for virtqueue add/get buffer
    
    Virtqueeus are used in both user thread and interrupt, so add spinlock
    to proetect them.

6.    virtio-blk.c: add spin lock to fix get/add virtqueue buffer at the same time err
    
    Virtqueues are used in both user thread and interrupt, so add spinlock to protect
    them.

7.    virtio-blk.c: change virtio blk req and resp to local variables
    
    So we can remove the mutex lock to improve the virtio-block driver
    performance

8.    virtio-rng.c: add spin lock to fix get/add virtqueue buffer at the same time err
    
    the virtqueue should be protected by the spinlock, because the virtqueues are used
    both in worker and interrupt.

9.    virtio-blk: add VIRTIO_BLK_F_BLK_SIZE feature
    
    Support configure the virtio block device block size to other value
    (default value is 512)
    
10.    virtio-blk: add VIRTIO_BLK_F_RO feature
    
    When feature VIRTIO_BLK_F_RO is set, virtio-blk only support read
    operation.

11.    virtio-blk: add VIRTIO_BLK_F_FLUSH features
    
    Should support the flush command only when virtio device support
    feature VIRTIO_BLK_F_FLUSH

12.    virtio/virtio-rng: make virtio-rng work for remoteproc transport layer
    
    For remoteproc transport layer, the virtio drivers can not use the malloced
    memory from the default system heap to communicate with the virtio devices,
    the buffers placed in virtqueue should be in the share memory region
    (mallcoed virtio_alloc_buf()).

13.    virtio-serial: support custom the virtio serial device name
    
    By setting config CONFIG_DRIVERS_VIRTIO_SERIAL_NAME to "ttyXX0;ttyXX1;..."
    to customize the virtio serial name.
    
    For example:
    If CONFIG_DRIVERS_VIRTIO_SERIAL_NAME="ttyBT;ttyTest0;ttyTest1",
    virtio-serial will register three uart devices with names:
    "/dev/ttyBT", "/dev/ttyTest0", "/dev/ttyTest1" to the VFS.
    
    nsh> ls dev
    /dev:
     console
     null
     telnet
     ttyBT
     ttyS0
     ttyTest0
     ttyTest1
     zero

14.    virtio-mmio: add secure virtio mmio device register api
    
    In secure state, call virtio_register_mmio_device_secure() to
    register the secure virtio mmio device;
    In non-secure state, call virtio_register_mmio_device() to
    register the non-secure virtio mmio device;
    Board should ensure not mixed use the secure and non-seucre mmio
    device.

5.    audio:add getlatency for virtio snd driver
    
    add getlatency in virtio snd driver

## Impact
All the virtio and vhost drivers

## Testing
qemu armv7a and armv8a

