### PR TITLE
arm64/toolchains:Add the following kasan compilation options

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -82,6 +82,14 @@ ifeq ($(CONFIG_MM_KASAN_GLOBAL),y)
   ARCHOPTIMIZATION += --param asan-globals=1
 endif
 
+ifeq ($(CONFIG_MM_KASAN_DISABLE_READS_CHECK),y)
+  ARCHOPTIMIZATION += --param asan-instrument-reads=0
+endif
+
+ifeq ($(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK),y)
+  ARCHOPTIMIZATION += --param asan-instrument-writes=0
+endif
+
 # Instrumentation options
 
 ifeq ($(CONFIG_ARCH_INSTRUMENT_ALL),y)


### PR DESCRIPTION
## Summary
1. --param asan-instrument-reads=0 and --param asan-instrument-writes=0 is supported in arm64, they have been added in other  arch toolchain.defs
## Impact

## Testing


