### PR TITLE
arch/arm/stm32/Kconfig: fix Kconfig error

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -2251,6 +2251,10 @@ config STM32_HAVE_HRTIM1
 	bool
 	default n
 
+config STM32_HAVE_HRTIM1_PLLCLK
+	bool
+	default n
+
 config STM32_HAVE_LTDC
 	bool
 	default n
@@ -8105,10 +8109,6 @@ config STM32_HRTIM_FAULT4
 	default n
 
 endif # STM32_HRTIM_FAULTS
-
-config STM32_HAVE_HRTIM1_PLLCLK
-	bool
-	default n
 
 config STM32_HRTIM_CLK_FROM_PLL
 	bool "HRTIM Clock from PLL"


### PR DESCRIPTION
## Summary

fix Kconfig error related to STM32_HAVE_HRTIM1_PLLCLK

```
CMake Warning at cmake/nuttx_kconfig.cmake:171 (message):
  Kconfig Configuration Error: warning: STM32_HAVE_HRTIM1_PLLCLK (defined at
  arch/arm/src/stm32/Kconfig:8109) has direct dependencies STM32_HRTIM &&
  ARCH_CHIP_STM32 && ARCH_ARM with value n, but is currently being y-selected
  by the following symbols

```

## Impact
fix kconfig error

## Testing
CI


