### PR TITLE
mm/sw_tags: add config for no longer checking for tags 0

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -326,6 +326,12 @@ config MM_KASAN_DISABLE_WRITES_CHECK
 	---help---
 		This option disable kasan writes check.
 
+config MM_KASAN_SKIP_ZERO_TAGS
+	bool "Enable skip check zero tags"
+	default LIBC_MODLIB
+	---help---
+		This option enables not checking for zero tags.
+
 config MM_KASAN_GLOBAL
 	bool "Enable global data check"
 	depends on MM_KASAN_ALL

--- a/mm/kasan/sw_tags.c
+++ b/mm/kasan/sw_tags.c
@@ -43,7 +43,7 @@
   (FAR void *)((((uint64_t)(addr)) & ~((uint64_t)0xff << KASAN_TAG_SHIFT)) | \
                (((uint64_t)(tag)) << KASAN_TAG_SHIFT))
 
-#define kasan_random_tag() (rand() % ((1 << (64 - KASAN_TAG_SHIFT)) - 1))
+#define kasan_random_tag() (1 + rand() % ((1 << (64 - KASAN_TAG_SHIFT)) - 2))
 
 #define KASAN_SHADOW_SCALE (sizeof(uintptr_t))
 
@@ -103,6 +103,14 @@ kasan_is_poisoned(FAR const void *addr, size_t size)
   uint8_t tag;
 
   tag = kasan_get_tag(addr);
+
+#ifdef CONFIG_MM_KASAN_SKIP_ZERO_TAGS
+  if (tag == 0)
+    {
+      return false;
+    }
+#endif
+
   p = kasan_mem_to_shadow(addr, size);
   if (p == NULL)
     {


### PR DESCRIPTION
## Summary
When dynamically loading, the read-only data of arm64 architecture is accessed through PC offset. When opening the tag kasan, because the PC value does not have a tag, accessing the read-only data will be detected with a tag mismatch error.
## Impact
No
## Testing
No
