### PR TITLE
nuttx/sim:Remove asan check in up_irq_save().

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostirq.c
+++ b/arch/sim/src/sim/posix/sim_hostirq.c
@@ -87,6 +87,7 @@ uint64_t up_irq_flags(void)
  *
  ****************************************************************************/
 
+__attribute__((no_sanitize_address))
 uint64_t up_irq_save(void)
 {
   union sigset_u nmask;


### PR DESCRIPTION
Sometimes asan may generate some false positives, so it is temporarily turned off.

## Summary

## Impact

## Testing