### PR TITLE
move "#define STRINGIFY(x)" to nuttx/macro.h

### DIFF
--- a/arch/arm64/include/arch.h
+++ b/arch/arm64/include/arch.h
@@ -34,7 +34,7 @@
 #ifndef __ASSEMBLY__
 #  include <stdint.h>
 #  include <stddef.h>
-#  include <nuttx/nuttx.h>
+#  include <nuttx/macro.h>
 #endif
 
 /****************************************************************************

--- a/arch/xtensa/src/common/xtensa_saveusercontext.c
+++ b/arch/xtensa/src/common/xtensa_saveusercontext.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
-#include <nuttx/nuttx.h>
+#include <nuttx/macro.h>
 
 #include <string.h>
 

--- a/include/nuttx/macro.h
+++ b/include/nuttx/macro.h
@@ -136,5 +136,10 @@
 #define FOREACH_ARG(action, ...) \
         FOREACH_ARG_(action, GET_ARG_COUNT(__VA_ARGS__), ##__VA_ARGS__)
 
+/* Stringify the arguments */
+
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x)  STRINGIFY_(x)
+
 #endif /* __INCLUDE_NUTTX_MACRO_H */
 

--- a/include/nuttx/nuttx.h
+++ b/include/nuttx/nuttx.h
@@ -78,9 +78,4 @@
 #define container_of(ptr, type, member) \
   ((type *)((uintptr_t)(ptr) - offsetof(type, member)))
 
-/* Stringify the arguments */
-
-#define STRINGIFY_(x) #x
-#define STRINGIFY(x)  STRINGIFY_(x)
-
 #endif /* __INCLUDE_NUTTX_NUTTX_H */

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -36,7 +36,7 @@
 #include <nuttx/board.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/init.h>
-#include <nuttx/nuttx.h>
+#include <nuttx/macro.h>
 #include <nuttx/symtab.h>
 #include <nuttx/trace.h>
 #include <nuttx/wqueue.h>


### PR DESCRIPTION
"#define STRINGIFY(x)" conflicts with https://github.com/mborgerding/kissfft define