### PR TITLE
fs/vfs: Avoid calling stat with oldrelpath twice in mountptrename

### DIFF
--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -352,14 +352,6 @@ static int mountptrename(FAR const char *oldpath, FAR struct inode *oldinode,
     {
       struct stat buf;
 
-#ifdef CONFIG_FS_NOTIFY
-      ret = oldinode->u.i_mops->stat(oldinode, oldpath, &buf);
-      if (ret >= 0)
-        {
-          oldisdir = S_ISDIR(buf.st_mode);
-        }
-#endif
-
 next_subdir:
       ret = oldinode->u.i_mops->stat(oldinode, newrelpath, &buf);
       if (ret >= 0)
@@ -434,6 +426,9 @@ next_subdir:
                   goto errout_with_newinode;
                 }
 
+#ifdef CONFIG_FS_NOTIFY
+              oldisdir = S_ISDIR(buf.st_mode);
+#endif
               if (oldinode->u.i_mops->unlink)
                 {
                   /* Attempt to remove the file before doing the rename.
@@ -450,6 +445,18 @@ next_subdir:
                 }
             }
         }
+#ifdef CONFIG_FS_NOTIFY
+      else
+        {
+          ret = oldinode->u.i_mops->stat(oldinode, oldrelpath, &buf);
+          if (ret < 0)
+            {
+              goto errout_with_newinode;
+            }
+
+          oldisdir = S_ISDIR(buf.st_mode);
+        }
+#endif
     }
 
   /* Perform the rename operation using the relative paths at the common


### PR DESCRIPTION

## Summary

fs/vfs: Avoid calling stat with oldrelpath twice in mountptrename
and return error directly if stat return failure

## Impact

## Testing

