### PR TITLE
task: fix cu assert when use ctrl + c

### DIFF
--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -130,6 +130,15 @@ int nxtask_terminate(pid_t pid)
 
   dtcb->flags |= TCB_FLAG_EXIT_PROCESSING;
 
+  /* Perform common task termination logic.  We need to do
+   * this as early as possible so that higher level clean-up logic
+   * can run in a healthy tasking environment.
+   *
+   * I suppose EXIT_SUCCESS is an appropriate return value???
+   */
+
+  nxtask_exithook(dtcb, EXIT_SUCCESS);
+
   /* Remove dtcb from tasklist, let remove_readtorun() do the job */
 
   task_state = dtcb->task_state;
@@ -169,16 +178,8 @@ int nxtask_terminate(pid_t pid)
 
   dtcb->task_state = task_state;
 
-  /* Perform common task termination logic.  We need to do
-   * this as early as possible so that higher level clean-up logic
-   * can run in a healthy tasking environment.
-   *
-   * I suppose EXIT_SUCCESS is an appropriate return value???
-   */
-
-  nxtask_exithook(dtcb, EXIT_SUCCESS);
-
   leave_critical_section(flags);
+
   /* Since all tasks pass through this function as the final step in their
    * exit sequence, this is an appropriate place to inform any
    * instrumentation layer that the task no longer exists.


### PR DESCRIPTION
## Summary

task: fix cu assert when use ctrl + c

Backtrace:
 backtrace_unwind+0x1da/0x1dc
 sched_backtrace+0x1c/0x30
 sched_dumpstack+0x20/0x68
 _assert+0x1dc/0x45c
 __assert+0x8/0x10
 nxsem_recover+0x46/0x50
 nxtask_recover+0x14/0x20
 nxtask_exithook+0x14/0x8c
 nxtask_terminate+0x2c/0x50
 pthread_cancel+0x44/0x74
 cu_main+0x26a/0x400
 nxtask_startup+0x14/0x28
 nxtask_start+0x4a/0x64

cu have two threads: cu & listener
```
cu thread
receive ctrl+c
pthread_cancel()
 nxtask_terminate()
   enter_critical_section()
   nxsched_remove_readytorun(listener)
   keep task state to WAIT
   leave_critical_section()
                                    UART RX IRQ happens
                                    sem_post(listener)
                                      remove the sem waitlist failed
                                      but semcount++
   nxtask_recover(listener)
    nxsem_recover(listener)
    semcount < 0 assert failed
```

Resolve:
Swap the nxtask_recover() & nxsched_remove_readytorun()


## Impact

nxtask_terminate 

## Testing

vela boards & sim


