### PR TITLE
arm/build: suppress LOAD RWX linker warning

### DIFF
--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -66,7 +66,7 @@ if(CONFIG_ARCH_TOOLCHAIN_GNU)
 
   if(GCCVER GREATER_EQUAL 12)
     add_compile_options(--param=min-pagesize=0)
-    if(CONFIG_ARCH_RAMFUNCS)
+    if(CONFIG_ARCH_RAMFUNCS OR NOT CONFIG_BOOT_RUNFROMFLASH)
       add_link_options(-Wl,--no-warn-rwx-segments)
     endif()
   endif()

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -317,6 +317,8 @@ else
       ARCHOPTIMIZATION += --param=min-pagesize=0
       ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
         LDFLAGS += --no-warn-rwx-segments
+      else ifeq ($(CONFIG_BOOT_RUNFROMFLASH),)
+        LDFLAGS += --no-warn-rwx-segments
       endif
     endif
   endif


### PR DESCRIPTION
Add --no-warn-rwx-segments in case of RAM boot mode to linker to suppress the below warning:
"nuttx has a LOAD segment with RWX permissions"

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Suppress the warning message "nuttx has a LOAD segment with RWX permissions" in case of RAM boot mode is selected.
RAM MODE: BOOT_RUNFROMEXTSRAM/BOOT_RUNFROMISRAM/BOOT_RUNFROMSDRAM/BOOT_COPYTORAM

## Impact

"nuttx has a LOAD segment with RWX permissions" is suppressed

## Testing

Tested on company internal's project, BOOT_RUNFROMISRAM is selected. I can't find a proper board to reproduce the issue in master.

