### PR TITLE
clang: support gcov ARM LLVM clang supports code coverage detection tools

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2759,6 +2759,7 @@ source "libs/libc/Kconfig"
 source "libs/libm/Kconfig"
 source "libs/libxx/Kconfig"
 source "libs/libdsp/Kconfig"
+source "libs/libbuiltin/Kconfig"
 endmenu
 
 menu "Open Asymmetric Multi Processing"

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -465,6 +465,12 @@ endif
 
 EXTRA_LIBS += $(COMPILER_RT_LIB)
 
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
+    COMPILER_UNWIND_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name libunwind.a))
+endif
+
+EXTRA_LIBS += $(COMPILER_UNWIND_LIB)
+
 ifeq ($(CONFIG_LIBM_TOOLCHAIN),y)
   ifeq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)
     ifeq ($(CONFIG_ARCH_FPU),y)

--- a/arch/risc-v/src/common/espressif/esp_libc_stubs.c
+++ b/arch/risc-v/src/common/espressif/esp_libc_stubs.c
@@ -348,12 +348,6 @@ int _system_r(struct _reent *r, const char *command)
   return 0;
 }
 
-void noreturn_function __assert_func(const char *file, int line,
-                                     const char *func, const char *expr)
-{
-  __assert(file, line, expr);
-}
-
 void _cleanup_r(struct _reent *r)
 {
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.c
@@ -4526,31 +4526,6 @@ esp_err_t esp_timer_delete(esp_timer_handle_t timer)
 }
 
 /****************************************************************************
- * Name: __assert_func
- *
- * Description:
- *   Delete timer and free resource
- *
- * Input Parameters:
- *   file  - assert file
- *   line  - assert line
- *   func  - assert function
- *   expr  - assert condition
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void __assert_func(const char *file, int line,
-                   const char *func, const char *expr)
-{
-  wlerr("ERROR: Assert failed in %s, %s:%d (%s)",
-        func, file, line, expr);
-  abort();
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32/esp32_libc_stubs.c
+++ b/arch/xtensa/src/esp32/esp32_libc_stubs.c
@@ -287,12 +287,6 @@ int _system_r(struct _reent *r, const char *command)
   return 0;
 }
 
-void noreturn_function __assert_func(const char *file, int line,
-                                     const char *func, const char *expr)
-{
-  __assert(file, line, expr);
-}
-
 void _cleanup_r(struct _reent *r)
 {
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_libc_stubs.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_libc_stubs.c
@@ -287,12 +287,6 @@ int _system_r(struct _reent *r, const char *command)
   return 0;
 }
 
-void noreturn_function __assert_func(const char *file, int line,
-                                     const char *func, const char *expr)
-{
-  __assert(file, line, expr);
-}
-
 void _cleanup_r(struct _reent *r)
 {
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c
@@ -336,12 +336,6 @@ int _system_r(struct _reent *r, const char *command)
   return 0;
 }
 
-void noreturn_function __assert_func(const char *file, int line,
-                                     const char *func, const char *expr)
-{
-  __assert(file, line, expr);
-}
-
 void _cleanup_r(struct _reent *r)
 {
 }

--- a/boards/arm/mps/mps2-an500/src/mps2_bringup.c
+++ b/boards/arm/mps/mps2-an500/src/mps2_bringup.c
@@ -61,6 +61,16 @@ static int mps2_bringup(void)
 
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmp file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at /tmp: %d\n", ret);
+    }
+#endif
+
   return ret;
 }
 

--- a/boards/arm/mps/mps2-an521/src/mps2_bringup.c
+++ b/boards/arm/mps/mps2-an521/src/mps2_bringup.c
@@ -61,6 +61,16 @@ static int mps2_bringup(void)
 
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmp file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at /tmp: %d\n", ret);
+    }
+#endif
+
   return ret;
 }
 

--- a/boards/arm/mps/mps3-an547/src/mps3_bringup.c
+++ b/boards/arm/mps/mps3-an547/src/mps3_bringup.c
@@ -61,6 +61,16 @@ static int mps3_bringup(void)
 
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmp file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at /tmp: %d\n", ret);
+    }
+#endif
+
   return ret;
 }
 

--- a/include/assert.h
+++ b/include/assert.h
@@ -197,6 +197,13 @@ void _assert(FAR const char *filename, int linenum,
 void __assert(FAR const char *filename, int linenum,
               FAR const char *msg) noreturn_function;
 
+/****************************************************************************
+ * Name: __assert_func
+ ****************************************************************************/
+
+void noreturn_function __assert_func(const char *file, int linenum,
+                                     const char *func, const char *msg);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -37,6 +37,14 @@
 #include <nuttx/lib/lib.h>
 
 /****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/* Streams */
