### PR TITLE
arch/x68_64: properly align ap boot stack for vector operations

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -398,6 +398,13 @@ ap_start:
 
 	/* Jump to ap_start routine */
 	movabs  $x86_64_ap_boot,   %rbx
+
+	/* We need to simulate the behavior of the call instruction, which by
+	 * default pushes 8 bytes of the RIP. Otherwise, the function's stack
+	 * won't be 16-byte aligned.
+	 */
+
+	pushq   $0
 	jmp     *%rbx
 #endif
 


### PR DESCRIPTION
## Summary
We need to simulate the behavior of the call instruction, which by default pushes 8 bytes of the RIP. Otherwise, the function's stack won't be 16-byte aligned.

## Impact
no impact
## Testing
SMP can start
