### PR TITLE
mm/mm_memalign: add debugging log

### DIFF
--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
+#include <debug.h>
 
 #include <nuttx/mm/mm.h>
 #include <nuttx/mm/kasan.h>
@@ -287,5 +288,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   alignedchunk = (uintptr_t)kasan_unpoison((FAR const void *)alignedchunk,
                                            size - MM_ALLOCNODE_OVERHEAD);
   DEBUGASSERT(alignedchunk % alignment == 0);
+  minfo("Aligned %"PRIxPTR" to %"PRIxPTR", size %zu\n",
+        rawchunk, alignedchunk, size);
   return (FAR void *)alignedchunk;
 }


### PR DESCRIPTION

## Summary

This adds debug log support for mm_memalign to help track memory issues. The logging is guarded with DEBUG_MM_INFO and is off by default.

## Impact

DEBUG_MM_INFO usages

## Testing

- local checks with `rv-virt:knsh` and `rv-virt:knsh64`
- CI checks


