### PR TITLE
Revert "nuttx/arch:Enabling ARCH_MATH_H is required when compiling sim with the 13.2 version of the toolchain"

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -120,7 +120,6 @@ config ARCH_SIM
 	select SERIAL_IFLOWCONTROL
 	select SCHED_HPWORK
 	select ARCH_HAVE_CPUINFO
-	select ARCH_MATH_H if LIBCXX
 	---help---
 		Linux/Cygwin user-mode simulation.
 


### PR DESCRIPTION
Reverts apache/nuttx#14088