### PR TITLE
pthread: We should not directly include arch/spinlock.h

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -35,7 +35,6 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
-#include <nuttx/arch.h>
 
 #if defined(CONFIG_TICKET_SPINLOCK) || defined(CONFIG_RW_SPINLOCK)
 #  include <nuttx/atomic.h>

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -49,7 +49,7 @@
  * SP_LOCKED and SP_UNLOCKED must constants of type spinlock_t.
  */
 
-#  include <arch/spinlock.h>
+#  include <nuttx/spinlock.h>
 #endif
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
We should not directly include arch/spinlock.h as it may cause compilation errors in C++.
    Instead, we should use nuttx/spinlock.h.

## Impact
none

## Testing
ci

