### PR TITLE
cmake(bugfix):Synchronize the compilation differences between CMake and Makefile in nuttx repo

### DIFF
--- a/arch/arm/src/arm/CMakeLists.txt
+++ b/arch/arm/src/arm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# arch/arm/src/armv7-m/CMakeLists.txt
+# arch/arm/src/arm/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,52 +18,28 @@
 #
 # ##############################################################################
 
-# TODO: do not use config to detect this
+set(SRCS arm_head.S)
 
-set(SRCS
-    arm_exception.S
-    arm_saveusercontext.S
-    arm_busfault.c
-    arm_dbgmonitor.c
-    arm_cache.c
-    arm_cpuinfo.c
-    arm_doirq.c
-    arm_hardfault.c
-    arm_initialstate.c
-    arm_itm.c
-    arm_memfault.c
-    arm_perf.c
-    arm_schedulesigaction.c
-    arm_sigdeliver.c
-    arm_svcall.c
-    arm_systemreset.c
-    arm_tcbinfo.c
-    arm_trigger_irq.c
-    arm_usagefault.c
-    arm_vectors.c)
+list(
+  APPEND
+  SRCS
+  arm_dataabort.c
+  arm_doirq.c
+  arm_initialstate.c
+  arm_prefetchabort.c
+  arm_schedulesigaction.c
+  arm_sigdeliver.c
+  arm_syscall.c
+  arm_tcbinfo.c
+  arm_undefinedinsn.c
+  arm_cache.S
+  arm_vectors.S
+  arm_vectortab.S
+  arm_saveusercontext.S)
 
-if(CONFIG_ARMV7M_SYSTICK)
-  list(APPEND SRCS arm_systick.c)
-endif()
-
-if(CONFIG_ARMV7M_ITMSYSLOG)
-  list(APPEND SRCS arm_itm_syslog.c)
-endif()
-
-if(CONFIG_ARMV7M_STACKCHECK)
-  list(APPEND SRCS arm_stackcheck.c)
-endif()
-
-if(CONFIG_ARCH_FPU)
-  list(APPEND SRCS arm_fpuconfig.c arm_fpucmp.c)
-endif()
-
-if(CONFIG_ARCH_RAMVECTORS)
-  list(APPEND SRCS arm_ramvec_initialize.c arm_ramvec_attach.c)
-endif()
-
-if(CONFIG_ARM_MPU OR CONFIG_ARM_MPU_EARLY_RESET)
-  list(APPEND SRCS arm_mpu.c)
+if(CONFIG_PAGING)
+  list(APPEND SRCS arm_pginitialize.c arm_checkmapping.c arm_allocpage.c
+       arm_va2pte.c)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/armv7-a/CMakeLists.txt
+++ b/arch/arm/src/armv7-a/CMakeLists.txt
@@ -46,11 +46,8 @@ list(
   arm_syscall.c
   arm_tcbinfo.c
   arm_undefinedinsn.c
+  arm_perf.c
   cp15_cacheops.c)
-
-if(CONFIG_ARCH_PERF_EVENTS)
-  list(APPEND SRCS arm_perf.c)
-endif()
 
 if(CONFIG_ARMV7A_GICv2M)
   list(APPEND SRCS arm_gicv2m.c)

--- a/arch/arm/src/armv8-m/CMakeLists.txt
+++ b/arch/arm/src/armv8-m/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRCS
     arm_initialstate.c
     arm_itm.c
     arm_memfault.c
+    arm_perf.c
     arm_sau.c
     arm_schedulesigaction.c
     arm_securefault.c
@@ -41,10 +42,6 @@ set(SRCS
     arm_trigger_irq.c
     arm_usagefault.c
     arm_vectors.c)
-
-if(CONFIG_ARCH_PERF_EVENTS)
-  list(APPEND SRCS arm_perf.c)
-endif()
 
 if(CONFIG_ARMV8M_SYSTICK)
   list(APPEND SRCS arm_systick.c)

