### PR TITLE
syslog: convert \n to \r\n in syslog framework layer

### DIFF
--- a/arch/arm/src/a1x/a1x_serial.c
+++ b/arch/arm/src/a1x/a1x_serial.c
@@ -1574,15 +1574,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_SERIAL_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1604,15 +1595,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_DEVICE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/am335x/am335x_serial.c
+++ b/arch/arm/src/am335x/am335x_serial.c
@@ -1378,15 +1378,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_SERIAL_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1408,15 +1399,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_DEVICE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/at32/at32_serial.c
+++ b/arch/arm/src/at32/at32_serial.c
@@ -3004,16 +3004,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 #endif
@@ -3033,15 +3023,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/c5471/c5471_serial.c
+++ b/arch/arm/src/c5471/c5471_serial.c
@@ -839,16 +839,6 @@ int up_putc(int ch)
   up_waittxready(priv);
   up_serialout(priv, UART_THR_OFFS, (uint8_t)ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, UART_THR_OFFS, '\r');
-    }
-
   up_waittxready(priv);
   up_restoreuartint(priv, ier);
   return ch;

--- a/arch/arm/src/cxd32xx/cxd32_serial.c
+++ b/arch/arm/src/cxd32xx/cxd32_serial.c
@@ -978,15 +978,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_CONSOLE
   up_restoreuartint(priv, ier);

--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -1116,15 +1116,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1146,15 +1137,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/dm320/dm320_serial.c
+++ b/arch/arm/src/dm320/dm320_serial.c
@@ -751,16 +751,6 @@ int up_putc(int ch)
   up_waittxready(priv);
   up_serialout(priv, UART_DTRR, (uint16_t)ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, UART_DTRR, '\r');
-    }
-
   up_waittxready(priv);
   up_restoreuartint(priv, ier);
   return ch;
@@ -803,16 +793,6 @@ int up_putc(int ch)
 {
   up_waittxready();
   putreg16((uint16_t)ch, DM320_REGISTER_BASE + UART_DTRR);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready();
-      putreg16((uint16_t)'\r', DM320_REGISTER_BASE + UART_DTRR);
-    }
 
   up_waittxready();
   return ch;

--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -815,16 +815,6 @@ int up_putc(int ch)
   uint32_t ien;
 
   efm32_disableuartint(priv, &ien);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      efm32_lowputc('\r');
-    }
-
   efm32_lowputc(ch);
   efm32_restoreuartint(priv, ien);
   return ch;
@@ -844,15 +834,6 @@ int up_putc(int ch)
 #ifdef HAVE_LEUART_CONSOLE
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      efm32_lowputc('\r');
-    }
-
   efm32_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -1192,16 +1192,6 @@ int up_putc(int ch)
   uint32_t ien;
 
   efm32_disableuartint(priv, &ien);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      efm32_lowputc('\r');
-    }
-
   efm32_lowputc(ch);
   efm32_restoreuartint(priv, ien);
 #endif
@@ -1223,15 +1213,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      efm32_lowputc('\r');
-    }
-
   efm32_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/eoss3/eoss3_serial.c
+++ b/arch/arm/src/eoss3/eoss3_serial.c
@@ -588,16 +588,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   eoss3_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   eoss3_restoreuartint(priv, ie);
 #endif
@@ -617,15 +607,6 @@ int up_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   /* Output the character */
 
   arm_lowputc(ch);

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2937,16 +2937,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 #endif
@@ -2966,15 +2956,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef CONSOLE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/imx1/imx_serial.c
+++ b/arch/arm/src/imx1/imx_serial.c
@@ -1166,16 +1166,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
   up_waittxready(priv);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_serialout(priv, UART_TXD0, (uint32_t)'\r');
-      up_waittxready(priv);
-    }
-
   up_serialout(priv, UART_TXD0, (uint32_t)ch);
   up_waittxready(priv);
   up_restoreuartint(priv, ier);
@@ -1224,17 +1214,6 @@ static inline void up_waittxready(void)
 int up_putc(int ch)
 {
   up_waittxready();
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      putreg32((uint16_t)'\r', IMX_REGISTER_BASE + UART_TXD0);
-      up_waittxready();
-    }
-
   putreg32((uint16_t)ch, IMX_REGISTER_BASE + UART_TXD0);
   return ch;
 }

--- a/arch/arm/src/imx6/imx_serial.c
+++ b/arch/arm/src/imx6/imx_serial.c
@@ -1124,16 +1124,6 @@ int up_putc(int ch)
    */
 
   imx_disableuartint(priv, &ier);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      imx_lowputc('\r');
-    }
-
   imx_lowputc(ch);
   imx_restoreuartint(priv, ier);
 
@@ -1190,17 +1180,6 @@ int up_putc(int ch)
 {
 #ifdef IMX_CONSOLE_VBASE
   imx_waittxready();
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      putreg32((uint16_t)'\r', IMX_CONSOLE_VBASE + UART_TXD_OFFSET);
-      imx_waittxready();
-    }
-
   putreg32((uint16_t)ch, IMX_CONSOLE_VBASE + UART_TXD_OFFSET);
 #endif
 

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -3678,16 +3678,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   imxrt_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      imxrt_lowputc('\r');
-    }
-
   imxrt_lowputc(ch);
   imxrt_restoreuartint(priv, ie);
 #endif
@@ -3708,15 +3698,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_LPUART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 

--- a/arch/arm/src/kinetis/kinetis_lpserial.c
+++ b/arch/arm/src/kinetis/kinetis_lpserial.c
@@ -1956,16 +1956,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   kinetis_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   kinetis_restoreuartint(priv, ie);
 #endif
@@ -1987,15 +1977,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_LPUART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -2148,16 +2148,6 @@ int up_putc(int ch)
   uint8_t ie;
 
   up_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreuartint(priv, ie);
 #endif
@@ -2179,15 +2169,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/kl/kl_serial.c
+++ b/arch/arm/src/kl/kl_serial.c
@@ -882,16 +882,6 @@ int up_putc(int ch)
   uint8_t ie;
 
   up_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      kl_lowputc('\r');
-    }
-
   kl_lowputc(ch);
   up_restoreuartint(priv, ie);
 #endif
