### PR TITLE
sim: fix asan address space conflict

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -287,9 +287,9 @@ ifeq ($(CONFIG_HOST_MACOS),y)
 else
   LDFLAGS += -Wl,--gc-sections
 
-  # Let the symbol table link from 0x400000
+  # Let the symbol table link from 0x50000000
   # which is more convenient for debugging.
-  LDFLAGS += -Wl,-Ttext-segment=0x400000
+  LDFLAGS += -Wl,-Ttext-segment=0x50000000
 endif
 
 ifeq ($(CONFIG_DEBUG_LINK_MAP),y)


### PR DESCRIPTION
## Summary
sim: fix asan address space conflict
Modify the starting position of the elf segment to 0x5000000

==2561587==Shadow memory range interleaves with an existing memory mapping. ASan cannot proceed correctly. ABORTING. ==2561587==ASan shadow was supposed to be located in the [0x1ffff000-0x3fffffff] range. ==2561587==Process memory map follows:
## Impact

## Testing
sim
