### PR TITLE
[BREAKING] types.h: time_t as int64_t

### DIFF
--- a/arch/sim/src/sim/sim_oneshot.c
+++ b/arch/sim/src/sim/sim_oneshot.c
@@ -132,7 +132,7 @@ static inline void sim_timer_current(struct timespec *ts)
 
 static inline void sim_reset_alarm(struct timespec *alarm)
 {
-  alarm->tv_sec  = UINT_MAX;
+  alarm->tv_sec  = INT_MAX;
   alarm->tv_nsec = NSEC_PER_SEC - 1;
 }
 
@@ -281,7 +281,7 @@ static int sim_max_delay(struct oneshot_lowerhalf_s *lower,
 {
   DEBUGASSERT(ts != NULL);
 
-  ts->tv_sec  = UINT_MAX;
+  ts->tv_sec  = INT_MAX;
   ts->tv_nsec = NSEC_PER_SEC - 1;
   return OK;
 }

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -251,10 +251,10 @@ typedef uint16_t     sa_family_t;
 
 #ifdef CONFIG_SYSTEM_TIME64
 typedef uint64_t     clock_t;
-typedef uint64_t     time_t;         /* Holds time in seconds */
+typedef int64_t      time_t;         /* Holds time in seconds */
 #else
 typedef uint32_t     clock_t;
-typedef uint32_t     time_t;         /* Holds time in seconds */
+typedef int32_t      time_t;         /* Holds time in seconds */
 #endif
 typedef int          clockid_t;      /* Identifies one time base source */
 typedef FAR void    *timer_t;        /* Represents one POSIX timer */


### PR DESCRIPTION
## Summary

types.h: time_t as int64_t

The following code will generate errors:
auto now = time(nullptr);
auto last_active_time = GetEventService(self->ctx_)->getActiveTime(); if (last_active_time + 60 * 1000 / 1000 <= now) {

src/ams/../controller/controller_timer.h: In lambda function: src/ams/../controller/controller_timer.h:117:57: warning: comparison of integer expressions of different signedness: 'long long int' and 'long long unsigned int' [-Wsign-compare]
  117 |                 if (last_active_time + 60 * 1000 / 1000 <= now) {


ref:
https://www.gnu.org/software/libc/manual/html_node/Time-Types.html
    
On POSIX-conformant systems, time_t is an integer type.

Advantage:
For the most POSIX applications they assume the time_t as signed and do compare with 0.
The code will become more compatible after this modification.

Disadvantage:
year 2038 problem


Someone think time_t will be overflow when set int32_t, should think his code should open TIME64 or handle the overflow himself.

## Impact

32 bit time_t is now signed
This will cause Y2038 problem, if your system has this problem, you should open TIME64 or handle the overflow.
 ‘ put things right once and for all ’

## Testing

CI


