### PR TITLE
fs/rpmsgfs[bug fix]: return real err value when open failed

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -322,7 +322,7 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       /* Error opening file */
 
-      ret = -EBADF;
+      ret = hf->fd;
       goto errout_with_buffer;
     }
 


### PR DESCRIPTION

## Summary

fs/rpmsgfs[bug fix]: return real err value when open failed

## Impact

get real errno for rpmsgfs open failed

## Testing

Ci


