### PR TITLE
libs/libc/fdt/Make.defs: cannot move due to directory not empty bugfix

### DIFF
--- a/libs/libc/fdt/Make.defs
+++ b/libs/libc/fdt/Make.defs
@@ -30,6 +30,7 @@ dtc:
 	$(call DOWNLOAD,https://github.com/dgibson/dtc/archive,v$(VERSION).zip,dtc.zip)
 	$(Q) mv dtc.zip fdt/dtc.zip
 	$(Q) unzip -o fdt/dtc.zip -d fdt
+	$(call DELDIR, fdt/dtc)
 	$(Q) mv fdt/dtc-$(VERSION) fdt/dtc
 else
 dtc:


### PR DESCRIPTION
## Summary

In current code, compiling with menuconfig updated for the third time will fail due to "Directory not empty" error.
```
...
 extracting: fdt/dtc-1.7.0/version_gen.h.in
  inflating: fdt/dtc-1.7.0/yamltree.c
mv: cannot move 'fdt/dtc-1.7.0' to 'fdt/dtc/dtc-1.7.0': Directory not empty
make[1]: *** [fdt/Make.defs:31: dtc] Error 1
make: *** [tools/Unix.mk:452: libs/libc/.context] Error 2
(failed reverse-i-search)`git comm': ^Ct checkout xtensa-1.22.x
```
This is because the first `mv fdt/dtc-1.7.0 fdt/dtc` did a directory rename as expected, the second `mv fdt/dtc-1.7.0 fdt/dtc` moves one folder into another folder.
So we need to remove old `fdt/dtc` before `mv`command to fix this issue.

## Impact

Remove old directory so that "mv" can succeed instead of triggering "Directory not empty" error.
Bug fixed.

## Testing

```
windrow@windrow-PC:~/push/nuttx/nuttx$ ./tools/configure.sh qemu-armv8a:netnsh
windrow@windrow-PC:~/push/nuttx/nuttx$ make -j32
...
windrow@windrow-PC:~/push/nuttx/nuttx$ make menuconfig
windrow@windrow-PC:~/push/nuttx/nuttx$ make -j32
...
windrow@windrow-PC:~/push/nuttx/nuttx$ make menuconfig
windrow@windrow-PC:~/push/nuttx/nuttx$ make -j32
...
```
