### PR TITLE
{Bp-13716} change nxsched_islocked_global to nxsched_islocked_tcb

### DIFF
--- a/include/nuttx/init.h
+++ b/include/nuttx/init.h
@@ -89,7 +89,7 @@ extern "C"
  * hardware resources may not yet be available to the OS-internal logic.
  */
 
-EXTERN uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
+EXTERN volatile uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
 
 /****************************************************************************
  * Public Function Prototypes

--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -35,6 +35,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
+#include <nuttx/init.h>
 
 #include "group/group.h"
 #include "sched/sched.h"
@@ -73,6 +74,12 @@ void nx_idle_trampoline(void)
 
   sched_note_start(tcb);
 #endif
+
+  /* wait until cpu0 in idle() */
+
+  while (!OSINIT_IDLELOOP());
+
+  sched_unlock();
 
   /* Enter the IDLE loop */
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -195,7 +195,7 @@ struct tasklist_s g_tasklisttable[NUM_TASK_STATES];
  * hardware resources may not yet be available to the kernel logic.
  */
 
-uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
+volatile uint8_t g_nx_initstate;  /* See enum nx_initstate_e */
 
 /****************************************************************************
  * Private Data
@@ -361,6 +361,7 @@ static void idle_task_initialize(void)
 
       tcb->pid        = i;
       tcb->task_state = TSTATE_TASK_RUNNING;
+      tcb->lockcount  = 1;
 
       /* Set the entry point.  This is only for debug purposes.  NOTE: that
        * the start_t entry point is not saved.  That is acceptable, however,
@@ -627,13 +628,6 @@ void nx_start(void)
   /* Initialize tasking data structures */
 
   task_initialize();
-
-  /* Disables context switching because we need take the memory manager
-   * semaphore on this CPU so that it will not be available on the other
-   * CPUs until we have finished initialization.
-   */
-
-  sched_lock();
 
   /* Initialize the instrument function */
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -297,9 +297,6 @@ extern volatile clock_t g_cpuload_total;
  */
 
 #ifdef CONFIG_SMP
-/* Used to keep track of which CPU(s) hold the IRQ lock. */
-
-extern volatile cpu_set_t g_cpu_lockset;
 
 /* This is the spinlock that enforces critical sections when interrupts are
  * disabled.
@@ -406,15 +403,12 @@ static inline_function FAR struct tcb_s *this_task(void)
 int  nxsched_select_cpu(cpu_set_t affinity);
 int  nxsched_pause_cpu(FAR struct tcb_s *tcb);
 void nxsched_process_delivered(int cpu);
-
-#  define nxsched_islocked_global() (g_cpu_lockset != 0)
-#  define nxsched_islocked_tcb(tcb) nxsched_islocked_global()
-
 #else
 #  define nxsched_select_cpu(a)     (0)
 #  define nxsched_pause_cpu(t)      (-38)  /* -ENOSYS */
-#  define nxsched_islocked_tcb(tcb) ((tcb)->lockcount > 0)
 #endif
+
+#define nxsched_islocked_tcb(tcb)   ((tcb)->lockcount > 0)
 
 /* CPU load measurement support */
 

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -194,7 +194,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
    * situation.
    */
 
-  if (nxsched_islocked_global())
+  if (nxsched_islocked_tcb(this_task()))
     {
       /* Add the new ready-to-run task to the g_pendingtasks task list for
        * now.
@@ -275,14 +275,6 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
       btcb->task_state = TSTATE_TASK_RUNNING;
 
       doswitch = true;
-
-      /* Resume scheduling lock */
-
-      DEBUGASSERT(g_cpu_lockset == 0);
-      if (btcb->lockcount > 0)
-        {
-          g_cpu_lockset |= (1 << cpu);
-        }
     }
 
   return doswitch;

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -199,7 +199,7 @@ bool nxsched_merge_pending(void)
    * some CPU other than this one is in a critical section.
    */
 
