### PR TITLE
Use BACKTRACE_BUFFER_SIZE to declare backtrace buffer

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -197,7 +197,7 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
   if ((MM_DUMP_ASSIGN(dump, buf) || MM_DUMP_ALLOC(dump, buf) ||
        MM_DUMP_LEAK(dump, buf)) && MM_DUMP_SEQNO(dump, buf))
     {
-      char tmp[CONFIG_MM_BACKTRACE * BACKTRACE_PTR_FMT_WIDTH + 1] = "";
+      char tmp[BACKTRACE_BUFFER_SIZE(CONFIG_MM_BACKTRACE)];
 
 #  if CONFIG_MM_BACKTRACE > 0
       FAR const char *format = " %0*p";

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -540,7 +540,7 @@ static void dump_tasks(void)
 #if CONFIG_LIBC_MUTEX_BACKTRACE > 0
 static void dump_lockholder(pid_t tid)
 {
-  char buf[CONFIG_LIBC_MUTEX_BACKTRACE * BACKTRACE_PTR_FMT_WIDTH + 1] = "";
+  char buf[BACKTRACE_BUFFER_SIZE(CONFIG_LIBC_MUTEX_BACKTRACE)];
   FAR mutex_t *mutex;
 
   mutex = (FAR mutex_t *)nxsched_get_tcb(tid)->waitobj;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

We have `BACKTRACE_BUFFER_SIZE ` now, thus use it direct for buffers to hold backtrace.


## Impact

Minor code refactor, no impact.

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


