### PR TITLE
lib/stdatomic: include stddef.h in atomic.h

### DIFF
--- a/include/nuttx/lib/stdatomic.h
+++ b/include/nuttx/lib/stdatomic.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

Fixed build issue:
error: expected '=', ',', ';', 'asm' or '__attribute__' before 'atomic_wchar_t'

## Impact

NA

## Testing

flagchip protected build success and ostest pass