### PR TITLE
arch/arm/stm32h7: add workaround for Renode

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -318,6 +318,13 @@ config STM32H7_PWR_LDO_SUPPLY
 
 endchoice # "STM32 H7 Power Supply Selection"
 
+config STM32H7_PWR_IGNORE_ACTVOSRDY
+	bool "Ignore PWR_CSR1_ACTVOSRDY bit"
+	default n
+	---help---
+		This option disable busy wait for PWR_CSR1_ACTVOSRDY during boot.
+		This is workaround for Renode simulation that doesn't implement this feature.
+
 config STM32H7_IO_CONFIG_A
 	bool
 	default n

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -926,11 +926,13 @@ void stm32_stdclockconfig(void)
         {
         }
 
+#ifndef CONFIG_STM32H7_PWR_IGNORE_ACTVOSRDY
       /* See Reference manual Section 5.4.1, System supply startup */
 
       while ((getreg32(STM32_PWR_CSR1) & PWR_CSR1_ACTVOSRDY) == 0)
         {
         }
+#endif
 
 #if STM32_VOS_OVERDRIVE && (STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1)
       /* Over-drive support for VOS1 */

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -890,11 +890,13 @@ void stm32_stdclockconfig(void)
         {
         }
 
+#ifndef CONFIG_STM32H7_PWR_IGNORE_ACTVOSRDY
       /* See Reference manual Section 5.4.1, System supply startup */
 
       while ((getreg32(STM32_PWR_CSR1) & PWR_CSR1_ACTVOSRDY) == 0)
         {
         }
+#endif
 
 #if STM32_VOS_OVERDRIVE && (STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1)
       /* Over-drive support for VOS1 */


### PR DESCRIPTION
## Summary

arch/arm/stm32h7: add workaround for Renode
Add an option to disable busy wait PWR_CSR1_ACTVOSRDY during boot which doesn't work with Renode simulation

## Impact

workaround to run `nucleo-h743zi/nsh` on Renode

## Testing

`nucleo-h743zi/nsh` on Renode


