### PR TITLE
drivers/input: fix complie err about undefined

### DIFF
--- a/drivers/input/ff_upper.c
+++ b/drivers/input/ff_upper.c
@@ -28,6 +28,7 @@
 #include <nuttx/input/ff.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/irq.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

There will be compilation errors about undefined reference to
`enter_critical_section'. Fixed by include irq.h

## Impact

N/A

## Testing

Test in vela


