### PR TITLE
libc/modlib: Make modlib selectable from defconfig

### DIFF
--- a/binfmt/Kconfig
+++ b/binfmt/Kconfig
@@ -50,9 +50,7 @@ config ELF
 	bool "Enable the ELF Binary Format"
 	default n
 	select BINFMT_LOADABLE
-	select LIBC_ARCH_ELF
 	select LIBC_MODLIB
-	select ARCH_USE_TEXT_HEAP if ARCH_HAVE_TEXT_HEAP
 	---help---
 		Enable support for the ELF binary format.  Default: n
 

--- a/libs/libc/modlib/Kconfig
+++ b/libs/libc/modlib/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config LIBC_MODLIB
-	bool
+	bool "Enable module library"
 	default n
 	select LIBC_ARCH_ELF
 	select ARCH_USE_TEXT_HEAP if ARCH_HAVE_TEXT_HEAP

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1783,7 +1783,6 @@ config MODULE
 	bool "Enable loadable OS modules"
 	default n
 	select LIBC_MODLIB
-	select ARCH_USE_TEXT_HEAP if ARCH_HAVE_TEXT_HEAP
 	---help---
 		Enable support for loadable OS modules.  Default: n
 


### PR DESCRIPTION
## Summary
since bootloader may call modlib functions directly to load elf firmware without binfmt, dlfcn or module.
BTW, this patch also remove the duplicated selecttion
## Impact
## Testing


