### PR TITLE
libc/newlib:Declaration of adding depth

### DIFF
--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -63,6 +63,8 @@ CSRCS += $(wildcard newlib/newlib/newlib/libm/complex/*.c)
 
 VPATH += :newlib/newlib/newlib/libm/common
 VPATH += :newlib/newlib/newlib/libm/complex
+DEPPATH += --dep-path newlib/newlib/newlib/libm/common
+DEPPATH += --dep-path newlib/newlib/newlib/libm/complex
 
 ifeq ($(CONFIG_ARCH_ARM),y)
   ARCH = arm
@@ -84,10 +86,14 @@ endif
 
 CSRCS += $(wildcard newlib/newlib/newlib/libm/machine/$(ARCH)/*.c)
 VPATH += :newlib/newlib/newlib/libm/machine/$(ARCH)
+DEPPATH += --dep-path newlib/newlib/newlib/libm/machine/$(ARCH)
+
 
 ifeq ($(CONFIG_ARCH_X86_64),y)
 CSRCS += $(wildcard newlib/newlib/newlib/libm/fenv/*.c)
 VPATH += :newlib/newlib/newlib/libm/fenv
+DEPPATH += --dep-path newlib/newlib/newlib/libm/fenv
+
 
 CFLAGS += ${INCDIR_PREFIX}newlib/newlib/newlib/libc/machine/shared_x86/sys
 endif
@@ -98,10 +104,13 @@ endif
 
 CSRCS += newlib/sincosl.c
 VPATH += :newlib
+DEPPATH += --dep-path newlib
+
 
 ifeq ($(CONFIG_LIBM_NEWLIB_HW_FP),y)
   CSRCS += $(wildcard newlib/newlib/newlib/libm/mathfp/*.c)
   VPATH += :newlib/newlib/newlib/libm/mathfp
+  DEPPATH += --dep-path newlib/newlib/newlib/libm/mathfp
   CFLAGS += -Wno-dangling-else
   CFLAGS += -Wno-endif-labels
   CFLAGS += -Wno-implicit-function-declaration
@@ -112,6 +121,7 @@ ifeq ($(CONFIG_LIBM_NEWLIB_HW_FP),y)
 else
   CSRCS += $(wildcard newlib/newlib/newlib/libm/math/*.c)
   VPATH += :newlib/newlib/newlib/libm/math
+  DEPPATH += --dep-path newlib/newlib/newlib/libm/math
 endif
 
 CSRCS := $(shell echo $(notdir $(CSRCS) | tr " " "\n" | sort | uniq))


### PR DESCRIPTION
VELAPLATFO-38120

Resolve the issue of inability to compile when opening newlib

Change-Id: Iaf3baf568aa608944bf25e9260455bded5493ebc

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
Declaration of adding depth
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

ostest
