### PR TITLE
build.yml[bugfix]:disable CMake Ninja for Msys2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,7 +328,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -N -R testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

CI in the msys2 environment, the CMake ninja generator will have a problem with parameters being too long

## Impact

Msys2

## Testing

Ci build