### PR TITLE
[bugfix]tools/mkdeps.c:add options for gen full path object target

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -390,6 +390,10 @@ static void parse_args(int argc, char **argv)
 
   g_altpath = strdup(".");
 
+  /* Ensure dep target obj path has a default value */
+
+  g_objpath = strdup(".");
+
   /* Accumulate CFLAGS up to "--" */
 
   for (argidx = 1; argidx < argc; argidx++)
@@ -765,7 +769,19 @@ static void do_dependency(const char *file)
           exit(EXIT_FAILURE);
         }
 
-      objname = basename(dupname);
+      /* Check g_altpath. If only the CURRENT path is included,
+       * the obj target use its own full path.
+       */
+
+      if (strcmp(g_altpath, ".") == 0)
+        {
+          objname = dupname;
+        }
+      else
+        {
+          objname = basename(dupname);
+        }
+
       dotptr  = strrchr(objname, '.');
       if (dotptr)
         {


### PR DESCRIPTION


## Summary

When the compilation file is a full path, the Make.dep target cannot correctly generate dependencies, causing incremental compilation to fail.

Check g_altpath. If only the CURRENT path is included, the obj target use its own full path, otherwise just use the filename.

add default value current path for obj-path.

## Impact

Make Make.dep to correctly generate targets with paths

## Testing
build with qemu-armv8a:nsh 
