### PR TITLE
bug/fix: Makefile expression error caused

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -309,7 +309,7 @@ else
    # Wrong warning array subscript [0] is outside array bounds:
    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 
-   ifeq ($(shell expr $(GCCVER) \>= 12), 1)
+   ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)
      ARCHOPTIMIZATION += --param=min-pagesize=0
      ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
        LDFLAGS += --no-warn-rwx-segments

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -61,7 +61,7 @@ endif
 CXXFLAGS += -Wno-shadow -Wno-sign-compare
 CXXFLAGS += -Wno-attributes -Wno-deprecated-declarations
 
-ifeq ($(shell expr $(GCCVER) \>= 12), 1)
+ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)
   CXXFLAGS += -Wno-maybe-uninitialized -Wno-alloc-size-larger-than
 endif
 


### PR DESCRIPTION
## Summary
expr: syntax error: unexpected argument "12"
expr: syntax error: unexpected argument "12"
## Impact
No
## Testing
No
