### PR TITLE
serial: use nxsig_tgkill instead of nxsig_kill

### DIFF
--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -352,7 +352,7 @@ void uart_recvchars_done(FAR uart_dev_t *dev)
 
   if (signo != 0)
     {
-      nxsig_kill(dev->pid, signo);
+      nxsig_tgkill(-1, dev->pid, signo);
     }
 #endif
 }

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -309,7 +309,7 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
   if (signo != 0)
     {
-      nxsig_kill(dev->pid, signo);
+      nxsig_tgkill(-1, dev->pid, signo);
     }
 #endif
 }


### PR DESCRIPTION
## Summary

serial: use nxsig_tgkill instead of nxsig_kill

Caused nxsig_tgkill is for the one thread, nxsig_kill for the group

## Impact

ctrl + c

## Testing

sim


