### PR TITLE
SAMA5D2. Fix DEBUGASSERT triggered in sam_updhs.c

### DIFF
--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -2374,11 +2374,6 @@ static void sam_dma_interrupt(struct sam_usbdev_s *priv, int epno)
 
   privep = &priv->eplist[epno];
 
-  /* Get the request from the head of the endpoint request queue */
-
-  privreq = sam_rqpeek(&privep->reqq);
-  DEBUGASSERT(privreq);
-
   /* Get the result of the DMA operation */
 
   dmastatus = sam_getreg(SAM_UDPHS_DMASTATUS(epno));
@@ -2439,7 +2434,12 @@ static void sam_dma_interrupt(struct sam_usbdev_s *priv, int epno)
         }
       else if (privep->epstate == UDPHS_EPSTATE_RECEIVING)
         {
-          /* privreg->inflight holds the total transfer size */
+          /* privreg->inflight holds the total transfer size
+           * Get the request from the head of the endpoint request queue
+          */
+
+          privreq           = sam_rqpeek(&privep->reqq);
+          DEBUGASSERT(privreq);
 
           xfrsize           = privreq->inflight;
           privreq->inflight = 0;
@@ -2495,7 +2495,12 @@ static void sam_dma_interrupt(struct sam_usbdev_s *priv, int epno)
        * BUFF_COUNT should not be zero.  BUFF_COUNT was set to the
        * 'inflight' count when the DMA started so the difference will
        * give us the actual size of the transfer.
+       *
+       * Get the request from the head of the endpoint request queue first.
        */
+
+      privreq            = sam_rqpeek(&privep->reqq);
+      DEBUGASSERT(privreq);
 
       bufcnt             = ((dmastatus & UDPHS_DMASTATUS_BUFCNT_MASK)
                            >> UDPHS_DMASTATUS_BUFCNT_SHIFT);


### PR DESCRIPTION
## Summary

When trying CDC/NCM I found that a debug assert was triggered. Initially I commented out the offending DEBUGASSERT and found the code worked just fine.

I don't know why the assert was placed there - perhaps with other uses of this driver there would always be data in the receive queue - so I moved the assignment to the places that actually needed and used the variable. 

I have checked that not only CDC/NCM (now) works but also that RNDIS still behaves as before, so it seems like a "safe" fix.

## Impact

None expected, but maybe reviewers with USB and DMA knowledge can comment.

## Testing

Custom board with SAMA5D27C-D1G, using either CDC/NCM or RNDIS connectivity.


