### PR TITLE
libs/libc/obstack: fix allocated chunk overrun due to invalid limit

### DIFF
--- a/include/obstack.h
+++ b/include/obstack.h
@@ -314,7 +314,7 @@ void obstack_free(FAR struct obstack *h, FAR void *object);
  *   size: number of bytes to be free for growth
  *
  * Assumptions/Limitations:
- *   The obstack's chunk_size is expected to be power of two. This helps to
+ *   The obstack's chunk_size is rounded up to be power of two. This helps to
  *   eliminate division that might not be implemented in the HW and thus
  *   inefficient.
  *


### PR DESCRIPTION

## Summary

This primarily fixes allocated memory overrun due to invalidly calculated limit of the chunk. The function here allocates chunk of size that includes required header. The error was that size of the chunk was invalidly again added when limit was being calculated. This was causing memory overrun and issues especially with object growing (reallocation).

The secondary fix here is to the algorithm that rounds the required size to the multiple of chunk size. In short chunk size must be reduced by one to get the correct mask. The condition that was generating the mask was also invalid because it must perform shift with at most one less than number of bits (not bytes).

## Impact

The stability fix.

## Testing

Tested on custom samv7 board. I have also proof tested the rounding mechanism with following code:

```
size_t round_up(size_t v, size_t mult) {
  size_t mask = mult - 1;
  for (unsigned i = 1; i < sizeof(size_t) * 8; i <<= 1)
    mask |= mask >> i;
  return (v + mask) & ~mask;
}

int main() {
	for (size_t mult = 1; mult < 100; mult++)
		for (size_t i = 1; i < 66; i++) {
			size_t r = round_up(i, mult);
			printf("%zd -> %zd\n", i, r);
			assert(r >= i);
		}
	return 0;
}
```
