### PR TITLE
fix GCCVER cmake define.

### DIFF
--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -60,7 +60,7 @@ set(NO_LTO "-fno-lto")
 if(CONFIG_ARCH_TOOLCHAIN_GNU)
   execute_process(COMMAND ${CMAKE_C_COMPILER} --version
                   OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
-  string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
+  string(REGEX MATCH "([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
                "${GCC_VERSION_OUTPUT}")
   set(GCCVER ${CMAKE_MATCH_1})
 

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -192,9 +192,9 @@ endif()
 if(CONFIG_ARCH_TOOLCHAIN_GNU)
   if(NOT GCCVER)
     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-                    OUTPUT_VARIABLE GCC_VERSION_INFO)
-    string(REGEX MATCH "[0-9]+\\.[0-9]+" GCC_VERSION ${GCC_VERSION_INFO})
-    string(REGEX REPLACE "\\..*" "" GCCVER ${GCC_VERSION})
+                    OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
+    string(REGEX MATCH "([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
+                 "${GCC_VERSION_OUTPUT}")
     set(GCCVER ${CMAKE_MATCH_1})
   endif()
   if(GCCVER GREATER_EQUAL 12)

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -261,7 +261,7 @@ if(CONFIG_RISCV_TOOLCHAIN STREQUAL GNU_RVG)
   if(NOT GCCVER)
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version
                     OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
-    string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
+    string(REGEX MATCH "([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
                  "${GCC_VERSION_OUTPUT}")
     set(GCCVER ${CMAKE_MATCH_1})
   endif()


### PR DESCRIPTION
## Summary
There are some errors in cmake's definition of GCCVER, which causes cmake to not find the definition of GCCVER when compiling. https://github.com/apache/nuttx/issues/14412 This has been fixed.

## Impact
libcxx

## Testing
ci test


