### PR TITLE
tools/esp32s3/Config.mk: fix "unterminated call to function" error

### DIFF
--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -114,7 +114,7 @@ endif
 ESPTOOL_BINS += $(FLASH_APP)
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-	ESPTOOL_BINS += $(shell printf "%#x\n" $$(( $(CONFIG_ESP32S3_KERNEL_OFFSET) + $(CONFIG_ESP32S3_KERNEL_IMAGE_SIZE) ))) nuttx_user.bin
+	ESPTOOL_BINS += $(shell printf "%\#x\n" $$(( $(CONFIG_ESP32S3_KERNEL_OFFSET) + $(CONFIG_ESP32S3_KERNEL_IMAGE_SIZE) ))) nuttx_user.bin
 endif
 
 # MERGEBIN -- Merge raw binary files into a single file


### PR DESCRIPTION
## Summary

this # would be parsed by make as a start of a comment.

## Impact

## Testing

bulild tested on macOS (ignoring https://github.com/apache/nuttx/issues/14390)

gmake version:
```
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0
```
