### PR TITLE
ci, doc: use pip install --user

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check Pull Request
         run: |
           echo "::add-matcher::nuttx/.github/nxstyle.json"
-          pip install cmake-format
+          pip install --user cmake-format
           cd nuttx
           commits="${{ github.event.pull_request.base.sha }}..HEAD"
           git log --oneline $commits

--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -96,7 +96,7 @@ check_file() {
     if ! command -v cmake-format &> /dev/null; then
       if [ $cmake_warning_once == 0 ]; then
         echo -e "\ncmake-format not found, run following command to install:"
-        echo "  $ pip install cmake-format"
+        echo "  $ pip install --user cmake-format"
         cmake_warning_once=1
       fi
       fail=1


### PR DESCRIPTION
## Summary

Since now most modern linux distributions will refuse to install packages using pip install, we can use --user, so it does not interfere with the systems site-packages.

The ideal solution is, however, to add cmake-format to the nuttx-ci-linux container.

This is to avoid the following error when we did:

```
$ pip install cmake-format

This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.
```


*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

Fixes the current CI checks.

## Testing

Check the CI run.

