### PR TITLE
Update esptool version on docs and build system

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3-legacy/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3-legacy/index.rst
@@ -90,7 +90,7 @@ Building and flashing
 
 First make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 Configure the NuttX project: ``./tools/configure.sh esp32c3-devkit:nsh``
 Run ``make`` to build the project.  Note that the conversion mentioned above is

--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -106,7 +106,7 @@ Building and flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32-C3 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 Configure the NuttX project: ``./tools/configure.sh esp32c3-generic:nsh``
 Run ``make`` to build the project.  Note that the conversion mentioned above is

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -105,7 +105,7 @@ Building and flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32-C6 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 Configure the NuttX project: ``./tools/configure.sh esp32c6-devkitc:nsh``
 Run ``make`` to build the project.  Note that the conversion mentioned above is

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -105,7 +105,7 @@ Building and flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert
 the ELF to a compatible ESP32-H2 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 Configure the NuttX project: ``./tools/configure.sh esp32h2-devkit:nsh``
 Run ``make`` to build the project.  Note that the conversion mentioned above is

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -129,7 +129,7 @@ Building and Flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert the ELF to a
 compatible ESP32 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 It's a two-step process where the first converts the ELF file into an ESP32 compatible binary
 and the second flashes it to the board. These steps are included in the build system and it is
@@ -573,7 +573,7 @@ Prerequisites
 First of all, we need to install ``imgtool`` (a MCUboot utility application to manipulate binary
 images) and ``esptool`` (the ESP32 toolkit)::
 
-    $ pip install imgtool esptool==4.8.dev4
+    $ pip install imgtool esptool
 
 We also need to make sure that the python modules are added to ``PATH``::
 

--- a/Documentation/platforms/xtensa/esp32s2/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/index.rst
@@ -122,7 +122,7 @@ Building and Flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert the ELF to a
 compatible ESP32-S2 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 It's a two-step process where the first converts the ELF file into an ESP32-S2 compatible binary
 and the second flashes it to the board. These steps are included in the build system and it is
@@ -457,7 +457,7 @@ Prerequisites
 First of all, we need to install ``imgtool`` (a MCUboot utility application to manipulate binary
 images) and ``esptool`` (the ESP32-S2 toolkit)::
 
-    $ pip install imgtool esptool==4.8.dev4
+    $ pip install imgtool esptool
 
 We also need to make sure that the python modules are added to ``PATH``::
 

--- a/Documentation/platforms/xtensa/esp32s3/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/index.rst
@@ -129,7 +129,7 @@ Building and Flashing
 
 First, make sure that ``esptool.py`` is installed.  This tool is used to convert the ELF to a
 compatible ESP32-S3 image and to flash the image into the board.
-It can be installed with: ``pip install esptool==4.8.dev4``.
+It can be installed with: ``pip install esptool``.
 
 It's a two-step process where the first converts the ELF file into an ESP32-S3 compatible binary
 and the second flashes it to the board. These steps are included in the build system and it is

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -387,7 +387,7 @@ RUN pip3 install cmake-format
 RUN pip3 install cvt2utf
 # Install pytest
 RUN pip3 install cxxfilt
-RUN pip3 install esptool==4.8.dev4
+RUN pip3 install esptool
 RUN pip3 install imgtool
 RUN pip3 install kconfiglib
 RUN pip3 install pexpect==4.8.0

--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -213,7 +213,7 @@ python_tools() {
     cmake-format \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool \
     imgtool==1.9.0 \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -145,7 +145,7 @@ python_tools() {
     CodeChecker \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool \
     imgtool \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -198,7 +198,7 @@ python_tools() {
     CodeChecker \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool \
     imgtool \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -238,7 +238,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \
@@ -270,7 +270,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \

--- a/tools/esp32c3/Config.mk
+++ b/tools/esp32c3/Config.mk
@@ -220,7 +220,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-C3 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -225,7 +225,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S2 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \

--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -139,7 +139,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S3 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \
@@ -171,7 +171,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S3 binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \

--- a/tools/espressif/Config.mk
+++ b/tools/espressif/Config.mk
@@ -139,7 +139,7 @@ define MKIMAGE
 	$(Q) echo "MKIMAGE: NuttX binary"
 	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \


### PR DESCRIPTION
Follows #13824

## Summary

This PR updates all esptool version references from development to latest.
A second issue regarding older esptool versions causing the build to silently fail will be addressed in a different PR due to test requirements.

## Impact

Espressif devices documentation and `pip install` sections of the build system.

## Testing

Internal CI build.


