### PR TITLE
[FIX CI] ci: use venv for check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Check Pull Request
         run: |
           echo "::add-matcher::nuttx/.github/nxstyle.json"
+          python -m venv .venv
+          source .venv/bin/activate
           pip install cmake-format
           cd nuttx
           commits="${{ github.event.pull_request.base.sha }}..HEAD"


### PR DESCRIPTION
## Summary

To avoid the following CI error:

```
This environment is externally managed
--> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.
```

## Impact

Fixes current checks CI.

## Testing

See the checks CI run.
