### PR TITLE
Add support fchstat and chstat  function for littlefs

### DIFF
--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -31,8 +31,10 @@ if(CONFIG_FS_LITTLEFS)
           ${CMAKE_BINARY_DIR}/fs/littlefs/littlefs
       PATCH_COMMAND
         patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
-        ${CMAKE_CURRENT_LIST_DIR}/lfs_util.patch COMMAND patch -p2 -d
-        ${CMAKE_CURRENT_LIST_DIR} < ${CMAKE_CURRENT_LIST_DIR}/lfs_getpath.patch)
+        ${CMAKE_CURRENT_LIST_DIR}/lfs_util.patch && patch -p2 -d
+        ${CMAKE_CURRENT_LIST_DIR} < ${CMAKE_CURRENT_LIST_DIR}/lfs_getpath.patch
+        && patch -p2 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/lfs_getsetattr.patch)
     FetchContent_MakeAvailable(littlefs)
   endif()
 

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -56,6 +56,7 @@ $(LITTLEFS_TARBALL):
 	$(Q) mv littlefs/littlefs-$(LITTLEFS_VERSION) littlefs/littlefs
 	$(Q) git apply littlefs/lfs_util.patch
 	$(Q) git apply littlefs/lfs_getpath.patch
+	$(Q) git apply littlefs/lfs_getsetattr.patch
 	$(Q) touch littlefs/.littlefsunpack
 
 # Download and unpack tarball if no git repo found

--- a/fs/littlefs/lfs_getsetattr.patch
+++ b/fs/littlefs/lfs_getsetattr.patch
@@ -1,0 +1,80 @@
+--- ./littlefs/littlefs/lfs.c
++++ ./littlefs/littlefs/lfs.c
+@@ -5717,6 +5717,41 @@ int lfs_file_path(lfs_t *lfs, lfs_file_t *file, char *path, lfs_size_t size) {
+     return err < 0 ? err : 0;
+ }
+ 
++lfs_ssize_t lfs_file_getattr(lfs_t *lfs, lfs_file_t *file,
++        uint8_t type, void *buffer, lfs_size_t size)
++{
++    int err = LFS_LOCK(lfs->cfg);
++    if (err) {
++        return err;
++    }
++    LFS_TRACE("lfs_file_setattr(%p, %p)", (void*)lfs, (void*)file);
++    LFS_TRACE("lfs_file_setattr(%"PRIu8", %p, %"PRIu32")",
++            type, buffer, size);
++    LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
++
++    return lfs_dir_get(lfs, &file->m, LFS_MKTAG(0x7ff, 0x3ff, 0),
++            LFS_MKTAG(LFS_TYPE_USERATTR + type,
++                file->id, lfs_min(size, lfs->attr_max)), buffer);
++}
++
++#ifndef LFS_READONLY
++int lfs_file_setattr(lfs_t *lfs, lfs_file_t *file,
++        uint8_t type, const void *buffer, lfs_size_t size)
++{
++    int err = LFS_LOCK(lfs->cfg);
++    if (err) {
++        return err;
++    }
++    LFS_TRACE("lfs_file_getattr(%p, %p)", (void*)lfs, (void*)file);
++    LFS_TRACE("lfs_file_getattr(%"PRIu8", %p, %"PRIu32")",
++            type, buffer, size);
++    LFS_ASSERT(lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
++
++    return lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
++            {LFS_MKTAG(LFS_TYPE_USERATTR + type, file->id, size), buffer}));
++}
++#endif
++
+ #ifndef LFS_READONLY
+ int lfs_mkdir(lfs_t *lfs, const char *path) {
+     int err = LFS_LOCK(lfs->cfg);
+--- ./littlefs/littlefs/lfs.h
++++ ./littlefs/littlefs/lfs.h
+@@ -611,6 +611,33 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
+ // Returns a negative error code on failure.
+ int lfs_file_path(lfs_t *lfs, lfs_file_t *file, char *path, lfs_size_t size);
+ 
++// Get a custom attribute of file
++//
++// Custom attributes are uniquely identified by an 8-bit type and limited
++// to LFS_ATTR_MAX bytes. When read, if the stored attribute is smaller than
++// the buffer, it will be padded with zeros. If the stored attribute is larger,
++// then it will be silently truncated. If no attribute is found, the error
++// LFS_ERR_NOATTR is returned and the buffer is filled with zeros.
++//
++// Returns the size of the attribute, or a negative error code on failure.
++// Note, the returned size is the size of the attribute on disk, irrespective
++// of the size of the buffer. This can be used to dynamically allocate a buffer
++// or check for existance.
++lfs_ssize_t lfs_file_getattr(lfs_t *lfs, lfs_file_t *file,
++        uint8_t type, void *buffer, lfs_size_t size);
++
++// Set custom attributes of file
++//
++// Custom attributes are uniquely identified by an 8-bit type and limited
++// to LFS_ATTR_MAX bytes. If an attribute is not found, it will be
++// implicitly created.
++//
++// Returns a negative error code on failure.
++#ifndef LFS_READONLY
++int lfs_file_setattr(lfs_t *lfs, lfs_file_t *file,
++        uint8_t type, const void *buffer, lfs_size_t size);
++#endif
++
+ /// Directory operations ///
+ 
+ #ifndef LFS_READONLY

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1554,6 +1554,7 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
           goto errout;
         }
 
