### PR TITLE
nuttx/elf.h: Fix build error with unknown type name 'bool'.

### DIFF
--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -29,6 +29,7 @@
 
 #include <elf.h>
 #include <arch/elf.h>
+#include <stdbool.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
nuttx/include/nuttx/elf.h:118:1: error: unknown type name 'bool'
  118 | bool up_checkarch(FAR const Elf_Ehdr *hdr);
      | ^~~~
nuttx/include/nuttx/elf.h:30:1: note: 'bool' is defined in header '<stdbool.h>'; did you forget to '#include <stdbool.h>'?
   29 | #include <arch/elf.h>
  +++ |+#include <stdbool.h>
   30 |

## Summary

## Impact

## Testing



