### PR TITLE
tools/mkdeps: increase MAX_BUFFER from 16384 to 65536

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -46,9 +46,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define MAX_BUFFER  (16384)
-#define MAX_EXPAND  (16384)
-#define MAX_SHQUOTE (16384)
+#define MAX_BUFFER  (65536)
+#define MAX_EXPAND  (65536)
+#define MAX_SHQUOTE (65536)
 
 /* MAX_PATH might be defined in stdlib.h */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

update MAX_BUFFER/MAX_EXPAND/MAX_SHQUOTE for deeper compilation paths in real condition

## Impact

support build nuttx in more deeper compilation paths.

## Testing

PASS Vela CI


