### PR TITLE
mm/Kconfig: fix build error when MM_BACKTRACE > 0 and disable mempool

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -241,7 +241,7 @@ config MM_HEAP_MEMPOOL_CHUNK_SIZE
 config MM_HEAP_MEMPOOL_BACKTRACE_SKIP
 	int "The skip depth of backtrace for mempool"
 	default 6
-	depends on MM_HEAP_MEMPOOL_THRESHOLD != 0 && MM_BACKTRACE > 0
+	depends on MM_BACKTRACE > 0
 	---help---
 		This number is the skipped backtrace depth for mempool.
 


### PR DESCRIPTION
## Summary
mempool is always be compiled, so when enable BACKTRACE but not enable memdpool, the MM_HEAP_MEMPOOL_BACKTRACE_SKIP is not defined mempool_add_backtrace() will compiled failed.

## Impact
mempool

## Testing
CI


