### PR TITLE
elf:fix a ci error

### DIFF
--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -32,7 +32,10 @@
 
 #include <nuttx/streams.h>
 #include <nuttx/memoryregion.h>
-#include <nuttx/elf.h>
+
+#ifdef CONFIG_ARM_COREDUMP_REGION
+#  include <nuttx/elf.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION


## Summary

Configuration/Tool: teensy-2.0/nsh
In file included from
/github/workspace/sources/nuttx/include/nuttx/coredump.h:35:0,
                 from
/github/workspace/sources/nuttx/sched/misc/coredump.h:28,
                 from ./init/nx_bringup.c:54:
/github/workspace/sources/nuttx/include/nuttx/elf.h:31:22: fatal error: arch/elf.h: No such file or directory

## Impact
non arm arch

## Testing
ci build


