### PR TITLE
sched/cpuload: fix SMP situation CPULOAD statistics are inaccurate

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1027,7 +1027,6 @@ config SCHED_CPULOAD_NONE
 
 config SCHED_CPULOAD_SYSCLK
 	bool "Use system clock"
-	depends on !SCHED_TICKLESS
 	---help---
 		If this option is enabled, the system clock is used for cpu load
 		measurement by default.
@@ -1077,18 +1076,17 @@ config SCHED_CPULOAD_CRITMONITOR
 
 endchoice
 
-if SCHED_CPULOAD_EXTCLK
-
 config SCHED_CPULOAD_TICKSPERSEC
-	int "External clock rate"
+	int "CPU load sampling clock frequency(HZ)"
 	default 100
 	---help---
-		If an external clock is used to drive the sampling for the CPU load
-		calculations, then this value must be provided.  This value provides
-		the rate of the external clock interrupts in units of ticks per
-		second.  The default value of 100 corresponds to a 100Hz clock.  NOTE:
+		CPU load sampling clock frequency, in HZ. Use sysclk clock source,
+		use wdt, EXTCLK clock source, use an external timer.
+		The default value of 100 corresponds to a 100Hz clock.  NOTE:
 		that 100Hz is the default frequency of the system time and, hence,
 		the worst possible choice in most cases.
+
+if SCHED_CPULOAD_EXTCLK
 
 choice
 	prompt "Select CPU load timer"

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -87,4 +87,8 @@ void clock_timer(void);
 
 void perf_init(void);
 
+#ifdef CONFIG_SCHED_CPULOAD_SYSCLK
+void cpuload_init(void);
+#endif
+
 #endif /* __SCHED_CLOCK_CLOCK_H */

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -231,6 +231,10 @@ void clock_initialize(void)
 
   perf_init();
 
+#ifdef CONFIG_SCHED_CPULOAD_SYSCLK
+  cpuload_init();
+#endif
+
   sched_trace_end();
 }
 

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -154,6 +154,59 @@ static void nxsched_critmon_cpuload(FAR struct tcb_s *tcb, clock_t current,
 #endif
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsched_critmon_cpuload
+ *
+ * Description:
+ *   Update the running time of all running threads when switching threads
+ *
+ * Input Parameters:
+ *   tcb   - The task that we are performing the load operations on.
+ *   current - The current time
+ *   tick - The ticks that we process in this cpuload.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
+static void nxsched_critmon_cpuload(FAR struct tcb_s *tcb, clock_t current,
+                                    clock_t tick)
+{
+  int i;
+  UNUSED(i);
+
+  /* Update the cpuload of the thread ready to be suspended */
+
+  nxsched_process_taskload_ticks(tcb, tick);
+
+  /* Update the cpuload of threads running on other CPUs */
+
+#  ifdef CONFIG_SMP
+  for (i = 0; i < CONFIG_SMP_NCPUS; i++)
+    {
+      FAR struct tcb_s *rtcb = current_task(i);
+
+      if (tcb->cpu == rtcb->cpu)
+        {
+          continue;
+        }
+
+      nxsched_process_taskload_ticks(rtcb, tick);
+
+      /* Update start time, avoid repeated statistics when the next call */
+
+      rtcb->run_start = current;
+    }
+#  endif
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 

--- a/sched/sched/sched_processtimer.c
+++ b/sched/sched/sched_processtimer.c
@@ -182,14 +182,6 @@ void nxsched_process_timer(void)
 
   clock_timer();
 
-#ifdef CONFIG_SCHED_CPULOAD_SYSCLK
-  /* Perform CPU load measurements (before any timer-initiated context
-   * switches can occur)
-   */
-
-  nxsched_process_cpuload();
-#endif
-
   /* Check if the currently executing task has exceeded its
    * timeslice.
    */

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -339,14 +339,6 @@ static clock_t nxsched_timer_process(clock_t ticks, clock_t elapsed,
   clock_update_wall_time();
 #endif
 
-#ifdef CONFIG_SCHED_CPULOAD_SYSCLK
-  /* Perform CPU load measurements (before any timer-initiated context
-   * switches can occur)
-   */
-
-  nxsched_process_cpuload_ticks(elapsed);
-#endif
-
   /* Check for operations specific to scheduling policy of the currently
    * active task.
    */


### PR DESCRIPTION
## Summary
1. sched/cpuload: fix SMP situation CPULOAD statistics are inaccurate
2. sched: fix the inaccurate cpuload statistics issue

## Impact

## Testing
sim
