### PR TITLE
clang:libclang_rt.builtins-xxx.a supports builtin

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2774,6 +2774,7 @@ source "libs/libc/Kconfig"
 source "libs/libm/Kconfig"
 source "libs/libxx/Kconfig"
 source "libs/libdsp/Kconfig"
+source "libs/libbuiltin/Kconfig"
 endmenu
 
 menu "Open Asymmetric Multi Processing"

--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -45,8 +45,8 @@ if(TOOLCHAIN_CLANG_CONFIG)
   execute_process(COMMAND clang --version
                   OUTPUT_VARIABLE clang_full_version_string)
 
-  string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" CLANGVER
-                       ${clang_full_version_string})
+  string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+\.[0-9]+).*" "\\1"
+                       CLANGVER ${clang_full_version_string})
 
   if(CLANGVER STREQUAL "14.0")
     set(TOOLCHAIN_CLANG_CONFIG ${TOOLCHAIN_CLANG_CONFIG}_nosys)
@@ -237,11 +237,24 @@ set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
 
 set(NUTTX_FIND_TOOLCHAIN_LIB_DEFINED true)
 
-function(nuttx_find_toolchain_lib)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_lib_path)
-  nuttx_add_extra_library(${extra_lib_path})
-endfunction()
+if(CONFIG_BUILTIN_TOOLCHAIN)
+  function(nuttx_find_toolchain_lib)
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+              --print-file-name
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE extra_lib_path)
+    nuttx_add_extra_library(${extra_lib_path})
+  endfunction()
+else()
+  function(nuttx_find_toolchain_lib)
+    if(ARGN)
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+                --print-file-name=${ARGN}
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE extra_lib_path)
+    endif()
+    nuttx_add_extra_library(${extra_lib_path})
+  endfunction()
+endif()

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -206,7 +206,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifneq ($(TOOLCHAIN_CLANG_CONFIG),)
     ifeq ($(CLANGVER),)
-      export CLANGVER := $(shell $(CC) --version | grep "clang version" | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/")
+      export CLANGVER := $(shell $(CC) --version | grep "clang version" | sed -E "s/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/")
     endif
 
     ifeq ($(CLANGVER),14.0)
@@ -448,14 +448,18 @@ endif
 
 # Add the builtin library
 
-COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
-ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
-  ifeq ($(wildcard $(COMPILER_RT_LIB)),)
-    # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
-    # then go ahead and try "--print-file-name"
-    COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),y)
+  COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
+  ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
+    ifeq ($(wildcard $(COMPILER_RT_LIB)),)
+      # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+      # then go ahead and try "--print-file-name"
+      COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+    endif
   endif
-else ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
+endif
+
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
   GHS_ROOT_PATH = $(shell which $(CC) | awk -F '/[^/]*$$' '{print $$1}')
   COMPILER_RT_LIB := -l$(GHS_ROOT_PATH)/lib/thumb2/libarch
   ifeq ($(CONFIG_ARCH_FPU),y)

--- a/libs/libbuiltin/.gitignore
+++ b/libs/libbuiltin/.gitignore
@@ -1,0 +1,3 @@
+compiler-rt-*.src.tar.xz
+*.o
+.depend

--- a/libs/libbuiltin/CMakeLists.txt
+++ b/libs/libbuiltin/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# libs/libbuiltin/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# Include the uClibc++ Make.defs file if selected.  If it is included, the
+# uClibc++/Make.defs file will add its files to the source file list, add its
+# DEPPATH info, and will add the appropriate paths to the VPATH variable
+#
+# Note that an error will occur if you select CONFIG_LIBXX_UCLIBCXX without
+# installing the uClibc++ package.  This is intentional to let you know about
+# the configuration problem.  Refer to the README.txt file in the NuttX uClibc++
+# GIT repository for more information
+
+nuttx_add_subdirectory()

