### PR TITLE
arch: support customized up_cpu_index() in AMP mode

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -243,11 +243,7 @@ static inline irqstate_t up_irq_enable(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
 
 noinstrument_function
 static inline_function uint32_t *up_current_regs(void)

--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -354,11 +354,7 @@ static inline void setcontrol(uint32_t control)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -460,7 +460,7 @@ static inline_function int up_cpu_index(void)
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
 #else
-#  define up_cpu_index() 0
+int up_cpu_index(void);
 #endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -559,11 +559,7 @@ static inline void setcontrol(uint32_t control)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -455,7 +455,7 @@ static inline_function int up_cpu_index(void)
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
 #else
-#  define up_cpu_index() 0
+int up_cpu_index(void);
 #endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -532,11 +532,7 @@ static inline void setcontrol(uint32_t control)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -455,7 +455,7 @@ static inline_function int up_cpu_index(void)
   return (mpidr & MPIDR_CPUID_MASK) >> MPIDR_CPUID_SHIFT;
 }
 #else
-#  define up_cpu_index() 0
+int up_cpu_index(void);
 #endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)

--- a/arch/arm/include/tlsr82/irq.h
+++ b/arch/arm/include/tlsr82/irq.h
@@ -259,11 +259,7 @@ static inline uint32_t getcontrol(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
 int up_cpu_index(void) noinstrument_function;
-#else
-#  define up_cpu_index() 0
-#endif /* CONFIG_SMP */
 
 static inline_function uint32_t up_getsp(void)
 {

--- a/arch/arm/src/common/CMakeLists.txt
+++ b/arch/arm/src/common/CMakeLists.txt
@@ -95,4 +95,8 @@ if(CONFIG_ARCH_TOOLCHAIN_GHS)
   list(APPEND SRCS ghs/lib_dummy.c)
 endif()
 
+if(NOT CONFIG_SMP)
+  list(APPEND SRCS arm_cpuindex.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/common/Make.defs
+++ b/arch/arm/src/common/Make.defs
@@ -73,6 +73,10 @@ ifeq ($(CONFIG_UNWINDER_ARM),y)
   CMN_CSRCS += arm_backtrace_unwind.c
 endif
 
+ifneq ($(CONFIG_SMP),y)
+  CMN_CSRCS += arm_cpuindex.c
+endif
+
 CMN_ASRCS += fork.S
 
 ifeq ($(CONFIG_ARCH_HAVE_FETCHADD),y)

--- a/arch/arm/src/common/arm_cpuindex.c
+++ b/arch/arm/src/common/arm_cpuindex.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/arm/src/common/arm_cpuindex.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_cpu_index
+ *
+ * Description:
+ *   Return the index of the physical core.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   An integer index of the physical core.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_SMP
+int weak_function up_cpu_index(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION

## Summary
Some app with same code runs on different cores in AMP mode, need know the physical core on which the function is called.
To support customized up_cpu_index().

## Impact
There is no impact for SMP up_cpu_index(),  and AMP in default.

## Testing
a customed armv7m board in vela
