### PR TITLE
Changed the i3c_priv_xfer's member to flags from rnw

### DIFF
--- a/include/nuttx/i3c/device.h
+++ b/include/nuttx/i3c/device.h
@@ -59,6 +59,15 @@
 #define I3C_MATCH_PART                  0x4
 #define I3C_MATCH_EXTRA_INFO            0x8
 
+/* Bit definitions for the flags field in struct i3c_priv_xfer
+ *
+ * I3C_MASTER_READ macro indicates a read data from slave to master
+ * I3C_MASTER_WRITE macro indicates a write data from slave to master
+ */
+
+#define I3C_MASTER_READ                 0x01
+#define I3C_MASTER_WRITE                0x00
+
 /* These macros should be used to i3c_device_id entries. */
 
 #define I3C_MATCH_MANUF_AND_PART (I3C_MATCH_MANUF | I3C_MATCH_PART)
@@ -142,7 +151,8 @@ enum i3c_hdr_mode
 };
 
 /* struct i3c_priv_xfer - I3C SDR private transfer
- * @rnw: encodes the transfer direction. true for a read, false for a write
+ * @flags: encodes the transfer direction. bit 0 indicates read or write,
+ *      set 1 for read, set 0 for write
  * @len: transfer length in bytes of the transfer
  * @data: input/output buffer
  * @data.in: input buffer. Must point to a DMA-able buffer
@@ -152,7 +162,7 @@ enum i3c_hdr_mode
 
 struct i3c_priv_xfer
 {
-  unsigned char rnw;
+  uint16_t flags;
   uint16_t len;
   union
   {


### PR DESCRIPTION
1.Changed the i3c_priv_xfer's member to flags from rnw

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