--- a/drivers/thermal/CMakeLists.txt
+++ b/drivers/thermal/CMakeLists.txt
@@ -1,0 +1,44 @@
+# ##############################################################################
+# drivers/thermal/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+# ##############################################################################
+
+# Include thermal sources
+
+if(CONFIG_THERMAL)
+  list(APPEND SRCS thermal_core.c)
+endif()
+
+if(CONFIG_THERMAL_GOVERNOR_STEP_WISE)
+  list(APPEND SRCS thermal_step_wise.c)
+endif()
+
+if(CONFIG_THERMAL_CDEV_CPUFREQ)
+  list(APPEND SRCS thermal_cpufreq_cooling.c)
+endif()
+
+if(CONFIG_THERMAL_PROCFS)
+  list(APPEND SRCS thermal_procfs.c)
+endif()
+
+if(CONFIG_THERMAL_DUMMY)
+  list(APPEND SRCS thermal_dummy.c)
+endif()
+
+target_sources(drivers PRIVATE ${SRCS})

--- a/fs/binfs/CMakeLists.txt
+++ b/fs/binfs/CMakeLists.txt
@@ -17,9 +17,10 @@
 # the License.
 #
 # ##############################################################################
+if(NOT CONFIG_DISABLE_MOUNTPOINT)
+  if(CONFIG_FS_BINFS)
 
-if(CONFIG_FS_BINFS)
+    target_sources(fs PRIVATE fs_binfs.c)
 
-  target_sources(fs PRIVATE fs_binfs.c)
-
+  endif()
 endif()

--- a/fs/notify/CMakeLists.txt
+++ b/fs/notify/CMakeLists.txt
@@ -1,7 +1,5 @@
 # ##############################################################################
-# libs/libc/spawn/CMakeLists.txt
-#
-# SPDX-License-Identifier: Apache-2.0
+# fs/notify/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -20,32 +18,6 @@
 #
 # ##############################################################################
 
-set(SRCS
-    lib_psfa_addaction.c
-    lib_psfa_addclose.c
-    lib_psfa_adddup2.c
-    lib_psfa_addopen.c
-    lib_psfa_destroy.c
-    lib_psfa_init.c
-    lib_psa_getflags.c
-    lib_psa_getschedparam.c
-    lib_psa_getschedpolicy.c
-    lib_psa_init.c
-    lib_psa_setflags.c
-    lib_psa_setschedparam.c
-    lib_psa_setschedpolicy.c
-    lib_psa_getsigmask.c
-    lib_psa_setsigmask.c
-    lib_psa_getstacksize.c
-    lib_psa_setstacksize.c
-    lib_psa_destroy.c)
-
-if(NOT CONFIG_BUILD_KERNEL)
-  list(APPEND SRCS lib_psa_getstacksize.c lib_psa_setstacksize.c)
+if(CONFIG_FS_NOTIFY)
+  target_sources(fs PRIVATE inotify.c)
 endif()
-
-if(CONFIG_DEBUG_FEATURES)
-  list(APPEND SRCS lib_psfa_dump.c lib_psa_dump.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})

--- a/fs/rpmsgfs/CMakeLists.txt
+++ b/fs/rpmsgfs/CMakeLists.txt
@@ -17,16 +17,18 @@
 # the License.
 #
 # ##############################################################################
+if(NOT CONFIG_DISABLE_MOUNTPOINT)
+  if(CONFIG_FS_RPMSGFS)
+    target_sources(fs PRIVATE rpmsgfs.c rpmsgfs_client.c)
+  endif()
 
-if(CONFIG_FS_RPMSGFS)
-  target_sources(fs PRIVATE rpmsgfs.c rpmsgfs_client.c)
-endif()
+  if(CONFIG_FS_RPMSGFS_SERVER)
+    target_sources(fs PRIVATE rpmsgfs_server.c)
+  endif()
 
