### PR TITLE
fix compile error

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -531,7 +531,13 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
 
   if (NULL == lock)
     {
-      int me = this_cpu();
+      int me;
+
+#ifdef CONFIG_SMP
+      me = up_cpu_index();
+#else
+      me = 0;
+#endif
       if (0 == g_irq_spin_count[me])
         {
           spin_lock_wo_note(&g_irq_spin);
@@ -698,7 +704,13 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
 {
   if (NULL == lock)
     {
-      int me = this_cpu();
+      int me;
+
+#ifdef CONFIG_SMP
+      me = up_cpu_index();
+#else
+      me = 0;
+#endif
       DEBUGASSERT(0 < g_irq_spin_count[me]);
       g_irq_spin_count[me]--;
 


### PR DESCRIPTION

## Summary
fix compile error

riscv-none-elf-ld: warning: /home/hujun5/downloads1/vela_sim/nuttx/nuttx has a LOAD segment with RWX permissions
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libarch.a(riscv_modifyreg32.o): in function `spin_lock_irqsave_wo_note':
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:534:(.text.modifyreg32+0x1e): undefined reference to `this_cpu'
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libarch.a(riscv_modifyreg32.o): in function `spin_unlock_irqrestore_wo_note':
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:701:(.text.modifyreg32+0x82): undefined reference to `this_cpu'
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libarch.a(bl602_serial.o): in function `spin_lock_irqsave_wo_note':
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:534:(.text.up_putc+0x12): undefined reference to `this_cpu'
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libarch.a(bl602_serial.o): in function `spin_unlock_irqrestore_wo_note':
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:701:(.text.up_putc+0x84): undefined reference to `this_cpu'
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libsched.a(irq_attach.o): in function `spin_lock_irqsave_wo_note':
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:534:(.text.irq_attach+0x26): undefined reference to `this_cpu'
riscv-none-elf-ld: /home/hujun5/downloads1/vela_sim/nuttx/staging/libsched.a(irq_attach.o):/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/spinlock.h:701: more undefined references to `this_cpu' follow

## Impact
none
## Testing
ci
