### PR TITLE
Feature/esp i2c bitbang

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -320,11 +320,17 @@ config ESPRESSIF_I2C
 	bool
 	default n
 
+config ESPRESSIF_I2C_PERIPH
+	bool
+	depends on (ESPRESSIF_I2C0 || ESPRESSIF_I2C1)
+	default n
+
 config ESPRESSIF_I2C0
 	bool "I2C 0"
 	default n
 	select ESPRESSIF_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESPRESSIF_I2C1
 	bool "I2C 1"
@@ -332,6 +338,17 @@ config ESPRESSIF_I2C1
 	depends on ARCH_CHIP_ESP32H2
 	select ESPRESSIF_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
+
+config ESPRESSIF_I2C_BITBANG
+	bool "I2C Bitbang"
+	default n
+	select I2C_BITBANG
+	select ESPRESSIF_I2C
+	select I2C
+	select I2C_BITBANG
+	---help---
+		Software implemented I2C peripheral with GPIOs. Suggested to use if I2C peripherals are already in use.
 
 config ESPRESSIF_SPI
 	bool
@@ -1574,12 +1591,28 @@ config ESPRESSIF_I2C1_SDAPIN
 
 endif # ESPRESSIF_I2C1
 
+if ESPRESSIF_I2C_BITBANG
+
+config ESPRESSIF_I2C_BITBANG_SCLPIN
+	int "I2C Bitbang SCL Pin"
+	default 0
+	range 0 21
+
+config ESPRESSIF_I2C_BITBANG_SDAPIN
+	int "I2C Bitbang SDA Pin"
+	default 1
+	range 0 21
+
+endif # ESPRESSIF_I2C_BITBANG
+
 config ESPRESSIF_I2CTIMEOSEC
 	int "Timeout seconds"
+	depends on ESPRESSIF_I2C_PERIPH
 	default 0
 
 config ESPRESSIF_I2CTIMEOMS
 	int "Timeout milliseconds"
+	depends on ESPRESSIF_I2C_PERIPH
 	default 500
 
 endmenu # I2C configuration

--- a/arch/risc-v/src/common/espressif/Make.defs
+++ b/arch/risc-v/src/common/espressif/Make.defs
@@ -99,7 +99,12 @@ ifeq ($(CONFIG_ESPRESSIF_TEMP),y)
 endif
 
 ifeq ($(CONFIG_ESPRESSIF_I2C),y)
-	CHIP_CSRCS += esp_i2c.c
+	ifeq ($(CONFIG_ESPRESSIF_I2C_PERIPH),y)
+		CHIP_CSRCS += esp_i2c.c
+	endif
+	ifeq ($(CONFIG_ESPRESSIF_I2C_BITBANG),y)
+		CHIP_CSRCS += esp_i2c_bitbang.c
+	endif
 endif
 
 ifeq ($(CONFIG_ESPRESSIF_SPI),y)

--- a/arch/risc-v/src/common/espressif/esp_i2c.c
+++ b/arch/risc-v/src/common/espressif/esp_i2c.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_ESPRESSIF_I2C
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -1604,4 +1604,4 @@ int esp_i2cbus_uninitialize(struct i2c_master_s *dev)
   return OK;
 }
 
-#endif /* CONFIG_ESPRESSIF_I2C */
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */

