### PR TITLE
x64: modify addr limit to support 64 bits addr backtrace

### DIFF
--- a/arch/x86_64/src/intel64/intel64_regdump.c
+++ b/arch/x86_64/src/intel64/intel64_regdump.c
@@ -90,7 +90,7 @@ void backtrace(uint64_t rbp)
 
   for (i = 0; i < 16; i++)
     {
-      if ((rbp < 0x200000) || (rbp > 0xffffffff))
+      if ((rbp < 0x200000) || (rbp > 0xfffffffff))
         {
           break;
         }


### PR DESCRIPTION
## Summary
modify addr limit to support 64 bits addr backtrace
## Impact
no impact 
## Testing
ostest
