### PR TITLE
setjmp: fix setjmp returns 0 when calling longjmp with 0 as the secon…

### DIFF
--- a/libs/libc/machine/arm/gnu/arch_setjmp.S
+++ b/libs/libc/machine/arm/gnu/arch_setjmp.S
@@ -170,7 +170,21 @@ longjmp:
 	vmsr		fpscr, r2			/* Restore the FPSCR */
 #endif /* CONFIG_ARCH_FPU */
 
-	mov		r0, r1				/* return val */
+	/* Check and substitute the given return value to 1 if it's 0 */
+
+	movs		r0, r1
+#ifdef CONFIG_ARCH_ARMV6M
+	/* ARMv6-M only supports branching with condition
+	 * So we fall back to not use IT blocks in that case
+	 */
+
+	bne		1f
+	movs		r0, #1
+1:
+#else
+	it		eq
+	moveq		r0, #1
+#endif
 	bx		lr
 
 	.size	longjmp, .-longjmp

--- a/libs/libc/machine/sim/arch_setjmp_x86.S
+++ b/libs/libc/machine/sim/arch_setjmp_x86.S
@@ -85,9 +85,11 @@ SYMBOL(setjmp):
 SYMBOL(longjmp):
 	movl	4(%esp), %ecx      /* jmpbuf in %ecx.  */
 	movl	8(%esp), %eax      /* Second argument is return value.  */
-
+	testl	%eax, %eax
+	jnz	1f
+	incl	%eax
 	/* Save the return address now.  */
-
+1:
 	movl	(JB_PC)(%ecx), %edx
 
 	/* Restore registers.  */

--- a/libs/libc/machine/sim/arch_setjmp_x86_64.S
+++ b/libs/libc/machine/sim/arch_setjmp_x86_64.S
@@ -130,9 +130,12 @@ SYMBOL(longjmp):
 	/* Setup return value */
 
 	movl	%esi,%eax
+	testl	%eax,%eax
+	jnz	1f
+	incl	%eax
 
 	/* Restore registers */
-
+1:
 	movq	JB_RBX(REGS),%rbx	/* Load 1: rbx */
 	movq	JB_RSP(REGS),%rsp	/* Load 2: rsp */
 	movq	JB_RBP(REGS),%rbp	/* Load 3: rdi */


### PR DESCRIPTION
## Summary

According to POSIX semantics https://pubs.opengroup.org/onlinepubs/009604599/functions/longjmp.html. The `setjmp` should return `1` instead of `0` when calling `longjmp` with 0 as the second argument.

## Impact

The current implementation of `setjmp` on some architectures misbehaves. In my case, it affects the CMocka framework.

## Testing

The testing code lives int the nuttx apps repository as a seperate patch.


