### PR TITLE
CI: Enable sim-02 build when we create or update a Complex PR

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -169,7 +169,7 @@ jobs:
             # If PR was Created or Modified: Exclude some boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-0[248], arm-1[02-9], risc-v-04..06, sim-02, xtensa-02"
+              echo "Excluding arm-0[248], arm-1[02-9], risc-v-04..06, sim-03, xtensa-02"
               boards=$(
                 echo '${{ inputs.boards }}' |
                 jq --compact-output \
@@ -177,7 +177,7 @@ jobs:
                   select(
                     test("arm-0[248]") == false and test("arm-1[02-9]") == false and
                     test("risc-v-0[4-9]") == false and
-                    test("sim-0[2-9]") == false and
+                    test("sim-0[3-9]") == false and
                     test("xtensa-0[2-9]") == false
                   )
                 )'


### PR DESCRIPTION
## Summary

CI Build Job sim-02 was disabled to reduce our usage of GitHub Runners, to comply with ASF Policy: https://github.com/apache/nuttx/issues/14376#issuecomment-2427837859

However this causes the Scheduled Merge Job to fail, due to reduced CI Checks: https://github.com/NuttX/nuttx/actions/runs/11490041505/job/31980056690#step:7:465

This PR re-enables sim-02 when we create or update a Complex PR.

## Impact

When we create or update a Complex PR, the CI Workflow will now run sim-02, for improved CI Checking.

## Testing

Creating a Complex PR now executes sim-02: https://github.com/lupyuen5/label-nuttx/actions/runs/11490590600?pr=82
