### PR TITLE
timer & nx_start small bug fix

### DIFF
--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -195,17 +195,17 @@ static bool timer_callback(FAR uint32_t *next_interval, FAR void *arg)
 
 void up_timer_set_lowerhalf(FAR struct timer_lowerhalf_s *lower)
 {
-  g_timer.lower = lower;
-
 #ifdef CONFIG_SCHED_TICKLESS
   TIMER_TICK_MAXTIMEOUT(lower, &g_oneshot_maxticks);
-  TIMER_TICK_SETTIMEOUT(g_timer.lower, g_oneshot_maxticks);
+  TIMER_TICK_SETTIMEOUT(lower, g_oneshot_maxticks);
 #else
-  TIMER_TICK_SETTIMEOUT(g_timer.lower, 1);
+  TIMER_TICK_SETTIMEOUT(lower, 1);
 #endif
 
-  TIMER_SETCALLBACK(g_timer.lower, timer_callback, NULL);
-  TIMER_START(g_timer.lower);
+  TIMER_SETCALLBACK(lower, timer_callback, NULL);
+  TIMER_START(lower);
+
+  g_timer.lower = lower;
 }
 
 /****************************************************************************

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -606,14 +606,16 @@ void nx_start(void)
 
   /* Initialize the logic that determine unique process IDs. */
 
-  g_npidhash = 1 << LOG2_CEIL(CONFIG_PID_INITIAL_COUNT);
-  while (g_npidhash <= CONFIG_SMP_NCPUS)
+  i = 1 << LOG2_CEIL(CONFIG_PID_INITIAL_COUNT);
+  while (i <= CONFIG_SMP_NCPUS)
     {
-      g_npidhash <<= 1;
+      i <<= 1;
     }
 
-  g_pidhash = kmm_zalloc(sizeof(*g_pidhash) * g_npidhash);
+  g_pidhash = kmm_zalloc(sizeof(*g_pidhash) * i);
   DEBUGASSERT(g_pidhash);
+
+  g_npidhash = i;
 
   /* IDLE Group Initialization **********************************************/
 


### PR DESCRIPTION
## Summary

timer & nx_start small bug fix:
1. sched: swap setting for g_npidhash
    
    in case of crash in kmm_zalloc, and crash dump use
    nxsched_foreach()

2. timer: set g_timer.lower after TIMER_START()
    
    in case of up_perf_gettime() get non-start value
    
## Impact

none

## Testing

bes board & sim