### PR TITLE
SAMA5 fix compiler warning in sam_adc.c

### DIFF
--- a/arch/arm/src/sama5/sam_adc.c
+++ b/arch/arm/src/sama5/sam_adc.c
@@ -1340,7 +1340,11 @@ static int sam_adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
 {
 #ifdef CONFIG_SAMA5_ADC_SWTRIG
   struct sam_adc_s *priv = (struct sam_adc_s *)dev->ad_priv;
+#  ifndef CONFIG_SAMA5_ADC_REGDEBUG
+  UNUSED(priv);
+#  endif
 #endif
+
   int ret = OK;
 
   ainfo("cmd=%d arg=%ld\n", cmd, arg);


### PR DESCRIPTION
## Summary

Compiler warning relating to unused variable has been fixed. It is a specific use case when the ADC is software triggered and with no ADC REGDEBUG in use.

Might be a better/cleaner fix but this works at least.

## Impact
None - it is a benign fix that simply cleans up the compilation

## Testing

On a custom board equipped with a SAMA5D27C-D1G using the ADC peripheral in SW TRIGGER mode.


