### PR TITLE
Fix disable msi when msi capability not exist issue

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1944,7 +1944,10 @@ int pci_connect_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
     {
       /* Disalbe MSI */
 
-      pci_disable_msi(dev, msi);
+      if (msi != 0)
+        {
+          pci_disable_msi(dev, msi);
+        }
 
       /* Enable MSI-X */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*When PCIe device have msix and not msi capability in qemu devices, we can not config MSI capability.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


