### PR TITLE
Pci fixbugs

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2m.c
+++ b/arch/arm/src/armv7-a/arm_gicv2m.c
@@ -54,7 +54,7 @@ struct gic_v2m_s
 
 static struct gic_v2m_s g_v2m =
 {
-  SP_LOCKED
+  SP_UNLOCKED
 };
 
 /****************************************************************************

--- a/arch/arm64/src/common/arm64_gicv2m.c
+++ b/arch/arm64/src/common/arm64_gicv2m.c
@@ -69,7 +69,7 @@ struct gic_v2m_s
 
 static struct gic_v2m_s g_v2m =
 {
-  SP_LOCKED
+  SP_UNLOCKED
 };
 
 /****************************************************************************

--- a/drivers/pci/pci_qemu_epc.c
+++ b/drivers/pci/pci_qemu_epc.c
@@ -660,7 +660,7 @@ static int qemu_epc_get_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno)
   base = pci_qep_func_base(qep, funcno);
   flags = qemu_epc_cfg_read16(qep, base + QEMU_EPC_BAR_CFG_MSI +
                               PCI_MSI_FLAGS);
-  if (!(flags & PCI_MSIX_FLAGS_ENABLE))
+  if (!(flags & PCI_MSI_FLAGS_ENABLE))
     {
       pcierr("msi is not enabled\n");
       return -EINVAL;


### PR DESCRIPTION
## Summary
1.qemu_epc_get_msi: flag should use msi enable flag
2.The gicv2m spinlock init status should unlocked
## Impact

## Testing

