### PR TITLE
netdb: fix may add duplicate DNS servers

### DIFF
--- a/libs/libc/netdb/lib_dnsforeach.c
+++ b/libs/libc/netdb/lib_dnsforeach.c
@@ -178,6 +178,7 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
             }
 #endif /* CONFIG_NETDB_RESOLVCONF_NONSTDPORT */
 
+          memset(&u, 0, sizeof(u));
 #ifdef CONFIG_NET_IPv4
           /* Try to convert the IPv4 address */
 


### PR DESCRIPTION
## Summary

struct sockaddr_in
{
  sa_family_t     sin_family;
  in_port_t       sin_port;
  struct in_addr  sin_addr;
  uint8_t         sin_zero[8];
};

sin_zero is probably a random number.

struct sockaddr_in6
{
  sa_family_t     sin6_family;
  in_port_t       sin6_port;
  uint32_t        sin6_flowinfo;
  struct in6_addr sin6_addr;
  uint32_t        sin6_scope_id;
};

sin6_flowinfo and sin6_scope_id is probably a random number.

Random numbers cause the same server configuration check failed, so let's initialize it.

## Impact

## Testing

local:sim

