### PR TITLE
`mempool` backtrace fix and de-init fix

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -197,20 +197,13 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
   if ((MM_DUMP_ASSIGN(dump, buf) || MM_DUMP_ALLOC(dump, buf) ||
        MM_DUMP_LEAK(dump, buf)) && MM_DUMP_SEQNO(dump, buf))
     {
+#  if CONFIG_MM_BACKTRACE > 0
       char tmp[BACKTRACE_BUFFER_SIZE(CONFIG_MM_BACKTRACE)];
 
-#  if CONFIG_MM_BACKTRACE > 0
-      FAR const char *format = " %0*p";
-      int i;
-
-      for (i = 0; i < CONFIG_MM_BACKTRACE &&
-                      buf->backtrace[i]; i++)
-        {
-          snprintf(tmp + i * BACKTRACE_PTR_FMT_WIDTH,
-                   sizeof(tmp) - i * BACKTRACE_PTR_FMT_WIDTH,
-                   format, BACKTRACE_PTR_FMT_WIDTH - 1,
-                   buf->backtrace[i]);
-        }
+      backtrace_format(tmp, sizeof(tmp), buf->backtrace,
+                       CONFIG_MM_BACKTRACE);
+#  else
+      FAR const char *tmp = "";
 #  endif
 
       syslog(LOG_INFO, "%6d%12zu%12lu%*p%s\n",

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -312,6 +312,8 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
   mempool_procfs_register(&pool->procfs, name);
 #  ifdef CONFIG_MM_BACKTRACE_DEFAULT
   pool->procfs.backtrace = true;
+#  elif CONFIG_MM_BACKTRACE > 0
+  pool->procfs.backtrace = false;
 #  endif
 #endif
 

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -303,7 +303,7 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
   size_t row;
   size_t col;
 
-  if (mpool == NULL || blk == NULL)
+  if (mpool == NULL || blk == NULL || mpool->dict == NULL)
     {
       return NULL;
     }
@@ -888,6 +888,7 @@ void mempool_multiple_deinit(FAR struct mempool_multiple_s *mpool)
     }
 
   mempool_multiple_free_chunk(mpool, mpool->dict);
+  mpool->dict = NULL;
   nxrmutex_destroy(&mpool->lock);
   mpool->free(mpool->arg, mpool);
 }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fix memory pool backtrace minor issues.
1. Should use `backtrace_format` to format backtrace now.
2. Default to turn of recording backtrace if `CONFIG_MM_BACKTRACE_DEFAULT ` is disabled. 

Fix memory pool de-init. 
Mark dict pointer as NULL after free, in case misuse of it.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

Minor fixes, should have no impact.

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

CI build test pass.


