### PR TITLE
openamp/libmetal: use config OPENAMP_CACHE to control lib metal cache…

### DIFF
--- a/openamp/libmetal.cmake
+++ b/openamp/libmetal.cmake
@@ -74,6 +74,10 @@ set(MACHINE ${CONFIG_ARCH})
 set(CMAKE_SYSTEM_NAME NuttX)
 set(WITH_DOC OFF)
 
+if(CONFIG_OPENAMP_CACHE)
+  add_compile_definitions(METAL_CACHE)
+endif()
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libmetal
                  ${CMAKE_CURRENT_BINARY_DIR}/libmetal EXCLUDE_FROM_ALL)
 

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -56,6 +56,10 @@ CSRCS += libmetal/lib/log.c
 CSRCS += libmetal/lib/shmem.c
 CSRCS += libmetal/lib/version.c
 
+ifeq ($(CONFIG_OPENAMP_CACHE),y)
+  CFLAGS += -DMETAL_CACHE
+endif
+
 CFLAGS += -DMETAL_INTERNAL
 
 LIBMETAL_HDRS_SEDEXP := \


### PR DESCRIPTION
## Summary
metal cache is a new config to control weather to use the cache API.

## Impact
openamp

## Testing
qemu armv8a


