### PR TITLE
Fdt mmio: add common fdt mmio virtio device register function

### DIFF
--- a/drivers/devicetree/CMakeLists.txt
+++ b/drivers/devicetree/CMakeLists.txt
@@ -24,6 +24,10 @@ if(CONFIG_DEVICE_TREE)
     list(APPEND SRCS fdt_pci.c)
   endif()
 
+  if(CONFIG_DRIVERS_VIRTIO_MMIO)
+    list(APPEND SRCS fdt_virtio_mmio.c)
+  endif()
+
   target_include_directories(drivers
                              PRIVATE ${NUTTX_DIR}/libs/libc/fdt/dtc/libfdt)
   target_sources(drivers PRIVATE ${SRCS})

--- a/drivers/devicetree/Make.defs
+++ b/drivers/devicetree/Make.defs
@@ -26,6 +26,10 @@ ifeq ($(CONFIG_PCI),y)
   CSRCS += fdt_pci.c
 endif
 
+ifeq ($(CONFIG_DRIVERS_VIRTIO_MMIO),y)
+  CSRCS += fdt_virtio_mmio.c
+endif
+
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)fdt$(DELIM)dtc$(DELIM)libfdt
 
 DEPPATH += --dep-path devicetree

--- a/drivers/devicetree/fdt_virtio_mmio.c
+++ b/drivers/devicetree/fdt_virtio_mmio.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ * drivers/devicetree/fdt_virtio_mmio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+
+#include <nuttx/fdt.h>
+#include <nuttx/virtio/virtio-mmio.h>
+
+#include <libfdt.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fdt_virtio_mmio_devices_register
+ *
+ * Description:
+ *   This function is used to register the virtio mmio devices from the
+ *   device tree
+ *
+ * Input Parameters:
+ *   fdt      - Device tree handle
+ *   irqbase  - Interrupt base number
+ *
+ * Returned Value:
+ *   Return 0 if success, nageative if failed
+ *
+ ****************************************************************************/
+
+int fdt_virtio_mmio_devices_register(FAR const void *fdt, int irqbase)
+{
+  uintptr_t addr;
+  int offset = -1;
+  int irqnum;
+  int ret;
+
+  for (; ; )
+    {
+      offset = fdt_node_offset_by_compatible(fdt, offset, "virtio,mmio");
+      if (offset == -FDT_ERR_NOTFOUND)
+        {
+          break;
+        }
+
+      addr = fdt_get_reg_base(fdt, offset, 0);
+      irqnum = fdt_get_irq(fdt, offset, 1, irqbase);
+      if (addr <= 0 || irqnum < 0)
+        {
+          return -EINVAL;
+        }
+
+      ret = virtio_register_mmio_device((FAR void *)addr, irqnum);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+  return OK;
+}

--- a/drivers/devicetree/fdt_virtio_mmio.c
+++ b/drivers/devicetree/fdt_virtio_mmio.c
@@ -22,6 +22,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/fdt.h>
@@ -76,7 +77,7 @@ int fdt_virtio_mmio_devices_register(FAR const void *fdt, int irqbase)
         }
 
       ret = virtio_register_mmio_device((FAR void *)addr, irqnum);
-      if (ret < 0)
+      if (ret < 0 && ret != -ENODEV)
         {
           return ret;
         }

--- a/include/nuttx/fdt.h
+++ b/include/nuttx/fdt.h
@@ -429,4 +429,24 @@ int fdt_load_prop_u32(FAR const void *fdt, int offset,
 int fdt_pci_ecam_register(FAR const void *fdt);
 #endif
 
+/****************************************************************************
+ * Name: fdt_virtio_mmio_devices_register
+ *
+ * Description:
+ *   This function is used to register the virtio mmio devices from the
+ *   device tree
+ *
+ * Input Parameters:
+ *   fdt      - Device tree handle
+ *   irqbase  - Interrupt base number
+ *
+ * Returned Value:
+ *   Return 0 if success, nageative if failed
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVERS_VIRTIO_MMIO
+int fdt_virtio_mmio_devices_register(FAR const void *fdt, int irqbase);
+#endif
+
 #endif /* __INCLUDE_NUTTX_FDT_H */


### PR DESCRIPTION
## Summary
    devicetree/fdt_virtio_mmio: implement the fdt_virtio_mmio_devices_register()
    
    So the borad level do not need implement the
    register_virtio_devices_from_fdt() again and again.

## Impact
New function

## Testing
qemu armv7a