-if(CONFIG_FS_RPMSGFS_SERVER)
-  target_sources(fs PRIVATE rpmsgfs_server.c)
-endif()
+  if(CONFIG_TRACE_RPMSGFS_FS)
+    set_source_files_properties(rpmsgfs.c PROPERTIES COMPILE_FLAGS
+                                                     -finstrument-functions)
+  endif()
 
-if(CONFIG_TRACE_RPMSGFS_FS)
-  set_source_files_properties(rpmsgfs.c DIRECTORY ..
-                              PROPERTIES COMPILE_FLAGS -finstrument-functions)
 endif()

--- a/fs/unionfs/CMakeLists.txt
+++ b/fs/unionfs/CMakeLists.txt
@@ -17,7 +17,8 @@
 # the License.
 #
 # ##############################################################################
-
-if(CONFIG_FS_UNIONFS)
-  target_sources(fs PRIVATE fs_unionfs.c)
+if(NOT CONFIG_DISABLE_MOUNTPOINT)
+  if(CONFIG_FS_UNIONFS)
+    target_sources(fs PRIVATE fs_unionfs.c)
+  endif()
 endif()

--- a/fs/userfs/CMakeLists.txt
+++ b/fs/userfs/CMakeLists.txt
@@ -17,7 +17,8 @@
 # the License.
 #
 # ##############################################################################
-
-if(CONFIG_FS_USERFS)
-  target_sources(fs PRIVATE fs_userfs.c)
+if(NOT CONFIG_DISABLE_MOUNTPOINT)
+  if(CONFIG_FS_USERFS)
+    target_sources(fs PRIVATE fs_userfs.c)
+  endif()
 endif()

--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -39,20 +39,19 @@ set(SRCS
     fs_rename.c
     fs_rmdir.c
     fs_select.c
-    fs_sendfile.c
     fs_stat.c
+    fs_sendfile.c
     fs_statfs.c
     fs_unlink.c
     fs_write.c
     fs_dir.c
     fs_fsync.c
+    fs_syncfs.c
     fs_truncate.c)
 
 # File lock support
 
 if(NOT "${CONFIG_FS_LOCK_BUCKET_SIZE}" STREQUAL "0")
-  set_source_files_properties(fs_lock.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
-                              PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/sched)
   list(APPEND SRCS fs_lock.c)
 endif()
 
@@ -77,9 +76,6 @@ endif()
 # Support for timerfd
 
 if(CONFIG_TIMER_FD)
-  set_source_files_properties(
-    fs_timerfd.c DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/..
-    PROPERTIES INCLUDE_DIRECTORIES ${NUTTX_DIR}/sched)
   list(APPEND SRCS fs_timerfd.c)
 endif()
 

--- a/fs/zipfs/CMakeLists.txt
+++ b/fs/zipfs/CMakeLists.txt
@@ -17,12 +17,13 @@
 # the License.
 #
 # ##############################################################################
+if(NOT CONFIG_DISABLE_MOUNTPOINT)
+  if(CONFIG_FS_ZIPFS)
 
-if(CONFIG_FS_ZIPFS)
+    target_sources(fs PRIVATE zip_vfs.c)
 
-  target_sources(fs PRIVATE zip_vfs.c)
-
-  target_include_directories(
-    fs PRIVATE ${CMAKE_CURRENT_LIST_DIR}/zlib/zlib/contrib/minizip
-               ${CMAKE_CURRENT_LIST_DIR}/zlib/zlib)
+    target_include_directories(
+      fs PRIVATE ${CMAKE_CURRENT_LIST_DIR}/zlib/zlib/contrib/minizip
+                 ${CMAKE_CURRENT_LIST_DIR}/zlib/zlib)
+  endif()
 endif()