--- a/libs/libbuiltin/Kconfig
+++ b/libs/libbuiltin/Kconfig
@@ -1,0 +1,36 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+comment "Toolchain Library Support"
+
+choice
+	prompt "Builtin toolchain support"
+	default BUILTIN_TOOLCHAIN
+	---help---
+		Choose to compile libraries related to toolchain into the OS
+
+config BUILTIN_COMPILER_RT
+	bool "Builtin LLVM Compiler-rt"
+	---help---
+		Compile the LLVM Compiler-rt library into the OS.
+
+config BUILTIN_TOOLCHAIN
+	bool "Link the toolchain library"
+	---help---
+		Use the toolchain library that comes with the compiler
+
+endchoice
+
+if BUILTIN_COMPILER_RT
+
+config COMPILER_RT_VERSION
+	string "Select LLVM Compiler-rt version"
+	default "17.0.1"
+
+config COMPILER_RT_HAS_BFLOAT16
+	bool "Enable support for bfloat16 in Compiler-rt"
+	default n
+
+endif # BUILTIN_COMPILER_RT

--- a/libs/libbuiltin/Makefile
+++ b/libs/libbuiltin/Makefile
@@ -1,0 +1,83 @@
+############################################################################
+# libs/libbuiltin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
+include compiler-rt/Make.defs
+endif
+
+BIN ?= libbuiltin$(LIBEXT)
+BINDIR ?= bin
+
+KBIN = libkbuiltin$(LIBEXT)
+KBINDIR = kbin
+
+AOBJS = $(addprefix $(BINDIR)$(DELIM), $(ASRCS:.S=$(OBJEXT)))
+COBJS = $(addprefix $(BINDIR)$(DELIM), $(CSRCS:.c=$(OBJEXT)))
+CXXOBJS = $(addprefix $(BINDIR)$(DELIM), $(CXXSRCS:.cxx=$(OBJEXT)))
+CPPOBJS = $(addprefix $(BINDIR)$(DELIM), $(CPPSRCS:.cpp=$(OBJEXT)))
+
+SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(CPPSRCS)
+OBJS = $(AOBJS) $(COBJS) $(CXXOBJS) $(CPPOBJS)
+
+all: $(OBJS)
+	$(call ARCHIVE, $(BIN), $(OBJS))
+
+.PHONY: depend clean distclean context $(LIBBUILTIN)
+
+$(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(CXXOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cxx
+	$(call COMPILEXX, $<, $@)
+
+$(CPPOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cpp
+	$(call COMPILEXX, $<, $@)
+
+context::
+
+.depend: $(LIBBUILTIN)
+	$(Q) touch $@
+
+depend: .depend
+
+$(BIN): depend
+	$(Q) $(MAKE) all EXTRAFLAGS="$(EXTRAFLAGS)"
+
+# C library for the kernel phase of the two-pass kernel build
+
+ifneq ($(BIN),$(KBIN))
+$(KBIN): $(OBJS)
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=$(KBINDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+endif
+
+clean:
+	$(call DELFILE, $(BIN))
+	$(Q) $(MAKE) -C bin  clean
+	$(Q) $(MAKE) -C kbin clean
+
+distclean: clean
+	$(Q) $(MAKE) -C bin  distclean
+	$(Q) $(MAKE) -C kbin distclean
+	$(call DELFILE, .depend)

--- a/libs/libbuiltin/bin/Makefile
+++ b/libs/libbuiltin/bin/Makefile
@@ -1,0 +1,35 @@
+############################################################################
+# libs/libbuiltin/bin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+all:
+.PHONY: clean distclean
+
+# Clean Targets:
+
+clean:
+	$(call DELFILE, *.o)
+
+# Deep clean -- removes all traces of the configuration
+
+distclean: clean
+	$(call DELFILE, *.dep)
+	$(call DELFILE, .depend)

--- a/libs/libbuiltin/compiler-rt/.gitignore
+++ b/libs/libbuiltin/compiler-rt/.gitignore
@@ -1,0 +1,1 @@
+/compiler-rt

--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -1,0 +1,438 @@
+# ##############################################################################
+# libs/libbuiltin/compiler-rt/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BUILTIN_COMPILER_RT)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/compiler-rt)
+
+    set(COMPILER_RT_VERSION ${CONFIG_COMPILER_RT_VERSION})
+
+    FetchContent_Declare(
+      compiler-rt
+      DOWNLOAD_NAME "compiler-rt-${COMPILER_RT_VERSION}.src.tar.xz"
+      DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
+      URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${COMPILER_RT_VERSION}/compiler-rt-${COMPILER_RT_VERSION}.src.tar.xz"
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/compiler-rt
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/libs/libbuiltin/compiler-rt
+          CONFIGURE_COMMAND
+          ""
+          BUILD_COMMAND
+          ""
+          INSTALL_COMMAND
+          ""
+          TEST_COMMAND
+          ""
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 100)
+
+    FetchContent_GetProperties(compiler-rt)
+
+    if(NOT compiler-rt_POPULATED)
+      FetchContent_Populate(compiler-rt)
+    endif()
+
+  endif()
+
+  nuttx_add_system_library(compiler-rt)
+
+  list(APPEND INCDIR ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/include)
+  list(APPEND INCDIR ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins)
+
+  # Arithmetic operations
+  set(RT_BUILTIN_SRCS
+      absvdi2.c
+      absvsi2.c
+      absvti2.c
+      adddf3.c
+      addtf3.c
+      addvdi3.c
+      addvsi3.c
+      addvti3.c
+      muldc3.c
+      muldf3.c
+      muldi3.c
+      mulodi4.c
+      mulosi4.c
+      muloti4.c
+      mulsc3.c
+      mulsf3.c
+      multc3.c
+      multf3.c
+      multi3.c
+      mulvdi3.c
+      mulvsi3.c
+      mulvti3.c
+      mulxc3.c
+      negdf2.c
+      negdi2.c
+      negsf2.c
+      negti2.c
+      negvdi2.c
+      negvsi2.c
+      negvti2.c
+      subdf3.c
+      subsf3.c
+      subtf3.c
+      subvdi3.c
+      subvsi3.c
+      subvti3.c)
+
+  # Floating point operations
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    floatdidf.c
+    floatdisf.c
+    floatditf.c
+    floatdixf.c
+    floatsidf.c
+    floatsisf.c
+    floatsitf.c
+    floattidf.c
+    floattisf.c
+    floattitf.c
+    floattixf.c
+    floatundidf.c
+    floatundisf.c
+    floatunditf.c
+    floatundixf.c
+    floatunsidf.c
+    floatunsisf.c
+    floatunsitf.c
+    floatuntidf.c
+    floatuntisf.c
+    floatuntitf.c
+    floatuntixf.c)
+
+  # Conversion and expansion operations
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    fixtfdi.c
+    fixtfsi.c
+    fixtfti.c
+    fixunsdfdi.c
+    fixunsdfsi.c
+    fixunsdfti.c
+    fixunssfdi.c
+    fixunssfsi.c
+    fixunssfti.c
+    fixunstfdi.c
+    fixunstfsi.c
+    fixunstfti.c
+    fixunsxfdi.c
+    fixunsxfsi.c
+    fixunsxfti.c
+    fixxfdi.c
+    fixxfti.c
+    extenddftf2.c
+    extendhfsf2.c
+    extendhftf2.c
+    extendsfdf2.c
+    extendsftf2.c
+    truncdfhf2.c
+    truncdfsf2.c
+    truncsfhf2.c
+    trunctfdf2.c
+    trunctfhf2.c
+    trunctfsf2.c)
+
+  # Bit manipulation operations
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    ashldi3.c
+    ashlti3.c
+    ashrdi3.c
+    ashrti3.c
+    clzti2.c
+    ctzdi2.c
+    ctzsi2.c
+    ctzti2.c
+    lshrdi3.c
+    lshrti3.c
+    popcountdi2.c
+    popcountsi2.c
+    popcountti2.c
+    paritydi2.c
+    paritysi2.c
+    parityti2.c)
+
+  # Division and modulo operations
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    divdc3.c
+    divdf3.c
+    divdi3.c
+    divmoddi4.c
+    divmodti4.c
+    divsc3.c
+    divsf3.c
+    divtc3.c
+    divtf3.c
+    divti3.c
+    divxc3.c
+    moddi3.c
+    modti3.c
+    udivdi3.c
+    udivmoddi4.c
+    udivmodti4.c
+    udivti3.c
+    umoddi3.c
+    umodti3.c)
+
+  # Atomic operations
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    atomic.c
+    atomic_flag_clear.c
+    atomic_flag_clear_explicit.c
+    atomic_flag_test_and_set.c
+    atomic_flag_test_and_set_explicit.c
+    atomic_signal_fence.c
+    atomic_thread_fence.c)
+
+  # Other function related files
+  list(
+    APPEND
+    RT_BUILTIN_SRCS
+    apple_versioning.c
+    clear_cache.c
+    cmpdi2.c
+    cmpti2.c
+    comparedf2.c
+    comparetf2.c
+    cpu_model.c
+    emutls.c
+    enable_execute_stack.c
+    eprintf.c
+    fp_mode.c
+    gcc_personality_v0.c
+    int_util.c
+    os_version_check.c
+    trampoline_setup.c
+    ucmpdi2.c
+    ucmpti2.c
+    powidf2.c
+    powisf2.c
+    powitf2.c
+    powixf2.c)
+
+  set(RT_BUILTIN_ARCH_SRCS)
+  # ARM-specific assembly files
+  if(CONFIG_ARCH_ARM)
+    set(RT_BUILTIN_ARCH arm)
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      adddf3vfp.S
+      addsf3.S
+      addsf3vfp.S
+      divmodsi4.S
+      divsi3.S
+      modsi3.S
+      subdf3vfp.S
+      subsf3vfp.S
+      muldf3vfp.S
+      mulsf3vfp.S
+      negdf2vfp.S
+      negsf2vfp.S)
+
+    # Floating-Point Operations
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      comparesf2.S
+      eqdf2vfp.S
+      eqsf2vfp.S
+      extendsfdf2vfp.S
+      fixdfsivfp.S
+      fixsfsivfp.S
+      fixunsdfsivfp.S
+      fixunssfsivfp.S
+      floatsidfvfp.S
+      floatsisfvfp.S
+      floatunssidfvfp.S
+      floatunssisfvfp.S
+      gedf2vfp.S
+      gesf2vfp.S
+      gtdf2vfp.S
+      gtsf2vfp.S
+      ledf2vfp.S
+      lesf2vfp.S
+      ltdf2vfp.S
+      ltsf2vfp.S
+      nedf2vfp.S
+      nesf2vfp.S
+      truncdfsf2vfp.S
+      unorddf2vfp.S
+      unordsf2vfp.S)
+
+    # Synchronization operations
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      sync_fetch_and_add_4.S
+      sync_fetch_and_add_8.S
+      sync_fetch_and_and_4.S
+      sync_fetch_and_and_8.S
+      sync_fetch_and_max_4.S
+      sync_fetch_and_max_8.S
+      sync_fetch_and_min_4.S
+      sync_fetch_and_min_8.S
+      sync_fetch_and_nand_4.S
+      sync_fetch_and_nand_8.S
+      sync_fetch_and_or_4.S
+      sync_fetch_and_or_8.S
+      sync_fetch_and_sub_4.S
+      sync_fetch_and_sub_8.S
+      sync_fetch_and_umax_4.S
+      sync_fetch_and_umax_8.S
+      sync_fetch_and_umin_4.S
+      sync_fetch_and_umin_8.S
+      sync_fetch_and_xor_4.S
+      sync_fetch_and_xor_8.S
+      sync_synchronize.S)
+
+    # Memory operations
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      aeabi_memcmp.S
+      aeabi_memcpy.S
+      aeabi_memmove.S
+      aeabi_memset.S
+      restore_vfp_d8_d15_regs.S
+      save_vfp_d8_d15_regs.S)
+
+    # Division and Modulus Operations
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      aeabi_idivmod.S
+      aeabi_ldivmod.S
+      aeabi_uidivmod.S
+      aeabi_uldivmod.S
+      udivmodsi4.S
+      udivsi3.S
+      umodsi3.S)
+
+    # Bitwise and Other Operations
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      bswapdi2.S
+      bswapsi2.S
+      chkstk.S
+      clzdi2.S
+      clzsi2.S)
+
+    # Branch and Control Flow
+    list(APPEND RT_BUILTIN_ARCH_SRCS switch16.S switch32.S switch8.S switchu8.S)
+
+  else()
+
+    # Other architectures
+    list(
+      APPEND
+      RT_BUILTIN_SRCS
+      addsf3.c
+      divsi3.c
+      modsi3.c
+      bswapdi2.c
+      bswapsi2.c
+      clzdi2.c
+      clzsi2.c
+      divmodsi4.c
+      udivmodsi4.c
+      udivsi3.c
+      umodsi3.c
+      comparesf2.c)
+
+  endif()
+
+  if(CONFIG_ARCH_ARM64)
+    set(ARCH "aarch64")
+    list(APPEND RT_BUILTIN_ARCH_SRCS chkstk.S lse.S fp_mode.c)
+  elseif(CONFIG_ARCH_RISCV)
+    set(ARCH "riscv")
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      muldi3.S
+      mulsi3.S
+      restore.S
+      save.S
+      fp_mode.c)
+  else()
+    list(APPEND RT_BUILTIN_SRCS muldi3.c)
+  endif()
+
+  if(CONFIG_ARCH_X86_64)
+    set(ARCH "x86_64")
+    list(
+      APPEND
+      RT_BUILTIN_ARCH_SRCS
+      chkstk2.S
+      chkstk.S
+      floatundidf.S
+      floatundisf.S
+      floatundixf.S
+      floatdidf.c
+      floatdisf.c
+      floatdixf.c)
+  else()
+    list(APPEND RT_BUILTIN_SRCS floatundidf.c floatundisf.c floatundixf.c)
+  endif()
+
+  list(APPEND INCDIR
+       ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${RT_BUILTIN_ARCH})
+
+  foreach(src ${RT_BUILTIN_SRCS})
+    string(PREPEND src ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/)
+    list(APPEND COMPILER_RT_SRCS ${src})
+  endforeach()
+
+  foreach(src ${RT_BUILTIN_ARCH_SRCS})
+    string(
+      PREPEND src
+      ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${RT_BUILTIN_ARCH}/)
+    list(APPEND COMPILER_RT_SRCS ${src})
+  endforeach()
+
+  # Add the sources to the target
+  target_sources(compiler-rt PRIVATE ${COMPILER_RT_SRCS})
+
+  target_compile_options(
+    compiler-rt
+    PRIVATE -Wno-shift-count-negative
+            -Wno-constant-conversion
+            -Wshift-count-overflow
+            -Wno-undef
+            -Wno-incompatible-pointer-types
+            -Wno-visibility
+            -Wno-macro-redefined)
+
+  target_include_directories(compiler-rt PRIVATE ${INCDIR})
+endif()

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -1,0 +1,162 @@
+############################################################################
+# libs/libbuiltin/compiler-rt/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(TOPDIR)/Make.defs
+
+LIBBUILTIN += compiler-rt
+
+COMPILER_RT_VERSION=$(CONFIG_COMPILER_RT_VERSION)
+
+ifeq ($(wildcard compiler-rt/compiler-rt/lib),)
+compiler-rt-$(COMPILER_RT_VERSION).src.tar.xz:
+	$(call DOWNLOAD,https://github.com/llvm/llvm-project/releases/download/llvmorg-$(COMPILER_RT_VERSION),$@)
+
+compiler-rt/compiler-rt: compiler-rt-$(COMPILER_RT_VERSION).src.tar.xz
+	$(Q) tar -xf $<
+	$(Q) mv compiler-rt-$(COMPILER_RT_VERSION).src $@
+	$(call DELDIR, $<)
+
+compiler-rt: compiler-rt/compiler-rt
+endif
+
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/include
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins
+FLAGS += -Wno-shift-count-negative -Wno-constant-conversion -Wshift-count-overflow
+FLAGS += -Wno-undef -Wno-incompatible-pointer-types -Wno-visibility -Wno-macro-redefined
+
+################# Builtin Library #################
+
+# Files related to arithmetic operations
+CSRCS += absvdi2.c absvsi2.c absvti2.c adddf3.c addtf3.c addvdi3.c addvsi3.c addvti3.c \
+         muldc3.c muldf3.c mulodi4.c mulosi4.c muloti4.c mulsc3.c mulsf3.c multc3.c multf3.c \
+         multi3.c mulvdi3.c mulvsi3.c mulvti3.c mulxc3.c negdf2.c negdi2.c negsf2.c negti2.c \
+         negvdi2.c negvsi2.c negvti2.c subdf3.c subsf3.c subtf3.c subvdi3.c subvsi3.c subvti3.c
+
+# Floating point processing related files
+CSRCS += floatdidf.c floatdisf.c floatditf.c floatdixf.c floatsidf.c floatsisf.c floatsitf.c \
+         floattidf.c floattisf.c floattitf.c floattixf.c floatunditf.c \
+         floatunsidf.c floatunsisf.c floatunsitf.c floatuntidf.c floatuntisf.c \
+         floatuntitf.c floatuntixf.c
+
+# Convert and expand related files
+CSRCS += fixtfdi.c fixtfsi.c fixtfti.c fixunsdfdi.c fixunsdfsi.c fixunsdfti.c fixunssfdi.c \
+         fixunssfsi.c fixunssfti.c fixunstfdi.c fixunstfsi.c fixunstfti.c fixunsxfdi.c fixunsxfsi.c \
+         fixunsxfti.c fixxfdi.c fixxfti.c extenddftf2.c extendhfsf2.c extendhftf2.c extendsfdf2.c \
+         extendsftf2.c truncdfhf2.c truncdfsf2.c truncsfhf2.c \
+         trunctfdf2.c trunctfhf2.c trunctfsf2.c
+
+ifeq ($(CONFIG_COMPILER_RT_HAS_BFLOAT16),y)
+  CSRCS += truncdfbf2.c truncsfbf2.c
+endif
+
+# Bit manipulation related files
+CSRCS += ashldi3.c ashlti3.c ashrdi3.c ashrti3.c \
+         clzti2.c ctzdi2.c ctzsi2.c ctzti2.c lshrdi3.c lshrti3.c popcountdi2.c popcountsi2.c \
+         popcountti2.c paritydi2.c paritysi2.c parityti2.c
+
+# Files related to division and modulo operations
+CSRCS += divdc3.c divdf3.c divdi3.c divmoddi4.c divmodti4.c divsc3.c divsf3.c \
+         divtc3.c divtf3.c divti3.c divxc3.c moddi3.c modti3.c udivdi3.c udivmoddi4.c \
+         udivmodti4.c udivti3.c umoddi3.c umodti3.c
+
+# Files related to atomic operations
+CSRCS += atomic.c atomic_flag_clear.c atomic_flag_clear_explicit.c atomic_flag_test_and_set.c \
+         atomic_flag_test_and_set_explicit.c atomic_signal_fence.c atomic_thread_fence.c
+
+# Other function related files
+CSRCS += apple_versioning.c clear_cache.c cmpdi2.c cmpti2.c comparedf2.c comparetf2.c \
+         cpu_model.c emutls.c enable_execute_stack.c eprintf.c fp_mode.c gcc_personality_v0.c \
+         int_util.c os_version_check.c trampoline_setup.c ucmpdi2.c ucmpti2.c powidf2.c powisf2.c \
+         powitf2.c powixf2.c
+
+# Bit manipulation related arch
+ifeq ($(CONFIG_ARCH_ARM),y)
+  ARCH = arm
+  # Arithmetic Operations
+  ASRCS += adddf3vfp.S addsf3.S addsf3vfp.S divmodsi4.S divsi3.S modsi3.S subdf3vfp.S subsf3vfp.S \
+           muldf3vfp.S mulsf3vfp.S negdf2vfp.S negsf2vfp.S
+
+  # Floating-Point Operations
+  ASRCS += comparesf2.S eqdf2vfp.S eqsf2vfp.S extendsfdf2vfp.S fixdfsivfp.S fixsfsivfp.S \
+           fixunsdfsivfp.S fixunssfsivfp.S floatsidfvfp.S floatsisfvfp.S floatunssidfvfp.S \
+           floatunssisfvfp.S gedf2vfp.S gesf2vfp.S gtdf2vfp.S gtsf2vfp.S ledf2vfp.S lesf2vfp.S \
+           ltdf2vfp.S ltsf2vfp.S nedf2vfp.S nesf2vfp.S truncdfsf2vfp.S unorddf2vfp.S unordsf2vfp.S
+
+  # Synchronization Operations
+  ASRCS += sync_fetch_and_add_4.S sync_fetch_and_add_8.S sync_fetch_and_and_4.S sync_fetch_and_and_8.S \
+         sync_fetch_and_max_4.S sync_fetch_and_max_8.S sync_fetch_and_min_4.S sync_fetch_and_min_8.S \
+         sync_fetch_and_nand_4.S sync_fetch_and_nand_8.S sync_fetch_and_or_4.S sync_fetch_and_or_8.S \
+         sync_fetch_and_sub_4.S sync_fetch_and_sub_8.S sync_fetch_and_umax_4.S sync_fetch_and_umax_8.S \
+         sync_fetch_and_umin_4.S sync_fetch_and_umin_8.S sync_fetch_and_xor_4.S sync_fetch_and_xor_8.S \
+         sync_synchronize.S
+  # Memory Operations
+  ASRCS += aeabi_memcmp.S aeabi_memcpy.S aeabi_memmove.S aeabi_memset.S restore_vfp_d8_d15_regs.S \
+         save_vfp_d8_d15_regs.S
+
+  # Division and Modulus Operations
+  ASRCS += aeabi_idivmod.S aeabi_ldivmod.S aeabi_uidivmod.S aeabi_uldivmod.S udivmodsi4.S udivsi3.S umodsi3.S
+
+  # Bitwise and Other Operations
+  ASRCS += bswapdi2.S bswapsi2.S chkstk.S clzdi2.S clzsi2.S
+
+  # Branch and Control Flow
+  ASRCS += switch16.S switch32.S switch8.S switchu8.S
+
+  CSRCS += aeabi_cdcmpeq_check_nan.c aeabi_cfcmpeq_check_nan.c aeabi_div0.c aeabi_drsub.c aeabi_frsub.c
+else
+  CSRCS += addsf3.c divsi3.c modsi3.c
+  CSRCS += bswapdi2.c bswapsi2.c clzdi2.c clzsi2.c
+  CSRCS += divmodsi4.c udivmodsi4.c udivsi3.c umodsi3.c
+  CSRCS += comparesf2.c
+endif
+
+ifeq ($(CONFIG_ARCH_ARM64),y)
+  ARCH = aarch64
+  ASRCS += chkstk.S lse.S
+  CSRCS += fp_mode.c
+endif
+
+ifeq ($(CONFIG_ARCH_RISCV),y)
+  ARCH = riscv
+  ASRCS += muldi3.S mulsi3.S restore.S save.S
+  CSRCS += fp_mode.c
+else
+  CSRCS += muldi3.c
+endif
+
+ifeq ($(CONFIG_ARCH_X86_64),y)
+  ARCH = x86_64
+  ASRCS += chkstk2.S chkstk.S floatundidf.S floatundisf.S floatundixf.S
+  CSRCS += floatdidf.c floatdisf.c floatdixf.c
+else
+  CSRCS += floatundidf.c floatundisf.c floatundixf.c
+endif
+
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
+
+AFLAGS += $(FLAGS)
+CFLAGS += $(FLAGS)
+CXXFLAGS += $(FLAGS)
+
+DEPPATH += --dep-path compiler-rt/compiler-rt/lib/builtins/${ARCH}
+VPATH += :compiler-rt/compiler-rt/lib/builtins/${ARCH}
+
+DEPPATH += --dep-path compiler-rt/compiler-rt/lib/builtins
+VPATH += :compiler-rt/compiler-rt/lib/builtins

--- a/libs/libbuiltin/kbin/Makefile
+++ b/libs/libbuiltin/kbin/Makefile
@@ -1,0 +1,35 @@
+############################################################################
+# libs/libbuiltin/kbin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+all:
+.PHONY: clean distclean
+
+# Clean Targets:
+
+clean:
+	$(call DELFILE, *.o)
+
+# Deep clean -- removes all traces of the configuration
+
+distclean: clean
+	$(call DELFILE, *.dep)
+	$(call DELFILE, .depend)

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -68,6 +68,12 @@ ifeq ($(CONFIG_BUILD_FLAT),y)
 
 KERNDEPDIRS += libs$(DELIM)libc mm
 
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+KERNDEPDIRS += libs$(DELIM)libbuiltin
+else
+CLEANDIRS += libs$(DELIM)libbuiltin
+endif
+
 ifeq ($(CONFIG_LIBM_TOOLCHAIN)$(CONFIG_LIBM_NONE),)
 KERNDEPDIRS += libs$(DELIM)libm
 else
@@ -83,6 +89,12 @@ endif
 else
 
 USERDEPDIRS += libs$(DELIM)libc mm
+
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+USERDEPDIRS += libs$(DELIM)libbuiltin
+else
+CLEANDIRS += libs$(DELIM)libbuiltin
+endif
 
 ifeq ($(CONFIG_LIBM_TOOLCHAIN)$(CONFIG_LIBM_NONE),)
 USERDEPDIRS += libs$(DELIM)libm

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -50,6 +50,12 @@ NUTTXLIBS += staging$(DELIM)libc$(LIBEXT)
 NUTTXLIBS += staging$(DELIM)libmm$(LIBEXT)
 NUTTXLIBS += staging$(DELIM)libarch$(LIBEXT)
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add libraries for math support.
 
 ifeq ($(CONFIG_LIBM_TOOLCHAIN)$(CONFIG_LIBM_NONE),)

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -52,6 +52,13 @@ NUTTXLIBS += staging$(DELIM)libkmm$(LIBEXT) staging$(DELIM)libkarch$(LIBEXT)
 USERLIBS  += staging$(DELIM)libproxies$(LIBEXT) staging$(DELIM)libc$(LIBEXT)
 USERLIBS  += staging$(DELIM)libmm$(LIBEXT) staging$(DELIM)libarch$(LIBEXT)
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+NUTTXLIBS += staging$(DELIM)libkbuiltin$(LIBEXT)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add libraries for math support.
 
 ifeq ($(CONFIG_LIBM_TOOLCHAIN)$(CONFIG_LIBM_NONE),)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -25,6 +25,12 @@
 #
 # Possible kernel-mode builds
 
+libs$(DELIM)libbuiltin$(DELIM)libkbuiltin$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C libs$(DELIM)libbuiltin libkbuiltin$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+
+staging$(DELIM)libkbuiltin$(LIBEXT): libs$(DELIM)libbuiltin$(DELIM)libkbuiltin$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 libs$(DELIM)libc$(DELIM)libkc$(LIBEXT): pass2dep
 	$(Q) $(MAKE) -C libs$(DELIM)libc libkc$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
@@ -168,6 +174,16 @@ $(ARCH_SRC)$(DELIM)libarch$(LIBEXT): pass1dep
 endif
 
 staging$(DELIM)libarch$(LIBEXT): $(ARCH_SRC)$(DELIM)libarch$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
+ifeq ($(CONFIG_BUILD_FLAT),y)
+libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT): pass2dep
+else
+libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT): pass1dep
+endif
+	$(Q) $(MAKE) -C libs$(DELIM)libbuiltin libbuiltin$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+staging$(DELIM)libbuiltin$(LIBEXT): libs$(DELIM)libbuiltin$(DELIM)libbuiltin$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 # Possible user-mode builds

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -52,6 +52,13 @@ NUTTXLIBS += staging$(DELIM)libkmm$(LIBEXT) staging$(DELIM)libkarch$(LIBEXT)
 USERLIBS  += staging$(DELIM)libproxies$(LIBEXT) staging$(DELIM)libc$(LIBEXT)
 USERLIBS  += staging$(DELIM)libmm$(LIBEXT) staging$(DELIM)libarch$(LIBEXT)
 
+# Add toolchain library support
+
+ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+NUTTXLIBS += staging$(DELIM)libkbuiltin$(LIBEXT)
+USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
+endif
+
 # Add libraries for math support.
 
 ifeq ($(CONFIG_LIBM_TOOLCHAIN)$(CONFIG_LIBM_NONE),)


### PR DESCRIPTION
## Summary
    1. enable CONFIG_BUILTIN_COMPILER_RT  to built libclang_rt.builtins-xxx.a and no longer use the compiler's built-in
    2. Modify clang version acquisition to get two decimal points
    3. It has been ported to support four architectures: ARM, ARM64, RISCV, and x86_64, among which ARM has been validated
    4. Align the ported compile-rt library with the clang version downloaded by ci to 17.0.1
## Impact
## Testing
     There is a problem with testbuild.sh, which causes the config I uploaded using the clang compiler to fail verification. I will fix this problem in the next patch and upload a defconfig that supports compiling this builtin.