### PR TITLE
Use memalign to align share memory to CPU cache line size

### DIFF
--- a/fs/fs_heap.c
+++ b/fs/fs_heap.c
@@ -68,6 +68,11 @@ FAR void *fs_heap_realloc(FAR void *oldmem, size_t size)
   return mm_realloc(g_fs_heap, oldmem, size);
 }
 
+FAR void *fs_heap_memalign(size_t alignment, size_t size)
+{
+  return mm_memalign(g_fs_heap, alignment, size);
+}
+
 void fs_heap_free(FAR void *mem)
 {
   mm_free(g_fs_heap, mem);

--- a/fs/fs_heap.h
+++ b/fs/fs_heap.h
@@ -43,6 +43,7 @@ FAR void *fs_heap_zalloc(size_t size) malloc_like1(1);
 FAR void *fs_heap_malloc(size_t size) malloc_like1(1);
 size_t    fs_heap_malloc_size(FAR void *mem);
 FAR void *fs_heap_realloc(FAR void *oldmem, size_t size) realloc_like(2);
+FAR void *fs_heap_memalign(size_t alignment, size_t size) malloc_like1(3);
 void      fs_heap_free(FAR void *mem);
 FAR char *fs_heap_strdup(FAR const char *s) malloc_like;
 FAR char *fs_heap_strndup(FAR const char *s, size_t size) malloc_like;
@@ -54,6 +55,7 @@ int       fs_heap_asprintf(FAR char **strp, FAR const char *fmt, ...)
 #  define fs_heap_malloc       kmm_malloc
 #  define fs_heap_malloc_size  kmm_malloc_size
 #  define fs_heap_realloc      kmm_realloc
+#  define fs_heap_memalign     kmm_memalign
 #  define fs_heap_free         kmm_free
 #  define fs_heap_strdup       strdup
 #  define fs_heap_strndup      strndup

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -28,6 +28,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/cache.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pgalloc.h>
 
@@ -54,7 +55,8 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
       size_t cachesize = up_get_dcache_linesize();
       if (cachesize > 0)
         {
-          object->paddr = fs_heap_memalign(cachesize, length);
+          object->paddr = fs_heap_memalign(cachesize,
+                                           ALIGN_UP(length, cachesize));
         }
       else
         {
@@ -78,7 +80,8 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
       size_t cachesize = up_get_dcache_linesize();
       if (cachesize > 0)
         {
-          object->paddr = kumm_memalign(cachesize, length);
+          object->paddr = kumm_memalign(cachesize,
+                                        ALIGN_UP(length, cachesize));
         }
       else
         {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add fs heap memalign API and use it for shm.

For kernel builds, shared memory is automatically aligned to page size.
For flat and protected builds, we align the memory size to the CPU cache
line size.

Failure to align memory properly could result in partial data read/write
by the CPU and peripherals, potentially causing data corruption during
cache flushes or invalidations.

## Impact

All share memory will be aligned. 

## Testing

Tested on internal project that uses arm-v7a, and share memory is allocated for GPU usage.


