### PR TITLE
include/strings: replace ffs from an inline function to a macro

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -73,73 +73,46 @@ extern "C"
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_BUILTIN_FFS
-static inline_function int ffs(int j)
-{
-  return __builtin_ffs(j);
-}
+#  define ffs(j) __builtin_ffs(j)
 #elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffs(int j)
-{
-  return __builtin_ctz(j) + 1;
-}
+#  define ffs(j) (__builtin_ctz(j) + 1)
 #else
 int ffs(int j);
 #endif
 
 #ifdef CONFIG_HAVE_BUILTIN_FFSL
-static inline_function int ffsl(long j)
-{
-  return __builtin_ffsl(j);
-}
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffsl(long j)
-{
-  return __builtin_ctzl(j) + 1;
-}
+#  define ffsl(j) __builtin_ffsl(j)
+#elif defined (CONFIG_HAVE_BUILTIN_CTZL)
+#  define ffsl(j) (__builtin_ctzl(j) + 1)
 #else
 int ffsl(long j);
 #endif
 
 #ifdef CONFIG_HAVE_LONG_LONG
 #  ifdef CONFIG_HAVE_BUILTIN_FFSLL
-static inline_function int ffsll(long long j)
-{
-    return __builtin_ffsll(j);
-}
-#  elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffsll(long long j)
-{
-    return __builtin_ctzll(j) + 1;
-}
+#    define ffsll(j) __builtin_ffsll(j)
+#  elif defined (CONFIG_HAVE_BUILTIN_CTZLL)
+#    define ffsll(j) (__builtin_ctzll(j) + 1)
 #  else
 int ffsll(long long j);
 #  endif
 #endif
 
 #ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int fls(int j)
-{
-  return (8 * sizeof(int)) - __builtin_clz(j);
-}
+#  define fls(j) ((8 * sizeof(int)) - __builtin_clz(j))
 #else
 int fls(int j);
 #endif
 
-#ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int flsl(long j)
-{
-  return (8 * sizeof(long)) - __builtin_clzl(j);
-}
+#ifdef CONFIG_HAVE_BUILTIN_CLSL
+#  define flsl(j) ((8 * sizeof(long)) - __builtin_clsl(j))
 #else
 int flsl(long j);
 #endif
 
 #ifdef CONFIG_HAVE_LONG_LONG
-#  ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int flsll(long long j)
-{
-  return (8 * sizeof(long long)) - __builtin_clzll(j);
-}
+#  ifdef CONFIG_HAVE_BUILTIN_CLZLL
+#    define flsll(j) ((8 * sizeof(long long)) - __builtin_clzll(j))
 #  else
 int flsll(long long j);
 #  endif

--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -60,7 +60,6 @@
 "feof","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *"
 "ferror","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *"
 "fflush","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *"
-"ffs","strings.h","","int","int"
 "fgetc","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *"
 "fgetpos","stdio.h","defined(CONFIG_FILE_STREAM)","int","FAR FILE *","FAR fpos_t *"
 "fgets","stdio.h","defined(CONFIG_FILE_STREAM)","FAR char *","FAR char *","int","FAR FILE *"


### PR DESCRIPTION
## Summary
using static inline functions sometimes generates compilation warnings: nxfonts/nxfonts_bitmaps_sans23x27.c:168:50: warning: declaration of ‘ffs’ shadows a built-in function [-Wshadow]
  168 | static __attribute__((always_inline)) inline int ffs(int j)

This problem also seems to exist in the Linux kernel: https://lore.kernel.org/all/20220812114438.1574-2-mailhol.vincent@wanadoo.fr/

I encountered several compilation errors caused by fss in CI.
![image](https://github.com/user-attachments/assets/e5221e2a-01a0-49a9-95a5-cd0d7f6f41f7)

## Impact

## Testing

