### PR TITLE
nuttx/fs:Rename node with inode.

### DIFF
--- a/fs/inode/fs_foreachinode.c
+++ b/fs/inode/fs_foreachinode.c
@@ -76,18 +76,18 @@ struct inode_path_s
  *
  ****************************************************************************/
 
-static int foreach_inodelevel(FAR struct inode *node,
+static int foreach_inodelevel(FAR struct inode *inode,
                               FAR struct inode_path_s *info)
 {
   int ret = OK;
 
   /* Visit each node at this level */
 
-  for (; node; node = node->i_peer)
+  for (; inode; inode = inode->i_peer)
     {
       /* Give the next inode to the callback */
 
-      ret = info->handler(node, info->path, info->arg);
+      ret = info->handler(inode, info->path, info->arg);
 
       /* Break out of the loop early if the handler returns a non-zero
        * value.
@@ -102,12 +102,12 @@ static int foreach_inodelevel(FAR struct inode *node,
        * of the inodes at that level.
        */
 
-      if (node->i_child)
+      if (inode->i_child)
         {
           /* Construct the path to the next level */
 
           int pathlen = strlen(info->path);
-          int namlen  = strlen(node->i_name) + 1;
+          int namlen  = strlen(inode->i_name) + 1;
 
           /* Make sure that this would not exceed the maximum path length */
 
@@ -120,8 +120,8 @@ static int foreach_inodelevel(FAR struct inode *node,
           /* Append the path segment to this inode and recurse */
 
           snprintf(&info->path[pathlen], sizeof(info->path) - pathlen,
-                   "/%s", node->i_name);
-          ret = foreach_inodelevel(node->i_child, info);
+                   "/%s", inode->i_name);
+          ret = foreach_inodelevel(inode->i_child, info);
 
           /* Truncate the path name back to the correct length */
 

--- a/fs/inode/fs_inodefind.c
+++ b/fs/inode/fs_inodefind.c
@@ -61,12 +61,12 @@ int inode_find(FAR struct inode_search_s *desc)
     {
       /* Found it */
 
-      FAR struct inode *node = desc->node;
-      DEBUGASSERT(node != NULL);
+      FAR struct inode *inode = desc->node;
+      DEBUGASSERT(inode != NULL);
 
       /* Increment the reference count on the inode */
 
-      atomic_fetch_add(&node->i_crefs, 1);
+      atomic_fetch_add(&inode->i_crefs, 1);
     }
 
   inode_unlock();

--- a/fs/inode/fs_inodefree.c
+++ b/fs/inode/fs_inodefree.c
@@ -45,35 +45,35 @@
  *
  ****************************************************************************/
 
-void inode_free(FAR struct inode *node)
+void inode_free(FAR struct inode *inode)
 {
   /* Verify that we were passed valid pointer to an inode */
 
-  if (node != NULL)
+  if (inode != NULL)
     {
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
       /* Symbol links should never have peers or children */
 
-      DEBUGASSERT(!INODE_IS_SOFTLINK(node) ||
-                  (node->i_peer == NULL && node->i_child == NULL));
+      DEBUGASSERT(!INODE_IS_SOFTLINK(inode) ||
+                  (inode->i_peer == NULL && inode->i_child == NULL));
 #endif
 
       /* Free all peers and children of this i_node */
 
-      inode_free(node->i_peer);
-      inode_free(node->i_child);
+      inode_free(inode->i_peer);
+      inode_free(inode->i_child);
 
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
       /* If the inode is a symbolic link, the free the path to the linked
        * entity.
        */
 
-      if (INODE_IS_SOFTLINK(node) && node->u.i_link != NULL)
+      if (INODE_IS_SOFTLINK(inode) && inode->u.i_link != NULL)
         {
-          fs_heap_free(node->u.i_link);
+          fs_heap_free(inode->u.i_link);
         }
 #endif
 
-      fs_heap_free(node);
+      fs_heap_free(inode);
     }
 }

--- a/fs/inode/fs_inodegetpath.c
+++ b/fs/inode/fs_inodegetpath.c
@@ -42,28 +42,28 @@
  *
  ****************************************************************************/
 
-int inode_getpath(FAR struct inode *node, FAR char *path, size_t len)
+int inode_getpath(FAR struct inode *inode, FAR char *path, size_t len)
 {
   if (path == NULL)
     {
       return -EINVAL;
     }
-  else if (node == NULL)
+  else if (inode == NULL)
     {
       path[0] = '\0';
       return OK;
     }
   else
     {
-      int ret = inode_getpath(node->i_parent, path, len);
+      int ret = inode_getpath(inode->i_parent, path, len);
       if (ret < 0)
         {
           return ret;
         }
     }
 
-  strlcat(path, node->i_name, len);
-  if (node->i_child || INODE_IS_MOUNTPT(node))
+  strlcat(path, inode->i_name, len);
+  if (inode->i_child || INODE_IS_MOUNTPT(inode))
     {
       strlcat(path, "/", len);
     }

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -78,32 +78,32 @@ static void inode_namecpy(FAR char *dest, FAR const char *src)
 
 static FAR struct inode *inode_alloc(FAR const char *name, mode_t mode)
 {
-  FAR struct inode *node;
+  FAR struct inode *inode;
   int namelen;
 
   namelen = inode_namelen(name);
-  node    = fs_heap_zalloc(FSNODE_SIZE(namelen));
-  if (node)
+  inode   = fs_heap_zalloc(FSNODE_SIZE(namelen));
+  if (inode)
     {
-      node->i_ino   = g_ino++;
-      atomic_init(&node->i_crefs, 1);
+      inode->i_ino   = g_ino++;
+      atomic_init(&inode->i_crefs, 1);
 #ifdef CONFIG_PSEUDOFS_ATTRIBUTES
-      node->i_mode  = mode;
-      clock_gettime(CLOCK_REALTIME, &node->i_atime);
-      node->i_mtime = node->i_atime;
-      node->i_ctime = node->i_atime;
+      inode->i_mode  = mode;
+      clock_gettime(CLOCK_REALTIME, &inode->i_atime);
+      inode->i_mtime = inode->i_atime;
+      inode->i_ctime = inode->i_atime;
 #endif
-      inode_namecpy(node->i_name, name);
+      inode_namecpy(inode->i_name, name);
     }
 
-  return node;
+  return inode;
 }
 
 /****************************************************************************
  * Name: inode_insert
  ****************************************************************************/
 
-static void inode_insert(FAR struct inode *node,
+static void inode_insert(FAR struct inode *inode,
                          FAR struct inode *peer,
                          FAR struct inode *parent)
 {
@@ -113,9 +113,9 @@ static void inode_insert(FAR struct inode *node,
 
   if (peer)
     {
-      node->i_peer   = peer->i_peer;
-      node->i_parent = parent;
-      peer->i_peer   = node;
+      inode->i_peer   = peer->i_peer;
+      inode->i_parent = parent;
+      peer->i_peer    = inode;
     }
 
   /* Then it must go at the head of parent's list of children. */
@@ -123,9 +123,9 @@ static void inode_insert(FAR struct inode *node,
   else
     {
       DEBUGASSERT(parent != NULL);
-      node->i_peer    = parent->i_child;
-      node->i_parent  = parent;
-      parent->i_child = node;
+      inode->i_peer   = parent->i_child;
+      inode->i_parent = parent;
+      parent->i_child = inode;
     }
 }
 

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -39,9 +39,9 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int _inode_compare(FAR const char *fname, FAR struct inode *node);
+static int _inode_compare(FAR const char *fname, FAR struct inode *inode);
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
-static int _inode_linktarget(FAR struct inode *node,
+static int _inode_linktarget(FAR struct inode *inode,
                              FAR struct inode_search_s *desc);
 #endif
 static int _inode_search(FAR struct inode_search_s *desc);
@@ -65,9 +65,9 @@ FAR struct inode *g_root_inode = NULL;
  *
  ****************************************************************************/
 
-static int _inode_compare(FAR const char *fname, FAR struct inode *node)
+static int _inode_compare(FAR const char *fname, FAR struct inode *inode)
 {
-  FAR char *nname = node->i_name;
+  FAR char *nname = inode->i_name;
 
   if (!fname)
     {
@@ -142,21 +142,21 @@ static int _inode_compare(FAR const char *fname, FAR struct inode *node)
  ****************************************************************************/
 
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
-static int _inode_linktarget(FAR struct inode *node,
+static int _inode_linktarget(FAR struct inode *inode,
                              FAR struct inode_search_s *desc)
 {
   unsigned int count = 0;
   bool save;
   int ret = -ENOENT;
 
-  DEBUGASSERT(desc != NULL && node != NULL);
+  DEBUGASSERT(desc != NULL && inode != NULL);
 
   /* An infinite loop is avoided only by the loop count. */
 
   save = desc->nofollow;
-  while (INODE_IS_SOFTLINK(node))
+  while (INODE_IS_SOFTLINK(inode))
     {
-      FAR const char *link = (FAR const char *)node->u.i_link;
+      FAR const char *link = (FAR const char *)inode->u.i_link;
 
       /* Reset and reinitialize the search descriptor.  */
 
@@ -181,8 +181,8 @@ static int _inode_linktarget(FAR struct inode *node,
 
       /* Set up for the next time through the loop */
 
-      node = desc->node;
-      DEBUGASSERT(node != NULL);
+      inode = desc->node;
+      DEBUGASSERT(inode != NULL);
     }
 
   desc->nofollow = save;
@@ -214,7 +214,7 @@ static int _inode_linktarget(FAR struct inode *node,
 static int _inode_search(FAR struct inode_search_s *desc)
 {
   FAR const char   *name;
-  FAR struct inode *node    = g_root_inode;
+  FAR struct inode *inode   = g_root_inode;
   FAR struct inode *left    = NULL;
   FAR struct inode *above   = NULL;
   FAR const char   *relpath = NULL;
@@ -237,9 +237,9 @@ static int _inode_search(FAR struct inode_search_s *desc)
    * matching node is found.
    */
 
-  while (node != NULL)
+  while (inode != NULL)
     {
-      int result = _inode_compare(name, node);
+      int result = _inode_compare(name, inode);
 
       /* Case 1:  The name is less than the name of the node.
        * Since the names are ordered, these means that there
@@ -249,7 +249,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
 
       if (result < 0)
         {
-          node = NULL;
+          inode = NULL;
           break;
         }
 
@@ -262,8 +262,8 @@ static int _inode_search(FAR struct inode_search_s *desc)
         {
           /* Continue looking to the "right" of this inode. */
 
-          left = node;
-          node = node->i_peer;
+          left  = inode;
+          inode = inode->i_peer;
         }
 
       /* The names match */
@@ -278,7 +278,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
            */
 
           name = inode_nextname(name);
-          if (*name == '\0' || INODE_IS_MOUNTPT(node))
+          if (*name == '\0' || INODE_IS_MOUNTPT(inode))
             {
               /* Either (1) we are at the end of the path, so this must be
                * the node we are looking for or else (2) this node is a
@@ -299,7 +299,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                * continue below the target of the link, not the link itself.
                */
 
-              if (INODE_IS_SOFTLINK(node))
+              if (INODE_IS_SOFTLINK(inode))
                 {
                   int status;
 
@@ -309,7 +309,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                    * instead.
                    */
 
-                  status = _inode_linktarget(node, desc);
+                  status = _inode_linktarget(inode, desc);
                   if (status < 0)
                     {
                       /* Probably means that the target of the symbolic link
@@ -323,7 +323,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                     {
                       FAR struct inode *newnode = desc->node;
 
-                      if (newnode != node)
+                      if (newnode != inode)
                         {
                           /* The node was a valid symbolic link and we have
                            * jumped to a different, spot in the pseudo file
@@ -339,7 +339,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
                                * was already set by _inode_linktarget().
                                */
 
-                              node    = newnode;
+                              inode   = newnode;
                               above   = desc->parent;
                               left    = desc->peer;
                               ret     = OK;
@@ -373,7 +373,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
 
                           /* Continue from this new inode. */
 
-                          node = newnode;
+                          inode = newnode;
                         }
                     }
                 }
@@ -381,9 +381,9 @@ static int _inode_search(FAR struct inode_search_s *desc)
 
               /* Keep looking at the next level "down" */
 
-              above = node;
+              above = inode;
               left  = NULL;
-              node  = node->i_child;
+              inode = inode->i_child;
             }
         }
     }
@@ -405,7 +405,7 @@ static int _inode_search(FAR struct inode_search_s *desc)
    */
 
   desc->path    = name;
-  desc->node    = node;
+  desc->node    = inode;
   desc->peer    = left;
   desc->parent  = above;
   desc->relpath = relpath;
@@ -492,16 +492,16 @@ int inode_search(FAR struct inode_search_s *desc)
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
   if (ret >= 0)
     {
-      FAR struct inode *node;
+      FAR struct inode *inode;
 
       /* Search completed successfully */
 
-      node    = desc->node;
-      DEBUGASSERT(node != NULL);
+      inode = desc->node;
+      DEBUGASSERT(inode != NULL);
 
       /* Is the terminal node a softlink? Should we follow it? */
 
-      if (!desc->nofollow && INODE_IS_SOFTLINK(node))
+      if (!desc->nofollow && INODE_IS_SOFTLINK(inode))
         {
           /* The terminating inode is a valid soft link:  Return the inode,
            * corresponding to link target.  _inode_linktarget() will follow
@@ -509,7 +509,7 @@ int inode_search(FAR struct inode_search_s *desc)
            * link target of the final symbolic link in the series.
            */
 
-          ret = _inode_linktarget(node, desc);
+          ret = _inode_linktarget(inode, desc);
           if (ret < 0)
             {
               /* The most likely cause for failure is that the target of the

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -132,7 +132,7 @@ struct inode_search_s
  * file system.
  */
 
-typedef int (*foreach_inode_t)(FAR struct inode *node,
+typedef int (*foreach_inode_t)(FAR struct inode *inode,
                                FAR char dirpath[PATH_MAX],
                                FAR void *arg);
 
@@ -308,7 +308,7 @@ int inode_chstat(FAR struct inode *inode,
  *
  ****************************************************************************/
 
-int inode_getpath(FAR struct inode *node, FAR char *path, size_t len);
+int inode_getpath(FAR struct inode *inode, FAR char *path, size_t len);
 
 /****************************************************************************
  * Name: inode_free
@@ -318,7 +318,7 @@ int inode_getpath(FAR struct inode *node, FAR char *path, size_t len);
  *
  ****************************************************************************/
 
-void inode_free(FAR struct inode *node);
+void inode_free(FAR struct inode *inode);
 
 /****************************************************************************
  * Name: inode_nextname


### PR DESCRIPTION
## Summary
In `fs/inode` directory, the variable name `FAR struct inode *node` is named inconsistently, with some using `node` and others using `inode`. To facilitate understanding, we will standardize the naming to `FAR struct inode *inode`.

## Impact

## Testing