@@ -911,15 +901,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      kl_lowputc('\r');
-    }
-
   kl_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/lc823450/lc823450_serial.c
+++ b/arch/arm/src/lc823450/lc823450_serial.c
@@ -1374,16 +1374,6 @@ int up_putc(int ch)
   up_waittxnotfull(priv);
   up_serialout(priv, UART_USTF, (uint32_t)ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxnotfull(priv);
-      up_serialout(priv, UART_USTF, (uint32_t)'\r');
-    }
-
   up_waittxnotfull(priv);
   up_restoreuartint(priv, im);
   return ch;
@@ -1401,15 +1391,6 @@ int up_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
@@ -1692,15 +1692,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1722,15 +1713,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/lpc214x/lpc214x_serial.c
+++ b/arch/arm/src/lpc214x/lpc214x_serial.c
@@ -792,16 +792,6 @@ int up_putc(int ch)
   up_waittxready(priv);
   up_serialout(priv, LPC214X_UART_THR_OFFSET, (uint8_t)ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, LPC214X_UART_THR_OFFSET, '\r');
-    }
-
   up_waittxready(priv);
   up_restoreuartint(priv, ier);
   return ch;
@@ -819,15 +809,6 @@ int up_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/lpc2378/lpc23xx_serial.c
+++ b/arch/arm/src/lpc2378/lpc23xx_serial.c
@@ -932,16 +932,6 @@ int up_putc(int ch)
   up_waittxready(priv);
   up_serialout(priv, UART_THR_OFFSET, (uint8_t) ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, UART_THR_OFFSET, '\r');
-    }
-
   up_waittxready(priv);
   up_restoreuartint(priv, ier);
   return ch;
@@ -959,15 +949,6 @@ int up_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/lpc31xx/lpc31_serial.c
+++ b/arch/arm/src/lpc31xx/lpc31_serial.c
@@ -808,15 +808,6 @@ int up_putc(int ch)
 
   up_disableuartint(priv, &ier);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   /* Output the character */
 
   arm_lowputc(ch);
@@ -836,15 +827,6 @@ int up_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   /* Output the character */
 
   arm_lowputc(ch);

--- a/arch/arm/src/lpc43xx/lpc43_serial.c
+++ b/arch/arm/src/lpc43xx/lpc43_serial.c
@@ -1356,15 +1356,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_SERIAL_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1386,15 +1377,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -1447,16 +1447,6 @@ int up_putc(int ch)
   uint32_t intset;
 
   lpc54_fifoint_disableall(priv, &intset);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   lpc54_fifoint_enable(priv, intset);
 #endif
@@ -1477,15 +1467,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_USART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/max326xx/max32660/max32660_serial.c
+++ b/arch/arm/src/max326xx/max32660/max32660_serial.c
@@ -832,16 +832,6 @@ int up_putc(int ch)
   uint32_t intset;
 
   max326_int_disableall(priv, &intset);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   max326_int_enable(priv, intset);
 #endif
@@ -862,15 +852,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 }

--- a/arch/arm/src/mx8mp/mx8mp_serial.c
+++ b/arch/arm/src/mx8mp/mx8mp_serial.c
@@ -1062,16 +1062,6 @@ int up_putc(int ch)
    */
 
   mx8mp_disableuartint(priv, &ier);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   mx8mp_restoreuartint(priv, ier);
 #endif
@@ -1127,17 +1117,6 @@ int up_putc(int ch)
 {
 #ifdef MX8MP_CONSOLE
   mx8mp_waittxready();
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      putreg32((uint16_t)'\r', MX8MP_CONSOLE + UART_TXD_OFFSET);
-      mx8mp_waittxready();
-    }
-
   putreg32((uint16_t)ch, MX8MP_CONSOLE + UART_TXD_OFFSET);
 #endif
 

--- a/arch/arm/src/nrf52/nrf52_serial.c
+++ b/arch/arm/src/nrf52/nrf52_serial.c
@@ -817,15 +817,6 @@ int up_putc(int ch)
 #ifdef HAVE_UART_CONSOLE
   /* struct nrf52_dev_s *priv = (struct nrf52_dev_s *)CONSOLE_DEV.priv; */
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 
@@ -845,15 +836,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/nrf53/nrf53_serial.c
+++ b/arch/arm/src/nrf53/nrf53_serial.c
@@ -817,15 +817,6 @@ int up_putc(int ch)
 #ifdef HAVE_UART_CONSOLE
   /* struct nrf53_dev_s *priv = (struct nrf53_dev_s *)CONSOLE_DEV.priv; */
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 
@@ -845,15 +836,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/nrf91/nrf91_serial.c
+++ b/arch/arm/src/nrf91/nrf91_serial.c
@@ -817,15 +817,6 @@ int up_putc(int ch)
 #ifdef HAVE_UART_CONSOLE
   /* struct nrf91_dev_s *priv = (struct nrf91_dev_s *)CONSOLE_DEV.priv; */
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 
@@ -845,15 +836,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/nuc1xx/nuc_serial.c
+++ b/arch/arm/src/nuc1xx/nuc_serial.c
@@ -1057,15 +1057,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      nuc_lowputc((uint32_t)'\r');
-    }
-
   nuc_lowputc((uint32_t)ch);
 #ifdef HAVE_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1087,15 +1078,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      nuc_lowputc((uint32_t)'\r');
-    }
-
   nuc_lowputc((uint32_t)ch);
 #endif
   return ch;

--- a/arch/arm/src/rp2040/rp2040_serial.c
+++ b/arch/arm/src/rp2040/rp2040_serial.c
@@ -1022,16 +1022,6 @@ int up_putc(int ch)
   uint32_t ier;
   up_disableuartint(priv, &ier);
 #endif
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #ifdef HAVE_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1053,15 +1043,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/rtl8720c/ameba_uart.c
+++ b/arch/arm/src/rtl8720c/ameba_uart.c
@@ -1078,15 +1078,6 @@ int up_putc(int ch)
 {
   struct ameba_s *priv = (struct ameba_s *)CONSOLE_DEV.priv;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      ameba_putc(priv, '\r');
-    }
-
   ameba_putc(priv, ch);
   return ch;
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -2552,16 +2552,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   s32k1xx_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      s32k1xx_lowputc('\r');
-    }
-
   s32k1xx_lowputc(ch);
   s32k1xx_restoreuartint(priv, ie);
 #endif
