### PR TITLE
sched/group: There is no need to use sched_[un]lock

### DIFF
--- a/sched/group/group_continue.c
+++ b/sched/group/group_continue.c
@@ -108,15 +108,12 @@ static int group_continue_handler(pid_t pid, FAR void *arg)
 
 int group_continue(FAR struct tcb_s *tcb)
 {
+  irqstate_t flags;
   int ret;
 
-  /* Lock the scheduler so that there this thread will not lose priority
-   * until all of its children are suspended.
-   */
-
-  sched_lock();
+  flags = enter_critical_section();
   ret = group_foreachchild(tcb->group, group_continue_handler, NULL);
-  sched_unlock();
+  leave_critical_section(flags);
   return ret;
 }
 

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -154,6 +154,7 @@ static int group_cancel_children_handler(pid_t pid, FAR void *arg)
 
 int group_kill_children(FAR struct tcb_s *tcb)
 {
+  irqstate_t flags;
   int ret;
 
   DEBUGASSERT(tcb->group);
@@ -163,19 +164,7 @@ int group_kill_children(FAR struct tcb_s *tcb)
       return 0;
     }
 
-#ifdef CONFIG_SMP
-  /* NOTE: sched_lock() is not enough for SMP
-   * because tcb->group will be accessed from the child tasks
-   */
-
-  irqstate_t flags = enter_critical_section();
-#else
-  /* Lock the scheduler so that there this thread will not lose priority
-   * until all of its children are suspended.
-   */
-
-  sched_lock();
-#endif
+  flags = enter_critical_section();
 
   /* Tell the children that this group has started exiting */
 
@@ -218,12 +207,8 @@ int group_kill_children(FAR struct tcb_s *tcb)
 
   ret = group_foreachchild(tcb->group, group_cancel_children_handler,
                            (FAR void *)((uintptr_t)tcb->pid));
-
-#ifdef CONFIG_SMP
   leave_critical_section(flags);
-#else
-  sched_unlock();
-#endif
+
   return ret;
 }
 

--- a/sched/group/group_suspendchildren.c
+++ b/sched/group/group_suspendchildren.c
@@ -101,16 +101,13 @@ static int group_suspend_children_handler(pid_t pid, FAR void *arg)
 
 int group_suspend_children(FAR struct tcb_s *tcb)
 {
+  irqstate_t flags;
   int ret;
 
-  /* Lock the scheduler so that there this thread will not lose priority
-   * until all of its children are suspended.
-   */
-
-  sched_lock();
+  flags = enter_critical_section();
   ret = group_foreachchild(tcb->group, group_suspend_children_handler,
                            (FAR void *)((uintptr_t)tcb->pid));
-  sched_unlock();
+  leave_critical_section(flags);
   return ret;
 }
 


### PR DESCRIPTION
## Summary
purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance. 2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.
## Impact
sched/group

## Testing
arm64 arm

