### PR TITLE
modify for set conn status with connected when receive event USRSOCK_EVENT_SENDTO_READY

### DIFF
--- a/net/usrsock/usrsock_event.c
+++ b/net/usrsock/usrsock_event.c
@@ -77,7 +77,8 @@ int usrsock_event(FAR struct usrsock_conn_s *conn)
           conn->state = USRSOCK_CONN_STATE_READY;
           events |= USRSOCK_EVENT_CONNECT_READY;
 
-          if (conn->resp.result == 0)
+          if ((conn->resp.result == 0) ||
+              (events & USRSOCK_EVENT_SENDTO_READY))
             {
               conn->connected = true;
             }


### PR DESCRIPTION
## Summary

The original process was to change conn->resp.result to 0 in usrsock_handle_response when receiving tcp ack status conn->state was USRSOCK_CONN_STATE_CONNECTING during the event USRSOCK_EVENT_SENDTO_READY. However, in exceptional circumstances, usrsock_handle_response was processed late, and conn->resp.result was not yet 0, resulting in the inability to change conn->connected status to connected when processing the USRSOCK_EVENT_SENDTO_READY event. Therefore, the modification method is to also change the conn->connected status to connected when the conn->state is USRSOCK_CONN_STATE_CONNECTING and the event is USRSOCK_EVENT_SENDTO_READY.

## Impact

NA

## Testing

NA


