### PR TITLE
arch: set current regs firstly in undefinedinsn

### DIFF
--- a/arch/arm/src/arm/arm_undefinedinsn.c
+++ b/arch/arm/src/arm/arm_undefinedinsn.c
@@ -42,6 +42,12 @@
 
 void arm_undefinedinsn(uint32_t *regs)
 {
+  /* Save the saved processor context in current_regs where it can be
+   * accessed for register dumps and possibly context switching.
+   */
+
+  up_set_current_regs(regs);
+
   if (regs[REG_PC] >= (uint32_t)_stext && regs[REG_PC] < (uint32_t)_etext)
     {
       _alert("Undefined instruction at 0x%" PRIx32 ": 0x%" PRIx32 "\n",
@@ -51,8 +57,6 @@ void arm_undefinedinsn(uint32_t *regs)
     {
       _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
     }
-
-  up_set_current_regs(regs);
 
   PANIC_WITH_REGS("panic", regs);
 }

--- a/arch/arm/src/armv7-a/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-a/arm_undefinedinsn.c
@@ -42,6 +42,12 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
+  /* Save the saved processor context in current_regs where it can be
+   * accessed for register dumps and possibly context switching.
+   */
+
+  up_set_current_regs(regs);
+
   if (regs[REG_PC] >= (uint32_t)_stext && regs[REG_PC] < (uint32_t)_etext)
     {
       _alert("Undefined instruction at 0x%" PRIx32 ": 0x%" PRIx32 "\n",
@@ -51,8 +57,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
     {
       _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
     }
-
-  up_set_current_regs(regs);
 
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */

--- a/arch/arm/src/armv7-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv7-r/arm_undefinedinsn.c
@@ -42,6 +42,12 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
+  /* Save the saved processor context in current_regs where it can be
+   * accessed for register dumps and possibly context switching.
+   */
+
+  up_set_current_regs(regs);
+
   if (regs[REG_PC] >= (uint32_t)_stext && regs[REG_PC] < (uint32_t)_etext)
     {
       _alert("Undefined instruction at 0x%" PRIx32 ": 0x%" PRIx32 "\n",
@@ -51,8 +57,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
     {
       _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
     }
-
-  up_set_current_regs(regs);
 
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */

--- a/arch/arm/src/armv8-r/arm_undefinedinsn.c
+++ b/arch/arm/src/armv8-r/arm_undefinedinsn.c
@@ -42,6 +42,12 @@
 
 uint32_t *arm_undefinedinsn(uint32_t *regs)
 {
+  /* Save the saved processor context in current_regs where it can be
+   * accessed for register dumps and possibly context switching.
+   */
+
+  up_set_current_regs(regs);
+
   if (regs[REG_PC] >= (uint32_t)_stext && regs[REG_PC] < (uint32_t)_etext)
     {
       _alert("Undefined instruction at 0x%" PRIx32 ": 0x%" PRIx32 "\n",
@@ -51,8 +57,6 @@ uint32_t *arm_undefinedinsn(uint32_t *regs)
     {
       _alert("Undefined instruction at 0x%" PRIx32 "\n", regs[REG_PC]);
     }
-
-  up_set_current_regs(regs);
 
   PANIC_WITH_REGS("panic", regs);
   return regs; /* To keep the compiler happy */


### PR DESCRIPTION

## Summary

Need to save the regs firstly in case syslog triggers another crash. Otherwise we may loose the register contents for the first exception.

## Impact

Now we have better chance to catch root cause for termination.

## Testing

Test on armv7-a qemu.

Modify hello_main.c to inject the fault.

```c
int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n");
  static const uint32_t instruction = 0x12345678;
  ((void (*)(void))&instruction)();
  return 0;
}
```

Compile and Execute:
```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm/qemu/qemu-armv7a/configs/nsh nuttx

ninja -C build

qemu-system-arm -cpu cortex-a7 -nographic -machine virt,virtualization=off,gic-version=2 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel build/nuttx -gdb tcp::1127

nsh> hello &
```

Connect to target using GDB
```
 gdb-multiarch build/nuttx -ex "tar rem:1127"
```

Execute `bt` will show the callstack in interrupt.
```shell
(gdb) bt
#0  arm_timer_get_freq () at /home/neo/projects/nuttx/nuttx/arch/arm/src/armv7-a/arm_timer.c:289
#1  0x4010be90 in arm_timer_current (lower_=<optimized out>, ts=0x40142c90)
    at /home/neo/projects/nuttx/nuttx/arch/arm/src/armv7-a/arm_timer.c:249
#2  0x4010c4b8 in ndelay_accurate (nanoseconds=<optimized out>) at /home/neo/projects/nuttx/nuttx/drivers/timers/arch_alarm.c:65
#3  up_ndelay (nanoseconds=<optimized out>) at /home/neo/projects/nuttx/nuttx/drivers/timers/arch_alarm.c:447
#4  0x4010c5b8 in up_udelay (microseconds=microseconds@entry=250000)
    at /home/neo/projects/nuttx/nuttx/drivers/timers/arch_alarm.c:430
#5  0x4010c5cc in up_mdelay (milliseconds=milliseconds@entry=250)
    at /home/neo/projects/nuttx/nuttx/drivers/timers/arch_alarm.c:415
#6  0x401067e4 in reset_board () at /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:781
#7  _assert (filename=filename@entry=0x4012f08a "/arch/arm/src/armv7-a/arm_undefinedinsn.c", linenum=linenum@entry=61,
    msg=msg@entry=0x4012e3bd "panic", regs=<optimized out>, regs@entry=0x40142db8)
    at /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:878
#8  0x4010bd90 in arm_undefinedinsn (regs=0x40142db8)
    at /home/neo/projects/nuttx/nuttx/arch/arm/src/armv7-a/arm_undefinedinsn.c:61
#9  0x401014b8 in arm_vectorundefinsn () at /home/neo/projects/nuttx/nuttx/arch/arm/src/armv7-a/arm_vectors.S:603
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb)

```

Load GDB Plugin and restore user registers(previously stored in `up_set_current_regs(regis)`)
```
(gdb) source nuttx/tools/gdb/__init__.py
(gdb) nxsetregs
(gdb) bt
#0  0x40138e98 in __FUNCTION__.0 ()
#1  0x40120040 in hello_main (argc=<optimized out>, argv=<optimized out>) at /home/neo/projects/nuttx/apps/examples/hello/hello_main.c:41
#2  0x4010d150 in nxtask_startup (entrypt=0x40120030 <hello_main>, argc=1, argv=0x40141f30) at /home/neo/projects/nuttx/nuttx/libs/libc/sched/task_startup.c:72
#3  0x40109c38 in nxtask_start () at /home/neo/projects/nuttx/nuttx/sched/task/task_start.c:116
#4  0x00000000 in ?? ()
(gdb)

```


