### PR TITLE
.gitignore: Add the .cache directory generated by clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 *.SystemMap
 *~
 .depend
+/.cache
 /.config
 /.config.*
 /.config-*


### PR DESCRIPTION
Use VSCode + clangd plugin to develop the code, the clangd will save the metadata into .cache directory, it is about the compile_commands.json:
  cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=True

Add the .cache into .gitignore for friendly clangd development environment.