### PR TITLE
sim bug fix

### DIFF
--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -108,7 +108,7 @@ static void allsyms_relocate(void)
  ****************************************************************************/
 
 #ifdef CONFIG_SIM_ASAN
-const char *__asan_default_options(void)
+noprofile_function const char *__asan_default_options(void)
 {
   return "abort_on_error=1"
          " alloc_dealloc_mismatch=0"
@@ -119,7 +119,7 @@ const char *__asan_default_options(void)
          " detect_stack_use_after_return=0";
 }
 
-const char *__lsan_default_options(void)
+noprofile_function const char *__lsan_default_options(void)
 {
   /* The fast-unwind implementation of leak-sanitizer will obtain the
    * current stack top/bottom and frame address(Stack Pointer) for
@@ -141,7 +141,7 @@ const char *__lsan_default_options(void)
 #endif
 
 #ifdef CONFIG_SIM_UBSAN
-const char *__ubsan_default_options(void)
+noprofile_function const char *__ubsan_default_options(void)
 {
 #ifdef CONFIG_SIM_UBSAN_DUMMY
   return "";

--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -108,11 +108,6 @@ static void allsyms_relocate(void)
  ****************************************************************************/
 
 #ifdef CONFIG_SIM_ASAN
-const char *__asan_default_suppressions(void)
-{
-  return "interceptor_via_lib:libasan.so";
-}
-
 const char *__asan_default_options(void)
 {
   return "abort_on_error=1"

--- a/arch/sim/src/sim/sim_idle.c
+++ b/arch/sim/src/sim/sim_idle.c
@@ -57,12 +57,14 @@ void up_idle(void)
 #ifdef CONFIG_PM
   static enum pm_state_e state = PM_NORMAL;
   enum pm_state_e newstate;
+#endif
   irqstate_t flags;
-
-  /* Fake some power management stuff for testing purposes */
 
   flags = enter_critical_section();
   sched_lock();
+
+#ifdef CONFIG_PM
+  /* Fake some power management stuff for testing purposes */
 
   newstate = pm_checkstate(PM_IDLE_DOMAIN);
   if (newstate != state)
@@ -83,8 +85,8 @@ void up_idle(void)
 
 #ifdef CONFIG_PM
   pm_changestate(PM_IDLE_DOMAIN, PM_RESTORE);
+#endif
 
   sched_unlock();
   leave_critical_section(flags);
-#endif
 }

--- a/arch/sim/src/sim/sim_sectionheap.c
+++ b/arch/sim/src/sim/sim_sectionheap.c
@@ -108,7 +108,7 @@ void *up_dataheap_memalign(size_t align, size_t size)
   if (g_dataheap == NULL)
     {
       g_dataheap = mm_initialize("dataheap",
-                                 host_allocheap(SIM_HEAP_SIZE, true),
+                                 host_allocheap(SIM_HEAP_SIZE, false),
                                  SIM_HEAP_SIZE);
     }
 

--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -279,6 +279,29 @@ static struct uart_dev_s g_tty3_dev =
 
 #if defined(USE_DEVCONSOLE) || CONFIG_SIM_UART_NUMBER > 0
 /****************************************************************************
+ * Name: uart_nputs
+ *
+ * Description:
+ *   Loop to write data to the UART until all the data is sent
+ *
+ ****************************************************************************/
+
+static void uart_nputs(int fd, const char *buf, size_t size)
+{
+  while (size > 0)
+    {
+      int ret = host_uart_puts(fd, buf, size);
+      if (ret < 0)
+        {
+          continue;
+        }
+
+      buf += ret;
+      size -= ret;
+    }
+}
+
+/****************************************************************************
  * Name: tty_setup
  *
  * Description:
@@ -617,7 +640,7 @@ static void tty_send(struct uart_dev_s *dev, int ch)
   struct tty_priv_s *priv = dev->priv;
   char c = ch;
 
-  host_uart_puts(dev->isconsole ? 1 : priv->fd, &c, 1);
+  uart_nputs(dev->isconsole ? 1 : priv->fd, &c, 1);
 }
 
 /****************************************************************************
@@ -757,12 +780,12 @@ void up_nputs(const char *str, size_t len)
 #ifdef USE_DEVCONSOLE
   if (str[len - 1] == '\n')
     {
-      host_uart_puts(1, str, len - 1);
-      host_uart_puts(1, "\r\n", 2);
+      uart_nputs(1, str, len - 1);
+      uart_nputs(1, "\r\n", 2);
     }
   else
     {
-      host_uart_puts(1, str, len);
+      uart_nputs(1, str, len);
     }
 #endif
 }

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -255,6 +255,13 @@
 
 #  define noinstrument_function __attribute__((no_instrument_function))
 
+/* The no_profile_instrument_function attribute on functions is used to
+ * inform the compiler that it should not process any profile feedback
+ * based optimization code instrumentation.
+ */
+
+#  define noprofile_function __attribute__((no_profile_instrument_function))
+
 /* The nooptimiziation_function attribute no optimize */
 
 #  define nooptimiziation_function __attribute__((optimize(0)))
@@ -585,6 +592,7 @@
 #  define inline_function inline
 #  define noinline_function
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function
 #  define nosanitize_address
 #  define nosanitize_undefined
@@ -731,6 +739,7 @@
 #  define inline_function inline
 #  define noinline_function
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function
 #  define nosanitize_address
 #  define nosanitize_undefined
@@ -845,6 +854,7 @@
 #  define inline_function inline
 #  define noinline_function
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function
 #  define nosanitize_address
 #  define nosanitize_undefined
@@ -938,6 +948,7 @@
 #  define inline_function __forceinline
 #  define noinline_function
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function
 #  define nosanitize_address
 #  define nosanitize_undefined
@@ -1021,6 +1032,7 @@
 #  define inline_function               __attribute__((always_inline)) inline
 #  define noinline_function             __attribute__((noinline))
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function      __attribute__((optimize(0)))
 #  define nosanitize_address
 #  define nosanitize_undefined
@@ -1089,6 +1101,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define noprofile_function
 #  define nooptimiziation_function
 #  define nosanitize_address
 #  define nosanitize_undefined


### PR DESCRIPTION
## Summary

sim bug fix:

sim: fix context-switch when do wdog callback()
sim/gcov: Fix conflicts between fprofile-orderate and __asan_default_options
arch/sim: dataheap should disable exec permission
arch/sim: fix uart could lose log

## Impact

sim

## Testing

sim
