### PR TITLE
cmake(bugfix):disable proxy and service source in open-amp

### DIFF
--- a/openamp/open-amp.cmake
+++ b/openamp/open-amp.cmake
@@ -100,6 +100,7 @@ else()
 endif()
 
 set(WITH_LIBMETAL_FIND OFF)
+set(WITH_PROXY OFF)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR)
   set(CMAKE_SYSTEM_PROCESSOR ${CONFIG_ARCH})
@@ -107,5 +108,8 @@ endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/open-amp
                  ${CMAKE_CURRENT_BINARY_DIR}/open-amp EXCLUDE_FROM_ALL)
+
+target_include_directories(
+  open_amp-static PRIVATE $<TARGET_PROPERTY:metal-static,INCLUDE_DIRECTORIES>)
 
 nuttx_add_external_library(open_amp-static MODE KERNEL)


### PR DESCRIPTION
## Summary

since we disable find_package(libmetal) so we need to set open_amp target include dirs link to metal target

## Impact

bugfix for open_amp cmake build

## Testing

qemu build pass


