### PR TITLE
cmake(bugfix):Fixed the issue that the host toolchain version cannot be specified

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -27,11 +27,6 @@ if(WIN32)
   return()
 endif()
 
-find_program(CMAKE_C_COMPILER gcc)
-find_program(CMAKE_CXX_COMPILER g++)
-
-set(CMAKE_PREPROCESSOR cc -E -P -x c)
-
 # NuttX is sometimes built as a native target. In that case, the __NuttX__ macro
 # is predefined by the compiler. https://github.com/NuttX/buildroot
 #


### PR DESCRIPTION
## Summary

SIM arch does not need to execute find_program

## Impact

this should fix issue https://github.com/apache/nuttx/issues/14413

## Testing

cmake -B build -DBOARD_CONFIG=sim/libcxxtest -GNinja
cmake --build build

