### PR TITLE
xtensa/esp32s3: enable encrypted flag based on partition and device

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_partition.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_partition.c
@@ -801,7 +801,7 @@ int esp32s3_partition_init(void)
       finfo("INFO: [size]:    0x%08" PRIx32 "\n", info->size);
       finfo("INFO: [flags]:   0x%08" PRIx32 "\n", info->flags);
       finfo("INFO: [mount]:   %s\n", path);
-      if (flags & PARTITION_FLAG_ENCRYPTED)
+      if (encrypt && (flags & PARTITION_FLAG_ENCRYPTED))
         {
           mtd_ll = mtd_encrypt;
           finfo("INFO: [encrypted]\n\n");


### PR DESCRIPTION
If device encryption is not enabled by eFuse, and partiton mark as encrypted flag, then encrypted MTD is used.

That is no problem in write and read operation, but failed while using spi_flash_mmap(...) since de-encrypt is not processed.

So, back to use non-encrypted MTD following API Guide: If flash encryption is not enabled, the flag "encrypted" has no effect



