### PR TITLE
Expand samplerate bits from 8 to 32, enchance encode capacity in sim offload.

### DIFF
--- a/arch/sim/src/sim/sim_offload.c
+++ b/arch/sim/src/sim/sim_offload.c
@@ -454,6 +454,7 @@ void *sim_audio_lame_init(struct audio_info_s *info)
     {
       lame_set_num_channels(codec->gfp, info->channels);
       lame_set_mode(codec->gfp, info->channels > 1 ? STEREO : MONO);
+      lame_set_in_samplerate(codec->gfp, (int)info->samplerate);
     }
 
   ret = lame_init_params(codec->gfp);
@@ -507,8 +508,17 @@ static int sim_audio_lame_encode(void *handle,
   chs = lame_get_num_channels(codec->gfp);
   samples = insize / (sizeof(short int) * chs);
 
-  ret = lame_encode_buffer_interleaved(codec->gfp, (short int *)in, samples,
-                                       codec->out, codec->max);
+  if (chs > 1)
+    {
+      ret = lame_encode_buffer_interleaved(codec->gfp, (short int *)in,
+                                          samples, codec->out, codec->max);
+    }
+  else
+    {
+      ret = lame_encode_buffer(codec->gfp, (short int *)in, NULL, samples,
+                              codec->out, codec->max);
+    }
+
   if (ret < 0)
     {
       return ret;

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -434,10 +434,10 @@ struct audio_caps_desc_s
 
 struct audio_info_s
 {
-  uint8_t samplerate;   /* Sample Rate of the audio data */
-  uint8_t channels;     /* Number of channels (1, 2, 5, 7) */
-  uint8_t format;       /* Audio data format */
-  uint8_t subformat;    /* Audio subformat
+  uint32_t samplerate;   /* Sample Rate of the audio data */
+  uint8_t  channels;     /* Number of channels (1, 2, 5, 7) */
+  uint8_t  format;       /* Audio data format */
+  uint8_t  subformat;    /* Audio subformat
                          * (maybe should be combined with format?
                          */
 };


### PR DESCRIPTION
## Summary
1. Current 8 bits data cannot represent sample rate bigger than 255,change samplerate data type from uint8_t to uint32_t to expand sample rate range. 
2. Set real sample rate and encode method separately, according to different pcm data format.

## Impact
Enhance current audio capacity.

## Testing
Build success in Sim.


