### PR TITLE
arch/x86_64: cpuid expect 32 bit variables

### DIFF
--- a/arch/x86_64/src/intel64/intel64_check_capability.c
+++ b/arch/x86_64/src/intel64/intel64_check_capability.c
@@ -56,9 +56,9 @@
 
 void x86_64_check_and_enable_capability(void)
 {
-  unsigned long ebx;
-  unsigned long ecx;
-  unsigned long require = 0;
+  uint32_t ebx;
+  uint32_t ecx;
+  uint32_t require = 0;
 
   /* Check SSE3 instructions availability */
 


### PR DESCRIPTION
## Summary
cpuid expect 32 bit variables
## Impact
no impact
## Testing
ostest
