### PR TITLE
sched/signal: change pthread_exit to nx_pthread_exit

### DIFF
--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -30,10 +30,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 #include <signal.h>
 #include <assert.h>
 
+#include <nuttx/pthread.h>
 #include <nuttx/sched.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/signal.h>
@@ -225,6 +225,8 @@ static void nxsig_abnormal_termination(int signo)
   group_kill_children(rtcb);
 #endif
 
+  tls_cleanup_popall(tls_get_info());
+
 #ifndef CONFIG_DISABLE_PTHREAD
   /* Check if the currently running task is actually a pthread */
 
@@ -235,7 +237,7 @@ static void nxsig_abnormal_termination(int signo)
        * REVISIT:  This will not work if HAVE_GROUP_MEMBERS is not set.
        */
 
-      pthread_exit(NULL);
+      nx_pthread_exit(NULL);
     }
   else
 #endif


### PR DESCRIPTION
## Summary

In protected build, kernel cannot call usersapce interface.

1. change pthread_exit to nx_pthread_exit.
2. add kernel tls cleanup.

## Impact

NA

## Testing

sabre-6quad:nsh and sabre-6quad:knsh with ostest pass