### PR TITLE
fix igmp group issue

### DIFF
--- a/net/igmp/igmp_group.c
+++ b/net/igmp/igmp_group.c
@@ -218,6 +218,10 @@ void igmp_grpfree(FAR struct net_driver_s *dev,
 
   wd_cancel(&group->wdog);
 
+  /* Cancel the workqueue */
+
+  work_cancel_sync(LPWORK, &group->work);
+
   /* Remove the group structure from the group list in the device structure */
 
   sq_rem((FAR sq_entry_t *)group, &dev->d_igmp_grplist);

--- a/net/igmp/igmp_leave.c
+++ b/net/igmp/igmp_leave.c
@@ -166,7 +166,7 @@ int igmp_leavegroup(struct net_driver_s *dev,
 
       /* Send a leave if the flag is set according to the state diagram */
 
-      if (IS_LASTREPORT(group->flags))
+      if (IFF_IS_UP(dev->d_flags) && IS_LASTREPORT(group->flags))
         {
           ninfo("Schedule Leave Group message\n");
           IGMP_STATINCR(g_netstats.igmp.leave_sched);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
1.when dev is down,the driver don't wait msg
2.when igmp_grpfree is excuted,it need cancel the work in the LPWORK
3.the modification is to solve the deadlock caused by work cancel not releasing netlock 
## Impact
igmp
## Testing
Manual verification

