### PR TITLE
libcxx: fix compile error

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -35,7 +35,7 @@
 #include <nuttx/compiler.h>
 #include <langinfo.h>
 
-#ifndef _MSC_VER
+#ifdef CONFIG_LIBCXXTOOLCHAIN
 
 /* GNU libstdc++ is expecting ctype.h to define a few macros for
  * locale related functions like C++ streams.

--- a/libs/libc/ctype/lib_ctype.c
+++ b/libs/libc/ctype/lib_ctype.c
@@ -32,7 +32,7 @@
  * Macro Definitions
  ****************************************************************************/
 
-#if defined(_MSC_VER)
+#ifndef CONFIG_LIBCXXTOOLCHAIN
 
 /* MSVC seems to conflict with theses macro if defined in the public area.
  * As such, they are defined in the private section to let NuttX build
@@ -47,7 +47,7 @@
 #define _X  0100
 #define _B  0200
 
-#endif
+#else
 
 /****************************************************************************
  * Private Types
@@ -98,3 +98,6 @@ const char _ctype_[] =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#endif
+


### PR DESCRIPTION
## Summary

libcxx: fix compile error

from ServiceManager.cpp:17:
/home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/ndk/include_cpp/android/binder_to_string.h:71:24: error: expected nested-name-specifier before numeric constant
   71 |     template <typename _U>
      |                        ^~
/home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/ndk/include_cpp/android/binder_to_string.h:71:24: error: expected ‘>’ before numeric constant
In file included from /home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ConnectionInfo.h:3,
                 from /home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceManager.h:3,
                 from /home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/aidl/android/os/BnServiceManager.h:4:
/home/ligd/platform/dev/apps/external/android/frameworks/native/libs/binder/ndk/include_cpp/android/binder_to_string.h:72:56: error: no matching function for call to ‘declval<1>()’
   72 |     static auto _test(int) -> decltype(std::declval<_U>().toString(), std::true_type());
      |                                        ~~~~~~~~~~~~~~~~^~
In file included from /home/ligd/platform/dev/nuttx/include/libcxx/__type_traits/is_convertible.h:18,

## Impact

CI

## Testing

CI


