### PR TITLE
arm_gicv2_dump: optimize gic dump

### DIFF
--- a/arch/arm/src/armv7-a/Kconfig
+++ b/arch/arm/src/armv7-a/Kconfig
@@ -17,6 +17,10 @@ config ARMV7A_HAVE_GICv2
 
 if ARMV7A_HAVE_GICv2
 
+config ARMV7A_GICv2_DUMP
+	bool "Dump the gic register"
+	default DEBUG_IRQ_INFO
+
 config ARMV7A_GIC_EOIMODE
 	bool "Enable GIC EOImode"
 	default n

--- a/arch/arm/src/armv7-a/arm_gicv2_dump.c
+++ b/arch/arm/src/armv7-a/arm_gicv2_dump.c
@@ -25,12 +25,23 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <syslog.h>
 #include <debug.h>
 
 #include "arm_internal.h"
 #include "gic.h"
 
-#if defined(CONFIG_ARMV7A_HAVE_GICv2) && defined(CONFIG_DEBUG_IRQ_INFO)
+#if defined(CONFIG_ARMV7A_HAVE_GICv2) && defined(CONFIG_ARMV7A_GICv2_DUMP)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_CPP_HAVE_VARARGS
+#  define gicdump(fmt, ...) syslog(LOG_ALERT, fmt, ##__VA_ARGS__)
+#else
+#  define gicdump(fmt, ...)
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -54,20 +65,20 @@
 
 static inline void arm_gic_dump_cpu(bool all, int irq, int nlines)
 {
-  irqinfo("  CPU Interface Registers:\n");
-  irqinfo("       ICR: %08x    PMR: %08x    BPR: %08x    IAR: %08x\n",
+  gicdump("  CPU Interface Registers:\n");
+  gicdump("       ICR: %08lx    PMR: %08lx    BPR: %08lx    IAR: %08lx\n",
           getreg32(GIC_ICCICR), getreg32(GIC_ICCPMR),
           getreg32(GIC_ICCBPR), getreg32(GIC_ICCIAR));
-  irqinfo("       RPR: %08x   HPIR: %08x   ABPR: %08x\n",
+  gicdump("       RPR: %08lx   HPIR: %08lx   ABPR: %08lx\n",
           getreg32(GIC_ICCRPR), getreg32(GIC_ICCHPIR),
           getreg32(GIC_ICCABPR));
-  irqinfo("      AIAR: %08x  AHPIR: %08x    IDR: %08x\n",
+  gicdump("      AIAR: %08lx  AHPIR: %08lx    IDR: %08lx\n",
           getreg32(GIC_ICCAIAR), getreg32(GIC_ICCAHPIR),
           getreg32(GIC_ICCIDR));
-  irqinfo("      APR1: %08x   APR2: %08x   APR3: %08x   APR4: %08x\n",
+  gicdump("      APR1: %08lx   APR2: %08lx   APR3: %08lx   APR4: %08lx\n",
           getreg32(GIC_ICCAPR1), getreg32(GIC_ICCAPR2),
           getreg32(GIC_ICCAPR3), getreg32(GIC_ICCAPR4));
-  irqinfo("    NSAPR1: %08x NSAPR2: %08x NSAPR3: %08x NSAPR4: %08x\n",
+  gicdump("    NSAPR1: %08lx NSAPR2: %08lx NSAPR3: %08lx NSAPR4: %08lx\n",
           getreg32(GIC_ICCNSAPR1), getreg32(GIC_ICCNSAPR2),
           getreg32(GIC_ICCNSAPR3), getreg32(GIC_ICCNSAPR4));
 }
@@ -95,7 +106,7 @@ static void arm_gic_dumpregs(uintptr_t regaddr, int nlines, int incr)
   incr <<= 2;
   for (i = 0; i < nlines; i += incr, regaddr += 16)
     {
-      irqinfo("         %08x %08x %08x %08x\n",
+      gicdump("         %08lx %08lx %08lx %08lx\n",
               getreg32(regaddr), getreg32(regaddr + 4),
               getreg32(regaddr + 8), getreg32(regaddr + 12));
     }
@@ -120,7 +131,7 @@ static void arm_gic_dumpregs(uintptr_t regaddr, int nlines, int incr)
 static inline void arm_gic_dump4(const char *name, uintptr_t regaddr,
                                  int nlines)
 {
-  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  gicdump("       %s[%08lx]\n", name, (unsigned long)regaddr);
   arm_gic_dumpregs(regaddr, nlines, 4);
 }
 
@@ -143,7 +154,7 @@ static inline void arm_gic_dump4(const char *name, uintptr_t regaddr,
 static inline void arm_gic_dump8(const char *name, uintptr_t regaddr,
                                  int nlines)
 {
-  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  gicdump("       %s[%08lx]\n", name, (unsigned long)regaddr);
   arm_gic_dumpregs(regaddr, nlines, 8);
 }
 
@@ -166,7 +177,7 @@ static inline void arm_gic_dump8(const char *name, uintptr_t regaddr,
 static inline void arm_gic_dump16(const char *name, uintptr_t regaddr,
                                   int nlines)
 {
-  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  gicdump("       %s[%08lx]\n", name, (unsigned long)regaddr);
   arm_gic_dumpregs(regaddr, nlines, 16);
 }
 
@@ -189,7 +200,7 @@ static inline void arm_gic_dump16(const char *name, uintptr_t regaddr,
 static inline void arm_gic_dump32(const char *name, uintptr_t regaddr,
                                   int nlines)
 {
-  irqinfo("       %s[%08lx]\n", name, (unsigned long)regaddr);
+  gicdump("       %s[%08lx]\n", name, (unsigned long)regaddr);
   arm_gic_dumpregs(regaddr, nlines, 32);
 }
 
@@ -211,8 +222,8 @@ static inline void arm_gic_dump32(const char *name, uintptr_t regaddr,
 
 static inline void arm_gic_dump_distributor(bool all, int irq, int nlines)
 {
-  irqinfo("  Distributor Registers:\n");
-  irqinfo("       DCR: %08x   ICTR: %08x   IIDR: %08x\n",
+  gicdump("  Distributor Registers:\n");
+  gicdump("       DCR: %08lx   ICTR: %08lx   IIDR: %08lx\n",
           getreg32(GIC_ICDDCR), getreg32(GIC_ICDICTR),
           getreg32(GIC_ICDIIDR));
 
@@ -231,25 +242,27 @@ static inline void arm_gic_dump_distributor(bool all, int irq, int nlines)
     }
   else
     {
-      irqinfo("       ISR: %08x   ISER: %08x   ISPR: %08x    SAR: %08x\n",
+      gicdump("       ISR: %08lx   ISER: %08lx   ISPR: %08lx"
+              "    SAR: %08lx\n",
               getreg32(GIC_ICDISR(irq)), getreg32(GIC_ICDISER(irq)),
               getreg32(GIC_ICDISPR(irq)), getreg32(GIC_ICDSAR(irq)));
-      irqinfo("       IPR: %08x   IPTR: %08x   ICFR: %08x  SPISR: %08x\n",
+      gicdump("       IPR: %08lx   IPTR: %08lx   ICFR: %08lx"
+              "  SPISR: %08lx\n",
               getreg32(GIC_ICDIPR(irq)), getreg32(GIC_ICDIPTR(irq)),
               getreg32(GIC_ICDICFR(irq)), getreg32(GIC_ICDSPISR(irq)));
-      irqinfo("     NSACR: %08x   SCPR: %08x\n",
+      gicdump("     NSACR: %08lx   SCPR: %08lx\n",
               getreg32(GIC_ICDNSACR(irq)), getreg32(GIC_ICDSCPR(irq)));
     }
 
-  irqinfo("       PIDR[%08lx]:\n", (unsigned long)GIC_ICDPIDR(0));
-  irqinfo("         %08x %08x %08x %08x\n",
+  gicdump("       PIDR[%08lx]:\n", (unsigned long)GIC_ICDPIDR(0));
+  gicdump("         %08lx %08lx %08lx %08lx\n",
           getreg32(GIC_ICDPIDR(0)), getreg32(GIC_ICDPIDR(1)),
           getreg32(GIC_ICDPIDR(2)), getreg32(GIC_ICDPIDR(3)));
-  irqinfo("         %08x %08x %08x %08x\n",
+  gicdump("         %08lx %08lx %08lx\n",
           getreg32(GIC_ICDPIDR(4)), getreg32(GIC_ICDPIDR(5)),
           getreg32(GIC_ICDPIDR(6)));
-  irqinfo("       CIDR[%08lx]:\n", (unsigned long)GIC_ICDCIDR(0));
-  irqinfo("         %08x %08x %08x %08x\n",
+  gicdump("       CIDR[%08lx]:\n", (unsigned long)GIC_ICDCIDR(0));
+  gicdump("         %08lx %08lx %08lx %08lx\n",
           getreg32(GIC_ICDCIDR(0)), getreg32(GIC_ICDCIDR(1)),
           getreg32(GIC_ICDCIDR(2)), getreg32(GIC_ICDCIDR(3)));
 }
@@ -280,15 +293,15 @@ void arm_gic_dump(const char *msg, bool all, int irq)
 
   if (all)
     {
-      irqinfo("GIC: %s NLINES=%u\n", msg, nlines);
+      gicdump("GIC: %s NLINES=%u\n", msg, nlines);
     }
   else
     {
-      irqinfo("GIC: %s IRQ=%d\n", msg, irq);
+      gicdump("GIC: %s IRQ=%d\n", msg, irq);
     }
 
   arm_gic_dump_cpu(all, irq, nlines);
   arm_gic_dump_distributor(all, irq, nlines);
 }
 
-#endif /* CONFIG_ARMV7A_HAVE_GICv2 && CONFIG_DEBUG_IRQ_INFO */
+#endif /* CONFIG_ARMV7A_HAVE_GICv2 && CONFIG_ARMV7A_GICv2_DUMP */

--- a/arch/arm/src/armv7-a/gic.h
+++ b/arch/arm/src/armv7-a/gic.h
@@ -872,7 +872,7 @@ int arm_smp_sched_handler(int irq, void *context, void *arg);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_IRQ_INFO
+#ifdef CONFIG_ARMV7A_GICv2_DUMP
 void arm_gic_dump(const char *msg, bool all, int irq);
 #else
 #  define arm_gic_dump(msg, all, irq)


### PR DESCRIPTION
## Summary
1. Add config CONFIG_ARMV7A_GICv2_DUMP to control gic dump, because irqinfo introduce too much other log;
2. Change the log api from irqinfo() to syslog(), syslog not append the function name in the log, so the gic dump format will not be destoried.

## Impact
ARMV7A GIC Debug Dump

## Testing
qemu armv7a


