### PR TITLE
mm/kconfig: set the default alignment of global variable out-of-bounds detection is 1

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -345,7 +345,10 @@ if MM_KASAN_GLOBAL
 
 config MM_KASAN_GLOBAL_ALIGN
 	int "KASan global alignment"
-	default 32
+	default 1
+	---help---
+		It is recommended to use 1, 2, 4, 8, 16, 32.
+		The maximum value is 32.
 
 endif # MM_KASAN_GLOBAL
 


### PR DESCRIPTION
## Summary
1. It is recommended to use 1 on qemu and 16 or even 32 on the device.
## Impact
No
## Testing
No
