### PR TITLE
fs/mnemofs: Add logs to bind and unbind.

### DIFF
--- a/fs/mnemofs/Kconfig
+++ b/fs/mnemofs/Kconfig
@@ -6,11 +6,18 @@
 config FS_MNEMOFS
 	bool "MNEMOFS NAND Flash File System"
 	default n
-	depends on !DISABLE_MOUNTPOINT && MTD_NAND 
+	depends on !DISABLE_MOUNTPOINT && MTD_NAND
 	---help---
 		Build the mnemofs NAND flash file system.
 
 if FS_MNEMOFS
+config MNEMOFS_EXTRA_DEBUG
+	bool "MNEMOFS Extra Debug Logs"
+	default n
+	depends on FS_MNEMOFS
+	---help---
+		Prints extra log information related to mnemofs.
+
 config MNEMOFS_JOURNAL_NBLKS
 	int "MNEMOFS Journal Block Count"
 	default 20

--- a/fs/mnemofs/mnemofs.h
+++ b/fs/mnemofs/mnemofs.h
@@ -98,6 +98,14 @@
 #define MFS_JRNL_LIM(sb)           (MFS_JRNL(sb).n_blks / 2)
 #define MFS_TRAVERSE_INITSZ        8
 
+#define MFS_LOG                    finfo
+#ifdef CONFIG_MNEMOFS_EXTRA_DEBUG
+#define MFS_EXTRA_LOG              finfo
+#else
+#define MFS_EXTRA_LOG
+#endif
+#define MFS_STRLITCMP(a, lit)      strncmp(a, lit, strlen(lit))
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -430,7 +438,7 @@ int mnemofs_flush(FAR struct mfs_sb_s *sb);
  * Name: mfs_jrnl_init
  *
  * Description:
- *   Initialize journal if device is already formatted.
+ *   Initializes journal when it's already formatted into the device.
  *
  * Input Parameters:
  *   sb  - Superblock instance of the device.
@@ -439,6 +447,9 @@ int mnemofs_flush(FAR struct mfs_sb_s *sb);
  * Returned Value:
  *   0   - OK
  *   < 0 - Error
+ *
+ * Assumptions/Limitations:
+ *   Does not initialize the master node.
  *
  ****************************************************************************/
 
@@ -463,6 +474,8 @@ int mfs_jrnl_init(FAR struct mfs_sb_s * const sb, mfs_t blk);
  *   If blk1 == 0 and blk2 == 0, this means that this will also format in the
  *   master blocks. If this is not satisfied, the provided values will be
  *   taken to denote the master nodes.
+ *
+ *   Does not format the master node.
  *
  ****************************************************************************/
 

