### PR TITLE
sched: fix omitted merging the pending queue regression

### DIFF
--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -104,6 +104,10 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
 void nxsched_remove_self(FAR struct tcb_s *tcb)
 {
   nxsched_remove_readytorun(tcb);
+  if (list_pendingtasks()->head)
+    {
+      nxsched_merge_pending();
+    }
 }
 #endif /* !CONFIG_SMP */
 


### PR DESCRIPTION

## Summary
sched: fix omitted merging the pending queue regression
This commit fixes the regression from https://github.com/apache/nuttx/pull/13995

## Impact
sched

## Testing
ci
