### PR TITLE
arm/qemuv7a: Modify link script

### DIFF
--- a/boards/arm/qemu/qemu-armv7a/README.txt
+++ b/boards/arm/qemu/qemu-armv7a/README.txt
@@ -1,0 +1,91 @@
+README.txt
+==========
+
+This board configuration will use QEMU to emulate generic ARM v7-A series
+hardware platform and provides support for these devices:
+
+ - GICv2 interrupt controllers
+ - ARM Generic Timer
+ - PL011 UART controller
+
+Contents
+========
+  - Getting Started
+  - Status
+  - Platform Features
+  - Debugging with QEMU
+  - FPU Support and Performance
+  - SMP Support
+  - References
+
+Getting Started
+===============
+
+1. Configuring and running
+  1.1 Single Core
+   Configuring NuttX and compile:
+   $ ./tools/configure.sh -l qemu-armv7a:nsh
+   $ make
+   Running with qemu
+   $ qemu-system-arm -cpu cortex-a7 -nographic \
+     -machine virt,virtualization=off,gic-version=2 \
+     -net none -chardev stdio,id=con,mux=on -serial chardev:con \
+     -mon chardev=con,mode=readline -kernel ./nuttx
+
+2. knsh
+------
+  This is a configuration of testing the BUILD_KERNEL configuration
+  $ cd nuttx
+  $ ./tools/configure.sh qemu-armv7a:knsh
+  $ make V=1 -j7
+  $ make export V=1
+  $ cd ../apps
+  $ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
+  $ make import V=1
+  $ cd ../nuttx
+  $ qemu-system-arm -semihosting -M virt -m 1024 -nographic -kernel ./nuttx
+
+  NuttShell (NSH) NuttX-12.3.0-RC0
+  nsh> uname -a
+  NuttX 12.3.0-RC0 28dee592a3-dirty Oct 12 2023 03:03:07 arm qemu-armv7a
+  nsh> ps
+    PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
+      0     0   0 FIFO     Kthread N-- Ready              0000000000000000 004088 000896  21.9%  Idle_Task
+      1     1 100 RR       Kthread --- Waiting  Semaphore 0000000000000000 004040 000304   7.5%  lpwork 0x40119398 0x401193ac
+      2     2 100 RR       Task    --- Running            0000000000000000 003032 001032  34.0%  /system/bin/init
+  nsh> free
+                     total       used       free    largest  nused  nfree
+          Kmem:  133058556      16644  133041912  133041152     41      3
+          Page:  134217728    1105920  133111808  133111808
+  nsh> /system/bin/hello
+  Hello, World!!
+  nsh>
+
+Debugging with QEMU
+===================
+
+The nuttx ELF image can be debugged with QEMU.
+
+1. To debug the nuttx (ELF) with symbols, make sure the following change have
+   applied to defconfig.
+
++CONFIG_DEBUG_SYMBOLS=y
+
+2. Run QEMU(at shell terminal 1)
+
+   Single Core
+   $ qemu-system-arm -cpu cortex-a7 -nographic \
+     -machine virt,virtualization=off,gic-version=2 \
+     -net none -chardev stdio,id=con,mux=on -serial chardev:con \
+     -mon chardev=con,mode=readline -kernel ./nuttx -S -s
+
+3. Run gdb with TUI, connect to QEMU, load nuttx and continue (at shell terminal 2)
+
+   $ arm-none-eabi-gdb -tui --eval-command='target remote localhost:1234' nuttx
+   (gdb) c
+   Continuing.
+   ^C
+   Program received signal SIGINT, Interrupt.
+   nx_start () at armv7-a/arm_head.S:209
+   (gdb)
+

--- a/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
+++ b/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/qemu/qemu-armv7a/scripts/dramboot_armv7a.ld
+ * boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,99 +17,111 @@
  * under the License.
  *
  ****************************************************************************/
+
+#include <nuttx/config.h>
+
 OUTPUT_ARCH(arm)
 ENTRY(__start)
-PHDRS
+
+MEMORY
 {
-  text PT_LOAD ;
+  ROM (rx) : ORIGIN = CONFIG_FLASH_START, LENGTH = CONFIG_FLASH_SIZE
+  RAM (rwx): ORIGIN = CONFIG_RAM_START,   LENGTH = CONFIG_RAM_SIZE
 }
