### PR TITLE
drivers/segger: inline note_sysview_get_timestamp

### DIFF
--- a/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
+++ b/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -56,6 +57,16 @@
 #define SEGGER_SYSVIEW_CPU_CACHE_LINE_SIZE CONFIG_SEGGER_RTT_CPU_CACHE_LINE_SIZE
 
 /****************************************************************************
+ * Name: note_sysview_get_timestamp
+ *
+ * Description:
+ *   Retrieve a system timestamp for SYSVIEW events.
+ *
+ ****************************************************************************/
+
+#define note_sysview_get_timestamp() perf_gettime()
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -72,8 +83,15 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: note_sysview_get_interrupt_id
+ *
+ * Description:
+ *   Retrieve the Id of the currently active interrupt.
+ *
+ ****************************************************************************/
+
 unsigned int note_sysview_get_interrupt_id(void);
-unsigned long note_sysview_get_timestamp(void);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -455,19 +455,6 @@ unsigned int note_sysview_get_interrupt_id(void)
 }
 
 /****************************************************************************
- * Name: note_sysview_get_timestamp
- *
- * Description:
- *   Retrieve a system timestamp for SYSVIEW events.
- *
- ****************************************************************************/
-
-unsigned long note_sysview_get_timestamp(void)
-{
-  return perf_gettime();
-}
-
-/****************************************************************************
  * Name: note_sysview_initialize
  *
  * Description:


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Avoid another layer of function call to get time.


## Impact

Minor code refactor, should have no impact.

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


