### PR TITLE
boards/arm/stm32f7: removed extra endif() from cmakefile for nucleo-f746zg nucleo-f722ze nucleo-f767zi

### DIFF
--- a/boards/arm/stm32f7/nucleo-f722ze/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/nucleo-f722ze/src/CMakeLists.txt
@@ -82,4 +82,3 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
-endif()

--- a/boards/arm/stm32f7/nucleo-f746zg/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/nucleo-f746zg/src/CMakeLists.txt
@@ -73,4 +73,3 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
-endif()

--- a/boards/arm/stm32f7/nucleo-f767zi/src/CMakeLists.txt
+++ b/boards/arm/stm32f7/nucleo-f767zi/src/CMakeLists.txt
@@ -73,4 +73,3 @@ endif()
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
-endif()


### PR DESCRIPTION
## Summary

fix this error (for nucleo-f746zg nucleo-f722ze nucleo-f767zi)

CMake Error at boards/arm/stm32f7/nucleo-f746zg/src/CMakeLists.txt:76 (endif):
  Flow control statements are not properly nested.
CMake Error at boards/arm/stm32f7/nucleo-f746zg/src/CMakeLists.txt:76 (endif):
  Flow control statements are not properly nested.
-- Configuring incomplete, errors occurred!

https://github.com/simbit18/nuttx_test_pr/actions/runs/11442005741/job/31831476469#step:7:359

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same
Allows you to build nuttx with cmake for nucleo-f746zg nucleo-f722ze nucleo-f767zi

## Testing
ci


