### PR TITLE
driver: add GOLDFISH_GPU_FB_PRIORITY for goldfish_gpu_fb_vsync_thread

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -72,6 +72,11 @@ config GOLDFISH_GPU_FB
 	depends on VIDEO_FB
 	default n
 
+config GOLDFISH_GPU_FB_PRIORITY
+	int "Goldfish GPU Framebuffer vsync task priority"
+	depends on GOLDFISH_GPU_FB
+	default 100
+
 config GOLDFISH_FB_VIDEO_MODE
 	bool "Goldfish Framebuffer display mode"
 	depends on GOLDFISH_FB

--- a/drivers/video/goldfish_gpu_fb.c
+++ b/drivers/video/goldfish_gpu_fb.c
@@ -568,7 +568,8 @@ int goldfish_gpu_fb_register(int display)
   snprintf(arg1, 32, "%p", fb);
   argv[0] = arg1;
   argv[1] = NULL;
-  pid = kthread_create("goldfish_gpu_fb_thread", SCHED_PRIORITY_DEFAULT,
+  pid = kthread_create("goldfish_gpu_fb_thread",
+                       CONFIG_GOLDFISH_GPU_FB_PRIORITY,
                        CONFIG_DEFAULT_TASK_STACKSIZE,
                        goldfish_gpu_fb_vsync_thread, argv);
   if (pid < 0)


### PR DESCRIPTION
We need to configure the priority of FB Vsync thread to prevent nxcamera from preempting scheduling without sleep, which currently causes issues with Goldfish x86_64's default FIFO scheduling.

## Summary

## Impact
goldfish gpu fb
## Testing
goldfish gpu fb
