### PR TITLE
cmake(Enhancement):enhance compile options for custom toolchain,implement the REVERSE opt of `add_compile_options()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ include(nuttx_add_symtab)
 include(nuttx_add_module)
 include(nuttx_add_dependencies)
 include(nuttx_export_header)
+include(nuttx_remove_compile_options)
 include(nuttx_source_file_properties)
 include(menuconfig)
 
@@ -404,6 +405,15 @@ endif()
 
 # Setup platform options (this needs to happen after project(), once the
 # toolchain file has been processed)
+
+# Support custom Toolchain options by custom Boards
+if(CONFIG_ARCH_BOARD_CUSTOM)
+  if(EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake
+     AND EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
+    # must be added AFTER ToolchainFile and BEFORE platform
+    include(${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
+  endif()
+endif()
 
 include(platform)
 

--- a/cmake/nuttx_remove_compile_options.cmake
+++ b/cmake/nuttx_remove_compile_options.cmake
@@ -1,0 +1,67 @@
+# ##############################################################################
+# cmake/nuttx_remove_compile_options.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# ~~~
+# nuttx_remove_compile_options
+#
+# Description:
+#  Customize to remove certain options
+#  in the default Arch ToolchainFile.
+#
+#   For example, a customized chip board uses a customized tool chain, which has compilation configuration conflicts with default.
+#   You can use this macro to remove it in the global compile options.
+#   This function is similar to the reverse operation of `add_compile_options()`
+#
+# Usage:
+#   nuttx_remove_compile_options(ARGNS)
+#
+# Parameters:
+#   ARGNS                : options regex that needs to be deleted
+#
+# Example:
+#   nuttx_remove_compile_options(-march -mabi)
+#
+#   befor: CFLAGS = -O2 -g -march=rv32if -mabi=ilp32f -mcpu=e907fp
+#   after: CFLAGS = -O2 -g -mcpu=e907fp
+#
+# ~~~
+
+function(nuttx_remove_compile_options)
+  get_property(
+    CURRENT_OPTIONS
+    DIRECTORY
+    PROPERTY COMPILE_OPTIONS)
+
+  set_property(DIRECTORY PROPERTY COMPILE_OPTIONS)
+
+  # Remove flags starting with regex
+  foreach(CURRENT_OPTION_VARIABLE ${CURRENT_OPTIONS})
+    set(MATCHED_FLAG)
+    foreach(regex ${ARGN})
+      string(REGEX MATCH "^${regex}" MATCHED ${CURRENT_OPTION_VARIABLE})
+      if(MATCHED)
+        string(CONCAT MATCHED_FLAG ${MATCHED_FLAG}${MATCHED})
+      endif()
+    endforeach()
+    if(NOT MATCHED_FLAG)
+      add_compile_options(${CURRENT_OPTION_VARIABLE})
+    endif()
+  endforeach()
+endfunction()


### PR DESCRIPTION
## Summary

add global moudle `nuttx_remove_compile_options()`. define custom board toolchain introduction.

Because CMake does not support the reverse operation of `add_compile_options`, 
the design logic of CMake is that if an option needs to be deleted, it should not be added in the first place.

However our arch scenario has a series of common configurations. When there is a customized board that needs to rewrite such configurations, it will face obstacles.

In Makefile, we can re-override variables such as CFLAGS. So this patch provides a CMake module to do the same thing

```cmake
# call in custom Toolchain file

# Example:
nuttx_remove_compile_options(-march -mabi)
#
#   befor: CFLAGS = -O2 -g -march=rv32if -mabi=ilp32f -mcpu=e907fp
#   after: CFLAGS = -O2 -g -mcpu=e907fp
``` 
## Impact

For custom board,  can create a Toolchain file in the` NUTTX_BOARD_ABS_DIR/cmake` directory and expand the compilation options.

## Testing
custom board
