### PR TITLE
Kconfig:Add an option to disable compilation of floating point

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -567,6 +567,14 @@ config ARCH_FLOAT_H
 		there is no assurance that the settings in this float.h are actually
 		correct for your platform!
 
+config DISABLE_FLOAT
+	bool "Disable floating point"
+	default n
+	---help---
+		Disable floating point support in the compiler. This will reduce
+		code size and increase performance. This option is only available
+		on some architectures.
+
 config ARCH_HAVE_STDARG_H
 	bool
 	default n

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -1207,6 +1207,12 @@
 #  undef CONFIG_FS_LARGEFILE
 #endif
 
+#ifdef CONFIG_DISABLE_FLOAT
+#  undef CONFIG_HAVE_FLOAT
+#  undef CONFIG_HAVE_DOUBLE
+#  undef CONFIG_HAVE_LONG_DOUBLE
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Add an option to disable compilation of floating point
## Impact

libs/libc

## Testing

qmue with mps3an547

some platform can't use float
