### PR TITLE
arch/arm64/src/imx9/imx9_lpuart.c: Fix parity get in TCGETS

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -1613,8 +1613,8 @@ static int imx9_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Return parity */
 
-        termiosp->c_cflag = (!priv->parity ? PARENB : 0) |
-                            (priv->parity ? PARODD : 0);
+        termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
+                            ((priv->parity == 1) ? PARODD : 0);
 
         /* Return stop bits */
 


### PR DESCRIPTION
This is a partial revert / fix for regression from 44d1811

## Summary

I just made a silly bug while cleaning up the code earlier. Correcting it here.

## Impact

TCGETS was returning wrong parity bits, causing wrong uart configuration occasionally when user was doing tcgets+tcsets.

## Testing

Tested on custom imx9 board
