### PR TITLE
usensor.c:fix container_of member error.

### DIFF
--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -228,7 +228,7 @@ static int usensor_get_info(FAR struct sensor_lowerhalf_s *lower,
 {
   FAR struct usensor_lowerhalf_s *ulower = container_of(lower,
                                            struct usensor_lowerhalf_s,
-                                           node);
+                                           driver);
 
   *info = ulower->info;
   return 0;
@@ -240,7 +240,7 @@ static int usensor_control(FAR struct sensor_lowerhalf_s *lower,
 {
   FAR struct usensor_lowerhalf_s *ulower = container_of(lower,
                                            struct usensor_lowerhalf_s,
-                                           node);
+                                           driver);
 
   if (cmd == SNIOC_SET_INFO)
     {


### PR DESCRIPTION
## Summary

- Fixed the error of container_of  incoming member.

## Impact

- N/A

## Testing

PC:Ubuntu 2004, x86 GCC 13.1, SIM
order: uorb_listener -n 10 sensor_accel_uncal

