### PR TITLE
CI: Apply the Refactored Build Rules based on Arch Labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # Fetch the source from nuttx and nuttx-apps repos
   Fetch-Source:
     runs-on: ubuntu-latest
     steps:
@@ -115,8 +117,23 @@ jobs:
           name: source-bundle
           path: sources.tar.gz
 
-  Linux:
+  # Select the Linux Builds based on PR Arch Label
+  Linux-Arch:
+    uses: apache/nuttx/.github/workflows/arch.yml@master
     needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        [
+          "arm-01", "other", "risc-v-01", "sim-01", "xtensa-01",
+          "arm-02", "risc-v-02", "sim-02", "xtensa-02",
+          "arm-03", "arm-04", "arm-05", "arm-06", "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13"
+        ]
+
+  # Run the selected Linux Builds
+  Linux:
+    needs: Linux-Arch
+    if: ${{ needs.Linux-Arch.outputs.skip_all_builds != '1' }}
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -124,90 +141,20 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        boards: [
-          arm-01, other, risc-v-01, sim-01, xtensa-01,
-          arm-02, risc-v-02, sim-02, xtensa-02,
-          arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13
-        ]
+        boards: ${{ fromJSON(needs.Linux-Arch.outputs.selected_builds) }}
 
     steps:
 
-      # Get the Arch for the PR: arm, arm64, risc-v, xtensa, ...
-      - name: Get arch
-        id: get-arch
-        run: |
-          # Get the Labels for the PR: "Arch: risc-v \n Size: XS"
-          pr=${{github.event.pull_request.number}}
-          if [[ "$pr" == "" ]]; then
-            exit
-          fi
-          numlabels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.[] | length')
-          labels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.labels[] | .name')
-
-          # Identify the Size and Arch Labels
-          if [[ "$labels" == *"Size: "* ]]; then
-            labels_contain_size=1
-          fi
-          if [[ "$labels" == *"Arch: arm"* ]]; then
-            arch_contains_arm_arm64=1
-          fi
-          if [[ "$labels" == *"Arch: risc-v"* ]]; then
-            arch_contains_riscv=1
-          fi
-          if [[ "$labels" == *"Arch: xtensa"* ]]; then
-            arch_contains_xtensa=1
-          fi
-
-          # We consider only PRs with 2 labels, including size
-          if [ $numlabels -ne 2 ] || [ $labels_contain_size -ne 1 ]; then
-            exit
-          fi
-          
-          # If "Arch: arm / arm64" is the only non-size label, then build other, arm-01, arm-02, ...
-          if [[ "$arch_contains_arm_arm64" == "1" ]]; then
-            if [[ "${{matrix.boards}}" == "arm"* ]] || [[ "${{matrix.boards}}" == "other"* ]]; then
-              echo Allow build: ${{matrix.boards}}
-            else
-              echo Skip build: ${{matrix.boards}}
-              echo "skip_build=1" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-          # If "Arch: risc-v" is the only non-size label, then build risc-v-01, risc-v-02
-          if [[ "$arch_contains_riscv" == "1" ]]; then
-            if [[ "${{matrix.boards}}" == "risc-v"* ]]; then
-              echo Allow build: ${{matrix.boards}}
-            else
-              echo Skip build: ${{matrix.boards}}
-              echo "skip_build=1" >> $GITHUB_OUTPUT
-            fi
-          fi
-
-          # If "Arch: xtensa" is the only non-size label, then build xtensa-01, xtensa-02
-          if [[ "$arch_contains_xtensa" == "1" ]]; then
-            if [[ "${{matrix.boards}}" == "xtensa"* ]]; then
-              echo Allow build: ${{matrix.boards}}
-            else
-              echo Skip build: ${{matrix.boards}}
-              echo "skip_build=1" >> $GITHUB_OUTPUT
-            fi
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Download Source Artifact
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
 
       - name: Extract sources
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         run: tar zxf sources.tar.gz
 
       - name: Docker Login
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -215,15 +162,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Pull
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
 
       - name: Export NuttX Repo SHA
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
       - name: Run builds
-        if: ${{ steps.get-arch.outputs.skip_build != '1' }}
         uses: ./sources/nuttx/.github/actions/ci-container
         env:
           BLOBDIR: /tools/blobs
