### PR TITLE
ci: add Python linter to check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Check Pull Request
         run: |
           echo "::add-matcher::nuttx/.github/nxstyle.json"
-          python -m venv .venv
+          python3 -m venv .venv
           source .venv/bin/activate
-          pip install cmake-format
+          pip install cmake-format black isort flake8
           cd nuttx
           commits="${{ github.event.pull_request.base.sha }}..HEAD"
           git log --oneline $commits


### PR DESCRIPTION
## Summary

Add Black, isort and Flake8 to `check` linter. This follows issues found in #14319 .
A previous modification was done on master #14176 but missed those packages.

## Impact

Installs Python linter packages to this release.

## Testing

Running tests on this PR.

@lupyuen @jerpelea