### PR TITLE
mps2-an500: add missing source file

### DIFF
--- a/arch/arm/src/armv7-m/CMakeLists.txt
+++ b/arch/arm/src/armv7-m/CMakeLists.txt
@@ -40,7 +40,8 @@ set(SRCS
     arm_tcbinfo.c
     arm_trigger_irq.c
     arm_usagefault.c
-    arm_vectors.c)
+    arm_vectors.c
+    arm_dbgmonitor.c)
 
 if(CONFIG_ARMV7M_SYSTICK)
   list(APPEND SRCS arm_systick.c)


### PR DESCRIPTION
## Summary

In this PR, we add the missing source files required by the MPS-AN500 prototyping board when building with Cmake.

## Impact

Broken building for the mps2-an500 board using cmake.

## Testing

The cmake build system


