### PR TITLE
risc-v/espressif: Fix alert message in `esp_setup_irq()`

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -527,7 +527,7 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
   if (cpuint < 0)
     {
       _alert("Unable to allocate CPU interrupt for source=%d\n",
-             priority, type);
+             source);
 
       PANIC();
     }


### PR DESCRIPTION


## Summary
Correct the alert message in `esp_setup_irq()` if
irq number allocation fails, the parameter number is not matched with format specifier.
## Impact
riscv/espressif
## Testing
esp32c3
