### PR TITLE
{Bp-14267} tools/espressif: add esptool version check to Espressif build system

### DIFF
--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -68,6 +68,8 @@ ESPTOOL_FLASH_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
 
 # Configure the variables according to build environment
 
+ESPTOOL_MIN_VERSION := 4.8.0
+
 ifdef ESPTOOL_BINDIR
 	ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
 		BL_OFFSET       := 0x1000
@@ -169,6 +171,7 @@ endef
 # MERGEBIN -- Merge raw binary files into a single file
 
 define MERGEBIN
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(ESPTOOL_BINDIR) ]; then \
 		echo "MERGEBIN error: Missing argument for binary files directory."; \
 		echo "USAGE: make ESPTOOL_BINDIR=<dir>"; \
@@ -236,13 +239,7 @@ else
 ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration for the ESP32 chip."; \
 		exit 1; \
@@ -268,13 +265,7 @@ endef
 else
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration."; \
 		exit 1; \

--- a/tools/esp32c3/Config.mk
+++ b/tools/esp32c3/Config.mk
@@ -68,6 +68,8 @@ ESPTOOL_FLASH_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
 
 # Configure the variables according to build environment
 
+ESPTOOL_MIN_VERSION := 4.8.0
+
 ifdef ESPTOOL_BINDIR
 	ifeq ($(CONFIG_ESP32C3_APP_FORMAT_LEGACY),y)
 		BL_OFFSET       := 0x0
@@ -162,6 +164,7 @@ endef
 # MERGEBIN -- Merge raw binary files into a single file
 
 define MERGEBIN
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(ESPTOOL_BINDIR) ]; then \
 		echo "MERGEBIN error: Missing argument for binary files directory."; \
 		echo "USAGE: make ESPTOOL_BINDIR=<dir>"; \
@@ -218,13 +221,7 @@ else
 ifeq ($(CONFIG_ESP32C3_APP_FORMAT_LEGACY),y)
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-C3 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration for the ESP32-C3 chip."; \
 		exit 1; \

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -68,6 +68,8 @@ ESPTOOL_FLASH_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
 
 # Configure the variables according to build environment
 
+ESPTOOL_MIN_VERSION := 4.8.0
+
 ifdef ESPTOOL_BINDIR
 	ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
 		BL_OFFSET        := 0x1000
@@ -153,6 +155,7 @@ endef
 # MERGEBIN -- Merge raw binary files into a single file
 
 define MERGEBIN
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(ESPTOOL_BINDIR) ]; then \
 		echo "MERGEBIN error: Missing argument for binary files directory."; \
 		echo "USAGE: make ESPTOOL_BINDIR=<dir>"; \
@@ -223,13 +226,7 @@ endef
 else
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S2 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration."; \
 		exit 1; \

--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -64,6 +64,8 @@ ESPTOOL_FLASH_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
 
 # Configure the variables according to build environment
 
+ESPTOOL_MIN_VERSION := 4.8.0
+
 ifdef ESPTOOL_BINDIR
 	ifeq ($(CONFIG_ESP32S3_APP_FORMAT_LEGACY),y)
 		BL_OFFSET       := 0x0
@@ -118,6 +120,7 @@ endif
 # MERGEBIN -- Merge raw binary files into a single file
 
 define MERGEBIN
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(ESPTOOL_BINDIR) ]; then \
 		echo "MERGEBIN error: Missing argument for binary files directory."; \
 		echo "USAGE: make ESPTOOL_BINDIR=<dir>"; \
@@ -137,13 +140,7 @@ endef
 ifeq ($(CONFIG_ESP32S3_APP_FORMAT_LEGACY),y)
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S3 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration for the ESP32-S3 chip."; \
 		exit 1; \
@@ -169,13 +166,7 @@ endef
 else
 define MKIMAGE
 	$(Q) echo "MKIMAGE: ESP32-S3 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration."; \
 		exit 1; \

--- a/tools/espressif/Config.mk
+++ b/tools/espressif/Config.mk
@@ -68,6 +68,8 @@ endif
 
 # Configure the variables according to build environment
 
