### PR TITLE
coredump bug fix

### DIFF
--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -51,10 +51,10 @@
 
 struct coredump_info_s
 {
-  uint32_t       magic;
-  struct utsname name;
-  time_t         time;
-  size_t         size;
+  uint32_t        magic;
+  struct utsname  name;
+  struct timespec time;
+  size_t          size;
 };
 
 /****************************************************************************

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -720,7 +720,7 @@ static void coredump_dump_blkdev(pid_t pid)
 
   info->magic = COREDUMP_MAGIC;
   info->size  = g_blockstream.common.nput;
-  info->time  = time(NULL);
+  clock_gettime(CLOCK_REALTIME, &info->time);
   uname(&info->name);
   ret = g_blockstream.inode->u.i_bops->write(g_blockstream.inode,
       (FAR void *)info, g_blockstream.geo.geo_nsectors - nsectors, nsectors);

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -777,11 +777,12 @@ int coredump_add_memory_region(FAR const void *ptr, size_t size)
 
               return 0;
             }
-          else if ((uintptr_t)ptr < region->end &&
+          else if ((uintptr_t)ptr < region->start &&
                    (uintptr_t)ptr + size >= region->end)
             {
-              /* start in region, end out of region */
+              /* start out of region, end out of region */
 
+              region->start = (uintptr_t)ptr;
               region->end = (uintptr_t)ptr + size;
               return 0;
             }
@@ -793,12 +794,11 @@ int coredump_add_memory_region(FAR const void *ptr, size_t size)
               region->start = (uintptr_t)ptr;
               return 0;
             }
-          else if ((uintptr_t)ptr < region->start &&
+          else if ((uintptr_t)ptr < region->end &&
                    (uintptr_t)ptr + size >= region->end)
             {
-              /* start out of region, end out of region */
+              /* start in region, end out of region */
 
-              region->start = (uintptr_t)ptr;
               region->end = (uintptr_t)ptr + size;
               return 0;
             }

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -730,6 +730,15 @@ static void coredump_dump_blkdev(pid_t pid)
       return;
     }
 
+  /* Close block device directly, make sure all data write to block device */
+
+  ret = g_blockstream.inode->u.i_bops->close(g_blockstream.inode);
+  if (ret < 0)
+    {
+      _alert("Coredump information close fail\n");
+      return;
+    }
+
   _alert("Finish coredump, write %d bytes to %s\n",
          info->size, CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
 }


### PR DESCRIPTION
## Summary

1. need close blk dev when do coredump finsh
2. fix memory region bug
3. measure the system's running time in milliseconds unit

## Impact
coredump
## Testing

qmue use coredump