### PR TITLE
drivers/fb: use ENOTTY to replace assert

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -606,8 +606,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_videoinfo_s *vinfo =
             (FAR struct fb_videoinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(vinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getvideoinfo != NULL);
+          DEBUGASSERT(vinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->getvideoinfo == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->getvideoinfo(fb->vtable, vinfo);
         }
         break;
@@ -617,7 +622,7 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_planeinfo_s *pinfo =
             (FAR struct fb_planeinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(pinfo != 0);
+          DEBUGASSERT(pinfo != NULL);
           ret = fb_get_planeinfo(fb, pinfo, pinfo->display);
         }
         break;
@@ -628,8 +633,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_cmap_s *cmap =
             (FAR struct fb_cmap_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(cmap != 0 && fb->vtable != NULL &&
-                      fb->vtable->getcmap != NULL);
+          DEBUGASSERT(cmap != NULL && fb->vtable != NULL);
+          if (fb->vtable->getcmap == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->getcmap(fb->vtable, cmap);
         }
         break;
@@ -639,8 +649,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR const struct fb_cmap_s *cmap =
             (FAR struct fb_cmap_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(cmap != 0 && fb->vtable != NULL &&
-                      fb->vtable->putcmap != NULL);
+          DEBUGASSERT(cmap != NULL && fb->vtable != NULL);
+          if (fb->vtable->putcmap == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->putcmap(fb->vtable, cmap);
         }
         break;
@@ -651,8 +666,12 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_cursorattrib_s *attrib =
             (FAR struct fb_cursorattrib_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(attrib != 0 && fb->vtable != NULL &&
-                      fb->vtable->getcursor != NULL);
+          DEBUGASSERT(attrib != NULL && fb->vtable != NULL);
+          if (fb->vtable->getcursor == NULL)
+            {
+              ret = -ENOTTY;
+            }
+
           ret = fb->vtable->getcursor(fb->vtable, attrib);
         }
         break;
@@ -662,8 +681,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_setcursor_s *cursor =
             (FAR struct fb_setcursor_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(cursor != 0 && fb->vtable != NULL &&
-                      fb->vtable->setcursor != NULL);
+          DEBUGASSERT(cursor != NULL && fb->vtable != NULL);
+          if (fb->vtable->setcursor == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setcursor(fb->vtable, cursor);
         }
         break;
@@ -674,7 +698,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           struct fb_area_s *area = (FAR struct fb_area_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(fb->vtable != NULL && fb->vtable->updatearea != NULL);
+          DEBUGASSERT(fb->vtable != NULL);
+          if (fb->vtable->updatearea == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->updatearea(fb->vtable, area);
         }
         break;
@@ -703,8 +733,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           struct fb_overlayinfo_s oinfo;
           FAR struct fb_priv_s *priv = filep->f_priv;
 
-          DEBUGASSERT(priv != NULL && fb->vtable != NULL &&
-                      fb->vtable->getoverlayinfo != NULL);
+          DEBUGASSERT(priv != NULL && fb->vtable != NULL);
+          if (fb->vtable->getoverlayinfo == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           if (arg != FB_NO_OVERLAY)
             {
               memset(&oinfo, 0, sizeof(oinfo));
@@ -723,8 +758,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getoverlayinfo != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->getoverlayinfo == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->getoverlayinfo(fb->vtable,
                                            oinfo->overlay, oinfo);
         }
@@ -735,8 +775,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->settransp != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->settransp == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->settransp(fb->vtable, oinfo);
         }
         break;
@@ -746,8 +791,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->setchromakey != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->setchromakey == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setchromakey(fb->vtable, oinfo);
         }
         break;
@@ -757,8 +807,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->setcolor != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->setcolor == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setcolor(fb->vtable, oinfo);
         }
         break;
@@ -768,8 +823,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->setblank != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->setblank == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setblank(fb->vtable, oinfo);
         }
         break;
@@ -779,8 +839,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->setarea != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->setarea == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setarea(fb->vtable, oinfo);
         }
         break;
@@ -790,8 +855,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayinfo_s *oinfo =
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->setdestarea != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->setdestarea == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setdestarea(fb->vtable, oinfo);
         }
         break;
