### PR TITLE
e1000: add polling mode support for tx/rx

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -45,13 +45,13 @@
 
 /* Packet buffer size */
 
-#define E1000_PKTBUF_SIZE     2048
-#define E1000_RCTL_BSIZE      E1000_RCTL_BSIZE_2048
+#define E1000_PKTBUF_SIZE       2048
+#define E1000_RCTL_BSIZE        E1000_RCTL_BSIZE_2048
 
 /* TX and RX descriptors */
 
-#define E1000_TX_DESC         256
-#define E1000_RX_DESC         256
+#define E1000_TX_DESC           256
+#define E1000_RX_DESC           256
 
 /* After RX packet is done, we provide free netpkt to the RX descriptor ring.
  * The upper-half network logic is responsible for freeing the RX packets
@@ -60,8 +60,8 @@
  * It's hard to tell how many spare buffers is needed, for now it's set to 8.
  */
 
-#define E1000_TX_QUOTA        E1000_TX_DESC
-#define E1000_RX_QUOTA        (E1000_RX_DESC + CONFIG_NET_E1000_RXSPARE)
+#define E1000_TX_QUOTA          (E1000_TX_DESC - 1)
+#define E1000_RX_QUOTA          (E1000_RX_DESC + CONFIG_NET_E1000_RXSPARE)
 
 /* NOTE: CONFIG_IOB_ALIGNMENT must match system D-CACHE line size */
 
@@ -75,30 +75,39 @@
 
 /* PCI BARs */
 
-#define E1000_MMIO_BAR        0
-#define E1000_FLASH_BAR       1
-#define E1000_IO_BAR          2
-#define E1000_MSIX_BAR        3
+#define E1000_MMIO_BAR          0
+#define E1000_FLASH_BAR         1
+#define E1000_IO_BAR            2
+#define E1000_MSIX_BAR          3
 
 /* E1000 interrupts */
 
-#define E1000_INTERRUPTS      (E1000_IC_RXO    | E1000_IC_RXT0 |  \
-                               E1000_IC_RXDMT0 | E1000_IC_LSC |   \
-                               E1000_IC_TXDW)
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD > 0
+#  define E1000_INTERRUPTS      (E1000_IC_LSC)
+#else
+#  define E1000_INTERRUPTS      (E1000_IC_RXO    | E1000_IC_RXT0 |  \
+                                 E1000_IC_RXDMT0 | E1000_IC_LSC |   \
+                                 E1000_IC_TXDW)
+#endif
 
 /* For MSI-X we allocate all interrupts to MSI-X vector 0 */
 
-#define E1000_MSIX_INTERRUPTS (E1000_IC_RXQ0 |   \
-                               E1000_IC_TXQ0 |   \
-                               E1000_IC_OTHER)
-#define E1000_MSIX_IVAR       (E1000_IVAR_RXQ0_EN | \
-                               E1000_IVAR_TXQ0_EN | \
-                               E1000_IVAR_OTHER_EN)
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD > 0
+#  define E1000_MSIX_INTERRUPTS (E1000_IC_OTHER)
+#  define E1000_MSIX_IVAR       (E1000_IVAR_OTHER_EN)
+#else
+#  define E1000_MSIX_INTERRUPTS (E1000_IC_RXQ0 |   \
+                                 E1000_IC_TXQ0 |   \
+                                 E1000_IC_OTHER)
+#  define E1000_MSIX_IVAR       (E1000_IVAR_RXQ0_EN | \
+                                 E1000_IVAR_TXQ0_EN | \
+                                 E1000_IVAR_OTHER_EN)
+#endif
 
 /* NIC specific Flags */
 
-#define E1000_RESET_BROKEN    (1 << 0)
-#define E1000_HAS_MSIX        (1 << 1)
+#define E1000_RESET_BROKEN      (1 << 0)
+#define E1000_HAS_MSIX          (1 << 1)
 
 /*****************************************************************************
  * Private Types
@@ -284,6 +293,9 @@ static const struct netdev_ops_s g_e1000_ops =
 #ifdef CONFIG_NET_MCASTGROUP
   .addmac   = e1000_addmac,
   .rmmac    = e1000_rmmac,
+#endif
+#if CONFIG_NETDEV_WORK_THREAD_POLLING_PERIOD > 0
+  .reclaim  = e1000_txdone,
 #endif
 };
 


### PR DESCRIPTION
## Summary
In scenarios that require high time accuracy, we do not want an interrupt from the NIC to interrupt the current task, so add support for polling mode.

## Impact

## Testing
qemu:x64