--- a/fs/mnemofs/mnemofs_master.c
+++ b/fs/mnemofs/mnemofs_master.c
@@ -340,11 +340,19 @@ int mfs_mn_fmt(FAR struct mfs_sb_s * const sb, const mfs_t mblk1,
     {
       goto errout;
     }
+  else
+    {
+      ret = OK;
+    }
 
   ret = mfs_write_page(sb, buf, sz, MFS_BLK2PG(sb, mblk2), 0);
   if (predict_false(ret < 0))
     {
       goto errout;
+    }
+  else
+    {
+      ret = OK;
     }
 
   mn.mblk_idx = 1;


### PR DESCRIPTION
Add logs and extra logs to mnemofs VFS methods for bind and unbind.

## Summary

Adds logs (`MFS_LOG` and `MFS_EXTRA_LOG`) to mnemofs, and implements them in `mnemofs_bind` and `mnemofs_unbind`.

## Impact

- Better debugging using the improved logs.
- **Build Impact**: No.
- **User Impact**: Better logs to report in case of crashes.
- **Documentation**: The code printing the logs also serve as section-wise docs.

## Testing

I confirm that changes are verified on local setup and works as intended:

Build Host(s): OS (Linux), CPU(Intel), compiler(GCC 13).
Target(s): arch(sim), sim:mnemofs.

Logs before:
```
nsh> mount -t mnemofs -o forceformat /dev/nand /hi
binfs_stat: Entry
find_blockdriver: pathname="/dev/nand"
find_blockdriver: /dev/nand is a MTD
mnemofs_bind: Mnemofs bind.
nand_wrapper: [UPPER 1 | ioctl] Command: 1537, Arg : 91328184813024
nand_wrapper: [UPPER 1 | ioctl] Done
mnemofs_bind: MTD Driver Geometry read. Page size: 128, Block size: 2048, Pages/Block: 16, Blocks: 1024
mnemofs_bind: Lock acquired.
mnemofs_bind: Force format.
mfs_ba_fmt: mnemofs: Block Allocator initialized, starting at page 16.
...
```
```
nsh> umount /hi
binfs_stat: Entry
mnemofs_unbind: Mnemofs unbind.
mfs_jrnl_free: Journal Freed.
mfs_ba_free: Block Allocator Freed.
mnemofs_unbind: Successfully unmounted mnemofs!
```

Logs After:
```
nsh> mount -t mnemofs -o forceformat /dev/nand /hi
binfs_stat: Entry
find_blockdriver: pathname="/dev/nand"
find_blockdriver: /dev/nand is a MTD
mnemofs_bind: [mnemofs | BIND] Entry.
mnemofs_bind: [mnemofs | BIND] Resetting temporary buffer.
mnemofs_bind: [mnemofs | BIND] Allocating superblock in memory.
mnemofs_bind: [mnemofs | BIND] Superblock allocated at 0x512000000040
mnemofs_bind: [mnemofs | BIND] Device is of MTD type.
nand_wrapper: [UPPER 1 | ioctl] Command: 1537, Arg : 91328184813024
nand_wrapper: [UPPER 1 | ioctl] Done
mnemofs_bind: [mnemofs | BIND] MTD Driver Geometry read.
mnemofs_bind: [mnemofs | BIND] MTD Driver Geometry details. Page size: 128, Block size: 2048, Pages/Block: 16, Blocks: 1024
mnemofs_bind: [mnemofs | BIND] FS-wide Mutex Initialized.
mnemofs_bind: [mnemofs | BIND] Mutex acquired.
mnemofs_bind: [mnemofs | BIND] SB initialized in-memory.
mnemofs_bind: [mnemofs | BIND] SB Details.
mnemofs_bind: [mnemofs | BIND]  Driver: 0x50c000000f40
mnemofs_bind: [mnemofs | BIND]  Page Size: 128
mnemofs_bind: [mnemofs | BIND]  Log Page Size: 7
mnemofs_bind: [mnemofs | BIND]  Block Size: 2048
mnemofs_bind: [mnemofs | BIND]  Log Block Size: 11
mnemofs_bind: [mnemofs | BIND]  Pages Per Block: 16
mnemofs_bind: [mnemofs | BIND]  Blocks: 1024
mnemofs_bind: [mnemofs | BIND]  Log Blocks: 10
mnemofs_bind: [mnemofs | BIND]  Journal Blocks: 20
mnemofs_bind: [mnemofs | BIND]  Flush State: 0
mnemofs_bind: [mnemofs | BIND] RW Buffer allocated.
mnemofs_bind: [mnemofs | BIND] Device formatting configured.
...
```
```
nsh> umount /hi
binfs_stat: Entry
mnemofs_unbind: [mnemofs | UNBIND] Entry.
mnemofs_unbind: [mnemofs | UNBIND] Superblock 0x512000000040.
mnemofs_unbind: [mnemofs | UNBIND] Driver 0x531000038720.
mfs_jrnl_free: Journal Freed.
mfs_ba_free: Block Allocator Freed.
mnemofs_unbind: [mnemofs | UNBIND] Mutex destroyed.
mnemofs_unbind: [mnemofs | UNBIND] RW Buffer freed.
mnemofs_unbind: [mnemofs | UNBIND] Superblock freed.
mnemofs_unbind: [mnemofs | UNBIND] Exit.
```