### PR TITLE
include: queue.h: Make flink clear after sq_rem

### DIFF
--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -188,6 +188,10 @@
                 { \
                   (q)->tail = NULL; \
                 } \
+              else \
+                { \
+                  tmp_node->flink = NULL; \
+                } \
             } \
           else \
             { \


### PR DESCRIPTION
## Summary
In the previous design, this member may be cleared or not cleared,
which results in the API's side effects not being a clear property.
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


