### PR TITLE
sched/instrument: rename stack_record.c to stack_monitor.c

### DIFF
--- a/sched/instrument/CMakeLists.txt
+++ b/sched/instrument/CMakeLists.txt
@@ -23,7 +23,7 @@
 set(SRCS instrument.c)
 
 if(NOT "${CONFIG_SCHED_STACK_RECORD}" STREQUAL "0")
-  list(APPEND SRCS stack_record.c)
+  list(APPEND SRCS stack_monitor.c)
 endif()
 
 if(CONFIG_SCHED_GPROF)

--- a/sched/instrument/Make.defs
+++ b/sched/instrument/Make.defs
@@ -23,7 +23,7 @@
 CSRCS += instrument.c
 
 ifneq ($(CONFIG_SCHED_STACK_RECORD),0)
-CSRCS += stack_record.c
+CSRCS += stack_monitor.c
 endif
 
 ifeq ($(CONFIG_SCHED_GPROF),y)

--- a/sched/instrument/instrument.c
+++ b/sched/instrument/instrument.c
@@ -31,7 +31,7 @@
  ****************************************************************************/
 
 #if CONFIG_SCHED_STACK_RECORD > 0
-extern struct instrument_s g_stack_record;
+extern struct instrument_s g_stack_monitor;
 #endif
 
 /****************************************************************************
@@ -55,6 +55,6 @@ extern struct instrument_s g_stack_record;
 void instrument_initialize(void)
 {
 #if CONFIG_SCHED_STACK_RECORD > 0
-  instrument_register(&g_stack_record);
+  instrument_register(&g_stack_monitor);
 #endif
 }

--- a/sched/instrument/stack_monitor.c
+++ b/sched/instrument/stack_monitor.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/instrument/stack_record.c
+ * sched/instrument/stack_monitor.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -33,21 +33,21 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void stack_record_enter(FAR void *this_fn, FAR void *call_site,
-                               FAR void *arg) noinstrument_function
-                               nooptimiziation_function;
-static void stack_record_leave(FAR void *this_fn, FAR void *call_site,
-                               FAR void *arg) noinstrument_function
-                               nooptimiziation_function;
+static void stack_monitor_enter(FAR void *this_fn, FAR void *call_site,
+                                FAR void *arg) noinstrument_function
+                                nooptimiziation_function;
+static void stack_monitor_leave(FAR void *this_fn, FAR void *call_site,
+                                FAR void *arg) noinstrument_function
+                                nooptimiziation_function;
 
 /****************************************************************************
  * Public Data
  ****************************************************************************/
 
-struct instrument_s g_stack_record =
+struct instrument_s g_stack_monitor =
 {
-  .enter = stack_record_enter,
-  .leave = stack_record_leave
+  .enter = stack_monitor_enter,
+  .leave = stack_monitor_leave
 };
 
 /****************************************************************************
@@ -58,8 +58,8 @@ struct instrument_s g_stack_record =
  * Name: stack_statistics
  ****************************************************************************/
 
-static void stack_record_enter(FAR void *this_fn, FAR void *call_site,
-                               FAR void *arg)
+static void stack_monitor_enter(FAR void *this_fn, FAR void *call_site,
+                                FAR void *arg)
 {
   FAR struct tcb_s *tcb = running_task();
   FAR void *sp = &tcb;
@@ -98,8 +98,8 @@ static void stack_record_enter(FAR void *this_fn, FAR void *call_site,
  * Name: stackrecord_leave
  ****************************************************************************/
 
-static void stack_record_leave(FAR void *this_fn, FAR void *call_site,
-                               FAR void *arg)
+static void stack_monitor_leave(FAR void *this_fn, FAR void *call_site,
+                                FAR void *arg)
 {
   FAR struct tcb_s *tcb = running_task();
   FAR void *sp = &tcb;


### PR DESCRIPTION
## Summary
sched/instrument: rename stack_record.c to stack_monitor.c to align with gprof naming convention.

## Impact

## Testing

