### PR TITLE
arch/x86_64: Resolving NUC Boot Failure Issue

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -195,8 +195,8 @@ __ap_entry:
  ****************************************************************************/
 
 	.code32
-	.section ".multiboot1", "a"
 #ifdef CONFIG_ARCH_MULTIBOOT1
+	.section ".multiboot1", "a"
 .set MB_FLAG_ALIGNED,   1       /* All boot modules must be loaded aligned */
 .set MB_FLAG_MEMINFO,   2       /* Boot with memory maps passing  */
 .set MB_FLAG_VIDEO,     4       /* Enable video mode  */

--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
@@ -46,6 +46,7 @@ SECTIONS
 
     .loader.rodata : {
         *(.loader.rodata)
+        *(.note.nuttx)
     }
 
     .loader.tdata_tbss : {


### PR DESCRIPTION
The segment of the Xen PVH boot protocol was not specified during linking and was placed before .loader.text, causing the boot to fail

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*
Resolving NUC Boot Failure Issue
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*
no impact
## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*
ostest

