### PR TITLE
nuttx/arch:Enabling ARCH_MATH_H is required when compiling sim with t…

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -121,6 +121,7 @@ config ARCH_SIM
 	select SERIAL_IFLOWCONTROL
 	select SCHED_HPWORK
 	select ARCH_HAVE_CPUINFO
+	select ARCH_MATH_H if LIBCXX
 	---help---
 		Linux/Cygwin user-mode simulation.
 


### PR DESCRIPTION
…he 13.2 version of the toolchain.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


