### PR TITLE
gnu++20:fix ld error.

### DIFF
--- a/libs/libxx/__config_site
+++ b/libs/libxx/__config_site
@@ -38,6 +38,9 @@
 #define _LIBCPP_ENABLE_HARDENED_MODE_DEFAULT 0
 #define _LIBCPP_ENABLE_DEBUG_MODE_DEFAULT 0
 
+#define _LIBCPP_DISABLE_DEPRECATION_WARNINGS 1
+#define _LIBCPP_AVAILABILITY_HAS_NO_VERBOSE_ABORT 1
+
 // __USE_MINGW_ANSI_STDIO gets redefined on MinGW
 #ifdef __clang__
 #  pragma clang diagnostic push


### PR DESCRIPTION
LD: nuttx
arm-none-eabi-ld: warning: net_sendfile.o: missing .note.GNU-stack section implies executable stack
arm-none-eabi-ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
arm-none-eabi-ld: warning: nuttx/nuttx has a LOAD segment with RWX permissions
arm-none-eabi-ld: apps/staging/libfeature.a(feature_framework.cpp.frameworks.base.feature_1.o): in function `std::__1::__throw_length_error[abi:un170006](char const*)':

## Summary


## Impact

## Testing

