### PR TITLE
CI: Validate all defconfig files before running any builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,59 @@ jobs:
             export ARTIFACTDIR=`pwd`/buildartifacts
             git config --global --add safe.directory /github/workspace/sources/nuttx
             git config --global --add safe.directory /github/workspace/sources/apps
+
+            # Validate the defconfig files in a temp folder, preserving the links
+            tar cf sources.tar sources/nuttx sources/apps
+            mkdir validate
+            pushd validate
+            tar xf ../sources.tar
+            pushd sources/nuttx
+            rm -rf .git ../apps/.git
+            testfile=tools/ci/testlist/${{matrix.boards}}.dat
+            echo Validating targets in $testfile
+            testlist=`grep -v -E "^(-|#)|^[C|c][M|m][A|a][K|k][E|e]" $testfile || true`
+
+            # For every target in the .dat file
+            for line in $testlist; do
+              firstch=${line:0:1}
+              if [ "X$firstch" == "X/" ]; then
+                dir=`echo $line | cut -d',' -f1`
+                list=`find boards$dir -name defconfig | cut -d'/' -f4,6`
+                for config in ${list}; do
+
+                  # Skip the Excluded Targets, like "-moxa:nsh"
+                  target=${config/\//:}
+                  if grep -e "-$target" $testfile; then
+                    echo Skipping Excluded Target $config
+                    continue
+                  fi
+
+                  # Skip the CMake Targets, like "CMake,nucleo-f334r8:adc"
+                  if grep "CMake,$target" $testfile; then
+                    echo Skipping CMake Target $config
+                    continue
+                  fi
+
+                  # Validate the target
+                  make distclean >/dev/null 2>&1 || true
+                  echo ./tools/refresh.sh --silent $config
+                  if ! ./tools/refresh.sh --silent $config; then
+                    echo Error: $config:1:1: error: $config is configured incorrectly. To fix it, run '"'tools/refresh.sh $config'"'
+                    fail=1
+                  fi
+                done
+              fi
+            done
+            popd ; popd
+            rm -rf sources.tar validate
+
+            # Quit if the defconfig validation failed
+            if [[ "$fail" == "1" ]]; then
+              echo Error: $testfile:1:1: error: Quitting, defconfig validation failed for $testfile
+              exit 1
+            fi
+
+            # Build the targets
             cd sources/nuttx/tools/ci
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
__TODO: This adds 15 mins to Every CI Job, might exceed our quota of GitHub Runner Minutes. Maybe we should trigger this in `github.com/nuttxpr`, whenever a PR is created / modified?__

## Summary

Currently, CI Build Jobs will validate the `defconfig` file just before compiling the NuttX Target (like `rv-virt:nsh`). This means that the Build Job might run for a while, before hitting a `defconfig` error and failing much later.

This PR updates the CI Workflow `build.yml` to validate all `defconfig` files before running any builds. This means that errors in the `defconfig` files will be flagged earlier. And the Build Job will terminate (with an error) before any build begins.

This behaviour is helpful for resolving CI Build Issues quickly. The code is derived from `tools/testbuild.sh`. The enhancement was suggested here: https://github.com/apache/nuttx/issues/14259

## Impact

The CI Workflow `build.yml` will validate all `defconfig` files before running any builds. This might take up to 15 mins for bigger jobs, like `arm-05`.

If any errors are found in `defconfig` files: The Build Job will terminate (with an error) after all `defconfig` files have been validated, before any build begins.

The Updated CI Workflow shall be synced to `nuttx-apps` repo in the next PR.

## Testing

We tested by creating an intentional error in a `defconfig` file:

__If defconfig validation fails:__ The Build Job terminates (with an error) after all `defconfig` files have been validated, before any build begins
https://github.com/lupyuen5/label-nuttx/actions/runs/11344293823/job/31548821624

```text
Validating targets in tools/ci/testlist/x86_64-01.dat
./tools/refresh.sh --silent qemu-intel64/nsh
  Normalize qemu-intel64/nsh
8d7
< CONFIG_AAA=y
Saving the new configuration file
Error: qemu-intel64/nsh:1:1: error: qemu-intel64/nsh is configured incorrectly. To fix it, run "tools/refresh.sh qemu-intel64/nsh"
...
Error: tools/ci/testlist/x86_64-01.dat:1:1: error: Quitting, defconfig validation failed for tools/ci/testlist/x86_64-01.dat
```

Errors are specially formatted to display correctly in the GitHub Actions Job Summary:

![Screenshot 2024-10-15 at 6 43 47 PM](https://github.com/user-attachments/assets/39ba335d-6d25-4cf1-97cc-bca6f0084747)

__If defconfig validation is successful:__ The Build Job continues to build the targets
https://github.com/lupyuen5/label-nuttx/actions/runs/11361897141/job/31604515998

```text
Validating targets in tools/ci/testlist/x86_64-01.dat
./tools/refresh.sh --silent qemu-intel64/nsh
  Normalize qemu-intel64/nsh
...
Configuration/Tool: qemu-intel64/nsh
  Building NuttX...
```
