### PR TITLE
sim_uart: rm LF to CRLF convertion

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -778,15 +778,7 @@ void sim_uartinit(void)
 void up_nputs(const char *str, size_t len)
 {
 #ifdef USE_DEVCONSOLE
-  if (str[len - 1] == '\n')
-    {
-      uart_nputs(1, str, len - 1);
-      uart_nputs(1, "\r\n", 2);
-    }
-  else
-    {
-      uart_nputs(1, str, len);
-    }
+  uart_nputs(1, str, len);
 #endif
 }
 


### PR DESCRIPTION
LF to CRLF has been converted in syslog framework

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
rm LF to CRLF convertion

## Impact
syslog

## Testing
selftest



