### PR TITLE
math32.h: remove typeof depends

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -328,12 +328,12 @@ extern "C"
       })
 
 #  define div_const(n, base) \
-    ((sizeof(typeof(n)) == sizeof(uint64_t)) ? div64_const(n, base) : ((n) / (base)))
+    ((sizeof(n) == sizeof(uint64_t)) ? div64_const(n, base) : ((n) / (base)))
 #  define div_const_roundup(n, base) \
-    ((sizeof(typeof(n)) == sizeof(uint64_t)) ? div64_const((n) + (base) - 1, base) : \
+    ((sizeof(n) == sizeof(uint64_t)) ? div64_const((n) + (base) - 1, base) : \
      (((n) + (base) - 1) / (base)))
 #  define div_const_roundnearest(n, base) \
-    ((sizeof(typeof(n)) == sizeof(uint64_t)) ? div64_const((n) + ((base) / 2), base) : \
+    ((sizeof(n) == sizeof(uint64_t)) ? div64_const((n) + ((base) / 2), base) : \
      (((n) + ((base) / 2)) / (base)))
 #else
 #  define div_const(n, base) ((n) / (base))


### PR DESCRIPTION
## Summary

math32.h: remove typeof depends


## Impact

CI

## Testing

CI


