### PR TITLE
cmake(clear warning):toolchain file do not need set parent scope

### DIFF
--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -66,9 +66,7 @@ execute_process(COMMAND ${CMAKE_C_COMPILER} --version
                 OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
 string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
              "${GCC_VERSION_OUTPUT}")
-set(GCCVER
-    ${CMAKE_MATCH_1}
-    PARENT_SCOPE)
+set(GCCVER ${CMAKE_MATCH_1})
 
 if(GCCVER EQUAL 12)
   add_compile_options(--param=min-pagesize=0)


### PR DESCRIPTION
## Summary
The warning printout of the CI log will slow down our ability to locate the real problem

toolchain file variable is global scope
dont need set parent scope

clear warning:
```shell
CMake Warning (dev) at /github/workspace/sources/nuttx/arch/arm/src/cmake/gcc.cmake:69 (set):
  Cannot set "GCCVER": current scope has no parent.
Call Stack (most recent call first):
  /github/workspace/sources/nuttx/arch/arm/src/cmake/Toolchain.cmake:56 (include)
  /github/workspace/sources/nuttx/build/CMakeFiles/3.26.0/CMakeSystem.cmake:6 (include)
  /github/workspace/sources/nuttx/build/CMakeFiles/CMakeScratch/TryCompile-ZJVOZO/CMakeLists.txt:5 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.
``` 
<img width="647" alt="image" src="https://github.com/user-attachments/assets/593592b5-6567-4108-8043-6f8bf4a62414">


## Impact

clear generator warning 

## Testing

cmake -B build -DBOARD_CONFIG=qemu-armv7a:nsh


