### PR TITLE
mm: Resolve a series of issues caused by opening the software tag kasan

### DIFF
--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -76,7 +76,6 @@ endif
 
 ifeq ($(CONFIG_ARCH_HAVE_MPU),y)
 CMN_CSRCS += arm64_mpu.c
-common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-hwaddress
 common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-address
 endif
 

--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -76,6 +76,8 @@ endif
 
 ifeq ($(CONFIG_ARCH_HAVE_MPU),y)
 CMN_CSRCS += arm64_mpu.c
+common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-hwaddress
+common/arm64_mpu.c_CFLAGS += -fno-sanitize=kernel-address
 endif
 
 ifeq ($(CONFIG_ARM64_PSCI),y)

--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -387,6 +387,12 @@ void arm64_mpu_init(bool is_primary_core)
   uint64_t  val;
   uint32_t  r_index;
 
+#ifdef CONFIG_MM_KASAN_SW_TAGS
+  val  = read_sysreg(tcr_el1);
+  val |= (TCR_TBI0 | TCR_TBI1 | TCR_ASID_8);
+  write_sysreg(val, tcr_el1);
+#endif
+
   /* Current MPU code supports only EL1 */
 
   __asm__ volatile ("mrs %0, CurrentEL" : "=r" (val));

--- a/arch/arm64/src/common/arm64_mpu.h
+++ b/arch/arm64/src/common/arm64_mpu.h
@@ -50,6 +50,14 @@
 #define MPU_RBAR_AP_POS     2U
 #define MPU_RBAR_AP_MSK     (0x3UL << MPU_RBAR_AP_POS)
 
+/* TCR_EL1 */
+
+#define TCR_AS_SHIFT        36U
+#define TCR_ASID_8          (0ULL << TCR_AS_SHIFT)
+#define TCR_ASID_16         (1ULL << TCR_AS_SHIFT)
+#define TCR_TBI0            (1ULL << 37)
+#define TCR_TBI1            (1ULL << 38)
+
 /* RBAR_EL1 XN */
 
 #define MPU_RBAR_XN_POS     1U

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -116,7 +116,8 @@ void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem, bool delay)
 
   /* Map the memory chunk into a free node */
 
-  node = (FAR struct mm_freenode_s *)((FAR char *)mem - MM_SIZEOF_ALLOCNODE);
+  node = (FAR struct mm_freenode_s *)
+         ((FAR char *)kasan_reset_tag(mem) - MM_SIZEOF_ALLOCNODE);
   nodesize = MM_SIZEOF_NODE(node);
 
   /* Sanity check against double-frees */

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -141,6 +141,8 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   kasan_poison((FAR void *)rawchunk,
                mm_malloc_size(heap, (FAR void *)rawchunk));
 
+  rawchunk = (uintptr_t)kasan_reset_tag((FAR void *)rawchunk);
+
   /* We need to hold the MM mutex while we muck with the chunks and
    * nodelist.
    */

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -132,7 +132,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   /* Map the memory chunk into an allocated node structure */
 
   oldnode = (FAR struct mm_allocnode_s *)
-    ((FAR char *)oldmem - MM_SIZEOF_ALLOCNODE);
+    ((FAR char *)kasan_reset_tag(oldmem) - MM_SIZEOF_ALLOCNODE);
 
   /* We need to hold the MM mutex while we muck with the nodelist. */
 


### PR DESCRIPTION
## Summary
1. add TBI setting to r82 when use SW_TAG
2. exclude mpu from sanitize for SMP mode
3. fix mempool crash when use KASAN SW_TAG
4. Fix mempool tag kasan error
## Impact
No
## Testing
No
