### PR TITLE
sched/task_exit.c: Refresh current CPU instead of relying on stale value

### DIFF
--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -76,17 +76,11 @@ int nxtask_exit(void)
   FAR struct tcb_s *rtcb;
   int ret;
 #ifdef CONFIG_SMP
-  int cpu;
-
-  /* Get the current CPU.  By assumption, we are within a critical section
-   * and, hence, the CPU index will remain stable.
-   *
-   * Avoid using this_task() because it may assume a state that is not
+  /* Avoid using this_task() because it may assume a state that is not
    * appropriate for an exiting task.
    */
 
-  cpu  = this_cpu();
-  dtcb = current_task(cpu);
+  dtcb = current_task(this_cpu());
 #else
   dtcb = this_task();
 #endif
@@ -111,7 +105,7 @@ int nxtask_exit(void)
   /* Get the new task at the head of the ready to run list */
 
 #ifdef CONFIG_SMP
-  rtcb = current_task(cpu);
+  rtcb = current_task(this_cpu());
 #else
   rtcb = this_task();
 #endif


### PR DESCRIPTION
## Summary

The comment about the CPU index remaining stable is incorrect. There is no guarantee the task does not yield during the exit process, meaning the CPU can most definitely change. Also, there is no reason why it should not be allowed to change -> refresh current CPU ID whenever is used.

This fixes a full system crash during process exit when the CPU changes and we query the current task from the old CPU.

## Impact

Fix task/process exit logic, when CONFIG_SMP=y. No other parts are affected.

## Testing

qemu-rv:ksmp64
Unpublished MPFS SMP target
