### PR TITLE
arch/x86_64:Add configuration to disable vectorization optimization

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -51,16 +51,20 @@ ifeq ($(CONFIG_FRAME_POINTER),y)
   ARCHOPTIMIZATION += -fno-omit-frame-pointer -fno-optimize-sibling-calls
 endif
 
+ifeq ($(CONFIG_ARCH_INTEL64_DISABLE_CET),y)
+  ARCHOPTIMIZATION += -fcf-protection=none
+endif
+
+ifeq ($(CONFIG_ARCH_INTEL64_DISABLE_VECTORIZE),y)
+  ARCHOPTIMIZATION += -fno-tree-vectorize
+endif
+
 ARCHCFLAGS += -fno-common -Wno-attributes
 ARCHCXXFLAGS += -fno-common -Wno-attributes -nostdinc++
 
 ARCHCPUFLAGS = -fno-pic -mcmodel=large -fno-stack-protector -mno-red-zone -mrdrnd
 ARCHPICFLAGS = -fPIC
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
-
-ifeq ($(CONFIG_ARCH_INTEL64_DISABLE_CET),y)
-  ARCHOPTIMIZATION += -fcf-protection=none
-endif
 
 # We have to use a cross-development toolchain under Cygwin because the native
 # Cygwin toolchains don't generate ELF binaries.

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -203,5 +203,9 @@ config ARCH_INTEL64_DISABLE_CET
 		It inserts the endbr64 instruction at the beginning of functions,
 		which may impact CPU branch prediction performance.
 
+config ARCH_INTEL64_DISABLE_VECTORIZE
+	bool "Disable vectorize completely"
+	---help---
+		Disable the compiler from vectorizing code optimization during compilation
 
 endif


### PR DESCRIPTION
## Summary
With aggresive optimization enabled (-O3), ostest FPU test will fail.This is because the compiler will generate additional vector instructions between subsequent up_fpucmp() calls (loop vectorization somewhere in usleep() call), which will consequently overwrite the expected FPU context (XMM registers).The compilation option -fno-tree-vectorize can avoid this issue.
## Impact
no impact
## Testing
ostest
