### PR TITLE
cmake:implement CMake build of xtensa arch

### DIFF
--- a/arch/xtensa/CMakeLists.txt
+++ b/arch/xtensa/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# arch/xtensa/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()

--- a/arch/xtensa/src/CMakeLists.txt
+++ b/arch/xtensa/src/CMakeLists.txt
@@ -1,0 +1,28 @@
+# ##############################################################################
+# arch/xtensa/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+add_subdirectory(common)
+add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
+# Include directories (before system ones) as PUBLIC so that it can be exposed
+# to libboard
+target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common)
+if(NOT CONFIG_BUILD_FLAT)
+  target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
+                                                          common)
+endif()

--- a/arch/xtensa/src/cmake/Toolchain.cmake
+++ b/arch/xtensa/src/cmake/Toolchain.cmake
@@ -1,0 +1,190 @@
+# ##############################################################################
+# arch/xtensa/src/cmake/Toolchain.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+
+if(CONFIG_XTENSA_TOOLCHAIN_XCC OR CONFIG_XTENSA_TOOLCHAIN_XCLANG)
+  set(TOOLCHAIN_PREFIX xt)
+endif()
+
+if(CONFIG_XTENSA_TOOLCHAIN_ESP)
+  set(TOOLCHAIN_PREFIX xtensa-${CONFIG_ARCH_CHIP}-elf-)
+endif()
+
+# Default toolchain
+if(CONFIG_XTENSA_TOOLCHAIN_XCC)
+
+  set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-xcc)
+  set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+  set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-xc++)
+  set(CMAKE_PREPROCESSOR ${TOOLCHAIN_PREFIX}-xcc -E -P -x c)
+
+  add_compile_options(-Wno-atomic-alignment)
+
+elseif(CONFIG_XTENSA_TOOLCHAIN_XCLANG)
+  set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-clang)
+  set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+  set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-clang++)
+  set(CMAKE_PREPROCESSOR ${TOOLCHAIN_PREFIX}-clang -E -P -x c)
+else()
+  set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+  set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+  set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+  set(CMAKE_PREPROCESSOR ${TOOLCHAIN_PREFIX}-gcc -E -P -x c)
+endif()
+
+set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip --strip-unneeded)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+set(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}-ar)
+set(CMAKE_NM ${TOOLCHAIN_PREFIX}-nm)
+set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-ranlib)
+
+# override the ARCHIVE command
+set(CMAKE_ARCHIVE_COMMAND "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_RANLIB_COMMAND "<CMAKE_RANLIB> <TARGET>")
+set(CMAKE_C_ARCHIVE_CREATE ${CMAKE_ARCHIVE_COMMAND})
+set(CMAKE_CXX_ARCHIVE_CREATE ${CMAKE_ARCHIVE_COMMAND})
+set(CMAKE_ASM_ARCHIVE_CREATE ${CMAKE_ARCHIVE_COMMAND})
+
+set(CMAKE_C_ARCHIVE_APPEND ${CMAKE_ARCHIVE_COMMAND})
+set(CMAKE_CXX_ARCHIVE_APPEND ${CMAKE_ARCHIVE_COMMAND})
+set(CMAKE_ASM_ARCHIVE_APPEND ${CMAKE_ARCHIVE_COMMAND})
+
+set(CMAKE_C_ARCHIVE_FINISH ${CMAKE_RANLIB_COMMAND})
+set(CMAKE_CXX_ARCHIVE_FINISH ${CMAKE_RANLIB_COMMAND})
+set(CMAKE_ASM_ARCHIVE_FINISH ${CMAKE_RANLIB_COMMAND})
+
+set(NO_LTO "-fno-lto")
+
+add_compile_options(-mlongcalls)
+
+add_compile_options(-mtext-section-literals)
+
+if(CONFIG_MM_KASAN_ALL)
+  add_compile_options(-fsanitize=kernel-address)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
+  add_compile_options(--param=asan-instrument-reads=0)
+endif()
+
+if(CONFIG_MM_KASAN_DISABLE_READS_CHECK)
+  add_compile_options(--param=asan-instrument-writes=0)
+endif()
+
+if(CONFIG_MM_UBSAN_ALL)
+  add_compile_options(${CONFIG_MM_UBSAN_OPTION})
+endif()
+
+if(CONFIG_MM_UBSAN_TRAP_ON_ERROR)
+  add_compile_options(-fsanitize-undefined-trap-on-error)
+endif()
+
+if(CONFIG_DEBUG_CUSTOMOPT)
+  add_compile_options(${CONFIG_DEBUG_OPTLEVEL})
+elseif(CONFIG_DEBUG_FULLOPT)
+  if(CONFIG_ARCH_TOOLCHAIN_CLANG)
+    add_compile_options(-Oz)
+  else()
+    add_compile_options(-Os)
+  endif()
+endif()
+
+if(NOT CONFIG_DEBUG_NOOPT)
+  add_compile_options(-fno-strict-aliasing)
+endif()
+
+if(CONFIG_FRAME_POINTER)
+  add_compile_options(-fno-omit-frame-pointer -fno-optimize-sibling-calls)
+else()
+  add_compile_options(-fomit-frame-pointer)
+endif()
+
+if(CONFIG_STACK_CANARIES)
+  add_compile_options(-fstack-protector-all)
+endif()
+
+if(CONFIG_STACK_USAGE)
+  add_compile_options(-fstack-usage)
+endif()
+
+if(${CONFIG_STACK_USAGE_WARNING})
+  if(NOT ${CONFIG_STACK_USAGE_WARNING} STREQUAL 0)
+    add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
+  endif()
+endif()
+
+if(CONFIG_ARCH_INSTRUMENT_ALL)
+  add_compile_options(-finstrument-functions)
+endif()
+
+add_compile_options(
+  -fno-common
+  -Wall
+  -Wshadow
+  -Wundef
+  -Wno-attributes
+  -Wno-unknown-pragmas
+  $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>
+  $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++>)
+
+if(NOT ${CONFIG_ARCH_TOOLCHAIN_CLANG})
+  add_compile_options(-Wno-psabi)
+endif()
+
+if(CONFIG_CXX_STANDARD)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
+endif()
+
+if(NOT CONFIG_CXX_EXCEPTION)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
+                      $<$<COMPILE_LANGUAGE:CXX>:-fcheck-new>)
+endif()
+
+if(NOT CONFIG_CXX_RTTI)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+endif()
+
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_link_options(-Wl,--gc-sections)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
+# Debug --whole-archive
+if(CONFIG_DEBUG_LINK_WHOLE_ARCHIVE)
+  add_link_options(-Wl,--whole-archive)
+endif()
+
+add_link_options(-nostdlib)
+add_link_options(-Wl,--entry=__start)
+
+if(CONFIG_DEBUG_LINK_MAP)
+  add_link_options(-Wl,--cref -Wl,-Map=nuttx.map)
+endif()
+
+if(CONFIG_DEBUG_SYMBOLS)
+  add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
+endif()

