### PR TITLE
task_exit.c: Add missing sched_note_stop()

### DIFF
--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -29,6 +29,8 @@
 #include <sched.h>
 #include <debug.h>
 
+#include <nuttx/sched_note.h>
+
 #include "sched/sched.h"
 
 #ifdef CONFIG_SMP
@@ -141,6 +143,7 @@ int nxtask_exit(void)
 #endif
 
   dtcb->task_state = TSTATE_TASK_INACTIVE;
+  sched_note_stop(dtcb);
   ret = nxsched_release_tcb(dtcb, dtcb->flags & TCB_FLAG_TTYPE_MASK);
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
## Summary

I noticed that sched_note_stop() is never called for tasks that exit normally. This patch fixes a regression from #13728 ; there is a missing call to sched_note_stop() in task_exit().

## Impact

Fixes the scheduler instrumentation when a task exits. Nothing else is affected.

## Testing

Private MPFS target with sched note driver.
