### PR TITLE
case SIOCGIWNAME: add filter out non-802.11 interfaces

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -630,7 +630,7 @@ static int netdev_wifr_ioctl(FAR struct socket *psock, int cmd,
       dev = netdev_findbyname(req->ifr_name);
       if (cmd == SIOCGIWNAME)
         {
-          if (dev == NULL)
+          if (dev == NULL || dev->d_lltype != NET_LL_IEEE80211)
             {
               ret = -ENODEV;
             }


### PR DESCRIPTION
## Summary

netdev_wifr_ioctl SIOCGIWNAME cmd, need to filter out non-802.11 interfaces

## Impact

Minor

## Testing

Manual test on vela
