### PR TITLE
arch/arm/stm32{|f7}/socketcan: fix debugassert for extid frames

### DIFF
--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -881,7 +881,7 @@ static int stm32can_transmit(struct stm32_can_s *priv)
   regval &= ~CAN_TIR_EXID_MASK;
   if (frame->can_id & CAN_EFF_FLAG)
     {
-      DEBUGASSERT(frame->can_id < (1 << 29));
+      DEBUGASSERT((frame->can_id ^ CAN_EFF_FLAG) < (1 << 29));
       regval |= (frame->can_id << CAN_TIR_EXID_SHIFT) | CAN_TIR_IDE;
     }
   else

--- a/arch/arm/src/stm32/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32/stm32_fdcan_sock.c
@@ -1682,7 +1682,7 @@ static int fdcan_send(struct stm32_fdcan_s *priv)
 #ifdef CONFIG_NET_CAN_EXTID
       if ((frame->can_id & CAN_EFF_FLAG) != 0)
         {
-          DEBUGASSERT(frame->can_id < (1 << 29));
+          DEBUGASSERT((frame->can_id ^ CAN_EFF_FLAG) < (1 << 29));
 
           txbuffer[0] |= BUFFER_R0_EXTID(frame->can_id) | BUFFER_R0_XTD;
         }

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -905,7 +905,7 @@ static int stm32can_transmit(struct stm32_can_s *priv)
   regval &= ~CAN_TIR_EXID_MASK;
   if (frame->can_id & CAN_EFF_FLAG)
     {
-      DEBUGASSERT(frame->can_id < (1 << 29));
+      DEBUGASSERT((frame->can_id ^ CAN_EFF_FLAG) < (1 << 29));
       regval |= (frame->can_id << CAN_TIR_EXID_SHIFT) | CAN_TIR_IDE;
     }
   else


### PR DESCRIPTION
## Summary
- arch/arm/stm32{|f7}/socketcan: fix debugassert for extid frames
fix debugassert for extid frames, we have to remove CAN_EFF_FLAG bit from the expression

## Impact
fix debugassert expression

## Testing
stm32 with `cansend` command
