### PR TITLE
libm/newlib: remove -Wno-maybe-uninitialized

### DIFF
--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -116,6 +116,6 @@ endif
 
 CSRCS := $(shell echo $(notdir $(CSRCS) | tr " " "\n" | sort | uniq))
 
-CFLAGS += -Wno-undef -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-maybe-uninitialized
+CFLAGS += -Wno-undef -Wno-unused-but-set-variable -Wno-unused-const-variable
 CFLAGS += ${INCDIR_PREFIX}newlib/newlib/newlib/libm/common
 CFLAGS += -D__int32_t=int32_t -D__uint32_t=uint32_t -D_REENT=0 -D_REENT_THREAD_LOCAL=1


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](../CONTRIBUTING.md).*

## Summary

Remove not needed warning suppression. 

Since there's no warning presents now.


## Impact

No impact, CI check will confirm if there's warnings.

## Testing

Tested with internal CI and reports no warnings.



