### PR TITLE
libc: Make getcwd() work even CONFIG_DISABLE_ENVIRON is enabled

### DIFF
--- a/libs/libc/stdlib/Kconfig
+++ b/libs/libc/stdlib/Kconfig
@@ -17,7 +17,6 @@ config LIBC_RAND_ORDER
 config LIBC_HOMEDIR
 	string "Home directory"
 	default "/"
-	depends on !DISABLE_ENVIRON
 	---help---
 		The home directory to use with operations like such as 'cd ~'
 

--- a/libs/libc/unistd/CMakeLists.txt
+++ b/libs/libc/unistd/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
     lib_swab.c
     lib_pathconf.c
     lib_sysconf.c
+    lib_getcwd.c
     lib_getentropy.c
     lib_getopt_common.c
     lib_getopt.c
@@ -82,7 +83,7 @@ if(NOT CONFIG_SCHED_USER_IDENTITY)
 endif()
 
 if(NOT CONFIG_DISABLE_ENVIRON)
-  list(APPEND SRCS lib_chdir.c lib_fchdir.c lib_getcwd.c lib_restoredir.c)
+  list(APPEND SRCS lib_chdir.c lib_fchdir.c lib_restoredir.c)
 endif()
 
 if(CONFIG_LIBC_EXECFUNCS)

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -23,8 +23,8 @@
 # Add the unistd C files to the build
 
 CSRCS += lib_access.c lib_daemon.c lib_swab.c lib_pathconf.c lib_sysconf.c
-CSRCS += lib_getentropy.c lib_getopt_common.c lib_getopt.c lib_getopt_long.c
-CSRCS += lib_getopt_longonly.c lib_getoptvars.c lib_getoptargp.c
+CSRCS += lib_getcwd.c lib_getentropy.c lib_getopt_common.c lib_getopt.c
+CSRCS += lib_getopt_long.c lib_getopt_longonly.c lib_getoptvars.c lib_getoptargp.c
 CSRCS += lib_getopterrp.c lib_getoptindp.c lib_getoptoptp.c lib_times.c
 CSRCS += lib_alarm.c lib_fstatvfs.c lib_statvfs.c lib_sleep.c lib_nice.c
 CSRCS += lib_setreuid.c lib_setregid.c lib_getrusage.c lib_utime.c lib_utimes.c
@@ -40,7 +40,7 @@ CSRCS += lib_seteuid.c lib_setegid.c lib_geteuid.c lib_getegid.c
 endif
 
 ifneq ($(CONFIG_DISABLE_ENVIRON),y)
-CSRCS += lib_chdir.c lib_fchdir.c lib_getcwd.c lib_restoredir.c
+CSRCS += lib_chdir.c lib_fchdir.c lib_restoredir.c
 endif
 
 ifeq ($(CONFIG_LIBC_EXECFUNCS),y)

--- a/libs/libc/unistd/lib_getcwd.c
+++ b/libs/libc/unistd/lib_getcwd.c
@@ -34,8 +34,6 @@
 
 #include "libc.h"
 
-#ifndef CONFIG_DISABLE_ENVIRON
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -95,10 +93,13 @@ FAR char *getcwd(FAR char *buf, size_t size)
       size = PATH_MAX + 1;
     }
 
+#ifndef CONFIG_DISABLE_ENVIRON
+
   /* If no working directory is defined, then default to the home directory */
 
   pwd = getenv("PWD");
   if (pwd == NULL)
+#endif /* !CONFIG_DISABLE_ENVIRON */
     {
       pwd = CONFIG_LIBC_HOMEDIR;
     }
@@ -126,4 +127,3 @@ FAR char *getcwd(FAR char *buf, size_t size)
   strlcpy(buf, pwd, size);
   return buf;
 }
-#endif /* !CONFIG_DISABLE_ENVIRON */


### PR DESCRIPTION
## Summary

since getcwd() can be implemented correctly without using environ

## Impact

extend getcwd usage

## Testing

ci

