### PR TITLE
sched: fix nxsched_process_delivered did not call hook

### DIFF
--- a/arch/arm/src/armv7-a/arm_smpcall.c
+++ b/arch/arm/src/armv7-a/arm_smpcall.c
@@ -68,9 +68,16 @@
 
 int arm_smp_sched_handler(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb;
   int cpu = this_cpu();
 
+  tcb = current_task(cpu);
+  nxsched_suspend_scheduler(tcb);
   nxsched_process_delivered(cpu);
+  tcb = current_task(cpu);
+  nxsched_resume_scheduler(tcb);
+
+  UNUSED(tcb);
   return OK;
 }
 

--- a/arch/arm/src/armv7-r/arm_smpcall.c
+++ b/arch/arm/src/armv7-r/arm_smpcall.c
@@ -68,9 +68,16 @@
 
 int arm_smp_sched_handler(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb;
   int cpu = this_cpu();
 
+  tcb = current_task(cpu);
+  nxsched_suspend_scheduler(tcb);
   nxsched_process_delivered(cpu);
+  tcb = current_task(cpu);
+  nxsched_resume_scheduler(tcb);
+
+  UNUSED(tcb);
   return OK;
 }
 

--- a/arch/arm64/src/common/arm64_smpcall.c
+++ b/arch/arm64/src/common/arm64_smpcall.c
@@ -67,9 +67,16 @@
 
 int arm64_smp_sched_handler(int irq, void *context, void *arg)
 {
+  struct tcb_s *tcb;
   int cpu = this_cpu();
 
+  tcb = current_task(cpu);
+  nxsched_suspend_scheduler(tcb);
   nxsched_process_delivered(cpu);
+  tcb = current_task(cpu);
+  nxsched_resume_scheduler(tcb);
+
+  UNUSED(tcb);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
sched: fix nxsched_process_delivered did not call hook

## Impact
add some hook will not affect function

## Testing
ostest



