### PR TITLE
nuttx/can.h: support timestamp for can frame.

### DIFF
--- a/Documentation/components/drivers/character/can.rst
+++ b/Documentation/components/drivers/character/can.rst
@@ -27,6 +27,10 @@ Files supporting CAN can be found in the following locations:
    directory for the specific processor ``<architecture>`` and for
    the specific ``<chip>`` CAN peripheral devices.
 
+``struct timeval ch_ts``: This member variable that store in the
+``can_hdr_s`` structure depends on ``CONFIG_CAN_TIMESTAMP`` and
+is used to store the timestamp of the CAN message.
+
 **Usage Note**: When reading from the CAN driver multiple messages
 may be returned, depending on (1) the size the returned can
 messages, and (2) the size of the buffer provided to receive CAN
@@ -34,3 +38,4 @@ messages. *Never assume that a single message will be returned*...
 if you do this, *you will lose CAN data* under conditions where
 your read buffer can hold more than one small message. Below is an
 example about how you should think of the CAN read operation:
+**Examples**: ``drivers/can/mcp2515.c``.

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -33,6 +33,14 @@ config CAN_ERRORS
 		bit will be set in the CAN message and the following message payload
 		will include a more detailed description of certain errors.
 
+config CAN_TIMESTAMP
+	bool "CAN timestamp reporting"
+	default n
+	---help---
+		Support CAN timestamp reporting. if this option is selected then
+		CAN timestamp reporting is enabled. in the CAN message the ch_ts
+		member variable will record the timestamp of each frame.
+
 config CAN_FD
 	bool "CAN FD"
 	default n

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -44,6 +44,10 @@
 #  include <nuttx/wqueue.h>
 #endif
 
+#ifdef CONFIG_CAN_TIMESTAMP
+#include <sys/time.h>
+#endif
+
 #ifdef CONFIG_CAN
 
 /****************************************************************************
@@ -592,6 +596,9 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
   uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
+#ifdef CONFIG_CAN_TIMESTAMP
+  struct timeval ch_ts;       /* record the timestamp of each frame */
+#endif
 } end_packed_struct;
 
 #else
@@ -609,6 +616,9 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_esi    : 1; /* Error State Indicator */
 #endif
   uint8_t      ch_tcf    : 1; /* Tx confirmation flag */
+#ifdef CONFIG_CAN_TIMESTAMP
+  struct timeval ch_ts;       /* record the timestamp of each frame */
+#endif
 } end_packed_struct;
 #endif
 


### PR DESCRIPTION
## Summary
nuttx/can.h: support timestamp for can frame
and update "can.rst" file for add struct timeval ch_ts info.
## Impact
NULL.
## Testing
tested on the board with cortex-M architecture.
