### PR TITLE
arp.h: make struct arpreq four-byte aligned

### DIFF
--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -65,7 +65,7 @@
 
 /* All ARP ioctls take a pointer to a struct arpreq as their parameter: */
 
-struct arpreq
+struct aligned_data(sizeof(FAR void *)) arpreq
 {
   struct sockaddr arp_pa;                /* Protocol address */
   struct sockaddr arp_ha;                /* Hardware address */


### PR DESCRIPTION
## Summary

current sizeof(struct sockaddr_in) is 66

arp/arp_table.c:241:28: runtime error: member access within misaligned address 0xe5f134e6 for type 'struct sockaddr_in', which requires 4 byte alignment 0xe5f134e6: note: pointer points here
 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00
             ^
    #0 0x543287c1 in arp_get_arpreq arp/arp_table.c:241
    #1 0x5432a11f in arp_snapshot arp/arp_table.c:574
    #2 0x5435f0be in netlink_fill_arptable netlink/netlink_route.c:547
    #3 0x5435ffca in netlink_get_neighbor netlink/netlink_route.c:715
    #4 0x54360116 in netlink_get_neighborlist netlink/netlink_route.c:743
    #5 0x54363b20 in netlink_route_sendto netlink/netlink_route.c:1382
    #6 0x542ef1b1 in netlink_sendmsg netlink/netlink_sockif.c:625
    #7 0x542be94d in psock_sendmsg socket/sendmsg.c:96
    #8 0x542bc94b in psock_sendto socket/sendto.c:134
    #9 0x542bcb28 in sendto socket/sendto.c:247
    #10 0x542bc5ea in send socket/send.c:163
    #11 0x542aa715 in netlib_get_arptable /home/mi/gaofengzhi/code/dev1025/apps/netutils/netlib/netlib_getarptab.c:152
    #12 0x54279109 in cmd_arp /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_netcmds.c:1197
    #13 0x54257faf in nsh_command /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_command.c:1263
    #14 0x54231982 in nsh_execute /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_parse.c:718
    #15 0x5423da42 in nsh_parse_command /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_parse.c:2619
    #16 0x5423e12a in nsh_parse /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_parse.c:2706
    #17 0x5424088f in nsh_session /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_session.c:245
    #18 0x5422efc9 in nsh_consolemain /home/mi/gaofengzhi/code/dev1025/apps/nshlib/nsh_consolemain.c:75
    #19 0x5419e89f in nsh_main /home/mi/gaofengzhi/code/dev1025/apps/system/nsh/nsh_main.c:74
    #20 0x54067ee1 in nxtask_startup sched/task_startup.c:70
    #21 0x53f366c6 in nxtask_start task/task_start.c:116
    #22 0x5409e1a4 in pre_start sim/sim_initialstate.c:52

## Impact

## Testing
sim:local with KASAN


