### PR TITLE
remove unused variable 'cpu_freq'

### DIFF
--- a/arch/arm64/src/common/arm64_perf.c
+++ b/arch/arm64/src/common/arm64_perf.c
@@ -74,7 +74,6 @@ clock_t up_perf_gettime(void)
 void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
   clock_t left;
-  unsigned long cpu_freq = read_sysreg(cntfrq_el0);
 
   ts->tv_sec  = elapsed / g_cpu_freq;
   left        = elapsed - ts->tv_sec * g_cpu_freq;


### PR DESCRIPTION
1. remove unused variable 'cpu_freq'


## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


