### PR TITLE
{Bp-13895} board/arm/nrf52: fix use up_interrupt_context to is_nesting_interrupt

### DIFF
--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_highpri.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_highpri.c
@@ -96,6 +96,11 @@ static struct highpri_s g_highpri;
  * Private Functions
  ****************************************************************************/
 
+static inline_function bool is_nesting_interrupt(void)
+{
+  return up_current_regs() != NULL;
+}
+
 /****************************************************************************
  * Name: timer_handler
  *
@@ -126,7 +131,7 @@ void timer_handler(void)
 
   /* Check if we are in an interrupt handle */
 
-  if (up_interrupt_context())
+  if (is_nesting_interrupt())
     {
       g_highpri.handler++;
     }

--- a/boards/arm/stm32/viewtool-stm32f107/src/stm32_highpri.c
+++ b/boards/arm/stm32/viewtool-stm32f107/src/stm32_highpri.c
@@ -103,6 +103,11 @@ static struct highpri_s g_highpri;
  * Private Functions
  ****************************************************************************/
 
+static inline_function bool is_nesting_interrupt(void)
+{
+  return up_current_regs() != NULL;
+}
+
 /****************************************************************************
  * Name: tim6_handler
  *
@@ -128,7 +133,7 @@ void tim6_handler(void)
 
   /* Check if we are in an interrupt handle */
 
-  if (up_interrupt_context())
+  if (is_nesting_interrupt())
     {
       g_highpri.handler++;
     }


### PR DESCRIPTION
## Summary
The case want to determine if a interrupt with higher priority the interrupt preemption occurred,
but up_interrupt_context indicates that we self inside interrupt/handedr mode.
As we previously did not handle the ramvector interrupt correctly, after update breaked the case.
We should use a more clear private function is_nesting_interrupt.

https://github.com/apache/nuttx/issues/13831

## Impact
RELEASE

## Testing
CI
