### PR TITLE
netdev:In netdev_default,If there is only one loopback network devices, it returns NULL

### DIFF
--- a/net/netdev/netdev_default.c
+++ b/net/netdev/netdev_default.c
@@ -75,9 +75,9 @@ FAR struct net_driver_s *netdev_default(void)
            * device).
            */
 
-          ret = dev;
           if (dev->d_lltype != NET_LL_LOOPBACK)
             {
+              ret = dev;
               break;
             }
         }


### PR DESCRIPTION


Referring to Linux,if there is only a loopback network device and the destination address does not belong to the loopback address, then the loopback network devices is not selected

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Referring to Linux,if there is only a loopback network device and the destination address does not belong to the loopback address, then the loopback network devices is not selected

## Impact

loopback network device

## Testing
Manual verification


