### PR TITLE
riscv_cpuindex.c: Fix usage of CONFIG_ARCH_RV_HARTID_BASE

### DIFF
--- a/arch/risc-v/src/common/riscv_cpuindex.c
+++ b/arch/risc-v/src/common/riscv_cpuindex.c
@@ -73,7 +73,7 @@ int up_this_cpu(void)
 
 int weak_function riscv_hartid_to_cpuid(int cpu)
 {
-  return cpu + CONFIG_ARCH_RV_HARTID_BASE;
+  return cpu - CONFIG_ARCH_RV_HARTID_BASE;
 }
 
 /****************************************************************************
@@ -87,5 +87,5 @@ int weak_function riscv_hartid_to_cpuid(int cpu)
 
 int weak_function riscv_cpuid_to_hartid(int cpu)
 {
-  return cpu - CONFIG_ARCH_RV_HARTID_BASE;
+  return cpu + CONFIG_ARCH_RV_HARTID_BASE;
 }


### PR DESCRIPTION

## Summary

The offset was supposed to assume hartid > cpuid, so when converting from hartid we must subtract the offset to get the cpuid and vice versa.

## Impact

Only RISC-V with SMP and CONFIG_ARCH_RV_HARTID_BASE != 0

## Testing

rv-virt:ksmp64
MPFS (unpublished SMP target)
