### PR TITLE
when COMPILE_OPTIONS is not set, skip the REMOVE_ITEM in ${HOSTSRCS}, fix msvc reported case.

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -290,9 +290,12 @@ set(HOSTSRCS ${WINHOSTSRCS})
 target_sources(nuttx PRIVATE ${HOSTSRCS})
 
 get_target_property(HOST_COMPILE_OPTIONS nuttx COMPILE_OPTIONS)
-foreach(remove_item IN LISTS SIM_NO_HOST_OPTIONS)
-  list(REMOVE_ITEM HOST_COMPILE_OPTIONS ${remove_item})
-endforeach()
-set_target_properties(nuttx PROPERTIES COMPILE_OPTIONS
-                                       "${HOST_COMPILE_OPTIONS}")
+if(HOST_COMPILE_OPTIONS)
+  foreach(remove_item IN LISTS SIM_NO_HOST_OPTIONS)
+    list(REMOVE_ITEM HOST_COMPILE_OPTIONS ${remove_item})
+  endforeach()
+  set_target_properties(nuttx PROPERTIES COMPILE_OPTIONS
+                                         "${HOST_COMPILE_OPTIONS}")
+endif()
+
 target_compile_definitions(nuttx PRIVATE ${HOST_DEFINITIONS})


### PR DESCRIPTION
## Summary
sim/cmake: compatible when nuttx COMPILE_OPTIONS is not set yet
#14440 
when COMPILE_OPTIONS is not set, cmake will report an error: 
HOST_COMPILE_OPTIONS-NOTFOUND

as we only want to do item remove. so let's skip the remove procedure at this case.

@simbit18 I did not try the win host and re-produce the problem, please help me verify if it will work, I will do verify later.

## Impact
fix bug when msvc build.

## Testing
CI-test & ubuntu sim:nsh.

