### PR TITLE
fs: fix compile break

### DIFF
--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -35,6 +35,7 @@
 #include <sched.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/lib/lib.h>
 


### PR DESCRIPTION
/home/neo/projects/vela/nuttx/fs/vfs/fs_dup2.c: In function 'file_dup3': /home/neo/projects/vela/nuttx/fs/inode/inode.h:73:35: error: implicit declaration of function '_SCHED_GETTID' [-Werror=implicit-function-declaration]
   73 |           int n = sched_backtrace(_SCHED_GETTID(), \
      |                                   ^~~~~~~~~~~~~
/home/neo/projects/vela/nuttx/fs/vfs/fs_dup2.c:177:3: note: in expansion of macro 'FS_ADD_BACKTRACE'
  177 |   FS_ADD_BACKTRACE(filep2);

## Summary

## Impact

## Testing

