### PR TITLE
cpuinfo: Decouple the fetch cpuinfo from up_perf_getfreq

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -528,6 +528,13 @@ config ARCH_HAVE_CPUINFO
 	bool
 	default n
 
+config ARCH_CPUINFO_FREQ_KHZ
+	int "Default CPU frequency"
+	default 0
+	depends on ARCH_HAVE_CPUINFO
+	---help---
+		Defines the CPU's default maximum frequency. Frequency unit KHZ.
+
 config ARCH_HAVE_TCBINFO
 	bool
 	default n

--- a/arch/arm/src/armv6-m/arm_cpuinfo.c
+++ b/arch/arm/src/armv6-m/arm_cpuinfo.c
@@ -51,11 +51,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* CPU Features */
 

--- a/arch/arm/src/armv7-a/arm_cpuinfo.c
+++ b/arch/arm/src/armv7-a/arm_cpuinfo.c
@@ -73,11 +73,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* CPU Features */
 

--- a/arch/arm/src/armv7-a/arm_fpuconfig.S
+++ b/arch/arm/src/armv7-a/arm_fpuconfig.S
@@ -75,6 +75,13 @@ arm_fpuconfig:
 	mcr		CP15_CPACR(r0)
 
 	/* Enable access to CP10 and CP11 in CP15.NSACR */
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+	mrc		CP15_NSACR(r0)
+	orr		r0, r0, #0xc00
+	mcr		CP15_NSACR(r0)
+#endif
+
 	/* REVISIT: Do we need to do this? */
 
 	/* Set FPEXC.EN (B30) */

--- a/arch/arm/src/armv7-m/arm_cpuinfo.c
+++ b/arch/arm/src/armv7-m/arm_cpuinfo.c
@@ -70,11 +70,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* CPU Features */
 

--- a/arch/arm/src/armv7-r/arm_cpuinfo.c
+++ b/arch/arm/src/armv7-r/arm_cpuinfo.c
@@ -73,11 +73,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* CPU Features */
 

--- a/arch/arm/src/armv7-r/arm_fpuconfig.S
+++ b/arch/arm/src/armv7-r/arm_fpuconfig.S
@@ -75,6 +75,13 @@ arm_fpuconfig:
 	mcr		CP15_CPACR(r0)
 
 	/* Enable access to CP10 and CP11 in CP15.NSACR */
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+	mrc		CP15_NSACR(r0)
+	orr		r0, r0, #0xc00
+	mcr		CP15_NSACR(r0)
+#endif
+
 	/* REVISIT: Do we need to do this? */
 
 	/* Set FPEXC.EN (B30) */

--- a/arch/arm/src/armv8-m/arm_cpuinfo.c
+++ b/arch/arm/src/armv8-m/arm_cpuinfo.c
@@ -74,11 +74,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* Cpu features */
 

--- a/arch/arm/src/armv8-r/arm_cpuinfo.c
+++ b/arch/arm/src/armv8-r/arm_cpuinfo.c
@@ -73,11 +73,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
       procfs_sprintf(buf, buf_size, &file_off, "BogoMIPS\t: %u.%02u\n",
                      (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                      (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                     CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
       /* CPU Features */
 

--- a/arch/arm/src/armv8-r/arm_fpuconfig.S
+++ b/arch/arm/src/armv8-r/arm_fpuconfig.S
@@ -75,6 +75,13 @@ arm_fpuconfig:
 	mcr		CP15_CPACR(r0)
 
 	/* Enable access to CP10 and CP11 in CP15.NSACR */
+
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
+	mrc		CP15_NSACR(r0)
+	orr		r0, r0, #0xc00
+	mcr		CP15_NSACR(r0)
+#endif
+
 	/* REVISIT: Do we need to do this? */
 
 	/* Set FPEXC.EN (B30) */

--- a/arch/xtensa/src/common/xtensa_cpuinfo.c
+++ b/arch/xtensa/src/common/xtensa_cpuinfo.c
@@ -105,11 +105,9 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
                  (CONFIG_BOARD_LOOPSPERMSEC / 1000),
                  (CONFIG_BOARD_LOOPSPERMSEC / 10) % 100);
 
-#if defined(CONFIG_ARCH_PERF_EVENTS)
-      procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %lu.%02lu\n",
-                     up_perf_getfreq() / 1000000,
-                     (up_perf_getfreq() / 10000) % 100);
-#endif
+  procfs_sprintf(buf, buf_size, &file_off, "cpu MHz\t\t: %u.%03u\n",
+                 CONFIG_ARCH_CPUINFO_FREQ_KHZ / 1000,
+                 CONFIG_ARCH_CPUINFO_FREQ_KHZ % 1000);
 
   /* Features */
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -410,6 +410,7 @@ void nxsched_process_cpuload_ticks(clock_t ticks);
 #ifdef CONFIG_SCHED_CRITMONITOR
 void nxsched_resume_critmon(FAR struct tcb_s *tcb);
 void nxsched_suspend_critmon(FAR struct tcb_s *tcb);
+void nxsched_update_critmon(FAR struct tcb_s *tcb);
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -224,6 +224,12 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload)
 
   DEBUGASSERT(cpuload);
 
+#ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
+  /* Update critmon in case of the target thread busyloop */
+
+  nxsched_update_critmon(nxsched_get_tcb(pid));
+#endif
+
   /* Momentarily disable interrupts.  We need (1) the task to stay valid
    * while we are doing these operations and (2) the tick counts to be
    * synchronized when read.


### PR DESCRIPTION

1.Add the default CPU frequency configuration.
2.arm/fpu: FPU is supported when the TEE is enabled
3.cpuload: add nxsched_update_critmon() to handle thread busyloop

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


