### PR TITLE
modify_sysreg: modify name to keep consistent with Linux

### DIFF
--- a/arch/arm64/include/arch.h
+++ b/arch/arm64/include/arch.h
@@ -55,7 +55,7 @@
 
 /****************************************************************************
  * Name:
- *   read_/write_/zero_/modify_ sysreg
+ *   read_sysreg/write_sysreg/zero_sysreg/sysreg_clear_set
  *
  * Description:
  *
@@ -84,9 +84,13 @@
                       ::: "memory");                \
   })
 
-#define modify_sysreg(v,m,a)                        \
-  write_sysreg((read_sysreg(a) & ~(m)) |            \
-               ((uintptr_t)(v) & (m)), a)
+/* Modify bits in a sysreg. Bits in the clear mask are zeroed,
+ * then bits in the set mask are set. Other bits are left as-is.
+ */
+
+#define sysreg_clear_set(sysreg, clear, set)          \
+    write_sysreg((read_sysreg(sysreg) & ~(clear)) |   \
+                 ((uintptr_t)(set) & (clear)), sysreg)
 
 /****************************************************************************
  * Inline functions

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -396,7 +396,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 #define up_current_regs()      (this_task()->xcp.regs)
 #define up_this_task()         ((struct tcb_s *)(read_sysreg(tpidr_el1) & ~1ul))
-#define up_update_task(t)      modify_sysreg(t, ~1ul, tpidr_el1)
+#define up_update_task(t)      sysreg_clear_set(tpidr_el1, ~1ul, t)
 #define up_interrupt_context() (read_sysreg(tpidr_el1) & 1)
 
 #define up_switch_context(tcb, rtcb)                              \


### PR DESCRIPTION
## Summary
    /*
     * Modify bits in a sysreg. Bits in the clear mask are zeroed, then bits in the
     * set mask are set. Other bits are left as-is.
     */
    #define sysreg_clear_set(sysreg, clear, set) do {			\
	    u64 __scs_val = read_sysreg(sysreg);				\
	    u64 __scs_new = (__scs_val & ~(u64)(clear)) | (set);		\
	    if (__scs_new != __scs_val)					\
		    write_sysreg(__scs_new, sysreg);			\
    } while (0)
## Impact
None
## Testing
None

