### PR TITLE
cmake: Renamed savedefconfig with refreshsilent

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -72,7 +72,7 @@ add_custom_target(
 
 # utility target to refresh .config from board's defconfig for GITHUB
 add_custom_target(
-  savedefconfig
+  refreshsilent
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/SAVEconfig
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/.config
           ${CMAKE_BINARY_DIR}/SAVEconfig
@@ -80,6 +80,17 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DEFCONFIG}
           ${CMAKE_BINARY_DIR}/.config
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} olddefconfig
+  COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} savedefconfig --out
+          ${CMAKE_BINARY_DIR}/defconfig.tmp
+  COMMAND ${CMAKE_COMMAND} -P ${NUTTX_DIR}/cmake/savedefconfig.cmake
+          ${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/defconfig.tmp
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/defconfig
+          ${NUTTX_DEFCONFIG}
+  WORKING_DIRECTORY ${NUTTX_DIR})
+
+# utility target to replace defconfig to board's defconfig
+add_custom_target(
+  savedefconfig
   COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} savedefconfig --out
           ${CMAKE_BINARY_DIR}/defconfig.tmp
   COMMAND ${CMAKE_COMMAND} -P ${NUTTX_DIR}/cmake/savedefconfig.cmake

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -450,8 +450,8 @@ function refresh_cmake {
     kconfig-tweak --file $nuttx/build/.config -d $toolchain
   fi
 
-  if ! cmake --build build -t savedefconfig 1>/dev/null; then
-    cmake --build build -t savedefconfig
+  if ! cmake --build build -t refreshsilent 1>/dev/null; then
+    cmake --build build -t refreshsilent
     fail=1
   fi
 


### PR DESCRIPTION
## Summary

Renamed savedefconfig -> refreshsilent name more consistent with the refresh stage for cmake on github.

Added new savedefconfig to fix
https://github.com/apache/nuttx/issues/14281

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

1. config with CMake
cmake -B build -DBOARD_CONFIG=nucleo-l152re:nsh

2. change any config with menuconfig
cmake --build build -t menuconfig
For example  Disable CONFIG_EXAMPLES_HELLO

3. savedefconfig use cmake
cmake --build build -t savedefconfig

now the build directory has the updated defconfig file

