### PR TITLE
remove up_current_regs in common code

### DIFF
--- a/arch/arm/src/arm/arm_sigdeliver.c
+++ b/arch/arm/src/arm/arm_sigdeliver.c
@@ -97,5 +97,7 @@ void arm_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
+
+  g_running_tasks[this_cpu()] = NULL;
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -56,7 +56,13 @@ void exception_direct(void)
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  FAR struct tcb_s *tcb;
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -80,13 +86,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #endif
 
       up_irq_save();
-      g_running_tasks[this_cpu()]->xcp.regs = regs;
     }
   else
     {
-      /* Dispatch irq */
-
-      tcb->xcp.regs = regs;
       irq_dispatch(irq, regs);
     }
 
@@ -100,7 +102,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Update scheduler parameters */
 
-  nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+  nxsched_suspend_scheduler(*running_task);
   nxsched_resume_scheduler(tcb);
 
   /* Record the new "running" task when context switch occurred.
@@ -108,7 +110,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    * crashes.
    */
 
-  g_running_tasks[this_cpu()] = tcb;
+  *running_task = tcb;
   regs = tcb->xcp.regs;
 #endif
 

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -119,6 +119,7 @@ int arm_svcall(int irq, void *context, void *arg)
 {
   struct tcb_s *tcb = this_task();
   uint32_t *regs = (uint32_t *)context;
+  uint32_t *new_regs = regs;
   uint32_t cmd;
 
   cmd = regs[REG_R0];
@@ -167,6 +168,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0);
+          new_regs = (uint32_t *)regs[REG_R1];
           tcb->xcp.regs = (uint32_t *)regs[REG_R1];
         }
         break;
@@ -191,8 +193,7 @@ int arm_svcall(int irq, void *context, void *arg)
       case SYS_switch_context:
         {
           DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
-          *(uint32_t **)regs[REG_R1] = regs;
-          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
+          new_regs = (uint32_t *)regs[REG_R2];
         }
         break;
 
@@ -446,12 +447,12 @@ int arm_svcall(int irq, void *context, void *arg)
    * switch.
    */
 
-  if (regs != tcb->xcp.regs)
+  if (regs != new_regs)
     {
       restore_critical_section(tcb, this_cpu());
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-      regs = (uint32_t *)tcb->xcp.regs;
+      regs = new_regs;
 
       svcinfo("SVCall Return:\n");
       svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -160,5 +160,7 @@ retry:
   leave_critical_section(regs[REG_CPSR]);
   rtcb->irqcount--;
 #endif
+
+  g_running_tasks[this_cpu()] = NULL;
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -56,7 +56,13 @@ void exception_direct(void)
 
 uint32_t *arm_doirq(int irq, uint32_t *regs)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  FAR struct tcb_s *tcb;
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -80,13 +86,9 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #endif
 
       up_irq_save();
-      g_running_tasks[this_cpu()]->xcp.regs = regs;
     }
   else
     {
-      /* Dispatch irq */
-
-      tcb->xcp.regs = regs;
       irq_dispatch(irq, regs);
     }
 
@@ -100,7 +102,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   /* Update scheduler parameters */
 
-  nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+  nxsched_suspend_scheduler(*running_task);
   nxsched_resume_scheduler(tcb);
 
   /* Record the new "running" task when context switch occurred.
@@ -108,7 +110,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
    * crashes.
    */
 
-  g_running_tasks[this_cpu()] = tcb;
+  *running_task = tcb;
   regs = tcb->xcp.regs;
 #endif
 

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -157,5 +157,7 @@ retry:
   leave_critical_section(regs[REG_CPSR]);
   rtcb->irqcount--;
 #endif
+
+  g_running_tasks[this_cpu()] = NULL;
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -156,10 +156,9 @@ static void dispatch_syscall(void)
 
 uint32_t *arm_syscall(uint32_t *regs)
 {
-  struct tcb_s *tcb = this_task();
-
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  FAR struct tcb_s *tcb = this_task();
   uint32_t cmd;
-  int cpu;
 #ifdef CONFIG_BUILD_PROTECTED
   uint32_t cpsr;
 #endif
@@ -168,7 +167,10 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   DEBUGASSERT(up_current_regs() == NULL);
 
-  tcb->xcp.regs = regs;
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -294,11 +296,6 @@ uint32_t *arm_syscall(uint32_t *regs)
        */
 
       case SYS_switch_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
-          *(uint32_t **)regs[REG_R1] = regs;
-          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
-        }
         break;
 
       /* R0=SYS_task_start:  This a user task start
@@ -564,24 +561,22 @@ uint32_t *arm_syscall(uint32_t *regs)
         break;
     }
 
-  if (regs != tcb->xcp.regs)
+  if (*running_task != tcb)
     {
-      cpu = this_cpu();
-
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_suspend_scheduler(*running_task);
       nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      g_running_tasks[cpu] = tcb;
+      *running_task = tcb;
 
       /* Restore the cpu lock */
 
