### PR TITLE
mps/cmake: add cmake build

### DIFF
--- a/boards/arm/mps/mps2-an500/CMakeLists.txt
+++ b/boards/arm/mps/mps2-an500/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/mps/mps3-an547/CMakeLists.txt
+# boards/arm/mps/mps2-an500/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/mps/mps2-an500/src/CMakeLists.txt
+++ b/boards/arm/mps/mps2-an500/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/mps/mps3-an547/CMakeLists.txt
+# boards/arm/mps/mps2-an500/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,4 +18,8 @@
 #
 # ##############################################################################
 
-add_subdirectory(src)
+set(SRCS mps2_bringup.c mps2_reset.c)
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/mps/mps2-an521/CMakeLists.txt
+++ b/boards/arm/mps/mps2-an521/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/mps/mps3-an547/CMakeLists.txt
+# boards/arm/mps/mps2-an521/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for

--- a/boards/arm/mps/mps2-an521/src/CMakeLists.txt
+++ b/boards/arm/mps/mps2-an521/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/mps/mps3-an547/CMakeLists.txt
+# boards/arm/mps/mps2-an521/src/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,4 +18,8 @@
 #
 # ##############################################################################
 
-add_subdirectory(src)
+set(SRCS mps2_bringup.c mps2_reset.c)
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/mps/mps3-an547/CMakeLists.txt
+++ b/boards/arm/mps/mps3-an547/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# boards/arm/mps3/mps3-an547/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/mps/mps3-an547/src/CMakeLists.txt
+++ b/boards/arm/mps/mps3-an547/src/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# boards/arm/mps/mps3-an547/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS mps3_bringup.c mps3_reset.c)
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")


### PR DESCRIPTION
## Summary
1. mps2-an500:add mps2-an500 cmake build
2. mps2-an521:add mps2-an521 cmake build
3. mps3-an547:add mps3-an547 cmake build
4. fix comments

## Impact
## Testing


