### PR TITLE
sched: export sched_getcpu API in AMP mode

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -235,6 +235,7 @@ void   task_testcancel(void);
 
 /* Task Scheduling Interfaces (based on POSIX APIs) */
 
+int    sched_getcpu(void);
 int    sched_setparam(pid_t pid, FAR const struct sched_param *param);
 int    sched_getparam(pid_t pid, FAR struct sched_param *param);
 int    sched_setscheduler(pid_t pid, int policy,
@@ -252,12 +253,10 @@ int    sched_setaffinity(pid_t pid, size_t cpusetsize,
                          FAR const cpu_set_t *mask);
 int    sched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask);
 int    sched_cpucount(FAR const cpu_set_t *set);
-int    sched_getcpu(void);
 #else
 #  define sched_setaffinity(p, c, m) 0
 #  define sched_getaffinity(p, c, m) (*(m) |= (1 << 0), 0)
 #  define sched_cpucount(s) 1
-#  define sched_getcpu() 0
 #endif /* CONFIG_SMP */
 
 /* Task Switching Interfaces (non-standard) */

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -36,6 +36,7 @@ SYSCALL_LOOKUP(prctl,                      2)
   SYSCALL_LOOKUP(getppid,                  0)
 #endif
 
+SYSCALL_LOOKUP(sched_getcpu,               0)
 SYSCALL_LOOKUP(sched_getparam,             2)
 SYSCALL_LOOKUP(sched_getscheduler,         1)
 SYSCALL_LOOKUP(sched_lock,                 0)
@@ -53,7 +54,6 @@ SYSCALL_LOOKUP(nxsched_get_stackinfo,      2)
 
 #ifdef CONFIG_SMP
   SYSCALL_LOOKUP(sched_getaffinity,        3)
-  SYSCALL_LOOKUP(sched_getcpu,             0)
   SYSCALL_LOOKUP(sched_setaffinity,        3)
 #endif
 

--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SRCS
     sched_lockcount.c
     sched_idletask.c
     sched_self.c
+    sched_getcpu.c
     sched_get_stackinfo.c
     sched_get_tls.c
     sched_sysinfo.c
@@ -55,14 +56,8 @@ if(CONFIG_PRIORITY_INHERITANCE)
 endif()
 
 if(CONFIG_SMP)
-  list(
-    APPEND
-    SRCS
-    sched_cpuselect.c
-    sched_getcpu.c
-    sched_getaffinity.c
-    sched_setaffinity.c
-    sched_process_delivered.c)
+  list(APPEND SRCS sched_cpuselect.c sched_getaffinity.c sched_setaffinity.c
+       sched_process_delivered.c)
 endif()
 
 if(CONFIG_SIG_SIGSTOP_ACTION)

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -30,14 +30,14 @@ CSRCS += sched_setscheduler.c sched_getscheduler.c
 CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c
 CSRCS += sched_lock.c sched_unlock.c sched_lockcount.c
 CSRCS += sched_idletask.c sched_self.c sched_get_stackinfo.c sched_get_tls.c
-CSRCS += sched_sysinfo.c sched_reprioritizertr.c sched_get_stateinfo.c
+CSRCS += sched_sysinfo.c sched_reprioritizertr.c sched_get_stateinfo.c sched_getcpu.c
 
 ifeq ($(CONFIG_PRIORITY_INHERITANCE),y)
 CSRCS += sched_reprioritize.c
 endif
 
 ifeq ($(CONFIG_SMP),y)
-CSRCS += sched_cpuselect.c sched_getcpu.c sched_process_delivered.c
+CSRCS += sched_cpuselect.c sched_process_delivered.c
 CSRCS += sched_getaffinity.c sched_setaffinity.c
 endif
 

--- a/sched/sched/sched_getcpu.c
+++ b/sched/sched/sched_getcpu.c
@@ -63,5 +63,5 @@
 
 int sched_getcpu(void)
 {
-  return this_cpu();  /* Does not fail */
+  return up_cpu_index();  /* Does not fail */
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -136,7 +136,7 @@
 "rmmod","nuttx/module.h","defined(CONFIG_MODULE)","int","FAR void *"
 "sched_backtrace","sched.h","defined(CONFIG_SCHED_BACKTRACE)","int","pid_t","FAR void **","int","int"
 "sched_getaffinity","sched.h","defined(CONFIG_SMP)","int","pid_t","size_t","FAR cpu_set_t *"
-"sched_getcpu","sched.h","defined(CONFIG_SMP)","int"
+"sched_getcpu","sched.h","","int"
 "sched_getparam","sched.h","","int","pid_t","FAR struct sched_param *"
 "sched_getscheduler","sched.h","","int","pid_t"
 "sched_lock","sched.h","","int"


### PR DESCRIPTION

## Summary
this_cpu is logical core number, up_cpu_index is physical core number.
In SMP, this_cpu and up_cpu_index are same.
In AMP, we can also use sched_getcpu API to know physical core id on which the function is called.

relate to https://github.com/apache/nuttx/pull/13886

## Impact
None

## Testing
Vela
