### PR TITLE
riscv/syscall: Fix sched_note instrumentation for BUILD_KERNEL

### DIFF
--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -65,6 +65,10 @@ void *riscv_perform_syscall(uintreg_t *regs)
 
       addrenv_switch(NULL);
 #endif
+      /* Update scheduler parameters */
+
+      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The sched_note calls were missing from riscv_perform_syscall().

## Impact

Fixes tiny regression, related to task instrumentation. Only RISC-V and BUILD_KERNEL=y are affected.

## Testing

Sched note works again!
