### PR TITLE
mtd/nvs: Trigger recovery process in nvs_startup

### DIFF
--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -234,12 +234,25 @@ static int nvs_flash_rd(FAR struct nvs_fs *fs, uint32_t addr,
   offset += addr & ADDR_OFFS_MASK;
 
   ret = MTD_READ(fs->mtd, offset, len, data);
-  if (ret < 0)
+  if (ret == -EBADMSG)
     {
-      return ret;
+      /* ECC fail first time
+       * try again to avoid transient electronic interference
+       */
+
+      ret = MTD_READ(fs->mtd, offset, len, data);
+      if (ret == -EBADMSG)
+        {
+          /* ECC fail second time
+           * fill ~erasestate to trigger recovery process
+           */
+
+          memset(data, ~fs->erasestate, len);
+          ret = 0;
+        }
     }
 
-  return OK;
+  return ret < 0 ? ret : 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
mtd/nvs: Trigger recovery process in nvs_startup when mtd driver return -EBADMSG