--- a/libs/libc/dirent/CMakeLists.txt
+++ b/libs/libc/dirent/CMakeLists.txt
@@ -22,15 +22,17 @@
 
 target_sources(
   c
-  PRIVATE lib_alphasort.c
-          lib_closedir.c
-          lib_dirfd.c
+  PRIVATE lib_readdirr.c
+          lib_telldir.c
+          lib_alphasort.c
+          lib_scandir.c
           lib_ftw.c
           lib_nftw.c
           lib_opendir.c
+          lib_fdopendir.c
+          lib_closedir.c
           lib_readdir.c
-          lib_readdirr.c
           lib_rewinddir.c
-          lib_scandir.c
           lib_seekdir.c
-          lib_telldir.c)
+          lib_dirfd.c
+          lib_versionsort.c)

--- a/libs/libc/gdbstub/CMakeLists.txt
+++ b/libs/libc/gdbstub/CMakeLists.txt
@@ -19,3 +19,7 @@
 # the License.
 #
 # ##############################################################################
+
+if(CONFIG_LIB_GDBSTUB)
+  target_sources(c PRIVATE lib_gdbstub.c)
+endif()

--- a/libs/libc/locale/CMakeLists.txt
+++ b/libs/libc/locale/CMakeLists.txt
@@ -29,5 +29,9 @@ if(CONFIG_LIBC_LOCALE)
             lib_newlocale.c
             lib_setlocale.c
             lib_uselocale.c
+            lib_catalog.c
+            lib_gettext.c
+            lib_langinfo.c
+            lib_iconv.c
             lib_maxlocale.c)
 endif()

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -46,6 +46,7 @@ list(
   lib_openat.c
   lib_mkdirat.c
   lib_utimensat.c
+  lib_mallopt.c
   lib_memoryregion.c
   lib_getnprocs.c
   lib_pathbuffer.c)

--- a/libs/libc/modlib/CMakeLists.txt
+++ b/libs/libc/modlib/CMakeLists.txt
@@ -31,6 +31,7 @@ if(CONFIG_LIBC_MODLIB)
     modlib_iobuffer.c
     modlib_load.c
     modlib_loadhdrs.c
+    modlib_verify.c
     modlib_read.c
     modlib_registry.c
     modlib_sections.c
@@ -38,7 +39,6 @@ if(CONFIG_LIBC_MODLIB)
     modlib_symtab.c
     modlib_uninit.c
     modlib_unload.c
-    modlib_verify.c
     modlib_gethandle.c
     modlib_getsymbol.c
     modlib_insert.c

--- a/libs/libc/net/CMakeLists.txt
+++ b/libs/libc/net/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRCS
     lib_base64.c
     lib_htons.c
     lib_htonl.c
+    lib_htonq.c
     lib_inetaddr.c
     lib_inetaton.c
     lib_inetntoa.c

--- a/libs/libc/netdb/CMakeLists.txt
+++ b/libs/libc/netdb/CMakeLists.txt
@@ -43,7 +43,11 @@ if(CONFIG_LIBC_NETDB)
     lib_gaistrerror.c
     lib_freeaddrinfo.c
     lib_getaddrinfo.c
-    lib_getnameinfo.c)
+    lib_getnameinfo.c
+    lib_rexec.c
+    lib_dn.c
+    lib_proto.c
+    lib_protor.c)
 
   # Add host file support
 

--- a/libs/libc/obstack/CMakeLists.txt
+++ b/libs/libc/obstack/CMakeLists.txt
@@ -19,3 +19,19 @@
 # the License.
 #
 # ##############################################################################
+
+target_sources(
+  c
+  PRIVATE lib_obstack_init.c
+          lib_obstack_alloc.c
+          lib_obstack_copy.c
+          lib_obstack_free.c
+          lib_obstack_make_room.c
+          lib_obstack_blank.c
+          lib_obstack_grow.c
+          lib_obstack_finish.c
+          lib_obstack_object_size.c
+          lib_obstack_room.c
+          lib_obstack_printf.c
+          lib_obstack_vprintf.c
+          lib_obstack_malloc.c)

--- a/libs/libc/pthread/CMakeLists.txt
+++ b/libs/libc/pthread/CMakeLists.txt
@@ -49,6 +49,8 @@ if(NOT CONFIG_DISABLE_PTHREAD)
     pthread_attr_getstack.c
     pthread_attr_setschedparam.c
     pthread_attr_getschedparam.c
