### PR TITLE
sched_backtrace: fix when dump running thread in other-core

### DIFF
--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -30,6 +30,59 @@
 
 #include "sched.h"
 
+#ifdef CONFIG_ARCH_HAVE_BACKTRACE
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+struct backtrace_arg_s
+{
+  pid_t pid;
+  FAR void **buffer;
+  int size;
+  int skip;
+  cpu_set_t saved_affinity;
+  uint16_t saved_flags;
+  bool need_restore;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int sched_backtrace_handler(FAR void *cookie)
+{
+  FAR struct backtrace_arg_s *arg = cookie;
+  FAR struct tcb_s *tcb;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
+
+  tcb = nxsched_get_tcb(arg->pid);
+
+  if (!tcb || tcb->task_state == TSTATE_TASK_INVALID ||
+      (tcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0)
+    {
+      /* There is no TCB with this pid or, if there is, it is not a task. */
+
+      leave_critical_section(flags);
+      return -ESRCH;
+    }
+
+  if (arg->need_restore)
+    {
+      tcb->affinity = arg->saved_affinity;
+      tcb->flags = arg->saved_flags;
+    }
+
+  leave_critical_section(flags);
+
+  return up_backtrace(tcb, arg->buffer, arg->size, arg->skip);
+}
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -44,7 +97,6 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_ARCH_HAVE_BACKTRACE
 int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
   FAR struct tcb_s *tcb = this_task();
@@ -65,18 +117,36 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
           if (tcb->task_state == TSTATE_TASK_RUNNING &&
               g_nx_initstate != OSINIT_PANIC)
             {
-              up_cpu_pause(tcb->cpu);
-            }
-#endif
+              struct backtrace_arg_s arg;
 
-          ret = up_backtrace(tcb, buffer, size, skip);
-#ifdef CONFIG_SMP
-          if (tcb->task_state == TSTATE_TASK_RUNNING &&
-              g_nx_initstate != OSINIT_PANIC)
-            {
-              up_cpu_resume(tcb->cpu);
+              if ((tcb->flags & TCB_FLAG_CPU_LOCKED) != 0)
+                {
+                  arg.pid = tcb->pid;
+                  arg.need_restore = false;
+                }
+              else
+                {
+                  arg.pid = tcb->pid;
+                  arg.saved_flags = tcb->flags;
+                  arg.saved_affinity = tcb->affinity;
+                  arg.need_restore = true;
+
+                  tcb->flags |= TCB_FLAG_CPU_LOCKED;
+                  CPU_SET(tcb->cpu, &tcb->affinity);
+                }
+
+              arg.buffer = buffer;
+              arg.size = size;
+              arg.skip = skip;
+              ret = nxsched_smp_call_single(tcb->cpu,
+                                            sched_backtrace_handler,
+                                            &arg, true);
             }
+          else
 #endif
+            {
+              ret = up_backtrace(tcb, buffer, size, skip);
+            }
         }
 
       leave_critical_section(flags);

--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -25,6 +25,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/sched.h>
+#include <nuttx/init.h>
 
 #include "sched.h"
 
@@ -45,16 +47,36 @@
 #ifdef CONFIG_ARCH_HAVE_BACKTRACE
 int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
-  FAR struct tcb_s *rtcb;
-  irqstate_t flags;
+  FAR struct tcb_s *tcb = this_task();
   int ret = 0;
-  if (tid >= 0)
+
+  if (tcb->pid == tid)
     {
-      flags = enter_critical_section();
-      rtcb  = nxsched_get_tcb(tid);
-      if (rtcb != NULL)
+      ret = up_backtrace(tcb, buffer, size, skip);
+    }
+  else
+    {
+      irqstate_t flags = enter_critical_section();
+
+      tcb = nxsched_get_tcb(tid);
+      if (tcb != NULL)
         {
-          ret = up_backtrace(rtcb, buffer, size, skip);
+#ifdef CONFIG_SMP
+          if (tcb->task_state == TSTATE_TASK_RUNNING &&
+              g_nx_initstate != OSINIT_PANIC)
+            {
+              up_cpu_pause(tcb->cpu);
+            }
+#endif
+
+          ret = up_backtrace(tcb, buffer, size, skip);
+#ifdef CONFIG_SMP
+          if (tcb->task_state == TSTATE_TASK_RUNNING &&
+              g_nx_initstate != OSINIT_PANIC)
+            {
+              up_cpu_resume(tcb->cpu);
+            }
+#endif
         }
 
       leave_critical_section(flags);


### PR DESCRIPTION
## Summary
fix when dump running thread in other-core

## Impact
sched_backtrace

## Testing
@jasonbu  give some testing info

