### PR TITLE
arch: fix the sched parameter update when exiting

### DIFF
--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -152,6 +152,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       cpu = this_cpu();
       tcb = current_task(cpu);
+
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_resume_scheduler(tcb);
+
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -66,11 +66,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -70,11 +70,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -68,6 +68,7 @@ void up_exit(int status)
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -67,6 +67,7 @@ void up_exit(int status)
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -66,11 +66,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -68,7 +68,7 @@ void up_exit(int status)
 
   /* Adjusts time slice for RR & SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -68,7 +68,7 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -69,6 +69,7 @@ void up_exit(int status)
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -64,9 +64,10 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for RR & SPORADIC cases */
+  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -66,13 +66,7 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
-
-  nxsched_resume_scheduler(tcb);
-
-  /* g_running_tasks is not valid now */
+  /* Scheduler parameters will update inside syscall */
 
   g_running_tasks[this_cpu()] = NULL;
 

--- a/arch/sim/src/sim/sim_exit.c
+++ b/arch/sim/src/sim/sim_exit.c
@@ -68,6 +68,7 @@ void up_exit(int status)
    */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
   /* Restore the cpu lock */
 

--- a/arch/sparc/src/common/sparc_exit.c
+++ b/arch/sparc/src/common/sparc_exit.c
@@ -70,9 +70,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Reset scheduler parameters */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/tricore/src/common/tricore_exit.c
+++ b/arch/tricore/src/common/tricore_exit.c
@@ -66,11 +66,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -70,6 +70,7 @@ void up_exit(int status)
    */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -69,6 +69,7 @@ void up_exit(int status)
    */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
   /* Context switch, rearrange MMU */
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -66,11 +66,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases
-   * NOTE: the API also adjusts the global IRQ control for SMP
-   */
+  /* Scheduler parameters will update inside syscall */
 
-  nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = NULL;
 
   /* Then switch contexts */
 

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -68,6 +68,7 @@ void up_exit(int status)
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
   /* Then switch contexts */
 

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -70,6 +70,7 @@ void up_exit(int status)
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
   nxsched_resume_scheduler(tcb);
+  g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running

--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -61,6 +61,13 @@
 
 void nxsched_suspend_scheduler(FAR struct tcb_s *tcb)
 {
+  /* Handle the task exiting case */
+
+  if (tcb != NULL)
+    {
+      return;
+    }
+
 #ifdef CONFIG_SCHED_SPORADIC
   /* Perform sporadic schedule operations */
 


### PR DESCRIPTION
## Summary

arch: fix the sched parameter update when exiting

The nxsched_resume_scheduler api will be call inside syscall if used, and don't have to be in up_exit.

tcb is already freed in up_exit/nxtask_exit before up_exit/nxsched_resume_scheduler

and if we make mempool threshold larger than tcb size, the delay free feature will also not work.

will cause a used after free, catched by qemu-armv7a project defconfig kasan.

## Impact

exit

## Testing

bes board & sim