### PR TITLE
lib_stdoutstream:need return write size

### DIFF
--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -86,7 +86,7 @@ static int stdoutstream_puts(FAR struct lib_outstream_s *self,
 
   do
     {
-      result = fwrite(buffer, len, 1, stream->handle);
+      result = fwrite(buffer, 1, len, stream->handle);
       if (result >= 0)
         {
           self->nput += result;


### PR DESCRIPTION

## Summary
lib_stdoutstream:need return write size
## Impact

bugfix

## Testing

qmue with mps3 an547

Previously, the return value would cause some code to fall into an infinite loop.

