### PR TITLE
driver/i2c/ipcc: Post sempahore only when it's value is smaller than one

### DIFF
--- a/drivers/i2c/i2c_slave_driver.c
+++ b/drivers/i2c/i2c_slave_driver.c
@@ -502,7 +502,7 @@ static int i2c_slave_callback(FAR void *arg, i2c_slave_complete_t status,
       priv->read_index = 0;
       priv->read_length = length;
 
-      while (nxsem_get_value(&priv->wait, &semcount) >= 0 && semcount <= 1)
+      while (nxsem_get_value(&priv->wait, &semcount) >= 0 && semcount <= 0)
         {
           nxsem_post(&priv->wait);
         }

--- a/drivers/ipcc/ipcc_read.c
+++ b/drivers/ipcc/ipcc_read.c
@@ -90,11 +90,10 @@ void ipcc_rxfree_notify(FAR struct ipcc_driver_s *priv)
 
   /* Notify all blocked readers that data is available to read */
 
-  do
+  while (nxsem_get_value(&priv->rxsem, &semval) >= 0 && semval <= 0)
     {
       nxsem_post(&priv->rxsem);
     }
-  while (nxsem_get_value(&priv->rxsem, &semval) == 0 && semval <= 0);
 }
 
 /****************************************************************************

--- a/drivers/ipcc/ipcc_write.c
+++ b/drivers/ipcc/ipcc_write.c
@@ -90,11 +90,10 @@ void ipcc_txfree_notify(FAR struct ipcc_driver_s *priv)
 
   /* Notify all blocked writers that data is available to write */
 
-  do
+  while (nxsem_get_value(&priv->txsem, &semval) >= 0 && semval <= 0)
     {
       nxsem_post(&priv->txsem);
     }
-  while (nxsem_get_value(&priv->txsem, &semval) == 0 && semval <= 0);
 }
 
 /****************************************************************************


### PR DESCRIPTION


## Summary

driver/i2c/ipcc: Post sempahore only when it's value is smaller than one to avoid waking up the waiting thread redundantly.


## Impact

avoid semphore count overflow

## Testing

vela
