### PR TITLE
.github/labler.yml: fix condition for Area: Bluetooth

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -170,7 +170,7 @@
 "Area: Bluetooth":
   - changed-files:
       - any-glob-to-any-file: 'wireless/bluetooth/**'
-      - any-glob-to-any-file: 'nuttx/drivers/wireless/bluetooth/**'
+      - any-glob-to-any-file: 'drivers/wireless/bluetooth/**'
       - any-glob-to-any-file: 'include/nuttx/wireless/bluetooth/**'
 
 "Area: Build system":


### PR DESCRIPTION
## Summary
.github/labler.yml: fix condition for Area: Bluetooth

I noticed that this PR https://github.com/apache/nuttx/pull/14311 hasn't a label assigned

## Impact
fix typo

## Testing
none