@@ -247,15 +191,26 @@ jobs:
           path: buildartifacts/
         continue-on-error: true
 
+  # Select the macOS Builds based on PR Arch Label
+  macOS-Arch:
+    uses: apache/nuttx/.github/workflows/arch.yml@master
+    needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        ["macos", "sim-01", "sim-02"]
+
+  # Run the selected macOS Builds
   macOS:
     permissions:
       contents: none
     runs-on: macos-13
-    needs: Fetch-Source
+    needs: macOS-Arch
+    if: ${{ needs.macOS-Arch.outputs.skip_all_builds != '1' }}
     strategy:
       max-parallel: 2
       matrix:
-        boards: [macos, sim-01, sim-02]
+        boards: ${{ fromJSON(needs.macOS-Arch.outputs.selected_builds) }}
     steps:
       - name: Download Source Artifact
         uses: actions/download-artifact@v4
@@ -296,14 +251,25 @@ jobs:
           path: buildartifacts/
         continue-on-error: true
 
-  msys2:
+  # Select the msys2 Builds based on PR Arch Label
+  msys2-Arch:
+    uses: apache/nuttx/.github/workflows/arch.yml@master
     needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        ["msys2"]
+
+  # Run the selected msys2 Builds
+  msys2:
+    needs: msys2-Arch
+    if: ${{ needs.msys2-Arch.outputs.skip_all_builds != '1' }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        boards: [msys2]
+        boards: ${{ fromJSON(needs.msys2-Arch.outputs.selected_builds) }}
 
     defaults:
       run:


### PR DESCRIPTION
## Summary

This PR continues to enhance the CI Workflow, to skip the unnecessary NuttX Builds. The PR will update the CI Build Workflow `build.yml`, to call the Refactored Build Rules in `arch.yml` (which is a Reusable Workflow).

The original rules were migrated from `build.yml` to `arch.yml`:
- We target only the Simple PRs: One Arch Label + One Size Label (e.g. "Arch: risc-v, Size: XS")
- For "Arch: risc-v": Build `risc-v-01`, `risc-v-02`
- For "Arch: xtensa": Build `xtensa-01`, `xtensa-02`
- The above rules apply when the PR is Created or Modified
- When the PR is Merged: All targets shall be built

This PR applies the New and Updated Rules defined in `arch.yml`:
- For "Arch: arm": Build `arm-01`, `arm-02`, ...
- For "Arch: arm64": Build `other`
- For "Arch: simulator": Build `sim-01`, `sim-02`
- For "Arch: x86_64": Build `other`
- For Simple PRs (One Arch Label + One Size Label): Skip the macOS and Windows builds (`macos`, `macos/sim-*`, `msys2`) since these builds are costly and slow
- Except for "Arch: Simulator", which will enable the macOS Builds for `sim-01` and `sim-02`
- If GitHub CLI Fails: Build all targets

The code is explained here: https://github.com/apache/nuttx/issues/13775

## Impact

For Simple PRs: CI Builds shall be skipped for the targets that don't match the Arch Label. macOS and Windows builds shall be skipped (except for "Arch: Simulator").

For Complex PRs: No change, all targets shall be built

## Testing

When we create a PR, the irrelevant builds will be totally omitted. (Merge PR will compile all targets, same for Others)
- Arm32: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210568917) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210753176)
- Arm64: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210569865) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210788405)
- RISC-V: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210570958) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11210827021)
- Simulator: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11198323126) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11203420967)
- x86_64: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11198850839) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11204336679)
- Xtensa: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11200284084) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11205160473)
- Others: [Create PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11199194493) / [Merge PR](https://github.com/lupyuen5/label-nuttx/actions/runs/11205997324)

Previously the irrelevant builds were skipped in seconds. Now the irrelevant builds (e.g. `arm-01`) are totally omitted for Simple PRs [(e.g. "Arch: risc-v")](https://github.com/lupyuen5/label-nuttx/actions/runs/11197522570)

![Screenshot 2024-10-06 at 11 39 43 AM](https://github.com/user-attachments/assets/8fb091b9-2ba0-4c3a-a533-af5c6609dab7)
