### PR TITLE
group/exitinof: replace spin_lock to critical_section avoid deadlock

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -432,7 +432,7 @@ int up_rtc_settime(const struct timespec *tp)
   irqstate_t flags;
   uint64_t count;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
 
 #ifdef RTC_DIRECT_CONTROL
   /* wait until previous write request is completed */
@@ -455,7 +455,7 @@ int up_rtc_settime(const struct timespec *tp)
   g_rtc_save->offset = (int64_t)count - (int64_t)cxd56_rtc_count();
 #endif
 
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
 
   rtc_dumptime(tp, "Setting time");
 

--- a/sched/group/group_exitinfo.c
+++ b/sched/group/group_exitinfo.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 
 #include <nuttx/sched.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/binfmt/binfmt.h>
 
 #include "sched/sched.h"
@@ -70,14 +69,14 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
   irqstate_t flags;
 
   DEBUGASSERT(bininfo != NULL);
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
 
   /* Get the TCB associated with the PID */
 
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      spin_unlock_irqrestore(NULL, flags);
+      leave_critical_section(flags);
       return -ESRCH;
     }
 
@@ -90,7 +89,7 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
 
   group->tg_bininfo = bininfo;
 
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
   return OK;
 }
 


### PR DESCRIPTION
## Summary

group/exitinof: replace spin_lock to critical_section avoid deadlock

holding the irqsaved spinlock first and then take critical section may cause deadlock in SMP case,
replace spin_lock to critical_section avoid deadlock


## Impact

SMP

## Testing

sim/smp
