### PR TITLE
timer_create:Checks whether the signo provided by the user is valid

### DIFF
--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -164,7 +164,9 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
   /* Sanity checks. */
 
   if (timerid == NULL || (clockid != CLOCK_REALTIME &&
-      clockid != CLOCK_MONOTONIC && clockid != CLOCK_BOOTTIME))
+      clockid != CLOCK_MONOTONIC && clockid != CLOCK_BOOTTIME) ||
+      (evp != NULL && evp->sigev_notify == SIGEV_SIGNAL &&
+       !GOOD_SIGNO(evp->sigev_signo)))
     {
       set_errno(EINVAL);
       return ERROR;


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
When the user sets an illegal signo, the error will only be known when timer_signotify is triggered during timeout.
By intercepting timer_create, we can directly locate the problem

**Changes:**
Added a check for the user signo provided by the user when using SIGEV_SIGNAL

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.



## Testing
Build Host(s): Linux x86
Target(s): sim/nsh

It does not affect the normal use of timer_create, because it only returns an error for the wrong scenario