### PR TITLE
riscv/cpustart: Ensure we receive Soft IRQ / IPI before booting CPU

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -77,7 +77,11 @@ void riscv_cpu_boot(int cpu)
 
   /* Wait interrupt */
 
-  asm("WFI");
+  do
+    {
+      asm("WFI");
+    }
+  while (READ_CSR(CSR_IP) != IP_SIP);
 
 #ifdef CONFIG_RISCV_PERCPU_SCRATCH
   /* Initialize the per CPU areas */


### PR DESCRIPTION
## Summary

Some spurious interrupt might wake WFI, ensure we got woken by IPI before continuing CPU boot.

## Impact

RISC-V SMP only, there should be no change to functionality

## Testing

rv-virt:ksmp64

