### PR TITLE
nuttx/can: support to Send message priority sorting function.

### DIFF
--- a/drivers/can/CMakeLists.txt
+++ b/drivers/can/CMakeLists.txt
@@ -19,7 +19,7 @@
 # ##############################################################################
 
 if(CONFIG_CAN)
-  set(SRCS can.c)
+  set(SRCS can.c can_sender.c)
 
   if(CONFIG_CAN_MCP2515)
     list(APPEND SRCS mcp2515.c)

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -118,6 +118,12 @@ config CAN_TXREADY
 		no longer full.  can_txready() will then awaken the
 		can_write() logic and the hang condition is avoided.
 
+config CAN_TXPRIORITY
+	bool "Prioritize sending based on canid"
+	default n
+	---help---
+		Prioritize sending based on canid.
+
 choice
 	prompt "TX Ready Work Queue"
 	default CAN_TXREADY_HIPRI

--- a/drivers/can/Make.defs
+++ b/drivers/can/Make.defs
@@ -22,7 +22,7 @@
 
 ifeq ($(CONFIG_CAN),y)
 
-CSRCS += can.c
+CSRCS += can.c can_sender.c
 
 ifeq ($(CONFIG_CAN_MCP2515),y)
 CSRCS += mcp2515.c

--- a/drivers/can/can_sender.c
+++ b/drivers/can/can_sender.c
@@ -1,0 +1,256 @@
+/****************************************************************************
+ * drivers/can/can_sender.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/can/can_sender.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: can_xmit_init
+ *
+ * Description:
+ *   Initial dev sender.
+ *
+ ****************************************************************************/
+
+void can_sender_init(FAR struct can_txcache_s *cd_sender)
+{
+#if defined(CONFIG_CAN_TXPRIORITY) && CONFIG_CAN_TXFIFOSIZE <= 0
+#  error "CONFIG_CAN_TXFIFOSIZE should be positive non-zero value"
+#endif
+
+#ifdef CONFIG_CAN_TXPRIORITY
+  int i;
+
+  list_initialize(&cd_sender->tx_free);
+  list_initialize(&cd_sender->tx_pending);
+  list_initialize(&cd_sender->tx_sending);
+
+  for (i = 0; i < CONFIG_CAN_TXFIFOSIZE; i++)
+    {
+      list_add_tail(&cd_sender->tx_free, &cd_sender->tx_buffer[i].list);
+    }
+
+#else
+  cd_sender->tx_head  = 0;
+  cd_sender->tx_queue = 0;
+  cd_sender->tx_tail  = 0;
+#endif
+}
+
+/****************************************************************************
+ * Name: can_add_sendnode
+ *
+ * Description:
+ *   Add message to sender.
+ *
+ ****************************************************************************/
+
+void can_add_sendnode(FAR struct can_txcache_s *cd_sender,
+                      FAR struct can_msg_s *msg, int msglen)
+{
+#ifdef CONFIG_CAN_TXPRIORITY
+  FAR struct list_node *node;
+  FAR struct can_msg_node_s *msg_node;
+  FAR struct can_msg_node_s *tmp_node;
+
+  node = list_remove_head(&cd_sender->tx_free);
+  msg_node = container_of(node, struct can_msg_node_s, list);
+  memcpy(&msg_node->msg, msg, msglen);
+
+  list_for_every_entry(&cd_sender->tx_pending, tmp_node,
+                       struct can_msg_node_s, list)
+    {
+      if (tmp_node->msg.cm_hdr.ch_id > msg->cm_hdr.ch_id)
+        {
+          /* Prioritize tx frame based on canid */
+
+          break;
+        }
+    }
+
+  if (&tmp_node->list == &cd_sender->tx_pending)
+    {
+      /* Inserted at the end of the linked list */
+
+      list_add_tail(&cd_sender->tx_pending, &msg_node->list);
+    }
+  else
+    {
+      list_add_before(&tmp_node->list, &msg_node->list);
+    }
+#else
+  memcpy(&cd_sender->tx_buffer[cd_sender->tx_tail], msg, msglen);
+
+  /* Increment the tail of the circular buffer */
+
+  cd_sender->tx_tail++;
+  if (cd_sender->tx_tail >= CONFIG_CAN_TXFIFOSIZE)
+    {
+      cd_sender->tx_tail = 0;
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: can_get_msg
+ *
+ * Description:
+ *   Get send message from sender.
+ *
+ ****************************************************************************/
+
+FAR struct can_msg_s *can_get_msg(FAR struct can_txcache_s *cd_sender)
+{
+  FAR struct can_msg_s *msg = NULL;
+
+#ifdef CONFIG_CAN_TXPRIORITY
+  FAR struct can_msg_node_s *msg_node;
+  FAR struct can_msg_node_s *tmp_node;
+
+  if (list_is_empty(&cd_sender->tx_pending))
+    {
+      return NULL;
+    }
+
+  msg_node = list_first_entry(&cd_sender->tx_pending,
+                              struct can_msg_node_s, list);
+  msg = &msg_node->msg;
+
+  /* Sort unconfirmed messages in ascending order */
+
+  list_for_every_entry(&cd_sender->tx_sending, tmp_node,
+                       struct can_msg_node_s, list)
+    {
+      if (tmp_node->msg.cm_hdr.ch_id == msg->cm_hdr.ch_id)
+        {
+          /* In order to prevent messages with the same ID from being
+           * sent out of order, as long as there is a message with the
+           * same ID that has not been sent in H/W, no data will be
+           * written to H/W
+           */
+
+          return NULL;
+        }
+
+      if (tmp_node->msg.cm_hdr.ch_id > msg->cm_hdr.ch_id)
+        {
+          break;
+        }
+    }
+
+  /* Move the node from tx_pending to tx_sending before
+   * sending(because dev_send() might call can_txdone()).
+   */
+
+  list_delete(&msg_node->list);
+
+  if (&tmp_node->list == &cd_sender->tx_sending)
+    {
+      list_add_tail(&cd_sender->tx_sending, &msg_node->list);
+    }
+  else
+    {
+      list_add_before(&tmp_node->list, &msg_node->list);
+    }
+
+#else
+  msg = &cd_sender->tx_buffer[cd_sender->tx_queue];
+
+  /* Increment the FIFO queue index before sending (because dev_send()
+   * might call can_txdone()).
+   */
+
+  cd_sender->tx_queue++;
+
+  if (cd_sender->tx_queue == CONFIG_CAN_TXFIFOSIZE)
+    {
+      cd_sender->tx_queue = 0;
+    }
+#endif
+
+  return msg;
+}
+
+/****************************************************************************
+ * Name: can_revert_msg
+ *
+ * Description:
+ *   Rever msg in sender, because sending failed.
+ *
+ ****************************************************************************/
+
+void can_revert_msg(FAR struct can_txcache_s *cd_sender,
+                    FAR struct can_msg_s *msg)
+{
+#ifdef CONFIG_CAN_TXPRIORITY
+  FAR struct can_msg_node_s *msg_node;
+
+  msg_node = container_of(msg, struct can_msg_node_s, msg);
+
+  list_delete(&msg_node->list);
+
+  list_add_head(&cd_sender->tx_pending, &msg_node->list);
+#else
+  UNUSED(msg);
+  if (cd_sender->tx_queue == 0)
+    {
+      cd_sender->tx_queue = CONFIG_CAN_TXFIFOSIZE - 1;
+    }
+  else
+    {
+      cd_sender->tx_queue--;
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: can_send_done
+ *
+ * Description:
+ *   Release the sender resources, after the tragic message is successfully
+ *   sent to the bus.
+ *
+ ****************************************************************************/
+
+void can_send_done(FAR struct can_txcache_s *cd_sender)
+{
+#ifdef CONFIG_CAN_TXPRIORITY
+  FAR struct list_node *node;
+
+  node = list_remove_head(&cd_sender->tx_sending);
+  list_add_head(&cd_sender->tx_free, node);
+#else
+  /* Remove the message at the head of the xmit FIFO */
+
+  cd_sender->tx_head++;
+  if (cd_sender->tx_head >= CONFIG_CAN_TXFIFOSIZE)
+    {
+      cd_sender->tx_head = 0;
+    }
+#endif
+}

--- a/include/nuttx/can/can_sender.h
+++ b/include/nuttx/can/can_sender.h
@@ -1,0 +1,239 @@
+/****************************************************************************
+ * include/nuttx/can/can_sender.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_CAN_SENDER_H
+#define __INCLUDE_NUTTX_CAN_SENDER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <nuttx/list.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/mutex.h>
+#include <nuttx/can/can.h>
+
+#ifdef CONFIG_CAN
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_CAN_TXPRIORITY
+
+/* There are three linked lists to manage TX buffer:
+ * tx_free     - can_write function get a tx_free node, write message, then
+ *               move this node to tx_pending list.
+ * tx_pending  - cache message send from application but not send to H/W.
+ *               Sorted in ascending order based on can_id.
+ * tx_sending  - Message in H/W is sending to bus, but not confirmation.
+ *               Sorted in ascending order based on can_id.
+ */
+
+#  define TX_EMPTY(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (list_length(&__sender->tx_free) == CONFIG_CAN_TXFIFOSIZE); \
+    }) \
+
+#  define TX_FULL(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      list_is_empty(&__sender->tx_free); \
+    }) \
+
+#  define TX_PENDING(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      !list_is_empty(&__sender->tx_pending); \
+    }) \
+
+#  define PENDING_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (list_length(&__sender->tx_pending)); \
+    }) \
+
+#  define SENDING_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (list_length(&__sender->tx_sending)); \
+    }) \
+
+#  define FREE_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (list_length(&__sender->tx_free)); \
+    }) \
+
+#else
+/* There are three fields used to manage TX FIFO buffer:
+ * tx_tail:  Incremented in can_write each time a message is queued in the
+ *           FIFO
+ * tx_head:  Incremented in can_txdone each time a message completes
+ * tx_queue: Incremented each time that a message is sent to the hardware.
+ *
+ * Logically (ignoring buffer wrap-around): tx_head <= tx_queue <= tx_tail
+ * tx_head == tx_queue == tx_tail means that the FIFO is empty
+ * tx_head < tx_queue == tx_tail means that all data has been queued, but
+ * we are still waiting for transmissions to complete.
+ */
+#  define TX_EMPTY(sender) \
+      ({ \
+        FAR struct can_txcache_s *__sender = (sender); \
+        (__sender->tx_head == __sender->tx_tail); \
+      }) \
+
+#  define TX_FULL(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (__sender->tx_head == \
+          (__sender->tx_tail + 1) % CONFIG_CAN_TXFIFOSIZE); \
+    }) \
+
+#  define TX_PENDING(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (__sender->tx_queue != __sender->tx_tail); \
+    }) \
+
+#  define PENDING_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (CONFIG_CAN_TXFIFOSIZE + __sender->tx_tail - __sender->tx_queue) \
+                                              % CONFIG_CAN_TXFIFOSIZE; \
+    }) \
+
+#  define SENDING_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (CONFIG_CAN_TXFIFOSIZE + __sender->tx_queue - __sender->tx_head) \
+                                              % CONFIG_CAN_TXFIFOSIZE; \
+    }) \
+
+#  define FREE_COUNT(sender) \
+    ({ \
+      FAR struct can_txcache_s *__sender = (sender); \
+      (CONFIG_CAN_TXFIFOSIZE - 1 - __sender->tx_tail + __sender->tx_head) \
+                                                % CONFIG_CAN_TXFIFOSIZE; \
+    }) \
+
+#endif  /* CONFIG_CAN_TXPRIORITY */
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: can_sender_init
+ *
+ * Description:
+ *   Initial dev sender.
+ *
+ * Input Parameters:
+ *   cd_sender  - The CAN device sender.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void can_sender_init(FAR struct can_txcache_s *cd_sender);
+
+/****************************************************************************
+ * Name: can_add_sendnode
+ *
+ * Description:
+ *   Add message to sender..
+ *
+ * Input Parameters:
+ *   cd_sender  - The CAN device sender.
+ *
+ * Returned Value:
+ *   CAN message which to be send.
+ *
+ ****************************************************************************/
+
+void can_add_sendnode(FAR struct can_txcache_s *cd_sender,
+                      FAR struct can_msg_s *msg, int msglen);
+
+/****************************************************************************
+ * Name: can_get_msg
+ *
+ * Description:
+ *   Get message from sender, and change sender recoder.
+ *
+ * Input Parameters:
+ *   cd_sender  - The CAN device sender.
+ *
+ * Returned Value:
+ *   CAN message which to be send.
+ *
+ ****************************************************************************/
+
+struct can_msg_s *can_get_msg(FAR struct can_txcache_s *cd_sender);
+
+/****************************************************************************
+ * Name: can_revert_msg
+ *
+ * Description:
+ *   Revert sender recoder when send failed.
+ *
+ * Input Parameters:
+ *   cd_sender  - The CAN device sender.
+ *   msg        - message which to be revert.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void can_revert_msg(FAR struct can_txcache_s *cd_sender,
+                    FAR struct can_msg_s *msg);
+
+/****************************************************************************
+ * Name: can_send_done
+ *
+ * Description:
+ *   Release the sender resources, after the tragic message is successfully
+ *   sent to the bus.
+ *
+ * Input Parameters:
+ *   cd_sender  - The CAN device sender.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void can_send_done(FAR struct can_txcache_s *cd_sender);
+
+#endif /* CONFIG_CAN */
+#endif /* __INCLUDE_NUTTX_CAN_SENDER_H */


### PR DESCRIPTION
Linked list-based priority sorting function for sending messages.

## Summary

This PR introduces a new priority-based sending mechanism for the CAN protocol stack, addressing the need for deterministic message delivery in time-critical applications. The change modifies the CAN driver files to implement a linked list-based priority queue for outgoing CAN frames.

The priority of a CAN frame is determined by CAN ID. This allows applications to prioritize critical messages, ensuring they are transmitted ahead of less important ones, even under high bus load.

## Impact

New Feature: Adds priority-based sending for CAN frames.
User Impact: YES. Users can now enable and configure priority sending using Kconfig options.
Build Impact: YES. To enable priority sending, users must select the CAN_TXPRIORITY during build configuration.
Compatibility Impact: Assess backward compatibility.

## Testing

The application layer sends unordered CAN messages, constructs a scenario where the sending queue is full, and manually adds log information to record the frame order in the priority sending queue. Print the frame.can_id information for each frame as follows:

tx_list has full, and frame order is : 0x193 ， 0x198, 0x19B, 0x1b5, 0x1b9, 0x259, 0x268, 0x2a1, 0x311, 0x319


