### PR TITLE
arch/x86_64: Fix SMP startup for ACRN Hypervisor

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -80,7 +80,8 @@ static int x86_64_ap_startup(int cpu)
 
   /* Send an INIT IPI to the CPU */
 
-  regval = MSR_X2APIC_ICR_INIT | dest;
+  regval = MSR_X2APIC_ICR_INIT | MSR_X2APIC_ICR_ASSERT
+           | MSR_X2APIC_ICR_LEVEL | dest;
   write_msr(MSR_X2APIC_ICR, regval);
 
   /* Wait for 10 ms */
@@ -95,16 +96,13 @@ static int x86_64_ap_startup(int cpu)
 
   /* Wait for AP ready */
 
-  up_udelay(300);
-  SP_DMB();
-
-  /* Check CPU ready flag */
-
-  if (x86_64_cpu_ready_get(cpu) == false)
+  do
     {
-      sinfo("failed to startup cpu=%d\n", cpu);
-      return -EBUSY;
+      up_udelay(300);
+      SP_DMB();
+      sinfo("wait for startup cpu=%d...\n", cpu);
     }
+  while (x86_64_cpu_ready_get(cpu) == false);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
This patch fixed SMP startup for ACRN Hypervisor.

## Impact
x86_64 SMP startup.

## Testing
Tested on NUC12 ACRN hypervisor and QEMU/KVM x86_64.
