### PR TITLE
irq: irq_attach_wqueue replace irq_attach_thread

### DIFF
--- a/arch/arm/src/armv7-m/Kconfig
+++ b/arch/arm/src/armv7-m/Kconfig
@@ -153,15 +153,15 @@ config ARMV7M_SYSTICK
 	---help---
 		Enable SysTick timer driver.
 
-config ARMV7M_SYSTICK_IRQ_THREAD
-	bool "attach irq by irq_attach_thread"
+config ARMV7M_SYSTICK_IRQ_WQUEUE
+	bool "attach irq by irq_attach_wqueue"
 	default n
 	depends on ARMV7M_SYSTICK
 
-if ARMV7M_SYSTICK_IRQ_THREAD
+if ARMV7M_SYSTICK_IRQ_WQUEUE
 
-config ARMV7M_SYSTICK_IRQ_THREAD_PRIORITY
-	int "SYSTICK IRQ THREAD PRIORITY"
+config ARMV7M_SYSTICK_IRQ_WQUEUE_PRIORITY
+	int "SYSTICK IRQ WQUEUE PRIORITY"
 	default 255
 	range 0 255
 
@@ -169,4 +169,4 @@ config ARMV7M_SYSTICK_IRQ_THREAD_STACK_SIZE
 	int "SYSTICK IRQ THREAD STACK SIZE"
 	default DEFAULT_TASK_STACKSIZE
 
-endif # ARMV7M_SYSTICK_IRQ_THREAD
+endif # ARMV7M_SYSTICK_IRQ_WQUEUE

--- a/arch/arm/src/armv7-m/arm_systick.c
+++ b/arch/arm/src/armv7-m/arm_systick.c
@@ -259,7 +259,7 @@ static int systick_interrupt(int irq, void *context, void *arg)
   return 0;
 }
 
-#ifdef CONFIG_ARMV7M_SYSTICK_IRQ_THREAD
+#ifdef CONFIG_ARMV7M_SYSTICK_IRQ_WQUEUE
 static int systick_isr_handle(int irq, void *regs, void *arg)
 {
   return IRQ_WAKE_THREAD;
@@ -301,11 +301,10 @@ struct timer_lowerhalf_s *systick_initialize(bool coreclk,
       putreg32(NVIC_SYSTICK_CTRL_TICKINT, NVIC_SYSTICK_CTRL);
     }
 
-#ifdef CONFIG_ARMV7M_SYSTICK_IRQ_THREAD
-  irq_attach_thread(NVIC_IRQ_SYSTICK, systick_isr_handle,
+#ifdef CONFIG_ARMV7M_SYSTICK_IRQ_WQUEUE
+  irq_attach_wqueue(NVIC_IRQ_SYSTICK, systick_isr_handle,
                     systick_interrupt, lower,
-                    CONFIG_ARMV7M_SYSTICK_IRQ_THREAD_PRIORITY,
-                    CONFIG_ARMV7M_SYSTICK_IRQ_THREAD_STACK_SIZE);
+                    CONFIG_ARMV7M_SYSTICK_IRQ_WQUEUE_PRIORITY);
 #else
   irq_attach(NVIC_IRQ_SYSTICK, systick_interrupt, lower);
 #endif


### PR DESCRIPTION
## Summary
irq_attach_wqueue replace irq_attach_thread
reason:
using a shared same priority queue can reduce memory consumption.
## Impact
isrthread
## Testing
ci test



