### PR TITLE
libc: Fix typo in libc/string/Kconfig.

### DIFF
--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -40,7 +40,7 @@ config LIBC_STRING_OPTIMIZE
 	bool "optimized string function"
 	depends on ALLOW_BSD_COMPONENTS
 	default y
-	--help--
+	---help---
 		Use optimized string function implementation based on newlib.
 
 config LIBC_PERROR_STDOUT


### PR DESCRIPTION
## Summary

* Changes in https://github.com/apache/nuttx/pull/13180 contained a typo `libs/libc/string/Kconfig` that broke initial `./tools/configure.sh`.
* Here goes the typo fix.
* Thank you @lupyuen for the hint! :-)

## Impact

* Initial Configure / Build.

## Testing

* FreeBSD 13.3 AMD64.
* Before fix:
```
% ./tools/configure.sh -B nucleo-l432kc:nsh
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
CP: arch/dummy/Kconfig to /XXX/nuttx.git/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /XXX/nuttx.git/boards/dummy/dummy_kconfig
LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /XXX/nuttx.git/boards/arm/stm32l4/nucleo-l432kc/include
LN: drivers/platform to /XXX/nuttx.git/drivers/dummy
LN: include/arch/chip to /XXX/nuttx.git/arch/arm/include/stm32l4
LN: arch/arm/src/chip to /XXX/nuttx.git/arch/arm/src/stm32l4
LN: arch/arm/src/board to /XXX/nuttx.git/boards/arm/stm32l4/nucleo-l432kc/src
mkkconfig in /XXX/nuttx-apps.git/audioutils
mkkconfig in /XXX/nuttx-apps.git/benchmarks
mkkconfig in /XXX/nuttx-apps.git/boot
mkkconfig in /XXX/nuttx-apps.git/canutils
mkkconfig in /XXX/nuttx-apps.git/crypto
mkkconfig in /XXX/nuttx-apps.git/database
mkkconfig in /XXX/nuttx-apps.git/examples/mcuboot
mkkconfig in /XXX/nuttx-apps.git/examples/module
mkkconfig in /XXX/nuttx-apps.git/examples/sotest
mkkconfig in /XXX/nuttx-apps.git/examples
mkkconfig in /XXX/nuttx-apps.git/fsutils
mkkconfig in /XXX/nuttx-apps.git/games
mkkconfig in /XXX/nuttx-apps.git/graphics
mkkconfig in /XXX/nuttx-apps.git/industry
mkkconfig in /XXX/nuttx-apps.git/inertial
mkkconfig in /XXX/nuttx-apps.git/interpreters/luamodules
mkkconfig in /XXX/nuttx-apps.git/interpreters
mkkconfig in /XXX/nuttx-apps.git/logging
mkkconfig in /XXX/nuttx-apps.git/lte
mkkconfig in /XXX/nuttx-apps.git/math
mkkconfig in /XXX/nuttx-apps.git/mlearning
mkkconfig in /XXX/nuttx-apps.git/netutils
mkkconfig in /XXX/nuttx-apps.git/sdr
mkkconfig in /XXX/nuttx-apps.git/system
mkkconfig in /XXX/nuttx-apps.git/testing
mkkconfig in /XXX/nuttx-apps.git/videoutils
mkkconfig in /XXX/nuttx-apps.git/wireless/bluetooth
mkkconfig in /XXX/nuttx-apps.git/wireless/ieee802154
mkkconfig in /XXX/nuttx-apps.git/wireless
mkkconfig in /XXX/nuttx-apps.git
libs/libc/string/Kconfig:44: syntax error
libs/libc/string/Kconfig:43: unknown option "--help--"
libs/libc/string/Kconfig:44: unknown option "Use"
gmake: *** [tools/Unix.mk:696: olddefconfig] Error 1
ERROR: failed to refresh
```

* After fix:
```
% ./tools/configure.sh -B nucleo-l432kc:nsh
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
CP: arch/dummy/Kconfig to /XXX/nuttx.git/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /XXX/nuttx.git/boards/dummy/dummy_kconfig
LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /XXX/nuttx.git/boards/arm/stm32l4/nucleo-l432kc/include
LN: drivers/platform to /XXX/nuttx.git/drivers/dummy
LN: include/arch/chip to /XXX/nuttx.git/arch/arm/include/stm32l4
LN: arch/arm/src/chip to /XXX/nuttx.git/arch/arm/src/stm32l4
LN: arch/arm/src/board to /XXX/nuttx.git/boards/arm/stm32l4/nucleo-l432kc/src
mkkconfig in /XXX/nuttx-apps.git/audioutils
mkkconfig in /XXX/nuttx-apps.git/benchmarks
mkkconfig in /XXX/nuttx-apps.git/boot
mkkconfig in /XXX/nuttx-apps.git/canutils
mkkconfig in /XXX/nuttx-apps.git/crypto
mkkconfig in /XXX/nuttx-apps.git/database
mkkconfig in /XXX/nuttx-apps.git/examples/mcuboot
mkkconfig in /XXX/nuttx-apps.git/examples/module
mkkconfig in /XXX/nuttx-apps.git/examples/sotest
mkkconfig in /XXX/nuttx-apps.git/examples
mkkconfig in /XXX/nuttx-apps.git/fsutils
mkkconfig in /XXX/nuttx-apps.git/games
mkkconfig in /XXX/nuttx-apps.git/graphics
mkkconfig in /XXX/nuttx-apps.git/industry
mkkconfig in /XXX/nuttx-apps.git/inertial
mkkconfig in /XXX/nuttx-apps.git/interpreters/luamodules
mkkconfig in /XXX/nuttx-apps.git/interpreters
mkkconfig in /XXX/nuttx-apps.git/logging
mkkconfig in /XXX/nuttx-apps.git/lte
mkkconfig in /XXX/nuttx-apps.git/math
mkkconfig in /XXX/nuttx-apps.git/mlearning
mkkconfig in /XXX/nuttx-apps.git/netutils
mkkconfig in /XXX/nuttx-apps.git/sdr
mkkconfig in /XXX/nuttx-apps.git/system
mkkconfig in /XXX/nuttx-apps.git/testing
mkkconfig in /XXX/nuttx-apps.git/videoutils
mkkconfig in /XXX/nuttx-apps.git/wireless/bluetooth
mkkconfig in /XXX/nuttx-apps.git/wireless/ieee802154
mkkconfig in /XXX/nuttx-apps.git/wireless
mkkconfig in /XXX/nuttx-apps.git
#
# configuration written to .config
#
```
