### PR TITLE
Rpmsg fs: rpmsgfs bug fix and enhancement

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <sys/uio.h>
+#include <termios.h>
 #include <fcntl.h>
 
 #include <nuttx/kmalloc.h>
@@ -396,6 +397,12 @@ static ssize_t rpmsgfs_ioctl_arglen(int cmd)
         return sizeof(int);
       case FIOC_FILEPATH:
         return PATH_MAX;
+      case TCDRN:
+      case TCFLSH:
+        return 0;
+      case TCGETS:
+      case TCSETS:
+        return sizeof(struct termios);
       case FIOC_SETLK:
       case FIOC_GETLK:
       case FIOC_SETLKW:

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -744,6 +744,7 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
       return -ENOMEM;
     }
 
+  nxsem_init(&priv->wait, 0, 0);
   strlcpy(priv->cpuname, cpuname, sizeof(priv->cpuname));
   ret = rpmsg_register_callback(priv,
                                 rpmsgfs_device_created,
@@ -752,11 +753,11 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
                                 NULL);
   if (ret < 0)
     {
+      nxsem_destroy(&priv->wait);
       fs_heap_free(priv);
       return ret;
     }
 
-  nxsem_init(&priv->wait, 0, 0);
   *handle = priv;
 
   return 0;


### PR DESCRIPTION
## Summary
1.    rpmsgfs/rpmsgfs_client: init the priv->wait before register rpmsg callback
    
    Should init the priv->wait before rpmsg_register_callback() because
    rpmsgfs_ns_bound() may has been called before rpmsg_register_callback()
    returned.

2.    rpmsgfs: add tty fd ioctl(TCGETS/TCSETS) support
    
    rpmsgfs client ioctl support TCDRN/TCFLSH/TCGETS/TCSETS

3.    rpmsgfs_server: add error log for rpmsgfs server ept callback
    
    Because the rpmsg_virtio will assert when endpoint callback return
    error, so add more error log to the rpmsgfs server to help to locate
    the root cause.

4.    rpmsgfs: remove memcpy in rpmsgfs open/close
    
    improve the rpmsgfs performance

## Impact
rpmsg fs

## Testing
sim:rpserver and rpproxy with procfs
