### PR TITLE
libs/xxx/CMakeLists.txt: add cmake compile support

### DIFF
--- a/libs/libc/string/CMakeLists.txt
+++ b/libs/libc/string/CMakeLists.txt
@@ -23,6 +23,7 @@
 # Add the string C files to the build
 
 set(SRCS
+    lib_bzero.c
     lib_ffs.c
     lib_ffsl.c
     lib_ffsll.c

--- a/libs/libm/libm/CMakeLists.txt
+++ b/libs/libm/libm/CMakeLists.txt
@@ -35,6 +35,10 @@ if(CONFIG_LIBM)
       lib_coshf.c
       lib_expf.c
       lib_fmodf.c
+      lib_fmax.c
+      lib_fmin.c
+      lib_fminf.c
+      lib_fmaxf.c
       lib_frexpf.c
       lib_ldexpf.c
       lib_logf.c


### PR DESCRIPTION
## Summary
libs/xxx/CMakeLists.txt: add cmake compile support

## Impact
Add the lib_bzero.c files to the build use it's API
Add the floating point math C files to the build to use it's API

## Testing
Test in vela


