### PR TITLE
tcp_input: if tcp->req > recvreq, send ack only when state is TCP_ESTABLISHED

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1214,7 +1214,7 @@ found:
                   return;
                 }
             }
-          else
+          else if ((conn->tcpstateflags & TCP_STATE_MASK) <= TCP_ESTABLISHED)
             {
 #ifdef CONFIG_NET_TCP_OUT_OF_ORDER
               /* Queue out-of-order segments. */


### PR DESCRIPTION

## Summary
we will drop packet when tcp_close_eventhandler
is register and invoke by tcp_input. then we will always early return and never stop, the peer will only close the connection if we send reset packet.

precondition:
close -> register tcp_close_eventhandler;

tcp_input -> tcp_callback(TCP_NEWDATA) -> devif_conn_event -> tcp_close_eventhandler -> flags &= ~TCP_NEWDATA -> NOT entry tcp_data_event -> conn->recvreq NOT increase

old flow:
tcp_input -> tcp->seqno greater than conn->rcvseq -> tcp_send(TCP_ACK)

with this patch:
tcp_input -> tcp->seqno greater than conn->rcvseq -> !TCP_ESTABLISHED -> case TCP_FIN_WAIT_1 -> dev->d_len greater than 0 -> tcp_reset


## Impact

## Testing
cortex-m33


