### PR TITLE
Deadlock detect fix

### DIFF
--- a/sched/misc/deadlock.c
+++ b/sched/misc/deadlock.c
@@ -71,6 +71,11 @@ static void collect_deadlock(FAR struct tcb_s *tcb, FAR void *arg)
               size_t i;
 
               next = ((FAR mutex_t *)sem)->holder;
+              if (next == NXMUTEX_NO_HOLDER)
+                {
+                  break;
+                }
+
               for (i = info->found; i < index; i++)
                 {
                   if (info->pid[i] == next)
@@ -82,6 +87,10 @@ static void collect_deadlock(FAR struct tcb_s *tcb, FAR void *arg)
 
               info->pid[index] = tcb->pid;
               tcb = nxsched_get_tcb(next);
+              if (tcb == NULL)
+                {
+                  break;
+                }
             }
         }
     }

--- a/sched/misc/deadlock.c
+++ b/sched/misc/deadlock.c
@@ -43,57 +43,87 @@ struct deadlock_info_s
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: waitmutex
+ ****************************************************************************/
+
+static FAR mutex_t *getmutex(FAR struct tcb_s *tcb)
+{
+  FAR sem_t *sem;
+
+  if (tcb == NULL)
+    {
+      return NULL;
+    }
+
+  if (tcb->task_state == TSTATE_WAIT_SEM)
+    {
+      sem = tcb->waitobj;
+      if (sem != NULL && (sem->flags & SEM_TYPE_MUTEX) != 0)
+        {
+          return (FAR mutex_t *)sem;
+        }
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
  * Name: collect_deadlock
  ****************************************************************************/
 
 static void collect_deadlock(FAR struct tcb_s *tcb, FAR void *arg)
 {
-  if (tcb->task_state == TSTATE_WAIT_SEM)
+  FAR struct deadlock_info_s *info = arg;
+  FAR mutex_t *mutex;
+  size_t index;
+
+  mutex = getmutex(tcb);
+  if (mutex == NULL)
     {
-      FAR sem_t *sem = tcb->waitobj;
+      return;
+    }
 
-      if (sem != NULL && (sem->flags & SEM_TYPE_MUTEX) != 0)
+  for (index = 0; index < info->found; index++)
+    {
+      if (info->pid[index] == tcb->pid)
         {
-          FAR struct deadlock_info_s *info = arg;
-          size_t index;
-
-          for (index = 0; index < info->found; index++)
-            {
-              if (info->pid[index] == tcb->pid)
-                {
-                  return;
-                }
-            }
-
-          for (index = info->found; index < info->count; index++)
-            {
-              pid_t next;
-              size_t i;
-
-              next = ((FAR mutex_t *)sem)->holder;
-              if (next == NXMUTEX_NO_HOLDER)
-                {
-                  break;
-                }
-
-              for (i = info->found; i < index; i++)
-                {
-                  if (info->pid[i] == next)
-                    {
-                      info->found = index;
-                      return;
-                    }
-                }
-
-              info->pid[index] = tcb->pid;
-              tcb = nxsched_get_tcb(next);
-              if (tcb == NULL)
-                {
-                  break;
-                }
-            }
+          return;
         }
     }
+
+  for (index = info->found; index < info->count; index++)
+    {
+      pid_t next;
+      size_t i;
+
+      next = mutex->holder;
+      if (next == NXMUTEX_NO_HOLDER)
+        {
+          break;
+        }
+
+      for (i = info->found; i < index; i++)
+        {
+          if (info->pid[i] == next)
+            {
+              info->found = index;
+              return;
+            }
+        }
+
+      info->pid[index] = tcb->pid;
+      tcb = nxsched_get_tcb(next);
+      mutex = getmutex(tcb);
+      if (mutex == NULL)
+        {
+          break;
+        }
+    }
+
+  /* if we not find deadlock, clear the pid array */
+
+  memset(&info->pid[info->found], 0,
+         (info->count - info->found) * sizeof(pid_t));
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fix deadlock detection.
1. If mutext has no holder(`NXMUTEX_NO_HOLDER `), stop the check.
2. Fix tcb is waiting for sem, we are unable to detect deadlock, ignore this case
3. Rewrite the code with better naming and comments, to make it more readable.
```
bug:
  thread 1: get mutexA
            wait a sem

  thread 2: wait mutexA

  This situation will be mistakenly judged as a deadlock.
```
## Impact

No impact.

## Testing

```
# Config
tools/configure.sh mps3-an547:nsh

# Run

> qemu-system-arm -M mps3-an547 -m 2G -nographic -kernel nuttx -gdb tcp::1127 -serial pty
QEMU 6.2.0 monitor - type 'help' for more information
(qemu) char device redirected to /dev/pts/4 (label serial0)

> minicom -D /dev/pts/4

> hello &
# press CTRL+/ to force panic
```
CONFIG_ARCH_DEADLOCKDUMP=y
CONFIG_TTY_FORCE_PANIC=y
```

Modify the hello_main.c to create a deadlock example.


```c
#include <nuttx/config.h>
#include <nuttx/semaphore.h>
#include <pthread.h>
#include <stdio.h>

mutex_t mutex1, mutex2, mutex3, mutex4;

void *thread1(void *arg)
{
  nxmutex_lock(&mutex1);
  printf("Thread 1 acquired mutex1\n");
  sleep(1);
  nxmutex_lock(&mutex2);
  printf("Thread 1 acquired mutex2\n");
  nxmutex_unlock(&mutex1);
  nxmutex_unlock(&mutex2);
  printf("Thread 1 finished\n");
  return NULL;
}

void *thread2(void *arg)
{
  nxmutex_lock(&mutex2);
  printf("Thread 2 acquired mutex2\n");
  sleep(1);
  nxmutex_lock(&mutex3);
  printf("Thread 2 acquired mutex1\n");
  nxmutex_unlock(&mutex2);
  nxmutex_unlock(&mutex3);
  printf("Thread 2 finished\n");
  return NULL;
}

void *thread3(void *arg)
{
  nxmutex_lock(&mutex3);
  printf("Thread 3 acquired mutex3\n");
  sleep(1);
  nxmutex_lock(&mutex4);
  printf("Thread 3 acquired mutex4\n");
  nxmutex_unlock(&mutex3);
  nxmutex_unlock(&mutex4);
  printf("Thread 3 finished\n");
  return NULL;
}

void *thread4(void *arg)
{
  nxmutex_lock(&mutex4);
  printf("Thread 4 acquired mutex4\n");
  nxmutex_lock(&mutex2);
  printf("Thread 4 acquired mutex2\n");
  nxmutex_unlock(&mutex4);
  nxmutex_unlock(&mutex2);
  printf("Thread 4 finished\n");
  return NULL;
}

int main(int argc, char *argv[])
{
  nxmutex_init(&mutex1);
  nxmutex_init(&mutex2);
  nxmutex_init(&mutex3);
  nxmutex_init(&mutex4);

  pthread_t t1, t2,t3,t4;
  pthread_create(&t1, NULL, thread1, NULL);
  pthread_create(&t2, NULL, thread2, NULL);
  pthread_create(&t3, NULL, thread3, NULL);
  pthread_create(&t4, NULL, thread4, NULL);

  pthread_join(t1, NULL);
  pthread_join(t2, NULL);
  pthread_join(t3, NULL);
  pthread_join(t4, NULL);

  nxmutex_destroy(&mutex1);
  nxmutex_destroy(&mutex2);
  nxmutex_destroy(&mutex3);
  nxmutex_destroy(&mutex4);
  return 0;
}
```