@@ -2582,15 +2572,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_LPUART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -4460,16 +4460,6 @@ int up_putc(int ch)
   uint32_t ie;
 
   s32k3xx_disableuartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      s32k3xx_lowputc('\r');
-    }
-
   s32k3xx_lowputc(ch);
   s32k3xx_restoreuartint(priv, ie);
 #endif
@@ -4490,15 +4480,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_LPUART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 

--- a/arch/arm/src/sam34/sam_lowputc.c
+++ b/arch/arm/src/sam34/sam_lowputc.c
@@ -306,15 +306,6 @@ void arm_lowputc(char ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/sama5/sam_lowputc.c
+++ b/arch/arm/src/sama5/sam_lowputc.c
@@ -319,14 +319,6 @@ int up_putc(int ch)
 {
 #if defined(SAMA5_HAVE_UART_CONSOLE) || defined(SAMA5_HAVE_USART_CONSOLE) || \
     defined(SAMA5_HAVE_FLEXCOM_CONSOLE) || defined(CONFIG_SAMA5_DBGU_CONSOLE)
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
 
   arm_lowputc(ch);
 #endif

--- a/arch/arm/src/samd2l2/sam_serial.c
+++ b/arch/arm/src/samd2l2/sam_serial.c
@@ -1047,16 +1047,6 @@ int up_putc(int ch)
    */
 
   flags = spin_lock_irqsave(NULL);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sam_lowputc('\r');
-    }
-
   sam_lowputc(ch);
   spin_unlock_irqrestore(NULL, flags);
 #endif
@@ -1076,15 +1066,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sam_lowputc('\r');
-    }
-
   sam_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/samd5e5/sam_serial.c
+++ b/arch/arm/src/samd5e5/sam_serial.c
@@ -1106,16 +1106,6 @@ int up_putc(int ch)
    */
 
   flags = spin_lock_irqsave(NULL);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sam_lowputc('\r');
-    }
-
   sam_lowputc(ch);
   spin_unlock_irqrestore(NULL, flags);
 #endif
@@ -1135,15 +1125,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sam_lowputc('\r');
-    }
-
   sam_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/samv7/sam_lowputc.c
+++ b/arch/arm/src/samv7/sam_lowputc.c
@@ -212,15 +212,6 @@ void arm_lowputc(char ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -3639,16 +3639,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 #endif
@@ -3668,15 +3658,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0 || CONSOLE_LPUART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
@@ -2581,16 +2581,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32serial_restoreusartint(priv, ie);
 #endif
@@ -2610,15 +2600,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_USART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
 

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
@@ -2014,16 +2014,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 
@@ -2044,15 +2034,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_USART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3799,16 +3799,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 #endif
@@ -3828,15 +3818,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -4008,16 +4008,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   up_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   up_restoreusartint(priv, ie);
 
@@ -4038,15 +4028,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -3268,16 +3268,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32l4serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32l4serial_restoreusartint(priv, ie);
 #endif
@@ -3297,15 +3287,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32l5/stm32l5_serial.c
+++ b/arch/arm/src/stm32l5/stm32l5_serial.c
@@ -3201,16 +3201,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32l5serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32l5serial_restoreusartint(priv, ie);
 #endif
@@ -3230,15 +3220,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32u5/stm32_serial.c
+++ b/arch/arm/src/stm32u5/stm32_serial.c
@@ -3201,16 +3201,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32serial_restoreusartint(priv, ie);
 #endif
@@ -3230,15 +3220,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32wb/stm32wb_serial.c
+++ b/arch/arm/src/stm32wb/stm32wb_serial.c
@@ -2834,16 +2834,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32wb_serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32wb_serial_restoreusartint(priv, ie);
 #endif
@@ -2863,15 +2853,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/stm32wl5/stm32wl5_serial.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_serial.c
@@ -2935,16 +2935,6 @@ int up_putc(int ch)
   uint16_t ie;
 
   stm32wl5serial_disableusartint(priv, &ie);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   stm32wl5serial_restoreusartint(priv, ie);
 #endif
@@ -2964,15 +2954,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #if CONSOLE_UART > 0
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/str71x/str71x_serial.c
+++ b/arch/arm/src/str71x/str71x_serial.c
@@ -960,16 +960,6 @@ int up_putc(int ch)
   up_waittxnotfull(priv);
   up_serialout(priv, STR71X_UART_TXBUFR_OFFSET, (uint16_t)ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxnotfull(priv);
-      up_serialout(priv, STR71X_UART_TXBUFR_OFFSET, (uint16_t)'\r');
-    }
-
   up_waittxnotfull(priv);
   up_restoreuartint(priv, ier);
 #endif
@@ -989,15 +979,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -1580,16 +1580,6 @@ int up_putc(int ch)
 
   up_disableuartint(priv, &im);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxnotfull(priv);
-      up_serialout(priv, TIVA_UART_DR_OFFSET, (uint32_t)'\r');
-    }
-
   up_waittxnotfull(priv);
   up_serialout(priv, TIVA_UART_DR_OFFSET, (uint32_t)ch);
 
@@ -1612,15 +1602,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/tlsr82/tlsr82_serial.c
+++ b/arch/arm/src/tlsr82/tlsr82_serial.c
@@ -1593,13 +1593,6 @@ static inline int tlsr82_uart_lowputc(int ch)
 #ifndef CONFIG_TLSR82_SPI_SYSLOG
 int up_putc(int ch)
 {
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      tlsr82_uart_lowputc('\r');
-    }
-
   tlsr82_uart_lowputc(ch);
 
   return 0;

--- a/arch/arm/src/tlsr82/tlsr82_spi_console.c
+++ b/arch/arm/src/tlsr82/tlsr82_spi_console.c
@@ -326,13 +326,6 @@ void spi_console_init(void)
 #ifdef CONFIG_TLSR82_SPI_SYSLOG
 int up_putc(int ch)
 {
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      spi_putc('\r');
-    }
-
   spi_putc((uint8_t)ch);
 
   return 0;

