### PR TITLE
gdbstub:remove ARCH_HAVE_DEBUG depends

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -43,7 +43,7 @@ config SERIAL_CONSOLE
 
 config SERIAL_GDBSTUB
 	bool "GDBSTUB Serial support"
-	depends on ARCH_HAVE_DEBUG
+	depends on LIB_GDBSTUB
 	default n
 
 config SERIAL_GDBSTUB_PATH

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1897,7 +1897,7 @@ int gdb_debugpoint_remove(int type, FAR void *addr, size_t size)
   point.addr = addr;
   point.size = size;
 
-  retrun nxsched_smp_call((1 << CONFIG_SMP_NCPUS) - 1,
+  return nxsched_smp_call((1 << CONFIG_SMP_NCPUS) - 1,
                           gdb_smp_debugpoint_remove, &point, true);
 #else
   return up_debugpoint_remove(type, addr, size);


### PR DESCRIPTION
## Summary

gdbstub:remove ARCH_HAVE_DEBUG depends

## Impact

gdbstub

## Testing

build wtih qmeu use gdbstub

