### PR TITLE
kconfig: Add link parameters that can print remaining memory information

### DIFF
--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -229,6 +229,8 @@ if(CONFIG_DEBUG_LINK_MAP)
   add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
 endif()
 
+add_link_options(-Wl,--print-memory-usage)
+
 if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
 endif()

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -324,6 +324,7 @@ else
   endif
 
   LDFLAGS += --entry=__start
+  LDFLAGS += --print-memory-usage
 
 endif
 

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -195,6 +195,8 @@ ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)
     LDFLAGS += --no-warn-rwx-segments
   endif
+
+  LDFLAGS += --print-memory-usage
 endif
 
 # Add the builtin library

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -200,4 +200,6 @@ if(CONFIG_ARCH_TOOLCHAIN_GNU)
   if(GCCVER GREATER_EQUAL 12)
     add_link_options(-Wl,--no-warn-rwx-segments)
   endif()
+
+  add_link_options(-Wl,--print-memory-usage)
 endif()

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -104,6 +104,7 @@ elseif(CONFIG_LTO_FULL)
   if(CONFIG_ARCH_TOOLCHAIN_GNU)
     add_compile_options(-fno-builtin)
     add_compile_options(-fuse-linker-plugin)
+    add_link_options(-wl,--print-memory-usage)
   endif()
 endif()
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -382,6 +382,7 @@ else
     endif
   endif
 
+  LDFLAGS += --print-memory-usage
 endif
 
 # Add the builtin library


### PR DESCRIPTION
## Summary
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      284272 B       512 KB     54.22%
           sram1:       13296 B         2 MB      0.63%
           sram2:          0 GB         2 MB      0.00%
CP: nuttx.hex
CP: nuttx.bin
## Impact
## Testing