### PR TITLE
sched: delete the dump file list when the thread exits

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -378,7 +378,7 @@ void files_initlist(FAR struct filelist *list)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DUMP_ON_EXIT
+#ifdef CONFIG_SCHED_DUMP_ON_EXIT
 void files_dumplist(FAR struct filelist *list)
 {
   int count = files_countlist(list);

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -886,7 +886,7 @@ void files_initlist(FAR struct filelist *list);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DUMP_ON_EXIT
+#ifdef CONFIG_SCHED_DUMP_ON_EXIT
 void files_dumplist(FAR struct filelist *list);
 #else
 #  define files_dumplist(l)


### PR DESCRIPTION
## Summary
sched: delete the dump file list when the thread exits 

Accessing the filelist of other tasks when the thread exits may cause a crash

## Impact

## Testing
sim