### PR TITLE
libc: Add debug assert to prevent tls allocation failure

### DIFF
--- a/libs/libc/tls/task_tls_destruct.c
+++ b/libs/libc/tls/task_tls_destruct.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/tls.h>
 #include <nuttx/mutex.h>
+#include <assert.h>
 
 /****************************************************************************
  * Private Data
@@ -104,6 +105,9 @@ int task_tls_alloc(tls_dtor_t dtor)
     }
 
   nxmutex_unlock(&g_tlslock);
+
+  DEBUGASSERT(ret != -EUSERS);
+
   return ret;
 }
 


### PR DESCRIPTION
So It's easy to find TASK_TLS_ELEM not enough error.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


