### PR TITLE
arch/arm64: fix build warnings

### DIFF
--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -352,7 +352,7 @@ void mpu_dump_region(void)
       write_sysreg(i, prselr_el1);
       prlar = read_sysreg(prlar_el1);
       prbar = read_sysreg(prbar_el1);
-      _info("MPU-%d, 0x%08X-0x%08X SH=%X AP=%X XN=%X\n", i,
+      _info("MPU-%d, 0x%08llX-0x%08llX SH=%llX AP=%llX XN=%llX\n", i,
             prbar & MPU_RBAR_BASE_MSK, prlar & MPU_RLAR_LIMIT_MSK,
             prbar & MPU_RBAR_SH_MSK, prbar & MPU_RBAR_AP_MSK,
             prbar & MPU_RBAR_XN_MSK);


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary


```
common/arm64_mpu.c:355:13: error: format '%llX' expects argument of type 'long long unsigned int', but argument 4 has type 'long unsigned int' [-Werror=format=]
  355 |       _info("MPU-%d, 0x%08llX-0x%08llX SH=%llX AP=%llX XN=%llX\n", i,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common/arm64_mpu.c:355:29: note: format string is defined here
  355 |       _info("MPU-%d, 0x%08llX-0x%08llX SH=%llX AP=%llX XN=%llX\n", i,
      |                        ~~~~~^
      |                             |
      |                             long long unsigned int
      |                        %08lX
common/arm64_mpu.c:355:13: error: format '%llX' expects argument of type 'long long unsigned int', but argument 5 has type 'long unsigned int' [-Werror=format=]
  355 |       _info("MPU-%d, 0x%08llX-0x%08llX SH=%llX AP=%llX XN=%llX\n", i,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common/arm64_mpu.c:355:38: note: format string is defined here
  355 |       _info("MPU-%d, 0x%08llX-0x%08llX SH=%llX AP=%llX XN=%llX\n", i,
```

## Impact
No impact.

## Testing

Disable CONFIG_DEBUG_INFO and build
```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm64/qemu/qemu-armv8a/configs/nsh_smp nuttx

ninja -C build
```


