### PR TITLE
sched/timer: Simplify setitimer implementation.

### DIFF
--- a/sched/timer/timer_setitimer.c
+++ b/sched/timer/timer_setitimer.c
@@ -89,7 +89,7 @@
 int setitimer(int which, FAR const struct itimerval *value,
               FAR struct itimerval *ovalue)
 {
-  FAR struct tcb_s *rtcb = this_task();
+  FAR struct tcb_s *rtcb;
   struct itimerspec spec;
   struct itimerspec ospec;
   irqstate_t flags;
@@ -101,20 +101,20 @@ int setitimer(int which, FAR const struct itimerval *value,
       return ERROR;
     }
 
+  rtcb = this_task();
+
+  flags = enter_critical_section();
+
   if (!rtcb->group->itimer)
     {
-      flags = enter_critical_section();
-      if (!rtcb->group->itimer)
-        {
-          ret = timer_create(CLOCK_REALTIME, NULL, &rtcb->group->itimer);
-        }
+      ret = timer_create(CLOCK_REALTIME, NULL, &rtcb->group->itimer);
+    }
 
-      leave_critical_section(flags);
+  leave_critical_section(flags);
 
-      if (ret != OK)
-        {
-          return ret;
-        }
+  if (ret != OK)
+    {
+      return ret;
     }
 
   TIMEVAL_TO_TIMESPEC(&value->it_value, &spec.it_value);


### PR DESCRIPTION
## Summary

The change is necessary to optimize the `setitimer` implementation by removing an unnecessary conditional branch that checks for the existence of an `itimer` within the task's group before creating one. This simplification enhances code readability and potentially improves performance by reducing the overhead of redundant checks. 

## Impact

This change affects the kernel's timer subsystem by streamlining the `setitimer` function. Users should experience no direct impact, but the system's efficiency in managing timers may improve slightly. The build process remains unchanged, and there are no hardware or documentation changes required. Security and compatibility are not affected by this change. The main impact is on the internal logic of the `setitimer` function.

## Testing

Tested on QEMU/x86_64 and QEMU/armv8a
