### PR TITLE
nuttx/drivers: add ept_release_cb for destroy server resource

### DIFF
--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -602,13 +602,6 @@ static int ioe_rpmsg_server_ept_cb(FAR struct rpmsg_endpoint *ept,
   return 0;
 }
 
-static void ioe_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
-{
-  rpmsg_destroy_ept(ept);
-
-  kmm_free(ept);
-}
-
 static bool ioe_rpmsg_server_match(FAR struct rpmsg_device *rdev,
                                    FAR void *priv_,
                                    FAR const char *name,
@@ -620,6 +613,11 @@ static bool ioe_rpmsg_server_match(FAR struct rpmsg_device *rdev,
   snprintf(eptname, RPMSG_NAME_SIZE, IOE_RPMSG_EPT_FORMAT, priv->name);
 
   return !strcmp(name, eptname);
+}
+
+static void ioe_rpmsg_server_ept_release(FAR struct rpmsg_endpoint *ept)
+{
+  kmm_free(ept);
 }
 
 static void ioe_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
@@ -637,9 +635,10 @@ static void ioe_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
     }
 
   ept->priv = priv;
+  ept->release_cb = ioe_rpmsg_server_ept_release;
 
   rpmsg_create_ept(ept, rdev, name, RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
-                   ioe_rpmsg_server_ept_cb, ioe_rpmsg_server_unbind);
+                   ioe_rpmsg_server_ept_cb, rpmsg_destroy_ept);
 }
 
 /****************************************************************************

--- a/drivers/misc/rpmsgblk_server.c
+++ b/drivers/misc/rpmsgblk_server.c
@@ -82,7 +82,6 @@ static bool rpmsgblk_ns_match(FAR struct rpmsg_device *rdev,
 static void rpmsgblk_ns_bind(FAR struct rpmsg_device *rdev,
                              FAR void *priv, FAR const char *name,
                              uint32_t dest);
-static void rpmsgblk_ns_unbind(FAR struct rpmsg_endpoint *ept);
 static int  rpmsgblk_ept_cb(FAR struct rpmsg_endpoint *ept,
                             FAR void *data, size_t len, uint32_t src,
                             FAR void *priv);
@@ -498,6 +497,18 @@ static bool rpmsgblk_ns_match(FAR struct rpmsg_device *rdev,
 }
 
 /****************************************************************************
+ * Name: rpmsgblk_ept_release
+ ****************************************************************************/
+
+static void rpmsgblk_ept_release(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsgblk_server_s *server = ept->priv;
+
+  inode_release(server->blknode);
+  kmm_free(server);
+}
+
+/****************************************************************************
  * Name: rpmsgblk_ns_bind
  ****************************************************************************/
 
@@ -526,30 +537,18 @@ static void rpmsgblk_ns_bind(FAR struct rpmsg_device *rdev,
     }
 
   server->ept.priv = server;
+  server->ept.release_cb = rpmsgblk_ept_release;
   server->bops = server->blknode->u.i_bops;
 
   ret = rpmsg_create_ept(&server->ept, rdev, name,
                          RPMSG_ADDR_ANY, dest,
-                         rpmsgblk_ept_cb, rpmsgblk_ns_unbind);
+                         rpmsgblk_ept_cb, rpmsg_destroy_ept);
   if (ret < 0)
     {
       ferr("endpoint create failed, ret=%d\n", ret);
       inode_release(server->blknode);
       kmm_free(server);
     }
