### PR TITLE
CI: Check out the correct branch of nuttx repo when compiling nuttx-apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
             esac
           fi
 
-          echo "name=$OS_REF" >> $GITHUB_OUTPUT
+          echo "os_ref=$OS_REF" >> $GITHUB_OUTPUT
           echo "apps_ref=$APPS_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout nuttx repo


### PR DESCRIPTION
## Summary

When compiling the Release Branch of `nuttx-apps`, our CI Workflow `build.yml` checks out the Master Branch of `nuttx` repo, which is incorrect. This happens due to a typo in `build.yml`: https://github.com/apache/nuttx/issues/14513

This PR fixes the typo in `build.yml` to checkout the correct branch of `nuttx` repo.

## Impact

When compiling the Release Branch of `nuttx-apps`, our CI Workflow `build.yml` now checks out the Release Branch of `nuttx` repo.

No changes when compiling the Master Branch of `nuttx` and `nuttx-apps` repos.

## Testing

__Before the PR:__ Fetch-Source Log shows that CI is incorrectly checking out the Master Branch of `nuttx` repo (instead of `releases/12.7`): https://github.com/apache/nuttx-apps/actions/runs/11518661640/job/32069568370#step:3:66
```text
/usr/bin/git checkout --progress --force -B master refs/remotes/origin/master
```

__After the PR:__ When we [change `name` to `os_ref`](https://github.com/lupyuen5/label-nuttx-apps/commit/cc44bf95320db2d53238097197b03c6f3485b338), CI correctly checks out the Release Branch of `nuttx` repo: https://github.com/lupyuen5/label-nuttx-apps/actions/runs/11528123257/job/32094821811#step:3:57
```text
/usr/bin/git checkout --progress --force -B releases/12.7 refs/remotes/origin/releases/12.7
```

__Regression Test:__
- Creating a PR in Master Branch works correctly: https://github.com/lupyuen5/label-nuttx/actions/runs/11529724978
- Merging a PR in Master Branch also works correctly: https://github.com/lupyuen5/label-nuttx/actions/runs/11529729994


