### PR TITLE
arch/x86_64: Fix up_timer_start.

### DIFF
--- a/arch/x86_64/src/intel64/intel64_tsc_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tsc_tickless.c
@@ -76,7 +76,12 @@
 
 extern unsigned long g_x86_64_timer_freq;
 
+#ifndef CONFIG_SCHED_TICKLESS_ALARM
+static uint64_t g_goal_time;
+#else
 static struct timespec g_goal_time_ts;
+#endif
+
 static uint64_t g_last_stop_time;
 static uint64_t g_start_tsc;
 static uint32_t g_timer_active;
@@ -336,7 +341,7 @@ void up_timer_expire(void)
   g_timer_active = 0;
 
   up_mask_tmr();
-  sched_timer_expiration();
+  nxsched_timer_expiration();
 }
 
 #else /* CONFIG_SCHED_TICKLESS_ALARM */

--- a/arch/x86_64/src/intel64/intel64_tsc_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tsc_tickless.c
@@ -303,6 +303,8 @@ int up_timer_start(const struct timespec *ts)
 
   up_tmr_sync_up();
 
+  up_unmask_tmr();
+
   ticks = up_ts2tick(ts) + rdtscp();
 
   g_timer_active = 1;
@@ -310,8 +312,6 @@ int up_timer_start(const struct timespec *ts)
   write_msr(MSR_IA32_TSC_DEADLINE, ticks);
 
   g_goal_time = ticks;
-
-  up_unmask_tmr();
 
   up_tmr_sync_down();
   return OK;


### PR DESCRIPTION
## Summary
This commit fixed up_timer.

## Impact
x86_64 up_timer.

## Testing
Tested on x86_64 qemu/kvm.
