### PR TITLE
dump more information when CONFIG_MM_DUMP_DETAILS_ON_FAILURE enabled, flush log before coredump

### DIFF
--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -378,6 +378,9 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #  endif
 #  ifdef CONFIG_MM_DUMP_DETAILS_ON_FAILURE
       mm_memdump(heap, &dump);
+      mwarn("Dump leak memory(thread exit, but memory not free):\n");
+      dump.pid = PID_MM_LEAK;
+      mm_memdump(heap, &dump);
 #  endif
 #endif
 #ifdef CONFIG_MM_PANIC_ON_FAILURE

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -381,6 +381,16 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       mwarn("Dump leak memory(thread exit, but memory not free):\n");
       dump.pid = PID_MM_LEAK;
       mm_memdump(heap, &dump);
+#    ifdef CONFIG_MM_HEAP_MEMPOOL
+      mwarn("Dump block used by mempool expand/trunk:\n");
+      dump.pid = PID_MM_MEMPOOL;
+      mm_memdump(heap, &dump);
+#    endif
+#    if CONFIG_MM_BACKTRACE >= 0
+      mwarn("Dump allocated orphan nodes. (neighbor of free nodes):\n");
+      dump.pid = PID_MM_ORPHAN;
+      mm_memdump(heap, &dump);
+#    endif
 #  endif
 #endif
 #ifdef CONFIG_MM_PANIC_ON_FAILURE

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -742,7 +742,12 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
 
 #if defined(CONFIG_BOARD_COREDUMP_SYSLOG) || \
     defined(CONFIG_BOARD_COREDUMP_BLKDEV)
-      /* Dump core information */
+
+  /* Flush previous SYSLOG data before possible long time coredump */
+
+  syslog_flush();
+
+  /* Dump core information */
 
 #  ifdef CONFIG_BOARD_COREDUMP_FULL
   coredump_dump(INVALID_PROCESS_ID);


### PR DESCRIPTION
## Summary
dump more information when CONFIG_MM_DUMP_DETAILS_ON_FAILURE enabled,
flush log before coredump.

## Impact
more log when do diagnostic in mass-production projects.

## Testing
CI-test. cortex-m33 board.
