### PR TITLE
x86_64:Fix ld error.

### DIFF
--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -97,6 +97,10 @@ ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}
 endif
 
+ifeq ($(CONFIG_CXX_EXCEPTION),y)
+  EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc_eh.a}}
+endif
+
 VPATH = chip:common:$(ARCH_SUBDIR)
 
 all: libarch$(LIBEXT)

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -138,6 +138,8 @@ AFLAGS += -Wa,--divide
 endif
 
 EXEEXT = .elf
+	
+LDFLAGS += -nostdlib -static
 
 # Loadable module definitions
 


### PR DESCRIPTION
LD: nuttx.elf
ld:in function `std::__1::ios_base::imbue(std::__1::locale const&)': 
nuttx/libs/libxx/libcxx/src/ios.cpp:129: undefined reference to `_Unwind_Resume'

## Summary

## Impact

## Testing

