### PR TITLE
imx8qm-mek: Resolve boot issue for non-EL3 environments

### DIFF
--- a/arch/arm64/src/imx8/imx8_boot.c
+++ b/arch/arm64/src/imx8/imx8_boot.c
@@ -80,9 +80,15 @@ const struct arm_mmu_config g_mmu_config =
 
 void arm64_el_init(void)
 {
-  write_sysreg(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, cntfrq_el0);
+  uint64_t el = arm64_current_el();
 
-  ARM64_ISB();
+  /* Only in EL3 we can write to cntfrq_el0. */
+
+  if (el == 3)
+    {
+      write_sysreg(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC, cntfrq_el0);
+      ARM64_ISB();
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This pull request is aimed at resolving an issue where unauthorized writes to the `cntfrq_el0` register occur during the system boot process when the system is not operating in EL3 (Exception Level 3) mode. The `cntfrq_el0` register is a read-only register in lower exception levels, and any writes to it can lead to unpredictable behavior. 

## Impact
This commit addresses the issue of unauthorized writes to cntfrq_el0 during boot when not in EL3 mode.

## Testing
Tested on QEMU-virt/armv8a



