### PR TITLE
uart_rpmsg: some bugs fixed

### DIFF
--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -344,6 +344,9 @@ static void uart_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
     {
       rpmsg_destroy_ept(&priv->ept);
     }
+
+  dev->dmatx.nbytes = dev->dmatx.length + dev->dmatx.nlength;
+  uart_xmitchars_done(dev);
 }
 
 static int uart_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,

--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -444,6 +444,7 @@ int uart_rpmsg_init(FAR const char *cpuname, FAR const char *devname,
       goto fail;
     }
 
+  nxmutex_init(&priv->lock);
   priv->cpuname = cpuname;
   priv->devname = devname;
 
@@ -456,10 +457,10 @@ int uart_rpmsg_init(FAR const char *cpuname, FAR const char *devname,
                                 NULL);
   if (ret < 0)
     {
+      nxmutex_destroy(&priv->lock);
       goto fail;
     }
 
-  nxmutex_init(&priv->lock);
   snprintf(dev_name, sizeof(dev_name), "%s%s",
            UART_RPMSG_DEV_PREFIX, devname);
   uart_register(dev_name, dev);

--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -384,9 +384,11 @@ static int uart_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
     {
       /* Get write-cmd, there are some data, we need receive them */
 
+      nxmutex_lock(&dev->recv.lock);
       priv->recv_data = data;
       uart_recvchars_dma(dev);
       priv->recv_data = NULL;
+      nxmutex_unlock(&dev->recv.lock);
 
       header->response = 1;
       rpmsg_send(ept, msg, sizeof(*msg));


### PR DESCRIPTION
## Summary
1.    serial/uart_rpmsg: should init the lock before call rpmsg_register_callback
    
    To avoid init the lock after this lock has been used.

2.    drivers/uart_rpmsg: add recv lock when received the data from peer
    
    The recv buffer is used both in user thread and rpmsg ept->callback
    thread, so add recv lock to protect the recv buffer.

3.    driver/uart_rpmsg: clear transmit buffer when remote exception occurred
    
    Make uart rpmsg work normally when restart the remote core

## Impact
uart rpmsg

## Testing
sim rpserver and rpproxy

