### PR TITLE
mempool: add the minimum size configuration of mempool

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -216,10 +216,11 @@ config MM_HEAP_MEMPOOL_THRESHOLD
 		== 0 Enable pool feature, but disable the umm/kmm pool function.
 		 < 0 Disable pool feature.
 
+if MM_HEAP_MEMPOOL_THRESHOLD > 0
+
 config MM_HEAP_MEMPOOL_EXPAND_SIZE
 	int "The expand size for each mempool in multiple mempool"
 	default 4096
-	depends on MM_HEAP_MEMPOOL_THRESHOLD > 0
 	---help---
 		This size describes the size of each expansion of each memory
 		pool with insufficient memory in the multi-level memory pool.
@@ -227,16 +228,22 @@ config MM_HEAP_MEMPOOL_EXPAND_SIZE
 config MM_HEAP_MEMPOOL_DICTIONARY_EXPAND_SIZE
 	int "The expand size for multiple mempool's dictionary"
 	default MM_HEAP_MEMPOOL_EXPAND_SIZE
-	depends on MM_HEAP_MEMPOOL_THRESHOLD > 0
 	---help---
 		This size describes the multiple mempool dictionary expand.
 
 config MM_HEAP_MEMPOOL_CHUNK_SIZE
 	int "The multiples pool chunk size"
 	default 0
-	depends on MM_HEAP_MEMPOOL_THRESHOLD > 0
 	---help---
 		This size describes the multiple mempool chunk size.
+
+config MM_MIN_BLKSIZE
+	int "Minimum memory block size"
+	default 0
+	---help---
+		Users can configure the minimum memory block size as needed
+
+endif # MM_HEAP_MEMPOOL_THRESHOLD > 0
 
 config MM_HEAP_MEMPOOL_BACKTRACE_SKIP
 	int "The skip depth of backtrace for mempool"

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -316,7 +316,11 @@ mm_initialize_pool(FAR const char *name,
 
       for (i = 0; i < MEMPOOL_NPOOLS; i++)
         {
+#  if CONFIG_MM_MIN_BLKSIZE != 0
+          poolsize[i] = (i + 1) * CONFIG_MM_MIN_BLKSIZE;
+#  else
           poolsize[i] = (i + 1) * MM_MIN_CHUNK;
+#  endif
         }
 
       def.poolsize        = poolsize;

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -1021,7 +1021,11 @@ mm_initialize_pool(FAR const char *name,
 
       for (i = 0; i < MEMPOOL_NPOOLS; i++)
         {
+#  if CONFIG_MM_MIN_BLKSIZE != 0
+          poolsize[i] = (i + 1) * CONFIG_MM_MIN_BLKSIZE;
+#  else
           poolsize[i] = (i + 1) * tlsf_align_size();
+#  endif
         }
 
       def.poolsize        = poolsize;


### PR DESCRIPTION
The minimum size of mempool can be configured through CONFIG_MM_MPOOL_MINISIZE

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
add the minimum size configuration of mempool
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
ostest

