### PR TITLE
CI: Split the RISC-V Build Jobs into smaller jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,11 @@ jobs:
         [
           "arm-01", "other", "risc-v-01", "sim-01", "xtensa-01",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
-          "arm-03", "arm-04", "arm-05", "arm-06", "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13", "arm-14"
+          "arm-03", "risc-v-03",
+          "arm-04", "risc-v-04",
+          "arm-05", "risc-v-05",
+          "arm-06", "risc-v-06",
+          "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13", "arm-14"
         ]
 
   # Run the selected Linux Builds

--- a/tools/ci/testlist/risc-v-01.dat
+++ b/tools/ci/testlist/risc-v-01.dat
@@ -1,1 +1,2 @@
-/risc-v/[a-e]*
+/risc-v/[a-d]*
+/risc-v/e[0-r]*

--- a/tools/ci/testlist/risc-v-02.dat
+++ b/tools/ci/testlist/risc-v-02.dat
@@ -1,6 +1,1 @@
-/risc-v/[f-s]*
--,arty_a7:.+
-
-# Boards build by CMake
-CMake,rv-virt:smp
-CMake,rv-virt:smp64
+/risc-v/esp32c[0-5]*

--- a/tools/ci/testlist/risc-v-03.dat
+++ b/tools/ci/testlist/risc-v-03.dat
@@ -1,0 +1,2 @@
+/risc-v/esp32c[6-z]*
+/risc-v/esp32[d-z]*

--- a/tools/ci/testlist/risc-v-04.dat
+++ b/tools/ci/testlist/risc-v-04.dat
@@ -1,0 +1,4 @@
+/risc-v/e[t-z]*
+/risc-v/[f-p]*
+/risc-v/q[0-d]*
+-,arty_a7:.+

--- a/tools/ci/testlist/risc-v-05.dat
+++ b/tools/ci/testlist/risc-v-05.dat
@@ -1,0 +1,1 @@
+/risc-v/qemu-rv/rv-virt/configs/[a-c]*

--- a/tools/ci/testlist/risc-v-06.dat
+++ b/tools/ci/testlist/risc-v-06.dat
@@ -1,0 +1,7 @@
+/risc-v/qemu-rv/rv-virt/configs/[d-z]*
+/risc-v/q[f-z]*
+/risc-v/[r-z]*
+
+# Boards build by CMake
+CMake,rv-virt:smp
+CMake,rv-virt:smp64


### PR DESCRIPTION
## Summary

To speed up the CI Workflow, this PR splits the CI Build Jobs for RISC-V into smaller jobs. Each job will now complete within 1 hour.

__Before the PR:__ There are 2 jobs for RISC-V, each requiring more than 1.5 hours
- `risc-v-01` (1 hour 42 mins): BL602, Ox64, ESP32-C3 / C6 / H2
- `risc-v-02` (1 hour 41 mins): K230, Icicle, QEMU, RV32M1-Vega

__After the PR:__ The build is spread across 6 jobs for RISC-V, each job completes within 1 hour
- `risc-v-01` (19 mins): BL602, Ox64
- `risc-v-02` (44 mins): ESP32-C3
- `risc-v-03` (45 mins): ESP32-C6, ESP32-H2
- `risc-v-04` (31 mins): K230, Icicle
- `risc-v-05` (41 mins): QEMU CITest
- `risc-v-06` (38 mins): Rest of QEMU, RV32M1-Vega

Following the same convention as the Arm32 Build Jobs, the above jobs are sorted by Target Name. Performance of the RISC-V Build Jobs is discussed in https://github.com/apache/nuttx/issues/13775

## Impact

With this PR, RISC-V Build Jobs will finish earlier:

[__Before the PR:__](https://github.com/apache/nuttx/actions/runs/11241832867) RISC-V Build Jobs take up to 1 hour 42 mins (`risc-v-01`) to complete.

[__After the PR:__](https://github.com/lupyuen5/label-nuttx/actions/runs/11255875050) RISC-V Build Jobs will take at most 45 mins (`risc-v-03`) to complete.

The Updated CI Workflow shall be synced to `nuttx-apps` repo in the next PR.

## Testing

We verified that RISC-V Build Jobs are executed successfully with the Updated CI Workflow: https://github.com/lupyuen5/label-nuttx/actions/runs/11255875050

Timings for the RISC-V Build Jobs:

[__Before the PR__](https://github.com/apache/nuttx/actions/runs/11241832867)
- risc-v-01: 1 hour 42 mins
- risc-v-02: 1 hour 41 mins

[__After the PR__](https://github.com/lupyuen5/label-nuttx/actions/runs/11255875050)
- risc-v-01: 19 mins
- risc-v-02: 44 mins
- risc-v-03: 45 mins
- risc-v-04: 31 mins
- risc-v-05: 41 mins
- risc-v-06: 38 mins
