### PR TITLE
samv7: fix QSPI build

### DIFF
--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -40,6 +40,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/spi/qspi.h>
 


### PR DESCRIPTION
## Summary

Commit 313d6df7 caused the following build error:

```
CC:  fixedmath/lib_b16atan2.c chip/sam_qspi.c: In function 'qspi_memory': chip/sam_qspi.c:1552:7: warning: implicit declaration of function 'IS_ALIGNED' [-Wimplicit-function-declaration]
 1552 |       IS_ALIGNED((uintptr_t)meminfo->buffer, 4) &&
      |       ^~~~~~~~~~
In file included from chip/sam_qspi.c:41:
chip/sam_qspi.c: In function 'qspi_alloc':
chip/sam_qspi.c:1591:21: warning: implicit declaration of function 'ALIGN_UP' [-Wimplicit-function-declaration]
 1591 |   return kmm_malloc(ALIGN_UP(buflen, 4));
```

This was caused by missing include of `nuttx.h` header defining `ALIGN_UP` and `IS_ALIGNED`.

## Impact

Fixes samv7 build with enabled QSPI.

## Testing

Build now passes, this should affect all platforms.