### PR TITLE
CMake/preprocess: fix typo PREPROCES -> PREPROCESS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,8 +583,8 @@ if(NOT CONFIG_ARCH_SIM)
   get_filename_component(LD_SCRIPT_NAME ${ldscript} NAME)
   set(LD_SCRIPT_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_NAME}.tmp")
 
-  nuttx_generate_preproces_target(SOURCE_FILE ${ldscript} TARGET_FILE
-                                  ${LD_SCRIPT_TMP})
+  nuttx_generate_preprocess_target(SOURCE_FILE ${ldscript} TARGET_FILE
+                                   ${LD_SCRIPT_TMP})
 
   add_custom_target(ldscript_tmp DEPENDS ${LD_SCRIPT_TMP})
   add_dependencies(nuttx ldscript_tmp)
@@ -761,8 +761,8 @@ if(CONFIG_BUILD_PROTECTED)
   # Pre-compile linker script
   get_filename_component(LD_SCRIPT_USER_NAME ${user_ldscript} NAME)
   set(LD_SCRIPT_USER_TMP "${CMAKE_BINARY_DIR}/${LD_SCRIPT_USER_NAME}.tmp")
-  nuttx_generate_preproces_target(SOURCE_FILE ${user_ldscript} TARGET_FILE
-                                  ${LD_SCRIPT_USER_TMP})
+  nuttx_generate_preprocess_target(SOURCE_FILE ${user_ldscript} TARGET_FILE
+                                   ${LD_SCRIPT_USER_TMP})
   add_custom_target(user_ldscript_tmp DEPENDS ${LD_SCRIPT_USER_TMP})
   add_dependencies(nuttx_user user_ldscript_tmp)
   set(user_ldscript ${LD_SCRIPT_USER_TMP})

--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -194,17 +194,17 @@ endif()
 
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P)
 
-# override nuttx_generate_preproces_target
+# override nuttx_generate_preprocess_target
 
-set(NUTTX_TOOLCHAIN_PREPROCES_DEFINED true)
+set(NUTTX_TOOLCHAIN_PREPROCESS_DEFINED true)
 
-function(nuttx_generate_preproces_target)
+function(nuttx_generate_preprocess_target)
 
   # parse arguments into variables
 
   nuttx_parse_function_args(
     FUNC
-    nuttx_generate_preproces_target
+    nuttx_generate_preprocess_target
     ONE_VALUE
     SOURCE_FILE
     TARGET_FILE

--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -101,7 +101,7 @@ function(nuttx_add_romfs)
     if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${rcpath})
       file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${rcpath})
     endif()
-    nuttx_generate_preproces_target(
+    nuttx_generate_preprocess_target(
       SOURCE_FILE ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX} TARGET_FILE
       ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX} DEPENDS nuttx_context)
     list(APPEND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})

--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -37,14 +37,14 @@ if(EXTRA_FLAGS)
 endif()
 
 # ~~~
-# nuttx_generate_preproces_target
+# nuttx_generate_preprocess_target
 #
 # Description:
 #   because different toolchains have different preprocessing instructions,
 #   we define the COMMON preprocessing target here.
 #
 # Prototype:
-#  nuttx_generate_preproces_target(
+#  nuttx_generate_preprocess_target(
 #    SOURCE_FILE
 #    ${single_source_file}
 #    TARGET_FILE
@@ -54,14 +54,14 @@ endif()
 # ~~~
 
 #
-if(NOT NUTTX_TOOLCHAIN_PREPROCES_DEFINED)
-  function(nuttx_generate_preproces_target)
+if(NOT NUTTX_TOOLCHAIN_PREPROCESS_DEFINED)
+  function(nuttx_generate_preprocess_target)
 
     # parse arguments into variables
 
     nuttx_parse_function_args(
       FUNC
-      nuttx_generate_preproces_target
+      nuttx_generate_preprocess_target
       ONE_VALUE
       SOURCE_FILE
       TARGET_FILE


### PR DESCRIPTION
## Summary

CMake/preprocess: fix typo PREPROCES -> PREPROCESS

correct the marco define from PREPROCES to PREPROCESS

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check