### PR TITLE
include/nuttx/arch.h: MSI alloc API should be always available

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2939,8 +2939,6 @@ int up_debugpoint_remove(int type, FAR void *addr, size_t size);
 
 #endif
 
-#ifdef CONFIG_PCI
-
 /****************************************************************************
  * Name: up_alloc_irq_msi
  *
@@ -2978,6 +2976,8 @@ int up_alloc_irq_msi(uint8_t busno, uint32_t devfn, FAR int *irq, int num);
  ****************************************************************************/
 
 void up_release_irq_msi(FAR int *irq, int num);
+
+#ifdef CONFIG_PCI
 
 /****************************************************************************
  * Name: up_connect_irq


### PR DESCRIPTION
MSI-like interrupts delivery can be used also for other devices than PCI, e.g HPET

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
MSI alloc API should be always available
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
qemu ostest