+ESPTOOL_MIN_VERSION := 4.8.0
+
 ifdef ESPTOOL_BINDIR
 	ifeq ($(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT),y)
 		BL_OFFSET       := 0x0000
@@ -104,6 +106,7 @@ ESPTOOL_BINS += $(FLASH_APP)
 # MERGEBIN -- Merge raw binary files into a single file
 
 define MERGEBIN
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(ESPTOOL_BINDIR) ]; then \
 		echo "MERGEBIN error: Missing argument for binary files directory."; \
 		echo "USAGE: make ESPTOOL_BINDIR=<dir>"; \
@@ -137,13 +140,7 @@ endef
 else
 define MKIMAGE
 	$(Q) echo "MKIMAGE: NuttX binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool==4.8.dev4\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
+	@python3 tools/espressif/check_esptool.py -v $(ESPTOOL_MIN_VERSION)
 	$(Q) if [ -z $(FLASH_SIZE) ]; then \
 		echo "Missing Flash memory size configuration."; \
 		exit 1; \

--- a/tools/espressif/check_esptool.py
+++ b/tools/espressif/check_esptool.py
@@ -1,0 +1,95 @@
+############################################################################
+# tools/espressif/check_esptool.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+import argparse
+import re
+import sys
+
+# Different package required if Python 3.8+
+if sys.version_info.minor < 8:
+    import pkg_resources
+
+    PYTHON_OLDER = True
+else:
+    from importlib.metadata import PackageNotFoundError, version
+
+    PYTHON_OLDER = False
+
+
+parser = argparse.ArgumentParser(
+    prog="check_esptool",
+    description="Checks esptool version and returns true or \
+    false if it matches target version",
+)
+parser.add_argument("-v", "--version", action="store", required=True)
+
+
+def parse_version(version_string) -> list:
+    """Regex patteren to extract version major and minor."""
+    pattern = r"(\d+)\.(\d+)"
+    match = re.search(pattern, version_string)
+
+    if match:
+        major = int(match.group(1))
+        minor = int(match.group(2))
+        return [major, minor]
+    else:
+        return []
+
+
+def check_version(min_esptool_version: str) -> int:
+    """Attempts to read 'esptool' version using pkg_resources (for
+    Python <3.8) or importlib. Compare current version with
+    'min_esptool_version' and returns.
+
+    Returns:
+        True: packages does not exist or outdated
+        False: package installed and up-to-date
+    """
+    if PYTHON_OLDER:
+        try:
+            version_str = pkg_resources.get_distribution("esptool").version
+        except pkg_resources.DistributionNotFound:
+            print("esptool.py not found. Please run: 'pip install esptool'")
+            print("Run make again to create the nuttx.bin image.")
+            return True
+    else:
+        try:
+            version_str = version("esptool")
+        except PackageNotFoundError:
+            print("esptool.py not found. Please run: 'pip install esptool'")
+            print("Run make again to create the nuttx.bin image.")
+            return True
+
+    esptool_version = parse_version(version_str)
+    min_esptool_version = parse_version(parser.version)
+
+    if esptool_version >= min_esptool_version:
+        return False
+
+    print("Unsupported esptool version:", version_str, "expects >=", parser.version)
+    print("Upgrade using: 'pip install --upgrade esptool' and run 'make' again")
+    return True
+
+
+if __name__ == "__main__":
+    parser = parser.parse_args()
+    sys.exit(check_version(parser.version))


### PR DESCRIPTION
**Summary**
Add a Python script to check if esptool is installed and if its version is up-to-date (see minimum version at ESPTOOL_MIN_VERSION on .mk files).

This fixes build issues as reported in https://github.com/apache/nuttx/issues/13824.

**Impact**
New Python script added. Stops build if esptool version is below 4.8.
Script runs for ESP32, S2, S3, C3, C6.

**Testing**
Tested locally and on internal CI with Python3.8+.

**NOTE**
backported https://github.com/apache/nuttx/pull/14176 to fix the CI