### PR TITLE
Revert "fs/inode: add pre-allocated task files to avoid allocator access

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -195,7 +195,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   spin_unlock_irqrestore(NULL, flags);
 
-  if (tmp != NULL && tmp != &list->fl_prefile)
+  if (tmp != NULL)
     {
       fs_heap_free(tmp);
     }
@@ -360,14 +360,7 @@ static int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2,
 
 void files_initlist(FAR struct filelist *list)
 {
-  /* The first row will reuse pre-allocated files, which will avoid
-   * unnecessary allocator accesses during file initialization.
-   */
-
-  list->fl_rows = 1;
   list->fl_crefs = 1;
-  list->fl_files = &list->fl_prefile;
-  list->fl_prefile = list->fl_prefiles;
 }
 
 /****************************************************************************
@@ -496,16 +489,10 @@ void files_putlist(FAR struct filelist *list)
           file_close(&list->fl_files[i][j]);
         }
 
-      if (i != 0)
-        {
-          fs_heap_free(list->fl_files[i]);
-        }
+      fs_heap_free(list->fl_files[i]);
     }
 
-  if (list->fl_files != &list->fl_prefile)
-    {
-      fs_heap_free(list->fl_files);
-    }
+  fs_heap_free(list->fl_files);
 }
 
 /****************************************************************************

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -510,15 +510,6 @@ struct filelist
   uint8_t           fl_rows;    /* The number of rows of fl_files array */
   uint8_t           fl_crefs;   /* The references to filelist */
   FAR struct file **fl_files;   /* The pointer of two layer file descriptors array */
-
-  /* Pre-allocated files to avoid allocator access during thread creation
-   * phase, For functional safety requirements, increase
-   * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK could also avoid allocator access
-   * caused by the file descriptor exceeding the limit.
-   */
-
-  FAR struct file  *fl_prefile;
-  struct file       fl_prefiles[CONFIG_NFILE_DESCRIPTORS_PER_BLOCK];
 };
 
 /* The following structure defines the list of files used for standard C I/O.


### PR DESCRIPTION


## Summary
Revert "fs/inode: add pre-allocated task files to avoid allocator access

This reverts commit 086834aae1722af2797fd5d4d0f79226ac11c2e9.

The refs in the filelist cannot protect the handles in the prefiles The prefiles and its associated group are allocated together, and when the group leaves, they are released together.
During a reboot process, the sync operation may encounter a "used after free" issue.

issue stack:

    (filep=filep@entry=0x3c482770) at ../../../fs/vfs/fs_close.c:80
    ../../../fs/vfs/fs_close.c:118
    ../../../fs/inode/fs_files.c:476
    /home/cibuild/Public/jenkinsversion/2148/nuttx/include/nuttx/fs/fs.h:870
    at ../../../fs/inode/fs_files.c:223
    <task_fssync(tcb_s*, void*)>, arg=0x0) at
../../../sched/sched/sched_foreach.c:73
    data=<optimized out>) at ../../../fs/fs_initialize.c:48
    ../../../sched/misc/reboot_notifier.c:87
    ../../../boards/boardctl.c:415
    argv=0x3d3e07e8) at ../../../../apps/nshlib/nsh_syscmds.c:465
    argc=argc@entry=2, argv=0x3d3e07e8, argv@entry=0x3d3e0820)
    at ../../../../apps/nshlib/nsh_command.c:1247
    argv=0x3d3e0820, argc=2, vtbl=0x3c5d2aa8) at
../../../../apps/nshlib/nsh_parse.c:847
    cmdline=cmdline@entry=0x3d3df93a "reboot") at
../../../../apps/nshlib/nsh_parse.c:2757
    "reboot") at ../../../../apps/nshlib/nsh_parse.c:2844
    argc=argc@entry=3, argv=0x3d3df920) at
../../../../apps/nshlib/nsh_session.c:146
    char**)>, isctty=isctty@entry=0) at
../../../../apps/nshlib/nsh_system.c:47
    out>) at ../../../../apps/nshlib/nsh_system.c:80
    entrypt=<optimized out>) at
../../../libs/libc/sched/task_startup.c:70

And the original prefile improvement was only 3 microseconds, which is very minimal, so reverting it is the best approach.


## Impact

Bug fix

## Testing

local test


