### PR TITLE
CI: Enable builds for msys2, msvc, arm-08, arm-10, arm-13 for Complex PRs

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -103,9 +103,9 @@ jobs:
         id: select-builds
         run: |
 
-          # Skip all macOS and Windows Builds
-          if [[ "${{ inputs.os }}" != "Linux" ]]; then
-            echo "Skipping all macOS and Windows Builds"
+          # Skip all macOS Builds
+          if [[ "${{ inputs.os }}" == "macOS" ]]; then
+            echo "Skipping all macOS Builds"
             echo "skip_all_builds=1" | tee -a $GITHUB_OUTPUT
             exit
           fi
@@ -169,13 +169,13 @@ jobs:
             # If PR was Created or Modified: Exclude some boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-0[248], arm-1[02-9], risc-v-04..06, sim-03, xtensa-02"
+              echo "Excluding arm-0[1249], arm-1[124-9], risc-v-04..06, sim-03, xtensa-02"
               boards=$(
                 echo '${{ inputs.boards }}' |
                 jq --compact-output \
                 'map(
                   select(
-                    test("arm-0[248]") == false and test("arm-1[02-9]") == false and
+                    test("arm-0[1249]") == false and test("arm-1[124-9]") == false and
                     test("risc-v-0[4-9]") == false and
                     test("sim-0[3-9]") == false and
                     test("xtensa-0[2-9]") == false


### PR DESCRIPTION
## Summary

This PR enables the CI Builds for msys2, msvc, arm-08, arm-10, arm-13 for Complex PRs. We disable the CI Builds for arm-01, arm-09, arm-11.

This will help to fix the recent breakage of builds: https://github.com/apache/nuttx/issues/14598

## Impact

When we create or update a Complex PR: CI Workflow will now build msys2, msvc, arm-08, arm-10, arm-13 (instead of arm-01, arm-09, arm-11)

No changes to Simple PRs.

## Testing

Creating a Complex PR will now build msys2, msvc, arm-08, arm-10, arm-13 (instead of arm-01, arm-09, arm-11):
https://github.com/lupyuen5/label-nuttx/actions/runs/11638217458

Creating a Simple Arm32 PR will build arm-01 to arm-14, like before:
https://github.com/lupyuen5/label-nuttx/actions/runs/11638211712
