### PR TITLE
arm/armv8-r: add implements of arm_get_mpid()

### DIFF
--- a/arch/arm/src/armv8-r/arm_gic.h
+++ b/arch/arm/src/armv8-r/arm_gic.h
@@ -30,6 +30,7 @@
 #include <arch/irq.h>
 #include <arch/chip/chip.h>
 
+#include "arm_internal.h"
 #include "arm.h"
 
 /****************************************************************************
@@ -350,7 +351,10 @@ void arm_gic_secondary_init(void);
  ****************************************************************************/
 
 #ifdef CONFIG_SMP
-uint64_t arm_get_mpid(int cpu);
+static inline uint64_t arm_get_mpid(int cpu)
+{
+  return CORE_TO_MPID(cpu, 0);
+}
 #else
 #  define arm_get_mpid(cpu) GET_MPIDR()
 #endif /* CONFIG_SMP */

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -205,7 +205,7 @@ extern void arm_fullcontextrestore(uint32_t *restoreregs);
   ({ \
     uint64_t __mpidr = GET_MPIDR(); \
     __mpidr &= ~(MPIDR_AFFLVL_MASK << MPIDR_AFF ## aff_level ## _SHIFT); \
-    __mpidr |= (cpu << MPIDR_AFF ## aff_level ## _SHIFT); \
+    __mpidr |= (core << MPIDR_AFF ## aff_level ## _SHIFT); \
     __mpidr &= MPIDR_ID_MASK; \
     __mpidr; \
   })


### PR DESCRIPTION
## Summary

1. arm/armv8-r: add implements of arm_get_mpid()
2. arch/arm: fix the bug of armv8-r macro GET_MPIDR

should be core not cpu

Signed-off-by: fanjiangang <fanjiangang@lixiang.com>
Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

armv8-r SMP