+    pthread_attr_setscope.c
+    pthread_attr_getscope.c
     pthread_barrierattr_init.c
     pthread_barrierattr_destroy.c
     pthread_barrierattr_getpshared.c

--- a/libs/libc/pwd/CMakeLists.txt
+++ b/libs/libc/pwd/CMakeLists.txt
@@ -19,9 +19,8 @@
 # the License.
 #
 # ##############################################################################
-
 set(SRCS lib_getpwnam.c lib_getpwnamr.c lib_getpwuid.c lib_getpwuidr.c
-         lib_pwd_globals.c)
+         lib_getpwent.c lib_pwd_globals.c)
 
 if(CONFIG_LIBC_PASSWD_FILE)
   list(APPEND SRCS lib_find_pwdfile.c)

--- a/libs/libc/signal/CMakeLists.txt
+++ b/libs/libc/signal/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(
           sig_orset.c
           sig_xorset.c
           sig_isemptyset.c
+          sig_killpg.c
+          sig_altstack.c
           sig_interrupt.c
           sig_hold.c
           sig_ignore.c
@@ -41,5 +43,4 @@ target_sources(
           sig_relse.c
           sig_set.c
           sig_signal.c
-          sig_wait.c
-          sig_killpg.c)
+          sig_wait.c)

--- a/libs/libc/stdio/CMakeLists.txt
+++ b/libs/libc/stdio/CMakeLists.txt
@@ -39,16 +39,20 @@ set(SRCS
     lib_putchar.c
     lib_getchar.c
     lib_puts.c
+    lib_gets_s.c
+    lib_gets.c
+    lib_libdgets.c
     lib_sscanf.c
     lib_vsscanf.c
     lib_libvscanf.c
-    lib_libbsprintf.c
     lib_libvsprintf.c
     lib_remove.c
     lib_tempnam.c
     lib_tmpnam.c
     lib_ultoa_invert.c
-    lib_putwchar.c)
+    lib_renameat.c
+    lib_putwchar.c
+    lib_libbsprintf.c)
 
 if(CONFIG_LIBC_FLOATINGPOINT)
   list(APPEND SRCS lib_dtoa_engine.c lib_dtoa_data.c)
@@ -75,8 +79,6 @@ if(CONFIG_FILE_STREAM)
     lib_getc.c
     lib_fgetc.c
     lib_fgets.c
-    lib_gets_s.c
-    lib_gets.c
     lib_libfgets.c
     lib_fwrite.c
     lib_libfwrite.c
@@ -104,11 +106,13 @@ if(CONFIG_FILE_STREAM)
     lib_setvbuf.c
     lib_libfilelock.c
     lib_libgetstreams.c
+    lib_setbuffer.c
     lib_fputwc.c
     lib_putwc.c
     lib_fputws.c
     lib_fopencookie.c
     lib_fmemopen.c
+    lib_open_memstream.c
     lib_fgetwc.c
     lib_getwc.c
     lib_ungetwc.c)

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -41,7 +41,8 @@ list(
   lib_syslograwstream.c
   lib_bufferedoutstream.c
   lib_hexdumpstream.c
-  lib_base64outstream.c)
+  lib_base64outstream.c
+  lib_fileoutstream.c)
 
 if(CONFIG_FILE_STREAM)
   list(APPEND SRCS lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c

--- a/libs/libc/string/CMakeLists.txt
+++ b/libs/libc/string/CMakeLists.txt
@@ -61,64 +61,29 @@ set(SRCS
     lib_explicit_bzero.c
     lib_bzero.c
     lib_strsignal.c
-    lib_timingsafe_bcmp.c
     lib_index.c
-    lib_rindex.c)
+    lib_rindex.c
+    lib_timingsafe_bcmp.c
+    lib_strverscmp.c
+    lib_mempcpy.c
+    lib_rawmemchr.c
+    lib_memchr.c
+    lib_memcmp.c
+    lib_memmove.c
+    lib_memset.c
+    lib_strchr.c
+    lib_strcmp.c
+    lib_strcpy.c
+    lib_strlcat.c
+    lib_strlcpy.c
+    lib_strlen.c
+    lib_strncpy.c
+    lib_strnlen.c)
 
