### PR TITLE
tools/esp32s3/Config.mk: fix "printf:`\': invalid format character"

### DIFF
--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -114,7 +114,15 @@ endif
 ESPTOOL_BINS += $(FLASH_APP)
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-	ESPTOOL_BINS += $(shell printf "%\#x\n" $$(( $(CONFIG_ESP32S3_KERNEL_OFFSET) + $(CONFIG_ESP32S3_KERNEL_IMAGE_SIZE) ))) nuttx_user.bin
+	# Check the operating system
+
+	ifeq ($(shell uname -s), Darwin)
+		# macOS
+		ESPTOOL_BINS += $(shell printf "%\#x\n" $$(( $(CONFIG_ESP32S3_KERNEL_OFFSET) + $(CONFIG_ESP32S3_KERNEL_IMAGE_SIZE) ))) nuttx_user.bin
+	else
+		# Linux and other systems
+		ESPTOOL_BINS += $(shell printf "%#x\n" $$(( $(CONFIG_ESP32S3_KERNEL_OFFSET) + $(CONFIG_ESP32S3_KERNEL_IMAGE_SIZE) ))) nuttx_user.bin
+	endif
 endif
 
 # MERGEBIN -- Merge raw binary files into a single file


### PR DESCRIPTION
## Summary

* tools/esp32s3/Config.mk: fix "printf:\`': invalid format character"

The error was introduced by #14393, which was intended to fix this line for MacOS. This commit makes this line dependent on the host OS to avoid any compilation errors.

## Impact

Fix compile issues related to the legacy bootloader of the ESP32-S3 on both Linux and MacOS. CI didn't get the error because `CONFIG_ESP32S3_MERGE_BINS` is not tested.

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.0 board (esp32s3-devkit:knsh + `CONFIG_ESP32S3_MERGE_BINS=y`).