### PR TITLE
fs_open:Adjust the definition of the open path

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -258,7 +258,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
       ret = -ENXIO;
     }
 
-  if (ret == -EISDIR)
+  if (ret == -EISDIR && ((oflags & O_WRONLY) == 0))
     {
       ret = dir_allocate(filep, desc.relpath);
     }


### PR DESCRIPTION
## Summary
Adjusted the opening of a directory node through open to check the parameters passed in.
Reference https://man7.org/linux/man-pages/man2/open.2.html
> EISDIR pathname refers to a directory and the access requested involved writing (that is, O_WRONLY or O_RDWR is set).

## Impact
**Is a new feature added?**: NO
**Impact on build**: NO
**Impact on hardware**: NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation**: NO,This patch does not introduce any new features
**Impact on compatibility**: This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh

After this adjustment, we cannot open a directory  with write behavior oflags by open
