### PR TITLE
vsprintf:fix bug when print int64 0x8000000000000000

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1018,7 +1018,11 @@ str_lpad:
           flags &= ~(FL_NEGATIVE | FL_ALT);
           if (x < 0)
             {
-              x = -x;
+#ifndef CONFIG_HAVE_LONG_LONG
+              x = -(unsigned long)x;
+#else
+              x = -(unsigned long long)x;
+#endif
               flags |= FL_NEGATIVE;
             }
 


### PR DESCRIPTION
## Summary
use sim32 print 0x8000000000000000 to reproduce this problem

stdio/lib_libvsprintf.c:1018:17: runtime error: negation of -9223372036854775808 cannot be represented in type 'long long int'; cast to an unsigned type to negate this value to itself
    #0 0x3326a86 in vsprintf_internal stdio/lib_libvsprintf.c:1018
    #1 0x332926b in lib_vsprintf stdio/lib_libvsprintf.c:1363
    #2 0x3777978 in vfprintf stdio/lib_vfprintf.c:52
    #3 0x671b3a0 in printf stdio/lib_printf.c:44
    #4 0x37abc0c in hello_main /data/project/code/vela-pt/apps/examples/hello/hello_main.c:38
    #5 0x33201d3 in nxtask_startup sched/task_startup.c:70
    #6 0x3208ecb in nxtask_start task/task_start.c:134
    #7 0x3357a49 in pre_start sim/sim_initialstate.c:52

## Impact
printf

## Testing
sim nsh


