### PR TITLE
arm64: default SPI affinity routing to CPU0

### DIFF
--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -506,7 +506,7 @@ void arm64_cpu_enable(void);
 #ifdef CONFIG_SMP
 uint64_t arm64_get_mpid(int cpu);
 #else
-#  define arm64_get_mpid(cpu) GET_MPIDR()
+#  define arm64_get_mpid(cpu) (GET_MPIDR() & MPIDR_ID_MASK)
 #endif /* CONFIG_SMP */
 
 /****************************************************************************

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -249,16 +249,6 @@ void arm64_gic_irq_enable(unsigned int intid)
   uint32_t mask = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
   uint32_t idx  = intid / GIC_NUM_INTR_PER_REG;
 
-  /* Affinity routing is enabled for Non-secure state (GICD_CTLR.ARE_NS
-   * is set to '1' when GIC distributor is initialized) ,so need to set
-   * SPI's affinity, now set it to be the PE on which it is enabled.
-   */
-
-  if (GIC_IS_SPI(intid))
-    {
-      arm64_gic_write_irouter((GET_MPIDR() & MPIDR_ID_MASK), intid);
-    }
-
   putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
 }
 
@@ -538,6 +528,7 @@ static void gicv3_cpuif_init(void)
 
 static void gicv3_dist_init(void)
 {
+  uint64_t      mpid;
   unsigned int  num_ints;
   unsigned int  intid;
   unsigned int  idx;
@@ -608,6 +599,15 @@ static void gicv3_dist_init(void)
     {
       idx = intid / GIC_NUM_CFG_PER_REG;
       putreg32(0, ICFGR(base, idx));
+    }
+
+  /* Configure SPI interrupt affinity routing to CPU0 */
+
+  mpid = arm64_get_mpid(0);
+
+  for (intid = GIC_SPI_INT_BASE; intid < num_ints; intid++)
+    {
+      putreg64(mpid, IROUTER(GIC_DIST_BASE, intid));
     }
 
   /* TODO: Some arrch64 Cortex-A core maybe without security state


### PR DESCRIPTION
1. Set SPI interrupt affinity routing default to CPU0, and keep them unchanged unless `up_affinity_irq` is called.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


