### PR TITLE
files_getlist:Handling the situation when tcb's grouplist is empty

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -210,6 +210,11 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
   int j;
 
   list = files_getlist(tcb);
+  if (list == NULL)
+    {
+      return;
+    }
+
   for (i = 0; i < list->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
@@ -442,12 +447,19 @@ void files_dumplist(FAR struct filelist *list)
 
 FAR struct filelist *files_getlist(FAR struct tcb_s *tcb)
 {
-  FAR struct filelist *list = &tcb->group->tg_filelist;
+  FAR struct filelist *list;
 
-  DEBUGASSERT(list->fl_crefs >= 1);
-  list->fl_crefs++;
+  if (tcb->group != NULL)
+    {
+      list = &tcb->group->tg_filelist;
+      if (list->fl_crefs > 0)
+        {
+          list->fl_crefs++;
+          return list;
+        }
+    }
 
-  return list;
+  return NULL;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
  When the device reboot through reboot_notify to notify the task fsync time, if there is a task in the exit process, there may be priority robbed off the phenomenon, and at this time the group->tg_filelist crefs has been 0, resulting in the ASSERT

**Changes**
Optimized the logic of files_getlist
```
  FAR struct filelist *list;
  if (tcb->group != NULL)
    {
      list = &tcb->group->tg_filelist;
      if (list->fl_crefs > 0)
        {
          list->fl_crefs++;
          return list;
        }
    }
  return NULL;
```

## Impact
**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh

The basic test is passed

```
End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         3        5
mxordblk  3e037f0  3db2930
uordblks   1ea648   1e8e48
fordblks  3e159b0  3e171b0

user_main: setjmp test
setjmp_test: Initializing jmp_buf
setjmp_test: Try jump
setjmp_test: Jump succeed

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         5        5
mxordblk  3db2930  3db2930
uordblks   1e8e48   1e8e48
fordblks  3e171b0  3e171b0

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         5        4
mxordblk  3db2930  3e05180
uordblks   1e8e48   1e8e48
fordblks  3e171b0  3e171b0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         4        4
mxordblk  3e05180  3df4970
uordblks   1e8e48   1f97e8
fordblks  3e171b0  3e06810

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     3fffff8  3fffff8
ordblks         1        4
mxordblk  3e28ab0  3df4970
uordblks   1d7548   1f97e8
fordblks  3e28ab0  3e06810
user_main: Exiting
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
```

