### PR TITLE
sim: fix sim smp boot regression

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostsmp.c
+++ b/arch/sim/src/sim/posix/sim_hostsmp.c
@@ -106,6 +106,8 @@ static void *sim_idle_trampoline(void *arg)
 
   host_cpu_started();
 
+  sim_unlock();
+
   /* The idle Loop */
 
   for (; ; )

--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -27,12 +27,22 @@
 #include <stdbool.h>
 #include <nuttx/arch.h>
 #include <sched/sched.h>
+#include <nuttx/init.h>
 
 #include "sim_internal.h"
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+void  sim_unlock(void)
+{
+  /* wait until cpu0 in idle() */
+
+  while (!OSINIT_IDLELOOP());
+
+  sched_unlock();
+}
 
 /****************************************************************************
  * Name: sim_doirq

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -206,6 +206,7 @@ extern char **g_argv;
 
 void sim_copyfullstate(xcpt_reg_t *dest, xcpt_reg_t *src);
 void *sim_doirq(int irq, void *regs);
+void  sim_unlock(void);
 
 /* sim_hostmisc.c ***********************************************************/
 

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -80,10 +80,7 @@
   do \
     { \
       g_cpu_irqset = 0; \
-      SP_DMB(); \
-      g_cpu_irqlock = SP_UNLOCKED; \
-      SP_DSB(); \
-      SP_SEV(); \
+      spin_unlock_wo_note(&g_cpu_irqlock); \
     } \
   while (0)
 #endif


### PR DESCRIPTION
## Summary
This commit fixes the regression from https://github.com/apache/nuttx/pull/13716

## Impact
sim

## Testing
sim:smp
ostest

