### PR TITLE
x86/x86_64: change the build result from nuttx.elf to nuttx

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -176,8 +176,6 @@ ifeq ($(CONFIG_HOST_MACOS),y)
 AFLAGS += -Wa,--divide
 endif
 
-EXEEXT = .elf
-	
 LDFLAGS += -nostdlib -static
 
 # Loadable module definitions


### PR DESCRIPTION
Just sync with other architecture.

*Note: Please adhere to [Contributing Guidelines](../CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
change the build result from nuttx.elf to nuttx
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
ostest

