### PR TITLE
inotify: support truncate and close calls

### DIFF
--- a/Documentation/components/filesystem/inotify.rst
+++ b/Documentation/components/filesystem/inotify.rst
@@ -90,11 +90,15 @@ calling inotify_add_watch and  may  be returned in the mask field returned by re
 
   **IN_ACCESS** :File was accessed
 
-  **IN_MODIFY** :File was modified
+  **IN_MODIFY** :File was modified (``write()`` or ``truncate()``)
 
   **IN_ATTRIB** :Metadata changed
 
   **IN_OPEN** :File was opened
+
+  **IN_CLOSE_WRITE** :File opened for writing was closed
+
+  **IN_CLOSE_NOWRITE** : File not opened for writing was closed
 
   **IN_MOVED_FROM** :File was moved from X
 

--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -1342,15 +1342,15 @@ void notify_open(FAR const char *path, int oflags)
  *
  ****************************************************************************/
 
-void notify_close(FAR struct file *filep)
+void notify_close(FAR const char *path, int oflags)
 {
-  if (filep->f_oflags & O_WROK)
+  if (oflags & O_WROK)
     {
-      notify_queue_filep_event(filep, IN_CLOSE_WRITE);
+      notify_queue_path_event(path, IN_CLOSE_WRITE);
     }
   else
     {
-      notify_queue_filep_event(filep, IN_CLOSE_NOWRITE);
+      notify_queue_path_event(path, IN_CLOSE_NOWRITE);
     }
 }
 

--- a/fs/notify/notify.h
+++ b/fs/notify/notify.h
@@ -42,7 +42,7 @@
 /* These are internal OS interface and are not available to applications */
 
 void notify_open(FAR const char *path, int oflags);
-void notify_close(FAR struct file *filep);
+void notify_close(FAR const char *path, int oflags);
 void notify_close2(FAR struct inode *inode);
 void notify_read(FAR struct file *filep);
 void notify_write(FAR struct file *filep);

--- a/fs/vfs/fs_close.c
+++ b/fs/vfs/fs_close.c
@@ -37,6 +37,33 @@
 #include "vfs/lock.h"
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_FS_NOTIFY
+static FAR char *file_get_path(FAR struct file *filep)
+{
+  FAR char *pathbuffer;
+  int ret;
+
+  pathbuffer = lib_get_pathbuffer();
+  if (pathbuffer == NULL)
+    {
+      return NULL;
+    }
+
+  ret = file_fcntl(filep, F_GETPATH, pathbuffer);
+  if (ret < 0)
+    {
+      lib_put_pathbuffer(pathbuffer);
+      return NULL;
+    }
+
+  return pathbuffer;
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -60,10 +87,21 @@
 int file_close_without_clear(FAR struct file *filep)
 {
   struct inode *inode;
+#ifdef CONFIG_FS_NOTIFY
+  FAR char *path;
+#endif
   int ret = OK;
 
   DEBUGASSERT(filep != NULL);
   inode = filep->f_inode;
+
+#ifdef CONFIG_FS_NOTIFY
+  /* We lose the path and inode during close and release, so obtain it
+   * in advance. Then we pass it to notify_close function.
+   */
+
+  path = file_get_path(filep);
+#endif
 
   /* Check if the struct file is open (i.e., assigned an inode) */
 
@@ -84,6 +122,14 @@ int file_close_without_clear(FAR struct file *filep)
 
       if (ret >= 0)
         {
+#ifdef CONFIG_FS_NOTIFY
+          if (path != NULL)
+            {
+              notify_close(path, filep->f_oflags);
+              lib_put_pathbuffer(path);
+            }
+#endif
+
           inode_release(inode);
         }
     }

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/fs/fs.h>
 
+#include "notify/notify.h"
 #include "inode/inode.h"
 
 /****************************************************************************
@@ -180,6 +181,9 @@ int ftruncate(int fd, off_t length)
   fs_putfilep(filep);
   if (ret >= 0)
     {
+#ifdef CONFIG_FS_NOTIFY
+      notify_write(filep);
+#endif
       return 0;
     }
 


### PR DESCRIPTION
## Summary
### a1b14df

`IN_MODIFY` event should occur on file modification, which includes truncate. This is consistent with the inotify usage on Linux.

### 7f2858a

Close operation on file should lead to `IN_CLOSE_WRITE` or `IN_CLOSE_NOWRITE` notifications. This commits adds the notification support. Notifying on close is a little bit trickier as a lower layer may not have the full file path after successful close and inode release. Calling notification before close is not a solution since close might
not end successfully. 
The solution is to obtain and buffer the path before calling close and then pass the buffered path to the notify_close. This required the change in `notify_close` function arguments: `filep` is no longer required, path and `oflags` are passed instead.

## Impact
Inotify now reports notification on close and truncate operations.

## Testing
Tested on SAMv7 custom board.

