### PR TITLE
toolchain/tasking: fix build break on tasking toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,7 +579,7 @@ endif()
 get_property(ldscript GLOBAL PROPERTY LD_SCRIPT)
 
 # Pre-compile linker script
-if(NOT CONFIG_ARCH_SIM)
+if(NOT CONFIG_ARCH_SIM AND NOT CONFIG_ARCH_TOOLCHAIN_TASKING)
   get_filename_component(LD_SCRIPT_NAME ${ldscript} NAME)
   set(LD_SCRIPT_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_NAME}.tmp")
 
@@ -623,6 +623,8 @@ if(NOT CONFIG_ARCH_SIM)
   # TODO: nostart/nodefault not applicable to nuttx toolchain
   if(CONFIG_ARCH_TOOLCHAIN_TASKING)
     target_link_libraries(nuttx PRIVATE --lsl-file=${ldscript} ${nuttx_libs})
+    # Remove executable suffix
+    set(CMAKE_EXECUTABLE_SUFFIX "")
   else()
     target_link_libraries(
       nuttx


### PR DESCRIPTION
## Summary

toolchain/tasking: fix build break on tasking toolchain

1. Tasking only support preprocess link script on linker phase
2. Remove executable suffix (.elf)

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

Tasking tc397