### PR TITLE
Fix config repeat define in include deconfig mode

### DIFF
--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -56,6 +56,8 @@ process_file() {
                 exit 1
             fi
         else
+            local key_config="$(echo "$line" | cut -d= -f1)="
+            sed -i "/$key_config/d" $output_file
             echo "$line" >> $output_file
         fi
     done < "$input_file"


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

we should process repeat define CONFIG when used #include “XXX/deconfig” mode

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


