### PR TITLE
Revert "libc/atomic: decoupling atomic and spinlock to avoid recursion"

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -151,6 +151,10 @@ void sched_note_spinlock_unlock(FAR volatile spinlock_t *spinlock);
 
 extern volatile spinlock_t g_irq_spin;
 
+/* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
+
+extern volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
+
 /****************************************************************************
  * Name: up_testset
  *
@@ -527,7 +531,14 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
 
   if (NULL == lock)
     {
-      spin_lock_wo_note(&g_irq_spin);
+      int me = this_cpu();
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_lock_wo_note(&g_irq_spin);
+        }
+
+      g_irq_spin_count[me]++;
+      DEBUGASSERT(0 != g_irq_spin_count[me]);
     }
   else
     {
@@ -546,7 +557,10 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
  * Description:
  *   If SMP is enabled:
  *     If the argument lock is not specified (i.e. NULL),
- *     disable local interrupts and take the global spinlock (g_irq_spin).
+ *     disable local interrupts and take the global spinlock (g_irq_spin)
+ *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
+ *     counter on the CPU is incremented to allow nested calls and return
+ *     the interrupt state.
  *
  *     If the argument lock is specified,
  *     disable local interrupts and take the lock spinlock and return
@@ -684,7 +698,14 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
 {
   if (NULL == lock)
     {
-      spin_unlock_wo_note(&g_irq_spin);
+      int me = this_cpu();
+      DEBUGASSERT(0 < g_irq_spin_count[me]);
+      g_irq_spin_count[me]--;
+
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_unlock_wo_note(&g_irq_spin);
+        }
     }
   else
     {
@@ -702,9 +723,11 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
  *
  * Description:
  *   If SMP is enabled:
- *     If the argument lock is not specified (i.e. NULL), release the
- *     spinlock (g_irq_spin) and restore the interrupt state as it was
- *     prior to the previous call to spin_lock_irqsave(NULL).
+ *     If the argument lock is not specified (i.e. NULL),
+ *     decrement the call counter (g_irq_spin_count[cpu]) and if it
+ *     decrements to zero then release the spinlock (g_irq_spin) and
+ *     restore the interrupt state as it was prior to the previous call to
+ *     spin_lock_irqsave(NULL).
  *
  *     If the argument lock is specified, release the lock and
  *     restore the interrupt state as it was prior to the previous call to

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -35,6 +35,7 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
+#include <nuttx/arch.h>
 
 #if defined(CONFIG_TICKET_SPINLOCK) || defined(CONFIG_RW_SPINLOCK)
 #  include <nuttx/atomic.h>

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -49,7 +49,7 @@
  * SP_LOCKED and SP_UNLOCKED must constants of type spinlock_t.
  */
 
-#  include <nuttx/spinlock.h>
+#  include <arch/spinlock.h>
 #endif
 
 /****************************************************************************

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -43,6 +43,10 @@
 
 volatile spinlock_t g_irq_spin = SP_UNLOCKED;
 
+/* Handles nested calls to spin_lock_irqsave and spin_unlock_irqrestore */
+
+volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
+
 #ifdef CONFIG_RW_SPINLOCK
 /* Used for access control */
 


### PR DESCRIPTION
## Summary

Revert "pthread: We should not directly include arch/spinlock.h as it may cause compilation errors in C++."
Revert "sched/spinlock: remove nesting spinlock support"
Revert "libc/atomic: decoupling atomic and spinlock to avoid recursion"

Further work(without this feature could be closed):
https://github.com/apache/nuttx/pull/14200

## Impact

N/A

## Testing

ci-check