### PR TITLE
mm/sw_tags: No longer check for tags 0

### DIFF
--- a/mm/kasan/sw_tags.c
+++ b/mm/kasan/sw_tags.c
@@ -43,7 +43,7 @@
   (FAR void *)((((uint64_t)(addr)) & ~((uint64_t)0xff << KASAN_TAG_SHIFT)) | \
                (((uint64_t)(tag)) << KASAN_TAG_SHIFT))
 
-#define kasan_random_tag() (rand() % ((1 << (64 - KASAN_TAG_SHIFT)) - 1))
+#define kasan_random_tag() (1 + rand() % ((1 << (64 - KASAN_TAG_SHIFT)) - 1))
 
 #define KASAN_SHADOW_SCALE (sizeof(uintptr_t))
 
@@ -103,6 +103,11 @@ kasan_is_poisoned(FAR const void *addr, size_t size)
   uint8_t tag;
 
   tag = kasan_get_tag(addr);
+  if (tag == 0x00)
+    {
+      return false;
+    }
+
   p = kasan_mem_to_shadow(addr, size);
   if (p == NULL)
     {


### PR DESCRIPTION
## Summary
The variable tags of the module in the dynamic loading process is 0, and not checking can reduce a lot of modifications Let's take a simple example:
The address of the module's global variable does not contain a label. However, if the memory where the module is loaded is the heap area, label protection is performed after opening label kasan, but the address of the module's global variable does not contain a label, and once it is run, it will be detected by kasan and an error will be reported.
## Impact
None
## Testing
None

