### PR TITLE
net/local: fix the return address is incorrect when accept

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -613,7 +613,8 @@ int local_release_halfduplex(FAR struct local_conn_s *conn);
  *
  ****************************************************************************/
 
-int local_open_client_rx(FAR struct local_conn_s *client, bool nonblock);
+int local_open_client_rx(FAR struct local_conn_s *client,
+                         FAR struct local_conn_s *server, bool nonblock);
 
 /****************************************************************************
  * Name: local_open_client_tx
@@ -623,7 +624,8 @@ int local_open_client_rx(FAR struct local_conn_s *client, bool nonblock);
  *
  ****************************************************************************/
 
-int local_open_client_tx(FAR struct local_conn_s *client, bool nonblock);
+int local_open_client_tx(FAR struct local_conn_s *client,
+                         FAR struct local_conn_s *server, bool nonblock);
 
 /****************************************************************************
  * Name: local_open_server_rx

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -151,9 +151,9 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
           /* Return the address family */
 
-          if (addr != NULL)
+          if (addr != NULL && conn->lc_peer != NULL)
             {
-              ret = local_getaddr(conn, addr, addrlen);
+              ret = local_getaddr(conn->lc_peer, addr, addrlen);
             }
 
           if (ret == OK && nonblock)

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -237,10 +237,10 @@ static int local_release_fifo(FAR const char *path)
 static int local_rx_open(FAR struct local_conn_s *conn, FAR const char *path,
                          bool nonblock)
 {
-  int oflags = nonblock ? O_RDONLY | O_NONBLOCK : O_RDONLY;
   int ret;
 
-  ret = file_open(&conn->lc_infile, path, oflags | O_CLOEXEC);
+  ret = file_open(&conn->lc_infile, path, O_RDONLY | O_NONBLOCK |
+                  O_CLOEXEC);
   if (ret < 0)
     {
       nerr("ERROR: Failed on open %s for reading: %d\n",
@@ -255,6 +255,20 @@ static int local_rx_open(FAR struct local_conn_s *conn, FAR const char *path,
        */
 
       return ret == -ENOENT ? -EFAULT : ret;
+    }
+
+  /* Clear O_NONBLOCK if it's meant to be blocking */
+
+  if (nonblock == false)
+    {
+      ret = nonblock;
+      ret = file_ioctl(&conn->lc_infile, FIONBIO, &ret);
+      if (ret < 0)
+        {
+          file_close(&conn->lc_infile);
+          conn->lc_infile.f_inode = NULL;
+          return ret;
+        }
     }
 
   return OK;
@@ -299,6 +313,8 @@ static int local_tx_open(FAR struct local_conn_s *conn, FAR const char *path,
       ret = file_ioctl(&conn->lc_outfile, FIONBIO, &ret);
       if (ret < 0)
         {
+          file_close(&conn->lc_outfile);
+          conn->lc_outfile.f_inode = NULL;
           return ret;
         }
     }
@@ -543,14 +559,15 @@ int local_release_halfduplex(FAR struct local_conn_s *conn)
  *
  ****************************************************************************/
 
-int local_open_client_rx(FAR struct local_conn_s *client, bool nonblock)
+int local_open_client_rx(FAR struct local_conn_s *client,
+                         FAR struct local_conn_s *server, bool nonblock)
 {
   char path[LOCAL_FULLPATH_LEN];
   int ret;
 
   /* Get the server-to-client path name */
 
-  local_sc_name(client, path);
+  local_sc_name(server, path);
 
   /* Then open the file for read-only access */
 
@@ -573,14 +590,15 @@ int local_open_client_rx(FAR struct local_conn_s *client, bool nonblock)
  *
  ****************************************************************************/
 
-int local_open_client_tx(FAR struct local_conn_s *client, bool nonblock)
+int local_open_client_tx(FAR struct local_conn_s *client,
+                         FAR struct local_conn_s *server, bool nonblock)
 {
   char path[LOCAL_FULLPATH_LEN];
   int ret;
 
   /* Get the client-to-server path name */
 
-  local_cs_name(client, path);
+  local_cs_name(server, path);
 
   /* Then open the file for write-only access */
 

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -1066,7 +1066,7 @@ static int local_socketpair(FAR struct socket *psocks[2])
 
   /* Open the client-side write-only FIFO. */
 
-  ret = local_open_client_tx(conns[0], nonblock);
+  ret = local_open_client_tx(conns[0], conns[1], nonblock);
   if (ret < 0)
     {
       goto errout;
@@ -1090,7 +1090,7 @@ static int local_socketpair(FAR struct socket *psocks[2])
 
   /* Open the client-side read-only FIFO */
 
-  ret = local_open_client_rx(conns[0], nonblock);
+  ret = local_open_client_rx(conns[0], conns[1], nonblock);
   if (ret < 0)
     {
       goto errout;


### PR DESCRIPTION
## Summary
The argument addr is a pointer to a sockaddr structure. This structure is filled in with the address of the peer socket, as known to the communications layer.

## Impact

## Testing
sim:local
