### PR TITLE
mpfs/smp: Add riscv_macros to mpfs_shead

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_shead.S
+++ b/arch/risc-v/src/mpfs/mpfs_shead.S
@@ -29,6 +29,7 @@
 #include "chip.h"
 #include "mpfs_memorymap.h"
 #include "riscv_internal.h"
+#include "riscv_macros.S"
 
 /****************************************************************************
  * Public Symbols


### PR DESCRIPTION
## Summary

Add riscv_macros to mpfs_shead to get definition for riscv_set_inital_sp macro

## Impact

Impact is only mpfs_shead.S, i.e. MPFS kernel mode build and CONFIG_SMP=y

## Testing

Build passes when CONFIG_SMP=y

