### PR TITLE
cmake(refine):fix cmake options typo and add EXTRA_FLAGS support

### DIFF
--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -33,8 +33,10 @@ foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
   endif()
 endforeach()
 
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
           --print-libgcc-file-name
   OUTPUT_STRIP_TRAILING_WHITESPACE
   OUTPUT_VARIABLE extra_library)
@@ -43,7 +45,7 @@ list(APPEND EXTRA_LIB ${extra_library})
 
 if(CONFIG_LIBM_TOOLCHAIN)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -52,7 +54,7 @@ endif()
 
 if(CONFIG_LIBSUPCXX)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libsupc++.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -61,7 +63,7 @@ endif()
 
 if(CONFIG_SCHED_GCOV)
   execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${NUTTX_EXTRA_FLAGS}
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libgcov.a
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
@@ -70,5 +72,4 @@ endif()
 
 nuttx_add_extra_library(${EXTRA_LIB})
 
-separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -86,21 +86,6 @@ function(nuttx_add_romfs)
     list(APPEND RCRAWS ${board_rcraws})
   endif()
 
-  get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
-                                                       COMPILE_OPTIONS)
-
-  set(ROMFS_CMAKE_C_FLAGS "")
-  foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
-    if(NOT FLAG MATCHES "^\\$<.*>$")
-      list(APPEND ROMFS_CMAKE_C_FLAGS ${FLAG})
-    else()
-      string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
-      if(matched)
-        list(APPEND ROMFS_CMAKE_C_FLAGS ${CMAKE_MATCH_1})
-      endif()
-    endif()
-  endforeach()
-
   foreach(rcsrc ${RCSRCS})
     if(IS_ABSOLUTE ${rcsrc})
       string(REGEX REPLACE "^(.*)/etc(/.*)?$" "\\1" SOURCE_ETC_PREFIX

--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -23,6 +23,12 @@
 # search. If the manual of the newly supported toolchain is different, you can
 # override these methods in the toolchain
 
+# Support CMake to define additional configuration options
+
+if(EXTRA_FLAGS)
+  add_compile_options(${EXTRA_FLAGS})
+endif()
+
 # ~~~
 # nuttx_generate_preproces_target
 #


### PR DESCRIPTION
## Summary

1. fix x86_64 cmake build platform.cmake option typo
2. remove unsue cmake options setting in romfs
3. add EXTRA_FLAGS support

## Impact
Bugfix and Enhancement,
No impact on current

## Testing

ubuntu sim
CI build


