### PR TITLE
riscv_macros.S: Allow using riscv_set_inital_sp for hart > 0

### DIFF
--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -393,7 +393,9 @@
 .macro riscv_set_inital_sp base, size, hartid
   la      t0, \base
   li      t1, \size
+#ifdef CONFIG_SMP
   mul     t1, \hartid, t1
+#endif
   add     t0, t0, t1
 
   /* ensure the last XCPTCONTEXT_SIZE is reserved for non boot CPU */


### PR DESCRIPTION
## Summary

In non-SMP mode there is only a single idlestack, so use that in all cases instead of offsetting by hart ID.

## Impact

RISC-V only. Allows booting with hart id != 0

## Testing

MPFS
rv-virt:ksmp64