### PR TITLE
Reapply "sched/spinlock: remove nesting spinlock support"

### DIFF
--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -43,10 +43,6 @@
 
 volatile spinlock_t g_irq_spin = SP_UNLOCKED;
 
-/* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
-
-volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
-
 #ifdef CONFIG_RW_SPINLOCK
 /* Used for access control */
 


### PR DESCRIPTION
## Summary
since https://github.com/apache/nuttx/pull/14200 fix the dead lock.
we reapply https://github.com/apache/nuttx/pull/14190

## Impact
none

## Testing
Build Host(s): Linux x86
Target(s): sim/smp

After that, there will be no warnings for compilation
make distclean -j20; ./tools/configure.sh -l sim:smp;make -j20
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/hujun5/downloads1/vela_sim/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/hujun5/downloads1/vela_sim/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/hujun5/downloads1/vela_sim/apps/platform/dummy
LN: include/arch to arch/sim/include
LN: include/arch/board to /home/hujun5/downloads1/vela_sim/nuttx/boards/sim/sim/sim/include
LN: drivers/platform to /home/hujun5/downloads1/vela_sim/nuttx/drivers/dummy
LN: include/arch/chip to /home/hujun5/downloads1/vela_sim/nuttx/arch/sim/include/sim
LN: arch/sim/src/chip to /home/hujun5/downloads1/vela_sim/nuttx/arch/sim/src/sim
LN: arch/sim/src/board to /home/hujun5/downloads1/vela_sim/nuttx/boards/sim/sim/sim/src
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/examples/mcuboot
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/examples
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/crypto
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/audioutils
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/logging
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/system
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/fsutils
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/benchmarks
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/database
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/interpreters/luamodules
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/interpreters
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/boot
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/testing
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/mlearning
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/graphics
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/netutils
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/sdr
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/canutils
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/lte
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/inertial
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/math
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/wireless/ieee802154
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/wireless/bluetooth
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/wireless
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/videoutils
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/games
mkkconfig in /home/hujun5/downloads1/vela_sim/apps/industry
mkkconfig in /home/hujun5/downloads1/vela_sim/apps
Loaded configuration '.config'
Configuration saved to '.config'
Create version.h
LN: platform/board to /home/hujun5/downloads1/vela_sim/apps/platform/dummy
Register: hello
Register: nsh
Register: sh
Register: taskset
Register: ostest
Register: getprime
Register: smp
CP:  /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/config.h
CP:  /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/fs/hostfs.h
LD:  nuttx



