### PR TITLE
CI: Split the targets in sim-01 and add sim-03

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         [
           "arm-01", "risc-v-01", "sim-01", "xtensa-01", "arm64-01", "x86_64-01", "other",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
-          "arm-03", "risc-v-03",
+          "arm-03", "risc-v-03", "sim-03",
           "arm-04", "risc-v-04",
           "arm-05", "risc-v-05",
           "arm-06", "risc-v-06",
@@ -202,7 +202,7 @@ jobs:
     with:
       os: macOS
       boards: |
-        ["macos", "sim-01", "sim-02"]
+        ["macos", "sim-01", "sim-02", "sim-03"]
 
   # Run the selected macOS Builds
   macOS:

--- a/tools/ci/testlist/sim-01.dat
+++ b/tools/ci/testlist/sim-01.dat
@@ -1,57 +1,13 @@
-/sim/*/*/*/[a-n]*
+/sim/*/*/*/[a-b]*
+/sim/*/*/*/c[0-i]*
 
 # macOS doesn't have ALSA
 -Darwin,sim:alsa
 
-# macOS doesn't have V4L2
--Darwin,sim:nxcamera
-
 # clang doesn't -fsanitize=kernel-address
--Darwin,sim:kasan
 -Darwin,sim:citest
-
-# macOS doesn't support ELF loading
--Darwin,sim:elf
--Darwin,sim:loadable
-
-# macOS doesn't support 32bit(CONFIG_SIM_M32=y) anymore
--Darwin,sim:module32
-
-# Do not build Linux configs
--Darwin,sim:linuxi2c
--Darwin,sim:linuxspi
-
-# macOS doesn't have X11
--Darwin,sim:lvgl_fb
--Darwin,sim:lvgl_lcd
--Darwin,sim:nimble
--Darwin,sim:nsh2
--Darwin,sim:nx11
--Darwin,sim:nxlines
--Darwin,sim:nxwm
-
-# Skip WebAssembly Micro Runtime
--Darwin,sim:wamr
-
-# macOS matter compilation is not currently supported
--Darwin,sim:matter
 
 # Boards build by CMake
 CMake,sim:alsa
 CMake,sim:bluetooth
 CMake,sim:bthcisock
-CMake,sim:dynconns
-CMake,sim:fb
-CMake,sim:foc
-CMake,sim:ipforward
-CMake,sim:linuxi2c
-CMake,sim:linuxspi
-CMake,sim:minibasic
-CMake,sim:mount
-CMake,sim:mtdpart
-CMake,sim:mtdrwb
-CMake,sim:nettest
-CMake,sim:note
-CMake,sim:nsh
-CMake,sim:nxffs
-CMake,sim:matter

--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -1,51 +1,51 @@
-/sim/*/*/*/[o-z]*
+/sim/*/*/*/c[j-z]*
+/sim/*/*/*/[d-n]*
 
-# macOS doesn't support 32bit anymore(CONFIG_SIM_M32=y)
--Darwin,sim:posix_spawn
--Darwin,sim:rpproxy
--Darwin,sim:rpserver
--Darwin,sim:sotest32
+# macOS doesn't have V4L2
+-Darwin,sim:nxcamera
 
 # clang doesn't -fsanitize=kernel-address
--Darwin,sim:ostest
--Darwin,sim:ostest_oneholder
+-Darwin,sim:kasan
 
-# macOS doesn't support --wrap flag
-# ld: unknown option: --wrap
--Darwin,sim:segger
+# macOS doesn't support ELF loading
+-Darwin,sim:elf
+-Darwin,sim:loadable
+
+# macOS doesn't support 32bit(CONFIG_SIM_M32=y) anymore
+-Darwin,sim:module32
+
+# Do not build Linux configs
+-Darwin,sim:linuxi2c
+-Darwin,sim:linuxspi
 
 # macOS doesn't have X11
--Darwin,sim:touchscreen
+-Darwin,sim:lvgl_fb
+-Darwin,sim:lvgl_lcd
+-Darwin,sim:nimble
+-Darwin,sim:nsh2
+-Darwin,sim:nx11
+-Darwin,sim:nxlines
+-Darwin,sim:nxwm
 
-# Do not build Windows configs
--,sim:windows
+# Skip WebAssembly Micro Runtime
+-Darwin,sim:wamr
 
-# macOS doesn't support simusb simhost
--Darwin,sim:usbdev
--Darwin,sim:usbhost
+# macOS matter compilation is not currently supported
+-Darwin,sim:matter
 
 # Boards build by CMake
-CMake,sim:ostest
-CMake,sim:ostest_oneholder
-CMake,sim:pf_ieee802154
-CMake,sim:pktradio
-CMake,sim:rc
-CMake,sim:romfs
-CMake,sim:rpproxy
-CMake,sim:rpserver
-CMake,sim:rtptools
-CMake,sim:sensor
-CMake,sim:sixlowpan
-CMake,sim:smartfs
-CMake,sim:smp
-CMake,sim:spiffs
-CMake,sim:tcpblaster
-CMake,sim:tcploop
-CMake,sim:udgram
-CMake,sim:unionfs
-CMake,sim:usbdev
-CMake,sim:usbhost
-CMake,sim:userfs
-CMake,sim:usrsocktest
-CMake,sim:ustream
-CMake,sim:vncserver
+CMake,sim:dynconns
+CMake,sim:fb
+CMake,sim:foc
+CMake,sim:ipforward
+CMake,sim:linuxi2c
+CMake,sim:linuxspi
+CMake,sim:minibasic
+CMake,sim:mount
+CMake,sim:mtdpart
+CMake,sim:mtdrwb
+CMake,sim:nettest
+CMake,sim:note
+CMake,sim:nsh
+CMake,sim:nxffs
+CMake,sim:matter

--- a/tools/ci/testlist/sim-03.dat
+++ b/tools/ci/testlist/sim-03.dat
@@ -1,0 +1,51 @@
+/sim/*/*/*/[o-z]*
+
+# macOS doesn't support 32bit anymore(CONFIG_SIM_M32=y)
+-Darwin,sim:posix_spawn
+-Darwin,sim:rpproxy
+-Darwin,sim:rpserver
+-Darwin,sim:sotest32
+
+# clang doesn't -fsanitize=kernel-address
+-Darwin,sim:ostest
+-Darwin,sim:ostest_oneholder
+
+# macOS doesn't support --wrap flag
+# ld: unknown option: --wrap
+-Darwin,sim:segger
+
+# macOS doesn't have X11
+-Darwin,sim:touchscreen
+
+# Do not build Windows configs
+-,sim:windows
+
+# macOS doesn't support simusb simhost
+-Darwin,sim:usbdev
+-Darwin,sim:usbhost
+
+# Boards build by CMake
+CMake,sim:ostest
+CMake,sim:ostest_oneholder
+CMake,sim:pf_ieee802154
+CMake,sim:pktradio
+CMake,sim:rc
+CMake,sim:romfs
+CMake,sim:rpproxy
+CMake,sim:rpserver
+CMake,sim:rtptools
+CMake,sim:sensor
+CMake,sim:sixlowpan
+CMake,sim:smartfs
+CMake,sim:smp
+CMake,sim:spiffs
+CMake,sim:tcpblaster
+CMake,sim:tcploop
+CMake,sim:udgram
+CMake,sim:unionfs
+CMake,sim:usbdev
+CMake,sim:usbhost
+CMake,sim:userfs
+CMake,sim:usrsocktest
+CMake,sim:ustream
+CMake,sim:vncserver


### PR DESCRIPTION
## Summary

CI Build Job sim-01 has become the bottleneck for compiling Complex PRs. This PR splits sim-01 and adds sim-03.

__Before the Split:__ Simulator Jobs take up to 1.5 hours to complete
- sim-01 (1 hour 31 mins): adb, citest, lvgl, matter
- sim-02 (28 mins): posix_test, sqlite

__After the Split:__ Simulator Jobs will complete within 1 hour
- sim-01 (58 mins): adb, citest
- sim-02 (35 mins): lvgl, matter
- sim-03 (28 mins): posix_test, sqlite

This will help us comply with the ASF Policy for GitHub Actions, as explained here: https://github.com/apache/nuttx/issues/14376

## Impact

When we create or modify a Complex PR, the CI Checks for Simulator will complete earlier. CI Job sim-01 will no longer be the bottleneck for compiling Complex PRs. 

## Testing

__Timings Before the Split:__ https://github.com/nuttxpr/nuttx/actions/runs/11430701907
- sim-01: 1 hour 31 mins
- sim-02: 28 mins

__Timings After the Split:__ https://github.com/lupyuen5/label-nuttx/actions/runs/11435289336
- sim-01: 58 mins
- sim-02: 35 mins
- sim-03: 28 mins
