### PR TITLE
local_sock: fix accept use-after-free

### DIFF
--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -172,6 +172,9 @@
   for((p) = (q)->head, (tmp) = (p) ? (p)->flink : NULL; \
       (p) != NULL; (p) = (tmp), (tmp) = (p) ? (p)->flink : NULL)
 
+#define dq_for_every(q, p) sq_for_every(q, p)
+#define dq_for_every_safe(q, p, tmp) sq_for_every_safe(q, p, tmp)
+
 #define sq_rem(p, q) \
   do \
     { \

--- a/net/local/local_release.c
+++ b/net/local/local_release.c
@@ -73,14 +73,13 @@ int local_release(FAR struct local_conn_s *conn)
     {
       FAR struct local_conn_s *accept;
       FAR dq_entry_t *waiter;
+      FAR dq_entry_t *tmp;
 
       DEBUGASSERT(conn->lc_proto == SOCK_STREAM);
 
       /* Are there still clients waiting for a connection to the server? */
 
-      for (waiter = dq_peek(&conn->u.server.lc_waiters);
-           waiter != NULL;
-           waiter = dq_next(&accept->u.accept.lc_waiter))
+      dq_for_every_safe(&conn->u.server.lc_waiters, waiter, tmp)
         {
           accept = container_of(waiter, struct local_conn_s,
                                 u.accept.lc_waiter);


### PR DESCRIPTION
## Summary
we should get next waiter before acceptor released

## Impact

## Testing
sim:local with kasan
