### PR TITLE
Minor fix for virtio/vhost/rpmsg subsystem

### DIFF
--- a/drivers/pci/pci_ivshmem.c
+++ b/drivers/pci/pci_ivshmem.c
@@ -187,8 +187,11 @@ static int ivshmem_unregister_device(FAR struct ivshmem_device_s *dev)
    * the device unmatched
    */
 
-  dev->drv->remove(dev);
-  dev->drv = NULL;
+  if (dev->drv)
+    {
+      dev->drv->remove(dev);
+    }
+
   return ret;
 }
 

--- a/drivers/pci/pci_uio_ivshmem.c
+++ b/drivers/pci/pci_uio_ivshmem.c
@@ -483,13 +483,8 @@ static int uio_ivshmem_probe(FAR struct ivshmem_device_s *dev)
   if (ret < 0)
     {
       pcierr("ERROR: Ivshmem register_driver failed, ret=%d\n", ret);
-      goto err;
     }
 
-  return ret;
-
-err:
-  ivshmem_unregister_driver(&udev->drv);
   return ret;
 }
 
@@ -503,7 +498,6 @@ static void uio_ivshmem_remove(FAR struct ivshmem_device_s *dev)
 
   unregister_driver(udev->name);
   ivshmem_detach_irq(dev);
-  kmm_free(udev);
 }
 
 /****************************************************************************

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -289,7 +289,7 @@ static int rpmsg_virtio_ivshmem_probe(FAR struct ivshmem_device_s *ivdev)
   ret = rpmsg_virtio_initialize(&priv->dev);
   if (ret < 0)
     {
-      pcierr("Rpmsg virtio intialize failed, ret=%d\n", ret);
+      rpmsgerr("Rpmsg virtio intialize failed, ret=%d\n", ret);
       goto err;
     }
 
@@ -299,14 +299,14 @@ static int rpmsg_virtio_ivshmem_probe(FAR struct ivshmem_device_s *ivdev)
                      rpmsg_virtio_ivshmem_wdog, (wdparm_t)priv);
       if (ret < 0)
         {
-          pcierr("ERROR: wd_start failed: %d\n", ret);
+          rpmsgerr("ERROR: wd_start failed: %d\n", ret);
+          goto err;
         }
     }
 
   return ret;
 
 err:
-  ivshmem_unregister_driver(&priv->drv);
   ivshmem_control_irq(ivdev, false);
   ivshmem_detach_irq(ivdev);
   return ret;
@@ -328,7 +328,6 @@ static void rpmsg_virtio_ivshmem_remove(FAR struct ivshmem_device_s *ivdev)
 
   ivshmem_control_irq(ivdev, false);
   ivshmem_detach_irq(ivdev);
-  kmm_free(priv);
 }
 
 /****************************************************************************

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -181,7 +181,7 @@ int vhost_register_driver(FAR struct vhost_driver *driver)
   list_for_every_entry(&g_vhost_bus.device, item, struct vhost_device_item_s,
                        node)
     {
-      if (driver->device == item->device->id.device)
+      if (item->driver == NULL && driver->device == item->device->id.device)
         {
           /* If found the device in the device list, call driver probe,
            * if probe success, assign item->driver to indicate the device

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -371,13 +371,20 @@ out:
 
 void vhost_register_drivers(void)
 {
+  struct metal_init_params params = METAL_INIT_DEFAULTS;
   int ret;
+
+  ret = metal_init(&params);
+  if (ret < 0)
+    {
+      vhosterr("metal_init failed, ret=%d\n", ret);
+    }
 
 #ifdef CONFIG_DRIVERS_VHOST_RNG
   ret = vhost_register_rng_driver();
   if (ret < 0)
     {
-      vrterr("vhost_register_rng_driver failed, ret=%d\n", ret);
+      vhosterr("vhost_register_rng_driver failed, ret=%d\n", ret);
     }
 #endif
 

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -151,25 +151,6 @@ static void vhost_defered_probe_work(FAR void *arg)
 }
 
 /****************************************************************************
- * Name: vhost_remove_device
- ****************************************************************************/
-
-static void vhost_remove_device(FAR struct vhost_device_item_s *item)
-{
-  /* Call driver remove and mark item->driver NULL to indicate
-   * the device unmatched.
-   */
-
-  item->driver->remove(item->device);
-  item->driver = NULL;
-
-  /* Remove the device from the device list and free memory */
-
-  list_delete(&item->node);
-  kmm_free(item);
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -352,7 +333,17 @@ int vhost_unregister_device(FAR struct vhost_device *device)
     {
       if (item->device == device)
         {
-          vhost_remove_device(item);
+          /* Call driver remove */
+
+          if (item->driver)
+            {
+              item->driver->remove(item->device);
+            }
+
+          /* Remove the device from the device list and free memory */
+
+          list_delete(&item->node);
+          kmm_free(item);
           goto out;
         }
     }
@@ -362,7 +353,8 @@ int vhost_unregister_device(FAR struct vhost_device *device)
     {
       if (item->device == device)
         {
-          vhost_remove_device(item);
+          list_delete(&item->node);
+          kmm_free(item);
           goto out;
         }
     }

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -297,6 +297,7 @@ int vhost_register_device(FAR struct vhost_device *device)
                * matched.
                */
 
+              device->priv = driver;
               if (driver->probe(device) >= 0)
                 {
                   item->driver = driver;

--- a/drivers/virtio/virtio.c
+++ b/drivers/virtio/virtio.c
@@ -364,12 +364,12 @@ int virtio_unregister_device(FAR struct virtio_device *device)
         container_of(node, struct virtio_device_item_s, node);
       if (item->device == device)
         {
-          /* Call driver remove and mark item->driver NULL to indicate
-           * the device unmatched
-           */
+          /* Call driver remove */
 
-          item->driver->remove(device);
-          item->driver = NULL;
+          if (item->driver)
+            {
+              item->driver->remove(device);
+            }
 
           /* Remove the device from the device list and free memory */
 


### PR DESCRIPTION
## Summary

- pci/ivshmem: Skip unregistering ivshmem driver
- rpmsg/ivshmem: Skip unregistering ivshmem driver 
- pci/ivshmem: Check drv isn't NULL before calling remove
- driver/vhost: Check driver isn't NULL before calling remove 
- driver/virtio: Check driver isn't NULL before calling remove 
- driver/vhost: vhost_register_device should set priv before inovking probe
- driver/vhost: Check driver is NULL before calling probe
- driver/vhost: Call metal_init in vhost_register_drivers 

## Impact

minor bug fix

## Testing

internal