### PR TITLE
arm/cxd56: use chip specific vectors to allow smpcall update regs

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1119,6 +1119,13 @@ config ARCH_RAMFUNCS
 		so that FLASH can be reconfigured while the MCU executes out of
 		SRAM.
 
+config ARCH_HAVE_CUSTOM_VECTORS
+	bool
+	default n
+	---help---
+		If ARCH_HAVE_CUSTOM_VECTORS is defined, Chip should provide vectors
+		table as an optimization.
+
 config ARCH_HAVE_RAMVECTORS
 	bool
 	default n

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -221,6 +221,7 @@ config ARCH_CHIP_LC823450
 	select ARCH_HAVE_HEAPCHECK
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_I2CRESET
+	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		ON Semiconductor LC823450 architectures (ARM dual Cortex-M3)
 

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -348,6 +348,7 @@ config ARCH_CHIP_RP2040
 	select ARM_HAVE_WFE_SEV
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_BOARD_COMMON
+	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
 

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -653,6 +653,7 @@ config ARCH_CHIP_CXD56XX
 	select ARCH_HAVE_SDIO if MMCSD
 	select ARCH_HAVE_MATH_H
 	select ARCH_HAVE_I2CRESET
+	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		Sony CXD56XX (ARM Cortex-M4) architectures
 

--- a/arch/arm/src/armv6-m/Make.defs
+++ b/arch/arm/src/armv6-m/Make.defs
@@ -26,8 +26,12 @@ CMN_ASRCS += arm_exception.S arm_saveusercontext.S
 
 CMN_CSRCS += arm_cpuinfo.c arm_doirq.c arm_hardfault.c arm_initialstate.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_svcall.c
-CMN_CSRCS += arm_systemreset.c arm_tcbinfo.c arm_vectors.c
+CMN_CSRCS += arm_systemreset.c arm_tcbinfo.c
 CMN_CSRCS += arm_trigger_irq.c
+
+ifneq ($(CONFIG_ARCH_HAVE_CUSTOM_VECTORS),y)
+  CMN_CSRCS += arm_vectors.c
+endif
 
 ifneq ($(filter y,$(CONFIG_DEBUG_FEATURES)$(CONFIG_ARM_COREDUMP_REGION)),)
   CMN_CSRCS += arm_dumpnvic.c

--- a/arch/arm/src/armv7-m/Make.defs
+++ b/arch/arm/src/armv7-m/Make.defs
@@ -29,7 +29,11 @@ CMN_CSRCS += arm_hardfault.c arm_initialstate.c arm_itm.c
 CMN_CSRCS += arm_memfault.c arm_perf.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_tcbinfo.c
-CMN_CSRCS += arm_trigger_irq.c arm_usagefault.c arm_vectors.c arm_dbgmonitor.c
+CMN_CSRCS += arm_trigger_irq.c arm_usagefault.c arm_dbgmonitor.c
+
+ifneq ($(CONFIG_ARCH_HAVE_CUSTOM_VECTORS),y)
+  CMN_CSRCS += arm_vectors.c
+endif
 
 ifeq ($(CONFIG_ARMV7M_SYSTICK),y)
   CMN_CSRCS += arm_systick.c

--- a/arch/arm/src/armv8-m/Make.defs
+++ b/arch/arm/src/armv8-m/Make.defs
@@ -30,7 +30,11 @@ CMN_CSRCS += arm_memfault.c arm_perf.c arm_sau.c
 CMN_CSRCS += arm_schedulesigaction.c arm_securefault.c arm_secure_irq.c
 CMN_CSRCS += arm_sigdeliver.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_tcbinfo.c
-CMN_CSRCS += arm_trigger_irq.c arm_usagefault.c arm_vectors.c arm_dbgmonitor.c
+CMN_CSRCS += arm_trigger_irq.c arm_usagefault.c arm_dbgmonitor.c
+
+ifneq ($(CONFIG_ARCH_HAVE_CUSTOM_VECTORS),y)
+  CMN_CSRCS += arm_vectors.c
+endif
 
 ifeq ($(CONFIG_ARMV8M_SYSTICK),y)
   CMN_CSRCS += arm_systick.c