--- a/arch/xtensa/src/cmake/platform.cmake
+++ b/arch/xtensa/src/cmake/platform.cmake
@@ -1,0 +1,84 @@
+# ##############################################################################
+# arch/xtensa/src/cmake/platform.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+get_directory_property(TOOLCHAIN_DIR_FLAGS DIRECTORY ${CMAKE_SOURCE_DIR}
+                                                     COMPILE_OPTIONS)
+
+set(NUTTX_EXTRA_FLAGS "")
+foreach(FLAG ${TOOLCHAIN_DIR_FLAGS})
+  if(NOT FLAG MATCHES "^\\$<.*>$")
+    list(APPEND NUTTX_EXTRA_FLAGS ${FLAG})
+  else()
+    string(REGEX MATCH "\\$<\\$<COMPILE_LANGUAGE:C>:(.*)>" matched ${FLAG})
+    if(matched)
+      list(APPEND NUTTX_EXTRA_FLAGS ${CMAKE_MATCH_1})
+    endif()
+  endif()
+endforeach()
+
+separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
+
+execute_process(
+  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+          --print-libgcc-file-name
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE extra_library)
+list(APPEND EXTRA_LIB ${extra_library})
+if(NOT CONFIG_LIBM)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libm.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_LIBSUPCXX_TOOLCHAIN)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libsupc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+if(CONFIG_SCHED_GCOV)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libgcov.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
+
+if(CONFIG_XTENSA_TOOLCHAIN_XCLANG)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --show-config=config
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE xt_path)
+
+  foreach(lib ${EXTRA_LIB})
+    file(GLOB_RECURSE find_lib ${xt_path}/xtensa-elf/lib/${lib}
+         ${xt_path}/xtensa-elf/lib/*/${lib})
+    nuttx_add_extra_library(${find_lib})
+  endforeach()
+else()
+  nuttx_add_extra_library(${EXTRA_LIB})
+endif()
+
+set(PREPROCESS ${CMAKE_PREPROCESSOR})

--- a/arch/xtensa/src/common/CMakeLists.txt
+++ b/arch/xtensa/src/common/CMakeLists.txt
@@ -1,0 +1,114 @@
+# ##############################################################################
+# arch/xtensa/src/common/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# The start-up, "head", file.  May be either a .S or a .c file.
+add_library(xtensa_head OBJECT)
+nuttx_add_library_internal(xtensa_head)
+get_property(
+  definitions
+  TARGET nuttx
+  PROPERTY NUTTX_KERNEL_DEFINITIONS)
+target_compile_definitions(xtensa_head PRIVATE ${definitions})
+
+get_property(
+  options
+  TARGET nuttx
+  PROPERTY NUTTX_KERNEL_COMPILE_OPTIONS)
+
+set(HEAD_SRCS xtensa_vectors.S xtensa_window_vector.S xtensa_windowspill.S
+              xtensa_int_handlers.S xtensa_user_handler.S)
+
+target_sources(xtensa_head PRIVATE ${HEAD_SRCS})
+target_include_directories(xtensa_head BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR})
+target_link_libraries(nuttx PRIVATE $<TARGET_OBJECTS:xtensa_head>)
+
+# Common Xtensa files (arch/xtensa/src/common)
+
+list(
+  APPEND
+  SRCS
+  xtensa_context.S
+  xtensa_cpuint.S
+  xtensa_panic.S
+  xtensa_assert.c
+  xtensa_cache.c
+  xtensa_cpenable.c
+  xtensa_cpuinfo.c
+  xtensa_createstack.c
+  xtensa_exit.c
+  xtensa_getintstack.c
+  xtensa_initialize.c
+  xtensa_initialstate.c
+  xtensa_irqdispatch.c
+  xtensa_lowputs.c
+  xtensa_mdelay.c
+  xtensa_modifyreg8.c
+  xtensa_modifyreg16.c
+  xtensa_modifyreg32.c
+  xtensa_mpu.c
+  xtensa_nputs.c
+  xtensa_oneshot.c
+  xtensa_perf.c
+  xtensa_releasestack.c
+  xtensa_registerdump.c
+  xtensa_sigdeliver.c
+  xtensa_switchcontext.c
+  xtensa_swint.c
+  xtensa_stackframe.c
+  xtensa_saveusercontext.c
+  xtensa_schedsigaction.c
+  xtensa_udelay.c
+  xtensa_usestack.c
+  xtensa_tcbinfo.c)
+
+# Configuration-dependent common Xtensa files
+
+if(CONFIG_ARCH_USE_TEXT_HEAP)
+  list(APPEND SRCS xtensa_loadstore.S)
+endif()
+
+if(CONFIG_ARCH_FPU)
+  list(APPEND SRCS xtensa_fpucmp.c)
+endif()
+
+if(CONFIG_SCHED_BACKTRACE)
+  list(APPEND SRCS xtensa_backtrace.c)
+endif()
+
+if(CONFIG_SMP)
+  list(APPEND SRCS xtensa_smpcall.c)
+endif()
+
+if(CONFIG_STACK_COLORATION)
+  list(APPEND SRCS xtensa_checkstack.c)
+endif()
+
+if(CONFIG_XTENSA_SEMIHOSTING_HOSTFS)
+  list(APPEND SRCS xtensa_simcall.S xtensa_hostfs.c)
+endif()
+
+if(CONFIG_BUILD_PROTECTED)
+  target_sources(arch_interface PRIVATE xtensa_signal_handler.S)
+  list(APPEND SRCS xtensa_dispatch_syscall.S)
+  list(APPEND SRCS xtensa_signal_dispatch.c xtensa_task_start.c
+       xtensa_pthread_start.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

implement CMake build of xtensa arch

## Impact

new features and forward compatibility

## Testing

```
configure:cmake -B build -DBOARD_CONFIG=iss-hifi4:nsh 
build:cmake --build build
run:xt-run build/nuttx
```
