### PR TITLE
net/local: fix used after free

### DIFF
--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -299,7 +299,7 @@ void local_free(FAR struct local_conn_s *conn)
 
   dq_rem(&conn->lc_conn.node, &g_local_connections);
 
-  if (local_peerconn(conn) && conn->lc_peer)
+  if (conn->lc_peer)
     {
       conn->lc_peer->lc_peer = NULL;
       conn->lc_peer = NULL;


### PR DESCRIPTION
## Summary
now the lc_path of the client will not be the same as that of the server. therefore, accept->peer = NULL will not be set when the client release the conn, then when release accept conn, set
client->peer(accept->peer->peer) = NULL will cause used after free.

## Impact

## Testing
sim:local

