### PR TITLE
net/rpmsg: Don't set POLLHUP if rpmsg channel has not been established

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -950,7 +950,8 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
         }
       else /* !_SS_ISCONNECTED(conn->sconn.s_flags) */
         {
-          if (!conn->ept.rdev || conn->unbind)
+          if ((!conn->ept.rdev || conn->unbind) &&
+              !_SS_INITD(conn->sconn.s_flags))
             {
               eventset |= POLLHUP;
             }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

net/rpmsg: Don't set POLLHUP if rpmsg channel has not been established

## Impact

none

## Testing
vela ci


