### PR TITLE
Revert "sched/spinlock: remove nesting spinlock support"

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -152,6 +152,10 @@ void sched_note_spinlock_unlock(FAR volatile spinlock_t *spinlock);
 
 extern volatile spinlock_t g_irq_spin;
 
+/* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
+
+extern volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
+
 /****************************************************************************
  * Name: up_testset
  *
@@ -528,7 +532,14 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
 
   if (NULL == lock)
     {
-      spin_lock_wo_note(&g_irq_spin);
+      int me = this_cpu();
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_lock_wo_note(&g_irq_spin);
+        }
+
+      g_irq_spin_count[me]++;
+      DEBUGASSERT(0 != g_irq_spin_count[me]);
     }
   else
     {
@@ -547,7 +558,10 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
  * Description:
  *   If SMP is enabled:
  *     If the argument lock is not specified (i.e. NULL),
- *     disable local interrupts and take the global spinlock (g_irq_spin).
+ *     disable local interrupts and take the global spinlock (g_irq_spin)
+ *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
+ *     counter on the CPU is incremented to allow nested calls and return
+ *     the interrupt state.
  *
  *     If the argument lock is specified,
  *     disable local interrupts and take the lock spinlock and return
@@ -685,7 +699,14 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
 {
   if (NULL == lock)
     {
-      spin_unlock_wo_note(&g_irq_spin);
+      int me = this_cpu();
+      DEBUGASSERT(0 < g_irq_spin_count[me]);
+      g_irq_spin_count[me]--;
+
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_unlock_wo_note(&g_irq_spin);
+        }
     }
   else
     {
@@ -703,9 +724,11 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
  *
  * Description:
  *   If SMP is enabled:
- *     If the argument lock is not specified (i.e. NULL), release the
- *     spinlock (g_irq_spin) and restore the interrupt state as it was
- *     prior to the previous call to spin_lock_irqsave(NULL).
+ *     If the argument lock is not specified (i.e. NULL),
+ *     decrement the call counter (g_irq_spin_count[cpu]) and if it
+ *     decrements to zero then release the spinlock (g_irq_spin) and
+ *     restore the interrupt state as it was prior to the previous call to
+ *     spin_lock_irqsave(NULL).
  *
  *     If the argument lock is specified, release the lock and
  *     restore the interrupt state as it was prior to the previous call to

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -43,6 +43,10 @@
 
 volatile spinlock_t g_irq_spin = SP_UNLOCKED;
 
+/* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
+
+volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
+
 #ifdef CONFIG_RW_SPINLOCK
 /* Used for access control */
 


### PR DESCRIPTION
## Summary

This reverts commit 5aa13bc490ea2e5a0d7462dd0131f9218a35f56a, Related to https://github.com/apache/nuttx/issues/14167

