### PR TITLE
sched: There is no need to use sched_[un]lock

### DIFF
--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -66,6 +66,7 @@
 int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 {
   FAR char **envp = NULL;
+  irqstate_t flags;
   size_t envc = 0;
   size_t size;
   int ret = OK;
@@ -80,7 +81,7 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
        * environment may be shared.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Count the strings */
 
@@ -142,7 +143,7 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 
       group->tg_envp = envp;
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/sched/environ/env_getenv.c
+++ b/sched/environ/env_getenv.c
@@ -63,7 +63,10 @@ FAR char *getenv(FAR const char *name)
   FAR struct tcb_s *rtcb;
   FAR struct task_group_s *group;
   FAR char *pvalue = NULL;
+  irqstate_t flags;
   ssize_t ret = OK;
+
+  flags = enter_critical_section();
 
   /* Verify that a string was passed */
 
@@ -75,7 +78,6 @@ FAR char *getenv(FAR const char *name)
 
   /* Get a reference to the thread-private environ in the TCB. */
 
-  sched_lock();
   rtcb  = this_task();
   group = rtcb->group;
 
@@ -83,7 +85,7 @@ FAR char *getenv(FAR const char *name)
 
   if (group == NULL || (ret = env_findvar(group, name)) < 0)
     {
-      goto errout_with_lock;
+      goto errout;
     }
 
   /* It does!  Get the value sub-string from the name=value string */
@@ -94,18 +96,17 @@ FAR char *getenv(FAR const char *name)
       /* The name=value string has no '='  This is a bug! */
 
       ret = -EINVAL;
-      goto errout_with_lock;
+      goto errout;
     }
 
   /* Adjust the pointer so that it points to the value right after the '=' */
 
   pvalue++;
-  sched_unlock();
+  leave_critical_section(flags);
   return pvalue;
 
-errout_with_lock:
-  sched_unlock();
 errout:
+  leave_critical_section(flags);
   set_errno(-ret);
   return NULL;
 }

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -63,6 +63,7 @@ int unsetenv(FAR const char *name)
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct task_group_s *group = rtcb->group;
+  irqstate_t flags;
   ssize_t idx;
 
   DEBUGASSERT(group);
@@ -77,7 +78,7 @@ int unsetenv(FAR const char *name)
 
   /* Check if the variable exists */
 
-  sched_lock();
+  flags = enter_critical_section();
   if (group && (idx = env_findvar(group, name)) >= 0)
     {
       /* It does!  Remove the name=value pair from the environment. */
@@ -85,7 +86,7 @@ int unsetenv(FAR const char *name)
       env_removevar(group, idx);
     }
 
-  sched_unlock();
+  leave_critical_section(flags);
   return OK;
 }
 

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -272,20 +272,11 @@ static inline void nxtask_signalparent(FAR struct tcb_s *ctcb, int status)
 #ifdef HAVE_GROUP_MEMBERS
   DEBUGASSERT(ctcb && ctcb->group);
 
-  /* Keep things stationary throughout the following */
-
-  sched_lock();
-
   /* Send SIGCHLD to all members of the parent's task group */
 
   nxtask_sigchild(ctcb->group->tg_ppid, ctcb, status);
-  sched_unlock();
 #else
   FAR struct tcb_s *ptcb;
-
-  /* Keep things stationary throughout the following */
-
-  sched_lock();
 
   /* Get the TCB of the receiving, parent task.  We do this early to
    * handle multiple calls to nxtask_signalparent.
@@ -296,7 +287,6 @@ static inline void nxtask_signalparent(FAR struct tcb_s *ctcb, int status)
     {
       /* The parent no longer exists... bail */
 
-      sched_unlock();
       return;
     }
 
@@ -307,7 +297,6 @@ static inline void nxtask_signalparent(FAR struct tcb_s *ctcb, int status)
    */
 
   nxtask_sigchild(ptcb, ctcb, status);
-  sched_unlock();
 #endif
 }
 #else

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -320,19 +320,10 @@ pid_t nxtask_start_fork(FAR struct task_tcb_s *child)
 
   pid = child->cmn.pid;
 
-  /* Eliminate a race condition by disabling pre-emption.  The child task
-   * can be instantiated, but cannot run until we call waitpid().  This
-   * assures us that we cannot miss the death-of-child signal (only
-   * needed in the SMP case).
-   */
-
-  sched_lock();
-
   /* Activate the task */
 
   nxtask_activate((FAR struct tcb_s *)child);
 
-  sched_unlock();
   return pid;
 }
 


### PR DESCRIPTION
## Summary
purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance. 2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.
## Impact
sched

## Testing
arm64 arm

