### PR TITLE
arch/x86_64:Configure arch delay using CONFIG_ALARM_ARCH

### DIFF
--- a/arch/x86_64/src/common/CMakeLists.txt
+++ b/arch/x86_64/src/common/CMakeLists.txt
@@ -23,14 +23,12 @@ set(SRCS
     x86_64_copystate.c
     x86_64_exit.c
     x86_64_getintstack.c
-    x86_64_mdelay.c
     x86_64_initialize.c
     x86_64_modifyreg8.c
     x86_64_modifyreg16.c
     x86_64_modifyreg32.c
     x86_64_nputs.c
     x86_64_switchcontext.c
-    x86_64_udelay.c
     x86_64_tcbinfo.c)
 
 if(CONFIG_ARCH_HAVE_FORK)
@@ -55,6 +53,10 @@ endif()
 
 if(CONFIG_ARCH_ADDRENV)
   list(APPEND SRCS x86_64_addrenv.c x86_64_addrenv_perms.c)
+endif()
+
+if(NOT CONFIG_ALARM_ARCH)
+  list(APPEND SRCS x86_64_udelay.c x86_64_mdelay.c)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/x86_64/src/common/Make.defs
+++ b/arch/x86_64/src/common/Make.defs
@@ -21,9 +21,9 @@
 # Common x86_64 files
 
 CMN_CSRCS += x86_64_allocateheap.c x86_64_copystate.c x86_64_exit.c
-CMN_CSRCS += x86_64_getintstack.c x86_64_mdelay.c x86_64_initialize.c
+CMN_CSRCS += x86_64_getintstack.c  x86_64_initialize.c x86_64_nputs.c
 CMN_CSRCS += x86_64_modifyreg8.c x86_64_modifyreg16.c x86_64_modifyreg32.c
-CMN_CSRCS += x86_64_nputs.c x86_64_switchcontext.c x86_64_udelay.c
+CMN_CSRCS += x86_64_switchcontext.c
 
 ifeq ($(CONFIG_ARCH_HAVE_FORK),y)
 CMN_CSRCS += x86_64_fork.c
@@ -48,4 +48,8 @@ endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)
 CMN_CSRCS += x86_64_addrenv.c x86_64_addrenv_perms.c
+endif
+
+ifndef CONFIG_ALARM_ARCH
+CMN_CSRCS += x86_64_udelay.c x86_64_mdelay.c
 endif


### PR DESCRIPTION
## Summary
Configure arch delay using CONFIG_ALARM_ARCH
## Impact
no impact
## Testing
ostest
