### PR TITLE
libc/machine:Add prefixes to libc functions implemented by arch

### DIFF
--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -155,6 +155,12 @@
 #  define LIBC_BUILD_STRRCHR
 #endif
 
+#ifdef CONFIG_MM_KASAN
+#  define ARCH_LIBCFUN(x)  arch_##x
+#else
+#  define ARCH_LIBCFUN(x)  x
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/libs/libc/machine/CMakeLists.txt
+++ b/libs/libc/machine/CMakeLists.txt
@@ -22,4 +22,10 @@
 
 add_subdirectory(${CONFIG_ARCH})
 
-target_sources(c PRIVATE arch_atomic.c)
+if(CONFIG_LIBC_ARCH_ATOMIC)
+  target_sources(c PRIVATE arch_atomic.c)
+endif()
+
+if(CONFIG_MM_KASAN)
+  target_sources(c PRIVATE arch_libc.c)
+endif()

--- a/libs/libc/machine/Make.defs
+++ b/libs/libc/machine/Make.defs
@@ -22,6 +22,10 @@
 
 CSRCS += arch_atomic.c
 
+ifeq ($(CONFIG_MM_KASAN),y)
+  CSRCS += arch_libc.c
+endif
+
 ifeq ($(CONFIG_ARCH_ARM),y)
 include $(TOPDIR)/libs/libc/machine/arm/Make.defs
 endif

--- a/libs/libc/machine/arch_libc.c
+++ b/libs/libc/machine/arch_libc.c
@@ -1,0 +1,292 @@
+/****************************************************************************
+ * libs/libc/machine/arch_libc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ARCH_MEMCHR
+FAR void *arch_memchr(FAR const void *s, int c, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMCPY
+FAR void *arch_memcpy(FAR void *dest, FAR const void *src, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMCMP
+int arch_memcmp(FAR const void *s1, FAR const void *s2, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMMOVE
+FAR void *arch_memmove(FAR void *dest, FAR const void *src, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMSET
+FAR void *arch_memset(FAR void *s, int c, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCMP
+int arch_strcmp(FAR const char *s1, FAR const char *s2);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCPY
+FAR char *arch_strcpy(FAR char *dest, FAR const char *src);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRLEN
+size_t arch_strlen(FAR const char *s);
+#else
+#define arch_strlen(s) strlen(s)
+#endif
+
+#ifdef CONFIG_LIBC_ARCHSTRNCPY
+FAR char *arch_strncpy(FAR char *dest, FAR const char *src, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCHR
+FAR char *arch_strchr(FAR const char *s, int c);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCHNUL
+FAR char *arch_strchrnul(FAR const char *s, int c);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRNCMP
+int arch_strncmp(FAR const char *s1, FAR const char *s2, size_t n);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRNLEN
+size_t arch_strnlen(FAR const char *s, size_t maxlen);
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRRCHR
+FAR char *arch_strrchr(FAR const char *s, int c);
+#endif
+
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+extern void __asan_loadN(FAR void *addr, size_t size);
+#    endif
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+extern void __asan_storeN(FAR void *addr, size_t size);
+#    endif
+#  endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ARCH_MEMCHR
+
+FAR void *memchr(FAR const void *s, int c, size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s, n);
+#    endif
+#  endif
+
+  return arch_memchr(s, c, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMCPY
+FAR void *memcpy(FAR void *dest, FAR const void *src, FAR size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+  __asan_storeN(dest, n);
+#    endif
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)src, n);
+#    endif
+#  endif
+  return arch_memcpy(dest, src, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMCMP
+int memcmp(FAR const void *s1, FAR const void *s2, size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+    __asan_loadN((FAR void *)s1, n);
+    __asan_loadN((FAR void *)s2, n);
+#   endif
+#  endif
+  return arch_memcmp(s1, s2, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMMOVE
+FAR void *memmove(FAR void *dest, FAR const void *src, FAR size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+  __asan_storeN(dest, n);
+#    endif
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)src, n);
+#    endif
+#  endif
+  return arch_memmove(dest, src, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_MEMSET
+FAR void *memset(FAR void *s, int c, FAR size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+  __asan_storeN(s, n);
+#    endif
+#  endif
+  return arch_memset(s, c, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCMP
+int strcmp(FAR const char *s1, FAR const char *s2)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s1, arch_strlen(s1) + 1);
+  __asan_loadN((FAR void *)s2, arch_strlen(s2) + 1);
+#    endif
+#  endif
+  return arch_strcmp(s1, s2);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCPY
+FAR char *strcpy(FAR char *dest, FAR const char *src)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+  __asan_storeN(dest, arch_strlen(src) + 1);
+#    endif
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)src, arch_strlen(src) + 1);
+#    endif
+#endif
+  return arch_strcpy(dest, src);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRLEN
+size_t strlen(FAR const char *s)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  size_t ret = arch_strlen(s);
+
+  __asan_loadN((FAR void *)s, ret + 1);
+  return ret;
+  #  endif
+#  else
+  return arch_strlen(s);
+#  endif
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCHSTRNCPY
+FAR char *strncpy(FAR char *dest, FAR const char *src, size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_WRITES_CHECK
+  __asan_storeN(dest, n);
+#    endif
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)src, n);
+#    endif
+#endif
+  return arch_strncpy(dest, src, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCHR
+FAR char *strchr(FAR const char *s, int c)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s, arch_strlen(s) + 1);
+#    endif
+#  endif
+
+  return arch_strchr(s, c);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRCHNUL
+FAR char *strchrnul(FAR const char *s, int c);
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s, arch_strlen(s) + 1);
+#    endif
+#  endif
+  return arch_strchrnul(s, c);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRNCMP
+int strncmp(FAR const char *s1, FAR const char *s2, size_t n)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s1, n);
+  __asan_loadN((FAR void *)s2, n);
+#    endif
+#  endif
+  return arch_strncmp(s1, s2, n);
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRNLEN
+size_t strnlen(FAR const char *s, size_t maxlen)
+{
+  size_t ret = arch_strnlen(s, maxlen);
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s, ret);
+#    endif
+#  endif
+
+  return ret;
+}
+#endif
+
+#ifdef CONFIG_LIBC_ARCH_STRRCHR
+FAR char *strrchr(FAR const char *s, int c)
+{
+#  ifdef CONFIG_MM_KASAN
+#    ifndef CONFIG_MM_KASAN_DISABLE_READS_CHECK
+  __asan_loadN((FAR void *)s, arch_strlen(s) + 1);
+#    endif
+#  endif
+  return arch_strrchr(s, c);
+}
+#endif

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memchr.S
@@ -139,10 +139,10 @@
 	.thumb_func
 	.align 4
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
 
-memchr:
+ARCH_LIBCFUN(memchr):
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	/* Use a simple loop if there are less than 8 bytes to search.  */
@@ -271,7 +271,7 @@ memchr:
 	bx	lr
 
 	.cfi_endproc
