### PR TITLE
[bugfix]checkpatch.sh:Fix checking for wrong cmake files

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -63,7 +63,7 @@ is_rust_file() {
 
 is_cmake_file() {
   file_name=$(basename $@)
-  if [ "$file_name" == "CMakeLists.txt" ] || [[ "$file_name" =~ "cmake" ]]; then
+  if [ "$file_name" == "CMakeLists.txt" ] || [[ "$file_name" =~ \.cmake$ ]]; then
     echo 1
   else
     echo 0


### PR DESCRIPTION
## Summary
patches ending with cmake should be checked.
Currently, any non-cmake files containing cmake keywords will be checked.
## Impact

solve https://github.com/apache/nuttx/pull/13913 check ci failed
## Testing
check workflow
