### PR TITLE
{Bp-13658} char driver CAN: add tx_confirm ability in upperCAN driver.

### DIFF
--- a/Documentation/platforms/arm/samv7/boards/same70-xplained/README.txt
+++ b/Documentation/platforms/arm/samv7/boards/same70-xplained/README.txt
@@ -695,7 +695,8 @@ MCAN1 Loopback Test
 
     Device Drivers -> CAN Driver support
        CONFIG_CAN=y                            # Enable the upper-half CAN driver
-       CONFIG_CAN_FIFOSIZE=8
+       CONFIG_CAN_TXFIFOSIZE=8
+       CONFIG_CAN_RXFIFOSIZE=8
        CONFIG_CAN_NPENDINGRTR=4
 
     System Type -> SAMV7 Peripheral Selections

--- a/Documentation/platforms/arm/samv7/boards/samv71-xult/README.txt
+++ b/Documentation/platforms/arm/samv7/boards/samv71-xult/README.txt
@@ -1288,7 +1288,8 @@ MCAN1 Loopback Test
 
     Device Drivers -> CAN Driver support
        CONFIG_CAN=y                            # Enable the upper-half CAN driver
-       CONFIG_CAN_FIFOSIZE=8
+       CONFIG_CAN_TXFIFOSIZE=8
+       CONFIG_CAN_RXFIFOSIZE=8
        CONFIG_CAN_NPENDINGRTR=4
 
     System Type -> SAMV7 Peripheral Selections

--- a/Documentation/platforms/arm/stm32f1/boards/cloudctrl/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/cloudctrl/index.rst
@@ -385,7 +385,11 @@ Cloudctrl-specific Configuration Options
 
    CONFIG_CAN - Enables CAN support (one or both of CONFIG_STM32_CAN1 or
    CONFIG_STM32_CAN2 must also be defined)
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/fire-stm32v2/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/fire-stm32v2/index.rst
@@ -501,7 +501,11 @@ M3 Wildfire-specific Configuration Options
    CONFIG_STM32_CAN2 must also be defined)
    CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
    Standard 11-bit IDs.
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/hymini-stm32/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/hymini-stm32/index.rst
@@ -282,7 +282,11 @@ HY-Mini specific Configuration Options
          CONFIG_STM32_CAN2 must also be defined)
        CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
          Standard 11-bit IDs.
-       CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+       CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+         of CAN messages.
+         Default: 8
+       CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+         of CAN messages.
          Default: 8
        CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
          Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/shenzhou/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/shenzhou/index.rst
@@ -395,7 +395,11 @@ Shenzhou-specific Configuration Options
 
    CONFIG_CAN - Enables CAN support (one or both of CONFIG_STM32_CAN1 or
    CONFIG_STM32_CAN2 must also be defined)
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm3210e-eval/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm3210e-eval/index.rst
@@ -444,7 +444,11 @@ STM3210E-EVAL-specific Configuration Options
    CONFIG_STM32_CAN2 must also be defined)
    CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
    Standard 11-bit IDs.
-   CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+   CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+   of CAN messages.
+   Default: 8
+   CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+   of CAN messages.
    Default: 8
    CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
    Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm32_tiny/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm32_tiny/index.rst
@@ -231,7 +231,11 @@ STM32 Tiny - specific Configuration Options
          CONFIG_STM32_CAN2 must also be defined)
        CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
          Standard 11-bit IDs.
-       CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+       CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+         of CAN messages.
+         Default: 8
+       CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+         of CAN messages.
          Default: 8
        CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
          Default: 4

--- a/Documentation/platforms/arm/stm32f1/boards/stm32f103-minimum/index.rst
+++ b/Documentation/platforms/arm/stm32f1/boards/stm32f103-minimum/index.rst
@@ -740,7 +740,11 @@ STM32F103 Minimum - specific Configuration Options
             CONFIG_STM32_CAN2 must also be defined)
           CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
             Standard 11-bit IDs.
-          CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+          CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+            of CAN messages.
+            Default: 8
+          CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+            of CAN messages.
             Default: 8
           CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
             Default: 4

--- a/Documentation/platforms/arm/stm32f2/index.rst
+++ b/Documentation/platforms/arm/stm32f2/index.rst
@@ -93,7 +93,12 @@ CAN
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.
   Default Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f3/index.rst
