### PR TITLE
Socketcan fixes

### DIFF
--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -109,8 +109,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           /* Copy the packet data into the device packet buffer and send it */
 
           int ret = devif_send(dev, pstate->snd_buffer,
-                               pstate->snd_buflen, 0);
-          dev->d_len = dev->d_sndlen;
+                               pstate->snd_buflen + pstate->pr_msglen, 0);
+          dev->d_len = dev->d_sndlen - pstate->pr_msglen;
           if (ret <= 0)
             {
               pstate->snd_sent = ret;
@@ -122,7 +122,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
             {
               memcpy(dev->d_buf + pstate->snd_buflen, pstate->pr_msgbuf,
                      pstate->pr_msglen);
-              dev->d_sndlen = pstate->snd_buflen + pstate->pr_msglen;
             }
         }
 

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -1032,6 +1032,7 @@ static int devif_poll_callback(FAR struct net_driver_s *dev)
 
 int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 {
+  unsigned len;
   uint16_t llhdrlen;
   FAR uint8_t *buf;
   int bstop;
@@ -1054,7 +1055,8 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
         {
           /* Copy iob to flat buffer */
 
-          iob_copyout(buf, dev->d_iob, dev->d_len, -llhdrlen);
+          len = MAX(dev->d_len, dev->d_sndlen);
+          iob_copyout(buf, dev->d_iob, len, -llhdrlen);
 
           /* Restore flat buffer pointer */
 

--- a/net/netdev/netdev_default.c
+++ b/net/netdev/netdev_default.c
@@ -75,7 +75,8 @@ FAR struct net_driver_s *netdev_default(void)
            * device).
            */
 
-          if (dev->d_lltype != NET_LL_LOOPBACK)
+          if (dev->d_lltype != NET_LL_LOOPBACK &&
+              dev->d_lltype != NET_LL_CAN)
             {
               ret = dev;
               break;


### PR DESCRIPTION
This PR fixes two issues with socketcan

1. Don't select CAN device as "default" netdev (e.g. in netdev_findbyaddr()). This causes sending IP data to socket can drivers.

3. Fix cmsg data (timeout timestamp) appending to socket can messages. This has broken at some point, I am not sure how/why:

- First, copy the cmsg (timeout time stamp) data into IOB together with the data in can_sendmsg.c/psock_send_eventhandler . Set the d_sndlen to message+timestamp length, and d_len to the actual data length.

- Second, in devif_poll, iob_copyout the max of (d_len, d_sndlen) to pass the data to the can drivers.

This PR has been tested in imx9 platform, with two network interfaces 1) ethernet, 2) can.
