### PR TITLE
goldfish fix forget clear interrrpt, add in cmake

### DIFF
--- a/drivers/timers/CMakeLists.txt
+++ b/drivers/timers/CMakeLists.txt
@@ -85,4 +85,8 @@ if(CONFIG_CAPTURE)
   list(APPEND SRCS capture.c)
 endif()
 
+if(CONFIG_GOLDFISH_TIMER)
+  list(APPEND SRCS goldfish_timer.c)
+endif()
+
 target_sources(drivers PRIVATE ${SRCS})

--- a/drivers/timers/goldfish_timer.c
+++ b/drivers/timers/goldfish_timer.c
@@ -203,6 +203,7 @@ static int goldfish_timer_interrupt(int irq,
   flags = spin_lock_irqsave(&lower->lock);
 
   putreg32(1, lower->base + GOLDFISH_TIMER_CLEAR_ALARM);
+  putreg32(1, lower->base + GOLDFISH_TIMER_CLEAR_INTERRUPT);
 
   if (lower->callback != NULL)
     {


### PR DESCRIPTION
## Summary
goldfish fix forget clear interrrpt, add in cmake

## Impact
before fix, the goldfish timer possible keep loop in handler,
after fix, behavior like normal timer.

## Testing
CI-test, goldfish simulator armv7a.
