### PR TITLE
nuttx/libc:Add _dl_find_object and dl_iterate_phdr function.

### DIFF
--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -70,6 +70,15 @@ if(CONFIG_SCHED_GCOV)
   list(APPEND EXTRA_LIB ${extra_library})
 endif()
 
+if(CONFIG_CXX_EXCEPTION)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcc_eh.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
 nuttx_add_extra_library(${EXTRA_LIB})
 
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/libs/libc/dlfcn/CMakeLists.txt
+++ b/libs/libc/dlfcn/CMakeLists.txt
@@ -21,5 +21,6 @@
 # ##############################################################################
 if(CONFIG_LIBC_DLFCN)
   target_sources(c PRIVATE lib_dlopen.c lib_dlclose.c lib_dlsym.c lib_dlerror.c
-                           lib_dlsymtab.c lib_dladdr.c)
+                           lib_dlsymtab.c)
 endif()
+target_sources(c PRIVATE lib_dlfind_object.c)

--- a/libs/libc/dlfcn/Make.defs
+++ b/libs/libc/dlfcn/Make.defs
@@ -27,9 +27,11 @@ ifeq ($(CONFIG_LIBC_DLFCN),y)
 CSRCS += lib_dlopen.c lib_dlclose.c lib_dlsym.c lib_dlerror.c lib_dlsymtab.c
 CSRCS += lib_dladdr.c
 
+endif
+
+CSRCS += lib_dlfind_object.c
+
 # Add the dlfcn.h directory to the build
 
 DEPPATH += --dep-path dlfcn
 VPATH += :dlfcn
-
-endif

--- a/libs/libc/dlfcn/lib_dlfind_object.c
+++ b/libs/libc/dlfcn/lib_dlfind_object.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * libs/libc/dlfcn/lib_dlfind_object.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+#include <stddef.h>
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+struct dl_find_object;
+struct dl_phdr_info;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int _dl_find_object(FAR void *address, FAR struct dl_find_object *result)
+{
+  return -1;
+}
+
+int dl_iterate_phdr(CODE int (*callback)(FAR struct dl_phdr_info *info,
+                                         size_t size, FAR void *data),
+                    FAR void *data)
+{
+  return 0;
+}


### PR DESCRIPTION
Add _dl_find_object() function, because when cxx_exception configuration is enabled, a link error occurs and that function cannot be found.

ld: /usr/lib/gcc/x86_64-linux-gnu/13/libgcc_eh.a(unwind-dw2-fde-dip.o): in function `_Unwind_Find_FDE':
(.text+0x250c): undefined reference to `_dl_find_object'

## Summary

## Impact

## Testing