+++ b/Documentation/platforms/arm/stm32f3/index.rst
@@ -140,7 +140,12 @@ CAN character device
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
   Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f4/index.rst
+++ b/Documentation/platforms/arm/stm32f4/index.rst
@@ -144,7 +144,12 @@ CAN
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default
   Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
   Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.

--- a/Documentation/platforms/arm/stm32f7/index.rst
+++ b/Documentation/platforms/arm/stm32f7/index.rst
@@ -189,7 +189,13 @@ CAN
 
 - CONFIG_CAN_EXTID - Enables support for the 29-bit extended ID.  Default Standard 11-bit IDs.
 
-- CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.  Default: 8
+- CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+  of CAN messages.
+  Default: 8
+   
+- CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+  of CAN messages.
+  Default: 8
 
 - CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.  Default: 4
 

--- a/arch/arm/src/at32/at32_can.c
+++ b/arch/arm/src/at32/at32_can.c
@@ -1586,7 +1586,7 @@ static int at32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 
@@ -1895,7 +1895,7 @@ static int at32can_sceinterrupt(int irq, void *context, void *arg)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
@@ -1356,7 +1356,7 @@ static void can_interrupt(struct lpc17_40_can_s *dev)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = ((rfs & CAN_RFS_FF) != 0);
 #else
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       if ((rfs & CAN_RFS_FF) != 0)
         {

--- a/arch/arm/src/sama5/sam_can.c
+++ b/arch/arm/src/sama5/sam_can.c
@@ -1318,7 +1318,7 @@ static inline void can_rxinterrupt(struct can_dev_s *dev, int mbndx,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* And provide the CAN message to the upper half logic */
 

--- a/arch/arm/src/sama5/sam_mcan.c
+++ b/arch/arm/src/sama5/sam_mcan.c
@@ -3459,14 +3459,14 @@ static void mcan_error(struct can_dev_s *dev, uint32_t status)
     {
       /* Format the CAN header for the error report. */
 
-      hdr.ch_id     = errbits;
-      hdr.ch_dlc    = CAN_ERROR_DLC;
-      hdr.ch_rtr    = 0;
-      hdr.ch_error  = 1;
+      hdr.ch_id    = errbits;
+      hdr.ch_dlc   = CAN_ERROR_DLC;
+      hdr.ch_rtr   = 0;
+      hdr.ch_error = 1;
 #ifdef CONFIG_CAN_EXTID
-      hdr.ch_extid  = 0;
+      hdr.ch_extid = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf   = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -3628,7 +3628,7 @@ static void mcan_receive(struct can_dev_s *dev, uint32_t *rxbuffer,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   if ((regval & BUFFER_R0_RTR) != 0)
     {

--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -3483,7 +3483,7 @@ static void mcan_error(struct can_dev_s *dev, uint32_t status)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -3535,9 +3535,9 @@ static void mcan_receive(struct can_dev_s *dev, uint32_t *rxbuffer,
   reginfo("R0: %08" PRIx32 "\n", regval);
 
 #ifdef CONFIG_CAN_ERRORS
-  hdr.ch_error  = 0;
+  hdr.ch_error = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf   = 0;
 
   if ((regval & BUFFER_R0_RTR) != 0)
     {

--- a/arch/arm/src/stm32/stm32_can.c
+++ b/arch/arm/src/stm32/stm32_can.c
@@ -1581,7 +1581,7 @@ static int stm32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 
@@ -1890,7 +1890,7 @@ static int stm32can_sceinterrupt(int irq, void *context, void *arg)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 

--- a/arch/arm/src/stm32/stm32_fdcan.c
+++ b/arch/arm/src/stm32/stm32_fdcan.c
@@ -2801,7 +2801,7 @@ static void fdcan_error(struct can_dev_s *dev, uint32_t status)
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -2846,7 +2846,7 @@ static void fdcan_receive(struct can_dev_s *dev,
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0;
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/arch/arm/src/stm32f7/stm32_can.c
+++ b/arch/arm/src/stm32f7/stm32_can.c
@@ -1518,7 +1518,7 @@ static int stm32can_rxinterrupt(struct can_dev_s *dev, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/arch/arm/src/stm32l4/stm32l4_can.c
+++ b/arch/arm/src/stm32l4/stm32l4_can.c
@@ -1445,7 +1445,7 @@ static int stm32l4can_rxinterrupt(int irq, void *context, int rxmb)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -59,6 +59,17 @@ config CAN_NPENDINGRTR
 	---help---
 		The size of the list of pending RTR requests. Default: 4
 
+config CAN_TXCONFIRM
+        bool "can txconfirm ability"
+        default n
+        ---help---
+                this section enables the can txconfirm ability.
+
+                Enabling this feature adds support for the can txconfirm
+                ability, the ability is used from CAN interrupt handler
+                when the transfer is complete, the ability will notify all
+                readers that the canid has been transferred.
+
 config CAN_TXREADY
 	bool "can_txready interface"
 	default n

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -39,11 +39,19 @@ config CAN_FD
 	---help---
 		Enables support for the CAN_FD mode.
 
-config CAN_FIFOSIZE
-	int "CAN driver I/O buffer size"
+config CAN_TXFIFOSIZE
+	int "CAN driver I/O tx buffer size"
 	default 8
+	range 1 255
 	---help---
-		The size of the circular buffer of CAN messages. Default: 8
+		The size of the circular tx buffer of CAN messages. Default: 8
+
+config CAN_RXFIFOSIZE
+	int "CAN driver I/O rx buffer size"
+	default 8
+	range 1 255
+	---help---
+		The size of the circular rx buffer of CAN messages. Default: 8
 
 config CAN_NPENDINGRTR
 	int "Number of pending RTRs"

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -365,10 +365,6 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
   FAR struct can_rxfifo_s *fifo;
   irqstate_t               flags;
   int                      ret = 0;
-#ifdef CONFIG_CAN_ERRORS
-  FAR struct inode        *inode = filep->f_inode;
-  FAR struct can_dev_s    *dev = inode->i_private;
-#endif
 
   caninfo("buflen: %zu\n", buflen);
 
@@ -388,18 +384,9 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
       flags = enter_critical_section();
 
 #ifdef CONFIG_CAN_ERRORS
-
-      /* Check for reader fifo overflow */
-
-      if (fifo->rx_overflow)
-        {
-          dev->cd_error |= CAN_ERROR5_RXOVERFLOW;
-          fifo->rx_overflow = false;
-        }
-
       /* Check for internal errors */
 
-      if (dev->cd_error != 0)
+      if (fifo->rx_error != 0)
         {
           FAR struct can_msg_s *msg;
 
@@ -422,11 +409,11 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 #endif
           msg->cm_hdr.ch_unused = 0;
           memset(&(msg->cm_data), 0, CAN_ERROR_DLC);
-          msg->cm_data[5]       = dev->cd_error;
+          msg->cm_data[5]       = fifo->rx_error;
 
           /* Reset the error flag */
 
-          dev->cd_error         = 0;
+          fifo->rx_error        = 0;
 
           ret = CAN_MSGLEN(CAN_ERROR_DLC);
           goto return_with_irqdisabled;
@@ -572,6 +559,7 @@ static int can_xmit(FAR struct can_dev_s *dev)
       if (ret < 0)
         {
           canerr("dev_send failed: %d\n", ret);
+          dev->cd_xmit.tx_queue = tmpndx;
           break;
         }
     }
@@ -893,19 +881,24 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* FIONWRITE: Return the number of CAN messages in the send queue     */
+      /* FIONWRITE: Return the number of CAN messages in the send queue */
 
       case FIONWRITE:
         {
-          *(FAR uint8_t *)arg = dev->cd_xmit.tx_tail;
+          *(FAR uint8_t *)arg = CONFIG_CAN_FIFOSIZE - 1 -
+                            (dev->cd_xmit.tx_tail - dev->cd_xmit.tx_head);
         }
         break;
 
-      /* FIONREAD: Return the number of CAN messages in the receive FIFO    */
+      /* FIONREAD: Return the number of CAN messages in the receive FIFO */
 
       case FIONREAD:
         {
-          *(FAR uint8_t *)arg = reader->fifo.rx_tail;
+          *(FAR uint8_t *)arg =
+#ifdef CONFIG_CAN_ERRORS
+                            (reader->fifo.rx_error != 0) +
+#endif
+                            reader->fifo.rx_tail - reader->fifo.rx_head;
         }
         break;
 
@@ -934,9 +927,8 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
   FAR struct can_dev_s *dev = inode->i_private;
   FAR struct can_reader_s *reader = NULL;
   pollevent_t eventset = 0;
-  int ndx;
-  int sval;
   irqstate_t flags;
+  int ndx;
   int ret;
   int i;
 
@@ -1001,20 +993,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Should we immediately notify on any of the requested events?
        * First, check if the xmit buffer is full.
-       *
-       * Get exclusive access to the cd_xmit buffer indices.  NOTE: that
-       * we do not let this wait be interrupted by a signal (we probably
-       * should, but that would be a little awkward).
        */
-
-      DEBUGASSERT(dev->cd_ntxwaiters < 255);
-      dev->cd_ntxwaiters++;
-      do
-        {
-          ret = nxsem_wait(&dev->cd_xmit.tx_sem);
-        }
-      while (ret < 0);
-      dev->cd_ntxwaiters--;
 
       ndx = dev->cd_xmit.tx_tail + 1;
       if (ndx >= CONFIG_CAN_FIFOSIZE)
@@ -1027,29 +1006,17 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
           eventset |= POLLOUT;
         }
 
-      nxsem_post(&dev->cd_xmit.tx_sem);
-
       /* Check whether there are messages in the RX FIFO. */
 
-      ret = nxsem_get_value(&reader->fifo.rx_sem, &sval);
-
-      if (ret < 0)
+      if (reader->fifo.rx_head != reader->fifo.rx_tail
+#ifdef CONFIG_CAN_ERRORS
+          || reader->fifo.rx_error != 0
+#endif
+         )
         {
-          DEBUGPANIC();
-          goto return_with_irqdisabled;
-        }
-      else if (sval > 0)
-        {
-          if (reader->fifo.rx_head != reader->fifo.rx_tail)
-            {
-              /* No need to wait, just notify the application immediately */
+          /* No need to wait, just notify the application immediately */
 
-              eventset |= POLLIN;
-            }
-          else
-            {
-              canerr("RX FIFO sem not locked but FIFO is empty.\n");
-            }
+          eventset |= POLLIN;
         }
 
       poll_notify(&fds, 1, eventset);
@@ -1102,14 +1069,11 @@ int can_register(FAR const char *path, FAR struct can_dev_s *dev)
   dev->cd_crefs      = 0;
   dev->cd_npendrtr   = 0;
   dev->cd_ntxwaiters = 0;
-#ifdef CONFIG_CAN_ERRORS
-  dev->cd_error      = 0;
-#endif
   list_initialize(&dev->cd_readers);
 
   /* Initialize semaphores */
 
-  nxsem_init(&dev->cd_xmit.tx_sem, 0, 1);
+  nxsem_init(&dev->cd_xmit.tx_sem, 0, 0);
   nxmutex_init(&dev->cd_closelock);
   nxmutex_init(&dev->cd_polllock);
 
@@ -1251,21 +1215,14 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           fifo->rx_tail = nexttail;
 
-          /* Notify all poll/select waiters that they can read from the
-           * cd_recv buffer
-           */
-
-          poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLIN);
-
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
             {
-              DEBUGPANIC();
 #ifdef CONFIG_CAN_ERRORS
               /* Report unspecified error */
 
-              dev->cd_error |= CAN_ERROR5_UNSPEC;
+              fifo->rx_error |= CAN_ERROR5_UNSPEC;
 #endif
-              return -EINVAL;
+              continue;
             }
 
           /* Unlock the binary semaphore, waking up can_read if it is
@@ -1285,9 +1242,18 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
         {
           /* Report rx overflow error */
 
-          fifo->rx_overflow = true;
+          fifo->rx_error |= CAN_ERROR5_RXOVERFLOW;
         }
 #endif
+    }
+
+  /* Notify all poll/select waiters that they can read from the
+   * cd_recv buffer
+   */
+
+  if (ret == OK)
+    {
+      poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLIN);
     }
 
   return ret;

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -300,6 +300,8 @@ static int can_close(FAR struct file *filep)
       return ret;
     }
 
+  flags = enter_critical_section(); /* Disable interrupts */
+
   list_for_every(&dev->cd_readers, node)
     {
       if (((FAR struct can_reader_s *)node) ==
@@ -341,11 +343,10 @@ static int can_close(FAR struct file *filep)
 
   /* Free the IRQ and disable the CAN device */
 
-  flags = enter_critical_section(); /* Disable interrupts */
-  dev_shutdown(dev);                /* Disable the CAN */
-  leave_critical_section(flags);
+  dev_shutdown(dev); /* Disable the CAN */
 
 errout:
+  leave_critical_section(flags);
   nxmutex_unlock(&dev->cd_closelock);
   return ret;
 }
@@ -719,14 +720,9 @@ static inline ssize_t can_rtrread(FAR struct file *filep,
 {
   FAR struct can_dev_s     *dev = filep->f_inode->i_private;
   FAR struct can_rtrwait_s *wait = NULL;
-  irqstate_t                flags;
   int                       i;
   int                       sval;
   int                       ret = -ENOMEM;
-
-  /* Disable interrupts through this operation */
-
-  flags = enter_critical_section();
 
   /* Find an available slot in the pending RTR list */
 
@@ -801,7 +797,6 @@ static inline ssize_t can_rtrread(FAR struct file *filep,
         }
     }
 
-  leave_critical_section(flags);
   return ret;
 }
 
@@ -815,8 +810,13 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   FAR struct can_dev_s    *dev    = inode->i_private;
   FAR struct can_reader_s *reader = filep->f_priv;
   int                      ret    = OK;
+  irqstate_t               flags;
 
   caninfo("cmd: %d arg: %ld\n", cmd, arg);
+
+  /* Disable interrupts through this operation */
+
+  flags = enter_critical_section();
 
   /* Handle built-in ioctl commands */
 
@@ -913,6 +913,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         break;
     }
 
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -1120,12 +1121,15 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 {
   FAR struct can_rxfifo_s *fifo;
   FAR struct list_node    *node;
+  irqstate_t               flags;
   int                      nexttail;
   int                      ret = -ENOMEM;
   int                      i;
   int                      sval;
 
   caninfo("ID: %" PRId32 " DLC: %d\n", (uint32_t)hdr->ch_id, hdr->ch_dlc);
+
+  flags = enter_critical_section();
 
   /* Check if adding this new message would over-run the drivers ability to
    * enqueue read data.
@@ -1256,6 +1260,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
       poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLIN);
     }
 
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -1332,9 +1337,12 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 int can_txdone(FAR struct can_dev_s *dev)
 {
   int ret = -ENOENT;
+  irqstate_t flags;
 
   caninfo("xmit head: %d queue: %d tail: %d\n",
           dev->cd_xmit.tx_head, dev->cd_xmit.tx_queue, dev->cd_xmit.tx_tail);
+
+  flags = enter_critical_section();
 
   /* Verify that the xmit FIFO is not empty */
 
@@ -1379,6 +1387,7 @@ int can_txdone(FAR struct can_dev_s *dev)
         }
     }
 
+  leave_critical_section(flags);
   return ret;
 }
 
@@ -1443,10 +1452,13 @@ int can_txdone(FAR struct can_dev_s *dev)
 int can_txready(FAR struct can_dev_s *dev)
 {
   int ret = -ENOENT;
+  irqstate_t flags;
 
   caninfo("xmit head: %d queue: %d tail: %d waiters: %d\n",
           dev->cd_xmit.tx_head, dev->cd_xmit.tx_queue, dev->cd_xmit.tx_tail,
           dev->cd_ntxwaiters);
+
+  flags = enter_critical_section();
 
   /* Verify that the xmit FIFO is not empty.  This is safe because interrupts
    * are always disabled when calling into can_xmit(); this cannot collide
@@ -1495,6 +1507,7 @@ int can_txready(FAR struct can_dev_s *dev)
 #endif
     }
 
+  leave_critical_section(flags);
   return ret;
 }
 #endif /* CONFIG_CAN_TXREADY */

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -902,6 +902,53 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      /* Set specfic can transceiver state */
+
+      case CANIOC_SET_TRANSVSTATE:
+        {
+          /* if we don't use dev->cd_transv->cts_ops, please initlize
+           * this poniter to NULL in lower board code when Board reset.
+           */
+
+          if (dev->cd_transv && dev->cd_transv->ct_ops
+              && dev->cd_transv->ct_ops->ct_setstate)
+            {
+              FAR const struct can_transv_ops_s *ct_ops =
+                                                dev->cd_transv->ct_ops;
+              ret = ct_ops->ct_setstate(dev->cd_transv, arg);
+            }
+          else
+            {
+              canerr("dev->cd_transv->cts_ops is NULL!");
+              ret = -ENOTTY;
+            }
+        }
+        break;
+
+      /* Get specfic can transceiver state */
+
+      case CANIOC_GET_TRANSVSTATE:
+        {
+          /* if we don't use dev->cd_transv->cts_ops, please initlize
+           * this poniter to NULL in lower board code when Board reset.
+           */
+
+          if (dev->cd_transv && dev->cd_transv->ct_ops
+              && dev->cd_transv->ct_ops->ct_getstate)
+            {
+              int *state = (FAR int *)arg;
+              FAR const struct can_transv_ops_s *ct_ops =
+                                                dev->cd_transv->ct_ops;
+              ret = ct_ops->ct_getstate(dev->cd_transv, state);
+            }
+          else
+            {
+              canerr("dev->cd_transv->cts_ops is NULL!");
+              ret = -ENOTTY;
+            }
+        }
+        break;
+
       /* Not a "built-in" ioctl command.. perhaps it is unique to this
        * lower-half, device driver.
        */

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -408,7 +408,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 #ifdef CONFIG_CAN_EXTID
           msg->cm_hdr.ch_extid  = 0;
 #endif
-          msg->cm_hdr.ch_unused = 0;
+          msg->cm_hdr.ch_tcf    = 0;
           memset(&(msg->cm_data), 0, CAN_ERROR_DLC);
           msg->cm_data[5]       = fifo->rx_error;
 
@@ -1219,7 +1219,11 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
               memcpy(&waitmsg->cm_hdr, hdr, sizeof(struct can_hdr_s));
 
               nbytes = can_dlc2bytes(hdr->ch_dlc);
-              memcpy(waitmsg->cm_data, data, nbytes);
+              if (nbytes)
+                {
+                  memcpy(waitmsg->cm_data, data, nbytes);
+                }
+
               dev->cd_npendrtr--;
 
               /* Restart the waiting thread and mark the entry unused */
@@ -1260,7 +1264,10 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
                  sizeof(struct can_hdr_s));
 
           nbytes = can_dlc2bytes(hdr->ch_dlc);
-          memcpy(fifo->rx_buffer[fifo->rx_tail].cm_data, data, nbytes);
+          if (nbytes)
+            {
+              memcpy(fifo->rx_buffer[fifo->rx_tail].cm_data, data, nbytes);
+            }
 
           /* Increment the tail of the circular buffer */
 

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -465,7 +465,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
 
           /* Increment the head of the circular message buffer */
 
-          if (++fifo->rx_head >= CONFIG_CAN_FIFOSIZE)
+          if (++fifo->rx_head >= CONFIG_CAN_RXFIFOSIZE)
             {
               fifo->rx_head = 0;
             }
@@ -549,7 +549,7 @@ static int can_xmit(FAR struct can_dev_s *dev)
        */
 
       tmpndx = dev->cd_xmit.tx_queue;
-      if (++dev->cd_xmit.tx_queue >= CONFIG_CAN_FIFOSIZE)
+      if (++dev->cd_xmit.tx_queue >= CONFIG_CAN_TXFIFOSIZE)
         {
           dev->cd_xmit.tx_queue = 0;
         }
@@ -615,7 +615,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
        */
 
       nexttail = fifo->tx_tail + 1;
-      if (nexttail >= CONFIG_CAN_FIFOSIZE)
+      if (nexttail >= CONFIG_CAN_TXFIFOSIZE)
         {
           nexttail = 0;
         }
@@ -885,7 +885,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case FIONWRITE:
         {
-          *(FAR uint8_t *)arg = CONFIG_CAN_FIFOSIZE - 1 -
+          *(FAR uint8_t *)arg = CONFIG_CAN_TXFIFOSIZE - 1 -
                             (dev->cd_xmit.tx_tail - dev->cd_xmit.tx_head);
         }
         break;
@@ -1044,7 +1044,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
        */
 
       ndx = dev->cd_xmit.tx_tail + 1;
-      if (ndx >= CONFIG_CAN_FIFOSIZE)
+      if (ndx >= CONFIG_CAN_TXFIFOSIZE)
         {
           ndx = 0;
         }
@@ -1235,7 +1235,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
       fifo = &reader->fifo;
 
       nexttail = fifo->rx_tail + 1;
-      if (nexttail >= CONFIG_CAN_FIFOSIZE)
+      if (nexttail >= CONFIG_CAN_RXFIFOSIZE)
         {
           nexttail = 0;
         }
@@ -1405,7 +1405,7 @@ int can_txdone(FAR struct can_dev_s *dev)
 
       /* Remove the message at the head of the xmit FIFO */
 
-      if (++dev->cd_xmit.tx_head >= CONFIG_CAN_FIFOSIZE)
+      if (++dev->cd_xmit.tx_head >= CONFIG_CAN_TXFIFOSIZE)
         {
           dev->cd_xmit.tx_head = 0;
         }

--- a/drivers/can/mcp2515.c
+++ b/drivers/can/mcp2515.c
@@ -2031,7 +2031,7 @@ static void mcp2515_error(FAR struct can_dev_s *dev, uint8_t status,
 #ifdef CONFIG_CAN_EXTID
       hdr.ch_extid  = 0;
 #endif
-      hdr.ch_unused = 0;
+      hdr.ch_tcf    = 0;
 
       /* And provide the error report to the upper half logic */
 
@@ -2141,7 +2141,7 @@ static void mcp2515_receive(FAR struct can_dev_s *dev, uint8_t offset)
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0; /* Error reporting not supported */
 #endif
-  hdr.ch_unused = 0;
+  hdr.ch_tcf    = 0;
 
   /* Extract the RTR bit */
 

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -549,7 +549,7 @@ struct can_rxfifo_s
   sem_t         rx_sem;
 
 #ifdef CONFIG_CAN_ERRORS
-  bool          rx_overflow;             /* Indicates the RX FIFO overflow event */
+  uint8_t       rx_error;                /* Flags to indicate internal device errors */
 #endif
   uint8_t       rx_head;                 /* Index to the head [IN] in the circular buffer */
   uint8_t       rx_tail;                 /* Index to the tail [OUT] in the circular buffer */
@@ -666,9 +666,6 @@ struct can_dev_s
   uint8_t              cd_crefs;         /* References counts on number of opens */
   uint8_t              cd_npendrtr;      /* Number of pending RTR messages */
   volatile uint8_t     cd_ntxwaiters;    /* Number of threads waiting to enqueue a message */
-#ifdef CONFIG_CAN_ERRORS
-  uint8_t              cd_error;         /* Flags to indicate internal device errors */
-#endif
   struct list_node     cd_readers;       /* List of readers */
   mutex_t              cd_closelock;     /* Locks out new opens while close is in progress */
   mutex_t              cd_polllock;      /* Manages exclusive access to cd_fds[] */

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -246,6 +246,26 @@
  *                   is returned with the errno variable set to indicate the
  *                   nature of the error.
  *   Dependencies:   None
+ *
+ * CANIOC_SET_STATE
+ *   Description:    Set specfic can controller state
+ *
+ *   Argument:       A pointer to an enumeration type that describes the CAN
+ *                   state
+ *   returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
+ *                   is returned with the errno variable set to indicate the
+ *                   nature of the error.
+ *   Dependencies:   None
+ *
+ * CANIOC_GET_STATE
+ *   Description:    Get specfic can controller state
+ *
+ *   Argument:       A pointer to an enumeration type that describes the CAN
+ *                   state
+ *   returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
+ *                   is returned with the errno variable set to indicate the
+ *                   nature of the error.
+ *   Dependencies:   None
  */
 
 #define CANIOC_RTR                _CANIOC(1)
@@ -263,6 +283,8 @@
 #define CANIOC_IFLUSH             _CANIOC(13)
 #define CANIOC_OFLUSH             _CANIOC(14)
 #define CANIOC_IOFLUSH            _CANIOC(15)
+#define CANIOC_SET_STATE          _CANIOC(16)
+#define CANIOC_GET_STATE          _CANIOC(17)
 
 #define CAN_FIRST                 0x0001         /* First common command */
 #define CAN_NCMDS                 15             /* 16 common commands   */
@@ -437,6 +459,14 @@
 #define CAN_FILTER_MASK           0  /* Address match under a mask */
 #define CAN_FILTER_DUAL           1  /* Dual address match */
 #define CAN_FILTER_RANGE          2  /* Match a range of addresses */
+
+/* the state is default state. Indicates that the can controller is closed */
+
+#define CAN_STATE_STOP            0
+
+/* Indicates that the can controller is in the awake state */
+
+#define CAN_STATE_START           1
 
 /* CAN bit timing support ***************************************************/
 

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -589,7 +589,7 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_brs    : 1; /* Bit Rate Switch */
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
-  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
+  uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
 } end_packed_struct;
 
 #else
@@ -606,7 +606,7 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_brs    : 1; /* Bit Rate Switch */
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
-  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
+  uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
 } end_packed_struct;
 #endif
 

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -59,7 +59,11 @@
  * CONFIG_CAN_FD - Enable support for CAN FD mode.
  *   For the upper half driver, this just means handling encoded DLC values
  *   (for values of DLC > 9).
