### PR TITLE
arch: support customized up_cpu_index() in AMP mode

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -231,34 +231,32 @@ static inline irqstate_t up_irq_enable(void)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 noinstrument_function

--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -342,23 +342,13 @@ static inline void setcontrol(uint32_t control)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {
@@ -376,13 +366,21 @@ static inline_function uint32_t up_getsp(void)
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 noinstrument_function

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -433,19 +433,11 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 noinstrument_function
 static inline_function int up_cpu_index(void)
 {
@@ -459,9 +451,7 @@ static inline_function int up_cpu_index(void)
 
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -547,23 +547,13 @@ static inline void setcontrol(uint32_t control)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {
@@ -581,13 +571,21 @@ static inline_function uint32_t up_getsp(void)
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 noinstrument_function

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -428,19 +428,11 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 noinstrument_function
 static inline_function int up_cpu_index(void)
 {
@@ -454,9 +446,7 @@ static inline_function int up_cpu_index(void)
 
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -520,23 +520,13 @@ static inline void setcontrol(uint32_t control)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {
@@ -554,13 +544,21 @@ static inline_function uint32_t up_getsp(void)
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 noinstrument_function

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -428,19 +428,11 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 noinstrument_function
 static inline_function int up_cpu_index(void)
 {
@@ -454,9 +446,7 @@ static inline_function int up_cpu_index(void)
 
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/tlsr82/irq.h
+++ b/arch/arm/include/tlsr82/irq.h
@@ -247,23 +247,13 @@ static inline uint32_t getcontrol(void)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 static inline_function uint32_t up_getsp(void)
 {
@@ -281,13 +271,21 @@ static inline_function uint32_t up_getsp(void)
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 noinstrument_function

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -73,7 +73,7 @@ static void arm_gic_init_done(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(NULL);
-  CPU_SET(up_cpu_index(), &g_gic_init_done);
+  CPU_SET(this_cpu(), &g_gic_init_done);
   spin_unlock_irqrestore(NULL, flags);
 }
 

--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -244,7 +244,7 @@ void arm_gic_irq_enable(unsigned int intid)
 
   if (GIC_IS_SPI(intid))
     {
-      arm_gic_write_irouter(up_cpu_index(), intid);
+      arm_gic_write_irouter(this_cpu(), intid);
     }
 
   putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
@@ -797,8 +797,7 @@ static void arm_gic_init(void)
   int       err;
 
   cpu               = this_cpu();
-  g_gic_rdists[cpu] = CONFIG_GICR_BASE +
-                      up_cpu_index() * CONFIG_GICR_OFFSET;
+  g_gic_rdists[cpu] = CONFIG_GICR_BASE + cpu * CONFIG_GICR_OFFSET;
 
   err = gic_validate_redist_version();
   if (err)

--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -41,12 +41,15 @@ set(SRCS
 
 if(CONFIG_SMP)
   list(APPEND SRCS cxd56_cpuidlestack.c)
-  list(APPEND SRCS cxd56_cpuindex.c)
   list(APPEND SRCS cxd56_smpcall.c)
   list(APPEND SRCS cxd56_cpustart.c)
   if(CONFIG_CXD56_TESTSET)
     list(APPEND SRCS cxd56_testset.c)
   endif()
+endif()
+
+if(CONFIG_ARCH_HAVE_MULTICPU)
+  list(APPEND SRCS cxd56_cpuindex.c)
 endif()
 
 if(CONFIG_ARCH_USE_TEXT_HEAP)

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -40,13 +40,16 @@ CHIP_CSRCS += cxd56_sysctl.c
 
 ifeq ($(CONFIG_SMP), y)
 CHIP_CSRCS += cxd56_cpuidlestack.c
-CHIP_CSRCS += cxd56_cpuindex.c
 CHIP_CSRCS += cxd56_smpcall.c
 CHIP_CSRCS += cxd56_cpustart.c
 ifeq ($(CONFIG_CXD56_TESTSET),y)
 CHIP_CSRCS += cxd56_testset.c
 CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
 endif
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU), y)
+CHIP_CSRCS += cxd56_cpuindex.c
 endif
 
 ifeq ($(CONFIG_ARCH_USE_TEXT_HEAP), y)

--- a/arch/arm/src/cxd56xx/cxd56_cpuindex.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpuindex.c
@@ -29,7 +29,7 @@
 #include "arm_internal.h"
 #include "cxd56_cpuindex.h"
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 
 /****************************************************************************
  * Public Functions
@@ -39,15 +39,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
@@ -58,4 +50,4 @@ int up_cpu_index(void)
   return getreg32(CXD56_ADSP_PID) - 2;
 }
 
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -91,11 +91,14 @@ endif
 
 ifeq ($(CONFIG_SMP), y)
 CHIP_CSRCS += lc823450_cpuidlestack.c
-CHIP_CSRCS += lc823450_cpuindex.c
 CHIP_CSRCS += lc823450_smpcall.c
 CHIP_CSRCS += lc823450_cpustart.c
 CHIP_CSRCS += lc823450_testset.c
 CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU), y)
+CHIP_CSRCS += lc823450_cpuindex.c
 endif
 
 ifeq ($(CONFIG_LC823450_SDRAM), y)

--- a/arch/arm/src/lc823450/lc823450_cpuindex.c
+++ b/arch/arm/src/lc823450/lc823450_cpuindex.c
@@ -44,15 +44,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -35,12 +35,15 @@ CHIP_CSRCS += rp2040_xosc.c
 CHIP_CSRCS += rp2040_pll.c
 
 ifeq ($(CONFIG_SMP),y)
-CHIP_CSRCS += rp2040_cpuindex.c
 CHIP_CSRCS += rp2040_cpustart.c
 CHIP_CSRCS += rp2040_smpcall.c
 CHIP_CSRCS += rp2040_cpuidlestack.c
 CHIP_CSRCS += rp2040_testset.c
 CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CHIP_CSRCS += rp2040_cpuindex.c
 endif
 
 ifeq ($(CONFIG_RP2040_DMAC),y)

--- a/arch/arm/src/rp2040/rp2040_cpuindex.c
+++ b/arch/arm/src/rp2040/rp2040_cpuindex.c
@@ -29,7 +29,7 @@
 #include "arm_internal.h"
 #include "hardware/rp2040_sio.h"
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 
 /****************************************************************************
  * Public Functions
@@ -39,15 +39,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
@@ -56,4 +48,4 @@ int up_cpu_index(void)
   return getreg32(RP2040_SIO_CPUID);
 }
 
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -137,11 +137,15 @@ endif # CONFIG_SCHED_TICKLESS
 endif # CONFIG_SAM34_TC
 
 ifeq ($(CONFIG_SMP),y)
-CHIP_CSRCS += sam4cm_cpuindex.c sam4cm_cpuidlestack.c
+CHIP_CSRCS += sam4cm_cpuidlestack.c
 CHIP_CSRCS += sam4cm_smpcall.c sam4cm_cpustart.c
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CHIP_CSRCS += sam4cm_idle.c
 endif
 endif # CONFIG_SMP
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CHIP_CSRCS += sam4cm_cpuindex.c
+endif # CONFIG_ARCH_HAVE_MULTICPU
 
 endif # CONFIG_ARCH_CHIP_SAM4CM

--- a/arch/arm/src/sam34/sam4cm_cpuindex.c
+++ b/arch/arm/src/sam34/sam4cm_cpuindex.c
@@ -27,8 +27,9 @@
 #include <nuttx/arch.h>
 
 #include "mpu.h"
+#include "arm_internal.h"
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 
 /****************************************************************************
  * Public Functions
@@ -38,15 +39,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
@@ -57,4 +50,4 @@ int up_cpu_index(void)
   return (getreg32(MPU_TYPE) == 0) ? 1 : 0;
 }
 
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -368,23 +368,13 @@ static inline void up_irq_restore(irqstate_t flags)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 #  define up_cpu_index() ((int)MPID_TO_CORE(GET_MPIDR()))
-#else
-#  define up_cpu_index() (0)
-#endif
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Name:

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -931,8 +931,7 @@ static void arm64_gic_init(void)
   int       err;
 
   cpu               = this_cpu();
-  g_gic_rdists[cpu] = CONFIG_GICR_BASE +
-                      up_cpu_index() * CONFIG_GICR_OFFSET;
+  g_gic_rdists[cpu] = CONFIG_GICR_BASE + cpu * CONFIG_GICR_OFFSET;
 
   err = gic_validate_redist_version();
   if (err)

--- a/arch/arm64/src/zynq-mpsoc/zynq_boot.c
+++ b/arch/arm64/src/zynq-mpsoc/zynq_boot.c
@@ -101,7 +101,7 @@ void arm64_el_init(void)
 #endif
 }
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 
 /****************************************************************************
  * Public Functions
@@ -111,19 +111,7 @@ void arm64_el_init(void)
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
@@ -165,7 +153,7 @@ int arm64_get_cpuid(uint64_t mpid)
   return MPID_TO_CORE(mpid, 0);
 }
 
-#endif /* CONFIG_SMP */
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Name: arm64_chip_boot

--- a/arch/avr/include/irq.h
+++ b/arch/avr/include/irq.h
@@ -88,24 +88,6 @@ EXTERN volatile uint8_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/ceva/include/irq.h
+++ b/arch/ceva/include/irq.h
@@ -113,23 +113,13 @@ EXTERN uint32_t *volatile g_current_regs[CONFIG_SMP_NCPUS];
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Inline functions
@@ -137,12 +127,20 @@ int up_cpu_index(void);
 
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/hc/include/irq.h
+++ b/arch/hc/include/irq.h
@@ -101,24 +101,6 @@ EXTERN volatile uint8_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/mips/include/irq.h
+++ b/arch/mips/include/irq.h
@@ -105,24 +105,6 @@ EXTERN volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/misoc/include/irq.h
+++ b/arch/misoc/include/irq.h
@@ -87,24 +87,6 @@ EXTERN volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/or1k/include/irq.h
+++ b/arch/or1k/include/irq.h
@@ -94,23 +94,13 @@ EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Inline functions
@@ -118,12 +108,20 @@ int up_cpu_index(void);
 
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/renesas/include/irq.h
+++ b/arch/renesas/include/irq.h
@@ -70,24 +70,6 @@ EXTERN volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -701,23 +701,13 @@ irqstate_t up_irq_enable(void);
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Inline Functions
@@ -725,12 +715,20 @@ int up_cpu_index(void);
 
 static inline_function uintreg_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uintreg_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uintreg_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(uintreg_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -44,7 +44,11 @@ if(NOT CONFIG_ALARM_ARCH)
 endif()
 
 if(CONFIG_SMP)
-  list(APPEND SRCS riscv_cpuindex.c riscv_smpcall.c riscv_cpustart.c)
+  list(APPEND SRCS riscv_smpcall.c riscv_cpustart.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MULTICPU)
+  list(APPEND SRCS riscv_cpuindex.c)
 endif()
 
 if(CONFIG_RISCV_MISALIGNED_HANDLER)

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -47,7 +47,11 @@ ifneq ($(CONFIG_ALARM_ARCH),y)
 endif
 
 ifeq ($(CONFIG_SMP),y)
-CMN_CSRCS += riscv_cpuindex.c riscv_smpcall.c riscv_cpustart.c
+CMN_CSRCS += riscv_smpcall.c riscv_cpustart.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CMN_CSRCS += riscv_cpuindex.c
 endif
 
 ifeq ($(CONFIG_RISCV_MISALIGNED_HANDLER),y)

--- a/arch/risc-v/src/common/riscv_cpuindex.c
+++ b/arch/risc-v/src/common/riscv_cpuindex.c
@@ -39,15 +39,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -86,23 +86,13 @@ EXTERN volatile xcpt_reg_t *g_current_regs[CONFIG_SMP_NCPUS];
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /* Name: up_irq_save, up_irq_restore, and friends.
  *
@@ -124,12 +114,20 @@ void up_irq_enable(void);
 
 static inline_function xcpt_reg_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (xcpt_reg_t *)g_current_regs[up_cpu_index()];
+#else
+  return (xcpt_reg_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(xcpt_reg_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /* Return the current value of the stack pointer */

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -154,6 +154,9 @@ endif
 
 ifeq ($(CONFIG_SMP),y)
   CSRCS += sim_smpsignal.c sim_cpuidlestack.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
   HOSTSRCS += sim_hostsmp.c
 endif
 

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -174,6 +174,9 @@ endif()
 
 if(CONFIG_SMP)
   list(APPEND SRCS sim_smpsignal.c sim_cpuidlestack.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MULTICPU)
   list(APPEND HOSTSRCS sim_hostsmp.c)
 endif()
 

--- a/arch/sim/src/sim/posix/sim_hostsmp.c
+++ b/arch/sim/src/sim/posix/sim_hostsmp.c
@@ -49,6 +49,8 @@ struct sim_cpuinfo_s
  ****************************************************************************/
 
 static pthread_key_t g_cpu_key;
+
+#ifdef CONFIG_SMP
 static pthread_t     g_cpu_thread[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
@@ -162,28 +164,6 @@ void host_cpu0_start(void)
 }
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-int up_cpu_index(void)
-{
-  void *value = pthread_getspecific(g_cpu_key);
-  return (int)((uintptr_t)value);
-}
-
-/****************************************************************************
  * Name: up_cpu_start
  *
  * Description:
@@ -264,8 +244,6 @@ void host_send_ipi(int cpu)
   pthread_kill(g_cpu_thread[cpu], SIGUSR1);
 }
 
-#ifdef CONFIG_SMP
-
 /****************************************************************************
  * Name: host_send_func_call_ipi(int cpu)
  ****************************************************************************/
@@ -273,5 +251,21 @@ void host_send_ipi(int cpu)
 void host_send_func_call_ipi(int cpu)
 {
   pthread_kill(g_cpu_thread[cpu], SIGUSR2);
+}
+#endif
+
+/****************************************************************************
+ * Name: up_cpu_index
+ *
+ * Description:
+ *   Return the real core number regardless CONFIG_SMP setting
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void)
+{
+  void *value = pthread_getspecific(g_cpu_key);
+  return (int)((uintptr_t)value);
 }
 #endif

--- a/arch/sparc/include/irq.h
+++ b/arch/sparc/include/irq.h
@@ -112,23 +112,13 @@ EXTERN volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Inline functions
@@ -136,12 +126,20 @@ int up_cpu_index(void);
 
 static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/sparc/src/s698pm/Make.defs
+++ b/arch/sparc/src/s698pm/Make.defs
@@ -54,5 +54,9 @@ endif
 # Configuration-dependent files
 
 ifeq ($(CONFIG_SMP),y)
-CHIP_CSRCS += s698pm_cpuindex.c s698pm_cpustart.c s698pm_smpcall.c s698pm_cpuidlestack.c
+CHIP_CSRCS += s698pm_cpustart.c s698pm_smpcall.c s698pm_cpuidlestack.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CHIP_CSRCS += s698pm_cpuindex.c
 endif

--- a/arch/sparc/src/s698pm/s698pm_cpuindex.c
+++ b/arch/sparc/src/s698pm/s698pm_cpuindex.c
@@ -39,19 +39,11 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void)
 {
   int cpu = 0;

--- a/arch/tricore/include/irq.h
+++ b/arch/tricore/include/irq.h
@@ -80,23 +80,13 @@ EXTERN volatile uintptr_t *g_current_regs[CONFIG_SMP_NCPUS];
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() (0)
-#endif
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Name: up_irq_enable
@@ -153,12 +143,20 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
 
 static inline_function uintptr_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uintptr_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uintptr_t *)g_current_regs[0];
+#endif
 }
 
 static inline_function void up_set_current_regs(uintptr_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/x86/include/irq.h
+++ b/arch/x86/include/irq.h
@@ -87,24 +87,6 @@ EXTERN volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/arch/x86_64/include/irq.h
+++ b/arch/x86_64/include/irq.h
@@ -83,19 +83,11 @@ extern "C"
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
 static inline_function int up_cpu_index(void)
 {
   int cpu;
@@ -108,9 +100,7 @@ static inline_function int up_cpu_index(void)
 
   return cpu;
 }
-#else
-#  define up_cpu_index() (0)
-#endif
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
  * Inline functions

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -405,33 +405,31 @@ irqstate_t xtensa_disable_interrupts(irqstate_t mask);
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void);
-#else
-#  define up_cpu_index() (0)
-#endif
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+int up_cpu_index(void) noinstrument_function;
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 noinstrument_function static inline_function uint32_t *up_current_regs(void)
 {
+#ifdef CONFIG_SMP
   return (uint32_t *)g_current_regs[up_cpu_index()];
+#else
+  return (uint32_t *)g_current_regs[0];
+#endif
 }
 
 noinstrument_function
 static inline_function void up_set_current_regs(uint32_t *regs)
 {
+#ifdef CONFIG_SMP
   g_current_regs[up_cpu_index()] = regs;
+#else
+  g_current_regs[0] = regs;
+#endif
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/common/espressif/esp_spiflash.c
+++ b/arch/xtensa/src/common/espressif/esp_spiflash.c
@@ -189,7 +189,7 @@ IRAM_ATTR void spiflash_start(void)
 
   nxmutex_lock(&s_flash_op_mutex);
   flags = enter_critical_section();
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   s_sched_suspended[cpu] = true;
 
 #ifndef CONFIG_ARCH_CHIP_ESP32S2
@@ -225,7 +225,7 @@ IRAM_ATTR void spiflash_end(void)
 
   flags = enter_critical_section();
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
 
   cache_invalidate_icache_all();
   cache_resume_icache(s_flash_op_cache_state[cpu] >> 16);

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -128,8 +128,11 @@ endif
 # Configuration-dependent ESP32 files
 
 ifeq ($(CONFIG_SMP),y)
-CHIP_ASRCS  = esp32_cpuindex.S
 CHIP_CSRCS += esp32_cpuidlestack.c esp32_cpustart.c esp32_intercpu_interrupt.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CHIP_ASRCS  = esp32_cpuindex.S
 endif
 
 ifeq ($(CONFIG_ESP32_UART),y)

--- a/arch/xtensa/src/esp32/esp32_cpuindex.S
+++ b/arch/xtensa/src/esp32/esp32_cpuindex.S
@@ -35,19 +35,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -44,8 +44,11 @@ CHIP_CSRCS += esp32s3_userspace.c
 endif
 
 ifeq ($(CONFIG_SMP),y)
-CHIP_ASRCS  = esp32s3_cpuindex.S
 CHIP_CSRCS += esp32s3_cpuidlestack.c esp32s3_cpustart.c esp32s3_intercpu_interrupt.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_MULTICPU),y)
+CHIP_ASRCS  = esp32s3_cpuindex.S
 endif
 
 ifeq ($(CONFIG_ESP32S3_EFUSE),y)

--- a/arch/xtensa/src/esp32s3/esp32s3_cpuindex.S
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpuindex.S
@@ -35,19 +35,7 @@
  * Name: up_cpu_index
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- *   If TLS is enabled, then the RTOS can get this information from the TLS
- *   info structure.  Otherwise, the MCU-specific logic must provide some
- *   mechanism to provide the CPU index.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Return the real core number regardless CONFIG_SMP setting
  *
  ****************************************************************************/
 

--- a/arch/z16/include/irq.h
+++ b/arch/z16/include/irq.h
@@ -74,24 +74,6 @@ EXTERN volatile FAR chipreg_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_cpu_index
- *
- * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- ****************************************************************************/
-
-#define up_cpu_index() (0)
-
-/****************************************************************************
  * Inline functions
  ****************************************************************************/
 

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -215,7 +215,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 
 #if defined(CONFIG_SMP)
-                             , up_cpu_index()
+                             , this_cpu()
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -100,6 +100,18 @@
 #define DEBUGPOINT_STEPPOINT     0x05
 
 /****************************************************************************
+ * Name: up_cpu_index
+ *
+ * Description:
+ *   Return the real core number regardless CONFIG_SMP setting
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_ARCH_HAVE_MULTICPU
+#  define up_cpu_index() 0
+#endif /* CONFIG_ARCH_HAVE_MULTICPU */
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -35,6 +35,7 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 
 #if defined(CONFIG_TICKET_SPINLOCK) || defined(CONFIG_RW_SPINLOCK)
 #  include <nuttx/atomic.h>
@@ -531,7 +532,7 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
 
   if (NULL == lock)
     {
-      int me = up_cpu_index();
+      int me = this_cpu();
       if (0 == g_irq_spin_count[me])
         {
           spin_lock_wo_note(&g_irq_spin);
@@ -698,7 +699,7 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
 {
   if (NULL == lock)
     {
-      int me = up_cpu_index();
+      int me = this_cpu();
       DEBUGASSERT(0 < g_irq_spin_count[me]);
       g_irq_spin_count[me]--;
 

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -606,7 +606,7 @@ static ssize_t tcp_recvfrom_result(int result, struct tcp_recvfrom_s *pstate)
 #ifdef CONFIG_NETDEV_RSS
 static void tcp_notify_recvcpu(FAR struct tcp_conn_s *conn)
 {
-  int cpu = up_cpu_index();
+  int cpu = this_cpu();
 
   if (cpu != conn->rcvcpu)
     {

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -628,7 +628,7 @@ static void udp_notify_recvcpu(FAR struct udp_conn_s *conn)
       return;
     }
 
-  cpu = up_cpu_index();
+  cpu = this_cpu();
   if (cpu != conn->rcvcpu)
     {
       if (conn->domain == PF_INET)

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -193,7 +193,7 @@ irqstate_t write_lock_irqsave(rwlock_t *lock)
 
   if (NULL == lock)
     {
-      int me = up_cpu_index();
+      int me = this_cpu();
       if (0 == g_irq_rwspin_count[me])
         {
           write_lock(&g_irq_rwspin);
@@ -243,7 +243,7 @@ void write_unlock_irqrestore(rwlock_t *lock, irqstate_t flags)
 {
   if (NULL == lock)
     {
-      int me = up_cpu_index();
+      int me = this_cpu();
       DEBUGASSERT(0 < g_irq_rwspin_count[me]);
       g_irq_rwspin_count[me]--;
 


### PR DESCRIPTION

## Summary
support customized up_cpu_index() in AMP mode

Some app with same code runs on different cores in AMP mode, need the physical core on which the function is called.

## Impact
arm

## Testing
ostest
