### PR TITLE
mm: fix tlsf compiler error

### DIFF
--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -605,7 +605,7 @@ static void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem,
   if (delay)
 #endif
     {
-      memset(mem, MM_FREE_MAGIC, nodesize);
+      memset(mem, MM_FREE_MAGIC, size);
     }
 #endif
 
@@ -1486,8 +1486,10 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                      size_t size)
 {
   FAR void *newmem;
+#ifndef CONFIG_MM_KASAN
   size_t oldsize;
   size_t newsize;
+#endif
 
   /* If oldmem is NULL, then realloc is equivalent to malloc */
 


### PR DESCRIPTION
## Summary
error: ‘nodesize’ undeclared (first use in this function)
  518 |       memset(mem, MM_FREE_MAGIC, nodesize);
tlsf/mm_tlsf.c:1288:10: warning: unused variable ‘newsize’ [-Wunused-variable]
 1288 |   size_t newsize;

## Impact

## Testing
sim
