### PR TITLE
Fix Kconfig

### DIFF
--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -40,7 +40,7 @@ config LIBC_STRING_OPTIMIZE
 	bool "optimized string function"
 	depends on ALLOW_BSD_COMPONENTS
 	default y
-	--help--
+	---help---
 		Use optimized string function implementation based on newlib.
 
 config LIBC_PERROR_STDOUT


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Minor typo in KConfig that result in 

```
libs/libc/string/Kconfig:44: syntax error
libs/libc/string/Kconfig:43: unknown option "--help--"
libs/libc/string/Kconfig:44: unknown option "Use"
```

## Impact

None

## Testing

None