-  if (!nxsched_islocked_global())
+  if (!nxsched_islocked_tcb(this_task()))
     {
       /* Find the CPU that is executing the lowest priority task */
 
@@ -237,7 +237,7 @@ bool nxsched_merge_pending(void)
            * Check if that happened.
            */
 
-          if (nxsched_islocked_global())
+          if (nxsched_islocked_tcb(this_task()))
             {
               /* Yes.. then we may have incorrectly placed some TCBs in the
                * g_readytorun list (unlikely, but possible).  We will have to

--- a/sched/sched/sched_process_delivered.c
+++ b/sched/sched/sched_process_delivered.c
@@ -112,9 +112,10 @@ void nxsched_process_delivered(int cpu)
 
   btcb = g_delivertasks[cpu];
 
-  for (next = tcb;
-      (next && btcb->sched_priority <= next->sched_priority);
+  for (next = tcb; btcb->sched_priority <= next->sched_priority;
       next = next->flink);
+
+  DEBUGASSERT(next);
 
   prev = next->blink;
   if (prev == NULL)

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -262,23 +262,6 @@ void nxsched_remove_running(FAR struct tcb_s *tcb)
       nxttcb = rtrtcb;
     }
 
-  /* Will pre-emption be disabled after the switch?  If the lockcount is
-   * greater than zero, then this task/this CPU holds the scheduler lock.
-   */
-
-  if (nxttcb->lockcount > 0)
-    {
-      /* Yes... make sure that scheduling logic knows about this */
-
-      g_cpu_lockset |= (1 << cpu);
-    }
-  else
-    {
-      /* No.. we may need to perform release our hold on the lock. */
-
-      g_cpu_lockset &= ~(1 << cpu);
-    }
-
   /* NOTE: If the task runs on another CPU(cpu), adjusting global IRQ
    * controls will be done in the pause handler on the new CPU(cpu).
    * If the task is scheduled on this CPU(me), do nothing because

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -70,7 +70,7 @@ static FAR struct tcb_s *nxsched_nexttcb(FAR struct tcb_s *tcb)
    * then use the 'nxttcb' which will probably be the IDLE thread.
    */
 
-  if (!nxsched_islocked_global())
+  if (!nxsched_islocked_tcb(this_task()))
     {
       /* Search for the highest priority task that can run on tcb->cpu. */
 

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -137,12 +137,6 @@ int nxtask_exit(void)
 
   rtcb->lockcount++;
 
-#ifdef CONFIG_SMP
-  /* Make sure that the system knows about the locked state */
-
-  g_cpu_lockset |= (1 << cpu);
-#endif
-
   rtcb->task_state = TSTATE_TASK_READYTORUN;
 
   /* Move the TCB to the specified blocked task list and delete it.  Calling
@@ -176,15 +170,6 @@ int nxtask_exit(void)
   /* Decrement the lockcount on rctb. */
 
   rtcb->lockcount--;
-
-#ifdef CONFIG_SMP
-  if (rtcb->lockcount == 0)
-    {
-      /* Make sure that the system knows about the unlocked state */
-
-      g_cpu_lockset &= ~(1 << cpu);
-    }
-#endif
 
   return ret;
 }


### PR DESCRIPTION
## Summary
1 To improve efficiency, we mimic Linux's behavior where preemption disabling is
only applicable to the current CPU and does not affect other CPUs.
2 In the future, we will implement "spinlock+sched_lock", and use it extensively.
Under such circumstances, if preemption is still globally disabled, it will seriously impact
the scheduling efficiency.
3 We have removed g_cpu_lockset and used irqcount in order to eliminate the dependency of
schedlock on critical sections in the future, simplify the logic, and further enhance the
performance of sched_lock.
4 We set lockcount to 1 in order to lock scheduling on all CPUs during startup, without
the need to provide additional functions to disable scheduling on other CPUs.
5 Cpu (1-n) must wait for cpu0 to enter the idle state before enabling scheduling because
it prevents CPUs1~n from competing with cpu0 for the memory manager mutex, which could
cause the cpu0 idle task to enter a wait state and trigger an assert.

size nuttx
before:
   text    data     bss     dec     hex filename
 265396   51057   63646  380099   5ccc3 nuttx
after:
   text    data     bss     dec     hex filename
 265184   51057   63642  379883   5cbeb nuttx

size -216


## Impact
RELEASE 

## Testing
CI
