### PR TITLE
Fix CDCNCM driver printf formatter compiler warning

### DIFF
--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -1073,7 +1073,7 @@ static void cdcncm_receive(FAR struct cdcncm_driver_s *self)
       if ((ndplen < opts->ndpsize + 2 * (opts->dgramitemlen * 2)) ||
           (ndplen % opts->ndpalign != 0))
         {
-          uerr("Bad NDP length: %x\n", ndplen);
+          uerr("Bad NDP length: %04" PRIx32 " \n", ndplen);
           return;
         }
 


### PR DESCRIPTION
## Summary

Minor debug printf formatter error resulting in compiler warning.
## Impact

## Testing

It compiles without warning when using this driver. The driver was - and is - working OK for me.

