### PR TITLE
board_reset: flush cache before reset

### DIFF
--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
+#include <nuttx/cache.h>
 #include <nuttx/lib/modlib.h>
 #include <nuttx/binfmt/symtab.h>
 #include <nuttx/drivers/ramdisk.h>
@@ -394,6 +395,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
       case BOARDIOC_POWEROFF:
         {
           reboot_notifier_call_chain(SYS_POWER_OFF, (FAR void *)arg);
+          up_flush_dcache_all();
           ret = board_power_off((int)arg);
         }
         break;
@@ -410,6 +412,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
       case BOARDIOC_RESET:
         {
           reboot_notifier_call_chain(SYS_RESTART, (FAR void *)arg);
+          up_flush_dcache_all();
           ret = board_reset((int)arg);
         }
         break;

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -28,6 +28,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
+#include <nuttx/cache.h>
 #include <nuttx/coredump.h>
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
@@ -565,6 +566,7 @@ static noreturn_function int pause_cpu_handler(FAR void *arg)
 {
   memcpy(g_last_regs[this_cpu()], up_current_regs(), sizeof(g_last_regs[0]));
   g_cpu_paused[this_cpu()] = true;
+  up_flush_dcache_all();
   while (1);
 }
 
@@ -742,6 +744,7 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
 static void reset_board(void)
 {
 #if CONFIG_BOARD_RESET_ON_ASSERT >= 1
+  up_flush_dcache_all();
   board_reset(CONFIG_BOARD_ASSERT_RESET_VALUE);
 #else
   for (; ; )


### PR DESCRIPTION
## Summary

This change adds cache flushing for debug purposes. Normally, cache operations are unnecessary since the system reboots. However, flushing the cache is required when the system crashes, allowing us to retain the entire memory after rebooting into the bootloader, where a full memory dump and further analysis can be performed.

## Impact

Should be minimal.

## Testing

This feature was tested on an internal project. When the system crashes, it reboots into the bootloader and uses USB to transfer the full memory to the host for inspection.
