### PR TITLE
arm/armv8-r: fix unable to switch context in ISR context

### DIFF
--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -58,7 +58,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    * and we will use this_task(). Therefore, it cannot be overridden.
    */
 
+#ifdef CONFIG_SMP
   if (irq != GIC_SMP_CPUSTART)
+#endif
     {
       tcb->xcp.regs = regs;
     }
@@ -72,11 +74,10 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
+  tcb = this_task();
 
   if (regs != tcb->xcp.regs)
     {
-      tcb = this_task();
-
       /* Update scheduler parameters */
 
       nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
@@ -87,7 +88,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
       regs = tcb->xcp.regs;
     }
 


### PR DESCRIPTION
## Summary

arm/armv8-r: fix unable to switch context in ISR context

Regression by https://github.com/apache/nuttx/pull/13651:
```
| commit 35c8c80a00a99ff0e19d51eaa74165bd830a36f8
| Author: ligd <liguiding1@xiaomi.com>
| Date:   Fri Jul 26 23:14:13 2024 +0800
|
| arch: change nxsched_suspend/resume_scheduler() called position
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

CI-CHECK