+      ret = 0;
       memset(&attr, 0, sizeof(attr));
     }
 
@@ -1570,6 +1571,15 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
   buf->st_blksize      = fs->cfg.block_size;
   buf->st_blocks       = (buf->st_size + buf->st_blksize - 1) /
                          buf->st_blksize;
+
+  if (info.type == LFS_TYPE_REG)
+    {
+      buf->st_mode |= S_IFREG;
+    }
+  else
+    {
+      buf->st_mode |= S_IFDIR;
+    }
 
 errout:
   nxmutex_unlock(&fs->lock);
@@ -1605,6 +1615,7 @@ static int littlefs_chstat(FAR struct inode *mountpt,
           goto errout;
         }
 
+      ret = 0;
       memset(&attr, 0, sizeof(attr));
     }
 

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1491,7 +1491,28 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
                           mode_t mode)
 {
   FAR struct littlefs_mountpt_s *fs;
+  FAR char *path = (FAR char *)relpath;
+  size_t len = strlen(relpath);
   int ret;
+
+  /* We need remove all the '/' in the end of relpath */
+
+  if (len > 0 && relpath[len - 1] == '/')
+    {
+      path = lib_get_pathbuffer();
+      if (path == NULL)
+        {
+          return -ENOMEM;
+        }
+
+      while (len > 0 && relpath[len - 1] == '/')
+        {
+          len--;
+        }
+
+      memcpy(path, relpath, len);
+      path[len] = '\0';
+    }
 
   /* Get the mountpoint private data from the inode structure */
 
@@ -1502,10 +1523,10 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
   ret = nxmutex_lock(&fs->lock);
   if (ret < 0)
     {
-      return ret;
+      goto errout;
     }
 
-  ret = lfs_mkdir(&fs->lfs, relpath);
+  ret = littlefs_convert_result(lfs_mkdir(&fs->lfs, path));
   if (ret >= 0)
     {
       struct littlefs_attr_s attr;
@@ -1517,15 +1538,21 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
       attr.at_ctim = 1000000000ull * time.tv_sec + time.tv_nsec;
       attr.at_atim = attr.at_ctim;
       attr.at_mtim = attr.at_ctim;
-      ret = littlefs_convert_result(lfs_setattr(&fs->lfs, relpath, 0,
+      ret = littlefs_convert_result(lfs_setattr(&fs->lfs, path, 0,
                                                 &attr, sizeof(attr)));
       if (ret < 0)
         {
-          lfs_remove(&fs->lfs, relpath);
+          lfs_remove(&fs->lfs, path);
         }
     }
 
   nxmutex_unlock(&fs->lock);
+
+errout:
+  if (path != relpath)
+    {
+      lib_put_pathbuffer(path);
+    }
 
   return ret;
 }

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -727,7 +727,6 @@ static int littlefs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   FAR struct littlefs_file_s *priv;
   FAR struct inode *inode;
   struct littlefs_attr_s attr;
-  char path[LFS_NAME_MAX];
   int ret;
 
   memset(buf, 0, sizeof(*buf));
@@ -792,7 +791,6 @@ static int littlefs_fchstat(FAR const struct file *filep,
   FAR struct littlefs_file_s *priv;
   FAR struct inode *inode;
   struct littlefs_attr_s attr;
-  char path[LFS_NAME_MAX];
   int ret;
 
   /* Recover our private data from the struct file instance */

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1444,6 +1444,25 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
     }
 
   ret = lfs_mkdir(&fs->lfs, relpath);
+  if (ret >= 0)
+    {
+      struct littlefs_attr_s attr;
+      struct timespec time;
+
+      clock_gettime(CLOCK_REALTIME, &time);
+      memset(&attr, 0, sizeof(attr));
+      attr.at_mode = mode;
+      attr.at_ctim = 1000000000ull * time.tv_sec + time.tv_nsec;
+      attr.at_atim = attr.at_ctim;
+      attr.at_mtim = attr.at_ctim;
+      ret = littlefs_convert_result(lfs_setattr(&fs->lfs, relpath, 0,
+                                                &attr, sizeof(attr)));
+      if (ret < 0)
+        {
+          lfs_remove(&fs->lfs, relpath);
+        }
+    }
+
   nxmutex_unlock(&fs->lock);
 
   return ret;
@@ -1556,6 +1575,7 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
       ret = 0;
       memset(&attr, 0, sizeof(attr));
+      attr.at_mode = S_IRWXG | S_IRWXU | S_IRWXO;
     }
 
   buf->st_mode         = attr.at_mode;

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1573,11 +1573,11 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
           goto errout;
         }
 
