### PR TITLE
arm/gicv3: replace this_cpu() to up_cpu_index()

### DIFF
--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -250,7 +250,7 @@ void arm_gic_irq_enable(unsigned int intid)
 
   if (GIC_IS_SPI(intid))
     {
-      arm_gic_write_irouter(this_cpu(), intid);
+      arm_gic_write_irouter(up_cpu_index(), intid);
     }
 
   putreg32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
@@ -809,7 +809,8 @@ static void arm_gic_init(void)
   int       err;
 
   cpu               = this_cpu();
-  g_gic_rdists[cpu] = CONFIG_GICR_BASE + cpu * CONFIG_GICR_OFFSET;
+  g_gic_rdists[cpu] = CONFIG_GICR_BASE +
+                      up_cpu_index() * CONFIG_GICR_OFFSET;
 
   err = gic_validate_redist_version();
   if (err)

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -383,6 +383,10 @@ static inline void up_irq_restore(irqstate_t flags)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_HAVE_MULTICPU
+#  ifndef MPID_TO_CORE
+#    define MPID_TO_CORE(mpid) \
+            (((mpid) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
+#  endif
 #  define up_cpu_index() ((int)MPID_TO_CORE(GET_MPIDR()))
 #endif /* CONFIG_ARCH_HAVE_MULTICPU */
 

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -257,7 +257,7 @@ void arm64_gic_irq_enable(unsigned int intid)
 #ifndef CONFIG_ARM64_GICV3_SPI_ROUTING_CPU0
   if (GIC_IS_SPI(intid))
     {
-      arm64_gic_write_irouter((GET_MPIDR() & MPIDR_ID_MASK), intid);
+      arm64_gic_write_irouter(up_cpu_index(), intid);
     }
 #endif
 
@@ -952,7 +952,8 @@ static void arm64_gic_init(void)
   int       err;
 
   cpu               = this_cpu();
-  g_gic_rdists[cpu] = CONFIG_GICR_BASE + cpu * CONFIG_GICR_OFFSET;
+  g_gic_rdists[cpu] = CONFIG_GICR_BASE +
+                      up_cpu_index() * CONFIG_GICR_OFFSET;
 
   err = gic_validate_redist_version();
   if (err)


### PR DESCRIPTION

## Summary

arm/gicv3: replace this_cpu() to up_cpu_index()

If the core id needs to be included in the hardware register
calculation, up_cpu_index() should be used instead of this_cpu().

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check