### PR TITLE
drivers/optee: Return error if optee_recv return prematurely

### DIFF
--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -291,24 +291,21 @@ static int optee_from_msg_param(FAR struct tee_ioctl_param *params,
   return 0;
 }
 
-static ssize_t optee_recv(FAR struct socket *psock, FAR void *msg,
-                          size_t size)
+static int optee_recv(FAR struct socket *psock, FAR void *msg, size_t size)
 {
-  size_t remain = size;
-
-  while (remain)
+  while (size > 0)
     {
-      ssize_t n = psock_recv(psock, msg, remain, 0);
+      ssize_t n = psock_recv(psock, msg, size, 0);
       if (n <= 0)
         {
-          return remain == size ? n : size - remain;
+          return n < 0 ? n : -EIO;
         }
 
-      remain -= n;
+      size -= n;
       msg = (FAR char *)msg + n;
     }
 
-  return size;
+  return 0;
 }
 
 static int optee_send_recv(FAR struct socket *psocket,


### PR DESCRIPTION
## Summary
drivers/optee: Return error if optee_recv return prematurely

## Impact
optee

## Testing
ci

