### PR TITLE
coredump.py:bug fix python file not have rename

### DIFF
--- a/tools/coredump.py
+++ b/tools/coredump.py
@@ -134,8 +134,8 @@ def main():
         outfile.close()
         os.unlink(tmp)
     else:
-        tmpfile.rename(args.output)
         tmpfile.close()
+        os.rename(tmp, args.output)
 
     print("Core file conversion completed: " + args.output)
 


### PR DESCRIPTION
## Summary

python api change

    tmpfile.rename(args.output)
    ^^^^^^^^^^^^^^
AttributeError: '_io.BufferedRandom' object has no attribute 'rename'. Did you mean: 'name'?


## Impact

coredump.py

## Testing

run coredump.py in ubuntu22.04 and ubuntu 24.04
