### PR TITLE
clang/ld.lld: clang17 and above support the option --print-memory-usage

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -216,6 +216,8 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
     ifeq "17.0" "$(word 1, $(sort 17.0 $(CLANGVER)))"
       TOOLCHAIN_CLANG_OPTION = -target
       ARCHCPUFLAGS += --target=arm-none-eabi
+
+      LDFLAGS += --print-memory-usage
     else
       TOOLCHAIN_CLANG_OPTION = --config
     endif


### PR DESCRIPTION
## Summary
1. cmake uses clang++ as a connector, and does not currently support: clang++: error: unknown argument: '-wl,--print-memory-usage' clang++: error: no input files
## Impact
NO
## Testing
No