### PR TITLE
sim: fix crash caused by function recursion

### DIFF
--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -112,6 +112,7 @@ void up_irq_enable(void);
  * Inline functions
  ****************************************************************************/
 
+noinstrument_function
 static inline_function xcpt_reg_t *up_current_regs(void)
 {
 #ifdef CONFIG_SMP


### PR DESCRIPTION
## Summary
114 up_interrupt_context () at /home/zhhyu/source/vela/dev/nuttx/include/arch/irq.h:163
115 stack_monitor_enter (this_fn=0x400145dc <up_current_regs>, call_site=0x4002d5c7 <__cyg_profile_func_enter+120>, arg=0x0) at instrument/stack_monitor.c:63
116 0x000000004002d5c7 in __cyg_profile_func_enter (this_fn=0x400145dc <up_current_regs>, call_site=0x4002d5c7 <__cyg_profile_func_enter+120>) at misc/lib_instrument.c:68
117 0x00000000400156c7 in up_current_regs () at instrument/stack_monitor.c:62
118 up_interrupt_context () at /home/zhhyu/source/vela/dev/nuttx/include/arch/irq.h:163
119 stack_monitor_enter (this_fn=0x400145dc <up_current_regs>, call_site=0x4002d5c7 <__cyg_profile_func_enter+120>, arg=0x0) at instrument/stack_monitor.c:63
120 0x000000004002d5c7 in __cyg_profile_func_enter (this_fn=0x400145dc <up_current_regs>, call_site=0x4002d5c7 <__cyg_profile_func_enter+120>) at misc/lib_instrument.c:68
121 0x00000000400156c7 in up_current_regs () at instrument/stack_monitor.c:62 
...

## Impact

## Testing
sim:local