+
+typedef struct file_struct FILE;
+
+/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -65,9 +73,15 @@
 
 /* The first three _iob entries are reserved for standard I/O */
 
+#ifdef CONFIG_ARM_TOOLCHAIN_CLANG
+FAR FILE * const stdin(void);
+FAR FILE * const stdout(void);
+FAR FILE * const stderr(void);
+#else
 #define stdin      lib_get_stream(0)
 #define stdout     lib_get_stream(1)
 #define stderr     lib_get_stream(2)
+#endif
 
 /* Path to the directory where temporary files can be created */
 
@@ -104,14 +118,6 @@
 #define feof_unlocked(stream)     feof(stream)
 #define ferror_unlocked(stream)   ferror(stream)
 #define fileno_unlocked(stream)   fileno(stream)
-
-/****************************************************************************
- * Public Type Definitions
- ****************************************************************************/
-
-/* Streams */
-
-typedef struct file_struct FILE;
 
 /****************************************************************************
  * Public Data

--- a/libs/libbuiltin/.gitignore
+++ b/libs/libbuiltin/.gitignore
@@ -1,0 +1,3 @@
+/compiler-rt/compiler-rt
+*.o
+.depend

--- a/libs/libbuiltin/Kconfig
+++ b/libs/libbuiltin/Kconfig
@@ -1,0 +1,29 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+comment "Toolchains Library Support"
+
+config TOOLCHAINS_BUILTIN
+	bool "Builtin toolchains support"
+	default n
+	---help---
+		Choose to compile libraries related to toolchains into the OS
+
+config BUILTIN_COMPILER_RT
+	bool "Builtin LLVM Compiler-rt"
+	depends on ARM_TOOLCHAIN_CLANG
+	select TOOLCHAINS_BUILTIN
+	default y
+	---help---
+		Compile the LLVM Compiler-rt library into the OS.
+
+if BUILTIN_COMPILER_RT
+
+config COMPILER_RT_VERSION
+	string "Select LLVM Compiler-rt version"
+	depends on BUILTIN_COMPILER_RT
+	default "15.0.2"
+
+endif # COMPILER_RT_VERSION

--- a/libs/libbuiltin/Makefile
+++ b/libs/libbuiltin/Makefile
@@ -1,0 +1,83 @@
+############################################################################
+# libs/libbuiltin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
+include compiler-rt/Make.defs
+endif
+
+BIN ?= libbuiltin$(LIBEXT)
+BINDIR ?= bin
+
+KBIN = libkbuiltin$(LIBEXT)
+KBINDIR = kbin
+
+AOBJS = $(addprefix $(BINDIR)$(DELIM), $(ASRCS:.S=$(OBJEXT)))
+COBJS = $(addprefix $(BINDIR)$(DELIM), $(CSRCS:.c=$(OBJEXT)))
+CXXOBJS = $(addprefix $(BINDIR)$(DELIM), $(CXXSRCS:.cxx=$(OBJEXT)))
+CPPOBJS = $(addprefix $(BINDIR)$(DELIM), $(CPPSRCS:.cpp=$(OBJEXT)))
+
+SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(CPPSRCS)
+OBJS = $(AOBJS) $(COBJS) $(CXXOBJS) $(CPPOBJS)
+
+all: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+
+.PHONY: depend clean distclean context $(LIBBUILTIN)
+
+$(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(CXXOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cxx
+	$(call COMPILEXX, $<, $@)
+
+$(CPPOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cpp
+	$(call COMPILEXX, $<, $@)
+
+context::
+
+.depend: $(LIBBUILTIN)
+	$(Q) touch $@
+
+depend: .depend
+
+$(BIN): depend
+	$(Q) $(MAKE) all EXTRAFLAGS="$(EXTRAFLAGS)"
+
+# C library for the kernel phase of the two-pass kernel build
+
+ifneq ($(BIN),$(KBIN))
+$(KBIN): $(OBJS)
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=$(KBINDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+endif
+
+clean:
+	$(call DELFILE, $(BIN))
+	$(Q) $(MAKE) -C bin  clean
+	$(Q) $(MAKE) -C kbin clean
+
+distclean: clean
+	$(Q) $(MAKE) -C bin  distclean
+	$(Q) $(MAKE) -C kbin distclean
+	$(call DELFILE, .depend)

--- a/libs/libbuiltin/bin/Makefile
+++ b/libs/libbuiltin/bin/Makefile
@@ -1,0 +1,35 @@
+############################################################################
+# libs/libbuiltin/bin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+all:
+.PHONY: clean distclean
+
+# Clean Targets:
+
+clean:
+	$(call DELFILE, *.o)
+
+# Deep clean -- removes all traces of the configuration
+
+distclean: clean
+	$(call DELFILE, *.dep)
+	$(call DELFILE, .depend)

--- a/libs/libbuiltin/compiler-rt/InstrProfilingPlatformNX.c
+++ b/libs/libbuiltin/compiler-rt/InstrProfilingPlatformNX.c
@@ -1,0 +1,131 @@
+/****************************************************************************
+ * libs/libbuiltin/compiler-rt/InstrProfilingPlatformNX.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "InstrProfiling.h"
+#include "InstrProfilingInternal.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern char __start__llvm_prf_names[];
+extern char __end__llvm_prf_names[];
+extern char __start__llvm_prf_data[];
+extern char __end__llvm_prf_data[];
+extern char __start__llvm_prf_vnds[];
+extern char __end__llvm_prf_vnds[];
+extern char __start__llvm_prf_cnts[];
+extern char __end__llvm_prf_cnts[];
+
+COMPILER_RT_VISIBILITY ValueProfNode *CurrentVNode = 0;
+COMPILER_RT_VISIBILITY ValueProfNode *EndVNode = 0;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+COMPILER_RT_VISIBILITY
+void __llvm_profile_register_function(void *Data_)
+{
+}
+
+COMPILER_RT_VISIBILITY
+void __llvm_profile_register_names_function(void *NamesStart,
+                                            uint64_t NamesSize)
+{
+}
+
+COMPILER_RT_VISIBILITY
+const __llvm_profile_data *__llvm_profile_begin_data(void)
+{
+  return &__start__llvm_prf_data;
+}
+
+COMPILER_RT_VISIBILITY
+const __llvm_profile_data *__llvm_profile_end_data(void)
+{
+  return &__end__llvm_prf_data;
+}
+
+COMPILER_RT_VISIBILITY
+const char *__llvm_profile_begin_names(void)
+{
+  return &__start__llvm_prf_names;
+}
+
+COMPILER_RT_VISIBILITY
+const char *__llvm_profile_end_names(void)
+{
+  return &__end__llvm_prf_names;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_begin_counters(void)
+{
+  return &__start__llvm_prf_cnts;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_end_counters(void)
+{
+  return &__end__llvm_prf_cnts;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_begin_bitmap(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_end_bitmap(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+uint32_t *__llvm_profile_begin_orderfile(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+ValueProfNode *__llvm_profile_begin_vnodes(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+ValueProfNode *__llvm_profile_end_vnodes(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY int __llvm_write_binary_ids(ProfDataWriter *Writer)
+{
+  return 0;
+}

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -1,0 +1,58 @@
+############################################################################
+# libs/libbuiltin/compiler-rt/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(TOPDIR)/Make.defs
+
+LIBBUILTIN += compiler-rt
+
+ifeq ($(wildcard compiler-rt/compiler-rt/lib),)
+compiler-rt-$(CONFIG_COMPILER_RT_VERSION).src.tar.xz:
+	$(call DOWNLOAD,https://github.com/llvm/llvm-project/releases/download/llvmorg-$(CONFIG_COMPILER_RT_VERSION),$@)
+
+compiler-rt/compiler-rt: compiler-rt-$(CONFIG_COMPILER_RT_VERSION).src.tar.xz
+	$(Q) tar -xf $<
+	$(Q) mv compiler-rt-$(CONFIG_COMPILER_RT_VERSION).src $@
+	$(call DELDIR, $<)
+
+compiler-rt: compiler-rt/compiler-rt
+endif
+
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/include
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/profile
+FLAGS += -Wno-strict-prototypes -Wno-shadow -Wno-cleardeprecated-pragma
+FLAGS += -Wno-deprecated-pragma -Wno-undef -Wno-incompatible-pointer-types
+FLAGS += -Wno-unknown-warning-option -Wno-deprecated-pragma
+FLAGS += -DCOMPILER_RT_HAS_UNAME
+
+CFLAGS += $(FLAGS)
+CXXFLAGS += $(FLAGS)
+
+CSRCS += GCDAProfiling.c InstrProfilingBuffer.c InstrProfiling.c InstrProfilingFile.c InstrProfilingInternal.c
+CSRCS += InstrProfilingMerge.c InstrProfilingMergeFile.c InstrProfilingNameVar.c
+CSRCS += InstrProfilingUtil.c InstrProfilingValue.c InstrProfilingVersionVar.c InstrProfilingWriter.c
+CPPSRCS += InstrProfilingRuntime.cpp
+
+CSRCS += InstrProfilingPlatformNX.c
+
+DEPPATH += --dep-path compiler-rt/compiler-rt/lib/profile
+VPATH += :compiler-rt/compiler-rt/lib/profile
+
+DEPPATH += --dep-path compiler-rt
+VPATH += :compiler-rt

--- a/libs/libbuiltin/kbin/Makefile
+++ b/libs/libbuiltin/kbin/Makefile
@@ -1,0 +1,35 @@
+############################################################################
+# libs/libbuiltin/kbin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+all:
+.PHONY: clean distclean
+
+# Clean Targets:
+
+clean:
+	$(call DELFILE, *.o)
+
+# Deep clean -- removes all traces of the configuration
+
+distclean: clean
+	$(call DELFILE, *.dep)
+	$(call DELFILE, .depend)

--- a/libs/libc/assert/lib_assert.c
+++ b/libs/libc/assert/lib_assert.c
@@ -38,3 +38,9 @@ void __assert(FAR const char *filename, int linenum, FAR const char *msg)
   _assert(filename, linenum, msg, NULL);
   abort();
 }
+
+void noreturn_function __assert_func(const char *file, int linenum,
+                                     const char *func, const char *msg)
+{
+  __assert(file, linenum, msg);
+}

--- a/libs/libc/stdio/lib_libgetstreams.c
+++ b/libs/libc/stdio/lib_libgetstreams.c
@@ -75,3 +75,20 @@ FAR struct file_struct *lib_get_stream(int fd)
 }
 
 #endif /* CONFIG_FILE_STREAM */
