### PR TITLE
fs poll optimize

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -495,7 +495,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
            * will return immediately.
            */
 
-          ret = nxsem_tickwait(&sem, MSEC2TICK(timeout));
+          ret = nxsem_tickwait(&sem, MSEC2TICK((clock_t)timeout));
           if (ret < 0)
             {
               if (ret == -ETIMEDOUT)

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -136,10 +136,11 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
  ****************************************************************************/
 
 static inline int poll_teardown(FAR struct pollfd *fds, nfds_t nfds,
-                                FAR int *count, int ret)
+                                FAR int *count)
 {
   unsigned int i;
   int status = OK;
+  int ret = OK;
 
   /* Process each descriptor in the list */
 
@@ -185,7 +186,7 @@ static void poll_cleanup(FAR void *arg)
   FAR struct pollfd_s *fdsinfo = (FAR struct pollfd_s *)arg;
   int count;
 
-  poll_teardown(fdsinfo->fds, fdsinfo->nfds, &count, OK);
+  poll_teardown(fdsinfo->fds, fdsinfo->nfds, &count);
 }
 
 /****************************************************************************
@@ -521,7 +522,7 @@ int poll(FAR struct pollfd *fds, nfds_t nfds, int timeout)
        * Preserve ret, if negative, since it holds the result of the wait.
        */
 
-      ret2 = poll_teardown(kfds, nfds, &count, ret);
+      ret2 = poll_teardown(kfds, nfds, &count);
       if (ret2 < 0 && ret >= 0)
         {
           ret = ret2;


### PR DESCRIPTION
## Summary

fs poll optimize:

fs: Set the poll return value according to the man manual
    
    The man manual describes that poll only has EFAULT, EINTR, EINVAL, and ENOMEM return values.
    If a file returns an error, the POLLERR event should be set and OK should be returned
    https://man7.org/linux/man-pages/man2/poll.2.html
    
    When using libuv to poll the socket, the socket poll returned an EBUSY error, causing libuv to abort.
    
    The expected logic should be to return OK, allowing libuv to notify the event listener that the POLLERR event occurred.
    
fs/vfs: result_independent_of_operands
    
    timeout is a type of int
    in MSEC2TICK, timeout may be multiplied by USEC_PER_MSEC
    and the result may be out of range of int
    Besides, this will induce following ERROR while running simulator:
    vfs/fs_poll.c:498:38: runtime error: signed integer overflow:
    19768268 * 1000 cannot be represented in type 'int'
    

## Impact

FS poll

## Testing

sim & qemu

