### PR TITLE
net/usrsock: usrsock supports offload netlink

### DIFF
--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -102,9 +102,10 @@ static int usrsock_sockif_setup(FAR struct socket *psock)
 {
   int ret;
 
-  if (psock->s_domain != PF_INET && psock->s_domain != PF_INET6)
+  if (psock->s_domain != PF_INET && psock->s_domain != PF_INET6 &&
+      psock->s_domain != PF_NETLINK)
     {
-      return -ENOTSUP; /* Only ipv4 and ipv6 support the offload */
+      return -ENOTSUP; /* Only ipv4, ipv6 and netlink support the offload */
     };
 
   /* Let the user socket logic handle the setup...


### PR DESCRIPTION
## Summary

supports the usrsock client to subscribe netlink events, so that it can detect events such as link connection changes.

## Impact

## Testing
cortex-m33


