### PR TITLE
mm/kasan: extern kasan API only MM_KASAN is enabled

### DIFF
--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -36,15 +36,19 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define kasan_init_early() kasan_stop()
-
 #ifndef CONFIG_MM_KASAN
 #  define kasan_poison(addr, size)
 #  define kasan_unpoison(addr, size) addr
 #  define kasan_register(addr, size)
 #  define kasan_unregister(addr)
 #  define kasan_reset_tag(addr) addr
+#  define kasan_start()
+#  define kasan_stop()
+#  define kasan_debugpoint(t,a,s) 0
+#  define kasan_init_early()
 #else
+
+#  define kasan_init_early() kasan_stop()
 
 /****************************************************************************
  * Public Function Prototypes
@@ -141,8 +145,6 @@ void kasan_unregister(FAR void *addr);
 
 FAR void *kasan_reset_tag(FAR const void *addr);
 
-#endif /* CONFIG_MM_KASAN */
-
 /****************************************************************************
  * Name: kasan_start
  *
@@ -203,5 +205,7 @@ int kasan_debugpoint(int type, FAR void *addr, size_t size);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* CONFIG_MM_KASAN */
 
 #endif /* __INCLUDE_NUTTX_MM_KASAN_H */

--- a/mm/kasan/hook.c
+++ b/mm/kasan/hook.c
@@ -115,7 +115,9 @@ struct kasan_watchpoint_s
 static struct kasan_watchpoint_s g_watchpoint[MM_KASAN_WATCHPOINT];
 #endif
 
+#ifdef CONFIG_MM_KASAN
 static uint32_t g_region_init;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -225,27 +227,29 @@ static inline void kasan_check_report(FAR const void *addr, size_t size,
                                       bool is_write,
                                       FAR void *return_address)
 {
+#ifdef CONFIG_MM_KASAN
   if (predict_false(size == 0 || g_region_init != KASAN_INIT_VALUE))
     {
       return;
     }
 
-#ifndef CONFIG_MM_KASAN_DISABLE_NULL_POINTER_CHECK
+#  ifndef CONFIG_MM_KASAN_DISABLE_NULL_POINTER_CHECK
   if (predict_false(addr == NULL))
     {
       kasan_report(addr, size, is_write, return_address);
     }
-#endif
+#  endif
 
-#ifndef CONFIG_MM_KASAN_NONE
+#  ifndef CONFIG_MM_KASAN_NONE
   if (predict_false(kasan_is_poisoned(addr, size)))
     {
       kasan_report(addr, size, is_write, return_address);
     }
-#endif
+#  endif
 
-#if MM_KASAN_WATCHPOINT > 0
+#  if MM_KASAN_WATCHPOINT > 0
   kasan_check_watchpoint(addr, size, is_write, return_address);
+#  endif
 #endif
 }
 
@@ -253,6 +257,7 @@ static inline void kasan_check_report(FAR const void *addr, size_t size,
  * Public Functions
  ****************************************************************************/
 
+#ifdef CONFIG_MM_KASAN
 void kasan_start(void)
 {
   g_region_init = KASAN_INIT_VALUE;
@@ -262,6 +267,7 @@ void kasan_stop(void)
 {
   g_region_init = 0;
 }
+#endif
 
 /****************************************************************************
  * Name: kasan_debugpoint


### PR DESCRIPTION
## Summary

mm/kasan: extern kasan API only MM_KASAN is enabled

this PR will fix `g_region_init` is incorrectly linked to the image if MM_KASAN is not enabled.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

CI-CHECK