### PR TITLE
Memory delay free kasan error fix and  memory note fix

### DIFF
--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -102,7 +102,18 @@ void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem, bool delay)
 
   nodesize = mm_malloc_size(heap, mem);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
-  memset(mem, MM_FREE_MAGIC, nodesize);
+#if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
+  /* If delay free is enabled, a memory node will be freed twice.
+   * The first time is to add the node to the delay list, and the second
+   * time is to actually free the node. Therefore, we only colorize the
+   * memory node the first time, when `delay` is set to true.
+   */
+
+  if (delay)
+#endif
+    {
+      memset(mem, MM_FREE_MAGIC, nodesize);
+    }
 #endif
 
   kasan_poison(mem, nodesize);

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -206,10 +206,9 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   mm_addfreechunk(heap, node);
   heap->mm_curused += 2 * MM_SIZEOF_ALLOCNODE;
-  mm_unlock(heap);
-
   sched_note_heap(NOTE_HEAP_ADD, heap, heapstart, heapsize,
                   heap->mm_curused);
+  mm_unlock(heap);
 }
 
 /****************************************************************************

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -359,7 +359,11 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #  ifdef CONFIG_MM_DUMP_DETAILS_ON_FAILURE
       struct mm_memdump_s dump =
       {
+#if CONFIG_MM_BACKTRACE >= 0
         PID_MM_ALLOC, 0, ULONG_MAX
+#else
+        PID_MM_ALLOC
+#endif
       };
 #  endif
 #endif

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -321,14 +321,19 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
     }
 
   DEBUGASSERT(ret == NULL || mm_heapmember(heap, ret));
+
+  if (ret)
+    {
+      sched_note_heap(NOTE_HEAP_ALLOC, heap, ret, nodesize,
+                      heap->mm_curused);
+    }
+
   mm_unlock(heap);
 
   if (ret)
     {
       MM_ADD_BACKTRACE(heap, node);
       ret = kasan_unpoison(ret, nodesize - MM_ALLOCNODE_OVERHEAD);
-      sched_note_heap(NOTE_HEAP_ALLOC, heap, ret, nodesize,
-                      heap->mm_curused);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
       memset(ret, MM_ALLOC_MAGIC, alignsize - MM_ALLOCNODE_OVERHEAD);
 #endif

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -277,15 +277,15 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
       heap->mm_maxused = heap->mm_curused;
     }
 
+  sched_note_heap(NOTE_HEAP_ALLOC, heap, (FAR void *)alignedchunk, size,
+                  heap->mm_curused);
+
   mm_unlock(heap);
 
   MM_ADD_BACKTRACE(heap, node);
 
   alignedchunk = (uintptr_t)kasan_unpoison((FAR const void *)alignedchunk,
                                            size - MM_ALLOCNODE_OVERHEAD);
-  sched_note_heap(NOTE_HEAP_ALLOC, heap, (FAR void *)alignedchunk, size,
-                  heap->mm_curused);
-
   DEBUGASSERT(alignedchunk % alignment == 0);
   return (FAR void *)alignedchunk;
 }

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -595,7 +595,18 @@ static void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem,
       size_t size = mm_malloc_size(heap, mem);
       UNUSED(size);
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
-      memset(mem, MM_FREE_MAGIC, size);
+#if CONFIG_MM_FREE_DELAYCOUNT_MAX > 0
+  /* If delay free is enabled, a memory node will be freed twice.
+   * The first time is to add the node to the delay list, and the second
+   * time is to actually free the node. Therefore, we only colorize the
+   * memory node the first time, when `delay` is set to true.
+   */
+
+  if (delay)
+#endif
+    {
+      memset(mem, MM_FREE_MAGIC, nodesize);
+    }
 #endif
 
       kasan_poison(mem, size);


### PR DESCRIPTION
## Summary

1. Hold lock when access mm struct field from sched_note_heap.
2. Fix kasan reported error when delay free feature is enabled. See comments in code.
```
  /* If delay free is enabled, a memory node will be freed twice.
   * The first time is to add the node to the delay list, and the second
   * time is to actually free the node. Therefore, we only colorize the
   * memory node the first time, when `delay` is set to true.
   */
```
~3. Remove CONFIG_MM_MAP_COUNT_MAX option. User should take care of it.~ It causes `ltp_interfaces_mmap_24_1` test to fail, remove this patch for now.

## Impact

Bug fixes should have no impact on existing projects.
 
## Testing

Local tested with qemu.

### Configure
```
tools/configure.sh mps3-an547:nsh
```

Change CONFIG_MM_REGIONS = 1 to reduce the heap size, in order to make kasan faster.

Enable
```
CONFIG_MM_KASAN=y
CONFIG_MM_FREE_DELAYCOUNT_MAX=16
CONFIG_MM_FILL_ALLOCATIONS=y
```

### Run
```
 qemu-system-arm -M mps3-an547 -m 2G -nographic -kernel nuttx -gdb tcp::1127 -serial pty
```
### Result
- Before the fix
```
kasan_report: kasan detected a write access error, address at 0x1019f08,size is 1, return address: 0xf4f7                                     │start () at armv8-m/arm_vectors.c:66
kasan_show_memory: Shadow bytes around the buggy address:                                                                                     │66        asm volatile ("mov lr, #0\n\t"
kasan_show_memory:   0x1019eb0: 8c 2a f8 01 9d 89 22 ca e0 e9 90 40 d1 d3 15 0a                                                               │(gdb) c
kasan_show_memory:   0x1019ec0: 41 f2 70 95 43 f1 ea aa 89 a6 e9 fb 5a 4e fc 62                                                               │Continuing.
kasan_show_memory:   0x1019ed0: fd 86 8c c0 a5 8c dc 24 e7 4a 1a c9 e9 64 bd 52                                                               │[Inferior 1 (process 1) exited normally]
kasan_show_memory:   0x1019ee0: 70 97 68 55 71 dc a1 de 1f 68 d2 9a e5 12 78 7b                                                               │(gdb) c
kasan_show_memory:   0x1019ef0: 83 ab c2 51 32 06 2b 97 65 76 26 e2 2c 06 25 72                                                               │The program is not being run.
kasan_show_memory:   0x1019f00: aa aa aa aa 61 03 00 00[c0 97 01 01 55 55 55 55                                                               │(gdb) tar rem:1127
kasan_show_memory:   0x1019f10: 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55                                                               │`/home/neo/projects/nuttx/nuttx/nuttx' has changed; re-reading symbols.
kasan_show_memory:   0x1019f20: 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55                                                               │Remote debugging using :1127
kasan_show_memory:   0x1019f30: 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55                                                               │
kasan_show_memory:   0x1019f40: 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55 55                                                               │Program received signal SIGTRAP, Trace/breakpoint trap.
dump_assert_info: Current Version: NuttX  12.7.0-RC0 1e556412c0d-dirty Oct  8 2024 14:36:37 arm                                               │start () at armv8-m/arm_vectors.c:66
dump_assert_info: Assertion failed panic: at file: kasan/hook.c:187 task: memstress process: memstress 0x3e56
```

- After the fix
memstress runs without kasan error.


