### PR TITLE
circbuf: fix circbuf_get_read/writeptr return *size = 0 when circbuf full

### DIFF
--- a/libs/libc/misc/lib_circbuf.c
+++ b/libs/libc/misc/lib_circbuf.c
@@ -567,19 +567,14 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
 FAR void *circbuf_get_writeptr(FAR struct circbuf_s *circ, FAR size_t *size)
 {
   size_t off;
-  size_t pos;
 
   DEBUGASSERT(circ);
 
+  *size = circbuf_space(circ);
   off = circ->head % circ->size;
-  pos = circ->tail % circ->size;
-  if (off >= pos)
+  if (off + *size > circ->size)
     {
       *size = circ->size - off;
-    }
-  else
-    {
-      *size = pos - off;
     }
 
   return (FAR char *)circ->base + off;
@@ -603,22 +598,17 @@ FAR void *circbuf_get_writeptr(FAR struct circbuf_s *circ, FAR size_t *size)
 FAR void *circbuf_get_readptr(FAR struct circbuf_s *circ, size_t *size)
 {
   size_t off;
-  size_t pos;
 
   DEBUGASSERT(circ);
 
-  off = circ->head % circ->size;
-  pos = circ->tail % circ->size;
-  if (pos > off)
+  *size = circbuf_used(circ);
+  off = circ->tail % circ->size;
+  if (off + *size > circ->size)
     {
-      *size = circ->size - pos;
-    }
-  else
-    {
-      *size = off - pos;
+      *size = circ->size - off;
     }
 
-  return (FAR char *)circ->base + pos;
+  return (FAR char *)circ->base + off;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
In circbuf_get_read/writeptr, when circbuf is full, off == pos, and *size = off - pos = 0. So add circbuf_is_full() condition to return correct *size.

## Impact
circbuf

## Testing
qemu armv8a


