### PR TITLE
arch/x86_64: The AP retrieves this_task after storing the CPU private…

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpu.c
+++ b/arch/x86_64/src/intel64/intel64_cpu.c
@@ -49,8 +49,8 @@
  * Public Data
  ****************************************************************************/
 
-extern volatile uint32_t   g_cpu_count;
-volatile static spinlock_t g_ap_boot;
+extern volatile uint32_t g_cpu_count;
+static spinlock_t        g_ap_boot;
 
 /* CPU private data */
 

--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -127,10 +127,8 @@ static int x86_64_ap_startup(int cpu)
 
 void x86_64_ap_boot(void)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb;
   uint8_t cpu = 0;
-
-  UNUSED(tcb);
 
   /* Do some checking on CPU compatibilities at the top of this function */
 
@@ -147,6 +145,9 @@ void x86_64_ap_boot(void)
   /* Store CPU private data */
 
   x86_64_cpu_priv_set(cpu);
+
+  tcb = this_task();
+  UNUSED(tcb);
 
   /* Configure interrupts */
 


### PR DESCRIPTION
… data

this_task obtains the CPU ID through the GS register, so the initial value of GS needs to be configured in x86_64_cpu_priv_set

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
The AP retrieves this_task after storing the CPU private
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

ostest