-	.size	memchr, . - memchr
+	.size	ARCH_LIBCFUN(memchr), . - ARCH_LIBCFUN(memchr)
 
 #elif __ARM_ARCH_ISA_THUMB >= 2 && defined (__ARM_FEATURE_DSP)
 
@@ -294,9 +294,9 @@ memchr:
 	.thumb_func
 	.align 2
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
-memchr:
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
+ARCH_LIBCFUN(memchr):
 	@ r0 = start of memory to scan
 	@ r1 = character to look for
 	@ r2 = length

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memcpy.S
@@ -163,7 +163,7 @@
 \f:
 	.endm
 
-def_fn memcpy p2align=6
+def_fn ARCH_LIBCFUN(memcpy) p2align=6
 
 	mov	dst, dstin	/* Preserve dstin, we need to return it.  */
 	cmp	count, #64
@@ -627,6 +627,6 @@ def_fn memcpy p2align=6
 	bne	.Ltail63unaligned
 	bx	lr
 
-	.size	memcpy, . - memcpy
+	.size	ARCH_LIBCFUN(memcpy), . - ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memmove.S
@@ -35,9 +35,9 @@
 
 	.thumb
 	.syntax unified
-	.global memmove
-	.type	memmove, %function
-memmove:
+	.global ARCH_LIBCFUN(memmove)
+	.type	ARCH_LIBCFUN(memmove), %function
+ARCH_LIBCFUN(memmove):
 	cmp	r0, r1
 	push	{r4}
 	bls	3f
@@ -67,6 +67,6 @@ memmove:
 	bne	4b
 	pop	{r4}
 	bx	lr
-	.size memmove, . - memmove
+	.size ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_memset.S
@@ -35,9 +35,9 @@
 
 	.arm
 	.syntax unified
-	.global memset
-	.type	memset, %function
-memset:
+	.global ARCH_LIBCFUN(memset)
+	.type	ARCH_LIBCFUN(memset), %function
+ARCH_LIBCFUN(memset):
 	mov         r3, r0
 	// At this point only d0, d1 are going to be used below.
 	vdup.8      q0, r1
@@ -147,6 +147,6 @@ memset:
 	strbcs      r1, [r3], #1
 	strbcs      r1, [r3], #1
 	bx          lr
-	.size memset, . - memset
+	.size ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_strcmp.S
@@ -53,9 +53,9 @@
 
 	.arm
 	.syntax unified
