### PR TITLE
Fix to compile parameters not taking effect When cmake version is greater than 3.18

### DIFF
--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CONFIG_FS_LITTLEFS)
   target_include_directories(fs PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
   if(CONFIG_TRACE_LITTLEFS_FS)
-    set_source_files_properties(lfs_vfs.c PROPERTIES COMPILE_FLAGS
-                                                     -finstrument-functions)
+    set_source_files_properties(lfs_vfs.c DIRECTORY ..
+                                PROPERTIES COMPILE_FLAGS -finstrument-functions)
   endif()
 endif()

--- a/fs/romfs/CMakeLists.txt
+++ b/fs/romfs/CMakeLists.txt
@@ -23,8 +23,8 @@ if(CONFIG_FS_ROMFS)
   target_sources(fs PRIVATE fs_romfs.c fs_romfsutil.c)
 
   if(CONFIG_TRACE_ROMFS_FS)
-    set_source_files_properties(fs_romfs.c PROPERTIES COMPILE_FLAGS
-                                                      -finstrument-functions)
+    set_source_files_properties(fs_romfs.c DIRECTORY ..
+                                PROPERTIES COMPILE_FLAGS -finstrument-functions)
   endif()
 
 endif()

--- a/fs/rpmsgfs/CMakeLists.txt
+++ b/fs/rpmsgfs/CMakeLists.txt
@@ -27,6 +27,6 @@ if(CONFIG_FS_RPMSGFS_SERVER)
 endif()
 
 if(CONFIG_TRACE_RPMSGFS_FS)
-  set_source_files_properties(rpmsgfs.c PROPERTIES COMPILE_FLAGS
-                                                   -finstrument-functions)
+  set_source_files_properties(rpmsgfs.c DIRECTORY ..
+                              PROPERTIES COMPILE_FLAGS -finstrument-functions)
 endif()


### PR DESCRIPTION
## Summary
Fix to compile parameters not taking effect When cmake version is greater than 3.18
https://cmake.org/cmake/help/latest/command/set_source_files_properties.html

New in version 3.18: By default, source file properties are only visible to targets added in the same directory (CMakeLists.txt). Visibility can be set in other directory scopes using one or both of the following options:

DIRECTORY <dirs>...
The source file properties will be set in each of the <dirs> directories' scopes. CMake must already know about each of these source directories, either by having added them through a call to [add_subdirectory()](https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory) or it being the top level source directory. Relative paths are treated as relative to the current source directory.
## Impact
flag configuration does not take effect when the cmake version is greater than 3.18
## Testing
Local test
