### PR TITLE
arhc/arm64: vector table may be far away form arm64_fatal_handle

### DIFF
--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -141,7 +141,7 @@ SECTION_FUNC(text, arm64_sync_exc)
 
     /* if this is a svc call ?*/
 
-    bne    arm64_fatal_handler
+    bne    2f
 
 #ifdef CONFIG_LIB_SYSCALL
     /* Handle user system calls separately */
@@ -189,6 +189,10 @@ reserved_syscall:
 
     mov    sp, x0
     b      arm64_exit_exception
+2:
+    adrp   x5, arm64_fatal_handler
+    add    x5, x5, #:lo12:arm64_fatal_handler
+    br     x5
 
 /****************************************************************************
  * Name: arm64_irq_handler
@@ -232,8 +236,10 @@ SECTION_FUNC(text, arm64_irq_handler)
 
 GTEXT(arm64_serror_handler)
 SECTION_FUNC(text, arm64_serror_handler)
-    mov    x0, sp
-    bl     arm64_fatal_handler
+    mov   x0, sp
+    adrp  x5, arm64_fatal_handler
+    add   x5, x5, #:lo12:arm64_fatal_handler
+    br    x5
     /* Return here only in case of recoverable error */
 
     b      arm64_exit_exception
@@ -249,7 +255,9 @@ SECTION_FUNC(text, arm64_serror_handler)
 GTEXT(arm64_mode32_handler)
 SECTION_FUNC(text, arm64_mode32_handler)
     mov    x0, sp
-    bl     arm64_fatal_handler
+    adrp  x5, arm64_fatal_handler
+    add   x5, x5, #:lo12:arm64_fatal_handler
+    br     x5
     /* Return here only in case of recoverable error */
 
     b      arm64_exit_exception
@@ -267,7 +275,9 @@ SECTION_FUNC(text, arm64_fiq_handler)
 #ifndef CONFIG_ARM64_DECODEFIQ
 
     mov    x0, sp
-    bl     arm64_fatal_handler
+    adrp  x5, arm64_fatal_handler
+    add   x5, x5, #:lo12:arm64_fatal_handler
+    br     x5
 
     /* Return here only in case of recoverable error */
 


### PR DESCRIPTION
use 33-bit (+/-4GB) pc-relative addressing to load the address of arm64_fatal_handle
Some project，the vector table in TCM， but the arm64_fatal_handle in ddr，this case 
vector table may be far away form arm64_fatal_handle

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*


## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


