### PR TITLE
sam_sfc.c incorrect EFUSEIOC name used

### DIFF
--- a/arch/arm/src/sama5/sam_sfc.c
+++ b/arch/arm/src/sama5/sam_sfc.c
@@ -215,7 +215,7 @@ static int sama5_sfc_lower_ioctl(struct efuse_lowerhalf_s *lower,
     {
       /* We don't have proprietary EFUSE ioctls */
 
-      case EFUSEIOC_SAMA5_MASK:
+      case EFUSEIOC_MASK:
         {
           minfo("Masking fuses register \n");
           sam_sfc_mask_read();


### PR DESCRIPTION
## Summary

Updated sam_sfc.c to call EFUSEIOC_MASK rather than EFUSEIOC_SAMA5_MASK - this error must have slipped through my original testing and submission of the SMA5 SFC functionality, or a later change to EFUSE IOCTL naming messed it up.

## Impact

Allows correct compilation

## Testing
Limited to compilation as no code I have or could find calls this IOCTL


