### PR TITLE
arch/arm/stm32: convert error to warning when CCM is not enabled

### DIFF
--- a/arch/arm/src/stm32/stm32_allocateheap.c
+++ b/arch/arm/src/stm32/stm32_allocateheap.c
@@ -466,7 +466,7 @@
 
 #    if CONFIG_MM_REGIONS < 2
 #      ifdef CONFIG_STM32_HAVE_CCM
-#        error "CCM SRAM excluded from the heap because CONFIG_MM_REGIONS < 2"
+#        warning "CCM SRAM excluded from the heap because CONFIG_MM_REGIONS < 2"
 #      endif
 #      undef CONFIG_STM32_CCMEXCLUDE
 #      define CONFIG_STM32_CCMEXCLUDE 1


### PR DESCRIPTION
## Summary

User may set CONFIG_MM_REGIONS=1 on purpose to disable CCM. This is a completely normal system config and should not be treated as error.

I found this problem trying to run Renode with stm32f4discovery/nsh but Renode doesn't support CCM so we have to disable it

## Impact
User can select CONFIG_MM_REGIONS=1

## Testing

stm32f4discovery/nsh on HW and Renode

