### PR TITLE
xtensa/esp32s3: inspect if partition mapped as text

### DIFF
--- a/arch/xtensa/include/esp32s3/partition.h
+++ b/arch/xtensa/include/esp32s3/partition.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * arch/xtensa/include/esp32s3/partition.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_INCLUDE_ESP32S3_PARTITION_H
+#define __ARCH_XTENSA_INCLUDE_ESP32S3_PARTITION_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* OTA image operation code */
+
+enum ota_img_ctrl_e
+{
+  OTA_IMG_GET_BOOT        = 0xe1,
+  OTA_IMG_SET_BOOT        = 0xe2,
+  OTA_IMG_INVALIDATE_BOOT = 0xe3,
+  OTA_IMG_IS_MAPPED_AS_TEXT = 0xe4,
+};
+
+/* OTA image boot sequency */
+
+enum ota_img_bootseq_e
+{
+  OTA_IMG_BOOT_FACTORY    = 0,
+  OTA_IMG_BOOT_OTA_0      = 1,
+  OTA_IMG_BOOT_OTA_1      = 2,
+  OTA_IMG_BOOT_SEQ_MAX
+};
+
+#endif /* __ARCH_XTENSA_INCLUDE_ESP32S3_PARTITION_H */

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
@@ -1374,3 +1374,24 @@ bool esp32s3_flash_encryption_enabled(void)
 
   return enabled;
 }
+
+/****************************************************************************
+ * Name: esp32s3_get_flash_address_mapped_as_text
+ *
+ * Description:
+ *   Get flash address which is currently mapped as text
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   flash address which is currently mapped as text
+ *
+ ****************************************************************************/
+
+uint32_t esp32s3_get_flash_address_mapped_as_text(void)
+{
+  uint32_t i = MMU_ADDR2PAGE((uint32_t)_stext) -
+               MMU_ADDR2PAGE(SOC_MMU_IBUS_VADDR_BASE);
+  return (FLASH_MMU_TABLE[i] & MMU_ADDRESS_MASK) * MMU_PAGE_SIZE;
+}

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.h
@@ -166,6 +166,22 @@ int esp32s3_spiflash_init(void);
 
 bool esp32s3_flash_encryption_enabled(void);
 
+/****************************************************************************
+ * Name: esp32s3_get_flash_address_mapped_as_text
+ *
+ * Description:
+ *   Get flash address which is currently mapped as text
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   flash address which is currently mapped as text
+ *
+ ****************************************************************************/
+
+uint32_t esp32s3_get_flash_address_mapped_as_text(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
arch/esp32s3/partition: Inspect if the MTD partition (factory/ota_0/ota_1) is mapped as text.
Relocate the enum ota_img_ctrl_e and ota_img_bootseq_e to a directory visible to the application.

## Impact
Only esp32s3

## Testing
Testing use esp32s3-devkitc


