### PR TITLE
ci: documentation workflow optimizations.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -12,9 +12,17 @@
 #
 ---
 name: "Build Documentation"
+
 on:
-  pull_request:
   push:
+    branches:
+      - master
+    paths:
+      - 'Documentation/**'
+
+  pull_request:
+    paths:
+      - 'Documentation/**'
 
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
@@ -31,19 +39,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-      - name: Install LaTeX packages
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y \
-            texlive-latex-recommended texlive-fonts-recommended \
-            texlive-latex-base texlive-latex-extra latexmk texlive-luatex \
-            fonts-freefont-otf xindy
       - name: Generate Documentation
         run: |
           cd Documentation/
           pip3 install pipenv
           pipenv install
-          pipenv run make html latexpdf
+          pipenv run make html
       - uses: actions/upload-artifact@v4
         with:
           name: sphinx-docs


### PR DESCRIPTION
## Summary

This change to the Documentation workflow adds the `paths` filter so that the GitHub workflow is only run whenever a path matching `Documentation/**` is modified. It also removes the PDF building step, which is not necessary since Documentation is built on the NuttX website.

Note from @cederom: We got final warning from Apache on exceeding CI usage and need find savings! This subject is discussed on dev@ mailing list.

## Impact

This will reduce the number of unnecessary Documentation workflow runs being performed for PRs that do not modify the documentation and thus do not require a rebuild. It also removes unnecessary building of PDF documents, which speeds up the workflow.

Since building the Documentation takes about 13 minutes on average, this should considerably reduce the amount of time the NuttX repository is using in GitHub workflows, bringing us closer to being within the [limit the Apache Foundation has set for workflow usage](https://infra.apache.org/github-actions-policy.html).

## Testing

Since this change only modifies the GitHub workflow, testing is performed by verifying that this PR (containing the updated workflow) will not trigger the Documentation workflow since nothing under the `Documentation/` sub-directory was modified.