### PR TITLE
arch/intel64_cpustart.c add missing spinlock include

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -29,8 +29,8 @@
 
 #include <arch/arch.h>
 #include <arch/irq.h>
+#include <arch/spinlock.h>
 #include <nuttx/arch.h>
-#include <nuttx/spinlock.h>
 
 #include "sched/sched.h"
 #include "init/init.h"


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](../CONTRIBUTING.md).*

## Summary
fixes gcc 14 error:

chip/intel64_cpustart.c:88:3: error: implicit declaration of function ‘SP_DMB’ [-Wimplicit-function-declaration]
   88 |   SP_DMB();

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
no impact
*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
ostest
