### PR TITLE
arp.h: make struct arpreq four-byte aligned

### DIFF
--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -65,7 +65,7 @@
 
 /* All ARP ioctls take a pointer to a struct arpreq as their parameter: */
 
-struct aligned_data(sizeof(FAR void *)) arpreq
+struct aligned_data(sizeof(uint32_t)) arpreq
 {
   struct sockaddr arp_pa;                /* Protocol address */
   struct sockaddr arp_ha;                /* Hardware address */


### PR DESCRIPTION

## Summary
avoid memory waste in 64-bit architectures.

## Impact

## Testing
sim:local


