### PR TITLE
Fix Infinite Loop in arm_dcache.c

### DIFF
--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -529,7 +529,7 @@ void up_enable_dcache(void)
   ARM_DSB();
   do
     {
-      int32_t tmpways = ways;
+      uint32_t tmpways = ways;
 
       do
         {


### PR DESCRIPTION
Infinite Loop can happen since `ways` is assigned to an `int32_t tmpways`. This can cause infinite loop if `ways` gets a sufficiently large integer.


```c
void up_enable_dcache(void)
{
  uint32_t ways;
  ccr = getreg32(NVIC_CFGCON);
  ways   = CCSIDR_WAYS(ccsidr);          /* (Number of ways) - 1 */

  ARM_DSB();
  do
    {
      int32_t tmpways = ways;

      do
        {
          sw = ((tmpways << wshift) | (sets << sshift));
          putreg32(sw, NVIC_DCISW);
        }
      while (tmpways--);
    }
  while (sets--);
}
```
