### PR TITLE
Bugfix/samv7 rswdt

### DIFF
--- a/arch/arm/src/samv7/sam_ethernet.h
+++ b/arch/arm/src/samv7/sam_ethernet.h
@@ -243,7 +243,7 @@ int sam_emac_setmacaddr(int intf, uint8_t mac[6]);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SAMV7_EMAC0_PHYINIT) | defined(CONFIG_SAMV7_EMAC1_PHYINIT)
+#if defined(CONFIG_SAMV7_EMAC0_PHYINIT) || defined(CONFIG_SAMV7_EMAC1_PHYINIT)
 int sam_phy_boardinitialize(int intf);
 #endif
 

--- a/arch/arm/src/samv7/sam_rswdt.c
+++ b/arch/arm/src/samv7/sam_rswdt.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <assert.h>
 #include <errno.h>
@@ -411,9 +412,9 @@ static int sam_getstatus(struct watchdog_lowerhalf_s *lower,
   status->timeleft = 0;
 
   wdinfo("Status     :\n");
-  wdinfo("  flags    : %08x\n", status->flags);
-  wdinfo("  timeout  : %d\n", status->timeout);
-  wdinfo("  timeleft : %d\n", status->timeleft);
+  wdinfo("  flags    : %08" PRIx32 "\n", status->flags);
+  wdinfo("  timeout  : %" PRIu32 "\n", status->timeout);
+  wdinfo("  timeleft : %" PRIu32 "\n", status->timeleft);
   return OK;
 }
 
@@ -441,13 +442,13 @@ static int sam_settimeout(struct watchdog_lowerhalf_s *lower,
   uint32_t regval;
 
   DEBUGASSERT(priv);
-  wdinfo("Entry: timeout=%d\n", timeout);
+  wdinfo("Entry: timeout=%" PRIu32 "\n", timeout);
 
   /* Can this timeout be represented? */
 
   if (timeout < RSWDT_MINTIMEOUT || timeout >= RSWDT_MAXTIMEOUT)
     {
-      wderr("ERROR: Cannot represent timeout: %d < %d > %d\n",
+      wderr("ERROR: Cannot represent timeout: %d < %" PRIu32 " > %d\n",
             RSWDT_MINTIMEOUT, timeout, RSWDT_MAXTIMEOUT);
       return -ERANGE;
     }
@@ -480,7 +481,7 @@ static int sam_settimeout(struct watchdog_lowerhalf_s *lower,
 
   priv->reload = reload;
 
-  wdinfo("reload=%d timeout: %d->%d\n",
+  wdinfo("reload=%" PRIu32 " timeout: %" PRIu32 "->%" PRIu32 "\n",
          reload, timeout, priv->timeout);
 
   /* Set the RSWDT_MR according to calculated value
@@ -525,7 +526,7 @@ static int sam_settimeout(struct watchdog_lowerhalf_s *lower,
 
   priv->started = true;
 
-  wdinfo("Setup: CR: %08x MR: %08x SR: %08x\n",
+  wdinfo("Setup: CR: %08" PRIx32 " MR: %08" PRIx32 " SR: %08" PRIx32 "\n",
          sam_getreg(SAM_RSWDT_CR), sam_getreg(SAM_RSWDT_MR),
          sam_getreg(SAM_RSWDT_SR));
 
@@ -651,7 +652,7 @@ int sam_rswdt_initialize(void)
 {
   struct sam_lowerhalf_s *priv = &g_wdtdev;
 
-  wdinfo("Entry: CR: %08x MR: %08x SR: %08x\n",
+  wdinfo("Entry: CR: %08" PRIx32 " MR: %08" PRIx32 " SR: %08" PRIx32 "\n",
          sam_getreg(SAM_RSWDT_CR), sam_getreg(SAM_RSWDT_MR),
          sam_getreg(SAM_RSWDT_SR));
 


### PR DESCRIPTION
## Summary
Fix compilation warning in `arch/arm/src/samv7/sam_rswdt.c` by usage of print modifiers from `inttypes.h`

## Impact
SAMv7 build with rswdt enabled produce less warnings

## Testing
Tested on SAMv7 based device