--- a/arch/arm/src/tms570/tms570_lowputc.c
+++ b/arch/arm/src/tms570/tms570_lowputc.c
@@ -229,15 +229,6 @@ void arm_lowputc(char ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
 #endif
   return ch;

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -1127,16 +1127,6 @@ int up_putc(int ch)
   uint32_t ccr;
 
   xmc4_disableuartint(priv, &ccr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   xmc4_restoreuartint(priv, ccr);
 #endif
@@ -1157,15 +1147,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm_lowputc('\r');
-    }
-
   arm_lowputc(ch);
   return ch;
 #endif

--- a/arch/arm64/src/a64/a64_serial.c
+++ b/arch/arm64/src/a64/a64_serial.c
@@ -1417,15 +1417,6 @@ int up_putc(int ch)
 #ifdef CONSOLE_DEV
   struct uart_dev_s *dev = &CONSOLE_DEV;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      a64_uart_wait_send(dev, '\r');
-    }
-
   a64_uart_wait_send(dev, ch);
 #endif
   return ch;

--- a/arch/arm64/src/imx8/imx8qm_serial.c
+++ b/arch/arm64/src/imx8/imx8qm_serial.c
@@ -1053,15 +1053,6 @@ int up_putc(int ch)
 {
   struct uart_dev_s *dev = &CONSOLE_DEV;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      imx8_send(dev, '\r');
-    }
-
   imx8_send(dev, (uint8_t)ch);
   return ch;
 }

--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2804,15 +2804,6 @@ int up_putc(int ch)
   imx9_disableuartint(priv, &ie);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      arm64_lowputc('\r');
-    }
-
   arm64_lowputc(ch);
 #ifdef CONSOLE_DEV
   imx9_restoreuartint(priv, ie);

--- a/arch/arm64/src/rk3399/rk3399_serial.c
+++ b/arch/arm64/src/rk3399/rk3399_serial.c
@@ -1360,15 +1360,6 @@ int up_putc(int ch)
 #ifdef CONSOLE_DEV
   struct uart_dev_s *dev = &CONSOLE_DEV;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      a64_uart_wait_send(dev, '\r');
-    }
-
   a64_uart_wait_send(dev, ch);
 #endif
   return ch;

--- a/arch/arm64/src/zynq-mpsoc/zynq_serial.c
+++ b/arch/arm64/src/zynq-mpsoc/zynq_serial.c
@@ -1313,15 +1313,6 @@ int up_putc(int ch)
 #ifdef CONSOLE_DEV
   struct uart_dev_s *dev = &CONSOLE_DEV;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      zynq_uart_wait_send(dev, '\r');
-    }
-
   zynq_uart_wait_send(dev, ch);
 #endif
   return ch;

--- a/arch/avr/src/at32uc3/at32uc3_serial.c
+++ b/arch/avr/src/at32uc3/at32uc3_serial.c
@@ -761,16 +761,6 @@ int up_putc(int ch)
   uint32_t imr;
 
   up_disableusartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
   up_restoreusartint(priv, imr);
 #endif
@@ -790,15 +780,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
 #endif
   return ch;

--- a/arch/avr/src/at90usb/at90usb_serial.c
+++ b/arch/avr/src/at90usb/at90usb_serial.c
@@ -567,16 +567,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   usart1_disableusartint(&imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
   usart1_restoreusartint(imr);
 #endif
@@ -596,15 +586,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
 #endif
   return ch;

--- a/arch/avr/src/atmega/atmega_serial.c
+++ b/arch/avr/src/atmega/atmega_serial.c
@@ -900,15 +900,6 @@ int up_putc(int ch)
   usart1_disableusartint(&imr);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
 
 #if defined(CONFIG_USART0_SERIAL_CONSOLE)
@@ -934,15 +925,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      avr_lowputc('\r');
-    }
-
   avr_lowputc(ch);
 #endif
   return ch;

--- a/arch/hc/src/m9s12/m9s12_serial.c
+++ b/arch/hc/src/m9s12/m9s12_serial.c
@@ -777,16 +777,6 @@ int up_putc(int ch)
   up_waittxnotfull(priv);
   up_send(CONSOLE_DEV, ch);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxnotfull(priv);
-      up_send(CONSOLE_DEV, '\r');
-    }
-
   up_waittxnotfull(priv);
   up_restoresciint(priv, im);
 #endif
@@ -807,16 +797,6 @@ int up_putc(int ch)
 {
 #ifdef CONFIG_ARCH_LOWPUTC
   hc_lowputc(ch);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      hc_lowputc('\r');
-    }
-
 #endif
   return ch;
 }

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -883,16 +883,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      mips_lowputc('\r');
-    }
-
   mips_lowputc(ch);
   up_restoreuartint(dev, imr);
 #endif
@@ -937,15 +927,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      mips_lowputc('\r');
-    }
-
   mips_lowputc(ch);
 #endif
   return ch;

--- a/arch/mips/src/pic32mz/pic32mz_serial.c
+++ b/arch/mips/src/pic32mz/pic32mz_serial.c
@@ -1420,16 +1420,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      mips_lowputc('\r');
-    }
-
   mips_lowputc(ch);
   up_restoreuartint(dev, imr);
 #endif
@@ -1474,15 +1464,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      mips_lowputc('\r');
-    }
-
   mips_lowputc(ch);
 #endif
   return ch;

--- a/arch/misoc/src/common/misoc_serial.c
+++ b/arch/misoc/src/common/misoc_serial.c
@@ -548,16 +548,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   misoc_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      misoc_lowputc('\r');
-    }
-
   misoc_lowputc(ch);
   misoc_restoreuartint(dev, imr);
 #endif
@@ -603,15 +593,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      misoc_lowputc('\r');
-    }
-
   misoc_lowputc(ch);
 #endif
 

--- a/arch/or1k/src/mor1kx/mor1kx_serial.c
+++ b/arch/or1k/src/mor1kx/mor1kx_serial.c
@@ -117,15 +117,6 @@ int up_putc(int ch)
 
   flags = spin_lock_irqsave(NULL);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      /* or1k_lowputc('\r'); */
-    }
-
   /* or1k_lowputc(ch); */
 
   spin_unlock_irqrestore(NULL, flags);

--- a/arch/renesas/src/m16c/m16c_serial.c
+++ b/arch/renesas/src/m16c/m16c_serial.c
@@ -1101,17 +1101,6 @@ int up_putc(int ch)
   uint8_t  ucon;
 
   up_disableuartint(priv, &ucon);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout16(priv, M16C_UART_TB, (uint16_t)'\r');
