### PR TITLE
sim/m64:Fix ld error.

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -313,4 +313,10 @@ ifeq ($(CONFIG_SIM_M32),y)
   LDMODULEFLAGS += -melf_i386
   SHMODULEFLAGS += -melf_i386
   LDELFFLAGS += -melf_i386
+else ifeq ($(CONFIG_HOST_MACOS),)
+  # To compile 64-bit Sim, adding no-pie is necessary to prevent linking errors
+  # but this may cause other issues on Ubuntu 20.
+  ARCHCFLAGS += -no-pie
+  ARCHPICFLAGS += -no-pie
+  LDFLAGS += -Wl,-no-pie
 endif


### PR DESCRIPTION

/usr/bin/ld: nuttx.rel: relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIE
/usr/bin/ld: failed to set dynamic section sizes: bad value

## Summary

## Impact

## Testing

