### PR TITLE
CI: Skip half of RISC-V, Xtensa and Simulator targets when a Complex PR is created / updated

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -160,13 +160,21 @@ jobs:
 
           # If Not a Simple PR: Build all targets
           if [[ "$quit" == "1" ]]; then
-            # If PR was Created or Modified: Exclude arm-08 to arm-14
+            # If PR was Created or Modified: Exclude some boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-08 to arm-14"
-              boards=$( 
+              echo "Excluding arm-08..14, risc-v-04..06, sim-02, xtensa-02"
+              boards=$(
                 echo '${{ inputs.boards }}' |
-                jq --compact-output 'map(select(test("arm-0[8-9]") == false and test("arm-1.+") == false))'
+                jq --compact-output \
+                'map(
+                  select(
+                    test("arm-0[8-9]") == false and test("arm-1.") == false and
+                    test("risc-v-0[4-9]") == false and
+                    test("sim-0[2-9]") == false and
+                    test("xtensa-0[2-9]") == false
+                  )
+                )'
               )
             fi
             echo "selected_builds=$boards" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

When we submit or update a Complex PR that affects All Architectures (Arm, RISC-V, Xtensa, etc): CI Workflow shall run only half the jobs for RISC-V, Xtensa and Simulator:
- `risc-v-01` to `03`
- `xtensa-01`
- `sim-01`

When the Complex PR is Merged: CI Workflow will still run all jobs for RISC-V, Xtensa and Simulator:
- `risc-v-01` to `06`
- `xtensa-01` to `02`
- `sim-01` to `02`

Simple PRs with One Single Arch / Board will build the same way as before:
- `risc-v-01` to `06`
- `xtensa-01` to `02`
- `sim-01` to `02`

We hope to lower drastically our usage of GitHub Runners before the ASF Deadline, as explained here: https://github.com/apache/nuttx/issues/14376

## Impact

When we submit or update a Complex PR: CI Workflow shall run only half the jobs for RISC-V, Xtensa and Simulator:
- `risc-v-01` to `03`
- `xtensa-01`
- `sim-01`

No changes to the CI Workflow when we merge a Complex PR. No impact for Simple PRs.

## Testing

Creating a Simple PR for RISC-V will run jobs `risc-v-01` to `06` (like before):
- See https://github.com/lupyuen5/label-nuttx/actions/runs/11402732507

Creating a Complex PR will only run jobs:
- `risc-v-01` to `03`
- `xtensa-01`
- `sim-01`
- See https://github.com/lupyuen5/label-nuttx/actions/runs/11402274172

Merging a Complex PR will run all jobs (like before):
- `risc-v-01` to `06`
- `xtensa-01` to `02`
- `sim-01` to `02`
- See https://github.com/lupyuen5/label-nuttx/actions/runs/11402751241
