### PR TITLE
fs/mnemofs: Fix extra log unused value error.

### DIFF
--- a/fs/mnemofs/mnemofs.h
+++ b/fs/mnemofs/mnemofs.h
@@ -98,11 +98,11 @@
 #define MFS_JRNL_LIM(sb)           (MFS_JRNL(sb).n_blks / 2)
 #define MFS_TRAVERSE_INITSZ        8
 
-#define MFS_LOG                    finfo
+#define MFS_LOG(fmt, ...)          finfo(fmt, ##__VA_ARGS__)
 #ifdef CONFIG_MNEMOFS_EXTRA_DEBUG
-#define MFS_EXTRA_LOG              finfo
+#define MFS_EXTRA_LOG(fmt, ...)    MFS_LOG(fmt, ##__VA_ARGS__)
 #else
-#define MFS_EXTRA_LOG
+#define MFS_EXTRA_LOG(fmt, ...)    { }
 #endif
 #define MFS_STRLITCMP(a, lit)      strncmp(a, lit, strlen(lit))
 


### PR DESCRIPTION
Fix the unused value error for when extra logs are OFF.

## Summary

This PR fixes the unused value error when extra logs are configured to be OFF in mnemofs. This issue occurs because initially the `MFS_EXTRA_LOG` was defined to be nothing when configured OFF, but configured to be `finfo` when turned on.

This meant when it was OFF, the contents inside the `()` were still present, but without the macro wrapper, which caused the compilation error.

## Impact

The users can now turn OFF the extra logs without compilation errors.

## Testing

The error was recognized by [this GitHub action](https://github.com/apache/nuttx/actions/runs/11459507141/job/31884231071?pr=14449).

I confirm that changes are verified on local setup and works as intended:

Build Host(s): OS (Linux), CPU(Intel), compiler(GCC 13).
Target(s): arch(sim), sim:mnemofs.