-      ret = 0;
       memset(&attr, 0, sizeof(attr));
       attr.at_mode = S_IRWXG | S_IRWXU | S_IRWXO;
     }
 
+  ret = 0;
   buf->st_mode         = attr.at_mode;
   buf->st_uid          = attr.at_uid;
   buf->st_gid          = attr.at_gid;
@@ -1635,7 +1635,6 @@ static int littlefs_chstat(FAR struct inode *mountpt,
           goto errout;
         }
 
-      ret = 0;
       memset(&attr, 0, sizeof(attr));
     }
 

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -80,6 +80,17 @@ struct littlefs_mountpt_s
   struct lfs            lfs;
 };
 
+struct littlefs_attr_s
+{
+  uint32_t at_ver;     /* For the later extension */
+  uint32_t at_mode;    /* File type, attributes, and access mode bits */
+  uint32_t at_uid;     /* User ID of file */
+  uint32_t at_gid;     /* Group ID of file */
+  uint64_t at_atim;    /* Time of last access */
+  uint64_t at_mtim;    /* Time of last modification */
+  uint64_t at_ctim;    /* Time of last status change */
+};
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -101,6 +112,8 @@ static int     littlefs_dup(FAR const struct file *oldp,
                             FAR struct file *newp);
 static int     littlefs_fstat(FAR const struct file *filep,
                               FAR struct stat *buf);
+static int     littlefs_fchstat(FAR const struct file *filep,
+                                FAR const struct stat *buf, int flags);
 static int     littlefs_truncate(FAR struct file *filep,
                                  off_t length);
 
@@ -133,6 +146,9 @@ static int     littlefs_rename(FAR struct inode *mountpt,
                                FAR const char *newrelpath);
 static int     littlefs_stat(FAR struct inode *mountpt,
                              FAR const char *relpath, FAR struct stat *buf);
+static int     littlefs_chstat(FAR struct inode *mountpt,
+                               FAR const char *relpath,
+                               FAR const struct stat *buf, int flags);
 
 /****************************************************************************
  * Public Data
@@ -158,7 +174,7 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */
   littlefs_fstat,         /* fstat */
-  NULL,                   /* fchstat */
+  littlefs_fchstat,       /* fchstat */
 
   littlefs_opendir,       /* opendir */
   littlefs_closedir,      /* closedir */
