### PR TITLE
Fix system crash when set CONFIG_PRIORITY_INHERITANCE=y

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -601,7 +601,7 @@ void nxsem_destroyholder(FAR sem_t *sem)
 #else
   /* There may be an issue if there are multiple holders of the semaphore. */
 
-  DEBUGASSERT(sem->holder.htcb == NULL);
+  DEBUGASSERT(sem->holder.htcb == NULL || sem->holder.htcb == this_task());
 
 #endif
 

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -319,7 +319,7 @@ static int nxsem_boostholderprio(FAR struct semholder_s *pholder,
    * because the thread is already running at a sufficient priority.
    */
 
-  if (rtcb->sched_priority > htcb->sched_priority)
+  if (rtcb && htcb && rtcb->sched_priority > htcb->sched_priority)
     {
       /* Raise the priority of the holder of the semaphore.  This
        * cannot cause a context switch because we have preemption
@@ -757,14 +757,13 @@ void nxsem_release_holder(FAR sem_t *sem)
               return;
             }
         }
-
-      /* The current task is not a holder */
-
-      DEBUGPANIC();
 #else
       pholder = &sem->holder;
-      DEBUGASSERT(pholder->htcb == rtcb);
-      nxsem_freeholder(sem, pholder);
+      if (pholder->htcb)
+        {
+          DEBUGASSERT(pholder->htcb == rtcb);
+          nxsem_freeholder(sem, pholder);
+        }
 #endif
     }
 }


### PR DESCRIPTION
## Summary

Fix system crash when set CONFIG_PRIORITY_INHERITANCE=y

1.
    set CONFIG_PRIORITY_INHERITANCE=y
    set CONFIG_SEM_PREALLOCHOLDERS=0 or CONFIG_SEM_PREALLOCHOLDERS=8
    
```
        #24 0x4dcab71 in __assert assert/lib_assert.c:37
        #25 0x4d6b0e9 in nxsem_destroyholder semaphore/sem_holder.c:602
        #26 0x4d80cf7 in nxsem_destroy semaphore/sem_destroy.c:80
        #27 0x4d80db9 in sem_destroy semaphore/sem_destroy.c:120
        #28 0x4dcb077 in nxmutex_destroy misc/lib_mutex.c:122
        #29 0x4dc6611 in pipecommon_freedev pipes/pipe_common.c:117
        #30 0x4dc7fdc in pipecommon_close pipes/pipe_common.c:397
        #31 0x4ed4f6d in file_close vfs/fs_close.c:78
        #32 0x6a91133 in local_free local/local_conn.c:184
        #33 0x6a92a9c in local_release local/local_release.c:129
        #34 0x6a91d1a in local_subref local/local_conn.c:271
        #35 0x6a75767 in local_close local/local_sockif.c:797
        #36 0x4e978f6 in psock_close socket/net_close.c:102
        #37 0x4eed1b9 in sock_file_close socket/socket.c:115
        #38 0x4ed4f6d in file_close vfs/fs_close.c:78
        #39 0x4ed1459 in nx_close_from_tcb inode/fs_files.c:754
        #40 0x4ed1501 in nx_close inode/fs_files.c:781
        #41 0x4ed154a in close inode/fs_files.c:819
        #42 0x6bcb9ce in property_get kvdb/client.c:307
        #43 0x6bcd465 in property_get_int32 kvdb/common.c:270
        #44 0x5106c9a in tz_offset_restore app/miwear_bluetooth.c:745
        #45 0x510893f in miwear_bluetooth_main app/miwear_bluetooth.c:1033
        #46 0x4dcf5c8 in nxtask_startup sched/task_startup.c:70
        #47 0x4d70873 in nxtask_start task/task_start.c:134
        #48 0x4e04a07 in pre_start sim/sim_initialstate.c:52
```

2.
    set CONFIG_PRIORITY_INHERITANCE=y
    set CONFIG_SEM_PREALLOCHOLDERS=0
    
```
semaphore/sem_holder.c:320:34: runtime error: member access within null pointer of type 'struct tcb_s'
        #0 0xd8b540 in nxsem_boostholderprio semaphore/sem_holder.c:320
        #1 0xd8c1cf in nxsem_boost_priority semaphore/sem_holder.c:703
        #2 0xda5dfa in nxsem_wait semaphore/sem_wait.c:145
        #3 0xda61d9 in nxsem_wait_uninterruptible semaphore/sem_wait.c:248
        #4 0x12f2477 in media_service_thread0 /home/ligd/platform/dev/apps/examples/hello/hello_main.c:44
        #5 0x1204154 in pthread_startup pthread/pthread_create.c:59
        #6 0x1cd906f in pthread_start pthread/pthread_create.c:139
        #7 0xe72fcb in pre_start sim/sim_initialstate.c:52
```


## Impact

sem when CONFIG_PRIORITY_INHERITANCE=y

## Testing

sim/nsh