### PR TITLE
Add base64 support to coredump to reduce syslog output size

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4666,6 +4666,13 @@ config BOARD_COREDUMP_COMPRESSION
 	---help---
 		Enable LZF compression algorithm for core dump content
 
+config BOARD_COREDUMP_BASE64STREAM
+	bool "Enable base64 encoding for output stream"
+	default n
+	depends on BOARD_COREDUMP_SYSLOG
+	---help---
+		Enable based64 encoded stream instead of default hexstream.
+
 config BOARD_ENTROPY_POOL
 	bool "Enable Board level storing of entropy pool structure"
 	default n
@@ -4890,4 +4897,3 @@ config BOARD_MEMORY_RANGE
 		end: end address of memory range
 		flags: Readable 0x1, writable 0x2, executable 0x4
 		example:0x1000,0x2000,0x1,0x2000,0x3000,0x3,0x3000,0x4000,0x7
-

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -243,6 +243,16 @@ struct lib_hexdumpstream_s
   char                        buffer[CONFIG_STREAM_HEXDUMP_BUFFER_SIZE + 1];
 };
 
+struct lib_base64outstream_s
+{
+  struct lib_outstream_s      common;
+  FAR struct lib_outstream_s *backend;
+  int                         pending;
+  unsigned char               bytes[3];
+  int                         nbytes;
+  char                        buffer[CONFIG_STREAM_BASE64_BUFFER_SIZE + 1];
+};
+
 /* This is a special stream that does buffered character I/O.  NOTE that is
  * CONFIG_SYSLOG_BUFFER is not defined, it is the same as struct
  * lib_outstream_s
@@ -445,6 +455,25 @@ void lib_bufferedoutstream(FAR struct lib_bufferedoutstream_s *stream,
 
 void lib_hexdumpstream(FAR struct lib_hexdumpstream_s *stream,
                        FAR struct lib_outstream_s *backend);
+
+/****************************************************************************
+ * Name: lib_base64stream
+ *
+ * Description:
+ *   Convert binary stream to base64 and redirect to syslog
+ *
+ * Input Parameters:
+ *   stream    - User allocated, uninitialized instance of struct
+ *               lib_base64stream_s to be initialized.
+ *   backend   - Stream backend port.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_base64outstream(FAR struct lib_base64outstream_s *stream,
+                         FAR struct lib_outstream_s *backend);
 
 /****************************************************************************
  * Name: lib_lowoutstream

--- a/libs/libc/net/lib_base64.c
+++ b/libs/libc/net/lib_base64.c
@@ -83,7 +83,12 @@ int b64_ntop(FAR const unsigned char *src, size_t srclen,
       *target++ = g_pad64;
     }
 
-  *target = '\0';
+  if (datalen >= targsize)
+    {
+      return -1;
+    }
+
+  *target = '\0'; /* Returned length doesn't include '\0' */
   return datalen;
 }
 

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -40,7 +40,8 @@ list(
   lib_syslogstream.c
   lib_syslograwstream.c
   lib_bufferedoutstream.c
-  lib_hexdumpstream.c)
+  lib_hexdumpstream.c
+  lib_base64outstream.c)
 
 if(CONFIG_FILE_STREAM)
   list(APPEND SRCS lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c

--- a/libs/libc/stream/Kconfig
+++ b/libs/libc/stream/Kconfig
@@ -29,4 +29,8 @@ config STREAM_HEXDUMP_BUFFER_SIZE
 	int "Output hexdump stream buffer size"
 	default 128
 
+config STREAM_BASE64_BUFFER_SIZE
+	int "Output base64 stream buffer size"
+	default 128
+
 endmenu # Locale Support

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -29,7 +29,7 @@ CSRCS += lib_rawoutstream.c lib_rawsistream.c lib_rawsostream.c
 CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
 CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
-CSRCS += lib_hexdumpstream.c lib_fileoutstream.c
+CSRCS += lib_hexdumpstream.c lib_base64outstream.c lib_fileoutstream.c
 
 # The remaining sources files depend upon C streams
 

--- a/libs/libc/stream/lib_base64outstream.c
+++ b/libs/libc/stream/lib_base64outstream.c
@@ -1,0 +1,182 @@
+/****************************************************************************
+ * libs/libc/stream/lib_base64outstream.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/streams.h>
+
+#include <resolv.h>
+
+/* Limit the output stream buffer size to multiple of 4 bytes. */
+
+#define STREAM_BASE64_BUFFER_SIZE (CONFIG_STREAM_BASE64_BUFFER_SIZE / 4 * 4)
+
+/****************************************************************************
+ * Name: base64stream_flush
+ ****************************************************************************/
+
+static int base64stream_flush(FAR struct lib_outstream_s *self)
+{
+  FAR struct lib_base64outstream_s *stream = (FAR void *)self;
+
+  if (stream->nbytes > 0)
+    {
+      b64_ntop(stream->bytes, stream->nbytes,
+               stream->buffer + stream->pending, 4 + 1);
+
+      stream->pending += 4;
+      stream->nbytes = 0;
+    }
+
+  lib_stream_puts(stream->backend, stream->buffer, stream->pending);
+  stream->pending = 0;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: base64stream_putc
+ ****************************************************************************/
+
+static void base64stream_putc(FAR struct lib_outstream_s *self, int ch)
+{
+  FAR struct lib_base64outstream_s *stream = (FAR void *)self;
+
+  stream->bytes[stream->nbytes++] = (char)ch;
+  if (stream->nbytes == 3)
+    {
+      b64_ntop(stream->bytes, 3,
+               stream->buffer + stream->pending, 4 + 1);
+      stream->pending += 4;
+      stream->nbytes = 0;
+      if (stream->pending == STREAM_BASE64_BUFFER_SIZE)
+        {
+          base64stream_flush(self);
+        }
+    }
+
+  self->nput++;
+}
+
+/****************************************************************************
+ * Name: base64stream_puts
+ ****************************************************************************/
+
+static int base64stream_puts(FAR struct lib_outstream_s *self,
+                             FAR const void *buf, int len)
+{
+  FAR struct lib_base64outstream_s *stream = (FAR void *)self;
+  FAR const unsigned char *input = (FAR const unsigned char *)buf;
+  int remaining = len;
+
+  if (stream->nbytes)
+    {
+      /* Flush the first three bytes */
+
+      int n = 3 - stream->nbytes;
+      if (n > remaining)
+        {
+          n = remaining;
+        }
+
+      memcpy(stream->bytes + stream->nbytes, input, n);
+      stream->nbytes += n;
+      remaining -= n;
+      input += n;
+      if (stream->nbytes == 3)
+        {
+          b64_ntop(stream->bytes, 3,
+                   stream->buffer + stream->pending, 4 + 1);
+          stream->pending += 4;
+          stream->nbytes = 0;
+          if (stream->pending == STREAM_BASE64_BUFFER_SIZE)
+            {
+              base64stream_flush(self);
+            }
+        }
+    }
+
+  while (remaining >= 3)
+    {
+      int outlen;
+      int n = (STREAM_BASE64_BUFFER_SIZE - stream->pending) / 4 * 3;
+      if (n > remaining)
+        {
+          n = remaining / 3 * 3;
+        }
+
+      outlen = n / 3 * 4;
+      b64_ntop(input, n, stream->buffer + stream->pending,
+               outlen + 1);
+      stream->pending += outlen;
+      input += n;
+      remaining -= n;
+      if (stream->pending == STREAM_BASE64_BUFFER_SIZE)
+        {
+          base64stream_flush(self);
+        }
+    }
+
+  if (remaining > 0)
+    {
+      memcpy(stream->bytes, input, remaining);
+      stream->nbytes = remaining;
+    }
+
+  self->nput += len;
+  return len;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_base64stream
+ *
+ * Description:
+ *   Convert binary stream to base64 and redirect to output stream
+ *
+ * Input Parameters:
+ *   stream    - User allocated, uninitialized instance of struct
+ *               lib_base64outstream_s to be initialized.
+ *   backend   - Stream backend port.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_base64outstream(FAR struct lib_base64outstream_s *stream,
+                         FAR struct lib_outstream_s *backend)
+{
+  struct lib_outstream_s *public = &stream->common;
+
+  public->putc    = base64stream_putc;
+  public->puts    = base64stream_puts;
+  public->flush   = base64stream_flush;
+  public->nput    = 0;
+
+  stream->pending = 0;
+  stream->backend = backend;
+}

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -112,6 +112,8 @@ static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
     {
       hexdumpstream_flush(self);
     }
+
+  self->nput++;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -136,8 +136,8 @@ static int hexdumpstream_puts(FAR struct lib_outstream_s *self,
       ret = bin2hex(p, ret, stream->buffer + stream->pending,
                     (outlen - stream->pending) / 2);
 
-      p              += ret;
-      remain         -= ret;
+      p               += ret;
+      remain          -= ret;
       stream->pending += ret * 2;
 
       if (stream->pending == outlen)
@@ -181,6 +181,6 @@ void lib_hexdumpstream(FAR struct lib_hexdumpstream_s *stream,
   public->flush   = hexdumpstream_flush;
   public->nput    = 0;
 
-  stream->pending  = 0;
-  stream->backend  = backend;
+  stream->pending = 0;
+  stream->backend = backend;
 }

--- a/tools/coredump.py
+++ b/tools/coredump.py
@@ -22,6 +22,7 @@
 ############################################################################
 
 import argparse
+import base64
 import binascii
 import os
 import struct
@@ -69,6 +70,20 @@ def unhexlify(infile, outfile):
         outfile.write(binascii.unhexlify(line))
 
 
+def unbase64file(infile, outfile):
+    input = ""
+    for line in infile.readlines():
+        line = line.strip()
+        if line == "":
+            break
+        index = line.rfind(" ")
+        if index > 0:
+            line = line[index + 1 :]
+
+        input += line
+    outfile.write(base64.b64decode(input))
+
+
 def parse_args():
     global args
     parser = argparse.ArgumentParser(
@@ -78,6 +93,12 @@ def parse_args():
     )
     parser.add_argument("input")
     parser.add_argument("-o", "--output", help="Output file in hex.")
+    parser.add_argument(
+        "--base64",
+        action="store_true",
+        default=False,
+        help="Set when input file is base64 encoded.",
+    )
     args = parser.parse_args()
 
 
@@ -94,7 +115,10 @@ def main():
     infile = open(args.input, "r")
     tmpfile = open(tmp, "wb+")
 
-    unhexlify(infile, tmpfile)
+    if args.base64:
+        unbase64file(infile, tmpfile)
+    else:
+        unhexlify(infile, tmpfile)
 
     infile.close()
 


### PR DESCRIPTION
## Summary

This PR added base64 encoded stream support, and use it as coredump output stream.
The output log size theoretically is smaller than hexdump. Thus could save some time if dump is large.

## Impact

No impact on existing projects.

## Testing

Tested on qemu.

### Configure

```
tools/configure.sh mps3-an547:nsh
```

Enable coredump support
```patch
diff --git a/boards/arm/mps/mps3-an547/configs/nsh/defconfig b/boards/arm/mps/mps3-an547/configs/nsh/defconfig
index 54f5e21f223..3726188d41a 100644
--- a/boards/arm/mps/mps3-an547/configs/nsh/defconfig
+++ b/boards/arm/mps/mps3-an547/configs/nsh/defconfig
@@ -16,6 +16,8 @@ CONFIG_ARCH_INTERRUPTSTACK=2048
 CONFIG_ARCH_STACKDUMP=y
 CONFIG_ARMV8M_SYSTICK=y
 CONFIG_ARMV8M_USEBASEPRI=y
+CONFIG_BOARD_COREDUMP_BASE64STREAM=y
+CONFIG_BOARD_COREDUMP_SYSLOG=y
 CONFIG_BUILTIN=y
 CONFIG_CMSDK_UART0=y
 CONFIG_CMSDK_UART0_BASE=0x49303000
@@ -35,6 +37,8 @@ CONFIG_DEBUG_SYMBOLS=y
 CONFIG_DEBUG_USAGEFAULT=y
 CONFIG_DEFAULT_TASK_STACKSIZE=4096
 CONFIG_DEV_ZERO=y
+CONFIG_ELF=y
+CONFIG_ELF_COREDUMP=y
 CONFIG_EXAMPLES_HELLO=y
```

### Trigger crash

```
nsh> mw -1
```

### Example of crash log
```
nsh> mw -1
arm_hardfault: Hard Fault escalation:
arm_busfault: PANIC!!! Bus Fault:
arm_busfault:   IRQ: 3 regs: 0x100ee50
arm_busfault:   BASEPRI: 000000f0 PRIMASK: 00000000 IPSR: 00000003 CONTROL: 00000000
arm_busfault:   CFSR: 00008200 HFSR: 40000000 DFSR: 00000000 BFAR: fffffffc AFSR: 00000000
arm_busfault: Bus Fault Reason:
arm_busfault:   Precise data bus error
dump_assert_info: Current Version: NuttX  12.7.0-RC0 481e8d85d89-dirty Oct  8 2024 16:16:07 arm
dump_assert_info: Assertion failed panic: at file: armv8-m/arm_busfault.c:113 task: nsh_main process: nsh_main 0xefbd
up_dump_register: R0: 00000000 R1: 00000010 R2: 00000000  R3: ffffffff
up_dump_register: R4: 0000f5b9 R5: 01000114 R6: 00000000  FP: 00000000
up_dump_register: R8: 00000000 SB: 00000000 SL: 00000000 R11: 00000000
up_dump_register: IP: 00000000 SP: 0100eea0 LR: 0000b9f3  PC: 00012c66
up_dump_register: xPSR: 81000000 BASEPRI: 000000f0 CONTROL: 00000000
up_dump_register: EXC_RETURN: fffffffd
dump_stack: User Stack:
dump_stack:   base: 0x100e130
dump_stack:   size: 00004056
dump_stack:     sp: 0x100eea0
stack_dump: 0x100ee80: 00000000 00000010 00000000 ffffffff 00000000 0000b9f3 00012c66 81000000
stack_dump: 0x100eea0: f0000002 0100ef88 00000002 0100f138 000000f0 00000000 ffffffff 00000000
stack_dump: 0x100eec0: 00000001 00000000 00000000 ffffffff 00000001 00012b71 0100f3f0 0100ef88
stack_dump: 0x100eee0: 00000002 0100f138 00000000 0100f3f0 00012c39 0003e7cc 00000001 0000fd6f
stack_dump: 0x100ef00: 00000000 00000000 00000000 0100ef88 00000002 0100f138 00000000 0100efc0
stack_dump: 0x100ef20: 00000001 000107ad 0003ddf9 0100f3f0 00000000 0100efc0 0100ef84 0100f138
stack_dump: 0x100ef40: 0100efc0 00000000 ffffffff 00000038 00000001 00000000 0003de05 00000001
stack_dump: 0x100ef60: 01000114 00011707 00000000 00000000 0100f3f0 0100f138 000000f0 00000000
stack_dump: 0x100ef80: 0100f3f0 0100f3f6 0100f3f0 0100f3f3 00000000 00000000 00000000 00000000
stack_dump: 0x100efa0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
stack_dump: 0x100efc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
stack_dump: 0x100efe0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
stack_dump: 0x100f000: 00000000 00000001 00000002 00000001 00000000 00000050 0100f3f0 0100f054
stack_dump: 0x100f020: 0000000a 0003db38 00000002 00000000 00000000 00000000 00000001 000117bd
stack_dump: 0x100f040: 0100f3f0 0100f138 00000050 0100f3f0 0100ddcc 0100f3f5 00000005 0100f388
stack_dump: 0x100f060: 0100f3f0 0100f3f0 00000001 0000f275 00000000 00000308 0100e118 00000001
stack_dump: 0x100f080: 00000001 0100f138 0100f138 00000006 0100ddcc 00000000 00000000 0000f053
stack_dump: 0x100f0a0: 0100e118 00000001 00000064 0100f138 00000064 0000eff3 0100e118 00000001
stack_dump: 0x100f0c0: 00000064 00000000 00000000 0000ab6d 00000000 0100e118 00000001 0000efbd
stack_dump: 0x100f0e0: 00000000 00005111 00000000 0100e118 00000000 0100dd08 00000001 00000001
stack_dump: 0x100f100: 0000508c 00000000 00000000 00000000 00000000 00000000 00000000 00000000
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x10001d0      2048      1236    60.3%    irq
dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x100b94c      4080       800    19.6%    Idle_Task
dump_task:       1     0 192 RR       Kthread -   Waiting Semaphore  0000000000000000 0x100cd40      4032       296     7.3%    hpwork 0x1004
dump_task:       2     2 100 RR       Task    -   Running            0000000000000000 0x100e130      4056       736    18.1%    nsh_main
WlYBAT8D/wd/RUxGAQEBAMAAAwQAKADADQA0IANgAAUCAAU0ACAgG4AAQAcAtCADwAAAOEAQ4AIAYD8ACCADAMkgCiADAEAgCkADAAcgA0A8YB8ADCADANwgCkADQBAg
A+AEHwAQIAMA4SAKIAMAQCALQAPAHwAgIAYAfCADAAMgAwhJZGxlX1Rhc2tACwFFAiAFgABAGwEcCCA/4BIA4AM74EsAQKcAlCADQITgA2vgJ6fgJwAEoAsAAbBBV+Ad
AAGAECGjAYEZIAggAyHrAEFADyAJYL/BZwZocHdvcmsA4By/4AQMIACgO+BQAECnwWega+Acp+ADAOAQGOAOAEBZB9TMAAG48AABQAcgDuAYAAAoIZMEI0UAAFIgAyAA
AAFADyAHYL/BZwduc2hfbWFpbiAK4Bi/4AEdgADgAzvgHAABAABaVgEAbQP/AQAA4CIAACAgAwCUIAMAASADB25zaF9tYWluIAoDAElFAiAFgAAAAyADARwIYCLgDADg
ASngIQAAECADQAAA/yAABbn1AAAUAeARX0AACaDuAAHzuQAAZixgJgCBQA8gB+D/AOD/AOD4AAEAAFpWAQBBA/8BAAAgAAKAgRkgBCADBAACAEF9QAcgAAjENh8APMkA
AQEgCwXQAQAB2wKABwKEhAQgEeD/AOD/AOD/AOCkAAEAAFpWAQC8A/8BAABgAAT9////AiAHB9TMAAG48AABQAcgDgUAI0UAAFIgAyAABQHvvq3eCKAHADAgEEAABGDc
AAEQIAcAgCADIAAAgKAHAAAgEwGAOCBDBDrNAAEEIA8ApSBDIGIAD6A/AQAkgAcC3hU6ICsgIwADICNAD+ADAyASQABgJ+ADAwMA3QABoGcB8PAgBOADAEBXIAYAASB7
YBoB/1AgBCAAQGMgBgACIBdga0AMAIygG+D/AOD/AODhAAEAAFpWAQA/A/8BAACAAAwJEAAAFN4AAQAAEAACIA9AAAEg4UAPCQAAbnNoX21haW4gCmAAA+++rd7g/wPg
/wPg/wPgpAMBvq1aVgEAFQP/BN7vvq3e4P8D4P8D4P8D4NcDAe++WlYBABUD/wSt3u++reD/A+D/A+D/A+DXAwHe71pWAQGEA/8Evq3e777g/wPgGQMERO4AAQAgAAQI
3QABLSAHAFwgDwBgIAMAECALwAAEU7kAAKAgEwDwIAsFufUAABQBgDPgDwAD/f///yAGAADAQyAOYA8A8yBHAWYsYDoIgQIAAPCI7wABIAcCADjxgFtAACAqYCtgJaAA
IBIA/0APB3ErAQDw8wAB4AM3IAZgEwA5IFcCzOcDYBABb/0gBOACAOAHLwDAIA9ACAatBwEA+d0DYD8gDmAXAIQgA0AnQAsgEmB7ADggB2AMIAABBd6AY0EDAQcXQAmA
AEBDQDfAx0APAPYgA0AHAPMgAyAS4GgAQHRA90AHQAAAUCADQI8EVPAAAQogCwI42wNgH+ADAEArAL0g10AnQM/AMwDMIh8A9SAHAAUgDwCIIAdAE0ADQC8BdfIgBCAA
BQgDAAAY4YATQANAP0ADAAYgC0A/IAZgAABTISTAJwBkIANAI0AHAfPv4AUXwAABbasgBCAAwBsAvSAnQAABEVEgBCAAQBcgBiLDAQABWlYBAEgD/wQBAAAAASADAYxQ
IASgAAApIAMBCMtgFmAACAEAAwB89gMABiALQAADcHJvYyAGBgARAwAALfYgCOD/AOD/AOD/AOCXAAEAAFpWAQAIAAkBAABgAAEAAA==

```

### Extract and convert log to coredump

Copy the base64 data to a standalone file, say crash.log.
Using tool coredump.py with `--base64` option to convert log to core file.
```
python3 nuttx/tools/coredump.py --base64 crash.log
```

### Load core file and analysis

```
gdb-multiarch nuttx/nuttx -c crash.core
...
#0  0x00001980 in nx_start () at init/nx_start.c:773
773           up_idle();
[Current thread is 1 (process 2)]
(gdb) bt
#0  0x00001980 in nx_start () at init/nx_start.c:773
#1  0x010001d0 in g_optstring ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) info threads
  Id   Target Id         Frame
* 1    process 2         0x00001980 in nx_start () at init/nx_start.c:773
  2    LWP 1             nxsem_wait (sem=0x1000008 <g_hpwork+8>) at semaphore/sem_wait.c:213
  3    LWP 2             0x00012c66 in cmd_mw (vtbl=0x100f138, argc=2, argv=0x100ef88) at nsh_dbgcmds.c:259
(gdb) t 3
[Switching to thread 3 (LWP 2)]
#0  0x00012c66 in cmd_mw (vtbl=0x100f138, argc=2, argv=0x100ef88) at nsh_dbgcmds.c:259
259               nsh_output(vtbl, "  %p = 0x%08" PRIx32, ptr, *ptr);
(gdb) bt
#0  0x00012c66 in cmd_mw (vtbl=0x100f138, argc=2, argv=0x100ef88) at nsh_dbgcmds.c:259
#1  0x00012b70 in nsh_command (vtbl=0x100f138, argc=2, argv=0x100ef88) at nsh_command.c:1263
#2  0x0000fd6e in nsh_execute (vtbl=0x100f138, argc=2, argv=0x100ef88, redirfile_in=0x0 <work_queue_priority>,
    redirfile_out=0x0 <work_queue_priority>, oflags=0) at nsh_parse.c:875
#3  0x00011706 in nsh_parse_command (vtbl=0x100f138, cmdline=0x100f3f0 <error: Cannot access memory at address 0x100f3f0>)
    at nsh_parse.c:2846
#4  0x000117bc in nsh_parse (vtbl=0x100f138, cmdline=0x100f3f0 <error: Cannot access memory at address 0x100f3f0>) at nsh_parse.c:2936
#5  0x0000f274 in nsh_session (pstate=0x100f138, login=1, argc=1, argv=0x100e118) at nsh_session.c:245
#6  0x0000f052 in nsh_consolemain (argc=1, argv=0x100e118) at nsh_consolemain.c:75
#7  0x0000eff2 in nsh_main (argc=1, argv=0x100e118) at nsh_main.c:74
#8  0x0000ab6c in nxtask_startup (entrypt=0xefbd <nsh_main>, argc=1, argv=0x100e118) at sched/task_startup.c:72
#9  0x00005110 in nxtask_start () at task/task_start.c:116
#10 0x00000000 in ?? ()
(gdb)


```

