### PR TITLE
fs/shm: support shm_open with flags O_TRUNC

### DIFF
--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -108,6 +108,17 @@ static int file_shm_open(FAR struct file *shm, FAR const char *name,
           inode_release(inode);
           goto errout_with_sem;
         }
+
+      /* If the shared memory object already exists, truncate it to
+       * zero bytes.
+       */
+
+      if ((oflags & O_TRUNC) == O_TRUNC && inode->i_private != NULL)
+        {
+          shmfs_free_object(inode->i_private);
+          inode->i_private = NULL;
+          inode->i_size = 0;
+        }
     }
   else
     {


### PR DESCRIPTION



## Summary
fs/shm: support shm_open with flags O_TRUNC
## Impact
bug fix
## Testing
testcase:
https://fossies.org/linux/posixtestsuite/conformance/interfaces/shm_open/25-1.c