- * CONFIG_CAN_FIFOSIZE - The size of the circular buffer of CAN messages.
+ * CONFIG_CAN_TXFIFOSIZE - The size of the circular tx buffer
+ *   of CAN messages.
+ *   Default: 8
+ * CONFIG_CAN_RXFIFOSIZE - The size of the circular rx buffer
+ *   of CAN messages.
  *   Default: 8
  * CONFIG_CAN_NPENDINGRTR - The size of the list of pending RTR requests.
  *   Default: 4
@@ -81,11 +85,18 @@
  * The configured size is limited to 255 to fit into a uint8_t.
  */
 
-#if !defined(CONFIG_CAN_FIFOSIZE)
-#  define CONFIG_CAN_FIFOSIZE 8
-#elif CONFIG_CAN_FIFOSIZE > 255
-#  undef  CONFIG_CAN_FIFOSIZE
-#  define CONFIG_CAN_FIFOSIZE 255
+#if !defined(CONFIG_CAN_TXFIFOSIZE)
+#  define CONFIG_CAN_TXFIFOSIZE 8
+#elif CONFIG_CAN_TXFIFOSIZE > 255
+#  undef  CONFIG_CAN_TXFIFOSIZE
+#  define CONFIG_CAN_TXFIFOSIZE 255
+#endif
+
+#if !defined(CONFIG_CAN_RXFIFOSIZE)
+#  define CONFIG_CAN_RXFIFOSIZE 8
+#elif CONFIG_CAN_RXFIFOSIZE > 255
+#  undef  CONFIG_CAN_RXFIFOSIZE
+#  define CONFIG_CAN_RXFIFOSIZE 255
 #endif
 
 #if !defined(CONFIG_CAN_NPENDINGRTR)
