### PR TITLE
sys/socket: fix struct sockaddr_storage alignment issue

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -327,7 +327,7 @@ struct sockaddr_storage
 
   /* Following fields are implementation-defined */
 
-  struct
+  struct __attribute__((packed))
   {
     char ss_pad1[SS_PAD1SIZE]; /* 6-byte pad; this is to make implementation-defined
                                 * pad up to alignment field that follows explicit in


### PR DESCRIPTION
## Summary
sys/socket: use __attribute__((packed)) to avoid changes in the size of struct sockaddr_storage due to struct alignment.

Referencing [RFC 2553#section-3.10](https://datatracker.ietf.org/doc/html/rfc2553#section-3.10) and the [POSIX standard documentation](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/socket.h.html).
Defines the maximum size of the structure, which is typically 128 bytes. But the current output structure size (sizeof(struct sockaddr_storage)) is 136, which does not match this.
This discrepancy can also lead to the following potential issues:
1.An increase in the .bss segment size.
2.Functions may experience alignment issues, such as getifaddrs(&ifap) being unable to read the correct IP address.
   The data passed to struct sockaddr_in is shifted, causing incorrect address parsing.

## Impact

## Testing
Testing with ESP32/ESP32S3 and sim.
