### PR TITLE
fs/nfs: fix offset in append mode and attributes after create

### DIFF
--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -367,7 +367,7 @@ static int nfs_filecreate(FAR struct nfsmount *nmp, FAR struct nfsnode *np,
 
       /* Save the attributes in the file data structure */
 
-      tmp = *ptr;  /* attributes_follows */
+      tmp = *ptr++;  /* attributes_follows */
       if (!tmp)
         {
           fwarn("WARNING: no file attributes\n");
@@ -730,6 +730,15 @@ static int nfs_open(FAR struct file *filep, FAR const char *relpath,
   /* Attach the private data to the struct file instance */
 
   filep->f_priv = np;
+
+  /* In write/append mode, we need to set the file pointer to the end of
+   * the file.
+   */
+
+  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+    {
+      filep->f_pos = (off_t)np->n_size;
+    }
 
   /* Then insert the new instance at the head of the list in the mountpoint
    * structure. It needs to be there (1) to handle error conditions that


### PR DESCRIPTION
## Summary

Fixes the following issues:
- When opening a NFS file in append mode, its file pointer was at offset 0 instead of the end of file.

- When creating a NFS file, the response read pointer wasn't advanced after reading the attributes_follows bool, which caused the attributes to be off by 4 bytes. For example, the file size read the GID.

## Impact

NFS now has a more correct behavior, closer to other file systems.

## Testing

Simulator, with a NFS mount (`nsh> nfsmount 10.0.1.1 /nfs /export udp`) and the following test program:
```c
int main(int argc, FAR char *argv[]) {
  for (int i = 0; i < 5; i++) {
    FILE *f = fopen("/nfs/test.txt", "a");
    long start_pos = ftell(f);

    fseek(f, 0, SEEK_END);
    long size = ftell(f);

    fseek(f, start_pos, SEEK_SET);

    const char* data = "Hello World";
    fwrite(data, strlen(data), 1, f);

    long end_pos = ftell(f);
    fclose(f);

    printf("size:%ld      start:%ld      end:%ld\n", size, start_pos, end_pos);
  }

  return 0;
}
```

Initial result:
```
size:281466386776064      start:0      end:11
size:11      start:0      end:11
size:11      start:0      end:11
size:11      start:0      end:11
size:11      start:0      end:11
```
After fix:
```
size:0      start:0      end:11
size:11      start:11      end:22
size:22      start:22      end:33
size:33      start:33      end:44
size:44      start:44      end:55
```