### PR TITLE
sim/alsa: fix runtime warning.

### DIFF
--- a/arch/sim/src/sim/sim_offload.c
+++ b/arch/sim/src/sim/sim_offload.c
@@ -353,10 +353,10 @@ static int sim_audio_mad_decode(void *handle,
   struct sim_mad_s *codec = (struct sim_mad_s *)handle;
   const mad_fixed_t *right_ch;
   const mad_fixed_t *left_ch;
+  uint32_t header;
   int nchannels;
   int nsamples;
   uint8_t *ptr;
-  int header;
   int i = 0;
   int size;
   int ret;
@@ -366,7 +366,10 @@ static int sim_audio_mad_decode(void *handle,
       return -ENODATA;
     }
 
-  header = in[0] << 24 | in[1] << 16 | in[2] << 8 | in[3];
+  header = ((uint32_t)in[0] << 24) |
+           ((uint32_t)in[1] << 16) |
+           ((uint32_t)in[2] << 8) |
+           ((uint32_t)in[3]);
   size = sim_mad_check(header);
   if (size < 0)
     {


### PR DESCRIPTION
sim/posix/sim_offload.c:369:18: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
    #0 0x3a146c2  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x3a146c2)
    #1 0x3a0ecb0  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x3a0ecb0)
    #2 0x3a1193a  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x3a1193a)
    #3 0x3a13141  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x3a13141)
    #4 0x39fc3ef  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x39fc3ef)
    #5 0x38ca7f2  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x38ca7f2)
    #6 0x39fc6cf  (/home/qiaohj/disk1/work/vela/nuttx/nuttx+0x39fc6cf)