### PR TITLE
cmake: fix the fdiagnostics-color handle issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,13 +391,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/arch/${CONFIG_ARCH}/src/cmake)
 set(CMAKE_TOOLCHAIN_FILE
     "${CMAKE_SOURCE_DIR}/arch/${CONFIG_ARCH}/src/cmake/Toolchain.cmake")
 
-# include common toolchain setting
-include(nuttx_toolchain)
-
 # Define project #############################################################
 # This triggers configuration
 
 project(NuttX LANGUAGES C CXX ASM)
+
+# include common toolchain setting
+include(nuttx_toolchain)
 
 if(WIN32)
   enable_language(ASM_MASM)

--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -53,11 +53,6 @@ endif()
 
 set(NO_LTO "-fno-lto")
 
-if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.9)
-  # force color for gcc > 4.9
-  add_compile_options(-fdiagnostics-color=always)
-endif()
-
 # Workaround to skip -Warray-bounds check due to bug of GCC-12: Wrong warning
 # array subscript [0] is outside array bounds:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523

--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -23,6 +23,13 @@
 # search. If the manual of the newly supported toolchain is different, you can
 # override these methods in the toolchain
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.9)
+    # force color for gcc > 4.9
+    add_compile_options(-fdiagnostics-color=always)
+  endif()
+endif()
+
 # Support CMake to define additional configuration options
 
 if(EXTRA_FLAGS)


### PR DESCRIPTION
## Summary
enable warning info output with color font decorate

## Impact
has no impact on current build procedure

## Testing
has tested on gnu compiler


