### PR TITLE
armv7-a:adjust gdb register order

### DIFF
--- a/arch/arm/src/armv7-a/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-a/arm_tcbinfo.c
@@ -34,23 +34,48 @@
 
 static const uint16_t g_reg_offs[] =
 {
-  TCB_REG_OFF(REG_R0),
-  TCB_REG_OFF(REG_R1),
-  TCB_REG_OFF(REG_R2),
-  TCB_REG_OFF(REG_R3),
-  TCB_REG_OFF(REG_R4),
-  TCB_REG_OFF(REG_R5),
-  TCB_REG_OFF(REG_R6),
-  TCB_REG_OFF(REG_R7),
-  TCB_REG_OFF(REG_R8),
-  TCB_REG_OFF(REG_R9),
-  TCB_REG_OFF(REG_R10),
-  TCB_REG_OFF(REG_R11),
-  TCB_REG_OFF(REG_R12),
-  TCB_REG_OFF(REG_R13),
-  TCB_REG_OFF(REG_R14),
-  TCB_REG_OFF(REG_R15),
-  TCB_REG_OFF(REG_CPSR),
+  TCB_REG_OFF(REG_R0),   /* 0 */
+  TCB_REG_OFF(REG_R1),   /* 1 */
+  TCB_REG_OFF(REG_R2),   /* 2 */
+  TCB_REG_OFF(REG_R3),   /* 3 */
+  TCB_REG_OFF(REG_R4),   /* 4 */
+  TCB_REG_OFF(REG_R5),   /* 5 */
+  TCB_REG_OFF(REG_R6),   /* 6 */
+  TCB_REG_OFF(REG_R7),   /* 7 */
+  TCB_REG_OFF(REG_R8),   /* 8 */
+  TCB_REG_OFF(REG_R9),   /* 9 */
+  TCB_REG_OFF(REG_R10),  /* 10 */
+  TCB_REG_OFF(REG_R11),  /* 11 */
+  TCB_REG_OFF(REG_R12),  /* 12 */
+  TCB_REG_OFF(REG_R13),  /* 13 */
+  TCB_REG_OFF(REG_R14),  /* 14 */
+  TCB_REG_OFF(REG_R15),  /* 15 */
+  UINT16_MAX,            /* 16 */
+  UINT16_MAX,            /* 17 */
+  UINT16_MAX,            /* 18 */
+  UINT16_MAX,            /* 19 */
+  UINT16_MAX,            /* 20 */
+  UINT16_MAX,            /* 21 */
+  UINT16_MAX,            /* 22 */
+  UINT16_MAX,            /* 23 */
+  UINT16_MAX,            /* 24 */
+  UINT16_MAX,            /* 25 */
+  UINT16_MAX,            /* 26 */
+  UINT16_MAX,            /* 27 */
+  UINT16_MAX,            /* 28 */
+  UINT16_MAX,            /* 29 */
+  UINT16_MAX,            /* 30 */
+  UINT16_MAX,            /* 31 */
+  UINT16_MAX,            /* 32 */
+  UINT16_MAX,            /* 33 */
+  UINT16_MAX,            /* 34 */
+  UINT16_MAX,            /* 35 */
+  UINT16_MAX,            /* 36 */
+  UINT16_MAX,            /* 37 */
+  UINT16_MAX,            /* 38 */
+  UINT16_MAX,            /* 39 */
+  UINT16_MAX,            /* 40 */
+  TCB_REG_OFF(REG_CPSR), /* 41 */
 
 #if 0
 #  ifdef CONFIG_ARCH_FPU


### PR DESCRIPTION
## Summary

armv7-a:adjust gdb register order

## Impact

debug

## Testing

Register arrangement inside gdb armv7a,
use coredump with armv7-a qemu and gdbstub pass it.


```
(gdb) maint print remote-registers
 Name         Nr  Rel Offset    Size  Type            Rmt Nr  g/G Offset
 r0            0    0      0       4 uint32_t              0           0
 r1            1    1      4       4 uint32_t              1           4
 r2            2    2      8       4 uint32_t              2           8
 r3            3    3     12       4 uint32_t              3          12
 r4            4    4     16       4 uint32_t              4          16
 r5            5    5     20       4 uint32_t              5          20
 r6            6    6     24       4 uint32_t              6          24
 r7            7    7     28       4 uint32_t              7          28
 r8            8    8     32       4 uint32_t              8          32
 r9            9    9     36       4 uint32_t              9          36
 r10          10   10     40       4 uint32_t             10          40
 r11          11   11     44       4 uint32_t             11          44
 r12          12   12     48       4 uint32_t             12          48
 sp           13   13     52       4 *1                   13          52
 lr           14   14     56       4 uint32_t             14          56
 pc           15   15     60       4 *1                   15          60
 f0           16   16     64      12 _arm_ext             16          64
 f1           17   17     76      12 _arm_ext             17          76
 f2           18   18     88      12 _arm_ext             18          88
 f3           19   19    100      12 _arm_ext             19         100
 f4           20   20    112      12 _arm_ext             20         112
 f5           21   21    124      12 _arm_ext             21         124
 f6           22   22    136      12 _arm_ext             22         136
 f7           23   23    148      12 _arm_ext             23         148
 fps          24   24    160       4 uint32_t             24         160
 cpsr         25   25    164       4 uint32_t             25         164
```

