### PR TITLE
libcxx: Ignore compile warnings.

### DIFF
--- a/libs/libxx/libcxx.cmake
+++ b/libs/libxx/libcxx.cmake
@@ -106,7 +106,7 @@ if(NOT CONFIG_CXX_LOCALIZATION)
 endif()
 
 set(FLAGS -Wno-attributes -Wno-deprecated-declarations -Wno-shadow
-          -Wno-sign-compare)
+          -Wno-sign-compare -Wno-cpp)
 
 if(GCCVER GREATER_EQUAL 12)
   list(APPEND FLAGS -Wno-maybe-uninitialized -Wno-alloc-size-larger-than)

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -58,7 +58,7 @@ ifeq ($(CONFIG_LIBSUPCXX), y)
 CXXFLAGS += ${DEFINE_PREFIX}__GLIBCXX__
 endif
 
-CXXFLAGS += -Wno-shadow -Wno-sign-compare
+CXXFLAGS += -Wno-shadow -Wno-sign-compare -Wno-cpp
 CXXFLAGS += -Wno-attributes -Wno-deprecated-declarations
 
 ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)


### PR DESCRIPTION
fix https://github.com/apache/nuttx/issues/14412 warning

## Summary
Why didn’t we have this problem before? Because we have recently optimized cxx, and related source files will not be compiled when CXX_EXCEPTION is turned off.

## Impact
enable CONFIG_LIBCXX and disable CONFIG_CXX_EXCEPTION

## Testing
ci-test
