### PR TITLE
Rpmsg ping: improve the rpmsg ping

### DIFF
--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -101,8 +101,6 @@ static int rpmsg_ping_ept_cb(FAR struct rpmsg_endpoint *ept,
                      i, data_len);
               break;
             }
-
-          msg->data[i] = 0;
         }
     }
 
@@ -132,9 +130,6 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept, int len,
       return -ENOMEM;
     }
 
-  len = MAX(len, sizeof(struct rpmsg_ping_msg_s));
-  len = MIN(len, *buf_len);
-
   msg->cmd = cmd;
 
   if ((msg->cmd & RPMSG_PING_RANDOMLEN_MASK) != 0)
@@ -146,13 +141,16 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept, int len,
       msg->len = len;
     }
 
+  msg->len = MAX(msg->len, sizeof(struct rpmsg_ping_msg_s));
+  msg->len = MIN(msg->len, *buf_len);
+
   if ((msg->cmd & RPMSG_PING_CHECK_MASK) != 0)
     {
       memset(msg->data, i, msg->len - sizeof(struct rpmsg_ping_msg_s) + 1);
     }
   else
     {
-      memset(msg->data, 0, msg->len);
+      memset(msg->data, 0, msg->len - sizeof(struct rpmsg_ping_msg_s) + 1);
     }
 
   if ((msg->cmd & RPMSG_PING_ACK_MASK) != 0)

--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -181,9 +181,9 @@ static void rpmsg_ping_logout(FAR const char *s, clock_t value)
   perf_convert(value, &ts);
 
 #ifdef CONFIG_SYSTEM_TIME64
-  syslog(LOG_INFO, "%s: %" PRIu64 " s, %ld ns\n", s, ts.tv_sec, ts.tv_nsec);
+  syslog(LOG_EMERG, "%s: %" PRIu64 " s, %ld ns\n", s, ts.tv_sec, ts.tv_nsec);
 #else
-  syslog(LOG_INFO, "%s: %" PRIu32 " s, %ld ns\n", s, ts.tv_sec, ts.tv_nsec);
+  syslog(LOG_EMERG, "%s: %" PRIu32 " s, %ld ns\n", s, ts.tv_sec, ts.tv_nsec);
 #endif
 }
 
@@ -200,7 +200,7 @@ static void rpmsg_ping_logout_rate(uint64_t len, clock_t avg)
   rateint = ratebits / 1000000;
   ratedec = ratebits - rateint * 1000000;
 
-  syslog(LOG_INFO, "rate: %zu.%06zu Mbits/sec\n", rateint, ratedec);
+  syslog(LOG_EMERG, "rate: %zu.%06zu Mbits/sec\n", rateint, ratedec);
 }
 
 /****************************************************************************
@@ -243,7 +243,9 @@ int rpmsg_ping(FAR struct rpmsg_endpoint *ept,
         }
     }
 
-  syslog(LOG_INFO, "ping times: %d\n", ping->times);
+  syslog(LOG_EMERG, "ping times: %d\n", ping->times);
+  syslog(LOG_EMERG, "buffer_len: %" PRIu32 ", send_len: %d\n",
+                    buf_len, send_len);
 
   rpmsg_ping_logout("avg", total / ping->times);
   rpmsg_ping_logout("min", min);

--- a/include/nuttx/rpmsg/rpmsg_ping.h
+++ b/include/nuttx/rpmsg/rpmsg_ping.h
@@ -41,7 +41,7 @@ struct rpmsg_ping_s
 {
   int  times;
   int  len;
-  int  ack;
+  int  cmd;
   int  sleep; /* unit: ms */
 };
 


### PR DESCRIPTION
## Summary
-    rpmsg_ping.c: fix msg data memset length
    
    The range of memset exceeds the size of the buffer

-    rpmsg_ping.c: change msg cmd type for more compatible
    
    Use bit mask method to represent the command, because it's more
    convenient to express multiple characteristics simultaneously.
    
-    rpmsg_ping.c: improve log level to LOG_EMERG
    
    Usually rpmsg ping logs are needed during testing,
    but too many other module logs can easily overwrite it,
    so improve the rpmsg ping log level, later we can setlogmask to
    a higher log level to mask other modules' logs.

-    rpmsg_ping.c: change check data to fluctuation value
    
    We can found the error happend packet more accurately based
    on the data value.

## Impact
rpmsg ping

## Testing
sim:rpserver and rpproxy