--- a/arch/risc-v/src/common/espressif/esp_i2c_bitbang.c
+++ b/arch/risc-v/src/common/espressif/esp_i2c_bitbang.c
@@ -1,0 +1,247 @@
+/****************************************************************************
+ * arch/risc-v/src/common/espressif/esp_i2c_bitbang.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#include <assert.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/i2c/i2c_bitbang.h>
+#include <nuttx/kmalloc.h>
+
+#include "espressif/esp_i2c_bitbang.h"
+#include "soc/gpio_sig_map.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct esp_i2c_bitbang_dev_s
+{
+  struct i2c_bitbang_lower_dev_s lower;
+  int sda_pin;
+  int scl_pin;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_init(struct i2c_bitbang_lower_dev_s *lower);
+static void esp_i2c_bitbang_set_scl(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value);
+static void esp_i2c_bitbang_set_sda(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value);
+static bool esp_i2c_bitbang_get_scl(struct i2c_bitbang_lower_dev_s *lower);
+static bool esp_i2c_bitbang_get_sda(struct i2c_bitbang_lower_dev_s *lower);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Lower-half I2C bitbang data  */
+
+const static struct i2c_bitbang_lower_ops_s g_ops =
+{
+  .initialize = esp_i2c_bitbang_init,
+  .set_scl    = esp_i2c_bitbang_set_scl,
+  .set_sda    = esp_i2c_bitbang_set_sda,
+  .get_scl    = esp_i2c_bitbang_get_scl,
+  .get_sda    = esp_i2c_bitbang_get_sda
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_init
+ *
+ * Description:
+ *   Initialize the I2C bit-bang driver
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_init(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev = lower->priv;
+
+  esp_gpiowrite(dev->scl_pin, 1);
+  esp_gpiowrite(dev->sda_pin, 1);
+
+  esp_configgpio(dev->scl_pin, INPUT_PULLUP | OUTPUT_OPEN_DRAIN);
+  esp_gpio_matrix_out(dev->scl_pin, SIG_GPIO_OUT_IDX, 0, 0);
+
+  esp_configgpio(dev->sda_pin, INPUT_PULLUP | OUTPUT_OPEN_DRAIN);
+  esp_gpio_matrix_out(dev->sda_pin, SIG_GPIO_OUT_IDX, 0, 0);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_set_scl
+ *
+ * Description:
+ *   Set SCL line value
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *   value - The value to be written (0 or 1).
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_set_scl(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  esp_gpiowrite(dev->scl_pin, value);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_set_sda
+ *
+ * Description:
+ *   Set SDA line value
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *   value - The value to be written (0 or 1).
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_set_sda(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  esp_gpiowrite(dev->sda_pin, value);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_get_scl
+ *
+ * Description:
+ *   Get value from SCL line
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   The boolean representation of the SCL line value (true/false).
+ *
+ ****************************************************************************/
+
+static bool esp_i2c_bitbang_get_scl(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  return esp_gpioread(dev->scl_pin);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_get_sda
+ *
+ * Description:
+ *   Get value from SDA line
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   The boolean representation of the SDA line value (true/false).
+ *
+ ****************************************************************************/
+
+static bool esp_i2c_bitbang_get_sda(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  return esp_gpioread(dev->sda_pin);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_i2cbus_bitbang_initialize
+ *
+ * Description:
+ *   Initialize the I2C bitbang driver. And return a unique instance of
+ *   struct struct i2c_master_s. This function may be called to obtain
+ *   multiple instances of the interface, each of which may be set up with
+ *   a different frequency and slave address.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Valid I2C device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *esp_i2cbus_bitbang_initialize(void)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+      (struct esp_i2c_bitbang_dev_s *)
+          kmm_malloc(sizeof(struct esp_i2c_bitbang_dev_s));
+
+  DEBUGASSERT(dev);
+
+  dev->lower.ops = &g_ops;
+  dev->lower.priv = dev;
+  dev->scl_pin = CONFIG_ESPRESSIF_I2C_BITBANG_SCLPIN;
+  dev->sda_pin = CONFIG_ESPRESSIF_I2C_BITBANG_SDAPIN;
+
+  return i2c_bitbang_initialize(&dev->lower);
+}
+#endif /* CONFIG_ESPRESSIF_I2C_BITBANG */

--- a/arch/risc-v/src/common/espressif/esp_i2c_bitbang.h
+++ b/arch/risc-v/src/common/espressif/esp_i2c_bitbang.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/espressif/esp_i2c.h
+ * arch/risc-v/src/common/espressif/esp_i2c_bitbang.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,76 +18,73 @@
  *
  ****************************************************************************/
 
-/****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#ifndef __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_H
-#define __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_H
+#ifndef __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H
+#define __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
 #include <nuttx/i2c/i2c_master.h>
+#include "espressif/esp_gpio.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef __ASSEMBLY__
-
-#ifdef CONFIG_ESPRESSIF_I2C0
-#  define ESPRESSIF_I2C0 0
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#  define ESPRESSIF_I2C_BITBANG 3
 #endif
 
-#ifdef CONFIG_ESPRESSIF_I2C1
-#  define ESPRESSIF_I2C1 1
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
 #endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
 /****************************************************************************
- * Name: esp_i2cbus_initialize
+ * Name: esp_i2cbus_bitbang_initialize
  *
  * Description:
- *   Initialize the selected I2C port. And return a unique instance of struct
- *   struct i2c_master_s.  This function may be called to obtain multiple
- *   instances of the interface, each of which may be set up with a
- *   different frequency and slave address.
+ *   Initialize the I2C bitbang driver. And return a unique instance of
+ *   struct struct i2c_master_s. This function may be called to obtain
+ *   multiple instances of the interface, each of which may be set up with
+ *   a different frequency and slave address.
  *
  * Input Parameters:
- *   port - Port number (for hardware that has multiple I2C interfaces)
+ *   None
  *
  * Returned Value:
  *   Valid I2C device structure reference on success; a NULL on failure
  *
  ****************************************************************************/
 
-struct i2c_master_s *esp_i2cbus_initialize(int port);
+struct i2c_master_s *esp_i2cbus_bitbang_initialize(void);
+#endif
 
-/****************************************************************************
- * Name: esp_i2cbus_uninitialize
- *
- * Description:
- *   De-initialize the selected I2C port, and power down the device.
- *
- * Input Parameters:
- *   dev - Device structure as returned by the esp_i2cbus_initialize()
- *
- * Returned Value:
- *   OK on success, ERROR when internal reference count mismatch or dev
- *   points to invalid hardware device.
- *
- ****************************************************************************/
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
-int esp_i2cbus_uninitialize(struct i2c_master_s *dev);
-#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */
-
-#endif /* __ASSEMBLY__ */
-#endif /* __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_H */
+#endif /* __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H */

--- a/arch/xtensa/src/common/espressif/Kconfig
+++ b/arch/xtensa/src/common/espressif/Kconfig
@@ -23,6 +23,23 @@ config ESPRESSIF_TEMP
 	---help---
 		A built-in sensor used to measure the chip's internal temperature.
 
+config ESPRESSIF_I2C_PERIPH
+       bool
+       depends on (ESP32S3_I2C0 || ESP32S3_I2C1) || (ESP32_I2C0 || ESP32_I2C1) || (ESP32S2_I2C0 || ESP32S2_I2C1)
+       default n
+
+config ESPRESSIF_I2C_BITBANG
+       bool "I2C Bitbang"
+       default n
+       select I2C_BITBANG
+       select ESP32S3_I2C if ARCH_CHIP_ESP32S3
+	   select ESP32S2_I2C if ARCH_CHIP_ESP32S2
+	   select ESP32_I2C if ARCH_CHIP_ESP32
+       select I2C
+       select I2C_BITBANG
+	---help---
+		Software implemented I2C peripheral with GPIOs. Suggested to use if I2C peripherals are already in use.
+
 config ESPRESSIF_SPIFLASH
 	bool "SPI Flash"
 	depends on ARCH_CHIP_ESP32S2
@@ -71,6 +88,21 @@ config ESPRESSIF_TEMP_THREAD_STACKSIZE
 		The stack size for the worker thread.
 
 endmenu # ESPRESSIF_TEMP
+
+menu "I2C bitbang configuration"
+	depends on ESPRESSIF_I2C_BITBANG
+
+config ESPRESSIF_I2C_BITBANG_SCLPIN
+       int "I2C Bitbang SCL Pin"
+       default 0
+       range 0 21
+
+config ESPRESSIF_I2C_BITBANG_SDAPIN
+       int "I2C Bitbang SDA Pin"
+       default 1
+       range 0 21
+
+endmenu # I2C bitbang configuration
 
 config ESPRESSIF_HAVE_OTA_PARTITION
 	bool

--- a/arch/xtensa/src/common/espressif/Make.defs
+++ b/arch/xtensa/src/common/espressif/Make.defs
@@ -40,6 +40,10 @@ ifeq ($(CONFIG_ESPRESSIF_TEMP),y)
 CHIP_CSRCS += esp_temperature_sensor.c
 endif
 
+ifeq ($(CONFIG_ESPRESSIF_I2C_BITBANG),y)
+CHIP_CSRCS += esp_i2c_bitbang.c
+endif
+
 ifeq ($(CONFIG_ESPRESSIF_SPIFLASH),y)
 CHIP_CSRCS += esp_spiflash.c
 ifeq ($(CONFIG_ESPRESSIF_MTD),y)

--- a/arch/xtensa/src/common/espressif/esp_i2c_bitbang.c
+++ b/arch/xtensa/src/common/espressif/esp_i2c_bitbang.c
@@ -1,0 +1,277 @@
+/****************************************************************************
+ * arch/xtensa/src/common/espressif/esp_i2c_bitbang.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#include <assert.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/i2c/i2c_bitbang.h>
+#include <nuttx/kmalloc.h>
+
+#include "espressif/esp_i2c_bitbang.h"
+
+#if defined(CONFIG_ARCH_CHIP_ESP32S3)
+#include "esp32s3_gpio.h"
+#include "hardware/esp32s3_gpio_sigmap.h"
+#elif defined(CONFIG_ARCH_CHIP_ESP32S2)
+#include "esp32s2_gpio.h"
+#include "esp32s2_gpio_sigmap.h"
+#else
+#include "esp32_gpio.h"
+#include "esp32_gpio_sigmap.h"
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_CHIP_ESP32S3)
+#define CONFIG_GPIO(pin, attr)                 esp32s3_configgpio(pin, attr)
+#define GPIO_MATRIX_OUT(pin, idx, inv, en_inv) esp32s3_gpio_matrix_out(pin, \
+                                                          idx, inv, en_inv)
+#define GPIO_WRITE(pin, value)                 esp32s3_gpiowrite(pin, value)
+#define GPIO_READ(pin)                         esp32s3_gpioread(pin)
+#elif defined(CONFIG_ARCH_CHIP_ESP32S2)
+#define CONFIG_GPIO(pin, attr)                 esp32s2_configgpio(pin, attr)
+#define GPIO_MATRIX_OUT(pin, idx, inv, en_inv) esp32s2_gpio_matrix_out(pin, \
+                                                          idx, inv, en_inv)
+#define GPIO_WRITE(pin, value)                 esp32s2_gpiowrite(pin, value)
+#define GPIO_READ(pin)                         esp32s2_gpioread(pin)
+#else
+#define CONFIG_GPIO(pin, attr)                 esp32_configgpio(pin, attr)
+#define GPIO_MATRIX_OUT(pin, idx, inv, en_inv) esp32_gpio_matrix_out(pin,   \
+                                                          idx, inv, en_inv)
+#define GPIO_WRITE(pin, value)                 esp32_gpiowrite(pin, value)
+#define GPIO_READ(pin)                         esp3_gpioread(pin)
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct esp_i2c_bitbang_dev_s
+{
+  struct i2c_bitbang_lower_dev_s lower;
+  int sda_pin;
+  int scl_pin;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_init(struct i2c_bitbang_lower_dev_s *lower);
+static void esp_i2c_bitbang_set_scl(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value);
+static void esp_i2c_bitbang_set_sda(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value);
+static bool esp_i2c_bitbang_get_scl(struct i2c_bitbang_lower_dev_s *lower);
+static bool esp_i2c_bitbang_get_sda(struct i2c_bitbang_lower_dev_s *lower);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Lower-half I2C bitbang data  */
+
+const static struct i2c_bitbang_lower_ops_s g_ops =
+{
+  .initialize = esp_i2c_bitbang_init,
+  .set_scl    = esp_i2c_bitbang_set_scl,
+  .set_sda    = esp_i2c_bitbang_set_sda,
+  .get_scl    = esp_i2c_bitbang_get_scl,
+  .get_sda    = esp_i2c_bitbang_get_sda
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_init
+ *
+ * Description:
+ *   Initialize the I2C bit-bang driver
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_init(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev = lower->priv;
+
+  GPIO_WRITE(dev->scl_pin, 1);
+  GPIO_WRITE(dev->sda_pin, 1);
+
+  CONFIG_GPIO(dev->scl_pin, INPUT_PULLUP | OUTPUT_OPEN_DRAIN);
+  GPIO_MATRIX_OUT(dev->scl_pin, SIG_GPIO_OUT_IDX, 0, 0);
+
+  CONFIG_GPIO(dev->sda_pin, INPUT_PULLUP | OUTPUT_OPEN_DRAIN);
+  GPIO_MATRIX_OUT(dev->sda_pin, SIG_GPIO_OUT_IDX, 0, 0);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_set_scl
+ *
+ * Description:
+ *   Set SCL line value
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *   value - The value to be written (0 or 1).
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_set_scl(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  GPIO_WRITE(dev->scl_pin, value);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_set_sda
+ *
+ * Description:
+ *   Set SDA line value
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *   value - The value to be written (0 or 1).
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp_i2c_bitbang_set_sda(struct i2c_bitbang_lower_dev_s *lower,
+                                    bool value)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  GPIO_WRITE(dev->sda_pin, value);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_get_scl
+ *
+ * Description:
+ *   Get value from SCL line
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   The boolean representation of the SCL line value (true/false).
+ *
+ ****************************************************************************/
+
+static bool esp_i2c_bitbang_get_scl(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  return GPIO_READ(dev->scl_pin);
+}
+
+/****************************************************************************
+ * Name: esp_i2c_bitbang_get_sda
+ *
+ * Description:
+ *   Get value from SDA line
+ *
+ * Input Parameters:
+ *   lower - A pointer the publicly visible representation of
+ *           the "lower-half" driver state structure.
+ *
+ * Returned Value:
+ *   The boolean representation of the SDA line value (true/false).
+ *
+ ****************************************************************************/
+
+static bool esp_i2c_bitbang_get_sda(struct i2c_bitbang_lower_dev_s *lower)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+    (struct esp_i2c_bitbang_dev_s *)lower->priv;
+
+  return GPIO_READ(dev->sda_pin);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_i2cbus_bitbang_initialize
+ *
+ * Description:
+ *   Initialize the I2C bitbang driver. And return a unique instance of
+ *   struct struct i2c_master_s. This function may be called to obtain
+ *   multiple instances of the interface, each of which may be set up with
+ *   a different frequency and slave address.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Valid I2C device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *esp_i2cbus_bitbang_initialize(void)
+{
+  struct esp_i2c_bitbang_dev_s *dev =
+      (struct esp_i2c_bitbang_dev_s *)
+          kmm_malloc(sizeof(struct esp_i2c_bitbang_dev_s));
+
+  DEBUGASSERT(dev);
+
+  dev->lower.ops = &g_ops;
+  dev->lower.priv = dev;
+  dev->scl_pin = CONFIG_ESPRESSIF_I2C_BITBANG_SCLPIN;
+  dev->sda_pin = CONFIG_ESPRESSIF_I2C_BITBANG_SDAPIN;
+
+  return i2c_bitbang_initialize(&dev->lower);
+}
+#endif /* CONFIG_ESPRESSIF_I2C_BITBANG */

--- a/arch/xtensa/src/common/espressif/esp_i2c_bitbang.h
+++ b/arch/xtensa/src/common/espressif/esp_i2c_bitbang.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/xtensa/src/esp32s2/esp32s2_i2c.h
+ * arch/xtensa/src/common/espressif/esp_i2c_bitbang.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,76 +18,72 @@
  *
  ****************************************************************************/
 
-/****************************************************************************
- * Included Files
- ****************************************************************************/
-
-#ifndef __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_I2C_H
-#define __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_I2C_H
+#ifndef __ARCH_XTENSA_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H
+#define __ARCH_XTENSA_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
 #include <nuttx/i2c/i2c_master.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef __ASSEMBLY__
-
-#ifdef CONFIG_ESP32S2_I2C0
-#  define ESP32S2_I2C0 0
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#  define ESPRESSIF_I2C_BITBANG 3
 #endif
 
-#ifdef CONFIG_ESP32S2_I2C1
-#  define ESP32S2_I2C1 1
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
 #endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
 /****************************************************************************
- * Name: esp32s2_i2cbus_initialize
+ * Name: esp_i2cbus_bitbang_initialize
  *
  * Description:
- *   Initialize the selected I2C port. And return a unique instance of struct
- *   struct i2c_master_s.  This function may be called to obtain multiple
- *   instances of the interface, each of which may be set up with a
- *   different frequency and slave address.
+ *   Initialize the I2C bitbang driver. And return a unique instance of
+ *   struct struct i2c_master_s. This function may be called to obtain
+ *   multiple instances of the interface, each of which may be set up with
+ *   a different frequency and slave address.
  *
  * Input Parameters:
- *   Port number (for hardware that has multiple I2C interfaces)
+ *   None
  *
  * Returned Value:
  *   Valid I2C device structure reference on success; a NULL on failure
  *
  ****************************************************************************/
 
-struct i2c_master_s *esp32s2_i2cbus_initialize(int port);
+struct i2c_master_s *esp_i2cbus_bitbang_initialize(void);
+#endif
 
-/****************************************************************************
- * Name: esp32s2_i2cbus_uninitialize
- *
- * Description:
- *   De-initialize the selected I2C port, and power down the device.
- *
- * Input Parameters:
- *   Device structure as returned by the esp32s2_i2cbus_initialize()
- *
- * Returned Value:
- *   OK on success, ERROR when internal reference count mismatch or dev
- *   points to invalid hardware device.
- *
- ****************************************************************************/
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
-int esp32s2_i2cbus_uninitialize(struct i2c_master_s *dev);
-#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */
-
-#endif /* __ASSEMBLY__ */
-#endif /* __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_I2C_H */
+#endif /* __ARCH_XTENSA_SRC_COMMON_ESPRESSIF_ESP_I2C_BITBANG_H */

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -760,11 +760,13 @@ config ESP32_I2C0
 	bool "I2C 0"
 	default n
 	select ESP32_I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32_I2C1
 	bool "I2C 1"
 	default n
 	select ESP32_I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32_TWAI0
 	bool "TWAI (CAN) 0"
@@ -1135,10 +1137,12 @@ endif # ESP32_I2C1
 config ESP32_I2CTIMEOSEC
 	int "Timeout seconds"
 	default 0
+	depends on ESPRESSIF_I2C_PERIPH
 
 config ESP32_I2CTIMEOMS
 	int "Timeout milliseconds"
 	default 500
+	depends on ESPRESSIF_I2C_PERIPH
 
 endmenu # I2C configuration
 

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -75,7 +75,9 @@ CHIP_CSRCS += esp32_ledc.c
 endif
 
 ifeq ($(CONFIG_ESP32_I2C),y)
+ifeq ($(CONFIG_ESPRESSIF_I2C_PERIPH),y)
 CHIP_CSRCS += esp32_i2c.c
+endif
 endif
 
 ifeq ($(CONFIG_ESP32_I2S),y)

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_ESP32_I2C
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -1569,4 +1569,4 @@ int esp32_i2cbus_uninitialize(struct i2c_master_s *dev)
   return OK;
 }
 
-#endif /* CONFIG_ESP32_I2C */
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */

--- a/arch/xtensa/src/esp32/esp32_i2c.h
+++ b/arch/xtensa/src/esp32/esp32_i2c.h
@@ -55,6 +55,7 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 /****************************************************************************
  * Name: esp32_i2cbus_initialize
  *
@@ -90,6 +91,7 @@ struct i2c_master_s *esp32_i2cbus_initialize(int port);
  ****************************************************************************/
 
 int esp32_i2cbus_uninitialize(struct i2c_master_s *dev);
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */
 
 #ifdef __cplusplus
 }

--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -471,12 +471,14 @@ config ESP32S2_I2C0
 	default n
 	select ESP32S2_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32S2_I2C1
 	bool "I2C 1"
 	default n
 	select ESP32S2_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32S2_TWAI
 	bool "TWAI (CAN)"
@@ -791,10 +793,12 @@ endif # ESP32S2_I2C1
 config ESP32S2_I2CTIMEOSEC
 	int "Timeout seconds"
 	default 0
+	depends on ESPRESSIF_I2C_PERIPH
 
 config ESP32S2_I2CTIMEOMS
 	int "Timeout milliseconds"
 	default 500
+	depends on ESPRESSIF_I2C_PERIPH
 
 endmenu # I2C Configuration
 

--- a/arch/xtensa/src/esp32s2/Make.defs
+++ b/arch/xtensa/src/esp32s2/Make.defs
@@ -54,7 +54,9 @@ CHIP_CSRCS += esp32s2_rng.c
 endif
 
 ifeq ($(CONFIG_ESP32S2_I2C),y)
+ifeq ($(CONFIG_ESPRESSIF_I2C_PERIPH),y)
 CHIP_CSRCS += esp32s2_i2c.c
+endif
 endif
 
 ifeq ($(CONFIG_ESP32S2_I2S),y)

--- a/arch/xtensa/src/esp32s2/esp32s2_i2c.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2c.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_ESP32S2_I2C
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 
 #include <assert.h>
 #include <debug.h>
@@ -1613,4 +1613,4 @@ int esp32s2_i2cbus_uninitialize(struct i2c_master_s *dev)
   return OK;
 }
 
-#endif /* CONFIG_ESP32S2_I2C */
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -683,12 +683,14 @@ config ESP32S3_I2C0
 	default n
 	select ESP32S3_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32S3_I2C1
 	bool "I2C 1"
 	default n
 	select ESP32S3_I2C
 	select I2C
+	select ESPRESSIF_I2C_PERIPH
 
 config ESP32S3_TWAI
 	bool "TWAI (CAN)"
@@ -1430,10 +1432,12 @@ endif # ESP32S3_I2C1
 config ESP32S3_I2CTIMEOSEC
 	int "Timeout seconds"
 	default 0
+	depends on ESPRESSIF_I2C_PERIPH
 
 config ESP32S3_I2CTIMEOMS
 	int "Timeout milliseconds"
 	default 500
+	depends on ESPRESSIF_I2C_PERIPH
 
 endmenu # I2C Configuration
 

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -114,7 +114,9 @@ CHIP_CSRCS += esp32s3_adc.c
 endif
 
 ifeq ($(CONFIG_ESP32S3_I2C),y)
+ifeq ($(CONFIG_ESPRESSIF_I2C_PERIPH),y)
 CHIP_CSRCS += esp32s3_i2c.c
+endif
 endif
 
 ifeq ($(CONFIG_ESP32S3_I2S),y)

--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_ESP32S3_I2C
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 
 #include <assert.h>
 #include <debug.h>
@@ -1647,4 +1647,4 @@ int esp32s3_i2cbus_uninitialize(struct i2c_master_s *dev)
   return OK;
 }
 
-#endif /* CONFIG_ESP32S3_I2C */
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */

--- a/arch/xtensa/src/esp32s3/esp32s3_i2c.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_i2c.h
@@ -51,6 +51,7 @@
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 /****************************************************************************
  * Name: esp32s3_i2cbus_initialize
  *
@@ -86,6 +87,7 @@ struct i2c_master_s *esp32s3_i2cbus_initialize(int port);
  ****************************************************************************/
 
 int esp32s3_i2cbus_uninitialize(struct i2c_master_s *dev);
+#endif /* CONFIG_ESPRESSIF_I2C_PERIPH */
 
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_XTENSA_SRC_ESP32S3_ESP32S3_I2C_H */

--- a/boards/risc-v/esp32c3/common/src/esp_board_bmp180.c
+++ b/boards/risc-v/esp32c3/common/src/esp_board_bmp180.c
@@ -31,7 +31,11 @@
 #include <nuttx/sensors/bmp180.h>
 #include <nuttx/i2c/i2c_master.h>
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
 #include "espressif/esp_i2c.h"
+#else
+#include "espressif/esp_i2c_bitbang.h"
+#endif
 
 #include "esp_board_bmp180.h"
 
@@ -64,7 +68,11 @@ int board_bmp180_initialize(int devno)
 
   /* Initialize BMP180 */
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
   i2c = esp_i2cbus_initialize(ESPRESSIF_I2C0);
+#else
+  i2c = esp_i2cbus_bitbang_initialize();
+#endif
 
   if (i2c)
     {

--- a/boards/risc-v/esp32c6/common/src/esp_board_bmp180.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_bmp180.c
@@ -31,7 +31,11 @@
 #include <nuttx/sensors/bmp180.h>
 #include <nuttx/i2c/i2c_master.h>
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
 #include "espressif/esp_i2c.h"
+#else
+#include "espressif/esp_i2c_bitbang.h"
+#endif
 
 #include "esp_board_bmp180.h"
 
@@ -64,7 +68,11 @@ int board_bmp180_initialize(int devno)
 
   /* Initialize BMP180 */
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
   i2c = esp_i2cbus_initialize(ESPRESSIF_I2C0);
+#else
+  i2c = esp_i2cbus_bitbang_initialize();
+#endif
 
   if (i2c)
     {

--- a/boards/risc-v/esp32h2/common/src/esp_board_bmp180.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_bmp180.c
@@ -31,7 +31,11 @@
 #include <nuttx/sensors/bmp180.h>
 #include <nuttx/i2c/i2c_master.h>
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
 #include "espressif/esp_i2c.h"
+#else
+#include "espressif/esp_i2c_bitbang.h"
+#endif
 
 #include "esp_board_bmp180.h"
 
@@ -63,7 +67,11 @@ int board_bmp180_initialize(int devno)
 
   /* Initialize BMP180 */
 
+#ifndef CONFIG_ESPRESSIF_I2C_BITBANG
   i2c = esp_i2cbus_initialize(ESPRESSIF_I2C0);
+#else
+  i2c = esp_i2cbus_bitbang_initialize();
+#endif
 
   if (i2c)
     {

--- a/boards/risc-v/esp32h2/common/src/esp_board_i2c.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_i2c.c
@@ -30,12 +30,41 @@
 
 #include <nuttx/i2c/i2c_master.h>
 
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#include "espressif/esp_i2c_bitbang.h"
+#endif
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 #include "espressif/esp_i2c.h"
+#endif
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+static int i2c_bitbang_driver_init(int bus)
+{
+  struct i2c_master_s *i2c;
+  int ret;
+
+  i2c = esp_i2cbus_bitbang_initialize();
+  if (i2c == NULL)
+    {
+      i2cerr("Failed to get I2C%d interface\n", bus);
+      return -ENODEV;
+    }
+
+  ret = i2c_register(i2c, bus);
+  if (ret < 0)
+    {
+      i2cerr("Failed to register I2C%d driver: %d\n", bus, ret);
+    }
+
+  return ret;
+}
+#endif
+
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 static int i2c_driver_init(int bus)
 {
   struct i2c_master_s *i2c;
@@ -57,6 +86,7 @@ static int i2c_driver_init(int bus)
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: board_i2c_init
@@ -84,6 +114,10 @@ int board_i2c_init(void)
 
 #ifdef CONFIG_ESPRESSIF_I2C1
   ret = i2c_driver_init(ESPRESSIF_I2C1);
+#endif
+
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+  ret = i2c_bitbang_driver_init(ESPRESSIF_I2C_BITBANG);
 #endif
 
   return ret;

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_i2c.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_i2c.c
@@ -30,12 +30,41 @@
 
 #include <nuttx/i2c/i2c_master.h>
 
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+#include "espressif/esp_i2c_bitbang.h"
+#endif
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 #include "esp32s3_i2c.h"
+#endif
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+static int i2c_bitbang_driver_init(int bus)
+{
+  struct i2c_master_s *i2c;
+  int ret;
+
+  i2c = esp_i2cbus_bitbang_initialize();
+  if (i2c == NULL)
+    {
+      i2cerr("Failed to get I2C%d interface\n", bus);
+      return -ENODEV;
+    }
+
+  ret = i2c_register(i2c, bus);
+  if (ret < 0)
+    {
+      i2cerr("Failed to register I2C%d driver: %d\n", bus, ret);
+    }
+
+  return ret;
+}
+#endif
+
+#ifdef CONFIG_ESPRESSIF_I2C_PERIPH
 static int i2c_driver_init(int bus)
 {
   struct i2c_master_s *i2c;
@@ -57,6 +86,7 @@ static int i2c_driver_init(int bus)
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: board_i2c_init
@@ -84,6 +114,10 @@ int board_i2c_init(void)
 
 #ifdef CONFIG_ESP32S3_I2C1
   ret = i2c_driver_init(ESP32S3_I2C1);
+#endif
+
+#ifdef CONFIG_ESPRESSIF_I2C_BITBANG
+  ret = i2c_bitbang_driver_init(ESPRESSIF_I2C_BITBANG);
 #endif
 
 #ifdef CONFIG_ESP32S3_I2C0


### PR DESCRIPTION
## Summary

Bitbang device supports are added due to flexibility on device testing and other use cases especially the devices which has one related peripheral (e.g. There is one SPI peripheral for C3 or there is one I2C peripheral for C6). This feature adds another interface for related peripheral in cases of when number of peripherals are not enough.

- esp32[c3|c6|h2]: Add I2C bitbang supoort
- esp32[s2|s3]: Add I2C bitbang supoort


## Impact
ESP32, ESP32S2, ESP32S3, ESP32C3, ESP32C6, ESP32H2

## Testing

Configurations used with `ESPRESSIF_I2C_BITBANG=y` and `CONFIG_I2CTOOL_MAXBUS=4`, `ESP32S3_I2C0=n`, `ESP32S3_I2C1=n`, ... options additionally:

```
esp32c3-generic:bmp180 
esp32c6-devkitc:bmp180 
esp32h2-devkit:bmp180 
esp32s3-devkit:i2c 
```

BMP180 sensor connected (GPIO0 - SCL, GPIO1 - SDA as default) and these command applied:

```
nsh> i2c dev -b 3 0x70 0x7f
NOTE: Some devices may not appear with this scan.
You may also try a scan with the -z flag to discover more devices using a zero-byte write request.
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:                                                 
10:                                                 
20:                                                 
30:                                                 
40:                                                                                                                                                                                  
50:                                                 
60:                                                 
70: -- -- -- -- -- -- -- 77 -- -- -- -- -- -- -- -- 

nsh> bmp180
Pressure value = 100405
Pressure value = 100395
Pressure value = 100399
Pressure value = 100399
Pressure value = 100394
Pressure value = 100398
...
```

Additionally, output checked with a logic analyzer

