### PR TITLE
sched: Use spinlock repalce sched_[un]lock in some place

### DIFF
--- a/sched/signal/sig_findaction.c
+++ b/sched/signal/sig_findaction.c
@@ -44,6 +44,7 @@
 FAR sigactq_t *nxsig_find_action(FAR struct task_group_s *group, int signo)
 {
   FAR sigactq_t *sigact = NULL;
+  irqstate_t flags;
 
   /* Verify the caller's sanity */
 
@@ -54,7 +55,7 @@ FAR sigactq_t *nxsig_find_action(FAR struct task_group_s *group, int signo)
        * protection.
        */
 
-      sched_lock();
+      flags = spin_lock_irqsave(NULL);
 
       /* Search the list for a sigaction on this signal */
 
@@ -62,7 +63,7 @@ FAR sigactq_t *nxsig_find_action(FAR struct task_group_s *group, int signo)
            ((sigact) && (sigact->signo != signo));
            sigact = sigact->flink);
 
-      sched_unlock();
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return sigact;

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -404,6 +404,7 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
                                     uint8_t ttype)
 {
   FAR struct tcb_s *rtcb = this_task();
+  irqstate_t flags;
   int ret;
 
   /* Assign a unique task ID to the task. */
@@ -481,10 +482,10 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
 
       /* Add the task to the inactive task list */
 
-      sched_lock();
+      flags = spin_lock_irqsave(NULL);
       dq_addfirst((FAR dq_entry_t *)tcb, list_inactivetasks());
       tcb->task_state = TSTATE_TASK_INACTIVE;
-      sched_unlock();
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return ret;


### PR DESCRIPTION

## Summary
Use spinlock repalce sched_[un]lock in some place
In SMP, sched_lock cannot prevent concurrent access

## Impact
none

## Testing
ci ostest


