### PR TITLE
drivers/spi_slave: call SPIS_DEV_NOTIFY when rx or tx complete for all spi slave driver

### DIFF
--- a/arch/arm/src/samv7/sam_spi_slave.c
+++ b/arch/arm/src/samv7/sam_spi_slave.c
@@ -462,6 +462,7 @@ static int spi_interrupt(int irq, void *context, void *arg)
 
           SPIS_DEV_RECEIVE(priv->dev, (const uint16_t *)&data,
                            sizeof(data));
+          SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
         }
 
       /* When a transfer starts, the data shifted out is the data present
@@ -509,6 +510,7 @@ static int spi_interrupt(int irq, void *context, void *arg)
 
           regval = spi_dequeue(priv);
           spi_putreg(priv, regval, SAM_SPI_TDR_OFFSET);
+          SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
         }
 
       /* The SPI slave hardware provides only an event when NSS rises

--- a/arch/arm/src/stm32h7/stm32_spi_slave.c
+++ b/arch/arm/src/stm32h7/stm32_spi_slave.c
@@ -710,6 +710,7 @@ static void spi_dmarxcallback(DMA_HANDLE handle, uint8_t isr, void *arg)
   /* Wake-up the SPI driver */
 
   priv->rxresult = isr | 0x080;  /* OR'ed with 0x80 to assure non-zero */
+  SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
 }
 #endif
 
@@ -729,6 +730,7 @@ static void spi_dmatxcallback(DMA_HANDLE handle, uint8_t isr, void *arg)
   /* Wake-up the SPI driver */
 
   priv->txresult = isr | 0x080;  /* OR'ed with 0x80 to assure non-zero */
+  SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
 }
 #endif
 

--- a/arch/risc-v/src/common/espressif/esp_spi_slave.c
+++ b/arch/risc-v/src/common/espressif/esp_spi_slave.c
@@ -578,6 +578,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
     {
       spi_slave_hal_store_result(&priv->ctx);
       priv->rx_length += transfer_size;
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
     }
 
 #ifdef CONFIG_ESPRESSIF_SPI2_DMA
@@ -592,6 +593,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
   if (transfer_size > 0 && priv->is_tx_enabled)
     {
       spislave_evict_sent_data(priv, transfer_size);
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
     }
 
   priv->ctx.bitlen = priv->tx_length;

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_spi_slave.c
@@ -863,6 +863,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
   if (transfer_size > 0)
     {
       spislave_store_result(priv, transfer_size);
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
     }
 
   spislave_prepare_next_rx(priv);
@@ -872,6 +873,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
   if (transfer_size > 0 && priv->is_tx_enabled)
     {
       spislave_evict_sent_data(priv, transfer_size);
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
     }
 
   spislave_prepare_next_tx(priv);

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -840,6 +840,8 @@ static int esp32_spislv_interrupt(int irq, void *context, void *arg)
           tmp = esp32_spi_get_reg(priv, SPI_W0_OFFSET + i);
           memcpy(priv->rxbuffer + priv->rxlen + i, &tmp, 4);
         }
+
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
     }
 
   priv->rxlen += n;
@@ -861,6 +863,8 @@ static int esp32_spislv_interrupt(int irq, void *context, void *arg)
           priv->txlen = 0;
           priv->txen = false;
         }
+
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
     }
 
   if (priv->txlen)

--- a/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spi_slave.c
@@ -966,6 +966,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
   if (transfer_size > 0)
     {
       spislave_store_result(priv, transfer_size);
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
     }
 
 #ifdef CONFIG_ESP32S2_SPI_DMA
@@ -977,6 +978,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
   if (priv->is_tx_enabled && transfer_size > 0)
     {
       spislave_evict_sent_data(priv, transfer_size);
+      SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
     }
 
   spislave_prepare_next_tx(priv);

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_slave.c
@@ -1054,6 +1054,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
       if (transfer_size > 0)
         {
           spislave_store_result(priv, transfer_size);
+          SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_RX_COMPLETE);
         }
 
 #ifdef CONFIG_ESP32S3_SPI_DMA
@@ -1074,6 +1075,7 @@ static int spislave_periph_interrupt(int irq, void *context, void *arg)
       if (priv->is_tx_enabled && transfer_size > 0)
         {
           spislave_evict_sent_data(priv, transfer_size);
+          SPIS_DEV_NOTIFY(priv->dev, SPISLAVE_TX_COMPLETE);
         }
 
       spislave_prepare_next_tx(priv);


### PR DESCRIPTION

## Summary

drivers/spi_slave: call SPIS_DEV_NOTIFY when rx or tx complete for all spi slave driver
This PR is related to issue:https://github.com/apache/nuttx/issues/14369

## Impact

call notify interface to notify userspace when read or write block

## Testing

local


