### PR TITLE
serial:update some bug fix,and functional improvements

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -316,6 +316,13 @@ config TTY_FORCE_PANIC_CHAR
 	---help---
 		Use Ctrl-? 0x1F inputs to determine whether panic system
 
+config TTY_FORCE_PANIC_REPEAT_COUNT
+	int "TTY force crash repeat count"
+	default 1
+	depends on TTY_FORCE_PANIC
+	---help---
+		Repeat how many times the panic char to determine whether panic system
+
 config TTY_SIGINT
 	bool "Support SIGINT"
 	default n

--- a/drivers/serial/Kconfig-16550
+++ b/drivers/serial/Kconfig-16550
@@ -554,4 +554,11 @@ config 16550_SET_MCR_OUT2
 	---help---
 		Some platforms require OUT2 of MCR being set for interrupt to be triggered
 
+config 16550_DLF_SIZE
+	int "DLF(Divisor Latch Fraction) size of DesignWare APB UART"
+	default 0
+	---help---
+		The bit width of DLF register for DesignWare APB UART.
+		DLF_SIZE=0 means no support. Default: 0
+
 endif # 16550_UART

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -85,6 +85,11 @@
  * Private Function Prototypes
  ****************************************************************************/
 
+/* Poll support */
+
+static void    uart_poll_notify(FAR uart_dev_t *dev, unsigned int min,
+                                unsigned int max, pollevent_t eventset);
+
 /* Write support */
 
 static int     uart_putxmitchar(FAR uart_dev_t *dev, int ch,
@@ -153,6 +158,28 @@ static struct work_s g_serial_work;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: uart_poll_notify
+ ****************************************************************************/
+
+static void uart_poll_notify(FAR uart_dev_t *dev, unsigned int min,
+                             unsigned int max, pollevent_t eventset)
+{
+  irqstate_t flags;
+
+  DEBUGASSERT(max > min && max - min <= CONFIG_SERIAL_NPOLLWAITERS);
+
+  flags = enter_critical_section();
+  nxsched_lock_irq();
+
+  /* Notify the fds in range dev->fds[min] - dev->fds[max] */
+
+  poll_notify(&dev->fds[min], max - min, eventset);
+
+  nxsched_unlock_irq();
+  leave_critical_section(flags);
+}
 
 /****************************************************************************
  * Name: uart_putxmitchar
@@ -762,7 +789,6 @@ static int uart_close(FAR struct file *filep)
       nxmutex_destroy(&dev->xmit.lock);
       nxmutex_destroy(&dev->recv.lock);
       nxmutex_destroy(&dev->closelock);
-      nxmutex_destroy(&dev->polllock);
       nxsem_destroy(&dev->xmitsem);
       nxsem_destroy(&dev->recvsem);
       uart_release(dev);
@@ -1629,8 +1655,9 @@ static int uart_poll(FAR struct file *filep,
   FAR struct inode *inode = filep->f_inode;
   FAR uart_dev_t   *dev   = inode->i_private;
   pollevent_t       eventset;
+  irqstate_t        flags;
   int               ndx;
-  int               ret;
+  int               ret = OK;
   int               i;
 
   /* Some sanity checking */
@@ -1642,17 +1669,9 @@ static int uart_poll(FAR struct file *filep,
     }
 #endif
 
+  flags = enter_critical_section();
+
   /* Are we setting up the poll?  Or tearing it down? */
-
-  ret = nxmutex_lock(&dev->polllock);
-  if (ret < 0)
-    {
-      /* A signal received while waiting for access to the poll data
-       * will abort the operation.
-       */
-
-      return ret;
-    }
 
   if (setup)
     {
@@ -1680,6 +1699,8 @@ static int uart_poll(FAR struct file *filep,
           ret       = -EBUSY;
           goto errout;
         }
+
+      leave_critical_section(flags);
 
       /* Should we immediately notify on any of the requested events?
        * First, check if the xmit buffer is full.
@@ -1729,7 +1750,7 @@ static int uart_poll(FAR struct file *filep,
         }
 #endif
 
-      poll_notify(&fds, 1, eventset);
+      uart_poll_notify(dev, i, i + 1, eventset);
     }
   else if (fds->priv != NULL)
     {
@@ -1749,10 +1770,14 @@ static int uart_poll(FAR struct file *filep,
 
       *slot     = NULL;
       fds->priv = NULL;
+
+      leave_critical_section(flags);
     }
 
+  return ret;
+
 errout:
-  nxmutex_unlock(&dev->polllock);
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -1783,7 +1808,6 @@ static int uart_unlink(FAR struct inode *inode)
       nxmutex_destroy(&dev->xmit.lock);
       nxmutex_destroy(&dev->recv.lock);
       nxmutex_destroy(&dev->closelock);
-      nxmutex_destroy(&dev->polllock);
       nxsem_destroy(&dev->xmitsem);
       nxsem_destroy(&dev->recvsem);
       uart_release(dev);
@@ -1918,7 +1942,6 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
   nxmutex_init(&dev->closelock);
   nxsem_init(&dev->xmitsem, 0, 0);
   nxsem_init(&dev->recvsem, 0, 0);
-  nxmutex_init(&dev->polllock);
 
 #ifdef CONFIG_SERIAL_TERMIOS
   dev->timeout = 0;
@@ -1952,7 +1975,7 @@ void uart_datareceived(FAR uart_dev_t *dev)
 {
   /* Notify all poll/select waiters that they can read from the recv buffer */
 
-  poll_notify(dev->fds, CONFIG_SERIAL_NPOLLWAITERS, POLLIN);
+  uart_poll_notify(dev, 0, CONFIG_SERIAL_NPOLLWAITERS, POLLIN);
 
   /* Is there a thread waiting for read data?  */
 
@@ -1986,7 +2009,7 @@ void uart_datasent(FAR uart_dev_t *dev)
 {
   /* Notify all poll/select waiters that they can write to xmit buffer */
 
-  poll_notify(dev->fds, CONFIG_SERIAL_NPOLLWAITERS, POLLOUT);
+  uart_poll_notify(dev, 0, CONFIG_SERIAL_NPOLLWAITERS, POLLOUT);
 
   /* Is there a thread waiting for space in xmit.buffer?  */
 
@@ -2025,6 +2048,7 @@ void uart_connected(FAR uart_dev_t *dev, bool connected)
    */
 
   flags = enter_critical_section();
+  nxsched_lock_irq();
   dev->disconnected = !connected;
   if (!connected)
     {
@@ -2045,6 +2069,7 @@ void uart_connected(FAR uart_dev_t *dev, bool connected)
       uart_wakeup(&dev->recvsem);
     }
 
+  nxsched_unlock_irq();
   leave_critical_section(flags);
 }
 #endif
@@ -2065,7 +2090,6 @@ void uart_reset_sem(FAR uart_dev_t *dev)
   nxsem_reset(&dev->recvsem,  0);
   nxmutex_reset(&dev->xmit.lock);
   nxmutex_reset(&dev->recv.lock);
-  nxmutex_reset(&dev->polllock);
 }
 
 /****************************************************************************

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1914,6 +1914,10 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
   dev->pid = INVALID_PROCESS_ID;
 #endif
 
+#ifdef CONFIG_TTY_FORCE_PANIC
+  dev->panic_count = 0;
+#endif
+
   /* If this UART is a serial console */
 
   if (dev->isconsole)
@@ -2126,8 +2130,16 @@ int uart_check_special(FAR uart_dev_t *dev, FAR const char *buf, size_t size)
 #ifdef CONFIG_TTY_FORCE_PANIC
       if (buf[i] == CONFIG_TTY_FORCE_PANIC_CHAR)
         {
-          PANIC_WITH_REGS("Force panic by user.", NULL);
+          if (++dev->panic_count >= CONFIG_TTY_FORCE_PANIC_REPEAT_COUNT)
+            {
+              PANIC_WITH_REGS("Force panic by user.", NULL);
+            }
+
           return 0;
+        }
+      else
+        {
+          dev->panic_count = 0;
         }
 #endif
 

--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -353,7 +353,6 @@ void uart_recvchars_done(FAR uart_dev_t *dev)
   if (signo != 0)
     {
       nxsig_kill(dev->pid, signo);
-      uart_reset_sem(dev);
     }
 #endif
 }

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -310,7 +310,6 @@ void uart_recvchars(FAR uart_dev_t *dev)
   if (signo != 0)
     {
       nxsig_kill(dev->pid, signo);
-      uart_reset_sem(dev);
     }
 #endif
 }

