### PR TITLE
Imx9 lpspi fixes

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -1323,7 +1323,7 @@ static void imx9_lpspi_exchange(struct spi_dev_s *dev,
 
   /* Convert the number of word to a number of bytes */
 
-  nbytes = (priv->nbits > 8) ? nwords << 2 : nwords;
+  nbytes = (priv->nbits > 8) ? nwords << 1 : nwords;
 
   /* Invalid DMA channels fall back to non-DMA method. */
 
@@ -1404,7 +1404,7 @@ static void imx9_lpspi_exchange(struct spi_dev_s *dev,
   config.daddr  = (uintptr_t) (rxbuffer ? priv->rxbuf : rxdummy);
   config.soff   = 0;
   config.doff   = rxbuffer ? adjust : 0;
-  config.iter   = nbytes;
+  config.iter   = nwords;
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
   config.dsize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
@@ -1418,7 +1418,7 @@ static void imx9_lpspi_exchange(struct spi_dev_s *dev,
   config.daddr  = priv->spibase + IMX9_LPSPI_TDR_OFFSET;
   config.soff   = txbuffer ? adjust : 0;
   config.doff   = 0;
-  config.iter   = nbytes;
+  config.iter   = nwords;
   config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
   config.ssize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;
   config.dsize  = adjust == 1 ? EDMA_8BIT : EDMA_16BIT;

--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -1386,14 +1386,6 @@ static void imx9_lpspi_exchange(struct spi_dev_s *dev,
                       (uintptr_t)priv->txbuf + nbytes);
     }
 
-  if (rxbuffer)
-    {
-      /* Prepare the RX buffer for DMA */
-
-      up_invalidate_dcache((uintptr_t)priv->rxbuf,
-                           (uintptr_t)priv->rxbuf + nbytes);
-    }
-
   /* Set up the DMA */
 
   adjust = (priv->nbits > 8) ? 2 : 1;
@@ -2079,6 +2071,12 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
           priv->txbuf = imx9_dma_alloc(CONFIG_IMX9_LPSPI_DMA_BUFFER_SIZE);
           priv->rxbuf = imx9_dma_alloc(CONFIG_IMX9_LPSPI_DMA_BUFFER_SIZE);
           DEBUGASSERT(priv->txbuf && priv->rxbuf);
+
+          /* Invalidate the RX buffer area initially */
+
+          up_invalidate_dcache((uintptr_t)priv->rxbuf,
+                               (uintptr_t)priv->rxbuf +
+                               CONFIG_IMX9_LPSPI_DMA_BUFFER_SIZE);
         }
     }
   else


### PR DESCRIPTION

## Summary

This PR corrects the 9-16 bit transfers on IMX9 LPSPI, where buffer lengths were handled wrong. The driver was originally tested only on 8-bit transfers.

Additionally, this syncs the driver with TII branch by adding a small optimization for cache invalidation.

## Impact

Impacts only imx9 platform and lpspi when using >8 bit transfers

## Testing

Tested on custom imx93 board, connected to adis16470 IMU via SPI, using 16-bit transfers.
