### PR TITLE
riscv_cpustart.c: Fix reading of interrupt status

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -81,7 +81,7 @@ void riscv_cpu_boot(int cpu)
     {
       asm("WFI");
     }
-  while (READ_CSR(CSR_IP) != IP_SIP);
+  while (!(READ_CSR(CSR_IP) & IP_SIP));
 
 #ifdef CONFIG_RISCV_PERCPU_SCRATCH
   /* Initialize the per CPU areas */


### PR DESCRIPTION
## Summary

Let's read the interrupt status correctly, by checking for the interrupt source bit instead of assuming no other status bit is set.

## Impact

RISC-V only. Fixes silly error made by https://github.com/apache/nuttx/pull/14366

## Testing

rv-virt:ksmp64
rv-virt:smp

qemu-system-riscv32 -semihosting -nographic -cpu rv32 -smp 8 -M virt,aclint=on -bios none -kernel nuttx

NuttShell (NSH) NuttX-10.4.0
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0   0   0 FIFO     Kthread   - Assigned           0000000000000000 0002032 0000684  33.6%  CPU0 IDLE
    1     0   1   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU1 IDLE
    2     0   2   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU2 IDLE
    3     0   3   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU3 IDLE
    4     0   4   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU4 IDLE
    5     0   5   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000564  27.7%  CPU5 IDLE
    6     0   6   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU6 IDLE
    7     0   7   0 FIFO     Kthread   - Running            0000000000000000 0002032 0000500  24.6%  CPU7 IDLE
    8     8   0 100 RR       Task      - Running            0000000000000000 0002000 0001628  81.4%! nsh_main
nsh> 

NuttShell (NSH) NuttX-10.4.0
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0   0   0 FIFO     Kthread   - Assigned           0000000000000000 0003056 0001848  60.4%  CPU0 IDLE
    1     0   1   0 FIFO     Kthread   - Running            0000000000000000 0003056 0001208  39.5%  CPU1 IDLE
    2     0   2   0 FIFO     Kthread   - Running            0000000000000000 0003056 0000680  22.2%  CPU2 IDLE
    3     0   3   0 FIFO     Kthread   - Running            0000000000000000 0003056 0000680  22.2%  CPU3 IDLE
    4     0 --- 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001968 0000720  36.5%  lpwork 0x80400100 0x80400148
    5     5   0 100 RR       Task      - Running            0000000000000000 0003008 0001752  58.2%  /system/bin/init
nsh> 