-if(NOT CONFIG_LIBC_ARCH_MEMCHR)
-  list(APPEND SRCS lib_memchr.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_MEMCMP)
-  list(APPEND SRCS lib_memcmp.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_MEMCPY)
-  if(CONFIG_MEMCPY_VIK)
-    list(APPEND SRCS lib_vikmemcpy.c)
-  else()
-    list(APPEND SRCS lib_memcpy.c)
-  endif()
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_MEMMOVE)
-  list(APPEND SRCS lib_memmove.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_MEMSET)
-  list(APPEND SRCS lib_memset.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRCHR)
-  list(APPEND SRCS lib_strchr.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRCMP)
-  list(APPEND SRCS lib_strcmp.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRCPY)
-  list(APPEND SRCS lib_strcpy.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRLCAT)
-  list(APPEND SRCS lib_strlcat.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRLCPY)
-  list(APPEND SRCS lib_strlcpy.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRLEN)
-  list(APPEND SRCS lib_strlen.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRNCPY)
-  list(APPEND SRCS lib_strncpy.c)
-endif()
-
-if(NOT CONFIG_LIBC_ARCH_STRNLEN)
-  list(APPEND SRCS lib_strnlen.c)
+if(CONFIG_MEMCPY_VIK)
+  list(APPEND SRCS lib_vikmemcpy.c)
+else()
+  list(APPEND SRCS lib_memcpy.c)
 endif()
 
 if(CONFIG_LIBC_LOCALE)

--- a/libs/libc/unistd/CMakeLists.txt
+++ b/libs/libc/unistd/CMakeLists.txt
@@ -42,11 +42,6 @@ set(SRCS
     lib_statvfs.c
     lib_sleep.c
     lib_nice.c
-    lib_usleep.c
-    lib_seteuid.c
-    lib_setegid.c
-    lib_geteuid.c
-    lib_getegid.c
     lib_setreuid.c
     lib_setregid.c
     lib_getrusage.c
@@ -64,11 +59,25 @@ set(SRCS
     lib_linkat.c
     lib_readlinkat.c
     lib_symlinkat.c
-    lib_flock.c
-    lib_unlinkat.c)
+    lib_unlinkat.c
+    lib_usleep.c
+    lib_getpgrp.c
+    lib_getpgid.c
+    lib_lockf.c
+    lib_flock.c)
 
 if(NOT CONFIG_SCHED_USER_IDENTITY)
-  list(APPEND SRCS lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c)
+  list(
+    APPEND
+    SRCS
+    lib_setuid.c
+    lib_setgid.c
+    lib_getuid.c
+    lib_getgid.c
+    lib_seteuid.c
+    lib_setegid.c
+    lib_geteuid.c
+    lib_getegid.c)
 endif()
 
 if(NOT CONFIG_DISABLE_ENVIRON)

--- a/libs/libc/wqueue/CMakeLists.txt
+++ b/libs/libc/wqueue/CMakeLists.txt
@@ -20,7 +20,6 @@
 #
 # ##############################################################################
 
-if(CONFIG_LIBC_USRWORK)
-  target_sources(c PRIVATE work_usrthread.c work_queue.c work_cancel.c
-                           work_signal.c work_lock.c)
+if(CONFIG_LIB_USRWORK)
+  target_sources(c PRIVATE work_usrthread.c work_queue.c work_cancel.c)
 endif()

--- a/mm/kmap/CMakeLists.txt
+++ b/mm/kmap/CMakeLists.txt
@@ -1,7 +1,5 @@
 # ##############################################################################
-# libs/libc/spawn/CMakeLists.txt
-#
-# SPDX-License-Identifier: Apache-2.0
+# mm/kmap/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -20,32 +18,6 @@
 #
 # ##############################################################################
 
