### PR TITLE
syslog: fix ramlog not work issue with cmake

### DIFF
--- a/drivers/syslog/CMakeLists.txt
+++ b/drivers/syslog/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 
 if(CONFIG_RAMLOG)
   list(APPEND SRCS ramlog.c)
+  if(CONFIG_RAMLOG_BUFFER_SECTION)
+    target_compile_definitions(
+      drivers PRIVATE -DRAMLOG_BUFFER_SECTION="${CONFIG_RAMLOG_BUFFER_SECTION}")
+  endif()
 endif()
 
 # Include SYSLOG drivers (only one should be enabled)


### PR DESCRIPTION

## Summary
 CONFIG_RAMLOG_BUFFER_SECTION is ineffective in the current CMake build environment 
## Impact
 ramlog

## Testing



