### PR TITLE
{Bp-14421} syslog: enable LF to CRLF config as default

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -36,7 +36,7 @@ config RAMLOG
 if RAMLOG
 config RAMLOG_CRLF
 	bool "RAMLOG CR/LF"
-	default n
+	default y
 	---help---
 		Pre-pend a carriage return before every linefeed that goes into the
 		RAM log.


### PR DESCRIPTION
**Summary**
enable LF to CRLF config as default

**Impact**
log output

**Testing**
selftest