### PR TITLE
makefile/clang: Compare versions for upward compatibility

### DIFF
--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -50,7 +50,7 @@ if(TOOLCHAIN_CLANG_CONFIG)
 
   if(CLANGVER STREQUAL "14.0")
     set(TOOLCHAIN_CLANG_CONFIG ${TOOLCHAIN_CLANG_CONFIG}_nosys)
-  elseif(CLANGVER STREQUAL "17.0")
+  elseif(CLANGVER STRGREATER_EQUAL "17.0")
     set(TOOLCHAIN_CLANG_OPTION -target)
     add_compile_options(--target=arm-none-eabi)
   else()

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -209,7 +209,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
       TOOLCHAIN_CLANG_CONFIG := $(TOOLCHAIN_CLANG_CONFIG)_nosys
     endif
 
-    ifeq ($(CLANGVER),17.0)
+    ifeq "17.0" "$(word 1, $(sort 17.0 $(CLANGVER)))"
       TOOLCHAIN_CLANG_OPTION = -target
       ARCHCPUFLAGS += --target=arm-none-eabi
     else


### PR DESCRIPTION
## Summary
1. The option also supports the latest version of ARM clang18
## Impact

## Testing

