### PR TITLE
sched/signal: Fix compilation errors for MSVC.

### DIFF
--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -63,11 +63,9 @@
 
 struct sigwork_s
 {
-#ifdef CONFIG_SIG_EVTHREAD
   struct work_s work;           /* Work queue structure */
   union sigval value;           /* Data passed with notification */
   sigev_notify_function_t func; /* Notification function */
-#endif
 };
 
 #ifdef __cplusplus
@@ -640,7 +638,7 @@ int nxsig_notification(pid_t pid, FAR struct sigevent *event,
 #ifdef CONFIG_SIG_EVTHREAD
 void nxsig_cancel_notification(FAR struct sigwork_s *work);
 #else
-#  define nxsig_cancel_notification(work) (void)(work)
+#  define nxsig_cancel_notification(work)
 #endif
 
 #ifdef __cplusplus

--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -63,7 +63,9 @@ struct posix_timer_s
   clock_t          pt_expected;    /* Expected absolute time */
   struct wdog_s    pt_wdog;        /* The watchdog that provides the timing */
   struct sigevent  pt_event;       /* Notification information */
+#ifdef CONFIG_SIG_EVTHREAD
   struct sigwork_s pt_work;
+#endif
 };
 
 /****************************************************************************

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -72,8 +72,13 @@ static void timer_timeout(wdparm_t itimer);
 
 static inline void timer_signotify(FAR struct posix_timer_s *timer)
 {
+#ifdef CONFIG_SIG_EVTHREAD
   DEBUGVERIFY(nxsig_notification(timer->pt_owner, &timer->pt_event,
                                  SI_TIMER, &timer->pt_work));
+#else
+  DEBUGVERIFY(nxsig_notification(timer->pt_owner, &timer->pt_event,
+                                 SI_TIMER, NULL));
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This commit removed the empty struct to fix compilation errors for the MSVC compiler.

## Impact
Fixed compilation errors for the MSVC compiler

## Testing
Tested with the MSVC compiler.