### PR TITLE
mm/mm_gran: fix compile warnings

### DIFF
--- a/mm/mm_gran/mm_grantable.c
+++ b/mm/mm_gran/mm_grantable.c
@@ -174,7 +174,10 @@ bool gran_match(const gran_t *gran, size_t posi, size_t size, bool used,
   uint32_t e;   /* expected cell value */
   gatr_t   r;   /* range helper */
 
-  gran_range(gran, posi, size, &r);
+  if (gran_range(gran, posi, size, &r) < 0)
+    {
+      memset(&r, 0, sizeof(r));
+    }
 
   /* check the ending cell */
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

mm_gran/mm_grantable.c:187:6: error: 'r.sidx' may be used uninitialized


## Impact

Warning fix only

## Testing

CI build pass.

