### PR TITLE
Fix make warn as error in pci drivers

### DIFF
--- a/drivers/pci/pci_ecam.c
+++ b/drivers/pci/pci_ecam.c
@@ -47,11 +47,11 @@
  ****************************************************************************/
 
 static int pci_ecam_read_config(FAR struct pci_bus_s *bus,
-                                unsigned int devfn, int where, int size,
+                                uint32_t devfn, int where, int size,
                                 FAR uint32_t *val);
 
 static int pci_ecam_write_config(FAR struct pci_bus_s *bus,
-                                 unsigned int devfn, int where, int size,
+                                 uint32_t devfn, int where, int size,
                                  uint32_t val);
 
 static int pci_ecam_read_io(FAR struct pci_bus_s *bus, uintptr_t addr,
@@ -199,7 +199,7 @@ static bool pci_ecam_addr_valid(FAR const struct pci_bus_s *bus,
  ****************************************************************************/
 
 static int pci_ecam_read_config(FAR struct pci_bus_s *bus,
-                                unsigned int devfn, int where, int size,
+                                uint32_t devfn, int where, int size,
                                 FAR uint32_t *val)
 {
   FAR void *addr;
@@ -257,7 +257,7 @@ static int pci_ecam_read_config(FAR struct pci_bus_s *bus,
  ****************************************************************************/
 
 static int pci_ecam_write_config(FAR struct pci_bus_s *bus,
-                                 unsigned int devfn, int where, int size,
+                                 uint32_t devfn, int where, int size,
                                  uint32_t val)
 {
   FAR void *addr;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

struct pci_ops_s defined uint32，unified data structure

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


