### PR TITLE
Contributing and PR template fix.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-*Note: Please adhere to [Contributing Guidelines](../CONTRIBUTING.md).*
+*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*
 
 ## Summary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Hi! Thank you for your interest in contributing to Apache NuttX RTOS :-)
 To help us successfully review your contribution, it is very
 important that you follow these guidelines.
 
+If you need more information please read the [Full Contributing Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html).
 
 ### Coding Standard
 
@@ -81,12 +82,6 @@ important that you follow these guidelines.
 
 ## References
 
-
-### Documentation
-
-For general notes on contributing to Apache NuttX continue reading [here](https://nuttx.apache.org/docs/latest/contributing/index.html).
-
-
 ### Example Pull Request Report
 
 #### Summary
@@ -133,6 +128,6 @@ For general notes on contributing to Apache NuttX continue reading [here](https:
 
   * [ ] This PR introduces only one functional change.
   * [ ] I have updated all required description fields above.
-  * [ ] My PR adheres to [CONTRIBUTING](../CONTRIBUTING.md) guidelines (git commit title and message, coding standard, etc).
+  * [ ] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
   * [ ] My PR is still work in progress (not ready for review).
   * [ ] My PR is ready for review and can be safely merged into a codebase.


### PR DESCRIPTION
## Summary

* Fix CONTRIBUTING.md github link reference.
* Full URL is provided to avoid relative/fork reference issues.
* Minor update on full contributing documentation.

## Impact

* PR template.
* Contributing Guidelines links.

## Testing

* Local testing and GitHub with this PR.