-}
-
-/****************************************************************************
- * Name: rpmsgblk_ns_unbind
- ****************************************************************************/
-
-static void rpmsgblk_ns_unbind(FAR struct rpmsg_endpoint *ept)
-{
-  FAR struct rpmsgblk_server_s *server = ept->priv;
-
-  rpmsg_destroy_ept(&server->ept);
-  inode_release(server->blknode);
-  kmm_free(server);
 }
 
 /****************************************************************************

--- a/drivers/power/supply/regulator_rpmsg.c
+++ b/drivers/power/supply/regulator_rpmsg.c
@@ -135,7 +135,6 @@ static void regulator_rpmsg_client_created(struct rpmsg_device *rdev,
 static void regulator_rpmsg_client_destroy(struct rpmsg_device *rdev,
                                            FAR void *priv);
 
-static void regulator_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept);
 static bool regulator_rpmsg_server_match(FAR struct rpmsg_device *rdev,
                                          FAR void *priv,
                                          FAR const char *name,
@@ -330,7 +329,16 @@ static void regulator_rpmsg_client_destroy(struct rpmsg_device *rdev,
     }
 }
 
-static void regulator_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
+static bool regulator_rpmsg_server_match(FAR struct rpmsg_device *rdev,
+                                         FAR void *priv,
+                                         FAR const char *name,
+                                         uint32_t dest)
+{
+  return strcmp(name, REGULATOR_RPMSG_EPT_NAME) == 0;
+}
+
+static void
+regulator_rpmsg_server_ept_release(FAR struct rpmsg_endpoint *ept)
 {
   FAR struct regulator_rpmsg_server_s *server = ept->priv;
   FAR struct regulator_rpmsg_s *reg;
@@ -350,16 +358,7 @@ static void regulator_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
     }
 
   nxmutex_destroy(&server->lock);
-  rpmsg_destroy_ept(ept);
   kmm_free(server);
-}
-
-static bool regulator_rpmsg_server_match(FAR struct rpmsg_device *rdev,
-                                         FAR void *priv,
-                                         FAR const char *name,
-                                         uint32_t dest)
-{
-  return strcmp(name, REGULATOR_RPMSG_EPT_NAME) == 0;
 }
 
 static void regulator_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
@@ -376,13 +375,14 @@ static void regulator_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
     }
 
   server->ept.priv = server;
+  server->ept.release_cb = regulator_rpmsg_server_ept_release;
   nxmutex_init(&server->lock);
   list_initialize(&server->regulator_list);
 
   rpmsg_create_ept(&server->ept, rdev, name,
                    RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
                    regulator_rpmsg_ept_cb,
-                   regulator_rpmsg_server_unbind);
+                   rpmsg_destroy_ept);
 }
 
 static int regulator_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,

--- a/drivers/reset/reset_rpmsg.c
+++ b/drivers/reset/reset_rpmsg.c
@@ -678,7 +678,16 @@ static int reset_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
   return ret;
 }
 
-static void reset_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
+static bool reset_rpmsg_server_match(FAR struct rpmsg_device *rdev,
+                                     FAR void *priv,
+                                     FAR const char *name,
+                                     uint32_t dest)
+{
+  return strcmp(name, RESET_RPMSG_EPT_NAME) == 0;
+}
+
+static void reset_rpmsg_server_ept_release(FAR struct rpmsg_endpoint *ept,
+                                           FAR void *priv)
 {
   FAR struct reset_rpmsg_server_s *server = ept->priv;
   FAR struct reset_rpmsg_s *reset;
@@ -692,17 +701,8 @@ static void reset_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
       kmm_free(reset);
     }
 
-  rpmsg_destroy_ept(ept);
   nxmutex_destroy(&server->lock);
   kmm_free(server);
-}
-
-static bool reset_rpmsg_server_match(FAR struct rpmsg_device *rdev,
-                                     FAR void *priv,
-                                     FAR const char *name,
-                                     uint32_t dest)
-{
-  return strcmp(name, RESET_RPMSG_EPT_NAME) == 0;
 }
 
 static void reset_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
@@ -719,13 +719,14 @@ static void reset_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
     }
 
   server->ept.priv = server;
+  server->ept.release_cb = reset_rpmsg_server_ept_release;
   list_initialize(&server->list);
   nxmutex_init(&server->lock);
 
   rpmsg_create_ept(&server->ept, rdev, name,
                    RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
                    reset_rpmsg_ept_cb,
-                   reset_rpmsg_server_unbind);
+                   rpmsg_destroy_ept);
 }
 
 /****************************************************************************

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -620,19 +620,6 @@ static int rpmsg_rtc_server_destroy(FAR struct rtc_lowerhalf_s *lower)
 }
 #endif
 
-static void rpmsg_rtc_server_ns_unbind(FAR struct rpmsg_endpoint *ept)
-{
-  FAR struct rpmsg_rtc_client_s *client = container_of(ept,
-                                            struct rpmsg_rtc_client_s, ept);
-  FAR struct rpmsg_rtc_server_s *server = ept->priv;
-
-  nxmutex_lock(&server->lock);
-  list_delete(&client->node);
-  nxmutex_unlock(&server->lock);
-  rpmsg_destroy_ept(&client->ept);
-  kmm_free(client);
-}
-
 #ifdef CONFIG_RTC_ALARM
 static void rpmsg_rtc_server_alarm_cb(FAR void *priv, int alarmid)
 {
@@ -720,6 +707,18 @@ static bool rpmsg_rtc_server_ns_match(FAR struct rpmsg_device *rdev,
   return !strcmp(name, RPMSG_RTC_EPT_NAME);
 }
 
+static void rpmsg_rtc_server_ept_release(FAR struct rpmsg_endpoint *ept)
+{
+  FAR struct rpmsg_rtc_client_s *client = container_of(ept,
+                                            struct rpmsg_rtc_client_s, ept);
+  FAR struct rpmsg_rtc_server_s *server = ept->priv;
+
+  nxmutex_lock(&server->lock);
+  list_delete(&client->node);
+  nxmutex_unlock(&server->lock);
+  kmm_free(client);
+}
+
 static void rpmsg_rtc_server_ns_bind(FAR struct rpmsg_device *rdev,
                                      FAR void *priv,
                                      FAR const char *name,
@@ -737,10 +736,12 @@ static void rpmsg_rtc_server_ns_bind(FAR struct rpmsg_device *rdev,
     }
 
   client->ept.priv = server;
+  client->ept.release_cb = rpmsg_rtc_server_ept_release;
+
   if (rpmsg_create_ept(&client->ept, rdev, RPMSG_RTC_EPT_NAME,
                        RPMSG_ADDR_ANY, dest,
                        rpmsg_rtc_server_ept_cb,
-                       rpmsg_rtc_server_ns_unbind) < 0)
+                       rpmsg_destroy_ept) < 0)
     {
       kmm_free(client);
       return;

--- a/drivers/wireless/bluetooth/bt_rpmsghci_server.c
+++ b/drivers/wireless/bluetooth/bt_rpmsghci_server.c
@@ -399,17 +399,18 @@ static int rpmsghci_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
 }
 
 /****************************************************************************
- * Name: rpmsghci_ns_unbind
+ * Name: rpmsghci_ept_release
  *
  * Description:
- *   Unbind from the rpmsg name service.
+ *   Release the rpmsg endpoint.
  *
  ****************************************************************************/
 
-static void rpmsghci_ns_unbind(FAR struct rpmsg_endpoint *ept)
+static void rpmsghci_ept_release(FAR struct rpmsg_endpoint *ept)
 {
-  rpmsg_destroy_ept(ept);
-  kmm_free(ept);
+  FAR struct rpmsghci_server_s *server = ept->priv;
+
+  kmm_free(server);
 }
 
 /****************************************************************************
@@ -426,9 +427,11 @@ static void rpmsghci_ns_bind(FAR struct rpmsg_device *rdev, FAR void *priv,
   FAR struct rpmsghci_server_s *server = priv;
 
   server->ept.priv = priv;
+  server->ept.release_cb = rpmsghci_ept_release;
+
   rpmsg_create_ept(&server->ept, rdev, name,
                    RPMSG_ADDR_ANY, dest,
-                   rpmsghci_ept_cb, rpmsghci_ns_unbind);
+                   rpmsghci_ept_cb, rpmsg_destroy_ept);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
use ept_release_cb to destory rpmsg services server dile resource to avoid the used-after-free issue

## Impact
All the rpmsg services

## Testing
sim rpserver and rpproxy
