### PR TITLE
group: access group in critical section

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -683,7 +683,7 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
 
   /* Show the task / thread argument list (skipping over the name) */
 
-  linesize   = group_argvstr(tcb, procfile->line, remaining);
+  linesize   = nxtask_argvstr(tcb, procfile->line, remaining);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                              remaining, &offset);
   totalsize += copysize;

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1203,7 +1203,7 @@ pid_t nxtask_start_fork(FAR struct task_tcb_s *child);
 void nxtask_abort_fork(FAR struct task_tcb_s *child, int errcode);
 
 /****************************************************************************
- * Name: group_argvstr
+ * Name: nxtask_argvstr
  *
  * Description:
  *   Safely read the contents of a task's argument vector, into a a safe
@@ -1219,7 +1219,7 @@ void nxtask_abort_fork(FAR struct task_tcb_s *child, int errcode);
  *
  ****************************************************************************/
 
-size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size);
+size_t nxtask_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size);
 
 /****************************************************************************
  * Name: group_exitinfo

--- a/sched/group/CMakeLists.txt
+++ b/sched/group/CMakeLists.txt
@@ -28,8 +28,7 @@ set(SRCS
     group_setuptaskfiles.c
     group_foreachchild.c
     group_killchildren.c
-    group_signal.c
-    group_argvstr.c)
+    group_signal.c)
 
 if(CONFIG_SCHED_HAVE_PARENT)
   if(CONFIG_SCHED_CHILD_STATUS)

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -23,7 +23,6 @@
 CSRCS += group_create.c group_join.c group_leave.c
 CSRCS += group_setupidlefiles.c group_setuptaskfiles.c
 CSRCS += group_foreachchild.c group_killchildren.c group_signal.c
-CSRCS += group_argvstr.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
 ifeq ($(CONFIG_SCHED_CHILD_STATUS),y)

--- a/sched/group/group_argvstr.c
+++ b/sched/group/group_argvstr.c
@@ -67,8 +67,7 @@ size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
 
   /* Sanity checks and idle tasks */
 
-  if (!tcb || !tcb->group || !tcb->group->tg_info || size < 1 ||
-      is_idle_task(tcb))
+  if (!tcb || size < 1 || is_idle_task(tcb))
     {
       *args = '\0';
       return 0;

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -365,7 +365,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 
   /* Stringify the argument vector */
 
-  group_argvstr(tcb, args, sizeof(args));
+  nxtask_argvstr(tcb, args, sizeof(args));
 
   /* get the task_state */
 

--- a/sched/task/CMakeLists.txt
+++ b/sched/task/CMakeLists.txt
@@ -21,6 +21,7 @@
 # ##############################################################################
 
 set(SRCS
+    task_argvstr.c
     task_create.c
     task_init.c
     task_setup.c

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -20,11 +20,11 @@
 #
 ############################################################################
 
-CSRCS += task_create.c task_init.c task_setup.c task_activate.c
-CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
-CSRCS += task_getgroup.c task_getpid.c task_prctl.c task_recover.c
-CSRCS += task_restart.c task_spawnparms.c task_cancelpt.c task_terminate.c
-CSRCS += task_gettid.c exit.c task_join.c
+CSRCS += task_argvstr.c task_create.c task_init.c task_setup.c
+CSRCS += task_activate.c task_start.c task_delete.c task_exit.c
+CSRCS += task_exithook.c task_getgroup.c task_getpid.c task_prctl.c
+CSRCS += task_recover.c task_restart.c task_spawnparms.c task_cancelpt.c
+CSRCS += task_terminate.c task_gettid.c exit.c task_join.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
 CSRCS += task_getppid.c task_reparent.c

--- a/sched/task/task_argvstr.c
+++ b/sched/task/task_argvstr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/group/group_argvstr.c
+ * sched/task/task_argvstr.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -27,7 +27,6 @@
 #include <nuttx/config.h>
 
 #include <sched.h>
-#include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
 
@@ -35,14 +34,13 @@
 #include <nuttx/tls.h>
 
 #include "sched/sched.h"
-#include "group/group.h"
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_argvstr
+ * Name: nxtask_argvstr
  *
  * Description:
  *   Safely read the contents of a task's argument vector, into a a safe
@@ -58,7 +56,7 @@
  *
  ****************************************************************************/
 
-size_t group_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
+size_t nxtask_argvstr(FAR struct tcb_s *tcb, FAR char *args, size_t size)
 {
   size_t n = 0;
 #ifdef CONFIG_ARCH_ADDRENV


### PR DESCRIPTION
## Summary

~Make sure `tcb` still exist when we access members of it.~

As discussed below, function `group_argvstr`  should be renamed to `nxtask_argvstr` because it's no longer depends on group.

Also current caller to `group_argvstr` is procfs and assert handler. Both of them are now have `enter_critical_section ` protected, thus we don't need to add guard inside `group_argvstr` .

PR is updated accordingly.

## Impact

Should be minimal.

## Testing

Tested on internal projects that has frequent task create/destroy and a periodic call to procfs.

