### PR TITLE
fs_open:Adjust the definition of the open path

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -258,7 +258,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
       ret = -ENXIO;
     }
 
-  if (ret == -EISDIR)
+  if (ret == -EISDIR && ((oflags & O_WRONLY) == 0))
     {
       ret = dir_allocate(filep, desc.relpath);
     }


### PR DESCRIPTION
## Summary
  Reference https://man7.org/linux/man-pages/man2/open.2.html
       EISDIR pathname refers to a directory and the access requested
              involved writing (that is, O_WRONLY or O_RDWR is set).

## Impact

## Testing

