### PR TITLE
sim/heap: malloc returns a valid pointer when allocating 0 bytes.

### DIFF
--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -375,8 +375,7 @@ void *mm_realloc(struct mm_heap_s *heap, void *oldmem,
 
   if (size == 0)
     {
-      mm_free(heap, oldmem);
-      return NULL;
+      size = 1;
     }
 
   oldsize = host_mallocsize(oldmem);


### PR DESCRIPTION
## Summary
The default heap management in nuttx returns a valid memory address when malloc(0).
In sim_heap, malloc(0) returns NULL, aligning the behavior of sim_heap with mm_heap

The man manual describes malloc as follows:
https://man7.org/linux/man-pages/man3/malloc.3.html

The malloc() function allocates size bytes and returns a pointer to the allocated memory.  
The memory is not initialized.  If size is 0, then malloc() returns a unique pointer value that can later
be successfully passed to free().

## Impact

## Testing
sim