@@ -622,7 +633,7 @@ struct can_rxfifo_s
   uint8_t       rx_head;                 /* Index to the head [IN] in the circular buffer */
   uint8_t       rx_tail;                 /* Index to the tail [OUT] in the circular buffer */
                                          /* Circular buffer of CAN messages */
-  struct can_msg_s rx_buffer[CONFIG_CAN_FIFOSIZE];
+  struct can_msg_s rx_buffer[CONFIG_CAN_RXFIFOSIZE];
 };
 
 struct can_txfifo_s
@@ -632,7 +643,7 @@ struct can_txfifo_s
   uint8_t       tx_queue;                /* Index to next message to send */
   uint8_t       tx_tail;                 /* Index to the tail [OUT] in the circular buffer */
                                          /* Circular buffer of CAN messages */
-  struct can_msg_s tx_buffer[CONFIG_CAN_FIFOSIZE];
+  struct can_msg_s tx_buffer[CONFIG_CAN_TXFIFOSIZE];
 };
 
 /* The following structure define the logic to handle


### PR DESCRIPTION
## Summary
multi backport
https://github.com/apache/nuttx/pull/13647
https://github.com/apache/nuttx/pull/13718
https://github.com/apache/nuttx/pull/13760
https://github.com/apache/nuttx/pull/13762
https://github.com/apache/nuttx/pull/13758

## Impact
RELEASE

## Testing
CI
