### PR TITLE
rptun: Remove include/nuttx/rptun/openamp.h

### DIFF
--- a/arch/risc-v/src/k230/k230_rptun.c
+++ b/arch/risc-v/src/k230/k230_rptun.c
@@ -42,7 +42,6 @@
 #include <nuttx/spi/spi.h>
 #include <nuttx/wqueue.h>
 
-#include <nuttx/rptun/openamp.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/drivers/addrenv.h>
 #include <nuttx/list.h>

--- a/arch/risc-v/src/mpfs/mpfs_ihc.c
+++ b/arch/risc-v/src/mpfs/mpfs_ihc.c
@@ -42,7 +42,6 @@
 #include <nuttx/spi/spi.h>
 #include <nuttx/wqueue.h>
 
-#include <nuttx/rptun/openamp.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/drivers/addrenv.h>
 #include <nuttx/list.h>

--- a/arch/risc-v/src/qemu-rv/qemu_rv_rptun.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_rptun.c
@@ -42,7 +42,6 @@
 #include <nuttx/spi/spi.h>
 #include <nuttx/wqueue.h>
 
-#include <nuttx/rptun/openamp.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/drivers/addrenv.h>
 #include <nuttx/list.h>

--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -32,7 +32,7 @@
 #include <nuttx/clk/clk_provider.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/semaphore.h>
 
 /****************************************************************************

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -35,7 +35,7 @@
 #include <nuttx/list.h>
 
 #ifdef CONFIG_UINPUT_RPMSG
-#  include <nuttx/rptun/openamp.h>
+#  include <nuttx/rpmsg/rpmsg.h>
 #endif
 
 /****************************************************************************

--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -33,7 +33,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -39,7 +39,7 @@
 #include <nuttx/mtd/smart.h>
 #include <nuttx/mutex.h>
 #include <nuttx/mmcsd.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "rpmsgblk.h"
 

--- a/drivers/misc/rpmsgblk_server.c
+++ b/drivers/misc/rpmsgblk_server.c
@@ -29,7 +29,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mmcsd.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "inode.h"
 #include "rpmsgblk.h"

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -39,7 +39,7 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/video/fb.h>
 #include <nuttx/mutex.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/net/ioctl.h>
 #include <nuttx/drivers/rpmsgdev.h>
 #include <nuttx/power/battery_ioctl.h>

--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -36,7 +36,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/drivers/rpmsgdev.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "rpmsgdev.h"
 

--- a/drivers/mtd/rpmsgmtd.c
+++ b/drivers/mtd/rpmsgmtd.c
@@ -35,7 +35,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/mutex.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "rpmsgmtd.h"
 

--- a/drivers/mtd/rpmsgmtd_server.c
+++ b/drivers/mtd/rpmsgmtd_server.c
@@ -30,7 +30,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mtd/mtd.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "rpmsgmtd.h"
 

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -39,7 +39,7 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/pkt.h>
 #include <nuttx/net/rpmsg.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/power/supply/regulator_rpmsg.c
+++ b/drivers/power/supply/regulator_rpmsg.c
@@ -34,7 +34,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/list.h>
 #include <nuttx/power/consumer.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/reset/reset_rpmsg.c
+++ b/drivers/reset/reset_rpmsg.c
@@ -33,7 +33,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/list.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/reset/reset.h>
 #include <nuttx/reset/reset-controller.h>
 

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -32,7 +32,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
 #include <nuttx/sensors/sensor.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -31,7 +31,7 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/serial/serial.h>
 #include <nuttx/serial/uart_rpmsg.h>
 

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -36,7 +36,7 @@
 #endif
 
 #include <nuttx/irq.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/syslog/syslog_rpmsg.h>
 #include <nuttx/wqueue.h>
 

--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -30,7 +30,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/list.h>
 #include <nuttx/mutex.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/syslog/syslog_rpmsg.h>
 
 #include "syslog.h"

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -28,7 +28,7 @@
 #include <nuttx/list.h>
 #include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/mutex.h>
 #include <nuttx/timers/rpmsg_rtc.h>
 #include <nuttx/timers/arch_rtc.h>

--- a/drivers/usrsock/usrsock_rpmsg.c
+++ b/drivers/usrsock/usrsock_rpmsg.c
@@ -23,7 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/net/dns.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/usrsock/usrsock_rpmsg.h>
 

--- a/drivers/usrsock/usrsock_rpmsg_server.c
+++ b/drivers/usrsock/usrsock_rpmsg_server.c
@@ -37,7 +37,7 @@
 #include <nuttx/net/dns.h>
 #include <nuttx/net/net.h>
 #include <nuttx/queue.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/usrsock/usrsock_rpmsg.h>
 #ifdef CONFIG_NETDEV_WIRELESS_IOCTL
 #include <nuttx/wireless/wireless.h>

--- a/drivers/wireless/bluetooth/bt_rpmsghci.c
+++ b/drivers/wireless/bluetooth/bt_rpmsghci.c
@@ -32,7 +32,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/net/bluetooth.h>
 #include <nuttx/semaphore.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/wireless/bluetooth/bt_rpmsghci.h>
 
 #include "bt_rpmsghci.h"

--- a/drivers/wireless/bluetooth/bt_rpmsghci_server.c
+++ b/drivers/wireless/bluetooth/bt_rpmsghci_server.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 #include <nuttx/kmalloc.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/wireless/bluetooth/bt_rpmsghci.h>
 
 #include "bt_rpmsghci.h"

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -31,7 +31,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/ioctl.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/semaphore.h>
 
 #include "rpmsgfs.h"

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -34,7 +34,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 
 #include "rpmsgfs.h"
 #include "fs_heap.h"

--- a/include/nuttx/rpmsg/rpmsg.h
+++ b/include/nuttx/rpmsg/rpmsg.h
@@ -122,17 +122,20 @@ void rpmsg_unregister_callback(FAR void *priv,
                                rpmsg_dev_cb_t device_destroy,
                                rpmsg_match_cb_t ns_match,
                                rpmsg_bind_cb_t ns_bind);
+
 void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
                    FAR const char *name, uint32_t dest);
 void rpmsg_ns_unbind(FAR struct rpmsg_device *rdev,
                      FAR const char *name, uint32_t dest);
+
 void rpmsg_device_created(FAR struct rpmsg_s *rpmsg);
 void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg);
+
 int rpmsg_register(FAR const char *path, FAR struct rpmsg_s *rpmsg,
                    FAR const struct rpmsg_ops_s *ops);
 void rpmsg_unregister(FAR const char *path, FAR struct rpmsg_s *rpmsg);
-int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg);
 
+int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg);
 int rpmsg_panic(FAR const char *cpuname);
 void rpmsg_dump_all(void);
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -36,7 +36,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/mm/circbuf.h>
-#include <nuttx/rptun/openamp.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/fs/ioctl.h>


### PR DESCRIPTION
## Summary
and use include/nuttx/rpmsg/rpmsg.h instead

## Impact
Only code refactor

## Testing
CI