-    }
-
   up_waittxready(priv);
   up_serialout16(priv, M16C_UART_TB, (uint16_t)ch);
 
@@ -1134,15 +1123,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIALCONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      renesas_lowputc('\r');
-    }
-
   renesas_lowputc(ch);
 #endif
   return ch;

--- a/arch/renesas/src/rx65n/rx65n_serial.c
+++ b/arch/renesas/src/rx65n/rx65n_serial.c
@@ -1700,16 +1700,6 @@ int up_putc(int ch)
   priv = (struct up_dev_s *)CONSOLE_DEV.priv;
   up_disablesciint(priv, &scr);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, RX_SCI_TDR_OFFSET, '\r');
-    }
-
   up_waittxready(priv);
   up_serialout(priv, RX_SCI_TDR_OFFSET, (uint8_t)ch);
   up_waittxready(priv);
@@ -1730,16 +1720,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      renesas_lowputc('\r');
-    }
-
   renesas_lowputc(ch);
 #endif
   return ch;

--- a/arch/renesas/src/sh1/sh1_serial.c
+++ b/arch/renesas/src/sh1/sh1_serial.c
@@ -887,17 +887,6 @@ int up_putc(int ch)
   uint8_t  scr;
 
   up_disablesciint(priv, &scr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_waittxready(priv);
-      up_serialout(priv, SH1_SCI_TDR_OFFSET, '\r');
-    }
-
   up_waittxready(priv);
   up_serialout(priv, SH1_SCI_TDR_OFFSET, (uint8_t)ch);
 
@@ -920,15 +909,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      renesas_lowputc('\r');
-    }
-
   renesas_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -891,15 +891,6 @@ int up_putc(int ch)
 #ifdef HAVE_SERIAL_CONSOLE
   irqstate_t flags = spin_lock_irqsave(NULL);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   spin_unlock_irqrestore(NULL, flags);
 #endif
@@ -945,15 +936,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/bl808/bl808_serial.c
+++ b/arch/risc-v/src/bl808/bl808_serial.c
@@ -1010,18 +1010,6 @@ int up_putc(int ch)
   uint8_t uart_idx = priv->config.idx;
   irqstate_t flags = enter_critical_section();
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      while ((getreg32(BL808_UART_FIFO_CONFIG_1(uart_idx)) &
-            UART_FIFO_CONFIG_1_TX_CNT_MASK) == 0);
-
-      putreg32('\r', BL808_UART_FIFO_WDATA(uart_idx));
-    }
-
   while ((getreg32(BL808_UART_FIFO_CONFIG_1(uart_idx)) &
             UART_FIFO_CONFIG_1_TX_CNT_MASK) == 0);
 

--- a/arch/risc-v/src/c906/c906_serial.c
+++ b/arch/risc-v/src/c906/c906_serial.c
@@ -670,16 +670,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
@@ -725,15 +715,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/common/espressif/esp_serial.c
+++ b/arch/risc-v/src/common/espressif/esp_serial.c
@@ -1155,15 +1155,6 @@ int up_putc(int ch)
   esp_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 
 #ifdef CONSOLE_UART
@@ -1223,15 +1214,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif /* HAVE_SERIAL_CONSOLE */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_serial.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_serial.c
@@ -1110,15 +1110,6 @@ int up_putc(int ch)
   esp32c3_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 
 #ifdef CONSOLE_UART
@@ -1146,15 +1137,6 @@ int up_putc(int ch)
 
   esp32c3_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
 
   riscv_lowputc(ch);
 

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -660,16 +660,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
@@ -715,15 +705,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/hpm6000/hpm_serial.c
+++ b/arch/risc-v/src/hpm6000/hpm_serial.c
@@ -1299,16 +1299,6 @@ int up_putc(int ch)
   uint32_t im;
 
   hpm_disableuartint(priv, &im);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      hpm_lowputc('\r');
-    }
-
   hpm_lowputc(ch);
   hpm_restoreuartint(priv, im);
 #endif
@@ -1328,15 +1318,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_UART_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/hpm6750/hpm6750_serial.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_serial.c
@@ -845,16 +845,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
@@ -900,15 +890,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -660,16 +660,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
@@ -715,15 +705,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -692,16 +692,6 @@ int up_putc(int ch)
   uint8_t imr;
 
   up_disableuartint(priv, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
@@ -747,15 +737,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/mpfs/mpfs_serial.c
+++ b/arch/risc-v/src/mpfs/mpfs_serial.c
@@ -1259,15 +1259,6 @@ int up_putc(int ch)
   up_disableuartint(priv, &ier);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #ifdef HAVE_SERIAL_CONSOLE
   up_restoreuartint(priv, ier);
@@ -1314,15 +1305,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
 #endif
   return ch;

--- a/arch/risc-v/src/rv32m1/rv32m1_serial.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_serial.c
@@ -1140,16 +1140,6 @@ int up_putc(int ch)
   uint32_t im;
 
   up_disableuartint(priv, &im);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      riscv_lowputc('\r');
-    }
-
   riscv_lowputc(ch);
   up_restoreuartint(priv, im);
 #endif

--- a/arch/sparc/src/bm3803/bm3803-serial.c
+++ b/arch/sparc/src/bm3803/bm3803-serial.c
@@ -877,16 +877,6 @@ int up_putc(int ch)
   uint8_t imr = 0;
 
   up_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
   up_restoreuartint(dev, imr);
 #endif
@@ -931,15 +921,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
 #endif
   return ch;

--- a/arch/sparc/src/bm3823/bm3823-serial.c
+++ b/arch/sparc/src/bm3823/bm3823-serial.c
@@ -872,16 +872,6 @@ int up_putc(int ch)
   uint8_t imr = 0;
 
   up_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
   up_restoreuartint(dev, imr);
 #endif
@@ -926,15 +916,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
 #endif
   return ch;

--- a/arch/sparc/src/s698pm/s698pm-serial.c
+++ b/arch/sparc/src/s698pm/s698pm-serial.c
@@ -958,16 +958,6 @@ int up_putc(int ch)
   uint8_t imr = 0;
 
   up_disableuartint(dev, &imr);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
   up_restoreuartint(dev, imr);
 #endif
