### PR TITLE
modlib/modlib_symbols.c: Fix usage of void* arithmetics

### DIFF
--- a/libs/libc/modlib/modlib_symbols.c
+++ b/libs/libc/modlib/modlib_symbols.c
@@ -429,7 +429,7 @@ int modlib_symvalue(FAR struct module_s *modp,
               "%08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
               loadinfo->iobuffer,
               (uintptr_t)sym->st_value, (uintptr_t)symbol->sym_value,
-              (uintptr_t)(sym->st_value + symbol->sym_value));
+              (uintptr_t)(sym->st_value + (uintptr_t)symbol->sym_value));
 
         sym->st_value += ((uintptr_t)symbol->sym_value);
       }


### PR DESCRIPTION
## Summary

In file included from modlib/modlib_symbols.c:34:
modlib/modlib_symbols.c: In function 'modlib_symvalue': modlib/modlib_symbols.c:432:41: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  432 |               (uintptr_t)(sym->st_value + symbol->sym_value));
      |                                         ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:156: bin/modlib_symbols.o] Error 1

## Impact

Fixes build error in modlib. No other modules affected.

## Testing

Build pass.

