### PR TITLE
ESP32C6-DevKit C/M Add necessary Import to compilation

### DIFF
--- a/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_boot.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_boot.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include "riscv_internal.h"
+#include "esp32c6-devkitc.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_boot.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_boot.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include "riscv_internal.h"
+#include "esp32c6-devkitm.h"
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION

## Summary

This PR allow esp32c6 devkit c and esp32c6 devkit m to start different app than nsh when CONFIG_BOARD_LATE_INITIALIZE is necessary

## Impact

It is now possible to compile the project when CONFIG_BOARD_LATE_INITIALIZE is enabled

## Testing

Go to master branch, follow steps below: 
![image](https://github.com/user-attachments/assets/0e4df447-d1f7-4084-8fe2-17cb0f5def99)
You will face compilation issue. 

Go to this branch, try again, now it is possible compile.


