### PR TITLE
sched: remove param in nxsched_remove_readytorun

### DIFF
--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -325,7 +325,7 @@ int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
 /* Task list manipulation functions */
 
 bool nxsched_add_readytorun(FAR struct tcb_s *rtrtcb);
-bool nxsched_remove_readytorun(FAR struct tcb_s *rtrtcb, bool merge);
+bool nxsched_remove_readytorun(FAR struct tcb_s *rtrtcb);
 void nxsched_remove_self(FAR struct tcb_s *rtrtcb);
 bool nxsched_add_prioritized(FAR struct tcb_s *tcb, DSEG dq_queue_t *list);
 void nxsched_merge_prioritized(FAR dq_queue_t *list1, FAR dq_queue_t *list2,

--- a/sched/sched/sched_reprioritizertr.c
+++ b/sched/sched/sched_reprioritizertr.c
@@ -64,7 +64,7 @@ bool nxsched_reprioritize_rtr(FAR struct tcb_s *tcb, int priority)
    * remove the head of the ready to run list.
    */
 
-  switch_needed = nxsched_remove_readytorun(tcb, false);
+  switch_needed = nxsched_remove_readytorun(tcb);
 
   /* Setup up the new task priority */
 

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -200,7 +200,7 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
 
           do
             {
-              bool check = nxsched_remove_readytorun(nxttcb, false);
+              bool check = nxsched_remove_readytorun(nxttcb);
               DEBUGASSERT(check == false);
               UNUSED(check);
 

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -77,7 +77,7 @@ static int nxsched_suspend_handler(FAR void *cookie)
       tcb->flags = arg->saved_flags;
     }
 
-  nxsched_remove_readytorun(tcb, false);
+  nxsched_remove_readytorun(tcb);
 
   tcb->task_state = TSTATE_TASK_STOPPED;
   dq_addlast((FAR dq_entry_t *)tcb, &g_stoppedtasks);
@@ -172,7 +172,12 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
       else
 #endif
         {
-          switch_needed = nxsched_remove_readytorun(tcb, true);
+          switch_needed = nxsched_remove_readytorun(tcb);
+
+          if (list_pendingtasks()->head)
+            {
+              switch_needed |= nxsched_merge_pending();
+            }
 
           /* Add the task to the specified blocked task list */
 

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -83,7 +83,7 @@ static int restart_handler(FAR void *cookie)
       tcb->flags = arg->saved_flags;
     }
 
-  nxsched_remove_readytorun(tcb, false);
+  nxsched_remove_readytorun(tcb);
 
   leave_critical_section(flags);
 
@@ -117,7 +117,7 @@ static void nxtask_reset_task(FAR struct tcb_s *tcb, bool remove)
 
   if (remove)
     {
-      nxsched_remove_readytorun(tcb, false);
+      nxsched_remove_readytorun(tcb);
     }
 
   /* Deallocate anything left in the TCB's signal queues */

--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -66,7 +66,7 @@ static int terminat_handler(FAR void *cookie)
       return -ESRCH;
     }
 
-  nxsched_remove_readytorun(tcb, false);
+  nxsched_remove_readytorun(tcb);
 
   leave_critical_section(flags);
   return OK;
@@ -164,7 +164,7 @@ int nxtask_terminate(pid_t pid)
   else
 #endif
     {
-      nxsched_remove_readytorun(dtcb, false);
+      nxsched_remove_readytorun(dtcb);
     }
 
   dtcb->task_state = task_state;


### PR DESCRIPTION
## Summary
after
   text    data     bss     dec     hex filename
 269732   51065   63335  384132   5dc84 nuttx

before
   text    data     bss     dec     hex filename
269784   51065   63335  384184   5dcb8 nuttx

size -52

## Impact
sched

## Testing
ci ostest