I found that this submission would cause ci warning, So should we revert it first?
```
machine/arch_atomic.c: In function ‘__atomic_load_2’:
machine/arch_atomic.c:51:22: warning: infinite recursion detected [-Winfinite-recursion]
   51 |   type weak_function __atomic_load_##n (FAR const volatile void *ptr, \
      |                      ^~~~~~~~~~~~~~
machine/arch_atomic.c:354:1: note: in expansion of macro ‘LOAD’
  354 | LOAD(2, uint16_t)
      | ^~~~
In file included from /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/atomic.h:84,
                 from /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/fs/fs.h:40,
                 from /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/sched.h:47,
                 from /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/arch.h:89,
                 from /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:38,
                 from machine/arch_atomic.c:31:
In function ‘spin_lock_wo_note’,
    inlined from ‘spin_lock_irqsave_wo_note’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:531:7,
    inlined from ‘spin_lock_irqsave’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:586:11,
    inlined from ‘__atomic_load_2’ at machine/arch_atomic.c:354:1:
/home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:244:10: note: recursive call
  244 |   while (atomic_load((FAR atomic_ushort *)&lock->tickets.owner) != ticket)
      |          ^~~~~~~~~~~
In function ‘spin_lock_wo_note’,
    inlined from ‘spin_lock_irqsave_wo_note’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:535:7,
    inlined from ‘spin_lock_irqsave’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:586:11,
    inlined from ‘__atomic_load_2’ at machine/arch_atomic.c:354:1:
/home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:244:10: note: recursive call
  244 |   while (atomic_load((FAR atomic_ushort *)&lock->tickets.owner) != ticket)
      |          ^~~~~~~~~~~
machine/arch_atomic.c: In function ‘__atomic_fetch_add_2’:
machine/arch_atomic.c:120:22: warning: infinite recursion detected [-Winfinite-recursion]
  120 |   type weak_function __atomic_fetch_add_##n (FAR volatile void *ptr,   \
      |                      ^~~~~~~~~~~~~~~~~~~
machine/arch_atomic.c:450:1: note: in expansion of macro ‘FETCH_ADD’
  450 | FETCH_ADD(2, uint16_t)
      | ^~~~~~~~~
In function ‘spin_lock_wo_note’,
    inlined from ‘spin_lock_irqsave_wo_note’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:531:7,
    inlined from ‘spin_lock_irqsave’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:586:11,
    inlined from ‘__atomic_fetch_add_2’ at machine/arch_atomic.c:450:1:
/home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:243:5: note: recursive call
  243 |     atomic_fetch_add((FAR atomic_ushort *)&lock->tickets.next, 1);
      |     ^~~~~~~~~~~~~~~~
In function ‘spin_lock_wo_note’,
    inlined from ‘spin_lock_irqsave_wo_note’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:535:7,
    inlined from ‘spin_lock_irqsave’ at /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:586:11,
    inlined from ‘__atomic_fetch_add_2’ at machine/arch_atomic.c:450:1:
/home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/spinlock.h:243:5: note: recursive call
  243 |     atomic_fetch_add((FAR atomic_ushort *)&lock->tickets.next, 1);
      |     ^~~~~~~~~~~~~~~~
```

## Impact

None,it just fix CI warning

## Testing

Build Host(s): Linux x86
Target(s): sim/smp

After that, there will be no warnings for compilation
```
╭─crafcat7@hp-prodesk-680-g4-mt ~/SSD/vela/nuttx.git/nuttx ‹master› 
╰─$ ./tools/configure.sh -l sim:smp                                                                                                                                          130 ↵
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/crafcat7/SSD/vela/nuttx.git/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/crafcat7/SSD/vela/nuttx.git/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/crafcat7/SSD/vela/nuttx.git/apps/platform/dummy
LN: include/arch to arch/sim/include
LN: include/arch/board to /home/crafcat7/SSD/vela/nuttx.git/nuttx/boards/sim/sim/sim/include
LN: drivers/platform to /home/crafcat7/SSD/vela/nuttx.git/nuttx/drivers/dummy
LN: include/arch/chip to /home/crafcat7/SSD/vela/nuttx.git/nuttx/arch/sim/include/sim
LN: arch/sim/src/chip to /home/crafcat7/SSD/vela/nuttx.git/nuttx/arch/sim/src/sim
LN: arch/sim/src/board to /home/crafcat7/SSD/vela/nuttx.git/nuttx/boards/sim/sim/sim/src
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/audioutils
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/benchmarks
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/boot
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/canutils
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/crypto
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/database
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/examples/mcuboot
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/examples
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/fsutils
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/games
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/graphics
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/industry
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/inertial
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/interpreters/luamodules
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/interpreters
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/logging
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/lte
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/math
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/mlearning
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/netutils
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/sdr
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/system
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/testing
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/videoutils
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/wireless/bluetooth
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/wireless/ieee802154
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps/wireless
mkkconfig in /home/crafcat7/SSD/vela/nuttx.git/apps
Loaded configuration '.config'
Configuration saved to '.config'
╭─crafcat7@hp-prodesk-680-g4-mt ~/SSD/vela/nuttx.git/nuttx ‹master› 
╰─$ make -j
Create version.h
LN: platform/board to /home/crafcat7/SSD/vela/nuttx.git/apps/platform/dummy
Register: hello
Register: nsh
Register: sh
Register: getprime
Register: smp
Register: ostest
Register: taskset
CP:  /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/config.h
CP:  /home/crafcat7/SSD/vela/nuttx.git/nuttx/include/nuttx/fs/hostfs.h
LD:  nuttx
```
