### PR TITLE
gcov: Fix typographical errors

### DIFF
--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -117,7 +117,7 @@ if(CONFIG_STACK_USAGE_WARNING AND NOT "${CONFIG_STACK_USAGE_WARNING}" STREQUAL
   add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -126,7 +126,7 @@ if(CONFIG_STACK_USAGE_WARNING AND NOT "${CONFIG_STACK_USAGE_WARNING}" STREQUAL
   add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -88,7 +88,7 @@ if(CONFIG_STACK_USAGE_WARNING AND NOT "${CONFIG_STACK_USAGE_WARNING}" STREQUAL
   add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -159,7 +159,7 @@ if(${CONFIG_STACK_USAGE_WARNING})
   endif()
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -90,13 +90,6 @@ config SIM_UBSAN_DUMMY
 	---help---
 		Keep SIM_UBSAN compile time but disable runtime actions.
 
-config SIM_GCOV_ALL
-	bool "Enable code coverage for the entire image"
-	default n
-	---help---
-		This option activates code coverage instrumentation for the
-		entire image.
-
 config SIM_GPROF
 	bool "Enable gprof"
 	depends on !SCHED_GPROF

--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -86,7 +86,7 @@ if(CONFIG_STACK_USAGE_WARNING)
   add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/tricore/src/cmake/ToolchainGnuc.cmake
+++ b/arch/tricore/src/cmake/ToolchainGnuc.cmake
@@ -84,7 +84,7 @@ if(CONFIG_STACK_CANARIES)
   add_compile_options(-fstack-protector-all)
 endif()
 
-if(CONFIG_ARCH_COVERAGE)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/arch/tricore/src/cmake/platform.cmake
+++ b/arch/tricore/src/cmake/platform.cmake
@@ -60,7 +60,7 @@ if(CONFIG_TRICORE_TOOLCHAIN_GNU)
       OUTPUT_VARIABLE extra_library)
     list(APPEND EXTRA_LIB ${extra_library})
   endif()
-  if(CONFIG_ARCH_COVERAGE)
+  if(CONFIG_SCHED_GCOV)
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
               --print-file-name=libgcov.a

--- a/arch/tricore/src/common/ToolchainGnuc.defs
+++ b/arch/tricore/src/common/ToolchainGnuc.defs
@@ -58,7 +58,7 @@ ifneq ($(CONFIG_STACK_USAGE_WARNING),0)
   ARCHOPTIMIZATION += -Wstack-usage=$(CONFIG_STACK_USAGE_WARNING)
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
+ifeq ($(CONFIG_SCHED_GCOV_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 
@@ -183,7 +183,7 @@ ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_SCHED_GCOV),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcov.a))
 endif
 

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -75,7 +75,7 @@ if(${CONFIG_STACK_USAGE_WARNING})
   endif()
 endif()
 
-if(CONFIG_SCHED_GCOV)
+if(CONFIG_SCHED_GCOV_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -72,7 +72,7 @@ ifneq ($(CONFIG_STACK_USAGE_WARNING),0)
   ARCHOPTIMIZATION += -Wstack-usage=$(CONFIG_STACK_USAGE_WARNING)
 endif
 
-ifeq ($(CONFIG_SIM_GCOV_ALL),y)
+ifeq ($(CONFIG_SCHED_GCOV_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1355,6 +1355,14 @@ config SCHED_GCOV
 		"-fprofile-generate -ftest-coverage" compilation parameters
 		to the file to be analyzed.
 
+config SCHED_GCOV_ALL
+	bool "Enable gcov call graph for all modules"
+	depends on SCHED_GCOV
+	default n
+	---help---
+		Enable gcov profiling for all code, it will instrument
+		all code, which will cause a large performance penalty for the code.
+
 config SCHED_GPROF
 	bool "Enable gprof profiling"
 	default n

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -620,7 +620,7 @@ define DOWNLOAD
 	$(ECHO_END)
 endef
 
-# CLONE - Git clone repository. Initializes a new Git repository in the 
+# CLONE - Git clone repository. Initializes a new Git repository in the
 #         folder on your local machine and populates it with the contents
 #         of the central repository.
 #         The third argument is an storage path. The second argument is used
@@ -784,7 +784,7 @@ else
   CONVERT_PATH = $1
 endif
 
-# Upper/Lower case string, add the `UL` prefix to private function 
+# Upper/Lower case string, add the `UL` prefix to private function
 
 ULPOP = $(wordlist 3,$(words $(1)),$(1))
 ULSUB = $(subst $(word 1,$(1)),$(word 2,$(1)),$(2))


### PR DESCRIPTION
## Summary

 1. CONFIG_ARCH_COVERAGE has been replaced by CONFIG_SCHED_GCOV
 2. Delete the SIM-specific GCOV_ALL configuration and change it to a universal configuration for all architectures

## Impact
## Testing

Enable CONFIG_SYSTEM_GCOV and CONFIG_SCHED_GCOV, CONFIG_SCHED_GCOV_ALL, nsh run "gcov -d /data " can generate gcda files for all files, that is, code coverage analysis generates files