@@ -1012,15 +1002,6 @@ int up_putc(int ch)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      sparc_lowputc('\r');
-    }
-
   sparc_lowputc(ch);
 #endif
   return ch;

--- a/arch/tricore/src/tc3xx/tc3xx_serial.c
+++ b/arch/tricore/src/tc3xx/tc3xx_serial.c
@@ -725,15 +725,6 @@ void tricore_serialinit(void)
 int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      tricore_lowputc('\r');
-    }
-
   tricore_lowputc(ch);
 #endif
   return ch;

--- a/arch/x86/src/qemu/qemu_serial.c
+++ b/arch/x86/src/qemu/qemu_serial.c
@@ -75,15 +75,6 @@ void uart_putreg(struct u16550_s *priv,
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      x86_lowputc('\r');
-    }
-
   x86_lowputc(ch);
   return ch;
 }

--- a/arch/x86_64/src/intel64/intel64_serial.c
+++ b/arch/x86_64/src/intel64/intel64_serial.c
@@ -90,15 +90,6 @@ void up_lowputc(char ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      up_lowputc('\r');
-    }
-
   up_lowputc(ch);
   return ch;
 }

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -2121,16 +2121,6 @@ int up_putc(int ch)
 
   esp32_disableallints(CONSOLE_DEV.priv, &intena);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      while (!esp32_txready(&CONSOLE_DEV));
-      esp32_send(&CONSOLE_DEV, '\r');
-    }
-
   while (!esp32_txready(&CONSOLE_DEV));
   esp32_send(&CONSOLE_DEV, ch);
 

--- a/arch/xtensa/src/esp32s2/esp32s2_serial.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_serial.c
@@ -1125,16 +1125,6 @@ int up_putc(int ch)
   uint32_t int_status;
 
   esp32s2_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      xtensa_lowputc('\r');
-    }
-
   xtensa_lowputc(ch);
   esp32s2_lowputc_restore_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
@@ -1187,15 +1177,6 @@ int up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   uint32_t int_status;
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      xtensa_lowputc('\r');
-    }
 
   xtensa_lowputc(ch);
 #endif

--- a/arch/xtensa/src/esp32s3/esp32s3_serial.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_serial.c
@@ -1218,15 +1218,6 @@ int up_putc(int ch)
   esp32s3_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      xtensa_lowputc('\r');
-    }
-
   xtensa_lowputc((char)ch);
 
 #ifdef CONSOLE_UART
@@ -1254,15 +1245,6 @@ int up_putc(int ch)
 
   esp32s3_lowputc_disable_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      xtensa_lowputc('\r');
-    }
 
   xtensa_lowputc(ch);
 

--- a/arch/z16/src/z16f/z16f_serial.c
+++ b/arch/z16/src/z16f/z16f_serial.c
@@ -755,15 +755,6 @@ int up_putc(int ch)
 
   state = z16f_disableuartirq(&CONSOLE_DEV);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR before LF */
-
-      z16f_consoleput('\r');
-    }
-
   /* Output the character */
 
   z16f_consoleput((uint8_t)ch);
@@ -821,15 +812,6 @@ static void z16f_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Output CR before LF */
-
-      z16f_putc('\r');
-    }
-
   /* Output character */
 
   z16f_putc(ch);

--- a/arch/z80/src/ez80/ez80_serial.c
+++ b/arch/z80/src/ez80/ez80_serial.c
@@ -741,16 +741,6 @@ int up_putc(int ch)
 
   ez80_disableuartint(priv);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Output CR before LF */
-
-      ez80_waittxready(priv);
-      ez80_serialout(priv, EZ80_UART_THR, '\r');
-    }
-
   /* Output the character */
 
   ez80_waittxready(priv);
@@ -806,15 +796,6 @@ static void ez80_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Output CR before LF */
-
-      ez80_putc('\r');
-    }
-
   /* Output character */
 
   ez80_putc(ch);

--- a/arch/z80/src/z180/z180_lowserial.c
+++ b/arch/z80/src/z180/z180_lowserial.c
@@ -61,15 +61,6 @@ int z80_lowputc(int ch)
 int up_putc(int ch)
 #endif
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Output CR before LF */
-
-      z180_putc('\r');
-    }
-
   /* Output the character */
 
   z180_putc(ch);

--- a/arch/z80/src/z8/z8_serial.c
+++ b/arch/z80/src/z8/z8_serial.c
@@ -734,15 +734,6 @@ int up_putc(int ch)
 
   state = z8_disableuartirq(&CONSOLE_DEV);
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR before LF */
-
-      z8_consoleput('\r');
-    }
-
   /* Output the character */
 
   z8_consoleput((uint8_t)ch);
@@ -807,15 +798,6 @@ static void z8_putc(int ch)
 
 int up_putc(int ch)
 {
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Output CR before LF */
-
-      z8_putc('\r');
-    }
-
   /* Output character */
 
   z8_putc(ch);

--- a/drivers/serial/serial_cmsdk.c
+++ b/drivers/serial/serial_cmsdk.c
@@ -778,16 +778,6 @@ int up_putc(int ch)
   uint32_t ier;
 
   ier = uart_cmsdk_disableuartint(priv);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      uart_cmsdk_putc(priv, '\r');
-    }
-
   uart_cmsdk_putc(priv, ch);
   uart_cmsdk_restoreuartint(priv, ier);
   return ch;

--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -1704,15 +1704,6 @@ int up_putc(int ch)
 {
   FAR struct u16550_s *priv = (FAR struct u16550_s *)CONSOLE_DEV.priv;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      u16550_putc(priv, '\r');
-    }
-
   u16550_putc(priv, ch);
 
   return ch;

--- a/drivers/serial/uart_pci_16550.c
+++ b/drivers/serial/uart_pci_16550.c
@@ -776,16 +776,6 @@ int up_putc(int ch)
    */
 
   flags = spin_lock_irqsave(NULL);
-
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      u16550_putc(CONSOLE_DEV.priv, '\r');
-    }
-
   u16550_putc(CONSOLE_DEV.priv, ch);
   spin_unlock_irqrestore(NULL, flags);
 

