### PR TITLE
arch/perf: modify the return value of up_perf_gettime to clock_t

### DIFF
--- a/arch/arm/src/armv7-a/arm_perf.c
+++ b/arch/arm/src/armv7-a/arm_perf.c
@@ -82,14 +82,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return cp15_pmu_rdccr();
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv7-m/arm_perf.c
+++ b/arch/arm/src/armv7-m/arm_perf.c
@@ -63,14 +63,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return getreg32(DWT_CYCCNT);
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv7-r/arm_perf.c
+++ b/arch/arm/src/armv7-r/arm_perf.c
@@ -82,14 +82,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return cp15_pmu_rdccr();
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv8-m/arm_perf.c
+++ b/arch/arm/src/armv8-m/arm_perf.c
@@ -63,14 +63,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return getreg32(DWT_CYCCNT);
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm/src/armv8-r/arm_perf.c
+++ b/arch/arm/src/armv8-r/arm_perf.c
@@ -74,14 +74,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return cp15_pmu_rdccr();
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/arm64/src/common/arm64_perf.c
+++ b/arch/arm64/src/common/arm64_perf.c
@@ -62,7 +62,7 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
 #ifdef CONFIG_ARCH_CLUSTER_PMU
   return pmu_get_cluccntr();
@@ -71,9 +71,10 @@ unsigned long up_perf_gettime(void)
 #endif
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
+  unsigned long cpu_freq = read_sysreg(cntfrq_el0);
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_perf.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_perf.c
@@ -60,7 +60,7 @@ void up_perf_init(void *arg)
  * Name: up_perf_gettime
  ****************************************************************************/
 
-unsigned long IRAM_ATTR up_perf_gettime(void)
+clock_t IRAM_ATTR up_perf_gettime(void)
 {
   return READ_CSR(CSR_PCCR_MACHINE);
 }
@@ -78,7 +78,7 @@ unsigned long up_perf_getfreq(void)
  * Name: up_perf_convert
  ****************************************************************************/
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
   ts->tv_sec  = elapsed / CYCLE_PER_SEC;
   elapsed    -= ts->tv_sec * CYCLE_PER_SEC;

--- a/arch/xtensa/src/common/xtensa_perf.c
+++ b/arch/xtensa/src/common/xtensa_perf.c
@@ -50,14 +50,14 @@ unsigned long up_perf_getfreq(void)
   return g_cpu_freq;
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
   return xtensa_getcount();
 }
 
-void up_perf_convert(unsigned long elapsed, struct timespec *ts)
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
-  unsigned long left;
+  clock_t left;
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -375,9 +375,9 @@ void up_perf_init(FAR void *arg)
   UNUSED(arg);
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
-  unsigned long ret = 0;
+  clock_t ret = 0;
 
   if (g_oneshot_lower != NULL)
     {
@@ -395,7 +395,7 @@ unsigned long up_perf_getfreq(void)
   return NSEC_PER_SEC;
 }
 
-void up_perf_convert(unsigned long elapsed, FAR struct timespec *ts)
+void up_perf_convert(clock_t elapsed, FAR struct timespec *ts)
 {
   clock_nsec2time(ts, elapsed);
 }

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -407,9 +407,9 @@ void up_perf_init(FAR void *arg)
   UNUSED(arg);
 }
 
-unsigned long up_perf_gettime(void)
+clock_t up_perf_gettime(void)
 {
-  unsigned long ret = 0;
+  clock_t ret = 0;
 
   if (g_timer.lower != NULL)
     {
@@ -424,8 +424,7 @@ unsigned long up_perf_getfreq(void)
   return USEC_PER_SEC;
 }
 
-void up_perf_convert(unsigned long elapsed,
-                     FAR struct timespec *ts)
+void up_perf_convert(clock_t elapsed, FAR struct timespec *ts)
 {
   clock_usec2time(ts, elapsed);
 }

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2831,9 +2831,9 @@ void arch_sporadic_resume(FAR struct tcb_s *tcb);
  ****************************************************************************/
 
 void up_perf_init(FAR void *arg);
-unsigned long up_perf_gettime(void);
+clock_t up_perf_gettime(void);
 unsigned long up_perf_getfreq(void);
-void up_perf_convert(unsigned long elapsed, FAR struct timespec *ts);
+void up_perf_convert(clock_t elapsed, FAR struct timespec *ts);
 
 /****************************************************************************
  * Name: up_show_cpuinfo

--- a/sched/clock/clock_perf.c
+++ b/sched/clock/clock_perf.c
@@ -94,7 +94,7 @@ void perf_init(void)
 clock_t perf_gettime(void)
 {
   FAR struct perf_s *perf = &g_perf;
-  unsigned long now = up_perf_gettime();
+  clock_t now = up_perf_gettime();
   irqstate_t flags = spin_lock_irqsave(&perf->lock);
   clock_t result;
 


### PR DESCRIPTION
## Summary
1. arch/perf: modify the return value of up_perf_gettime to clock_t
2. clock/perf: add critical section protection

## Impact
none

## Testing
sim
