### PR TITLE
libc: Fix lib_arc4random.c:111:(.text.arc4random_buf+0x26): undefined reference to `clock_systime_ticks'

### DIFF
--- a/libs/libc/stdlib/lib_arc4random.c
+++ b/libs/libc/stdlib/lib_arc4random.c
@@ -30,8 +30,8 @@
 #include <string.h>
 #include <sys/param.h>
 #include <sys/random.h>
+#include <time.h>
 
-#include <nuttx/clock.h>
 #include <nuttx/hashtable.h>
 
 /****************************************************************************
@@ -108,7 +108,7 @@ void arc4random_buf(FAR void *bytes, size_t nbytes)
 
   while (nbytes > 0)
     {
-      uint32_t hash  = HASH(clock_systime_ticks() - nbytes, 32);
+      uint32_t hash  = HASH(clock() - nbytes, 32);
       size_t   ncopy = MIN(nbytes, sizeof(hash));
 
       memcpy(bytes, &hash, ncopy);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

by replacing clock_systime_ticks with clock

## Impact

fix the build break reported by:
https://github.com/NuttX/nuttx/actions/runs/11540264972/job/32129220872#step:7:101

## Testing

ci