--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -1065,15 +1065,6 @@ int up_putc(int ch)
 {
   FAR struct uart_dev_s *dev = &CONSOLE_DEV;
 
-  /* Check for LF */
-
-  if (ch == '\n')
-    {
-      /* Add CR */
-
-      pl011_putc(dev, '\r');
-    }
-
   pl011_putc(dev, ch);
 
   return ch;

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -49,6 +49,13 @@ config SYSLOG_DEFAULT_MASK
 if SYSLOG
 comment "SYSLOG options"
 
+config SYSLOG_CRLF
+	bool "Syslog convert LF to CRLF"
+	default n
+	---help---
+		Pre-pend a carriage return before every linefeed that goes into the
+		syslog.
+
 config SYSLOG_MAX_CHANNELS
 	int "Maximum SYSLOG channels"
 	default 1

--- a/drivers/syslog/syslog_chardev.c
+++ b/drivers/syslog/syslog_chardev.c
@@ -107,7 +107,8 @@ static int syslog_chardev_ioctl(FAR struct file *filep,
 
           strlcpy(info[i].sc_name, channel->sc_name,
                   sizeof(info[i].sc_name));
-          info[i].sc_disable = channel->sc_disable;
+          info[i].sc_disable =
+                  channel->sc_state & SYSLOG_CHANNEL_DISABLE;
         }
     }
   else if (cmd == SYSLOGIOC_SETFILTER)
@@ -129,7 +130,9 @@ static int syslog_chardev_ioctl(FAR struct file *filep,
           return -ENOENT;
         }
 
-      channel->sc_disable = info->sc_disable;
+      channel->sc_state = info->sc_disable ?
+                          channel->sc_state | SYSLOG_CHANNEL_DISABLE :
+                          channel->sc_state & ~SYSLOG_CHANNEL_DISABLE;
     }
 
   return OK;

--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -161,7 +161,6 @@ int syslog_add_intbuffer(int ch)
   uint32_t endndx;
   unsigned int inuse;
   int ret = OK;
-  int i;
 
   /* Disable concurrent modification from interrupt handling logic */
 
