### PR TITLE
tools/checkpatch: fix isort doesn't return error

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -83,9 +83,15 @@ check_file() {
   fi
 
   if [ ${@##*.} == 'py' ]; then
-    black --check $@ || fail=1
-    flake8 --config ${TOOLDIR}/../.github/linters/setup.cfg $@ || fail=1
-    isort --settings-path ${TOOLDIR}/../.github/linters/setup.cfg $@ || fail=1
+    setupcfg="${TOOLDIR}/../.github/linters/setup.cfg"
+    black --check "$@" || fail=1
+    flake8 --config "${setupcfg}" "$@" || fail=1
+    isort --diff --check-only --settings-path "${setupcfg}" "$@"
+    if [ $? -ne 0 ]; then
+      # Format in place
+      isort --settings-path "${setupcfg}" "$@"
+      fail=1
+    fi
   elif [ "$(is_rust_file $@)" == "1" ]; then
     if ! command -v rustfmt &> /dev/null; then
       fail=1


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Flag --diff will output the changes content.
Flag --check-only will return exit code. It can be used together with --diff.

Run isort again to format the code in place, to make the behavior same as before.


## Impact

If isort check fails, now CI will report error.


## Testing

Tested on CI and it detects py format issue correctly.