+
 SECTIONS
 {
-  . = 0x40101000;
 
-  /* where the global variable out-of-bounds detection information located */
+  /* Where the global variable out-of-bounds detection information located */
 
 #ifdef CONFIG_MM_KASAN_GLOBAL
   .kasan.unused : {
     *(.data..LASANLOC*)
-  }
+  } > ROM
   .kasan.global : {
     KEEP (*(.data..LASAN0))
     KEEP (*(.data.rel.local..LASAN0))
-  }
+  } > ROM
   .kasan.shadows : {
     *(.kasan.shadows)
-  }
+  } > ROM
 #endif
 
   .text : {
-        _stext = .;            /* Text section */
-       *(.vectors)
-       *(.text)
-       *(.text.cold)
-       *(.text.unlikely)
-       *(.fixup)
-       *(.gnu.warning)
-  } :text
+      _stext = .;            /* Text section */
+      __text_start = .;
+      *(.vectors)
+      *(.text*)
+      *(.fixup)
+      *(.gnu.warning)
+  } > ROM
+
   . = ALIGN(4096);
+
   .init_section : {
-        _sinit = ABSOLUTE(.);
-        KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
-        _einit = ABSOLUTE(.);
-  } :text
-  . = ALIGN(4096);
-  _etext = .; /* End_1 of .text */
-  _sztext = _etext - _stext;
+      _sinit = ABSOLUTE(.);
+      KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+      KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+      _einit = ABSOLUTE(.);
+      . = ALIGN(8);
+      _etext = .; /* End_1 of .text */
+      _sztext = _etext - _stext;
+  } > ROM
+
+  .ARM.extab : {
+      *(.ARM.extab*)
+  } > ROM
+
+  /* .ARM.exidx is sorted, so has to go in its own output section.  */
+
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx : {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > ROM
+  PROVIDE_HIDDEN (__exidx_end = .);
+
   .rodata : {
-        _srodata = .;          /* Read-only data */
-       *(.rodata)
-       *(.rodata.*)
-       *(.data.rel.ro)
-       *(.data.rel.ro.*)
-  } :text
-  . = ALIGN(4096);
-  _erodata = .;                /* End of read-only data */
-  _szrodata = _erodata - _srodata;
-  _eronly = .;  /* End of read-only data */
+      _srodata = .;          /* Read-only data */
+      *(.rodata*)
+      *(.data.rel.ro*)
+      KEEP(*(SORT(.scattered_array*)));
+      . = ALIGN(8);
+      _erodata = .;
+  } > ROM
+
+  _eronly = LOADADDR(.data);
   .data : {                    /* Data */
-        _sdata = .;
-       *(.data.page_aligned)
-       *(.data)
-       . = ALIGN(8);
-       __start_impls = .;
-        *(.impls)
-        KEEP(*(.impls))
-        . = ALIGN(4);
-        __stop_impls = .;
-       *(.data.rel)
-       *(.data.rel.*)
-       CONSTRUCTORS
-  } :text
-  _edata = .; /* End+1 of .data */
+      _sdata = .;
+      *(.data*)
+      . = ALIGN(8);
+      __start_impls = .;
+      *(.impls)
+      KEEP(*(.impls))
+      . = ALIGN(4);
+      __stop_impls = .;
+      _edata = .;
+  } > RAM AT > ROM
+
+  .noinit : {
+      _snoinit = ABSOLUTE(.);
+      *(.noinit*)
+      _enoinit = ABSOLUTE(.);
+  } > RAM
+
   .bss : {                     /* BSS */
        _sbss = .;
-       *(.bss)
-       . = ALIGN(1 << 3);
-  } :text
-  . = ALIGN(4096);
-  _ebss = .;
-  _szbss = _ebss - _sbss;
-  .initstack : {             /* INIT STACK */
-       _s_initstack = .;
-       *(.initstack)
-       . = ALIGN(16);
-  } :text
-  . = ALIGN(4096);
-  _e_initstack = . ;
-  _szdata = _e_initstack - _sdata;
+       *(.bss*)
+       . = ALIGN(8);
+       _ebss = .;
+  } > RAM
+
   /* Sections to be discarded */
   /DISCARD/ : {
        *(.exit.text)
        *(.exit.data)
        *(.exitcall.exit)
-       *(.eh_frame)
   }
+
   /* Stabs debugging sections.  */
   .stab 0 : { *(.stab) }
   .stabstr 0 : { *(.stabstr) }


### PR DESCRIPTION
## Summary
1. Modify to map to the specified memory, CONFIG_FLASH_START and CONFIG_RAM_START
2. Add explanation README.TXT
## Impact
All configurations under qemev7a have been specified with CONFIG_FLASH_START CONFIG_FLASH_SIZE, CONFIG_RAM-START, and CONFIG_RAM_SIZE
## Testing
No


