### PR TITLE
drivers/battery: Fix Goldfish Battery x64 unresponsive interrupt issue

### DIFF
--- a/drivers/power/battery/goldfish_battery.c
+++ b/drivers/power/battery/goldfish_battery.c
@@ -321,8 +321,9 @@ int goldfish_battery_register(FAR void *regs, int irq)
       goto fail;
     }
 
-  GOLDFISH_BATTERY_WRITE(data, BATTERY_INT_ENABLE, BATTERY_INT_MASK);
   up_enable_irq(data->irq);
+  GOLDFISH_BATTERY_WRITE(data, BATTERY_INT_ENABLE, BATTERY_INT_MASK);
+
   batinfo("goldfish_battery_register over");
   return 0;
 fail:


### PR DESCRIPTION
## Summary
GOLDFISH_BATTERY_WRITE will enable qemu to generate an interrupt, and a status value will be set in the interrupt. If Vela does not respond to this interrupt, we will not receive the interrupt in the future. Here, we need to ensure that we enable Vela's interrupt first, and then enable qemu to generate an interrupt

## Impact
no impact
## Testing
x86 goldfish
