### PR TITLE
CI: Build only Arm32 Targets arm-01 / 03 / 05 / 06 / 07 / 09 / 11 for Complex PRs

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -169,13 +169,13 @@ jobs:
             # If PR was Created or Modified: Exclude some boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-08..14, risc-v-04..06, sim-02, xtensa-02"
+              echo "Excluding arm-0[248], arm-1[02-9], risc-v-04..06, sim-02, xtensa-02"
               boards=$(
                 echo '${{ inputs.boards }}' |
                 jq --compact-output \
                 'map(
                   select(
-                    test("arm-0[8-9]") == false and test("arm-1.") == false and
+                    test("arm-0[248]") == false and test("arm-1[02-9]") == false and
                     test("risc-v-0[4-9]") == false and
                     test("sim-0[2-9]") == false and
                     test("xtensa-0[2-9]") == false


### PR DESCRIPTION
## Summary

This PR updates the Build Rules `arch.yml` to build only these Arm32 Targets when we create or update a Complex PR:
- arm-01, arm-03, arm-05, arm-06, arm-07, arm-09, arm-11

No changes for Simple PRs (arm-01 to arm-14) and for Merging PRs (also arm-01 to arm-14).

This will improve our breadth of CI Checks across Arm32 Targets, as explained here: https://github.com/apache/nuttx/issues/14376

## Impact

We build only these Arm32 Targets when we create or update a Complex PR:
- arm-01, arm-03, arm-05, arm-06, arm-07, arm-09, arm-11

No changes for Simple PRs and for Merging PRs.

## Testing

Creating a Complex PR will build only arm-01, arm-03, arm-05, arm-06, arm-07, arm-09, arm-11
- https://github.com/lupyuen5/label-nuttx/actions/runs/11426738940

Creating a Simple PR will build arm-01 to arm-14
- https://github.com/lupyuen5/label-nuttx/actions/runs/11426754144

Merging a PR will also build arm-01 to arm-14
- https://github.com/lupyuen5/label-nuttx/actions/runs/11426771087
