### PR TITLE
misc/dev_mem: fix compile error in aarch64

### DIFF
--- a/drivers/misc/dev_mem.c
+++ b/drivers/misc/dev_mem.c
@@ -208,7 +208,7 @@ static int devmem_mmap(FAR struct file *filep,
 int devmem_register(void)
 {
   FAR struct memory_region_s *region;
-  bool merge = (_edata == _sbss);
+  bool merge = (&_edata[0] == &_sbss[0]);
   ssize_t len = 0;
   int ret;
 


### PR DESCRIPTION
## Summary
misc/dev_mem.c:203:24: error: comparison between two arrays [-Werror=array-compare]
  203 |   bool merge = (_edata == _sbss);
      |                        ^~
misc/dev_mem.c:203:24: note: use '&_edata[0] == &_sbss[0]' to compare the addresses

## Impact
dev mem

## Testing
qmeu armv8a
