### PR TITLE
rpmsg_port_spi_slave: fix compile error when enable RPMSG_PORT_SPI_SL…

### DIFF
--- a/include/nuttx/rpmsg/rpmsg_port.h
+++ b/include/nuttx/rpmsg/rpmsg_port.h
@@ -56,7 +56,7 @@ struct rpmsg_port_config_s
   FAR void       *rxbuf;
 };
 
-#ifdef CONFIG_RPMSG_PORT_SPI
+#if defined(CONFIG_RPMSG_PORT_SPI) || defined(CONFIG_RPMSG_PORT_SPI_SLAVE)
 
 /* There are two gpios used for communication between two chips. At the SPI
  * master side, mreq is an output gpio pin which is used to notify the


### PR DESCRIPTION
struct rpmsg_port_spi_config_s needs to be included by both rpmsg_port_spi/rpmsg_port_spi_slave driver.

Change-Id: I4efd6037ab91f0fae1d7885f2df757d52314b5cb

## Summary

struct rpmsg_port_spi_config_s is used by rpmsg_port_spi_slave driver, but it is not included by CONFIG_RPMSG_PORT_SPI_SLAVE which will cause a build error when CONFIG_RPMSG_PORT_SPI_SLAVE is enabled but CONFIG_RPMSG_PORT_SPI is not.

## Impact

build success when only CONFIG_RPMSG_PORT_SPI_SLAVE.

## Testing

enable CONFIG_RPMSG_PORT_SPI_SLAVE but not CONFIG_RPMSG_PORT_SPI.


