### PR TITLE
arch/x86_64:Add nanosecond delay interface to TSC

### DIFF
--- a/arch/x86_64/src/common/x86_64_udelay.c
+++ b/arch/x86_64/src/common/x86_64_udelay.c
@@ -56,6 +56,9 @@
 
 void up_udelay(useconds_t microseconds)
 {
+#ifdef CONFIG_ARCH_INTEL64_HAVE_TSC
+  up_ndelay(microseconds * NSEC_PER_USEC);
+#else
   volatile int i;
 
   /* We'll do this a little at a time because we expect that the
@@ -99,4 +102,5 @@ void up_udelay(useconds_t microseconds)
 
       microseconds--;
     }
+#endif
 }

--- a/arch/x86_64/src/intel64/CMakeLists.txt
+++ b/arch/x86_64/src/intel64/CMakeLists.txt
@@ -78,6 +78,7 @@ if(CONFIG_ARCH_INTEL64_HAVE_TSC)
   else()
     list(APPEND SRCS intel64_tsc_timerisr.c)
   endif()
+  list(APPEND SRCS intel64_tsc_ndelay.c)
 endif()
 
 if(CONFIG_INTEL64_HPET)

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -67,6 +67,7 @@ CHIP_CSRCS += intel64_tsc_tickless.c
 else
 CHIP_CSRCS += intel64_tsc_timerisr.c
 endif
+CHIP_CSRCS += intel64_tsc_ndelay.c
 endif
 
 ifeq ($(CONFIG_INTEL64_HPET),y)


### PR DESCRIPTION
## Summary
Add nanosecond delay interface to TSC
## Impact
no impact
## Testing
ostest
