### PR TITLE
clang: support gcov ARM LLVM clang supports code coverage detection

### DIFF
--- a/libs/libbuiltin/Kconfig
+++ b/libs/libbuiltin/Kconfig
@@ -33,4 +33,8 @@ config COMPILER_RT_HAS_BFLOAT16
 	bool "Enable support for bfloat16 in Compiler-rt"
 	default n
 
+config COMPILER_RT_PROFILE
+	bool "Enable profiling support in Compiler-rt"
+	default n
+
 endif # BUILTIN_COMPILER_RT

--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -406,6 +406,46 @@ if(CONFIG_BUILTIN_COMPILER_RT)
     list(APPEND RT_BUILTIN_SRCS floatundidf.c floatundisf.c floatundixf.c)
   endif()
 
+  if(CONFIG_COMPILER_RT_PROFILE)
+
+    target_include_directories(
+      compiler-rt PRIVATE ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile)
+
+    target_compile_options(
+      compiler-rt
+      PRIVATE -DCOMPILER_RT_HAS_UNAME
+              -Wno-cleardeprecated-pragma
+              -Wno-deprecated-pragma
+              -Wno-incompatible-pointer-types
+              -Wno-shadow
+              -Wno-strict-prototypes
+              -Wno-undef
+              -Wno-unknown-warning-option)
+
+    set(RT_PROFILE_SRCS
+        GCDAProfiling.c
+        InstrProfiling.c
+        InstrProfilingBuffer.c
+        InstrProfilingFile.c
+        InstrProfilingInternal.c
+        InstrProfilingMerge.c
+        InstrProfilingMergeFile.c
+        InstrProfilingNameVar.c
+        InstrProfilingUtil.c
+        InstrProfilingValue.c
+        InstrProfilingVersionVar.c
+        InstrProfilingWriter.c
+        InstrProfilingRuntime.cpp)
+
+    foreach(src ${RT_PROFILE_SRCS})
+      string(PREPEND src ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile/)
+      list(APPEND COMPILER_RT_SRCS ${src})
+    endforeach()
+
+    list(APPEND COMPILER_RT_SRCS InstrProfilingPlatform.c)
+
+  endif()
+
   list(APPEND INCDIR
        ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${RT_BUILTIN_ARCH})
 

--- a/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
+++ b/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
@@ -1,0 +1,129 @@
+/****************************************************************************
+ * libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "InstrProfiling.h"
+#include "InstrProfilingInternal.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern char __start__llvm_prf_names[];
+extern char __end__llvm_prf_names[];
+extern char __start__llvm_prf_data[];
+extern char __end__llvm_prf_data[];
+extern char __start__llvm_prf_cnts[];
+extern char __end__llvm_prf_cnts[];
+
+COMPILER_RT_VISIBILITY ValueProfNode *CurrentVNode = 0;
+COMPILER_RT_VISIBILITY ValueProfNode *EndVNode = 0;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+COMPILER_RT_VISIBILITY
+void __llvm_profile_register_function(void *Data_)
+{
+}
+
+COMPILER_RT_VISIBILITY
+void __llvm_profile_register_names_function(void *NamesStart,
+                                            uint64_t NamesSize)
+{
+}
+
+COMPILER_RT_VISIBILITY
+const __llvm_profile_data *__llvm_profile_begin_data(void)
+{
+  return &__start__llvm_prf_data;
+}
+
+COMPILER_RT_VISIBILITY
+const __llvm_profile_data *__llvm_profile_end_data(void)
+{
+  return &__end__llvm_prf_data;
+}
+
+COMPILER_RT_VISIBILITY
+const char *__llvm_profile_begin_names(void)
+{
+  return &__start__llvm_prf_names;
+}
+
+COMPILER_RT_VISIBILITY
+const char *__llvm_profile_end_names(void)
+{
+  return &__end__llvm_prf_names;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_begin_counters(void)
+{
+  return &__start__llvm_prf_cnts;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_end_counters(void)
+{
+  return &__end__llvm_prf_cnts;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_begin_bitmap(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+char *__llvm_profile_end_bitmap(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+uint32_t *__llvm_profile_begin_orderfile(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+ValueProfNode *__llvm_profile_begin_vnodes(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY
+ValueProfNode *__llvm_profile_end_vnodes(void)
+{
+  return 0;
+}
+
+COMPILER_RT_VISIBILITY int __llvm_write_binary_ids(ProfDataWriter *Writer)
+{
+  return 0;
+}

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -149,6 +149,36 @@ else
   CSRCS += floatundidf.c floatundisf.c floatundixf.c
 endif
 
+ifeq ($(CONFIG_COMPILER_RT_PROFILE),y)
+
+# Include paths
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/profile
+
+# Suppress specific warnings
+FLAGS += -Wno-cleardeprecated-pragma -Wno-deprecated-pragma -Wno-incompatible-pointer-types
+FLAGS += -Wno-shadow -Wno-strict-prototypes -Wno-undef -Wno-unknown-warning-option
+
+# Define compiler-specific macros
+FLAGS += -DCOMPILER_RT_HAS_UNAME
+
+# Disable code coverage analysis for the library
+FLAGS += -fno-profile-generate
+
+# Profile support source files
+CSRCS += GCDAProfiling.c InstrProfilingBuffer.c InstrProfiling.c InstrProfilingFile.c InstrProfilingInternal.c
+CSRCS += InstrProfilingMerge.c InstrProfilingMergeFile.c InstrProfilingNameVar.c
+CSRCS += InstrProfilingUtil.c InstrProfilingValue.c InstrProfilingVersionVar.c InstrProfilingWriter.c
+CPPSRCS += InstrProfilingRuntime.cpp
+
+# Profile platform support
+CSRCS += InstrProfilingPlatform.c
+
+# Dependency and search paths
+DEPPATH += --dep-path compiler-rt/compiler-rt/lib/profile
+VPATH += :compiler-rt/compiler-rt/lib/profile
+
+endif
+
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
 
 AFLAGS += $(FLAGS)
@@ -160,3 +190,6 @@ VPATH += :compiler-rt/compiler-rt/lib/builtins/${ARCH}
 
 DEPPATH += --dep-path compiler-rt/compiler-rt/lib/builtins
 VPATH += :compiler-rt/compiler-rt/lib/builtins
+
+DEPPATH += --dep-path compiler-rt
+VPATH += :compiler-rt

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -644,6 +644,13 @@ static const char *g_white_files[] =
   "arm_asm.h",
 
   /* Skip Mixed case
+   * Ref:
+   * libs/libbuiltin/
+   */
+
+  "InstrProfilingPlatform.c",
+
+  /* Skip Mixed case
    * arch/arm/src/phy62xx/uart.c:1229:13: error: Mixed case identifier found
    */
 


