### PR TITLE
ARM64 bug fix

### DIFF
--- a/Documentation/platforms/arm64/qemu/boards/qemu-armv8a/README.txt
+++ b/Documentation/platforms/arm64/qemu/boards/qemu-armv8a/README.txt
@@ -152,6 +152,12 @@ Getting Started
    Configuring NuttX and compile:
    $ ./tools/configure.sh -l qemu-armv8a:knsh
    $ make
+   $ make export V=1
+   $ pushd ../apps
+   $ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
+   $ make import V=1
+   $ popd
+
    Running with qemu
    $ qemu-system-aarch64 -semihosting -cpu cortex-a53 -nographic \
      -machine virt,virtualization=on,gic-version=3 \

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -119,11 +119,6 @@ int up_backtrace(struct tcb_s *tcb,
   struct regs_context * p_regs;
   int ret;
 
-  if (rtcb == NULL)
-    {
-      rtcb = running_task();
-    }
-
   if (size <= 0 || !buffer)
     {
       return 0;

--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -160,12 +160,24 @@ void arm64_stack_color(void *stackbase, size_t nbytes)
   uintptr_t end;
   size_t nwords;
   uint32_t *ptr;
+  uintptr_t sp;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = STACK_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
-          up_getsp(); /* 0: colorize the running stack */
+  start = (uintptr_t)STACK_ALIGN_UP((uintptr_t)stackbase);
+
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      end = up_getsp();
+      if (end > (uintptr_t)&sp)
+        {
+          end = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      end = (uintptr_t)stackbase + nbytes;
+    }
 
   /* Get the adjusted size based on the top and bottom of the stack */
 

--- a/arch/arm64/src/common/arm64_mmu.h
+++ b/arch/arm64/src/common/arm64_mmu.h
@@ -212,6 +212,13 @@
     __arg;                                                          \
   })
 
+/* csselr_el1 */
+
+#define CSSELR_EL1_IND_SHIFT         0
+#define CSSELR_EL1_IND_MASK          BIT_MASK(1)
+#define CSSELR_EL1_LEVEL_SHIFT       1
+#define CSSELR_EL1_LEVEL_MASK        BIT_MASK(3)
+
 /* Convenience macros to represent the ARMv8-A-specific
  * configuration for memory access permission and
  * cache-ability attribution.

--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -387,6 +387,12 @@ void arm64_mpu_init(bool is_primary_core)
   uint64_t  val;
   uint32_t  r_index;
 
+#ifdef CONFIG_MM_KASAN_SW_TAGS
+  val  = read_sysreg(tcr_el1);
+  val |= (TCR_TBI0 | TCR_TBI1 | TCR_ASID_8);
+  write_sysreg(val, tcr_el1);
+#endif
+
   /* Current MPU code supports only EL1 */
 
   __asm__ volatile ("mrs %0, CurrentEL" : "=r" (val));

--- a/arch/arm64/src/common/arm64_mpu.h
+++ b/arch/arm64/src/common/arm64_mpu.h
@@ -50,6 +50,14 @@
 #define MPU_RBAR_AP_POS     2U
 #define MPU_RBAR_AP_MSK     (0x3UL << MPU_RBAR_AP_POS)
 
+/* TCR_EL1 */
+
+#define TCR_AS_SHIFT        36U
+#define TCR_ASID_8          (0ULL << TCR_AS_SHIFT)
+#define TCR_ASID_16         (1ULL << TCR_AS_SHIFT)
+#define TCR_TBI0            (1ULL << 37)
+#define TCR_TBI1            (1ULL << 38)
+
 /* RBAR_EL1 XN */
 
 #define MPU_RBAR_XN_POS     1U

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -38,19 +38,6 @@
     .file    "arm64_vectors.S"
 
 /****************************************************************************
- * Assembly Macros
- ****************************************************************************/
-
-.macro arm64_exception_context_save xreg0, xreg1 xfp
-
-    /* Save the current task's SP_EL0 and exception depth */
-    mrs    \xreg0, sp_el0
-    mrs    \xreg1, tpidrro_el0
-    stp    \xreg0, \xreg1, [\xfp, #8 * REG_SP_EL0]
-
-.endm
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -94,8 +81,6 @@ SECTION_FUNC(text, up_saveusercontext)
     mrs    x5,  spsr_el1
 #endif
     stp    x4,  x5,  [x0, #8 * REG_ELR]
-
-    arm64_exception_context_save x4 x5 x0
 
     ret
 


### PR DESCRIPTION
## Summary

arch/arm64: Add the interface for icache and dcache.
arch/arm64: Fixed arm64_cache_get_info obtaining cache.
arm64_checkstack: fix crash, optimize the stack color, sync with arm
arm64: fix backtrace failed
arm64-r/mpu: add TBI setting to r82 when use SW_TAG

@pussuw 
Removed un-used function arm64_exception_context_save(), how do you think ?

## Impact

arm64

## Testing

xiaomi armv8r board & qemu

qemu-armv8a:nsh
qemu-armv8a:nsh_smp
qemu-armv8a:knsh
