### PR TITLE
cmake(bugfix):add dependencies for nuttx_post ensure time order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ add_executable(nuttx)
 add_custom_target(nuttx_post)
 if(CONFIG_BUILD_PROTECTED)
   add_executable(nuttx_user)
+  add_dependencies(nuttx_post nuttx_user)
   nuttx_add_library_internal(nuttx_user)
 endif()
 
@@ -730,6 +731,21 @@ if(CONFIG_ARCH_SIM)
   file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "nuttx\n")
 endif()
 
+# Generate system map using the compiler toolchain. Conventionally, the tool
+# which dump symbols are called nm, though, some compiler toolchain may have a
+# different name.
+if(NOT WIN32)
+  add_custom_command(
+    OUTPUT System.map
+    COMMAND
+      ${CMAKE_NM} nuttx | grep -v
+      '\(compiled\)\|\(\${CMAKE_C_OUTPUT_EXTENSION}$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)'
+      | sort > System.map
+    DEPENDS nuttx)
+  add_custom_target(systemmap ALL DEPENDS System.map)
+  add_dependencies(nuttx_post systemmap)
+endif()
+
 # Userspace portion ##########################################################
 
 if(CONFIG_BUILD_PROTECTED)
@@ -798,6 +814,7 @@ if(CONFIG_BUILD_PROTECTED)
     COMMAND ${CMAKE_NM} nuttx_user > User.map
     DEPENDS nuttx_user)
   add_custom_target(usermap ALL DEPENDS User.map)
+  add_dependencies(nuttx_post usermap)
 
   # generate binary outputs in different formats (.bin, .hex, etc)
   nuttx_generate_outputs(nuttx_user)


### PR DESCRIPTION
## Summary
systemmap and usermap depends nuttx_post(in protected build mode)

avoiding time order confusion

## Impact

fixed a bug where the map file was executed before compilation.

## Testing

qemu protected build