### PR DESCRIPTION
## Summary
1. clang: Support compiling rt.profile library
```
      1. Since the implementation of gcov has changed since clang17, versions before clang17 need to use the libunwind.a file
```
2. llvm gcov supports interrupt code coverage detection, as shown below
   for the code coverage analysis of armv8-m/arm_doirq.c:

```
 -:    0:Source:armv8-m/arm_doirq.c
            -:    0:Graph:./arm_doirq.gcno
            -:    0:Data:./arm_doirq.gcda
            -:    0:Runs:1
            -:    0:Programs:1
            -:    1:/****************************************************************************
            -:    2: * arch/arm/src/armv8-m/arm_doirq.c
            -:    3: *
            -:    4: * Licensed to the Apache Software Foundation (ASF) under one or more
            -:    5: * contributor license agreements.  See the NOTICE file distributed with
            -:    6: * this work for additional information regarding copyright ownership.  The
            -:    7: * ASF licenses this file to you under the Apache License, Version 2.0 (the
            -:    8: * "License"); you may not use this file except in compliance with the
            -:    9: * License.  You may obtain a copy of the License at
            -:   10: *
            -:   11: *   http://www.apache.org/licenses/LICENSE-2.0
            -:   12: *
            -:   13: * Unless required by applicable law or agreed to in writing, software
            -:   14: * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
            -:   15: * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
            -:   16: * License for the specific language governing permissions and limitations
            -:   17: * under the License.
            -:   18: *
            -:   19: ****************************************************************************/
            -:   20:
            -:   21:/****************************************************************************
            -:   22: * Included Files
            -:   23: ****************************************************************************/
            -:   24:
            -:   25:#include <nuttx/config.h>
            -:   26:
            -:   27:#include <stdint.h>
            -:   28:#include <assert.h>
            -:   29:
            -:   30:#include <nuttx/irq.h>
            -:   31:#include <nuttx/arch.h>
            -:   32:#include <nuttx/board.h>
            -:   33:#include <arch/board/board.h>
            -:   34:#include <sched/sched.h>
            -:   35:
            -:   36:#include "arm_internal.h"
            -:   37:#include "exc_return.h"
            -:   38:#include "nvic.h"
            -:   39:#include "psr.h"
            -:   40:
            -:   41:/****************************************************************************
            -:   42: * Public Functions
            -:   43: ****************************************************************************/
            -:   44:
         4395:   45:void exception_direct(void)
            -:   46:{
         4395:   47:  int irq = getipsr();
            -:   48:
            -:   49:#ifdef CONFIG_ARCH_FPU
         4395:   50:  __asm__ __volatile__
            -:   51:    (
            -:   52:      "mov r0, %0\n"
            -:   53:      "vmsr fpscr, r0\n"
            -:   54:      :
            -:   55:      : "i" (ARMV8M_FPSCR_LTPSIZE_NONE)
            -:   56:    );
            -:   57:#endif
            -:   58:
         4395:   59:  arm_ack_irq(irq);
         4395:   60:  irq_dispatch(irq, NULL);
            -:   61:
         4395:   62:  if (g_running_tasks[this_cpu()] != this_task())
            -:   63:    {
           36:   64:      up_trigger_irq(NVIC_IRQ_PENDSV, 0);
           36:   65:    }
         4395:   66:}
            -:   67:
           37:   68:uint32_t *arm_doirq(int irq, uint32_t *regs)
            -:   69:{
           37:   70:  struct tcb_s *tcb = this_task();
            -:   71:
            -:   72:  board_autoled_on(LED_INIRQ);
            -:   73:#ifdef CONFIG_SUPPRESS_INTERRUPTS
            -:   74:  PANIC();
            -:   75:#else
            -:   76:
            -:   77:  /* Acknowledge the interrupt */
            -:   78:
           37:   79:  arm_ack_irq(irq);
            -:   80:
            -:   81:  /* Set current regs for crash dump */
            -:   82:
           37:   83:  up_set_current_regs(regs);
            -:   84:
           37:   85:  if (irq == NVIC_IRQ_PENDSV)
            -:   86:    {
            -:   87:#ifdef CONFIG_ARCH_HIPRI_INTERRUPT
            -:   88:      /* Dispatch the PendSV interrupt */
            -:   89:
            -:   90:      irq_dispatch(irq, regs);
            -:   91:#endif
            -:   92:
           17:   93:      up_irq_save();
           17:   94:      g_running_tasks[this_cpu()]->xcp.regs = regs;
           17:   95:    }
            -:   96:  else
            -:   97:    {
            -:   98:      /* Dispatch irq */
            -:   99:
           20:  100:      tcb->xcp.regs = regs;
           20:  101:      irq_dispatch(irq, regs);
            -:  102:    }
            -:  103:
            -:  104:  /* If a context switch occurred while processing the interrupt then
            -:  105:   * current_regs may have change value.  If we return any value different
            -:  106:   * from the input regs, then the lower level will know that a context
            -:  107:   * switch occurred during interrupt processing.
            -:  108:   */
            -:  109:
           37:  110:  tcb = this_task();
            -:  111:
            -:  112:  /* Update scheduler parameters */
            -:  113:
            -:  114:  nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
            -:  115:  nxsched_resume_scheduler(tcb);
            -:  116:
            -:  117:  /* Record the new "running" task when context switch occurred.
            -:  118:   * g_running_tasks[] is only used by assertion logic for reporting
            -:  119:   * crashes.
            -:  120:   */
            -:  121:
           37:  122:  g_running_tasks[this_cpu()] = tcb;
           37:  123:  regs = tcb->xcp.regs;
            -:  124:#endif
            -:  125:
            -:  126:  /* Clear current regs */
            -:  127:
           37:  128:  up_set_current_regs(NULL);
            -:  129:
            -:  130:  board_autoled_off(LED_INIRQ);
            -:  131:
            -:  132:#ifdef CONFIG_ARMV8M_TRUSTZONE_HYBRID
            -:  133:  if (((1 << this_cpu()) & CONFIG_ARMV8M_TRUSTZONE_CPU_BITMASK) == 0)
            -:  134:    {
            -:  135:      regs[REG_EXC_RETURN] &=
            -:  136:        ~(EXC_RETURN_EXC_SECURE | EXC_RETURN_SECURE_STACK);
            -:  137:    }
            -:  138:  else
            -:  139:    {
            -:  140:      regs[REG_EXC_RETURN] |=
            -:  141:        (EXC_RETURN_EXC_SECURE | EXC_RETURN_SECURE_STACK);
            -:  142:    }
            -:  143:#endif
            -:  144:
           37:  145:  return regs;
            -:  146:}
```
## Impact
## Testing
Enable CONFIG_SYSTEM_GCOV CONFIG_SCHED_GCOV and add compilation options to -fprofile-generate --coverage to the module that needs to analyze code coverage, and execute gcov -d /data/xxxx to get the analysis data