-      restore_critical_section(tcb, cpu);
+      restore_critical_section(tcb, this_cpu());
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm/src/armv8-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-r/arm_sigdeliver.c
@@ -155,5 +155,7 @@ retry:
   leave_critical_section(regs[REG_CPSR]);
   rtcb->irqcount--;
 #endif
+
+  g_running_tasks[this_cpu()] = NULL;
   arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -156,9 +156,9 @@ static void dispatch_syscall(void)
 
 uint32_t *arm_syscall(uint32_t *regs)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  FAR struct tcb_s *tcb = this_task();
   uint32_t cmd;
-  int cpu;
 #ifdef CONFIG_BUILD_PROTECTED
   uint32_t cpsr;
 #endif
@@ -167,7 +167,10 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   DEBUGASSERT(up_current_regs() == NULL);
 
-  tcb->xcp.regs = regs;
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   /* Current regs non-zero indicates that we are processing an interrupt;
    * current_regs is also used to manage interrupt level context switches.
@@ -293,11 +296,6 @@ uint32_t *arm_syscall(uint32_t *regs)
        */
 
       case SYS_switch_context:
-        {
-          DEBUGASSERT(regs[REG_R1] != 0 && regs[REG_R2] != 0);
-          *(uint32_t **)regs[REG_R1] = regs;
-          tcb->xcp.regs = (uint32_t *)regs[REG_R2];
-        }
         break;
 
       /* R0=SYS_task_start:  This a user task start
@@ -563,24 +561,22 @@ uint32_t *arm_syscall(uint32_t *regs)
         break;
     }
 
-  if (regs != tcb->xcp.regs)
+  if (*running_task != tcb)
     {
-      cpu = this_cpu();
-
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[cpu]);
+      nxsched_suspend_scheduler(*running_task);
       nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      g_running_tasks[cpu] = tcb;
+      *running_task = tcb;
 
       /* Restore the cpu lock */
 
-      restore_critical_section(tcb, cpu);
+      restore_critical_section(tcb, this_cpu());
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -160,5 +160,7 @@ retry:
   leave_critical_section(flags);
   rtcb->irqcount--;
 #endif
+
+  g_running_tasks[this_cpu()] = NULL;
   arm64_fullcontextrestore(rtcb);
 }

--- a/arch/avr/src/avr/avr_doirq.c
+++ b/arch/avr/src/avr/avr_doirq.c
@@ -57,6 +57,13 @@
 
 uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      avr_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/avr/src/avr/avr_switchcontext.c
+++ b/arch/avr/src/avr/avr_switchcontext.c
@@ -85,6 +85,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -58,6 +58,13 @@
 
 uint32_t *avr_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      avr_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/avr/src/avr32/avr_switchcontext.c
+++ b/arch/avr/src/avr32/avr_switchcontext.c
@@ -99,6 +99,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       avr_switchcontext(rtcb->xcp.regs, tcb->xcp.regs);

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -59,6 +59,13 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
     }
   else
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+      if (*running_task != NULL)
+        {
+          (*running_task)->xcp.regs = regs;
+        }
+
       /* Current regs non-zero indicates that we are processing an interrupt;
        * current_regs is also used to manage interrupt level context
        * switches.
@@ -80,7 +87,7 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
         {
           /* Update scheduler parameters */
 
