### PR TITLE
libs/modlib: Load data using `up_textheap_data_address`

### DIFF
--- a/libs/libc/modlib/modlib_load.c
+++ b/libs/libc/modlib/modlib_load.c
@@ -57,6 +57,13 @@
 
 #define _ALIGN_UP(v, a)  (((v) + ((a) - 1)) & ~((a) - 1))
 
+#ifdef CONFIG_ARCH_USE_TEXT_HEAP
+#  define buffer_data_address(p) \
+            (FAR uint8_t *)up_textheap_data_address((FAR void *)p)
+#else
+#  define buffer_data_address(p) ((FAR uint8_t *)p)
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -343,7 +350,8 @@ static inline int modlib_loadfile(FAR struct mod_loadinfo_s *loadinfo)
             {
               if (phdr->p_flags & PF_X)
                 {
-                  ret = modlib_read(loadinfo, text, phdr->p_filesz,
+                  ret = modlib_read(loadinfo, buffer_data_address(text),
+                                    phdr->p_filesz,
                                     phdr->p_offset);
                 }
               else
@@ -441,8 +449,8 @@ static inline int modlib_loadfile(FAR struct mod_loadinfo_s *loadinfo)
 
               /* Read the section data from sh_offset to the memory region */
 
-              ret = modlib_read(loadinfo, *pptr, shdr->sh_size,
-                                shdr->sh_offset);
+              ret = modlib_read(loadinfo, buffer_data_address(*pptr),
+                                shdr->sh_size, shdr->sh_offset);
               if (ret < 0)
                 {
                   berr("ERROR: Failed to read section %d: %d\n", i, ret);


### PR DESCRIPTION
## Summary

* libs/modlib: Load data using `up_textheap_data_address`

Some chips have different memory addressing spaces for the same region. This is true, for instance, for ESP32-S3: the same memory region can be accessed using the data bus or the data bus using different address ranges. The instruction bus, however, requires word-aligned access. That being said, it is recommended to use the data bus while copying sections to the text heap to avoid any illegal access using the instruction bus address which will be later used to run the program.

## Impact

Fix https://github.com/apache/nuttx/issues/14487

## Testing

Internal CI testing + ESP32-S3-DevKitC-1 v1.0:

Build steps:

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:elf && make flash ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom -D /dev/ttyUSB0
```

And, then, run elf example:
```
nsh> elf
```