### PR TITLE
net: Remove IFF_DOWN flag to compatible with Linux/*BSD

### DIFF
--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_tja1153.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_tja1153.c
@@ -316,7 +316,7 @@ int s32k3xx_tja1153_initialize(int bus)
 
   /* Bring down the interface */
 
-  ifr.ifr_flags = IFF_DOWN;
+  ifr.ifr_flags = 0;
   ret = ioctl(sock, SIOCSIFFLAGS, (unsigned long)&ifr);
   if (ret < 0)
     {

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -921,8 +921,7 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
 
   if (!priv->bc_bifup)
     {
-      wlerr("ERROR: invalid state "
-            "(IFF_DOWN, unable to execute command: %x)\n", cmd);
+      wlerr("ERROR: invalid state (unable to execute command: %x)\n", cmd);
       return -EPERM;
     }
 

--- a/include/net/if.h
+++ b/include/net/if.h
@@ -48,7 +48,6 @@
 
 /* Interface flag bits */
 
-#define IFF_DOWN           (1 << 0)  /* Interface is down */
 #define IFF_UP             (1 << 1)  /* Interface is up */
 #define IFF_RUNNING        (1 << 2)  /* Carrier is available */
 #define IFF_IPv6           (1 << 3)  /* Configured for IPv6 packet (vs ARP or IPv4) */

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -990,10 +990,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
             arp_acd_setup(dev);
 #endif /* CONFIG_NET_ARP_ACD */
           }
-
-        /* Is this a request to take the interface down? */
-
-        else if ((req->ifr_flags & IFF_DOWN) != 0)
+        else
           {
             /* Yes.. take the interface down */
 


### PR DESCRIPTION
## Summary

turn off interface by checking IFF_UP flag isn't set: https://github.com/apache/nuttx/issues/1838

## Impact

improve the compatibility

## Testing

internal