### PR TITLE
arch/x86_64:Add CXX configuration for enabling x86_64 support for C++ applications.

### DIFF
--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -92,6 +92,17 @@ add_link_options(-Wl,--no-relax)
 add_compile_options(-fno-pic -mcmodel=large)
 add_compile_options(-mno-red-zone)
 
+add_compile_options(
+  -U_AIX
+  -U_WIN32
+  -U__APPLE__
+  -U__FreeBSD__
+  -U__NetBSD__
+  -U__linux__
+  -U__sun__
+  -U__unix__
+  -U__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__)
+
 if(CONFIG_DEBUG_LINK_MAP)
   add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
 endif()
@@ -107,6 +118,11 @@ add_compile_options(
 
 if(CONFIG_CXX_STANDARD)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
+endif()
+
+if(CONFIG_LIBCXX)
+  add_compile_options(-D__GLIBCXX__)
+  add_compile_options(-D_LIBCPP_DISABLE_AVAILABILITY)
 endif()
 
 if(NOT CONFIG_LIBCXXTOOLCHAIN)


### PR DESCRIPTION


## Summary


## Impact


## Testing



