### PR TITLE
mmcsd: refine emmc capacity calculate

### DIFF
--- a/drivers/mmcsd/mmcsd_csd.h
+++ b/drivers/mmcsd/mmcsd_csd.h
@@ -116,6 +116,8 @@
 
 #define MMCSD_CSD_VDDWCURRMAX(csd) ((csd[4] >> 2) & 7)
 
+#define MMCSD_CSD_CSIZE_THRESHOLD   0xfff
+
 /* C_SIZE_MULT 47-49 Device size multiplier */
 
 #define MMCSD_CSD_CSIZEMULT(csd) (((csd[4] & 3) << 1) | (csd[5] >> 15))
@@ -289,6 +291,8 @@
 
 #define MMCSD_CSD_VDDWCURRMAX(csd) ((csd[9] >> 2) & 7)
 #define SD20_CSD_VDDWCURRMAX(csd) (6)
+
+#define MMCSD_CSD_CSIZE_THRESHOLD   0xfff
 
 /* C_SIZE_MULT 47-49 Device size multiplier */
 


### PR DESCRIPTION
## Summary
If the card is MMC and it has Block addressing, then C_SIZE parameter is used to compute the device capacity for devices up to 2 GB of density only, while SEC_COUNT is used to calculate densities greater than 2 GB. When the device density is greater than 2GB, 0xFFF should be set to C_SIZE bitfield (See 7.3.12)
## Impact
   mmcsd
## Testing
  cortext M55
