### PR TITLE
arm: fix dataabort on qemu-armv7a:knsh

### DIFF
--- a/arch/arm/src/qemu/qemu_memorymap.c
+++ b/arch/arm/src/qemu/qemu_memorymap.c
@@ -57,6 +57,10 @@ static const struct section_mapping_s g_section_mapping[] =
     VIRT_PCIE_PSECTION, VIRT_PCIE_VSECTION,
     MMU_IOFLAGS, _NSECTIONS(VIRT_PCIE_SECSIZE)
   },
+  {
+    VIRT_DDR_PSECTION, VIRT_DDR_VSECTION,
+    MMU_MEMFLAGS, _NSECTIONS(VIRT_DDR_SECSIZE)
+  },
 };
 
 /****************************************************************************

--- a/arch/arm/src/qemu/qemu_memorymap.h
+++ b/arch/arm/src/qemu/qemu_memorymap.h
@@ -42,6 +42,7 @@
 #define VIRT_IO_PSECTION         0x08000000  /* 0x08000000-0x0e000000 */
 #define VIRT_SEC_MEM_PSECTION    0x0e000000  /* 0x0e000000-0x0f000000 */
 #define VIRT_PCIE_PSECTION       0x10000000  /* 0x10000000-0x40000000 */
+#define VIRT_DDR_PSECTION        0x40000000  /* 0x40000000-0x50000000 */
 
 /* Qemu virt Virtual Memory Map *********************************************/
 
@@ -49,6 +50,7 @@
 #define VIRT_IO_VSECTION         VIRT_IO_PSECTION
 #define VIRT_SEC_MEM_VSECTION    VIRT_SEC_MEM_PSECTION
 #define VIRT_PCIE_VSECTION       VIRT_PCIE_PSECTION
+#define VIRT_DDR_VSECTION        VIRT_DDR_PSECTION
 
 /* Sizes of memory regions in bytes. */
 
@@ -56,6 +58,7 @@
 #define VIRT_IO_SECSIZE          (96*1024*1024)
 #define VIRT_SEC_MEM_SECSIZE     (16*1024*1024)
 #define VIRT_PCIE_SECSIZE        (3*256*1024*1024)
+#define VIRT_DDR_SECSIZE         (256*1024*1024)
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary
add memory map for DDR region
fix arm-v7a/knsh boot dataabort on arm_addrenv_utils.c first time memset after arm_pgvaddr.

## Impact
will dataabort before fix.
```
[    0.008000] arm_dataabort: Data abort. PC: 00606d42 DFAR: 48000000 DFSR: 00000805
[    0.008000] dump_assert_info: Current Version: NuttX  12.7.0-RC0 e00fbc5557d-dirty Oct 21 2024 20:26:19 arm
[    0.008000] dump_assert_info: Assertion failed panic: at file: armv7-a/arm_dataabort.c:161 task: Idle_Task process: Kernel 0x600c05
[    0.008000] up_dump_register: R0: 48000000 R1: 00000000 R2: 48000400  R3: 48000000
[    0.008000] up_dump_register: R4: 48000000 R5: 0000000b R6: 00000000  FP: 40205e00
[    0.008000] up_dump_register: R8: 00000000 SB: 80000000 SL: 0000a108 R11: 0000015f
[    0.008000] up_dump_register: IP: 00000028 SP: 40202df0 LR: 0060903f  PC: 00606d42
```


## Testing
CI test.
```bash
# nuttx dir ubuntu environment.
./tools/configure.sh -l qemu-armv7a:knsh
make -j
make export -j
cd ../apps
./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
make import -j
cd ../nuttx
qemu-system-arm -semihosting -M virt -m 1024 -nographic -kernel ./nuttx
```

