### PR TITLE
arch: cxd56xx: Add SD card 4-bit capability

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_sdhci.c
+++ b/arch/arm/src/cxd56xx/cxd56_sdhci.c
@@ -1358,6 +1358,8 @@ static sdio_capset_t cxd56_sdio_capabilities(struct sdio_dev_s *dev)
 
 #ifdef CONFIG_CXD56_SDIO_WIDTH_D1_ONLY
   caps |= SDIO_CAPS_1BIT_ONLY;
+#else
+  caps |= SDIO_CAPS_4BIT;
 #endif
 #ifdef CONFIG_CXD56_SDIO_DMA
   caps |= SDIO_CAPS_DMASUPPORTED;


### PR DESCRIPTION
## Summary
The mmcsd driver has been updated to require SDIO_CAPS_4BIT to be explicitly specified for SD card 4-bit support.

## Impact
Only for spresense board.

## Testing
Test on spresesense board with SD card.
