### PR TITLE
xtensa/esp32s3: add support for getting country code

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -5884,7 +5884,15 @@ int esp_wifi_sta_country(struct iwreq *iwr, bool set)
     }
   else
     {
-      return -ENOSYS;
+      memset(&country, 0x00, sizeof(wifi_country_t));
+      ret = esp_wifi_get_country(&country);
+      if (ret)
+        {
+          wlerr("Failed to get country info ret=%d\n", ret);
+          return wifi_errno_trans(ret);
+        }
+
+      memcpy(iwr->u.data.pointer, country.cc, 2);
     }
 
   return OK;

--- a/arch/xtensa/src/esp32s3/esp32s3_wlan.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wlan.c
@@ -1377,6 +1377,10 @@ static int wlan_ioctl(struct net_driver_s *dev,
         ret = ops->country(iwr, true);
         break;
 
+      case SIOCGIWCOUNTRY:  /* Set country code */
+        ret = ops->country(iwr, false);
+        break;
+
       case SIOCGIWSENS:    /* Get sensitivity (dBm) */
         ret = ops->rssi(iwr, false);
         break;


### PR DESCRIPTION
## Summary
xtensa/esp32s3: add wapi support for getting country code commands on ESP32-S3

## Impact
Only esp32s3

## Testing
Testing use esp32s3-devkitc

```
nsh> wapi show wlan0
wlan0 Configuration:
IP: 10.0.0.2
NetMask: 255.255.255.0
Frequency: 2412
Flag: WAPI_FREQ_AUTO
Channel: 1
Frequency: 2412
ESSID:
Flag: WAPI_ESSID_OFF
Mode: WAPI_MODE_MANAGED
AP: ff:ff:ff:ff:ff:ff
BitRate: 0
Flag: WAPI_BITRATE_AUTO
TxPower: 20
Flag: WAPI_TXPOWER_DBM
Sense: -128
Country: CN
```