--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -37,7 +37,8 @@ set(SRCS
     cxd56_icc.c
     cxd56_powermgr.c
     cxd56_farapi.c
-    cxd56_sysctl.c)
+    cxd56_sysctl.c
+    cxd56_vectors.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS cxd56_cpuidlestack.c)

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -37,6 +37,7 @@ CHIP_CSRCS += cxd56_icc.c
 CHIP_CSRCS += cxd56_powermgr.c
 CHIP_CSRCS += cxd56_farapi.c
 CHIP_CSRCS += cxd56_sysctl.c
+CHIP_CSRCS += cxd56_vectors.c
 
 ifeq ($(CONFIG_SMP), y)
 CHIP_CSRCS += cxd56_cpuidlestack.c

--- a/arch/arm/src/cxd56xx/cxd56_vectors.c
+++ b/arch/arm/src/cxd56xx/cxd56_vectors.c
@@ -1,0 +1,107 @@
+/****************************************************************************
+ * arch/arm/src/cxd56xx/cxd56_vectors.c
+ *
+ *   Copyright (C) 2012 Michael Smith. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "ram_vectors.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/* Chip-specific entrypoint */
+
+extern void __start(void);
+
+static void start(void)
+{
+  /* Zero lr to mark the end of backtrace */
+
+  asm volatile ("mov lr, #0\n\t"
+                "b  __start\n\t");
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Common exception entrypoint */
+
+extern void exception_common(void);
+extern void exception_direct(void);
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+
+/****************************************************************************
+ * Public data
+ ****************************************************************************/
+
+/* The cx56 use CXD56_IRQ_SMP_CALL to do SMP call.
+ * When sig dispatch do up_schedule_sigaction, need to make a new frame to
+ * run arm_sigdeliver. But the exception_direct cannot handle xcp.regs as we
+ * did not update the regs when c-function expection handler is called.
+ *
+ * We need to use exception_common to handle SMP call.
+ */
+
+const void * const _vectors[] locate_data(".vectors")
+  aligned_data(VECTAB_ALIGN) =
+{
+  /* Initial stack */
+
+  IDLE_STACK,
+
+  /* Reset exception handler */
+
+  start,
+
+  /* Vectors 2 - n point directly at the generic handler */
+
+  [2 ... NVIC_IRQ_PENDSV] = &exception_common,
+  [NVIC_IRQ_SYSTICK ... (CXD56_IRQ_SMP_CALL - 1)]
+                          = &exception_direct,
+  [CXD56_IRQ_SMP_CALL]    = &exception_common,
+  [(CXD56_IRQ_SMP_CALL + 1) ... (15 + ARMV7M_PERIPHERAL_INTERRUPTS)]
+                          = &exception_direct
+};

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -22,7 +22,7 @@ include armv7-m/Make.defs
 
 CHIP_CSRCS  = lc823450_allocateheap2.c lc823450_start.c lc823450_irq.c lc823450_timer.c
 CHIP_CSRCS += lc823450_lowputc.c lc823450_serial.c lc823450_clockconfig.c
-CHIP_CSRCS += lc823450_syscontrol.c lc823450_gpio.c
+CHIP_CSRCS += lc823450_syscontrol.c lc823450_gpio.c lc823450_vectors.c
 
 # Configuration-dependent LC823450 files
 

--- a/arch/arm/src/lc823450/lc823450_vectors.c
+++ b/arch/arm/src/lc823450/lc823450_vectors.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * arch/arm/src/lc823450/lc823450_vectors.c
+ *
+ *   Copyright (C) 2012 Michael Smith. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "ram_vectors.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/* Chip-specific entrypoint */
+
+extern void __start(void);
+
+static void start(void)
+{
+  /* Zero lr to mark the end of backtrace */
+
+  asm volatile ("mov lr, #0\n\t"
+                "b  __start\n\t");
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Common exception entrypoint */
+
+extern void exception_common(void);
+extern void exception_direct(void);
+
+/****************************************************************************
+ * Public data
+ ****************************************************************************/
+
+/* The v7m vector table consists of an array of function pointers, with the
+ * first slot (vector zero) used to hold the initial stack pointer.
+ *
+ * As all exceptions (interrupts) are routed via exception_common, we just
+ * need to fill this array with pointers to it.
+ *
+ * Note that the [ ... ] designated initializer is a GCC extension.
+ */
+
+const void * const _vectors[] locate_data(".vectors")
+                              aligned_data(VECTAB_ALIGN) =
+{
+  /* Initial stack */
+
+  IDLE_STACK,
+
+  /* Reset exception handler */
+
+  start,
+
+  /* Vectors 2 - n point directly at the generic handler */
+
+  [2 ... NVIC_IRQ_PENDSV]    = &exception_common,
+  [(NVIC_IRQ_PENDSV + 1) ... (LC823450_IRQ_SMP_CALL_01 - 1)]
+                             = &exception_direct,
+  [LC823450_IRQ_SMP_CALL_01] = &exception_common,
+  [(LC823450_IRQ_SMP_CALL_01 + 1) ... (LC823450_IRQ_SMP_CALL_11 - 1)]
+                             = &exception_direct,
+  [LC823450_IRQ_SMP_CALL_11] = &exception_common,
+  [(LC823450_IRQ_SMP_CALL_11 + 1) ... (15 + ARMV7M_PERIPHERAL_INTERRUPTS)]
+                             = &exception_direct
+};

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -33,6 +33,7 @@ CHIP_CSRCS += rp2040_pio.c
 CHIP_CSRCS += rp2040_clock.c
 CHIP_CSRCS += rp2040_xosc.c
 CHIP_CSRCS += rp2040_pll.c
+CHIP_CSRCS += rp2040_vectors.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += rp2040_cpustart.c

--- a/arch/arm/src/rp2040/rp2040_vectors.c
+++ b/arch/arm/src/rp2040/rp2040_vectors.c
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/rp2040_vectors.c
+ *
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Cloned from the ARMv7-M version:
+ *
+ *   Copyright (C) 2012 Michael Smith. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "ram_vectors.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+
+#ifndef ARMV6M_PERIPHERAL_INTERRUPTS
+#  error ARMV6M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/* Chip-specific entrypoint */
+
+extern void __start(void);
+
+static void start(void)
+{
+  /* Zero lr to mark the end of backtrace */
+
+  asm volatile ("mov lr, %0\n\t"
+                "bx      %1\n\t"
+                :
+                : "r"(0), "r"(__start));
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Common exception entrypoint */
+
+extern void exception_common(void);
+extern void exception_direct(void);
+
+/****************************************************************************
+ * Public data
+ ****************************************************************************/
+
+/* The v6m vector table consists of an array of function pointers, with the
+ * first slot (vector zero) used to hold the initial stack pointer.
+ *
+ * As all exceptions (interrupts) are routed via exception_common, we just
+ * need to fill this array with pointers to it.
+ *
+ * Note that the [ ... ] designated initializer is a GCC extension.
+ */
+
+const void * const _vectors[] locate_data(".vectors")
+                              aligned_data(VECTAB_ALIGN) =
+{
+  /* Initial stack */
+
+  IDLE_STACK,
+
+  /* Reset exception handler */
+
+  start,
+
+  /* Vectors 2 - n point directly at the generic handler */
+
+  [2 ... NVIC_IRQ_PENDSV] = &exception_common,
+  [(NVIC_IRQ_PENDSV + 1) ... (RP2040_SMP_CALL_PROC0 - 1)]
+                          = &exception_direct,
+  [RP2040_SMP_CALL_PROC0 ... RP2040_SMP_CALL_PROC1]
+                          = &exception_common,
+  [(RP2040_SMP_CALL_PROC1 + 1) ... (15 + ARMV6M_PERIPHERAL_INTERRUPTS)]
+                          = &exception_direct,
+};

--- a/arch/arm/src/sam34/Kconfig
+++ b/arch/arm/src/sam34/Kconfig
@@ -247,6 +247,7 @@ config ARCH_CHIP_SAM4CM
 	default n
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_TICKLESS
+	select ARCH_HAVE_CUSTOM_VECTORS
 
 config ARCH_CHIP_SAM4L
 	bool

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -29,6 +29,10 @@ include armv7-m/Make.defs
 CHIP_CSRCS  = sam_allocateheap.c sam_irq.c sam_lowputc.c sam_serial.c
 CHIP_CSRCS += sam_start.c
 
+ifeq ($(CONFIG_ARCH_HAVE_CUSTOM_VECTORS),y)
+CHIP_CSRCS += sam_vectors.c
+endif
+
 # Configuration-dependent SAM3/4 files
 
 ifneq ($(CONFIG_SCHED_TICKLESS),y)

--- a/arch/arm/src/sam34/sam_vectors.c
+++ b/arch/arm/src/sam34/sam_vectors.c
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * arch/arm/src/sam34/sam_vectors.c
+ *
+ *   Copyright (C) 2012 Michael Smith. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "ram_vectors.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/* Chip-specific entrypoint */
+
+extern void __start(void);
+
+static void start(void)
+{
+  /* Zero lr to mark the end of backtrace */
+
+  asm volatile ("mov lr, #0\n\t"
+                "b  __start\n\t");
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Common exception entrypoint */
+
+extern void exception_common(void);
+extern void exception_direct(void);
+
+/****************************************************************************
+ * Public data
+ ****************************************************************************/
+
+/* The v7m vector table consists of an array of function pointers, with the
+ * first slot (vector zero) used to hold the initial stack pointer.
+ *
+ * As all exceptions (interrupts) are routed via exception_common, we just
+ * need to fill this array with pointers to it.
+ *
+ * Note that the [ ... ] designated initializer is a GCC extension.
+ */
+
+const void * const _vectors[] locate_data(".vectors")
+                              aligned_data(VECTAB_ALIGN) =
+{
+  /* Initial stack */
+
+  IDLE_STACK,
+
+  /* Reset exception handler */
+
+  start,
+
+  /* Vectors 2 - n point directly at the generic handler */
+
+  [2 ... NVIC_IRQ_PENDSV] = &exception_common,
+  [(NVIC_IRQ_PENDSV + 1) ... (SAM_IRQ_SMP_CALL0 - 1)]
+                          = &exception_direct,
+  [SAM_IRQ_SMP_CALL0]     = &exception_common,
+  [(SAM_IRQ_SMP_CALL0 + 1) ... (SAM_IRQ_SMP_CALL1 - 1)]
+                          = &exception_direct,
+  [SAM_IRQ_SMP_CALL1]     = &exception_common,
+  [(SAM_IRQ_SMP_CALL1 + 1) ... (15 + ARMV7M_PERIPHERAL_INTERRUPTS)]
+                          = &exception_direct
+};


### PR DESCRIPTION
## Summary
When sig dispatch do up_schedule_sigaction, need to make a new frame to run arm_sigdeliver. But the exception_direct cannot handle xcp.regs as we are using c-function exception handler.
Need to use exception_common to handle SMP call.

issue from https://github.com/apache/nuttx/pull/13606#issuecomment-2406601519
@masayuki2009 please review the update, and see it at your environments also work as expected.

use chip specific vector cxd56_vectors to make CXD56_IRQ_SMP_CALL not use c-call version exception handler.

## Impact
can pass the self-test in Spresense CPU=3 case.
for self-test, the _vector still in .map, maybe we should add option to make unique between cxd56_vectors and _vectors.

## Testing
CI-test.
```bash
./tools/configure.sh -l spresense/smp 
kconfig-tweak --set-val CONFIG_SMP_NCPUS 3
make -j
./tools/flash_writer.py -s -c /dev/ttyUSB0 -d -b 115200 -n nuttx.spk
minicom -D /dev/ttyUSB0 -b 115200 -C log/ttysprense-$(date +"%Y-%m-%d-%H-%M-%S").log
ostest
```
