### PR TITLE
armv8-r/cp15: fix the problem of op1 operand confusion in ICC_SGI1R

### DIFF
--- a/arch/arm/include/armv8-r/cp15.h
+++ b/arch/arm/include/armv8-r/cp15.h
@@ -173,7 +173,7 @@
 #define CP15_ICC_SRE(r)       _CP15(0, r, c12, c12, 5)    /* ICC_SRE */
 #define CP15_ICC_HSRE(r)      _CP15(4, r, c12,  c9, 5)    /* ICC_HSRE */
 #define CP15_ICC_IGRPEN1(r)   _CP15(0, r, c12, c12, 7)    /* ICC_IGRPEN1 */
-#define CP15_ICC_SGI1R(lo,hi) _CP15_64(2, lo, hi, c12)    /* ICC_SGI1R */
+#define CP15_ICC_SGI1R(lo,hi) _CP15_64(0, lo, hi, c12)    /* ICC_SGI1R */
 
 #define CP15_SET(reg, value)            \
   do                                    \


### PR DESCRIPTION
## Summary

armv8-r/cp15: fix the problem of op1 operand confusion in ICC_SGI1R

Reference:

https://developer.arm.com/documentation/100026/0103/Generic-Interrupt-Controller/GIC-programmers-model/CPU-Interface-Registers

              CRn   Op1    CRm    Op2
    ICC_SGI0R  -     2     c12     -
    ICC_SGI1R  -     0     c12     -

![image](https://github.com/user-attachments/assets/fc8f660a-9c77-4301-ac65-1c99b52e8842)


Signed-off-by: fanjiangang <fanjiangang@lixiang.com>
Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check