--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -760,7 +760,16 @@ static inline void u16550_enablebreaks(FAR struct u16550_s *priv,
 #ifndef CONFIG_16550_SUPRESS_CONFIG
 static inline uint32_t u16550_divisor(FAR struct u16550_s *priv)
 {
-  return (priv->uartclk + (priv->baud << 3)) / (priv->baud << 4);
+  uint32_t base = 16 * priv->baud;
+  uint32_t quot = priv->uartclk / base;
+  uint32_t rem  = priv->uartclk % base;
+  uint32_t frac = ((rem << CONFIG_16550_DLF_SIZE) + base / 2) / base;
+
+#if CONFIG_16550_DLF_SIZE != 0
+  return quot | (frac << 16);
+#else
+  return quot + frac;
+#endif
 }
 #endif
 
@@ -778,7 +787,7 @@ static int u16550_setup(FAR struct uart_dev_s *dev)
 {
 #ifndef CONFIG_16550_SUPRESS_CONFIG
   FAR struct u16550_s *priv = (FAR struct u16550_s *)dev->priv;
-  uint16_t div;
+  uint32_t div;
   uint32_t lcr;
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL) || \
     defined(CONFIG_16550_SET_MCR_OUT2)
@@ -855,7 +864,10 @@ static int u16550_setup(FAR struct uart_dev_s *dev)
   /* Set the BAUD divisor */
 
   div = u16550_divisor(priv);
-  u16550_serialout(priv, UART_DLM_OFFSET, div >> 8);
+#if CONFIG_16550_DLF_SIZE != 0
+  u16550_serialout(priv, UART_DLF_OFFSET, (div >> 16) & 0xff);
+#endif
+  u16550_serialout(priv, UART_DLM_OFFSET, (div >>  8) & 0xff);
   u16550_serialout(priv, UART_DLL_OFFSET, div & 0xff);
 
 #ifdef CONFIG_16550_WAIT_LCR

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -242,6 +242,13 @@
 #  define this_cpu()                 (0)
 #endif
 
+/* Task Switching Interfaces (non-standard).
+ * These two macros can be called in interrupt context.
+ */
+
+#define nxsched_lock_irq() (up_interrupt_context() ? OK : sched_lock())
+#define nxsched_unlock_irq() (up_interrupt_context() ? OK : sched_unlock())
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -321,7 +321,6 @@ struct uart_dev_s
   sem_t                xmitsem;      /* Wakeup user waiting for space in xmit.buffer */
   sem_t                recvsem;      /* Wakeup user waiting for data in recv.buffer */
   mutex_t              closelock;    /* Locks out new open while close is in progress */
-  mutex_t              polllock;     /* Manages exclusive access to fds[] */
 
   /* I/O buffers */
 

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -310,6 +310,10 @@ struct uart_dev_s
   pid_t                pid;          /* Thread PID to receive signals (-1 if none) */
 #endif
 
+#ifdef CONFIG_TTY_FORCE_PANIC
+  int                  panic_count;
+#endif
+
   /* Terminal control flags */
 
   tcflag_t             tc_iflag;     /* Input modes */

--- a/include/nuttx/serial/uart_16550.h
+++ b/include/nuttx/serial/uart_16550.h
@@ -173,20 +173,35 @@
 
 /* Register offsets *********************************************************/
 
-#define UART_RBR_OFFSET        0  /* (DLAB =0) Receiver Buffer Register */
-#define UART_THR_OFFSET        0  /* (DLAB =0) Transmit Holding Register */
-#define UART_DLL_OFFSET        0  /* (DLAB =1) Divisor Latch LSB */
-#define UART_DLM_OFFSET        1  /* (DLAB =1) Divisor Latch MSB */
-#define UART_IER_OFFSET        1  /* (DLAB =0) Interrupt Enable Register */
-#define UART_IIR_OFFSET        2  /* Interrupt ID Register */
-#define UART_FCR_OFFSET        2  /* FIFO Control Register */
-#define UART_LCR_OFFSET        3  /* Line Control Register */
-#define UART_MCR_OFFSET        4  /* Modem Control Register */
-#define UART_LSR_OFFSET        5  /* Line Status Register */
-#define UART_MSR_OFFSET        6  /* Modem Status Register */
-#define UART_SCR_OFFSET        7  /* Scratch Pad Register */
-#define UART_USR_OFFSET        31 /* UART Status Register */
-#define UART_DLF_OFFSET        48 /* Divisor Latch Fraction Register */
+#define UART_RBR_INCR          0  /* (DLAB =0) Receiver Buffer Register */
+#define UART_THR_INCR          0  /* (DLAB =0) Transmit Holding Register */
+#define UART_DLL_INCR          0  /* (DLAB =1) Divisor Latch LSB */
+#define UART_DLM_INCR          1  /* (DLAB =1) Divisor Latch MSB */
+#define UART_IER_INCR          1  /* (DLAB =0) Interrupt Enable Register */
+#define UART_IIR_INCR          2  /* Interrupt ID Register */
+#define UART_FCR_INCR          2  /* FIFO Control Register */
+#define UART_LCR_INCR          3  /* Line Control Register */
+#define UART_MCR_INCR          4  /* Modem Control Register */
+#define UART_LSR_INCR          5  /* Line Status Register */
+#define UART_MSR_INCR          6  /* Modem Status Register */
+#define UART_SCR_INCR          7  /* Scratch Pad Register */
+#define UART_USR_INCR          31 /* UART Status Register */
+#define UART_DLF_INCR          48 /* Divisor Latch Fraction Register */
+
+#define UART_RBR_OFFSET        (CONFIG_16550_REGINCR*UART_RBR_INCR)
+#define UART_THR_OFFSET        (CONFIG_16550_REGINCR*UART_THR_INCR)
+#define UART_DLL_OFFSET        (CONFIG_16550_REGINCR*UART_DLL_INCR)
+#define UART_DLM_OFFSET        (CONFIG_16550_REGINCR*UART_DLM_INCR)
+#define UART_IER_OFFSET        (CONFIG_16550_REGINCR*UART_IER_INCR)
+#define UART_IIR_OFFSET        (CONFIG_16550_REGINCR*UART_IIR_INCR)
+#define UART_FCR_OFFSET        (CONFIG_16550_REGINCR*UART_FCR_INCR)
+#define UART_LCR_OFFSET        (CONFIG_16550_REGINCR*UART_LCR_INCR)
+#define UART_MCR_OFFSET        (CONFIG_16550_REGINCR*UART_MCR_INCR)
+#define UART_LSR_OFFSET        (CONFIG_16550_REGINCR*UART_LSR_INCR)
+#define UART_MSR_OFFSET        (CONFIG_16550_REGINCR*UART_MSR_INCR)
+#define UART_SCR_OFFSET        (CONFIG_16550_REGINCR*UART_SCR_INCR)
+#define UART_USR_OFFSET        (CONFIG_16550_REGINCR*UART_USR_INCR)
+#define UART_DLF_OFFSET        (CONFIG_16550_REGINCR*UART_DLF_INCR)
 
 /* Register bit definitions *************************************************/
 

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -416,6 +416,36 @@ int nxsig_queue(int pid, int signo, union sigval value);
 int nxsig_kill(pid_t pid, int signo);
 
 /****************************************************************************
+ * Name: nxsig_tgkill
+ *
+ * Description:
+ *   The tgkill() system call can be used to send any signal to a thread.
+ *   See kill() for further information as this is just a simple wrapper
+ *   around the kill() function.
+ *
+ * Input Parameters:
+ *   gid   - The id of the task to receive the signal.
+ *   tid   - The id of the thread to receive the signal. Only positive,
+ *           non-zero values of 'tid' are supported.
+ *   signo - The signal number to send.  If 'signo' is zero, no signal is
+ *           sent, but all error checking is performed.
+ *
+ * Returned Value:
+ *    On success the signal was send and zero is returned. On error -1 is
+ *    returned, and errno is set one of the following error numbers:
+ *
+ *    EINVAL An invalid signal was specified.
+ *    EPERM  The thread does not have permission to send the
+ *           signal to the target thread.
+ *    ESRCH  No thread could be found corresponding to that
+ *           specified by the given thread ID
+ *    ENOSYS Do not support sending signals to process groups.
+ *
+ ****************************************************************************/
+
+int nxsig_tgkill(pid_t pid, pid_t tid, int signo);
+
+/****************************************************************************
  * Name: nxsig_waitinfo
  *
  * Description:


### PR DESCRIPTION
## Summary
update some bug fix,and functional improvements

Fix system apps cu_main() ctrl + c crash bug:
1. fix cu ctrl+c crash.
2. use nxsig_tgkill instead of nxsig_kill

Fix syslog can't output after serial setup:
3. serial/pl011: fix can't up_putc() after setup

Fix poll crash:
4. serial.c: should protect the fds when calling poll_notify

Fix PCI serial driver init crash:
5. make sure that interrupts are disabled during init
This is a proper fix for an unexpected MSI interrupt for PCI serial driver.

Feature enhancements --- force panic feature use two ctrl+c
6. support force panic only when repeat the panic char

Feature enhancements --- Add new option
7.  Add 16550_DLF_SIZE option for DesignWare UART.


## Impact
serial
## Testing
vela