### PR TITLE
sched/pthread: There is no need to use sched_[un]lock

### DIFF
--- a/arch/arm/src/at32/at32_rtc_lowerhalf.c
+++ b/arch/arm/src/at32/at32_rtc_lowerhalf.c
@@ -511,6 +511,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -522,7 +523,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -552,7 +553,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
           ret = at32_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -565,6 +566,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
 #endif
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->id == 0);
   priv = (struct at32_lowerhalf_s *)lower;
@@ -575,7 +577,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in seconds */
 
@@ -585,7 +587,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_getdatetime(&time);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 
@@ -598,7 +600,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_gettime(&ts);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 #else
@@ -629,7 +631,7 @@ static int at32_setrelative(struct rtc_lowerhalf_s *lower,
           cbinfo->priv = NULL;
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -734,6 +736,7 @@ static int at32_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -744,14 +747,14 @@ static int at32_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id   = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = at32_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/cxd56xx/cxd56_rtc_lowerhalf.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc_lowerhalf.c
@@ -361,6 +361,7 @@ static int cxd56_setrelative(struct rtc_lowerhalf_s *lower,
   struct timespec ts;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT((RTC_ALARM0 <= alarminfo->id) &&
@@ -372,7 +373,7 @@ static int cxd56_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
 #if defined(CONFIG_RTC_HIRES)
       /* Get the higher resolution time */
@@ -380,7 +381,7 @@ static int cxd56_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_gettime(&ts);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 #else
@@ -406,7 +407,7 @@ static int cxd56_setrelative(struct rtc_lowerhalf_s *lower,
 
       ret = cxd56_setalarm(lower, &setalarm);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
+++ b/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
@@ -363,6 +363,7 @@ kinetis_setrelative(struct rtc_lowerhalf_s *lower,
   time_t seconds;
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA);
@@ -374,7 +375,7 @@ kinetis_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
 #if defined(CONFIG_RTC_DATETIME)
       /* Get the broken out time and convert to seconds */
@@ -382,7 +383,7 @@ kinetis_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_getdatetime(&time);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 
@@ -394,7 +395,7 @@ kinetis_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_gettime(&ts);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 #endif
@@ -421,7 +422,7 @@ kinetis_setrelative(struct rtc_lowerhalf_s *lower,
 
       ret = kinetis_setalarm(lower, &setalarm);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -498,6 +499,7 @@ static int kinetis_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA);
@@ -508,12 +510,12 @@ static int kinetis_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
       ret = kinetis_rtc_rdalarm(&ts);
 
       localtime_r((const time_t *)&ts.tv_sec,
                   (struct tm *)alarminfo->time);
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/lpc54xx/lpc54_rtc_lowerhalf.c
+++ b/arch/arm/src/lpc54xx/lpc54_rtc_lowerhalf.c
@@ -365,6 +365,7 @@ static int lpc54_setrelative(struct rtc_lowerhalf_s *lower,
   struct lpc54_cbinfo_s *cbinfo;
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->id == 0);
   priv = (struct lpc54_lowerhalf_s *)lower;
@@ -375,7 +376,7 @@ static int lpc54_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in seconds */
 
@@ -403,7 +404,7 @@ static int lpc54_setrelative(struct rtc_lowerhalf_s *lower,
           cbinfo->priv = NULL;
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
+++ b/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
@@ -430,6 +430,7 @@ static int max326_setrelative(struct rtc_lowerhalf_s *lower,
 #endif
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->id == 0);
   priv = (struct max326_lowerhalf_s *)lower;
@@ -440,7 +441,7 @@ static int max326_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in seconds */
 
@@ -450,7 +451,7 @@ static int max326_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_getdatetime(&time);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 
@@ -463,7 +464,7 @@ static int max326_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_gettime(&ts);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 #else
@@ -494,7 +495,7 @@ static int max326_setrelative(struct rtc_lowerhalf_s *lower,
           cbinfo->priv = NULL;
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/sama5/sam_mcan.c
+++ b/arch/arm/src/sama5/sam_mcan.c
@@ -3035,7 +3035,6 @@ static int mcan_send(struct can_dev_s *dev, struct can_msg_s *msg)
    * the MCAN device was opened O_NONBLOCK.
    */
 
-  sched_lock();
   mcan_buffer_reserve(priv);
 
   /* Get exclusive access to the MCAN peripheral */
@@ -3044,11 +3043,8 @@ static int mcan_send(struct can_dev_s *dev, struct can_msg_s *msg)
   if (ret < 0)
     {
       mcan_buffer_release(priv);
-      sched_unlock();
       return ret;
     }
-
-  sched_unlock();
 
   /* Get our reserved Tx FIFO/queue put index */
 

--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -3019,16 +3019,10 @@ static int mcan_send(struct can_dev_s *dev, struct can_msg_s *msg)
    * not full and cannot become full at least until we add our packet to
    * the FIFO.
    *
-   * We can't get exclusive access to MCAN resources here because that
-   * lock the MCAN while we wait for a free buffer.  Instead, the
-   * scheduler is locked here momentarily.  See discussion in
-   * mcan_buffer_reserve() for an explanation.
-   *
    * REVISIT: This needs to be extended in order to handler case where
    * the MCAN device was opened O_NONBLOCK.
    */
 
-  sched_lock();
   mcan_buffer_reserve(priv);
 
   /* Get exclusive access to the MCAN peripheral */
@@ -3037,11 +3031,8 @@ static int mcan_send(struct can_dev_s *dev, struct can_msg_s *msg)
   if (ret < 0)
     {
       mcan_buffer_release(priv);
-      sched_unlock();
       return ret;
     }
-
-  sched_unlock();
 
   /* Get our reserved Tx FIFO/queue put index */
 

--- a/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
@@ -515,6 +515,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -526,7 +527,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -556,7 +557,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
           ret = stm32_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -569,6 +570,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
 #endif
   struct timespec ts;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->id == 0);
   priv = (struct stm32_lowerhalf_s *)lower;
@@ -579,7 +581,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in seconds */
 
@@ -589,7 +591,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_getdatetime(&time);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 
@@ -602,7 +604,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_gettime(&ts);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 #else
@@ -633,7 +635,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
           cbinfo->priv = NULL;
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -738,6 +740,7 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -748,14 +751,14 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id   = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = stm32_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/stm32f7/stm32_qencoder.c
+++ b/arch/arm/src/stm32f7/stm32_qencoder.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/sensors/qencoder.h>
 
 #include <arch/board/board.h>
@@ -1022,6 +1023,7 @@ static int stm32_position(struct qe_lowerhalf_s *lower, int32_t *pos)
 {
   struct stm32_lowerhalf_s *priv = (struct stm32_lowerhalf_s *)lower;
 #ifdef HAVE_16BIT_TIMERS
+  irqstate_t flags;
   int32_t position;
   int32_t verify;
   uint32_t count;
@@ -1030,19 +1032,15 @@ static int stm32_position(struct qe_lowerhalf_s *lower, int32_t *pos)
 
   /* Loop until we are certain that no interrupt occurred between samples */
 
+  flags = spin_lock_irqsave(NULL);
   do
     {
-      /* Don't let another task preempt us until we get the measurement.
-       * The timer interrupt may still be processed.
-       */
-
-      sched_lock();
       position = priv->position;
       count    = stm32_getreg32(priv, STM32_GTIM_CNT_OFFSET);
       verify   = priv->position;
-      sched_unlock();
     }
   while (position != verify);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Return the position measurement */
 

--- a/arch/arm/src/stm32f7/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32f7/stm32_rtc_lowerhalf.c
@@ -433,6 +433,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -444,7 +445,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -474,7 +475,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
           ret = stm32_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -558,6 +559,7 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -568,14 +570,14 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = stm32_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/stm32h7/stm32_qencoder.c
+++ b/arch/arm/src/stm32h7/stm32_qencoder.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/sensors/qencoder.h>
 
 #include <arch/board/board.h>
@@ -1023,6 +1024,7 @@ static int stm32_position(struct qe_lowerhalf_s *lower, int32_t *pos)
 {
   struct stm32_lowerhalf_s *priv = (struct stm32_lowerhalf_s *)lower;
 #ifdef HAVE_16BIT_TIMERS
+  irqstate_t flags;
   int32_t position;
   int32_t verify;
   uint32_t count;
@@ -1031,19 +1033,15 @@ static int stm32_position(struct qe_lowerhalf_s *lower, int32_t *pos)
 
   /* Loop until we are certain that no interrupt occurred between samples */
 
+  flags = spin_lock_irqsave(NULL);
   do
     {
-      /* Don't let another task preempt us until we get the measurement.
-       * The timer interrupt may still be processed
-       */
-
-      sched_lock();
       position = priv->position;
       count    = stm32_getreg32(priv, STM32_GTIM_CNT_OFFSET);
       verify   = priv->position;
-      sched_unlock();
     }
   while (position != verify);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Return the position measurement */
 

--- a/arch/arm/src/stm32h7/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32h7/stm32_rtc_lowerhalf.c
@@ -434,6 +434,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -445,7 +446,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -475,7 +476,7 @@ static int stm32_setrelative(struct rtc_lowerhalf_s *lower,
           ret = stm32_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -559,6 +560,7 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -569,14 +571,14 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = stm32_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
@@ -399,6 +399,7 @@ stm32l4_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -410,7 +411,7 @@ stm32l4_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -440,7 +441,7 @@ stm32l4_setrelative(struct rtc_lowerhalf_s *lower,
           ret = stm32l4_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -525,6 +526,7 @@ static int stm32l4_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -535,14 +537,14 @@ static int stm32l4_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = stm32l4_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/arm/src/stm32wb/stm32wb_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32wb/stm32wb_rtc_lowerhalf.c
@@ -398,6 +398,7 @@ stm32wb_setrelative(struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -409,7 +410,7 @@ stm32wb_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       /* Get the current time in broken out format */
 
@@ -439,7 +440,7 @@ stm32wb_setrelative(struct rtc_lowerhalf_s *lower,
           ret = stm32wb_setalarm(lower, &setalarm);
         }
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -523,6 +524,7 @@ static int stm32wb_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
@@ -533,14 +535,14 @@ static int stm32wb_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = stm32wb_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/mips/src/pic32mx/pic32mx_gpio.c
+++ b/arch/mips/src/pic32mx/pic32mx_gpio.c
@@ -301,7 +301,6 @@ void pic32mx_dumpgpio(uint32_t pinset, const char *msg)
 
       /* The following requires exclusive access to the GPIO registers */
 
-      sched_lock();
       gpioinfo("IOPORT%c pinset: %04x base: %08x -- %s\n",
                'A' + port, pinset, base, msg);
       gpioinfo("   TRIS: %08x   PORT: %08x    LAT: %08x    ODC: %08x\n",
@@ -313,7 +312,6 @@ void pic32mx_dumpgpio(uint32_t pinset, const char *msg)
                getreg32(PIC32MX_IOPORT_CNCON),
                getreg32(PIC32MX_IOPORT_CNEN),
                getreg32(PIC32MX_IOPORT_CNPUE));
-      sched_unlock();
     }
 }
 #endif

--- a/arch/renesas/src/rx65n/rx65n_rtc_lowerhalf.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc_lowerhalf.c
@@ -416,6 +416,7 @@ static int rx65n_setrelative(struct rtc_lowerhalf_s *lower,
   struct timespec rtc_time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
 
@@ -425,7 +426,7 @@ static int rx65n_setrelative(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
 #if defined(CONFIG_RTC_DATETIME)
       /* Get the broken out time and convert to seconds */
@@ -434,7 +435,7 @@ static int rx65n_setrelative(struct rtc_lowerhalf_s *lower,
       ret = up_rtc_getdatetime(&time);
       if (ret < 0)
         {
-          sched_unlock();
+          leave_critical_section(flags);
           return ret;
         }
 
@@ -478,7 +479,7 @@ static int rx65n_setrelative(struct rtc_lowerhalf_s *lower,
 
       /* Remember the callback information */
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;
@@ -546,6 +547,7 @@ static int rx65n_rdalarm(struct rtc_lowerhalf_s *lower,
 {
   struct alm_rdalarm_s lowerinfo;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
   if (alarminfo->id >= 0)
@@ -554,14 +556,14 @@ static int rx65n_rdalarm(struct rtc_lowerhalf_s *lower,
        * about being suspended and working on an old time.
        */
 
-      sched_lock();
+      flags = enter_critical_section();
 
       lowerinfo.ar_id = alarminfo->id;
       lowerinfo.ar_time = alarminfo->time;
 
       ret = rx65n_rtc_rdalarm(&lowerinfo);
 
-      sched_unlock();
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/arch/z80/src/ez80/ez80_rtc_lowerhalf.c
+++ b/arch/z80/src/ez80/ez80_rtc_lowerhalf.c
@@ -405,6 +405,7 @@ static int ez80_setrelative(FAR struct rtc_lowerhalf_s *lower,
   struct tm time;
   time_t seconds;
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->id == 0);
 
@@ -412,7 +413,7 @@ static int ez80_setrelative(FAR struct rtc_lowerhalf_s *lower,
    * about being suspended and working on an old time.
    */
 
-  sched_lock();
+  flags = enter_critical_section();
 
   /* Get the current time in broken out format */
 
@@ -441,7 +442,7 @@ static int ez80_setrelative(FAR struct rtc_lowerhalf_s *lower,
       ret = ez80_setalarm(lower, &setalarm);
     }
 
-  sched_unlock();
+  leave_critical_section(flags);
   return ret;
 }
 #endif
@@ -516,6 +517,7 @@ static int ez80_rdalarm(FAR struct rtc_lowerhalf_s *lower,
                         FAR struct lower_rdalarm_s *alarminfo)
 {
   int ret = -EINVAL;
+  irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL &&
               alarminfo->time != NULL && alarminfo->id == 0);
@@ -524,9 +526,9 @@ static int ez80_rdalarm(FAR struct rtc_lowerhalf_s *lower,
    * about being suspended and working on an old time.
    */
 
-  sched_lock();
+  flags = enter_critical_section();
   ret = ez80_rtc_rdalarm((FAR struct tm *)alarminfo->time);
-  sched_unlock();
+  leave_critical_section(flags);
 
   return ret;
 }

--- a/boards/arm/cxd56xx/drivers/audio/cxd56_audio_dma.c
+++ b/boards/arm/cxd56xx/drivers/audio/cxd56_audio_dma.c
@@ -241,7 +241,6 @@ static CXD56_AUDIO_ECODE exec_dma_ch_sync_workaround(
       /* Lock interrupt */
 
       up_irq_disable();
-      sched_lock();
 
       /* Wait smp interrupt. */
 
@@ -255,7 +254,6 @@ static CXD56_AUDIO_ECODE exec_dma_ch_sync_workaround(
 
       if (timeout_cnt == DMA_TIMEOUT_CNT)
         {
-          sched_unlock();
           up_irq_enable();
           return CXD56_AUDIO_ECODE_DMA_SMP_TIMEOUT;
         }
@@ -270,7 +268,6 @@ static CXD56_AUDIO_ECODE exec_dma_ch_sync_workaround(
 
       /* Unlock interrupt */
 
-      sched_unlock();
       up_irq_enable();
 
       /* Wait for 1sample tramsfer. */

--- a/boards/arm/sam34/sam4s-xplained-pro/src/sam_wdt.c
+++ b/boards/arm/sam34/sam4s-xplained-pro/src/sam_wdt.c
@@ -183,8 +183,6 @@ int sam_watchdog_initialize(void)
   /* Start Kicker task */
 
 #if defined(CONFIG_WDT_THREAD)
-  sched_lock();
-
   int taskid = kthread_create(CONFIG_WDT_THREAD_NAME,
                               CONFIG_WDT_THREAD_PRIORITY,
                               CONFIG_WDT_THREAD_STACKSIZE,
@@ -193,7 +191,6 @@ int sam_watchdog_initialize(void)
   DEBUGASSERT(taskid > 0);
   UNUSED(taskid);
 
-  sched_unlock();
 #endif
   return OK;
 errout_with_dev:

--- a/boards/sparc/bm3803/xx3803/src/bm3803_wdt.c
+++ b/boards/sparc/bm3803/xx3803/src/bm3803_wdt.c
@@ -142,8 +142,6 @@ int xx3803_watchdog_initialize(void)
 
 #if defined(CONFIG_XX3803_WDG_THREAD)
 
-  sched_lock();
-
   /* Spawn wdog daemon thread */
 
   int taskid = kthread_create(CONFIG_XX3803_WDG_THREAD_NAME,
@@ -153,8 +151,6 @@ int xx3803_watchdog_initialize(void)
 
   DEBUGASSERT(taskid > 0);
   UNUSED(taskid);
-
-  sched_unlock();
 
 #endif /* CONFIG_XX3803_WDG_THREAD */
 

--- a/boards/sparc/s698pm/s698pm-dkit/src/s698pm_wdt.c
+++ b/boards/sparc/s698pm/s698pm-dkit/src/s698pm_wdt.c
@@ -142,8 +142,6 @@ int s698pm_dkit_watchdog_initialize(void)
 
 #if defined(CONFIG_S698PM_DKIT_WDG_THREAD)
 
-  sched_lock();
-
   /* Spawn wdog daemon thread */
 
   int taskid = kthread_create(CONFIG_S698PM_DKIT_WDG_THREAD_NAME,
@@ -153,8 +151,6 @@ int s698pm_dkit_watchdog_initialize(void)
 
   DEBUGASSERT(taskid > 0);
   UNUSED(taskid);
-
-  sched_unlock();
 
 #endif /* CONFIG_S698PM_DKIT_WDG_THREAD */
 

--- a/libs/libc/aio/aio_suspend.c
+++ b/libs/libc/aio/aio_suspend.c
@@ -92,13 +92,6 @@ int aio_suspend(FAR const struct aiocb * const list[], int nent,
 
   DEBUGASSERT(list);
 
-  /* Lock the scheduler so that no I/O events can complete on the worker
-   * thread until we set our wait set up.  Pre-emption will, of course, be
-   * re-enabled while we are waiting for the signal.
-   */
-
-  sched_lock();
-
   /* Check each entry in the list.  Break out of the loop if any entry
    * has completed.
    */
@@ -111,7 +104,6 @@ int aio_suspend(FAR const struct aiocb * const list[], int nent,
         {
           /* Yes, return success */
 
-          sched_unlock();
           return OK;
         }
     }
@@ -128,7 +120,6 @@ int aio_suspend(FAR const struct aiocb * const list[], int nent,
   sigaddset(&set, SIGPOLL);
 
   ret = sigtimedwait(&set, NULL, timeout);
-  sched_unlock();
   return ret >= 0 ? OK : ERROR;
 }
 

--- a/libs/libc/aio/lio_listio.c
+++ b/libs/libc/aio/lio_listio.c
@@ -160,10 +160,6 @@ static void lio_sighandler(int signo, siginfo_t *info, void *ucontext)
   DEBUGASSERT(sighand && sighand->list);
   aiocbp->aio_priv = NULL;
 
-  /* Prevent any asynchronous I/O completions while the signal handler runs */
-
-  sched_lock();
-
   /* Check if all of the pending I/O has completed */
 
   ret = lio_checkio(sighand->list, sighand->nent);
@@ -188,8 +184,6 @@ static void lio_sighandler(int signo, siginfo_t *info, void *ucontext)
 
       lib_free(sighand);
     }
-
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/libs/libc/signal/sig_pause.c
+++ b/libs/libc/signal/sig_pause.c
@@ -50,7 +50,6 @@ int sigpause(int signo)
 
   /* Get the current set of blocked signals */
 
-  sched_lock();
   ret = sigprocmask(SIG_SETMASK, NULL, &set);
   if (ret == OK)
     {
@@ -66,6 +65,5 @@ int sigpause(int signo)
       ret = sigsuspend(&set);
     }
 
-  sched_unlock();
   return ret;
 }

--- a/libs/libc/unistd/lib_chdir.c
+++ b/libs/libc/unistd/lib_chdir.c
@@ -109,7 +109,6 @@ int chdir(FAR const char *path)
    * support 'cd -' in NSH)
    */
 
-  sched_lock();
   oldpwd = getenv("PWD");
   if (!oldpwd)
     {
@@ -122,7 +121,6 @@ int chdir(FAR const char *path)
 
   ret = setenv("PWD", abspath, TRUE);
   lib_free(abspath);
-  sched_unlock();
 
   return ret;
 }

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -442,8 +442,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 #endif
     }
 
-  sched_lock();
-
   /* Return the thread information to the caller */
 
   if (thread != NULL)
@@ -454,8 +452,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   /* Then activate the task */
 
   nxtask_activate((FAR struct tcb_s *)ptcb);
-
-  sched_unlock();
 
   return OK;
 

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -150,10 +150,6 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
   DEBUGASSERT(mutex != NULL);
   if (mutex != NULL)
     {
-      /* Make sure that no unexpected context switches occur */
-
-      sched_lock();
-
       /* Error out if the mutex is already in an inconsistent state. */
 
       if ((mutex->flags & _PTHREAD_MFLAGS_INCONSISTENT) != 0)
@@ -201,8 +197,6 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
                 }
             }
         }
-
-      sched_unlock();
     }
 
   return ret;
@@ -234,10 +228,6 @@ int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex)
   DEBUGASSERT(mutex != NULL);
   if (mutex != NULL)
     {
-      /* Make sure that no unexpected context switches occur */
-
-      sched_lock();
-
       /* Error out if the mutex is already in an inconsistent state. */
 
       if ((mutex->flags & _PTHREAD_MFLAGS_INCONSISTENT) != 0)
@@ -269,8 +259,6 @@ int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex)
               pthread_mutex_add(mutex);
             }
         }
-
-      sched_unlock();
     }
 
   return ret;

--- a/sched/pthread/pthread_mutexconsistent.c
+++ b/sched/pthread/pthread_mutexconsistent.c
@@ -84,10 +84,6 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
     {
       pid_t pid;
 
-      /* Make sure the mutex is stable while we make the following checks. */
-
-      sched_lock();
-
       pid = mutex_get_holder(&mutex->mutex);
 
       /* Is the mutex available? */
@@ -133,8 +129,6 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
           mutex->flags &= _PTHREAD_MFLAGS_ROBUST;
           ret = OK;
         }
-
-      sched_unlock();
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/pthread/pthread_mutexdestroy.c
+++ b/sched/pthread/pthread_mutexdestroy.c
@@ -69,12 +69,6 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
     {
       pid_t pid;
 
-      /* Make sure the semaphore is stable while we make the following
-       * checks.
-       */
-
-      sched_lock();
-
       pid = mutex_get_holder(&mutex->mutex);
 
       /* Is the mutex available? */
@@ -141,8 +135,6 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
           status = mutex_destroy(&mutex->mutex);
           ret = ((status < 0) ? -status : OK);
         }
-
-      sched_unlock();
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -82,12 +82,6 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
       pid_t pid = mutex_get_holder(&mutex->mutex);
 #endif
 
-      /* Make sure the semaphore is stable while we make the following
-       * checks.  This all needs to be one atomic action.
-       */
-
-      sched_lock();
-
       /* Try to get the semaphore. */
 
       status = pthread_mutex_trytake(mutex);
@@ -163,8 +157,6 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
         {
           ret = status;
         }
-
-      sched_unlock();
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -115,7 +115,6 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
   irqstate_t     flags;
   int            ret = OK;
 
-  sched_lock();
   DEBUGASSERT(stcb != NULL && stcb->group != NULL);
 
   /* Find the group sigaction associated with this signal */
@@ -203,7 +202,6 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
         }
     }
 
-  sched_unlock();
   return ret;
 }
 


### PR DESCRIPTION
## Summary
purpose:
1 sched_lock is very time-consuming, and reducing its invocations can improve performance. 2 sched_lock is prone to misuse, and narrowing its scope of use is to prevent people from referencing incorrect code and using it

test:
We can use qemu for testing.
compiling
make distclean -j20; ./tools/configure.sh -l qemu-armv8a:nsh_smp ;make -j20 running
qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx

We have also tested this patch on other ARM hardware platforms.

## Impact
sched

## Testing
ci