+
+#ifdef CONFIG_ARM_TOOLCHAIN_CLANG
+FAR struct file_struct * const stdin(void)
+{
+  return lib_get_stream(0);
+}
+
+FAR struct file_struct * const stdout(void)
+{
+  return lib_get_stream(1);
+}
+
+FAR struct file_struct * const stderr(void)
+{
+  return lib_get_stream(2);
+}
+#endif

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -120,6 +120,13 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 CONTEXTDIRS += libs$(DELIM)libxx
 endif
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_TOOLCHAINS_BUILTIN), y)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 ifeq ($(CONFIG_NX),y)
 KERNDEPDIRS += graphics
 CONTEXTDIRS += graphics
@@ -185,6 +192,10 @@ endif
 
 ifeq ($(CONFIG_MM_TLSF_MANAGER),y)
 CONTEXTDIRS += mm
+endif
+
+ifeq ($(CONFIG_TOOLCHAINS_BUILTIN),y)
+CLEANDIRS += libs$(DELIM)libbuiltin
 endif
 
 CLEANDIRS += $(KERNDEPDIRS) $(USERDEPDIRS)

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -82,6 +82,13 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 NUTTXLIBS += staging$(DELIM)libxx$(LIBEXT)
 endif
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_TOOLCHAINS_BUILTIN),y)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add library for application support.
 
 ifneq ($(APPDIR),)

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -72,6 +72,13 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 USERLIBS += staging$(DELIM)libxx$(LIBEXT)
 endif
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_TOOLCHAINS_BUILTIN),y)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add libraries for network support
 
 ifeq ($(CONFIG_NET),y)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -31,6 +31,12 @@ libs$(DELIM)libc$(DELIM)libkc$(LIBEXT): pass2dep
 staging$(DELIM)libkc$(LIBEXT): libs$(DELIM)libc$(DELIM)libkc$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
