### PR TITLE
sched: fix nxsched_suspend_scheduler regression

### DIFF
--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -63,7 +63,7 @@ void nxsched_suspend_scheduler(FAR struct tcb_s *tcb)
 {
   /* Handle the task exiting case */
 
-  if (tcb != NULL)
+  if (tcb == NULL)
     {
       return;
     }


### PR DESCRIPTION
## Summary
sched: fix nxsched_suspend_scheduler regression
This commit fixes the regression from https://github.com/apache/nuttx/pull/13877

## Impact
sched

## Testing
ci 
