### PR TITLE
Doc: migration 1

### DIFF
--- a/Documentation/guides/disabling_stackdumpdebug.rst
+++ b/Documentation/guides/disabling_stackdumpdebug.rst
@@ -1,0 +1,15 @@
+=========================================
+Disabling the Stack Dump During Debugging
+=========================================
+
+.. warning:: 
+    Migrated from: 
+    https://cwiki.apache.org/confluence/display/NUTTX/Disabling+the+Stack+Dump+During+Debugging
+
+The stack dump routine can clutter the output of GDB during debugging. 
+To disable it, set this configuration option in the defconfig file of
+the board configuration:
+
+.. code-block:: c
+
+    CONFIG_ARCH_STACKDUMP=n

--- a/Documentation/guides/include_files_board_h.rst
+++ b/Documentation/guides/include_files_board_h.rst
@@ -1,0 +1,73 @@
+==========================
+Including Files in board.h
+==========================
+
+.. warning:: 
+    Migrated from: https://cwiki.apache.org/confluence/display/NUTTX/Including+Files+in+board.h
+
+Global Scope of board.h
+=======================
+
+Each board under the ``boards/`` directory must provide a header file call 
+``board.h`` in the board's ``include/`` sub-directory.
+
+When the board is configured symbolic links will be created to the board's 
+``board.h`` header file at ``include/arch/board/board.h``. Header files at that 
+location have `Global Scope` meaning they can be included by C/C++ logic 
+anywhere in the system. For example, the ``board.h`` file can be included by
+any file with:
+
+.. code-block:: C
+
+    #include <arch/board/board.h>
+
+Restricted Scope of Architecture-Specific Header Files
+======================================================
+
+Each architecture also provides internal architecture-specific header files 
+that can be included only by (1) the architecture logic itself and (2) by 
+board logic based on that architecture. This is made possible by special 
+include path options in the CFLAGS provided by the NuttX build system to 
+the architecture and board logic `only`.
+
+For this reason, the scope of the architecture-specific header files is 
+`restricted`. Any attempt to include the architecture-specific header files 
+by logic other than architecture- or board-specific logic will result in a 
+compilation error. This is the intended behavior; it is implemented this way 
+to prevent the use of such `restricted`, non-portable files throughout the OS. 
+Doing so would degrade the modularity of the OS and would take many giant 
+steps down the path toward `spaghetti code`.
+
+
+Errors due to Mixed Scope of Header Files
+=========================================
+
+The ``board.h`` header file is included in many contexts including both by the 
+architecture- and board-specific logic but also by other common OS logic. 
+As examples:
+
+* Architecture-specific code may include the ``board.h`` header file to get GPIO 
+  pin definitions or to get configuration information to configure processor 
+  clocking.
+* Common LED and button drivers include board's ``board.h`` header file to get 
+  LED and button definitions, respectively.
+* Applications may include the ``board.h`` header file to get, for example, 
+  ``boardctl()`` board-specific IOCTL commands.
+
+In the first example, the ``board.h`` header file often uses pre-processor symbols 
+that require definition from an architecture-specific header file. For example, 
+GPIO pin definitions or clock configuration register settings. However, `you 
+must avoid the temptation to include any of those architecture-specific header 
+files in the board.h header file. This is prohibited!` That would be a 
+"time bomb" waiting to cause a compilation failure in the future.
+
+So How Do I Avoid This?
+=======================
+
+The only way to avoid this header file inclusion trap is:
+
+* Never include architecture-specific header files in the ``board.h`` header file. 
+  Instead,
+* Include the header files needed by the the ``board.h`` header file in the C file 
+  that includes ``board.h``
+* Make sure that ``board.h`` is the last header file included.

--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -39,3 +39,4 @@ Guides
   changing_systemclockconfig.rst
   usingkernelthreads.rst
   armv7m_runtimestackcheck.rst
+  disabling_stackdumpdebug.rst

--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -41,3 +41,4 @@ Guides
   armv7m_runtimestackcheck.rst
   disabling_stackdumpdebug.rst
   include_files_board_h.rst
+  specialstuff_in_nuttxheaderfiles.rst

--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -40,3 +40,4 @@ Guides
   usingkernelthreads.rst
   armv7m_runtimestackcheck.rst
   disabling_stackdumpdebug.rst
+  include_files_board_h.rst

--- a/Documentation/guides/specialstuff_in_nuttxheaderfiles.rst
+++ b/Documentation/guides/specialstuff_in_nuttxheaderfiles.rst
@@ -1,0 +1,72 @@
+=======================================================
+Why can't I put my special stuff in NuttX header files?
+=======================================================
+
+.. warning::
+    Migrated from: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=139629466
+
+The Problem
+===========
+
+I am very picky about what goes into NuttX header files. I don't accept 
+non-standardized changes to go into them just to permit external code to 
+compile; nor do I accept changes that imply something is implemented in 
+NuttX when it is not (although there are cases like that in the header 
+files now).
+
+* But I want to use `newlib` logic that depends on certain definitions on the 
+  Nuttx header files!
+* But I am trying to compile an application that depends on non-standard 
+  declarations in header files! Or prototypes for functions that are not 
+  provided by NuttX! Or types that are not used by NuttX!
+
+You will find that I am very stubborn on this subject and you will be wasting 
+your time and energy if you try to get kruft included into NuttX header files 
+for your personal purposes.
+
+A Work-Around
+=============
+
+But there is a work-around for my pickiness and stubborn-ness (at least for 
+compilers like GCC that support the GNU extensions). Let's suppose you wanted 
+to add this definition:
+
+.. code-block:: c
+
+    #define I_AM_A_NERD true
+
+to the standard ``time.h`` header file. You submitted a patch to do this and 
+I refused it. Now what?
+
+While I refuse to put non-standard or useless stuff in NuttX header files, 
+there are ways to work around this. Suppose that you create a directory 
+called ``myincludes/`` and in your ``myincludes/`` directory is a header called 
+``time.h``. This ``time.h`` header file consists of:
+
+.. code-block:: C
+
+    #define I_AM_A_NERD true
+    #include_next <time.h>
+
+Then in your ``CFLAGS``, you use an ``-isystem`` setting to include header 
+files from ``myincludes/`` before any header files from the NuttX ``include/`` 
+directory. Then when your application includes ``time.h``, the version of 
+``time.h`` in ``myincludes/`` is the one that will be included. That version 
+will define ``I_AM_A_NERD`` as you want and then include the next file named 
+``time.h`` in the compiler's include path. That file will be the standard 
+``time.h`` header file that is provided in the NuttX ``include/`` directory
+
+In this way you an append or modify any of the NuttX header files to suit 
+your own purposes without my having to accept changes that I do not want 
+into the NuttX repository.
+
+When Does It Make Sense?
+========================
+
+When does it make sense to add new definitions, types, and function prototypes 
+to the NuttX header files? Only under the following conditions:
+
+* The changes are standard and specified in OpenGroup.org
+* The changes are provided by a patch that includes the full, verified 
+  implementation of the feature that uses the types and implements the 
+  functions.


### PR DESCRIPTION
## Summary

This PR migrate 3 other pages from the Confluence wiki to the official wiki:

- Disabling the Stack Dump During Debugging 
- Including files in board.h
- Why can't I put my special stuff in NuttX header files?

## Impact

None, update the wiki

## Testing

Build with `make autobuild`