@@ -185,27 +184,42 @@ int syslog_add_intbuffer(int ch)
   if (inuse == CONFIG_SYSLOG_INTBUFSIZE - 1)
     {
       int oldch = syslog_remove_intbuffer();
+      int i;
+
       for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
         {
-          if (g_syslog_channel[i] == NULL)
+          FAR syslog_channel_t *channel = g_syslog_channel[i];
+
+          if (channel == NULL)
             {
               break;
             }
 
 #ifdef CONFIG_SYSLOG_IOCTL
-          if (g_syslog_channel[i]->sc_disable)
+          if (channel->sc_state & SYSLOG_CHANNEL_DISABLE)
             {
               continue;
             }
 #endif
 
-          /* Select which putc function to use for this flush */
-
-          if (g_syslog_channel[i]->sc_ops->sc_force)
+          if (channel->sc_ops->sc_force == NULL)
             {
-              g_syslog_channel[i]->sc_ops->sc_force(
-                                           g_syslog_channel[i], oldch);
+              continue;
             }
+
+#ifdef CONFIG_SYSLOG_CRLF
+          /* Check for LF */
+
+          if (oldch == '\n' &&
+              !(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+            {
+              /* Add CR */
+
+              channel->sc_ops->sc_force(channel, '\r');
+            }
+#endif
+
+          channel->sc_ops->sc_force(channel, oldch);
         }
 
         ret = -ENOSPC;
@@ -248,10 +262,8 @@ int syslog_add_intbuffer(int ch)
 
 int syslog_flush_intbuffer(bool force)
 {
-  syslog_putc_t putfunc;
   irqstate_t flags;
   int ch;
-  int i;
 
   /* This logic is performed with the scheduler disabled to protect from
    * concurrent modification by other tasks.
@@ -259,8 +271,10 @@ int syslog_flush_intbuffer(bool force)
 
   flags = enter_critical_section();
 
-  do
+  for (; ; )
     {
+      int i;
+
       /* Transfer one character to time.  This is inefficient, but is
        * done in this way to: (1) Deal with concurrent modification of
        * the interrupt buffer from interrupt activity, (2) Avoid keeper
@@ -269,16 +283,23 @@ int syslog_flush_intbuffer(bool force)
        */
 
       ch = syslog_remove_intbuffer();
+      if (ch == EOF)
+        {
+          break;
+        }
 
       for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
         {
-          if ((g_syslog_channel[i] == NULL) || (ch == EOF))
+          FAR syslog_channel_t *channel = g_syslog_channel[i];
+          syslog_putc_t putfunc;
+
+          if (channel == NULL)
             {
               break;
             }
 
 #ifdef CONFIG_SYSLOG_IOCTL
-          if (g_syslog_channel[i]->sc_disable)
+          if (channel->sc_state & SYSLOG_CHANNEL_DISABLE)
             {
               continue;
             }
@@ -286,13 +307,24 @@ int syslog_flush_intbuffer(bool force)
 
           /* Select which putc function to use for this flush */
 
-          putfunc = force ? g_syslog_channel[i]->sc_ops->sc_force :
-                    g_syslog_channel[i]->sc_ops->sc_putc;
+          putfunc = force ? channel->sc_ops->sc_force :
+                    channel->sc_ops->sc_putc;
 
-          putfunc(g_syslog_channel[i], ch);
+#ifdef CONFIG_SYSLOG_CRLF
+          /* Check for LF */
+
+          if (ch == '\n' &&
+              !(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+            {
+              /* Add CR */
+
+              putfunc(channel, '\r');
+            }
+#endif
+
+          putfunc(channel, ch);
         }
     }
-  while (ch != EOF);
 
   leave_critical_section(flags);
 

--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -57,8 +57,7 @@
 
 static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 {
-  size_t nwritten = 0;
-  int i;
+  size_t nwritten;
 
   if (up_interrupt_context() || sched_idletask())
     {
@@ -73,9 +72,12 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
       else
 #endif
         {
+          int i;
+
           for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
             {
               FAR syslog_channel_t *channel = g_syslog_channel[i];
+              nwritten = 0;
 
               if (channel == NULL)
                 {
@@ -83,7 +85,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
                 }
 
 #ifdef CONFIG_SYSLOG_IOCTL
-              if (channel->sc_disable)
+              if (channel->sc_state & SYSLOG_CHANNEL_DISABLE)
                 {
                   continue;
                 }
@@ -91,14 +93,76 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 
               if (channel->sc_ops->sc_write_force != NULL)
                 {
-                  nwritten =
-                    channel->sc_ops->sc_write_force(channel, buffer, buflen);
+#ifdef CONFIG_SYSLOG_CRLF
+                  if (!(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+                    {
+                      size_t head;
+
+                      for (head = 0; head < buflen; head++)
+                        {
+                          ssize_t ret;
+
+                          /* Check for LF */
+
+                          if (buffer[head] != '\n')
+                            {
+                              continue;
+                            }
+
+                          ret = channel->sc_ops->sc_write_force(channel,
+                                                          buffer + nwritten,
+                                                          head - nwritten);
+                          if (ret < 0)
+                            {
+                              return ret;
+                            }
+
+                          ret = channel->sc_ops->sc_write_force(channel,
+                                                                "\r\n", 2);
+                          if (ret < 0)
+                            {
+                              return ret;
+                            }
+
+                          nwritten = head + 1;
+                        }
+                    }
+#endif
+
+                  if (nwritten < buflen)
+                    {
+                      ssize_t ret;
+
+                      ret = channel->sc_ops->sc_write_force(channel,
+                                                          buffer + nwritten,
+                                                          buflen - nwritten);
+                      if (ret < 0)
+                        {
+                          return ret;
+                        }
+                      else
+                        {
+                          nwritten += ret;
+                        }
+                    }
                 }
               else
                 {
                   DEBUGASSERT(channel->sc_ops->sc_force != NULL);
                   for (nwritten = 0; nwritten < buflen; nwritten++)
                     {
+#ifdef CONFIG_SYSLOG_CRLF
+                      /* Check for LF */
+
+                      if (buffer[nwritten] == '\n' &&
+                          !(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+                        {
+                          /* Add CR */
+
+                          channel->sc_ops->sc_force(channel, '\r');
+                        }
+#endif
+
                       channel->sc_ops->sc_force(channel, buffer[nwritten]);
                     }
                 }
@@ -107,9 +171,12 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
     }
   else
     {
+      int i;
+
       for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
         {
           FAR syslog_channel_t *channel = g_syslog_channel[i];
+          nwritten = 0;
 
           if (channel == NULL)
             {
@@ -117,7 +184,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
             }
 
 #ifdef CONFIG_SYSLOG_IOCTL
-          if (channel->sc_disable)
+          if (channel->sc_state & SYSLOG_CHANNEL_DISABLE)
             {
               continue;
             }
@@ -125,13 +192,77 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 
           if (channel->sc_ops->sc_write != NULL)
             {
-              nwritten = channel->sc_ops->sc_write(channel, buffer, buflen);
+#ifdef CONFIG_SYSLOG_CRLF
+              if (!(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+                {
+                  size_t head;
+
+                  for (head = 0; head < buflen; head++)
+                    {
+                      size_t ret;
+
+                      /* Check for LF */
+
+                      if (buffer[head] != '\n')
+                        {
+                          continue;
+                        }
+
+                      ret = channel->sc_ops->sc_write(channel,
+                                                      buffer + nwritten,
+                                                      head - nwritten);
+                      if (ret < 0)
+                        {
+                          return ret;
+                        }
+
+                      /* Add CR */
+
+                      ret = channel->sc_ops->sc_write(channel, "\r\n", 2);
+                      if (ret < 0)
+                        {
+                          return ret;
+                        }
+
+                      nwritten = head + 1;
+                    }
+                }
+#endif
+
+              if (nwritten < buflen)
+                {
+                  ssize_t ret;
+
+                  ret = channel->sc_ops->sc_write(channel,
+                                                  buffer + nwritten,
+                                                  buflen - nwritten);
+                  if (ret < 0)
+                    {
+                      return ret;
+                    }
+                  else
+                    {
+                      nwritten += ret;
+                    }
+                }
             }
           else
             {
               DEBUGASSERT(channel->sc_ops->sc_putc != NULL);
               for (nwritten = 0; nwritten < buflen; nwritten++)
                 {
+#ifdef CONFIG_SYSLOG_CRLF
+                  /* Check for LF */
+
+                  if (buffer[nwritten] == '\n' &&
+                      !(channel->sc_state & SYSLOG_CHANNEL_DISABLE_CRLF))
+                    {
+                      /* Add CR */
+
+                      channel->sc_ops->sc_putc(channel, '\r');
+                    }
+#endif
+
                   channel->sc_ops->sc_putc(channel, buffer[nwritten]);
                 }
             }

--- a/drivers/virtio/virtio-serial.c
+++ b/drivers/virtio/virtio-serial.c
@@ -672,13 +672,6 @@ int up_putc(int ch)
 {
   if (g_virtio_console != NULL)
     {
-      if (ch == '\n')
-        {
-          /* Add CR */
-
-          virtio_serial_send(g_virtio_console, '\r');
-        }
-
       virtio_serial_send(g_virtio_console, ch);
     }
 

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -88,7 +88,10 @@
 
 #define SYSLOGIOC_SETFILTER _SYSLOGIOC(0x0002)
 
-#define SYSLOG_CHANNEL_NAME_LEN 32
+#define SYSLOG_CHANNEL_NAME_LEN       32
+
+#define SYSLOG_CHANNEL_DISABLE        0x01
+#define SYSLOG_CHANNEL_DISABLE_CRLF   0x02
 
 /****************************************************************************
  * Public Types
@@ -144,10 +147,14 @@ struct syslog_channel_s
   /* Syslog channel name */
 
   char sc_name[SYSLOG_CHANNEL_NAME_LEN];
+#endif
+  /* Syslog channel state:
+   * bit0: the channel is disabled
+   * bit1: the channel disable CRLF conversion
+   */
 
-  /* Syslog channel enable status, true is disable */
-
-  bool sc_disable;
+#if defined(CONFIG_SYSLOG_IOCTL) || defined(CONFIG_SYSLOG_CRLF)
+  uint8_t sc_state;
 #endif
 };
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Move the CRLF transformation logic into the syslog framework for unified processing.

## Impact

log output

## Testing

selftest

