### PR TITLE
qemu-intel64: Fixes the linker 'noexecstack' warning

### DIFF
--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -83,6 +83,10 @@ if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
 endif()
 
+if(CONFIG_HOST_LINUX)
+  add_link_options(-Wl,-z,noexecstack)
+endif()
+
 # Architecture flags
 
 add_link_options(-Wl,--entry=__pmode_entry)

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -106,6 +106,10 @@ ifeq ($(CONFIG_DEBUG_LINK_WHOLE_ARCHIVE),y)
   LDFLAGS += --whole-archive
 endif
 
+ifeq ($(CONFIG_HOST_LINUX),y)
+  LDFLAGS += -z noexecstack
+endif
+
 ifeq ($(CONFIG_LIBCXX),y)
   # Linux C++ ABI seems vary.
   # Probably __GLIBCXX__ is the best bet.


### PR DESCRIPTION
Fix the linker warning based on these two commits:

 ld: warning: fork.o: missing .note.GNU-stack section implies executable stack
 ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

commit 36ac81211454 ("sim: Fixes the following linker warning:"),
commit b5d640acc5b3 ("fix Cygwin/MSYS2  ld: unrecognized option '-z'")