-set(SRCS
-    lib_psfa_addaction.c
-    lib_psfa_addclose.c
-    lib_psfa_adddup2.c
-    lib_psfa_addopen.c
-    lib_psfa_destroy.c
-    lib_psfa_init.c
-    lib_psa_getflags.c
-    lib_psa_getschedparam.c
-    lib_psa_getschedpolicy.c
-    lib_psa_init.c
-    lib_psa_setflags.c
-    lib_psa_setschedparam.c
-    lib_psa_setschedpolicy.c
-    lib_psa_getsigmask.c
-    lib_psa_setsigmask.c
-    lib_psa_getstacksize.c
-    lib_psa_setstacksize.c
-    lib_psa_destroy.c)
-
-if(NOT CONFIG_BUILD_KERNEL)
-  list(APPEND SRCS lib_psa_getstacksize.c lib_psa_setstacksize.c)
+if(CONFIG_MM_KMAP)
+  target_sources(mm PRIVATE kmm_map.c)
 endif()
-
-if(CONFIG_DEBUG_FEATURES)
-  list(APPEND SRCS lib_psfa_dump.c lib_psa_dump.c)
-endif()
-
-target_sources(c PRIVATE ${SRCS})

--- a/mm/kmm_heap/CMakeLists.txt
+++ b/mm/kmm_heap/CMakeLists.txt
@@ -37,7 +37,8 @@ if(CONFIG_MM_KERNEL_HEAP)
       kmm_memalign.c
       kmm_realloc.c
       kmm_zalloc.c
-      kmm_heapmember.c)
+      kmm_heapmember.c
+      kmm_memdump.c)
 
   if(CONFIG_DEBUG_MM)
     list(APPEND SRCS kmm_checkcorruption.c)

--- a/mm/umm_heap/CMakeLists.txt
+++ b/mm/umm_heap/CMakeLists.txt
@@ -23,8 +23,10 @@
 # User heap allocator
 
 set(SRCS
+    umm_globals.c
     umm_initialize.c
     umm_addregion.c
+    umm_malloc_size.c
     umm_brkaddr.c
     umm_calloc.c
     umm_extend.c
@@ -35,9 +37,7 @@ set(SRCS
     umm_realloc.c
     umm_zalloc.c
     umm_heapmember.c
-    umm_globals.c
-    umm_memdump.c
-    umm_malloc_size.c)
+    umm_memdump.c)
 
 if(CONFIG_BUILD_KERNEL)
   list(APPEND SRCS umm_sbrk.c)

--- a/sched/clock/CMakeLists.txt
+++ b/sched/clock/CMakeLists.txt
@@ -22,13 +22,13 @@
 
 set(SRCS
     clock.c
-    clock_perf.c
     clock_initialize.c
     clock_settime.c
     clock_gettime.c
     clock_realtime2absticks.c
     clock_systime_ticks.c
-    clock_systime_timespec.c)
+    clock_systime_timespec.c
+    clock_perf.c)
 
 if(CONFIG_CLOCK_TIMEKEEPING)
   list(APPEND SRCS clock_timekeeping.c)

--- a/sched/semaphore/CMakeLists.txt
+++ b/sched/semaphore/CMakeLists.txt
@@ -32,8 +32,8 @@ set(CSRCS
     sem_post.c
     sem_recover.c
     sem_reset.c
-    sem_rw.c
-    sem_waitirq.c)
+    sem_waitirq.c
+    sem_rw.c)
 
 if(CONFIG_PRIORITY_INHERITANCE)
   list(APPEND CSRCS sem_initialize.c sem_holder.c sem_setprotocol.c)


### PR DESCRIPTION
## Summary
sync CMake missing sources

There are differences between the current CMake base and Makefile. 
This patch synchronizes the differences between modules 
so that the CMake compilation content should be consistent with the Makefile.

## Impact
[arm ach, fs, sched, mm , libc, drivers]

## Testing
all CI build
