### PR TITLE
Kconfig:fix typo

### DIFF
--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -40,7 +40,7 @@ config LIBC_STRING_OPTIMIZE
 	bool "optimized string function"
 	depends on ALLOW_BSD_COMPONENTS
 	default y
-	--help--
+	---help---
 		Use optimized string function implementation based on newlib.
 
 config LIBC_PERROR_STDOUT


### PR DESCRIPTION
## Summary

libs/libc/string/Kconfig:44: syntax error
libs/libc/string/Kconfig:43: unknown option "--help--"
libs/libc/string/Kconfig:44: unknown option "Use"
make: *** [olddefconfig] Error 1

## Impact

nothing
## Testing

macos make config
