### PR TITLE
rpmsg services: should release the tx buffer when rpmsg_send_nocopy failed

### DIFF
--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -497,6 +497,10 @@ static int64_t clk_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
           ret = cookie.result;
         }
     }
+  else
+    {
+      rpmsg_release_tx_buffer(ept, msg);
+    }
 
   nxsem_destroy(&cookie.sem);
   return ret;

--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -395,6 +395,7 @@ static ssize_t rpmsgblk_write(FAR struct inode *inode,
                               sizeof(*msg) - 1 + msg->nsectors * sectorsize);
       if (ret < 0)
         {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
           goto out;
         }
     }
@@ -859,6 +860,11 @@ static int rpmsgblk_send_recv(FAR struct rpmsgblk_s *priv,
 
   if (ret < 0)
     {
+      if (copy == false)
+        {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
+        }
+
       goto fail;
     }
 

--- a/drivers/misc/rpmsgblk_server.c
+++ b/drivers/misc/rpmsgblk_server.c
@@ -224,8 +224,12 @@ static int rpmsgblk_read_handler(FAR struct rpmsg_endpoint *ept,
                                (FAR unsigned char *)rsp->buf,
                                msg->startsector, nsectors);
       rsp->header.result = ret;
-      rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret * msg->sectorsize) +
-                        sizeof(*rsp) - 1);
+      if (rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret * msg->sectorsize) +
+                                      sizeof(*rsp) - 1) < 0)
+        {
+          rpmsg_release_tx_buffer(ept, rsp);
+        }
+
       if (ret <= 0)
         {
           ferr("mtd block read failed\n");
@@ -327,6 +331,7 @@ static int rpmsgblk_mmc_cmd_handler(FAR struct rpmsg_endpoint *ept,
   size_t rsplen;
   size_t arglen;
   uint32_t space;
+  int ret;
 
   arglen = sizeof(struct mmc_ioc_cmd);
   if (!ioc->write_flag)
@@ -358,8 +363,13 @@ static int rpmsgblk_mmc_cmd_handler(FAR struct rpmsg_endpoint *ept,
 
   rsp->header.result = server->bops->ioctl(server->blknode, rsp->request,
                                            (unsigned long)rsp->buf);
+  ret = rpmsg_send_nocopy(ept, rsp, rsplen);
+  if (ret < 0)
+    {
+      rpmsg_release_tx_buffer(ept, rsp);
+    }
 
-  return rpmsg_send_nocopy(ept, rsp, rsplen);
+  return ret;
 }
 
 /****************************************************************************
@@ -380,6 +390,7 @@ static int rpmsgblk_mmc_multi_cmd_handler(FAR struct rpmsg_endpoint *ept,
   size_t rsp_off;
   uint32_t space;
   uint64_t i;
+  int ret;
 
   arglen = sizeof(struct mmc_ioc_multi_cmd) +
            mioc->num_of_cmds * sizeof(struct mmc_ioc_cmd);
@@ -427,8 +438,13 @@ static int rpmsgblk_mmc_multi_cmd_handler(FAR struct rpmsg_endpoint *ept,
 
   rsp->header.result = server->bops->ioctl(server->blknode, rsp->request,
                                            (unsigned long)rsp->buf);
+  ret = rpmsg_send_nocopy(ept, rsp, rsplen);
+  if (ret < 0)
+    {
+      rpmsg_release_tx_buffer(ept, rsp);
+    }
 
-  return rpmsg_send_nocopy(ept, rsp, rsplen);
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/mtd/rpmsgmtd_server.c
+++ b/drivers/mtd/rpmsgmtd_server.c
@@ -166,8 +166,9 @@ static int rpmsgmtd_bread_handler(FAR struct rpmsg_endpoint *ept,
       rsp->header.result = ret;
       rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret * msg->blocksize) +
                         sizeof(*rsp) - 1);
-      if (ret <= 0)
+      if (ret < 0)
         {
+          rpmsg_release_tx_buffer(ept, rsp);
           ferr("mtd block read failed\n");
           break;
         }
@@ -246,8 +247,9 @@ static int rpmsgmtd_read_handler(FAR struct rpmsg_endpoint *ept,
 
       rsp->header.result = ret;
       rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret) + sizeof(*rsp) - 1);
-      if (ret <= 0)
+      if (ret < 0)
         {
+          rpmsg_release_tx_buffer(ept, rsp);
           break;
         }
 

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -214,6 +214,11 @@ static int net_rpmsg_drv_transmit(FAR struct net_driver_s *dev, bool nocopy)
 
   if (ret < 0)
     {
+      if (nocopy)
+        {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
+        }
+
       NETDEV_TXERRORS(dev);
       return ret;
     }

--- a/drivers/note/noterpmsg_driver.c
+++ b/drivers/note/noterpmsg_driver.c
@@ -151,7 +151,11 @@ static bool noterpmsg_transfer(FAR struct noterpmsg_driver_s *drv,
       memcpy(buffer, drv->buffer + drv->tail, space);
       memcpy(buffer + space, drv->buffer, len - space);
 
-      rpmsg_send_nocopy(&drv->ept, buffer, len);
+      if (rpmsg_send_nocopy(&drv->ept, buffer, len) < 0)
+        {
+          rpmsg_release_tx_buffer(&drv->ept, buffer);
+        }
+
       drv->tail = noterpmsg_next(drv, drv->tail, len);
     }
 }

--- a/drivers/power/supply/regulator_rpmsg.c
+++ b/drivers/power/supply/regulator_rpmsg.c
@@ -546,6 +546,10 @@ static int regulator_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
           ret = cookie.result;
         }
     }
+  else
+    {
+      rpmsg_release_tx_buffer(ept, msg);
+    }
 
   nxsem_destroy(&cookie.sem);
   return ret;

--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -168,6 +168,11 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept,
       ret = rpmsg_send_nocopy(ept, msg, len);
     }
 
+  if (ret < 0)
+    {
+      rpmsg_release_tx_buffer(ept, msg);
+    }
+
   return ret;
 }
 

--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -217,7 +217,10 @@ static void uart_rpmsg_dmasend(FAR struct uart_dev_s *dev)
   msg->header.result  = -ENXIO;
   msg->header.cookie  = (uintptr_t)dev;
 
-  rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len);
+  if (rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len) < 0)
+    {
+      rpmsg_release_tx_buffer(&priv->ept, msg);
+    }
 }
 
 static void uart_rpmsg_dmareceive(FAR struct uart_dev_s *dev)

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -168,7 +168,11 @@ static bool syslog_rpmsg_transfer(FAR struct syslog_rpmsg_s *priv, bool wait)
       msg->count          = len;
       priv->tail         += len;
       msg->header.command = SYSLOG_RPMSG_TRANSFER;
-      rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len);
+      if (rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len) < 0)
+        {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
+        }
+
       len                 = SYSLOG_RPMSG_COUNT(priv);
 
       leave_critical_section(flags);

--- a/drivers/usrsock/usrsock_rpmsg.c
+++ b/drivers/usrsock/usrsock_rpmsg.c
@@ -100,6 +100,10 @@ static int usrsock_rpmsg_send_dns_request(FAR void *arg,
   net_lock();
   ret = rpmsg_send_nocopy(ept, dns, sizeof(*dns) + addrlen);
   net_unlock();
+  if (ret < 0)
+    {
+      rpmsg_release_tx_buffer(ept, dns);
+    }
 
   return ret;
 }
@@ -225,6 +229,7 @@ int usrsock_request(FAR struct iovec *iov, unsigned int iovcnt)
       ret = rpmsg_send_nocopy(&priv->ept, buf, ret);
       if (ret < 0)
         {
+          rpmsg_release_tx_buffer(&priv->ept, buf);
           break;
         }
 

--- a/drivers/wireless/bluetooth/bt_rpmsghci.c
+++ b/drivers/wireless/bluetooth/bt_rpmsghci.c
@@ -130,6 +130,7 @@ static int rpmsghci_send(FAR struct rpmsghci_s *priv, uint32_t command,
   ret = rpmsg_send_nocopy(&priv->ept, msg, len);
   if (ret < 0)
     {
+      rpmsg_release_tx_buffer(&priv->ept, msg);
       goto errout;
     }
 

--- a/drivers/wireless/bluetooth/bt_rpmsghci_server.c
+++ b/drivers/wireless/bluetooth/bt_rpmsghci_server.c
@@ -132,6 +132,7 @@ static int rpmsghci_send(FAR struct rpmsghci_server_s *priv,
   ret = rpmsg_send_nocopy(&priv->ept, msg, len);
   if (ret < 0)
     {
+      rpmsg_release_tx_buffer(&priv->ept, msg);
       goto errout;
     }
 

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -373,6 +373,11 @@ static int rpmsgfs_send_recv(FAR struct rpmsgfs_s *priv,
 
   if (ret < 0)
     {
+      if (copy == false)
+        {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
+        }
+
       goto fail;
     }
 
@@ -550,6 +555,7 @@ ssize_t rpmsgfs_client_write(FAR void *handle, int fd,
       ret = rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + space);
       if (ret < 0)
         {
+          rpmsg_release_tx_buffer(&priv->ept, msg);
           goto out;
         }
 

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -391,7 +391,11 @@ static int rpmsgfs_read_handler(FAR struct rpmsg_endpoint *ept,
         }
 
       rsp->header.result = ret;
-      rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret) + sizeof(*rsp));
+      if (rpmsg_send_nocopy(ept, rsp, (ret < 0 ? 0 : ret) + sizeof(*rsp))
+          < 0)
+        {
+          rpmsg_release_tx_buffer(ept, rsp);
+        }
 
       if (ret <= 0)
         {


### PR DESCRIPTION
## Summary
Otherwise, the tx buffer will be discarded and can no longer be obtained

## Impact
All the rpmsg services

## Testing
sim rpserver and rpproxy
