### PR TITLE
libc/machine: Fix the error caused by tag kasan

### DIFF
--- a/libs/libc/machine/arm64/arch_elf.c
+++ b/libs/libc/machine/arm64/arch_elf.c
@@ -35,6 +35,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/bits.h>
 #include <nuttx/elf.h>
+#include <nuttx/mm/kasan.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -183,6 +184,9 @@ aarch64_insn_encode_immediate(enum insn_imm_type_e type,
 static uint64_t do_reloc(enum reloc_op_e op,
                          uintptr_t place, uint64_t val)
 {
+  val = (uint64_t)kasan_reset_tag((FAR const void *)val);
+  place = (uint64_t)kasan_reset_tag((FAR const void *)place);
+
   switch (op)
     {
       case RELOC_OP_ABS:


### PR DESCRIPTION
## Summary
1. Use address addition and subtraction, no longer as the return value of the address. Tags must be removed before calculation
## Impact

## Testing

