### PR TITLE
nuttx/atomic.h:Add use condition for using stdatomic.h

### DIFF
--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -76,7 +76,8 @@ extern "C++"
 }
 #  elif __has_include(<stdatomic.h>) && \
         ((defined(__cplusplus) && __cplusplus >= 201103L) || \
-         (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L))
+         (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)) && \
+         !defined(__STDC_NO_ATOMICS__)
 #    if !(__clang__) && defined(__cplusplus)
 #      define _Atomic
 #    endif


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
  On some compiler platforms, although it is a standard after C11, it does not provide an ATOMIC toolchain implementation, so we can use this macro to determine whether it supports toolchain atomic

**Changes:**
  add check !defined(__STDC_NO_ATOMICS__)
  If the macro constant __STDC_NO_ATOMICS__(C11) is defined by the compiler, the header <stdatomic.h>, the keyword _Atomic, and all of the names listed here are not provided.

  refer to:https://en.cppreference.com/w/c/atomic  

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh
It does not affect the compilation results in my commonly used projects