@@ -802,8 +872,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayblit_s *blit =
             (FAR struct fb_overlayblit_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(blit != 0 && fb->vtable != NULL &&
-                      fb->vtable->blit != NULL);
+          DEBUGASSERT(blit != NULL && fb->vtable != NULL);
+          if (fb->vtable->blit == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->blit(fb->vtable, blit);
         }
         break;
@@ -813,8 +888,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_overlayblend_s *blend =
             (FAR struct fb_overlayblend_s *)((uintptr_t)arg);
 
-          DEBUGASSERT(blend != 0 && fb->vtable != NULL &&
-                      fb->vtable->blend != NULL);
+          DEBUGASSERT(blend != NULL && fb->vtable != NULL);
+          if (fb->vtable->blend == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->blend(fb->vtable, blend);
         }
         break;
@@ -826,7 +906,7 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             (FAR struct fb_overlayinfo_s *)((uintptr_t)arg);
           union fb_paninfo_u paninfo;
 
-          DEBUGASSERT(oinfo != 0 && fb->vtable != NULL);
+          DEBUGASSERT(oinfo != NULL && fb->vtable != NULL);
 
           memcpy(&paninfo, oinfo, sizeof(*oinfo));
 
@@ -843,8 +923,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case FBIOSET_POWER:
         {
-          DEBUGASSERT(fb->vtable != NULL &&
-                      fb->vtable->setpower != NULL);
+          DEBUGASSERT(fb->vtable != NULL);
+          if (fb->vtable->setpower == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->setpower(fb->vtable, (int)arg);
         }
         break;
@@ -853,9 +938,14 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           FAR int *power = (FAR int *)((uintptr_t)arg);
 
-          DEBUGASSERT(power != NULL && fb->vtable != NULL &&
-                      fb->vtable->getpower != NULL);
-          *(power) = fb->vtable->getpower(fb->vtable);
+          DEBUGASSERT(power != NULL && fb->vtable != NULL);
+          if (fb->vtable->getpower == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
+          *power = fb->vtable->getpower(fb->vtable);
         }
         break;
 
@@ -863,9 +953,14 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           FAR int *rate = (FAR int *)((uintptr_t)arg);
 
-          DEBUGASSERT(rate != NULL && fb->vtable != NULL &&
-                      fb->vtable->getframerate != NULL);
-          *(rate) = fb->vtable->getframerate(fb->vtable);
+          DEBUGASSERT(rate != NULL && fb->vtable != NULL);
+          if (fb->vtable->getframerate == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
+          *rate = fb->vtable->getframerate(fb->vtable);
         }
         break;
 
@@ -915,8 +1010,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_var_screeninfo *varinfo =
             (FAR struct fb_var_screeninfo *)((uintptr_t)arg);
 
-          DEBUGASSERT(varinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getvideoinfo != NULL);
+          DEBUGASSERT(varinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->getvideoinfo == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->getvideoinfo(fb->vtable, &vinfo);
           if (ret < 0)
             {
@@ -1007,8 +1107,13 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           FAR struct fb_fix_screeninfo *fixinfo =
             (FAR struct fb_fix_screeninfo *)((uintptr_t)arg);
 
-          DEBUGASSERT(fixinfo != 0 && fb->vtable != NULL &&
-                      fb->vtable->getvideoinfo != NULL);
+          DEBUGASSERT(fixinfo != NULL && fb->vtable != NULL);
+          if (fb->vtable->getvideoinfo == NULL)
+            {
+              ret = -ENOTTY;
+              break;
+            }
+
           ret = fb->vtable->getvideoinfo(fb->vtable, &vinfo);
           if (ret < 0)
             {


### PR DESCRIPTION
## Summary

Some drivers may not implement certain ioctls, but applications may still call these ioctl functions for consistency. In this case, to avoid an assertion, return ENOTTY.

## Impact

framebuffer driver

## Testing

CI-test