-	.global strcmp
-	.type	strcmp, %function
-strcmp:
+	.global ARCH_LIBCFUN(strcmp)
+	.type	ARCH_LIBCFUN(strcmp), %function
+ARCH_LIBCFUN(strcmp):
 	pld	[r0, #0]
 	pld	[r1, #0]
 	eor	r2, r0, r1
@@ -303,6 +303,6 @@ strcmp:
 	ldr	r4, [sp], #4
 	ldr	r5, [sp], #4
 	bx	lr
-	.size strcmp, . - strcmp
+	.size ARCH_LIBCFUN(strcmp), . - ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/arm/armv7-a/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-a/gnu/arch_strlen.S
@@ -107,7 +107,7 @@
 #define tmp1		r4		/* Overlaps const_0  */
 #define tmp2		r5
 
-def_fn	strlen p2align=6
+def_fn	ARCH_LIBCFUN(strlen) p2align=6
 	pld	[srcin, #0]
 	strd	r4, r5, [sp, #-8]!
 	bic	src, srcin, #7
@@ -185,6 +185,6 @@ def_fn	strlen p2align=6
 	movne	data1a, const_m1
 	mov	const_0, #0
 	b	.Lstart_realigned
-	.size	strlen, . - strlen
+	.size	ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memchr.S
@@ -140,10 +140,10 @@
 	.thumb_func
 	.align 4
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
 
-memchr:
+ARCH_LIBCFUN(memchr):
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	/* Use a simple loop if there are less than 8 bytes to search.  */
@@ -272,7 +272,7 @@ memchr:
 	bx	lr
 
 	.cfi_endproc
-	.size	memchr, . - memchr
+	.size	ARCH_LIBCFUN(memchr), . - ARCH_LIBCFUN(memchr)
 
 #elif __ARM_ARCH_ISA_THUMB >= 2 && defined (__ARM_FEATURE_DSP)
 
@@ -295,9 +295,9 @@ memchr:
 	.thumb_func
 	.align 2
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
-memchr:
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
+ARCH_LIBCFUN(memchr):
 	@ r0 = start of memory to scan
 	@ r1 = character to look for
 	@ r2 = length

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memcpy.S
@@ -96,11 +96,11 @@
 	.text
 	.section .text.memcpy
 	.align	2
-	.global	memcpy
+	.global	ARCH_LIBCFUN(memcpy)
 	.thumb
 	.thumb_func
-	.type	memcpy, %function
-memcpy:
+	.type	ARCH_LIBCFUN(memcpy), %function
+ARCH_LIBCFUN(memcpy):
 	@ r0: dst
 	@ r1: src
 	@ r2: len
@@ -355,6 +355,6 @@ memcpy:
 #endif
 	bx	lr
 
-	.size	memcpy, .-memcpy
+	.size	ARCH_LIBCFUN(memcpy), .-ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memmove.S
@@ -37,9 +37,9 @@
 	.syntax unified
 	.text
 	.section .text.memmove
-	.global memmove
-	.type	memmove, %function
-memmove:
+	.global ARCH_LIBCFUN(memmove)
+	.type	ARCH_LIBCFUN(memmove), %function
+ARCH_LIBCFUN(memmove):
 	cmp	r0, r1
 	push	{r4}
 	bls	3f
@@ -69,6 +69,6 @@ memmove:
 	bne	4b
 	pop	{r4}
 	bx	lr
-	.size memmove, . - memmove
+	.size ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_memset.S
@@ -37,9 +37,9 @@
 	.syntax unified
 	.text
 	.section .text.memset
-	.global memset
-	.type	memset, %function
-memset:
+	.global ARCH_LIBCFUN(memset)
+	.type	ARCH_LIBCFUN(memset), %function
+ARCH_LIBCFUN(memset):
 	stmfd	sp!, {r0, r4-r7, lr}
 	rsb	r3, r0, #0
 	ands	r3, r3, #3
@@ -106,6 +106,6 @@ memset:
 	movs	r2, r2, lsl #2
 	strbcs	r1, [r0]
 	ldmfd	sp!, {r0, r4-r7, pc}
-	.size memset, . - memset
+	.size ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcmp.S
@@ -81,7 +81,7 @@
 
 	.thumb
 	.syntax unified
-def_fn strcmp
+def_fn ARCH_LIBCFUN(strcmp)
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	eor	tmp1, src1, src2
@@ -413,6 +413,6 @@ def_fn strcmp
 	.cfi_def_cfa_offset 0
 	bx	lr
 	.cfi_endproc
-	.size strcmp, . - strcmp
+	.size ARCH_LIBCFUN(strcmp), . - ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strcpy.S
@@ -62,11 +62,11 @@
     .text
     .section .text.strcpy
     .align  2
-    .global strcpy
+    .global ARCH_LIBCFUN(strcpy)
     .thumb
-    .type   strcpy, %function
+    .type  ARCH_LIBCFUN(strcpy), %function
 
-strcpy:
+ARCH_LIBCFUN(strcpy):
     push    {result, tmp1, tmp2, tmp3, src_offset}
     eor     tmp1, dst, src
     tst     tmp1, #3 

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_strlen.S
@@ -108,7 +108,7 @@
 #define tmp1		r4		/* Overlaps const_0  */
 #define tmp2		r5
 
-def_fn	strlen p2align=6
+def_fn	ARCH_LIBCFUN(strlen) p2align=6
 	pld	[srcin, #0]
 	strd	r4, r5, [sp, #-8]!
 	bic	src, srcin, #7
@@ -186,6 +186,6 @@ def_fn	strlen p2align=6
 	movne	data1a, const_m1
 	mov	const_0, #0
 	b	.Lstart_realigned
-	.size	strlen, . - strlen
+	.size	ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memchr.S
@@ -139,10 +139,10 @@
 	.thumb_func
 	.align 4
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
 
-memchr:
+ARCH_LIBCFUN(memchr):
 	.cfi_sections .debug_frame
 	.cfi_startproc
 	/* Use a simple loop if there are less than 8 bytes to search.  */
@@ -271,7 +271,7 @@ memchr:
 	bx	lr
 
 	.cfi_endproc
-	.size	memchr, . - memchr
+	.size	ARCH_LIBCFUN(memchr), . - ARCH_LIBCFUN(memchr)
 
 #elif __ARM_ARCH_ISA_THUMB >= 2 && defined (__ARM_FEATURE_DSP)
 
@@ -294,9 +294,9 @@ memchr:
 	.thumb_func
 	.align 2
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
-memchr:
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
+ARCH_LIBCFUN(memchr):
 	@ r0 = start of memory to scan
 	@ r1 = character to look for
 	@ r2 = length

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memcpy.S
@@ -163,7 +163,7 @@
 \f:
 	.endm
 
-def_fn memcpy p2align=6
+def_fn ARCH_LIBCFUN(memcpy) p2align=6
 
 	mov	dst, dstin	/* Preserve dstin, we need to return it.  */
 	cmp	count, #64
@@ -627,6 +627,6 @@ def_fn memcpy p2align=6
 	bne	.Ltail63unaligned
 	bx	lr
 
-	.size	memcpy, . - memcpy
+	.size	ARCH_LIBCFUN(memcpy), . - ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memmove.S
@@ -35,9 +35,9 @@
 
 	.thumb
 	.syntax unified
-	.global memmove
-	.type	memmove, %function
-memmove:
+	.global ARCH_LIBCFUN(memmove)
+	.type	ARCH_LIBCFUN(memmove), %function
+ARCH_LIBCFUN(memmove):
 	cmp	r0, r1
 	push	{r4}
 	bls	3f
@@ -67,6 +67,6 @@ memmove:
 	bne	4b
 	pop	{r4}
 	bx	lr
-	.size memmove, . - memmove
+	.size ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_memset.S
@@ -35,9 +35,9 @@
 
 	.arm
 	.syntax unified
-	.global memset
-	.type	memset, %function
-memset:
+	.global ARCH_LIBCFUN(memset)
+	.type	ARCH_LIBCFUN(memset), %function
+ARCH_LIBCFUN(memset):
 	mov         r3, r0
 	// At this point only d0, d1 are going to be used below.
 	vdup.8      q0, r1
@@ -147,6 +147,6 @@ memset:
 	strbcs      r1, [r3], #1
 	strbcs      r1, [r3], #1
 	bx          lr
-	.size memset, . - memset
+	.size ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_strcmp.S
@@ -55,9 +55,9 @@
 
 	.arm
 	.syntax unified
-	.global strcmp
-	.type	strcmp, %function
-strcmp:
+	.global ARCH_LIBCFUN(strcmp)
+	.type	ARCH_LIBCFUN(strcmp), %function
+ARCH_LIBCFUN(strcmp):
 	pld	[r0, #0]
 	pld	[r1, #0]
 	eor	r2, r0, r1
@@ -305,6 +305,6 @@ strcmp:
 	ldr	r4, [sp], #4
 	ldr	r5, [sp], #4
 	bx	lr
-	.size strcmp, . - strcmp
+	.size ARCH_LIBCFUN(strcmp), . - ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/arm/armv7-r/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-r/gnu/arch_strlen.S
@@ -107,7 +107,7 @@
 #define tmp1		r4		/* Overlaps const_0  */
 #define tmp2		r5
 
-def_fn	strlen p2align=6
+def_fn	ARCH_LIBCFUN(strlen) p2align=6
 	pld	[srcin, #0]
 	strd	r4, r5, [sp, #-8]!
 	bic	src, srcin, #7
@@ -185,6 +185,6 @@ def_fn	strlen p2align=6
 	movne	data1a, const_m1
 	mov	const_0, #0
 	b	.Lstart_realigned
-	.size	strlen, . - strlen
+	.size	ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memchr.S
@@ -147,10 +147,10 @@
 	.thumb_func
 	.align 4
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
 
-memchr:
+ARCH_LIBCFUN(memchr):
 	.cfi_sections .debug_frame
 	.cfi_startproc
 #if __ARM_FEATURE_PAC_DEFAULT
@@ -295,7 +295,7 @@ memchr:
 	bx	lr
 
 	.cfi_endproc
-	.size	memchr, . - memchr
+	.size	ARCH_LIBCFUN(memchr), . - ARCH_LIBCFUN(memchr)
 
 #elif __ARM_ARCH_ISA_THUMB >= 2 && defined (__ARM_FEATURE_DSP)
 
@@ -318,9 +318,9 @@ memchr:
 	.thumb_func
 	.align 2
 	.p2align 4,,15
-	.global memchr
-	.type memchr,%function
-memchr:
+	.global ARCH_LIBCFUN(memchr)
+	.type ARCH_LIBCFUN(memchr),%function
+ARCH_LIBCFUN(memchr):
 	@ r0 = start of memory to scan
 	@ r1 = character to look for
 	@ r2 = length

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memcpy.S
@@ -105,11 +105,11 @@
 	.syntax unified
 	.text
 	.align	2
-	.global	memcpy
+	.global	ARCH_LIBCFUN(memcpy)
 	.thumb
 	.thumb_func
-	.type	memcpy, %function
-memcpy:
+	.type	ARCH_LIBCFUN(memcpy), %function
+ARCH_LIBCFUN(memcpy):
 	@ r0: dst
 	@ r1: src
 	@ r2: len
@@ -395,6 +395,6 @@ memcpy:
 #endif /* __ARM_FEATURE_PAC_DEFAULT */
 	bx	lr
 #endif
-	.size	memcpy, .-memcpy
+	.size	ARCH_LIBCFUN(memcpy), .-ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memmove.S
@@ -43,9 +43,9 @@
 
 	.thumb
 	.syntax unified
-	.global memmove
-	.type	memmove, %function
-memmove:
+	.global ARCH_LIBCFUN(memmove)
+	.type	ARCH_LIBCFUN(memmove), %function
+ARCH_LIBCFUN(memmove):
 #if __ARM_FEATURE_PAC_DEFAULT
 #  if __ARM_FEATURE_BTI_DEFAULT
 	pacbti	ip, lr, sp
@@ -88,6 +88,6 @@ memmove:
 	aut	ip, lr, sp
 #endif /* __ARM_FEATURE_PAC_DEFAULT */
 	bx	lr
-	.size memmove, . - memmove
+	.size ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_memset.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_memset.S
@@ -69,9 +69,9 @@
 
 	.thumb
 	.syntax unified
-	.global memset
-	.type	memset, %function
-memset:
+	.global ARCH_LIBCFUN(memset)
+	.type	ARCH_LIBCFUN(memset), %function
+ARCH_LIBCFUN(memset):
 #if __ARM_FEATURE_PAC_DEFAULT
 #  if __ARM_FEATURE_BTI_DEFAULT
 	pacbti	ip, lr, sp
@@ -166,6 +166,6 @@ memset:
 	ldmfd	sp!, {r0, r4-r7, pc}
 #  endif /* __ARM_FEATURE_PAC_DEFAULT */
 #endif
-	.size memset, . - memset
+	.size ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_strcmp.S
@@ -88,7 +88,7 @@
 
 	.thumb
 	.syntax unified
-def_fn strcmp
+def_fn ARCH_LIBCFUN(strcmp)
 	.cfi_sections .debug_frame
 	.cfi_startproc
 #if __ARM_FEATURE_PAC_DEFAULT
@@ -439,6 +439,6 @@ def_fn strcmp
 #endif /* __ARM_FEATURE_PAC_DEFAULT */
 	bx	lr
 	.cfi_endproc
-	.size strcmp, . - strcmp
+	.size ARCH_LIBCFUN(strcmp), . - ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_strcpy.S
@@ -68,11 +68,11 @@
     .syntax unified
     .text
     .align  2
-    .global strcpy
+    .global ARCH_LIBCFUN(strcpy)
     .thumb
-    .type   strcpy, %function
+    .type   ARCH_LIBCFUN(strcpy), %function
 
-strcpy:
+ARCH_LIBCFUN(strcpy):
 #if __ARM_FEATURE_PAC_DEFAULT
 #  if __ARM_FEATURE_BTI_DEFAULT
     pacbti  ip, lr, sp

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_strlen.S
@@ -115,7 +115,7 @@
 #define tmp1		r4		/* Overlaps const_0  */
 #define tmp2		r5
 
-def_fn	strlen p2align=6
+def_fn	ARCH_LIBCFUN(strlen) p2align=6
 #if __ARM_FEATURE_PAC_DEFAULT
 #  if __ARM_FEATURE_BTI_DEFAULT
 	pacbti	ip, lr, sp
@@ -203,6 +203,6 @@ def_fn	strlen p2align=6
 	movne	data1a, const_m1
 	mov	const_0, #0
 	b	.Lstart_realigned
-	.size	strlen, . - strlen
+	.size	ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_memchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_memchr.S
@@ -80,7 +80,7 @@
 \f:
 	.endm
 
-def_fn memchr
+def_fn ARCH_LIBCFUN(memchr)
 	/* Do not dereference srcin if no bytes to compare.  */
 	cbz	cntin, .Lzero_length
 	/*
@@ -174,6 +174,6 @@ def_fn memchr
 	mov	result, #0
 	ret
 
-	.size	memchr, . - memchr
+	.size	ARCH_LIBCFUN(memchr), . - ARCH_LIBCFUN(memchr)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_memcmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_memcmp.S
@@ -94,7 +94,7 @@
 \f:
         .endm
 
-def_fn memcmp p2align=6
+def_fn ARCH_LIBCFUN(memcmp) p2align=6
 	subs	limit, limit, 8
 	b.lo	L(less8)
 
@@ -197,6 +197,6 @@ L(byte_loop):
 	sub	result, data1w, data2w
 	ret
 
-	.size	memcmp, . - memcmp
+	.size	ARCH_LIBCFUN(memcmp), . - ARCH_LIBCFUN(memcmp)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_memcpy.S
+++ b/libs/libc/machine/arm64/gnu/arch_memcpy.S
@@ -111,7 +111,7 @@
    well as non-overlapping copies.
 */
 
-def_fn memcpy p2align=6
+def_fn ARCH_LIBCFUN(memcpy) p2align=6
 	prfm	PLDL1KEEP, [src]
 	add	srcend, src, count
 	add	dstend, dstin, count
@@ -233,6 +233,6 @@ L(copy_long):
 	stp	C_l, C_h, [dstend, -16]
 	ret
 
-	.size	memcpy, . - memcpy
+	.size	ARCH_LIBCFUN(memcpy), . - ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_memmove.S
+++ b/libs/libc/machine/arm64/gnu/arch_memmove.S
@@ -100,7 +100,7 @@
    unrolled loop processes 64 bytes per iteration.
 */
 
-def_fn memmove, 6
+def_fn ARCH_LIBCFUN(memmove), 6
 	sub	tmp1, dstin, src
 	cmp	count, 96
 	ccmp	tmp1, count, 2, hi
@@ -158,6 +158,6 @@ def_fn memmove, 6
 	stp	C_l, C_h, [dstin]
 3:	ret
 
-	.size	memmove, . - memmove
+	.size	ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_memset.S
+++ b/libs/libc/machine/arm64/gnu/arch_memset.S
@@ -92,7 +92,7 @@
 \f:
 	.endm
 
-def_fn memset p2align=6
+def_fn ARCH_LIBCFUN(memset) p2align=6
 
 	dup	v0.16B, valw
 	add	dstend, dstin, count
@@ -243,6 +243,6 @@ L(zva_other):
 	sub	dst, dst, 32		/* Bias dst for tail loop.  */
 	b	L(tail64)
 
-	.size	memset, . - memset
+	.size	ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_strchr.S
@@ -84,7 +84,7 @@
 \f:
 	.endm
 
-def_fn strchr
+def_fn ARCH_LIBCFUN(strchr)
 	/* Magic constant 0x40100401 to allow us to identify which lane
 	   matches the requested byte.  Magic constant 0x80200802 used
 	   similarly for NUL termination.  */
@@ -162,6 +162,6 @@ def_fn strchr
 	csel	result, result, xzr, eq
 	ret
 
-	.size	strchr, . - strchr
+	.size	ARCH_LIBCFUN(strchr), . - ARCH_LIBCFUN(strchr)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strchrnul.S
+++ b/libs/libc/machine/arm64/gnu/arch_strchrnul.S
@@ -80,7 +80,7 @@
 \f:
 	.endm
 
-def_fn strchrnul
+def_fn ARCH_LIBCFUN(strchrnul)
 	/* Magic constant 0x40100401 to allow us to identify which lane
 	   matches the termination condition.  */
 	mov	wtmp2, #0x0401
@@ -147,6 +147,6 @@ def_fn strchrnul
 	add	result, src, tmp1, lsr #1
 	ret
 
-	.size	strchrnul, . - strchrnul
+	.size	ARCH_LIBCFUN(strchrnul), . - ARCH_LIBCFUN(strchrnul)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strcmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_strcmp.S
@@ -76,7 +76,7 @@
 #define pos		x11
 
 	/* Start of performance-critical section  -- one 64B cache line.  */
-def_fn strcmp p2align=6
+def_fn ARCH_LIBCFUN(strcmp) p2align=6
 	eor	tmp1, src1, src2
 	mov	zeroones, #REP8_01
 	tst	tmp1, #7
@@ -206,6 +206,6 @@ L(loop_misaligned):
 L(done):
 	sub	result, data1, data2
 	ret
-	.size	strcmp, .-strcmp
+	.size	ARCH_LIBCFUN(strcmp), .-ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strcpy.S
+++ b/libs/libc/machine/arm64/gnu/arch_strcpy.S
@@ -38,7 +38,7 @@
  * ARMv8-a, AArch64, unaligned accesses, min page size 4k.
  */
 
-/* To build as stpcpy, define BUILD_STPCPY before compiling this file.
+/* To build as stpcpy.
 
    To test the page crossing code path more thoroughly, compile with
    -DSTRCPY_TEST_PAGE_CROSS - this will force all copies through the slower
@@ -67,12 +67,6 @@
 #define pos		x15
 #define len		x16
 #define to_align	x17
-
-#ifdef BUILD_STPCPY
-#define STRCPY stpcpy
-#else
-#define STRCPY strcpy
-#endif
 
 	.macro def_fn f p2align=0
 	.text
@@ -113,7 +107,7 @@
 
 #define MIN_PAGE_SIZE (1 << MIN_PAGE_P2)
 
-def_fn STRCPY p2align=6
+def_fn ARCH_LIBCFUN(strcpy) p2align=6
 	/* For moderately short strings, the fastest way to do the copy is to
 	   calculate the length of the string in the same way as strlen, then
 	   essentially do a memcpy of the result.  This avoids the need for
@@ -178,9 +172,6 @@ def_fn STRCPY p2align=6
 #endif
 	str	data2, [dst, #1]
 	str	data1, [dstin]
-#ifdef BUILD_STPCPY
-	add	dstin, dst, #8
-#endif
 	ret
 
 .Lfp_le8:
@@ -200,9 +191,6 @@ def_fn STRCPY p2align=6
 	/* 4->7 bytes to copy.  */
 	str	data2w, [dst, #-3]
 	str	data1w, [dstin]
-#ifdef BUILD_STPCPY
-	mov	dstin, dst
-#endif
 	ret
 .Lfp_lt4:
 	cbz	pos, .Lfp_lt2
@@ -215,9 +203,6 @@ def_fn STRCPY p2align=6
 .Lfp_lt2:
 	/* Null-terminated string.  Last character must be zero!  */
 	strb	wzr, [dst]
-#ifdef BUILD_STPCPY
-	mov	dstin, dst
-#endif
 	ret
 
 	.p2align 6
@@ -273,9 +258,6 @@ def_fn STRCPY p2align=6
 	add	dst, dst, pos, lsr #3
 	ldp	data1, data2, [src, #-32]
 	stp	data1, data2, [dst, #-16]
-#ifdef BUILD_STPCPY
-	sub	dstin, dst, #1
-#endif
 	ret
 
 .Lpage_cross:
@@ -339,6 +321,6 @@ def_fn STRCPY p2align=6
 	bic	has_nul2, tmp3, tmp4
 	b	.Lfp_gt8
 
-	.size	STRCPY, . - STRCPY
+	.size	ARCH_LIBCFUN(strcpy), . - ARCH_LIBCFUN(strcpy)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strlen.S
+++ b/libs/libc/machine/arm64/gnu/arch_strlen.S
@@ -113,7 +113,7 @@
 	   whether the first fetch, which may be misaligned, crosses a page
 	   boundary.  */
 
-def_fn strlen p2align=6
+def_fn ARCH_LIBCFUN(strlen) p2align=6
 	and	tmp1, srcin, MIN_PAGE_SIZE - 1
 	mov	zeroones, REP8_01
 	cmp	tmp1, MIN_PAGE_SIZE - 16
@@ -243,6 +243,6 @@ L(page_cross):
 	csel	data2, data2, tmp2, eq
 	b	L(page_cross_entry)
 
-	.size	strlen, . - strlen
+	.size	ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strncmp.S
+++ b/libs/libc/machine/arm64/gnu/arch_strncmp.S
@@ -83,7 +83,7 @@
 	.rep 7
 	nop	/* Pad so that the loop below fits a cache line.  */
 	.endr
-def_fn strncmp
+def_fn ARCH_LIBCFUN(strncmp)
 	cbz	limit, .Lret0
 	eor	tmp1, src1, src2
 	mov	zeroones, #REP8_01
@@ -295,6 +295,6 @@ def_fn strncmp
 .Lret0:
 	mov	result, #0
 	ret
-	.size strncmp, . - strncmp
+	.size ARCH_LIBCFUN(strncmp), . - ARCH_LIBCFUN(strncmp)
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strnlen.S
+++ b/libs/libc/machine/arm64/gnu/arch_strnlen.S
@@ -86,7 +86,7 @@
 	mov	len, limit
 	ret
 
-def_fn strnlen
+def_fn ARCH_LIBCFUN(strnlen)
 	cbz	limit, .Lhit_limit
 	mov	zeroones, #REP8_01
 	bic	src, srcin, #15
@@ -189,6 +189,6 @@ def_fn strnlen
 	csinv	data1, data1, xzr, le
 	csel	data2, data2, data2a, le
 	b	.Lrealigned
-	.size	strnlen, . - .Lstart	/* Include pre-padding in size.  */
+	.size	ARCH_LIBCFUN(strnlen), . - .Lstart	/* Include pre-padding in size.  */
 
 #endif

--- a/libs/libc/machine/arm64/gnu/arch_strrchr.S
+++ b/libs/libc/machine/arm64/gnu/arch_strrchr.S
@@ -90,7 +90,7 @@
 \f:
 	.endm
 
-def_fn strrchr
+def_fn ARCH_LIBCFUN(strrchr)
 	/* Magic constant 0x40100401 to allow us to identify which lane
 	   matches the requested byte.  Magic constant 0x80200802 used
 	   similarly for NUL termination.  */
@@ -180,6 +180,6 @@ def_fn strrchr
 
 	ret
 
-	.size	strrchr, . - strrchr
+	.size	ARCH_LIBCFUN(strrchr), . - ARCH_LIBCFUN(strrchr)
 
 #endif

--- a/libs/libc/machine/risc-v/gnu/arch_memcpy.S
+++ b/libs/libc/machine/risc-v/gnu/arch_memcpy.S
@@ -41,7 +41,7 @@
 
 	.text
 
-memcpy:
+ARCH_LIBCFUN(memcpy):
 	move		t6, a0  /* Preserve return value */
 
 	/* Defer to byte-oriented copy for small sizes */

--- a/libs/libc/machine/risc-v/gnu/arch_memset.S
+++ b/libs/libc/machine/risc-v/gnu/arch_memset.S
@@ -19,9 +19,9 @@
 #ifdef LIBC_BUILD_MEMSET
 
 .text
-.global memset
-.type	memset, @function
-memset:
+.global ARCH_LIBCFUN(memset)
+.type	ARCH_LIBCFUN(memset), @function
+ARCH_LIBCFUN(memset):
 	li t1, 15
 	move a4, a0
 	bleu a2, t1, .Ltiny
@@ -108,6 +108,6 @@ memset:
 	add a2, a2, a5
 	bleu a2, t1, .Ltiny
 	j .Laligned
-	.size	memset, .-memset
+	.size	ARCH_LIBCFUN(memset), .-ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/risc-v/gnu/arch_strcmp.S
+++ b/libs/libc/machine/risc-v/gnu/arch_strcmp.S
@@ -21,9 +21,9 @@
 #include "asm.h"
 
 .text
-.globl strcmp
-.type  strcmp, @function
-strcmp:
+.globl ARCH_LIBCFUN(strcmp)
+.type  ARCH_LIBCFUN(strcmp), @function
+ARCH_LIBCFUN(strcmp):
 	or    a4, a0, a1
 	li    t2, -1
 	and   a4, a4, SZREG-1
@@ -182,7 +182,7 @@ strcmp:
 	foundnull 1 3
 	foundnull 2 3
 #endif
-.size	strcmp, .-strcmp
+.size	ARCH_LIBCFUN(strcmp), .-ARCH_LIBCFUN(strcmp)
 
 #if SZREG == 8
 .section .srodata.cst8,"aM",@progbits,8

--- a/libs/libc/machine/xtensa/arch_memcpy.S
+++ b/libs/libc/machine/xtensa/arch_memcpy.S
@@ -55,9 +55,9 @@
   .local  .Lbytecopy
 
   .align  4
-  .global memcpy
-  .type memcpy, @function
-memcpy:
+  .global ARCH_LIBCFUN(memcpy)
+  .type ARCH_LIBCFUN(memcpy), @function
+ARCH_LIBCFUN(memcpy):
   ENTRY(16)
   /* a2 = dst, a3 = src, a4 = len */
 
@@ -281,6 +281,6 @@ __memcpy_aux:
 
   .end schedule
 
-  .size memcpy, . - memcpy
+  .size ARCH_LIBCFUN(memcpy), . - ARCH_LIBCFUN(memcpy)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_memmove.S
+++ b/libs/libc/machine/xtensa/arch_memmove.S
@@ -47,7 +47,7 @@
  ****************************************************************************/
   .text
   .begin schedule
-  .global memmove
+  .global ARCH_LIBCFUN(memmove)
 
 /*
  * Byte by byte copy
@@ -310,7 +310,7 @@
           # return to main algorithm
 
   .align  4
-memmove:
+ARCH_LIBCFUN(memmove):
 
   ENTRY(16)
   # a2/ dst, a3/ src, a4/ len
@@ -484,6 +484,6 @@ memmove:
   RET(16)
 
   .end schedule
-  .size memmove, . - memmove
+  .size ARCH_LIBCFUN(memmove), . - ARCH_LIBCFUN(memmove)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_memset.S
+++ b/libs/libc/machine/xtensa/arch_memset.S
@@ -64,9 +64,9 @@
 	.local	.Ldst2mod4
 
 	.align	4
-	.global	memset
-	.type	memset, @function
-memset:
+	.global	ARCH_LIBCFUN(memset)
+	.type	ARCH_LIBCFUN(memset), @function
+ARCH_LIBCFUN(memset):
   ENTRY(16)
 	/* a2 = dst, a3 = c, a4 = length */
 
@@ -180,6 +180,6 @@ __memset_aux:
 
 	.end schedule
 
-	.size	memset, . - memset
+	.size	ARCH_LIBCFUN(memset), . - ARCH_LIBCFUN(memset)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_strcmp.S
+++ b/libs/libc/machine/xtensa/arch_strcmp.S
@@ -48,11 +48,11 @@
   .align  4
   .literal_position
 
-  .global strcmp
-  .type strcmp,@function
+  .global ARCH_LIBCFUN(strcmp)
+  .type ARCH_LIBCFUN(strcmp),@function
   .align  4
 
-strcmp:
+ARCH_LIBCFUN(strcmp):
 
 #if XCHAL_HAVE_LOOPS && XCHAL_HAVE_DENSITY && !XCHAL_HAVE_BE && XCHAL_HAVE_FLIX3
 /*  Fast version for FLIX3 Little Endian */
@@ -764,6 +764,6 @@ strcmp:
 #endif /* FLIX3 */
 
   .end  schedule
-  .size strcmp, . - strcmp
+  .size ARCH_LIBCFUN(strcmp), . - ARCH_LIBCFUN(strcmp)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_strcpy.S
+++ b/libs/libc/machine/xtensa/arch_strcpy.S
@@ -41,9 +41,9 @@
   .begin schedule
   .align  4
   .literal_position
-  .global strcpy
-  .type strcpy, @function
-strcpy:
+  .global ARCH_LIBCFUN(strcpy)
+  .type ARCH_LIBCFUN(strcpy), @function
+ARCH_LIBCFUN(strcpy):
   ENTRY(16)
   /* a2 = dst, a3 = src */
 
@@ -245,6 +245,6 @@ strcpy:
 #endif /* 0 */
   .end schedule
 
-  .size strcpy, . - strcpy
+  .size ARCH_LIBCFUN(strcpy), . - ARCH_LIBCFUN(strcpy)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_strlen.S
+++ b/libs/libc/machine/xtensa/arch_strlen.S
@@ -41,9 +41,9 @@
   .begin schedule
   .align  4
   .literal_position
-  .global strlen
-  .type strlen, @function
-strlen:
+  .global ARCH_LIBCFUN(strlen)
+  .type ARCH_LIBCFUN(strlen), @function
+ARCH_LIBCFUN(strlen):
   ENTRY(16)
   /* a2 = s */
 
@@ -125,6 +125,6 @@ strlen:
 
   .end schedule
 
-  .size strlen, . - strlen
+  .size ARCH_LIBCFUN(strlen), . - ARCH_LIBCFUN(strlen)
 
 #endif

--- a/libs/libc/machine/xtensa/arch_strncpy.S
+++ b/libs/libc/machine/xtensa/arch_strncpy.S
@@ -73,9 +73,9 @@ __strncpy_aux:
   RET(16)
 
   .align  4
-  .global strncpy
-  .type strncpy, @function
-strncpy:
+  .global ARCH_LIBCFUN(strncpy)
+  .type ARCH_LIBCFUN(strncpy), @function
+ARCH_LIBCFUN(strncpy):
   ENTRY(16)
   /* a2 = dst, a3 = src */
 
@@ -266,6 +266,6 @@ strncpy:
 3:  RET(16)
 .end schedule
 
-  .size strncpy, . - strncpy
+  .size ARCH_LIBCFUN(strncpy), . - ARCH_LIBCFUN(strncpy)
 
 #endif


### PR DESCRIPTION
## Summary

kasan does not instrument the assembly function,
so it is checked in advance before calling.
If Kasan is not turned on, the speed and space will be almost unchanged under compiler optimization.


## Impact

kasan/mm

## Testing

qmue with kasan