@@ -174,7 +190,7 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_rmdir,         /* rmdir */
   littlefs_rename,        /* rename */
   littlefs_stat,          /* stat */
-  NULL                    /* chstat */
+  littlefs_chstat         /* chstat */
 };
 
 /****************************************************************************
@@ -325,6 +341,26 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
       /* Error opening file */
 
       goto errout;
+    }
+
+  if (oflags & LFS_O_CREAT)
+    {
+      struct littlefs_attr_s attr;
+      struct timespec time;
+
+      clock_gettime(CLOCK_REALTIME, &time);
+      memset(&attr, 0, sizeof(attr));
+      attr.at_mode = mode;
+      attr.at_ctim = 1000000000ull * time.tv_sec + time.tv_nsec;
+      attr.at_atim = attr.at_ctim;
+      attr.at_mtim = attr.at_ctim;
+      ret = littlefs_convert_result(lfs_setattr(&fs->lfs, relpath, 0,
+                                                &attr, sizeof(attr)));
+      if (ret < 0)
+        {
+          lfs_remove(&fs->lfs, relpath);
+          goto errout_with_file;
+        }
     }
 
   /* In append mode, we need to set the file pointer to the end of the
@@ -690,6 +726,7 @@ static int littlefs_fstat(FAR const struct file *filep, FAR struct stat *buf)
   FAR struct littlefs_mountpt_s *fs;
   FAR struct littlefs_file_s *priv;
   FAR struct inode *inode;
+  char path[LFS_NAME_MAX];
   int ret;
 
   memset(buf, 0, sizeof(*buf));
@@ -708,17 +745,57 @@ static int littlefs_fstat(FAR const struct file *filep, FAR struct stat *buf)
       return ret;
     }
 
-  buf->st_size = lfs_file_size(&fs->lfs, &priv->file);
+  ret = lfs_file_path(&fs->lfs, &priv->file, path, sizeof(path));
   nxmutex_unlock(&fs->lock);
-
-  if (buf->st_size < 0)
+  if (ret < 0)
     {
-      return littlefs_convert_result(buf->st_size);
+      return ret;
     }
 
-  buf->st_mode    = S_IRWXO | S_IRWXG | S_IRWXU | S_IFREG;
-  buf->st_blksize = fs->cfg.block_size;
-  buf->st_blocks  = (buf->st_size + buf->st_blksize - 1) / buf->st_blksize;
+  ret = littlefs_stat(inode, path, buf);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+static int littlefs_fchstat(FAR const struct file *filep,
+                            FAR const struct stat *buf, int flags)
+{
+  FAR struct littlefs_mountpt_s *fs;
+  FAR struct littlefs_file_s *priv;
+  FAR struct inode *inode;
+  char path[LFS_NAME_MAX];
+  int ret;
+
+  /* Recover our private data from the struct file instance */
+
+  priv  = filep->f_priv;
+  inode = filep->f_inode;
+  fs    = inode->i_private;
+
+  /* Call LFS to get file size */
+
+  ret = nxmutex_lock(&fs->lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = lfs_file_path(&fs->lfs, &priv->file, path, sizeof(path));
+  nxmutex_unlock(&fs->lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = littlefs_chstat(inode, path, buf, flags);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   return OK;
 }
@@ -1445,6 +1522,7 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 {
   FAR struct littlefs_mountpt_s *fs;
   struct lfs_info info;
+  struct littlefs_attr_s attr;
   int ret;
 
   memset(buf, 0, sizeof(*buf));
@@ -1462,28 +1540,112 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
     }
 
   ret = lfs_stat(&fs->lfs, relpath, &info);
-  nxmutex_unlock(&fs->lock);
-
-  if (ret >= 0)
+  if (ret < 0)
     {
-      /* Convert info to stat */
-
-      buf->st_mode = S_IRWXO | S_IRWXG | S_IRWXU;
-      if (info.type == LFS_TYPE_REG)
-        {
-          buf->st_mode |= S_IFREG;
-          buf->st_size = info.size;
-        }
-      else
-        {
-          buf->st_mode |= S_IFDIR;
-          buf->st_size = 0;
-        }
-
-      buf->st_blksize = fs->cfg.block_size;
-      buf->st_blocks  = (buf->st_size + buf->st_blksize - 1) /
-                        buf->st_blksize;
+      goto errout;
     }
 
+  ret = littlefs_convert_result(lfs_getattr(&fs->lfs, relpath, 0,
+                                            &attr, sizeof(attr)));
+  if (ret < 0)
+    {
+      if (ret != -ENODATA)
+        {
+          goto errout;
+        }
+
+      memset(&attr, 0, sizeof(attr));
+    }
+
+  buf->st_mode         = attr.at_mode;
+  buf->st_uid          = attr.at_uid;
+  buf->st_gid          = attr.at_gid;
+  buf->st_atim.tv_sec  = attr.at_atim / 1000000000ull;
+  buf->st_atim.tv_nsec = attr.at_atim % 1000000000ull;
+  buf->st_mtim.tv_sec  = attr.at_mtim / 1000000000ull;
+  buf->st_mtim.tv_nsec = attr.at_mtim % 1000000000ull;
+  buf->st_ctim.tv_sec  = attr.at_ctim / 1000000000ull;
+  buf->st_ctim.tv_nsec = attr.at_ctim % 1000000000ull;
+  buf->st_size         = info.size;
+  buf->st_blksize      = fs->cfg.block_size;
+  buf->st_blocks       = (buf->st_size + buf->st_blksize - 1) /
+                         buf->st_blksize;
+
+errout:
+  nxmutex_unlock(&fs->lock);
+  return ret;
+}
+
+static int littlefs_chstat(FAR struct inode *mountpt,
+                           FAR const char *relpath,
+                           FAR const struct stat *buf, int flags)
+{
+  FAR struct littlefs_mountpt_s *fs;
+  struct littlefs_attr_s attr;
+  int ret;
+
+  /* Get the mountpoint private data from the inode structure */
+
+  fs = mountpt->i_private;
+
+  /* Call LFS to get file size */
+
+  ret = nxmutex_lock(&fs->lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = littlefs_convert_result(lfs_getattr(&fs->lfs, relpath, 0,
+                                            &attr, sizeof(attr)));
+  if (ret < 0)
+    {
+      if (ret != -ENODATA)
+        {
+          goto errout;
+        }
+
+      memset(&attr, 0, sizeof(attr));
+    }
+
+  if ((CH_STAT_MODE & flags) == CH_STAT_MODE)
+    {
+      attr.at_mode = buf->st_mode;
+    }
+
+  if ((CH_STAT_UID & flags) == CH_STAT_UID)
+    {
+      attr.at_uid = buf->st_uid;
+    }
+
+  if ((CH_STAT_GID & flags) == CH_STAT_GID)
+    {
+      attr.at_gid = buf->st_gid;
+    }
+
+  attr.at_ctim = 1000000000ull * buf->st_ctim.tv_sec +
+                 buf->st_ctim.tv_nsec;
+
+  if ((CH_STAT_ATIME & flags) == CH_STAT_ATIME)
+    {
+      attr.at_atim = 1000000000ull * buf->st_atim.tv_sec +
+                     buf->st_atim.tv_nsec;
+    }
+
+  if ((CH_STAT_MTIME & flags) == CH_STAT_MTIME)
+    {
+      attr.at_mtim = 1000000000ull * buf->st_mtim.tv_sec +
+                     buf->st_mtim.tv_nsec;
+    }
+
+  ret = littlefs_convert_result(lfs_setattr(&fs->lfs, relpath, 0,
+                                            &attr, sizeof(attr)));
+  if (ret < 0)
+    {
+      goto errout;
+    }
+
+errout:
+  nxmutex_unlock(&fs->lock);
   return ret;
 }


### PR DESCRIPTION
## Summary
add functions for littlefs : 

static int     littlefs_fchstat(FAR const struct file *filep, 
                                          FAR const struct stat *buf, int flags);
static int     littlefs_chstat(FAR struct inode *mountpt,
                                         FAR const char *relpath,
                                         FAR const struct stat *buf, int flags);

## Impact

littlefs_vfs  

## Testing
NuttxSyscallTestSuites
NuttxFsTestSuites