-          nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+          nxsched_suspend_scheduler(*running_task);
           nxsched_resume_scheduler(this_task());
 
           /* Record the new "running" task when context switch occurred.

--- a/arch/ceva/src/common/ceva_exit.c
+++ b/arch/ceva/src/common/ceva_exit.c
@@ -78,6 +78,8 @@ void _exit(int status)
 
   sched_resume_scheduler(tcb);
 
+  g_running_tasks[this_cpu()] = tcb;
+
   /* Then switch contexts */
 
   ceva_fullcontextrestore(tcb->xcp.regs);

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -58,6 +58,13 @@
 
 uint8_t *hc_doirq(int irq, uint8_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      hc_copystate((*running_task)->xcp.regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/hc/src/common/hc_switchcontext.c
+++ b/arch/hc/src/common/hc_switchcontext.c
@@ -102,6 +102,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       hc_fullcontextrestore(tcb->xcp.regs);

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -58,6 +58,13 @@
 
 uint32_t *mips_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      mips_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/mips/src/pic32mx/pic32mx_decodeirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_decodeirq.c
@@ -70,11 +70,17 @@
 
 uint32_t *pic32mx_decodeirq(uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 #ifdef CONFIG_PIC32MX_NESTED_INTERRUPTS
   uint32_t *savestate;
 #endif
   uint32_t regval;
   int irq;
+
+  if (*running_task != NULL)
+    {
+      mips_copystate((*running_task)->xcp.regs, regs);
+    }
 
   /* If the board supports LEDs, turn on an LED now to indicate that we are
    * processing an interrupt.

--- a/arch/mips/src/pic32mx/pic32mx_exception.c
+++ b/arch/mips/src/pic32mx/pic32mx_exception.c
@@ -53,10 +53,16 @@
 
 uint32_t *pic32mx_exception(uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 #ifdef CONFIG_DEBUG_FEATURES
   uint32_t cause;
   uint32_t epc;
 #endif
+
+  if (*running_task != NULL)
+    {
+      mips_copystate((*running_task)->xcp.regs, regs);
+    }
 
   /* If the board supports LEDs, turn on an LED now to indicate that we are
    * processing an interrupt.

--- a/arch/mips/src/pic32mz/pic32mz_decodeirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_decodeirq.c
@@ -69,6 +69,13 @@
 
 uint32_t *pic32mz_decodeirq(uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      mips_copystate((*running_task)->xcp.regs, regs);
+    }
+
 #ifdef CONFIG_PIC32MZ_NESTED_INTERRUPTS
   uint32_t *savestate;
 #endif

--- a/arch/mips/src/pic32mz/pic32mz_exception.c
+++ b/arch/mips/src/pic32mz/pic32mz_exception.c
@@ -52,10 +52,16 @@
 
 uint32_t *pic32mz_exception(uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 #ifdef CONFIG_DEBUG_FEATURES
   uint32_t cause;
   uint32_t epc;
 #endif
+
+  if (*running_task != NULL)
+    {
+      mips_copystate((*running_task)->xcp.regs, regs);
+    }
 
   /* If the board supports LEDs, turn on an LED now to indicate that we are
    * processing an interrupt.

--- a/arch/misoc/src/lm32/lm32_doirq.c
+++ b/arch/misoc/src/lm32/lm32_doirq.c
@@ -45,6 +45,13 @@
 
 uint32_t *lm32_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      lm32_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 
   /* Current regs non-zero indicates that we are processing an interrupt;

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -45,6 +45,13 @@
 
 uint32_t *minerva_doirq(int irq, uint32_t * regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      minerva_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 
   /* Current regs non-zero indicates that we are processing an interrupt;

--- a/arch/or1k/src/common/or1k_doirq.c
+++ b/arch/or1k/src/common/or1k_doirq.c
@@ -41,6 +41,13 @@
 
 uint32_t *or1k_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      or1k_copyfullstate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/or1k/src/common/or1k_switchcontext.c
+++ b/arch/or1k/src/common/or1k_switchcontext.c
@@ -106,6 +106,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       or1k_fullcontextrestore(tcb->xcp.regs);

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -58,6 +58,13 @@
 
 uint32_t *renesas_doirq(int irq, uint32_t * regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      renesas_copystate((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/renesas/src/common/renesas_switchcontext.c
+++ b/arch/renesas/src/common/renesas_switchcontext.c
@@ -102,6 +102,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       renesas_fullcontextrestore(tcb->xcp.regs);

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -99,7 +99,7 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
    * returning from the interrupt.
    */
 
-  if ((*running_task) != tcb)
+  if (*running_task != tcb)
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -113,7 +113,7 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_suspend_scheduler(*running_task);
       nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task when context switch occurred.

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -54,7 +54,7 @@ void *riscv_perform_syscall(uintreg_t *regs)
   riscv_swint(0, regs, NULL);
   tcb = this_task();
 
-  if ((*running_task) != tcb)
+  if (*running_task != tcb)
     {
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -67,7 +67,7 @@ void *riscv_perform_syscall(uintreg_t *regs)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
+      nxsched_suspend_scheduler(*running_task);
       nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by

--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -63,6 +63,13 @@ void *sim_doirq(int irq, void *context)
   sim_saveusercontext(regs, ret);
   if (ret == 0)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+      if (*running_task != NULL)
+        {
+          sim_copyfullstate((*running_task)->xcp.regs, regs);
+        }
+
       up_set_current_regs(regs);
 
       /* Deliver the IRQ */

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -105,6 +105,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       restore_critical_section(tcb, this_cpu());
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       sim_fullcontextrestore(tcb->xcp.regs);

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -58,6 +58,13 @@
 
 uint32_t *sparc_doirq(int irq, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      trap_flush_task((*running_task)->xcp.regs, regs);
+    }
+
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -44,11 +44,18 @@
 
 IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
 #else
   Ifx_CPU_ICR icr;
   uintptr_t *regs;
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   icr.U = __mfcr(CPU_ICR);
   regs = (uintptr_t *)__mfcr(CPU_PCXI);

--- a/arch/x86/src/common/x86_switchcontext.c
+++ b/arch/x86/src/common/x86_switchcontext.c
@@ -102,6 +102,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       x86_fullcontextrestore(tcb->xcp.regs);

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -65,6 +65,13 @@
 
 void xtensa_panic(int xptcode, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
+
   up_set_current_regs(regs);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */

--- a/arch/z16/src/common/z16_doirq.c
+++ b/arch/z16/src/common/z16_doirq.c
@@ -58,7 +58,13 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
 #else
   if ((unsigned)irq < NR_IRQS)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
       FAR chipreg_t *savestate;
+
+      if (*running_task != NULL)
+        {
+          z16_copystate((*running_task)->xcp.regs, regs)
+        }
 
       /* Nested interrupts are not supported in this implementation.  If
        * you want to implement nested interrupts, you would have to (1)

--- a/arch/z16/src/common/z16_switchcontext.c
+++ b/arch/z16/src/common/z16_switchcontext.c
@@ -93,6 +93,10 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       RESTORE_USERCONTEXT(tcb);

--- a/arch/z16/src/z16f/z16f_sysexec.c
+++ b/arch/z16/src/z16f/z16f_sysexec.c
@@ -47,7 +47,13 @@
 
 void z16f_sysexec(FAR chipreg_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   uint16_t excp;
+
+  if (*running_task != NULL)
+    {
+      z16_copystate((*running_task)->xcp.regs, regs)
+    }
 
   /* Save that register reference so that it can be used for built-in
    * diagnostics.

--- a/arch/z80/src/common/z80_doirq.c
+++ b/arch/z80/src/common/z80_doirq.c
@@ -44,6 +44,13 @@
 
 FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      z80_copystate((*running_task)->xcp.regs, regs)
+    }
+
   board_autoled_on(LED_INIRQ);
 
   DECL_SAVESTATE();

--- a/arch/z80/src/common/z80_switchcontext.c
+++ b/arch/z80/src/common/z80_switchcontext.c
@@ -105,6 +105,10 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
 
       nxsched_resume_scheduler(tcb);
 
+      /* Record the new "running" task */
+
+      g_running_tasks[this_cpu()] = tcb;
+
       /* Then switch contexts */
 
       RESTORE_USERCONTEXT(tcb);

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -181,17 +181,17 @@ static int tcbinfo_close(FAR struct file *filep)
 }
 
 /****************************************************************************
- * Name: tcbinfo_current_regs
+ * Name: tcbinfo_running_regs
  *
  * Description:
- *   A special version of up_current_regs() that is non-optimized.
+ *   A special version of running_regs() that is non-optimized.
  *
  ****************************************************************************/
 
 nooptimiziation_function
-FAR static void *tcbinfo_current_regs(void)
+FAR static void *tcbinfo_running_regs(void)
 {
-  return up_current_regs();
+  return running_regs();
 }
 
 /****************************************************************************
@@ -217,8 +217,8 @@ static ssize_t tcbinfo_read(FAR struct file *filep, FAR char *buffer,
     {
       linesize = procfs_snprintf(attr->line, TCBINFO_LINELEN,
                                  "pointer %p size %zu current regs %p\n",
-                                  &g_tcbinfo, sizeof(struct tcbinfo_s),
-                                  tcbinfo_current_regs());
+                                 &g_tcbinfo, sizeof(struct tcbinfo_s),
+                                 tcbinfo_running_regs());
 
       /* Save the linesize in case we are re-entered with f_pos > 0 */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -244,6 +244,8 @@
 #  define this_cpu()                 (0)
 #endif
 
+#define running_regs()               ((void *)(g_running_tasks[this_cpu()]->xcp.regs))
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -871,6 +873,12 @@ EXTERN clock_t g_premp_max[CONFIG_SMP_NCPUS];
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
 EXTERN clock_t g_crit_max[CONFIG_SMP_NCPUS];
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0 */
+
+/* g_running_tasks[] holds a references to the running task for each CPU.
+ * It is valid only when up_interrupt_context() returns true.
+ */
+
+EXTERN FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
 
 EXTERN const struct tcbinfo_s g_tcbinfo;
 

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1039,7 +1039,7 @@ static void gdb_get_registers(FAR struct gdb_state_s *state)
     {
       if (up_interrupt_context())
         {
-          reg = (FAR uint8_t *)up_current_regs();
+          reg = (FAR uint8_t *)running_regs();
         }
       else
         {

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -129,7 +129,7 @@ dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
 FAR struct tcb_s *g_delivertasks[CONFIG_SMP_NCPUS];
 #endif
 
-/* g_running_tasks[] holds a references to the running task for each cpu.
+/* g_running_tasks[] holds a references to the running task for each CPU.
  * It is valid only when up_interrupt_context() returns true.
  */
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -304,7 +304,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
       /* Try to restore SP from current_regs if assert from interrupt. */
 
       tcbstack_sp = up_interrupt_context() ?
-                    up_getusrsp((FAR void *)up_current_regs()) : 0;
+                    up_getusrsp((FAR void *)running_regs()) : 0;
       if (tcbstack_sp < tcbstack_base || tcbstack_sp >= tcbstack_top)
         {
           tcbstack_sp = 0;
@@ -607,7 +607,7 @@ static void dump_deadlock(void)
 
 static noreturn_function int pause_cpu_handler(FAR void *arg)
 {
-  memcpy(g_last_regs[this_cpu()], up_current_regs(), sizeof(g_last_regs[0]));
+  memcpy(g_last_regs[this_cpu()], running_regs(), sizeof(g_last_regs[0]));
   g_cpu_paused[this_cpu()] = true;
   up_flush_dcache_all();
   while (1);

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -309,7 +309,7 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
     {
       if (up_interrupt_context())
         {
-          regs = (FAR uintptr_t *)up_current_regs();
+          regs = (FAR uintptr_t *)running_regs();
         }
       else
         {

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -197,12 +197,6 @@ extern dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
 
 extern FAR struct tcb_s *g_delivertasks[CONFIG_SMP_NCPUS];
 
-/* g_running_tasks[] holds a references to the running task for each cpu.
- * It is valid only when up_interrupt_context() returns true.
- */
-
-extern FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
-
 /* This is the list of all tasks that are ready-to-run, but cannot be placed
  * in the g_readytorun list because:  (1) They are higher priority than the
  * currently active task at the head of the g_readytorun list, and (2) the

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -82,7 +82,7 @@ class Nxsetregs(gdb.Command):
         super(Nxsetregs, self).__init__("nxsetregs", gdb.COMMAND_USER)
 
     def invoke(self, args, from_tty):
-        gdb.execute("set $_current_regs=tcbinfo_current_regs()")
+        gdb.execute("set $_current_regs=tcbinfo_running_regs()")
         current_regs = gdb.parse_and_eval("$_current_regs")
         tcbinfo = gdb.parse_and_eval("g_tcbinfo")
         arg = args.split(" ")


### PR DESCRIPTION

## Summary
When entering an exception or interrupt, there are two sets of registers:
one is the "running regs", which we need to save,
and the other is the "ready to running regs", which we may soon use.
For consistency in logic, we can always store the "running regs" in the regs field of g_running_tasks,
otherwise it may lead to errors in the storage location of the "running regs."

When we need to access the "running regs," we should uniformly retrieve them from the regs field of g_running_tasks.

As the next step, we will rename the set_current_regs/up_current_regs functions
for each architecture to more appropriate names, solely for the purpose of identifying interrupts.


## Impact
context switch logic

## Testing
**Build Host:**
* OS: Ubuntu 20.04
* CPU: x86_64 
* Compiler: GCC 9.4.0

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx


