### PR TITLE
irq: force inline up_interrupt_context

### DIFF
--- a/arch/ceva/include/irq.h
+++ b/arch/ceva/include/irq.h
@@ -152,7 +152,7 @@ static inline_function void up_set_current_regs(uint32_t *regs)
  *
  ****************************************************************************/
 
-static inline bool up_interrupt_context(void)
+static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();

--- a/arch/or1k/include/irq.h
+++ b/arch/or1k/include/irq.h
@@ -133,7 +133,7 @@ static inline_function void up_set_current_regs(uint32_t *regs)
  *
  ****************************************************************************/
 
-static inline bool up_interrupt_context(void)
+static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -799,7 +799,7 @@ noinstrument_function static inline void up_irq_restore(irqstate_t flags)
  *
  ****************************************************************************/
 
-noinstrument_function static inline bool up_interrupt_context(void)
+noinstrument_function static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -153,7 +153,7 @@ static inline uintptr_t up_getsp(void)
  ****************************************************************************/
 
 noinstrument_function
-static inline bool up_interrupt_context(void)
+static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();

--- a/arch/sparc/include/irq.h
+++ b/arch/sparc/include/irq.h
@@ -151,7 +151,7 @@ static inline_function void up_set_current_regs(uint32_t *regs)
  *
  ****************************************************************************/
 
-static inline bool up_interrupt_context(void)
+static inline_function bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
   irqstate_t flags = up_irq_save();


### PR DESCRIPTION
## Summary
reason:
Replace "inline" with "inline_function" for "up_interrupt_context" to ensure consistency with other arch

## Impact
ceva or1k risc-v sim sparc

## Testing
ci ostest


