### PR TITLE
rpmsg_sockif: add some modifaction for rpsocket

### DIFF
--- a/include/netpacket/rpmsg.h
+++ b/include/netpacket/rpmsg.h
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 #define RPMSG_SOCKET_CPU_SIZE           16
-#define RPMSG_SOCKET_NAME_SIZE          16
+#define RPMSG_SOCKET_NAME_SIZE          108
 
 /****************************************************************************
  * Public Type Definitions

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -120,7 +120,6 @@ struct rpmsg_socket_conn_s
   FAR struct rpmsg_socket_conn_s *next;
 
   /* server listen-scoket listening: backlog > 0;
-   * server listen-scoket closed: backlog = -1;
    * others: backlog = 0;
    */
 
@@ -825,11 +824,6 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
   FAR struct rpmsg_socket_conn_s *server = psock->s_conn;
   int ret = 0;
 
-  if (server->backlog == -1)
-    {
-      return -ECONNRESET;
-    }
-
   if (!_SS_ISLISTENING(server->sconn.s_flags))
     {
       return -EINVAL;
@@ -875,11 +869,6 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
           else
             {
               ret = net_sem_wait(&server->recvsem);
-              if (server->backlog == -1)
-                {
-                  ret = -ECONNRESET;
-                }
-
               if (ret < 0)
                 {
                   break;
@@ -930,12 +919,6 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
       if (_SS_ISLISTENING(conn->sconn.s_flags))
         {
-          if (conn->backlog == -1)
-            {
-              ret = -ECONNRESET;
-              goto errout;
-            }
-
           if (conn->next)
             {
               eventset |= POLLIN;

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -334,7 +334,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
 
   if (head->cmd == RPMSG_SOCKET_CMD_SYNC)
     {
-      nxmutex_lock(&conn->recvlock);
+      nxmutex_lock(&conn->sendlock);
       conn->sendsize = head->size;
       conn->cred.pid = head->pid;
       conn->cred.uid = head->uid;
@@ -346,7 +346,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
 
       rpmsg_socket_post(&conn->sendsem);
       rpmsg_socket_poll_notify(conn, POLLOUT);
-      nxmutex_unlock(&conn->recvlock);
+      nxmutex_unlock(&conn->sendlock);
     }
   else if (head->cmd == RPMSG_SOCKET_CMD_DATA)
     {
@@ -764,10 +764,10 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
       return ret;
     }
 
-  nxmutex_lock(&conn->recvlock);
+  nxmutex_lock(&conn->sendlock);
   if (conn->sendsize == 0)
     {
-      nxmutex_unlock(&conn->recvlock);
+      nxmutex_unlock(&conn->sendlock);
       if (_SS_ISNONBLOCK(conn->sconn.s_flags))
         {
           return -EINPROGRESS;
@@ -788,7 +788,7 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
     }
   else
     {
-      nxmutex_unlock(&conn->recvlock);
+      nxmutex_unlock(&conn->sendlock);
     }
 
   return ret;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](../CONTRIBUTING.md).*

## Summary
1.  add rpmsg_socket_ept_release for free connection
     to  Fix possible use-after-free issues when closing

2.  sendsize should be protected by sendlock

3.  remove backlog=-1 because patch1 has removed

4. Minor cleanups
  Simplify the message process in rpmsg_socket_send_single and fix the style issue

5. use hash to handle rp_name
   expand the user's rpname size
   hash when exceed RPMSG_SOCKET_NAME_LEN due to the limitation of eptname

## Impact

none

## Testing

sim


