### PR TITLE
include/nuttx/spinlock.h: fix gcc14 compilation error

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -35,6 +35,7 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
+#include <nuttx/sched.h>
 
 #if defined(CONFIG_TICKET_SPINLOCK) || defined(CONFIG_RW_SPINLOCK)
 #  include <nuttx/atomic.h>


### PR DESCRIPTION
## Summary

include/nuttx/spinlock.h: fix gcc14 compilation error
fix implicit declaration of function ‘this_cpu’

## Impact
fix compilation for gcc14

## Testing
CI


