### PR TITLE
pthread_cond remove csection  and sched_lock

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -269,6 +269,7 @@ struct pthread_cond_s
 {
   sem_t sem;
   clockid_t clockid;
+  volatile int16_t lock_count;
 };
 
 #ifndef __PTHREAD_COND_T_DEFINED

--- a/libs/libc/pthread/pthread_condinit.c
+++ b/libs/libc/pthread/pthread_condinit.c
@@ -74,6 +74,7 @@ int pthread_cond_init(FAR pthread_cond_t *cond,
   else
     {
       cond->clockid = attr ? attr->clockid : CLOCK_REALTIME;
+      cond->lock_count = 0;
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -75,7 +75,6 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
                            clockid_t clockid,
                            FAR const struct timespec *abstime)
 {
-  irqstate_t flags;
   int ret = OK;
   int status;
 
@@ -114,14 +113,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       sinfo("Give up mutex...\n");
 
-      /* We must disable pre-emption and interrupts here so that
-       * the time stays valid until the wait begins.   This adds
-       * complexity because we assure that interrupts and
-       * pre-emption are re-enabled correctly.
-       */
-
-      sched_lock();
-      flags = enter_critical_section();
+      cond->lock_count--;
 
       /* Give up the mutex */
 
@@ -136,12 +128,6 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
             }
         }
 
-      /* Restore interrupts  (pre-emption will be enabled
-       * when we fall through the if/then/else)
-       */
-
-      leave_critical_section(flags);
-
       /* Reacquire the mutex (retaining the ret). */
 
       sinfo("Re-locking...\n");
@@ -151,12 +137,6 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
         {
           ret = status;
         }
-
-      /* Re-enable pre-emption (It is expected that interrupts
-       * have already been re-enabled in the above logic)
-       */
-
-      sched_unlock();
     }
 
   leave_cancellation_point();

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -60,7 +60,6 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 {
   int status;
   int ret;
-  irqstate_t flags;
 
   sinfo("cond=%p mutex=%p\n", cond, mutex);
 
@@ -89,13 +88,8 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
       sinfo("Give up mutex / take cond\n");
 
-      flags = enter_critical_section();
-      sched_lock();
+      cond->lock_count--;
       ret = pthread_mutex_breaklock(mutex, &nlocks);
-
-      /* Take the semaphore.  This may be awakened only be a signal (EINTR)
-       * or if the thread is canceled (ECANCELED)
-       */
 
       status = -nxsem_wait_uninterruptible(&cond->sem);
       if (ret == OK)
@@ -104,9 +98,6 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
           ret = status;
         }
-
-      sched_unlock();
-      leave_critical_section(flags);
 
       /* Reacquire the mutex.
        *


### PR DESCRIPTION
## Summary
We decouple semcount from business logic by using an independent counting variable, which allows us to remove critical sections in many cases.

## Impact
pthread_cond

## Testing
ci ostest

**Build Host:**
* OS: Ubuntu 20.04
* CPU: x86_64 
* Compiler: GCC 9.4.0

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
