### PR TITLE
sched/group: clear tcb group after group_release

### DIFF
--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -238,8 +238,16 @@ int nxsig_action(int signo, FAR const struct sigaction *act,
    * execution, no special precautions should be necessary.
    */
 
-  DEBUGASSERT(rtcb != NULL && rtcb->group != NULL);
+  DEBUGASSERT(rtcb != NULL);
+
   group = rtcb->group;
+
+  /* If the value of group is null, the task may have exited */
+
+  if (group == NULL)
+    {
+      return -EINVAL;
+    }
 
   /* Verify the signal number */
 


### PR DESCRIPTION
## Summary

nxsig_action will use tcb group when group release, so need clear tcb group after group_release.

[ap] dump_assert_info: Assertion failed : at file: signal/sig_action.c:205 task: ofonod process: Kernel 0xec89d5
[ap] sched_dumpstack: backtrace:
[ap] sched_dumpstack: [29] [<0x66e2e2>] backtrace_unwind+0x105/0x108
[ap] sched_dumpstack: [29] [<0x660272>] sched_backtrace+0x41/0x48
[ap] sched_dumpstack: [29] [<0x61c4dc>] sched_dumpstack+0x33/0x80
[ap] sched_dumpstack: [29] [<0x6023e4>] _assert+0x19b/0x39c
[ap] sched_dumpstack: [29] [<0x61b7e4>] __assert+0x7/0x10
[ap] sched_dumpstack: [29] [<0x6071a2>] nxsig_action+0x119/0x248
[ap] sched_dumpstack: [29] [<0x6072d8>] sigaction+0x7/0x24
[ap] sched_dumpstack: [29] [<0x66a072>] signal+0x4d/0x80
[ap] sched_dumpstack: [29] [<0x100fd36>] signalfd_file_close+0x35/0x60
[ap] sched_dumpstack: [29] [<0x64a7d8>] file_close+0x1b/0x44
[ap] sched_dumpstack: [29] [<0x649ac0>] files_putlist+0x2b/0x70
[ap] sched_dumpstack: [29] [<0x60491a>] group_leave+0x99/0xe4
[ap] sched_dumpstack: [29] [<0x605df8>] nxtask_exithook+0x4f/0xf4
[ap] sched_dumpstack: [29] [<0x603ca0>] _exit+0x33/0x3c
[ap] sched_dumpstack: [29] [<0x61ecf0>] abort+0x7/0xc

## Impact

task_exit

## Testing

BES board with ostest and monkey test pass