### PR TITLE
stm32f429i-disco: disable TM32_FB_CMAP

### DIFF
--- a/boards/arm/stm32/stm32f429i-disco/configs/fb/defconfig
+++ b/boards/arm/stm32/stm32f429i-disco/configs/fb/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_ARCH_FPU is not set
+# CONFIG_STM32_FB_CMAP is not set
 # CONFIG_STM32_FLASH_PREFETCH is not set
 CONFIG_ARCH="arm"
 CONFIG_ARCH_BOARD="stm32f429i-disco"


### PR DESCRIPTION
## Summary
The default bpp is STM32_LTDC_L1_L8, when TM32_FB_CMAP=y,and The default bpp is STM32_LTDC_L1_RGB565 when TM32_FB_CMAP=n. The color-format bpp  of stm32f429i is 16, so we should be disable TM32_FB_CMAP, otherwise fb demo will result in an error.

## Impact
stm32f429i fb demo

## Testing
run fb dmeo on stm32f429i