+libs$(DELIM)libbuiltin$(DELIM)libkbuiltin$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C libs$(DELIM)libbuiltin libkbuiltin$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+
+staging$(DELIM)libkbuiltin$(LIBEXT): libs$(DELIM)libbuiltin$(DELIM)libkbuiltin$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 libs$(DELIM)libm$(DELIM)libkm$(LIBEXT): pass2dep
 	$(Q) $(MAKE) -C libs$(DELIM)libm libkm$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
@@ -200,6 +206,16 @@ endif
 	$(Q) $(MAKE) -C libs$(DELIM)libnx libnx$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libnx$(LIBEXT): libs$(DELIM)libnx$(DELIM)libnx$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
+ifeq ($(CONFIG_BUILD_FLAT),y)
+libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT): pass2dep
+else
+libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT): pass1dep
+endif
+	$(Q) $(MAKE) -C libs$(DELIM)libbuiltin libbuiltin$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+staging$(DELIM)libbuiltin$(LIBEXT): libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 ifeq ($(CONFIG_BUILD_FLAT),y)

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -80,6 +80,13 @@ ifeq ($(CONFIG_HAVE_CXX),y)
 USERLIBS += staging$(DELIM)libxx$(LIBEXT)
 endif
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_TOOLCHAINS_BUILTIN),y)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add library for application support.
 
 ifneq ($(APPDIR),)

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -640,6 +640,7 @@ static const char *g_white_files[] =
    * libs/libc/machine/arm/arm_asm.h
    */
 
+  "libs/libbuiltin/compiler-rt/InstrProfilingPlatformNX.c",
   "arm-acle-compat.h",
   "arm_asm.h",
   NULL


### PR DESCRIPTION
## Summary
1. arm llvm clang: llvm comes with unwind library, add unwind compilation、
2. stdio.h: stdin, stdout, stderr are symbols in llvm. If they are macros, there will be a compilation error.
3. clang: support gcov ARM LLVM clang supports code coverage detection tools
4. mps/bringup: Add initialization of tmpfs
## Impact
## Testing

