### PR TITLE
boards/nucleo-l432kc: Add internal DAC code.

### DIFF
--- a/boards/arm/stm32l4/nucleo-l432kc/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/include/board.h
@@ -63,8 +63,14 @@
 
 /* Analog pin selections ****************************************************/
 
+/* ADC
+ * Build time configurable pins are defined in ../src/stm32_adc.c.
+ * ADC1 with DMA: GPIO_ADC1_IN11 (PA6/A5), GPIO_ADC1_IN12 (PA7/A6).
+ * ADC1 no DMA  : GPIO_ADC1_IN11 (PA6/A5).
+ */
+
 /* DAC
- * Default is PA4 (same as ADC, do not use both at the same time)
+ * DAC1: GPIO_DAC1_OUT_1 (PA4/A3).
  */
 
 #define GPIO_DAC1_OUT            GPIO_DAC1_OUT_1

--- a/boards/arm/stm32l4/nucleo-l432kc/src/Makefile
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/Makefile
@@ -40,6 +40,10 @@ ifeq ($(CONFIG_STM32L4_ADC),y)
 CSRCS += stm32_adc.c
 endif
 
+ifeq ($(CONFIG_STM32L4_DAC),y)
+CSRCS += stm32_dac.c
+endif
+
 ifeq ($(CONFIG_DAC7571),y)
 CSRCS += stm32_dac7571.c
 endif

--- a/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
@@ -185,6 +185,18 @@ int stm32l4_adc_setup(void);
 #endif
 
 /****************************************************************************
+ * Name: stm32l4_dac_setup
+ *
+ * Description:
+ *   Initialize DAC and register the DAC driver.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DAC
+int stm32l4_dac_setup(void);
+#endif
+
+/****************************************************************************
  * Name: stm32_dac7571initialize
  *
  * Description:

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
@@ -257,6 +257,16 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
+#ifdef CONFIG_STM32L4_DAC
+  /* Initialize DAC and register the DAC driver. */
+
+  ret = stm32l4_dac_setup();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: stm32l4_dac_setup failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_DAC7571
   /* Initialize and register DAC7571 */
 

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_dac.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_dac.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/arm/stm32l4/nucleo-l432kc/src/stm32_dac.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/board.h>
+#include <nuttx/analog/dac.h>
+
+#include "stm32l4_gpio.h"
+#include "stm32l4_dac.h"
+#include "nucleo-l432kc.h"
+
+#include <arch/board/board.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_STM32L4_DAC1
+static struct dac_dev_s *g_dac;
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32l4_dac_setup
+ ****************************************************************************/
+
+int stm32l4_dac_setup(void)
+{
+  static bool initialized = false;
+
+  if (!initialized)
+    {
+#ifdef CONFIG_STM32L4_DAC1
+      int ret;
+
+      g_dac = stm32l4_dacinitialize(0);
+      if (g_dac == NULL)
+        {
+          aerr("ERROR: Failed to get DAC1 interface\n");
+          return -ENODEV;
+        }
+
+      /* Register the DAC driver at "/dev/dac0" */
+
+      ret = dac_register("/dev/dac0", g_dac);
+      if (ret < 0)
+        {
+          aerr("ERROR: dac_register failed: %d\n", ret);
+          return ret;
+        }
+#endif
+
+      initialized = true;
+    }
+
+  return OK;
+}


### PR DESCRIPTION
## Summary

* Nucleo-L432KC board was missing internal MCU DAC initialization code.
* DAC is now available on PA4/A3 and /dev/dac0 when enabled.
* Updated info on ADC inputs (PA6/A5,PA7/A6) depending on configuration.
* Most boards have pins hadrcoded in `*.h` and `*.c` files, here too, would be nice to have them configurable via Kconfig, but there is no generic mechanism for that yet?

## Impact

boards / nucleo-l432kc can now use DAC.

## Testing

* Build host: FreeBSD 13.3 AMD64.
* Test setup: oscilloscope on A4, generator on A5 nucleo pins.
* Before: DAC was not available even though enabled in the config.
* After: DAC is available as `/dev/dac0` and controllable with example `dac` application.

```
nsh> uname -a
NuttX 12.7.0-RC0 a94c099b7d-dirty Oct 19 2024 06:44:25 arm nucleo-l432kc
nsh> ls /dev
/dev:
 adc0
 console
 dac0
 null
 random
 rtc0
 ttyS0
nsh> adc -n1
adc_main: g_adcstate.count: 1
adc_main: Hardware initialized. Opening the ADC device: /dev/adc0
Sample:
1: channel: 11 value: 1310
nsh> dac put 1024
devpath=/dev/dac0 data=1024 delay=0
write: ret=5, errno=0
wrote: chan=0, data=1024
ret=1
```


