### PR TITLE
pci_ivshmem.c: ivshmem_support_irq API support

### DIFF
--- a/drivers/pci/pci_ivshmem.c
+++ b/drivers/pci/pci_ivshmem.c
@@ -414,6 +414,19 @@ int ivshmem_control_irq(FAR struct ivshmem_device_s *dev, bool on)
 }
 
 /****************************************************************************
+ * Name: ivshmem_support_irq
+ *
+ * Description:
+ *   Judge if support ivshmem interrupt
+ *
+ ****************************************************************************/
+
+bool ivshmem_support_irq(FAR struct ivshmem_device_s *dev)
+{
+  return dev->vmid != IVSHMEM_INVALID_VMID;
+}
+
+/****************************************************************************
  * Name: ivshmem_kick_peer
  *
  * Description:

--- a/include/nuttx/pci/pci_ivshmem.h
+++ b/include/nuttx/pci/pci_ivshmem.h
@@ -117,6 +117,16 @@ int ivshmem_detach_irq(FAR struct ivshmem_device_s *dev);
 int ivshmem_control_irq(FAR struct ivshmem_device_s *dev, bool on);
 
 /****************************************************************************
+ * Name: ivshmem_support_irq
+ *
+ * Description:
+ *   judge if support ivshmem interrupt
+ *
+ ****************************************************************************/
+
+bool ivshmem_support_irq(FAR struct ivshmem_device_s *dev);
+
+/****************************************************************************
  * Name: ivshmem_kick_peer
  *
  * Description:


### PR DESCRIPTION
## Summary
ivshmem based driver can use this api to judge weather current ivshmem device support irq or not, and use polling mode or irq mode to process the event.

## Impact
ivshmem based drivers

## Testing
qemu armv8a and rptun-ivshmem


