### PR TITLE
ricv/riscv_cpuid: Return meaningful values for CPU/Hart ID when SMP=no

### DIFF
--- a/arch/risc-v/src/common/riscv_cpuindex.c
+++ b/arch/risc-v/src/common/riscv_cpuindex.c
@@ -71,9 +71,13 @@ int up_this_cpu(void)
  *
  ****************************************************************************/
 
-int weak_function riscv_hartid_to_cpuid(int cpu)
+int weak_function riscv_hartid_to_cpuid(int hart)
 {
-  return cpu - CONFIG_ARCH_RV_HARTID_BASE;
+#ifdef CONFIG_SMP
+  return hart - CONFIG_ARCH_RV_HARTID_BASE;
+#else
+  return 0;
+#endif
 }
 
 /****************************************************************************
@@ -87,5 +91,9 @@ int weak_function riscv_hartid_to_cpuid(int cpu)
 
 int weak_function riscv_cpuid_to_hartid(int cpu)
 {
+#ifdef CONFIG_SMP
   return cpu + CONFIG_ARCH_RV_HARTID_BASE;
+#else
+  return (int)riscv_mhartid();
+#endif
 }

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -436,7 +436,7 @@ uintptr_t riscv_mhartid(void);
  *
  ****************************************************************************/
 
-int riscv_hartid_to_cpuid(int cpu);
+int riscv_hartid_to_cpuid(int hart);
 
 /****************************************************************************
  * Name: riscv_cpuid_to_hartid


### PR DESCRIPTION
## Summary

Return 0 for CPU ID for any hart ID, and return the current Hart ID for any CPU ID. At least these values are somewhat usable / meaningful in non-SMP configurations.

## Impact

RISC-V and non-SMP only.

## Testing

MPFS SMP and non-SMP targets
