### PR TITLE
arch/x86_64: Resolve weak symbol compilation relocation errors

### DIFF
--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -89,7 +89,7 @@ add_link_options(-Wl,--entry=__pmode_entry)
 add_link_options(-z max-page-size=0x1000)
 add_link_options(-no-pie -nostdlib)
 add_link_options(-Wl,--no-relax)
-add_compile_options(-fPIC)
+add_compile_options(-fno-pic -mcmodel=large)
 add_compile_options(-mno-red-zone)
 
 if(CONFIG_DEBUG_LINK_MAP)

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -32,7 +32,7 @@ ifeq ($(CONFIG_FRAME_POINTER),y)
   ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-optimize-sibling-calls
 endif
 
-ARCHCPUFLAGS = -fPIC -fno-stack-protector -mno-red-zone -mrdrnd
+ARCHCPUFLAGS = -fno-pic -mcmodel=large -fno-stack-protector -mno-red-zone -mrdrnd
 ARCHPICFLAGS = -fPIC
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 


### PR DESCRIPTION
## Summary
Resolve weak symbol compilation relocation errors
## Impact
no impact
## Testing
Can be compiled through
