### PR TITLE
x64: add acrn ioapic init support

### DIFF
--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -323,8 +323,8 @@ static void up_ioapic_init(void)
 
   for (i = 0; i < maxintr; i++)
     {
-      up_ioapic_pin_set_vector(i, TRIGGER_RISING_EDGE, IRQ0 + i);
-      up_ioapic_mask_pin(i);
+      up_ioapic_pin_set_vector(i, TRIGGER_RISING_EDGE |
+                               IOAPIC_PIN_DISABLE, IRQ0 + i);
     }
 }
 #endif


### PR DESCRIPTION
if we two step to set interrupt trigger and disable interrupt, acrn will inject #GP exception

## Summary
add acrn ioapic init support
## Impact
no impact
## Testing
ostest
