### PR TITLE
fs/mnemofs: Fix open and rmdir return value and seek out of bounds.

### DIFF
--- a/fs/mnemofs/mnemofs_fsobj.c
+++ b/fs/mnemofs/mnemofs_fsobj.c
@@ -491,6 +491,8 @@ int mfs_pitr_rm(FAR struct mfs_sb_s * const sb,
   struct mfs_pitr_s        pitr;
   FAR struct mfs_dirent_s *dirent = NULL;
 
+  /* TODO: MFS_LOG */
+
   mfs_pitr_init(sb, path, depth, &pitr, true);
   mfs_pitr_readdirent(sb, path, &pitr, &dirent);
 
@@ -559,8 +561,8 @@ errout:
 
 void mfs_pitr_free(FAR const struct mfs_pitr_s * const pitr)
 {
-  finfo("Pitr at depth %u with CTZ (%u, %u) freed.",
-        pitr->depth, pitr->p.ctz.idx_e, pitr->p.ctz.pg_e);
+  MFS_EXTRA_LOG("MFS_PITR_FREE", "Parent iterator at %p freed.", pitr);
+  MFS_EXTRA_LOG_PITR(pitr);
 }
 
 void mfs_pitr_adv_off(FAR struct mfs_pitr_s * const pitr,
@@ -587,10 +589,10 @@ void mfs_pitr_adv_tochild(FAR struct mfs_pitr_s * const pitr,
 {
   /* (pitr->depth + 1) - 1 is the child's index. */
 
+  MFS_EXTRA_LOG("MFS_PITR_ADV_TOCHILD", "Advance pitr to child's offset.");
+  MFS_EXTRA_LOG_PITR(pitr);
+  MFS_EXTRA_LOG("MFS_PITR_ADV_TOCHILD", "New offset %" PRIu32, pitr->c_off);
   pitr->c_off = path[pitr->depth].off;
-
-  finfo("Pitr at depth %u with CTZ (%u, %u) advanced to %u offset.",
-        pitr->depth, pitr->p.ctz.idx_e, pitr->p.ctz.pg_e, pitr->c_off);
 }
 
 int mfs_pitr_readdirent(FAR const struct mfs_sb_s * const sb,
@@ -749,7 +751,7 @@ static int search_ctz_by_name(FAR const struct mfs_sb_s * const sb,
 
   name_hash = mfs_hash(name, namelen);
 
-  ret = mfs_lru_updatedinfo(sb, path, depth);
+  ret = mfs_lru_getupdatedinfo(sb, path, depth);
   if (predict_false(ret < 0))
     {
       goto errout;
@@ -989,6 +991,7 @@ errout:
 
 void mfs_free_patharr(FAR struct mfs_path_s *path)
 {
+  MFS_EXTRA_LOG("MFS_FREE_PATHARR", "Path array at %p freed.", path);
   fs_heap_free(path);
 }
 

--- a/fs/mnemofs/mnemofs_lru.c
+++ b/fs/mnemofs/mnemofs_lru.c
@@ -949,9 +949,9 @@ errout:
   return ret;
 }
 
-int mfs_lru_updatedinfo(FAR const struct mfs_sb_s * const sb,
-                        FAR struct mfs_path_s * const path,
-                        const mfs_t depth)
+int mfs_lru_getupdatedinfo(FAR const struct mfs_sb_s * const sb,
+                           FAR struct mfs_path_s * const path,
+                           const mfs_t depth)
 {
   int                    ret  = OK;
   bool                   found;


### PR DESCRIPTION
## Summary

This PR fixes:
- Renamed `struct mfs_fsdirent` to `struct mfs_fsdirent_s` to follow the C Contributing Guidelines for styling.
- Update `mnemofs_open` return value to `-ENOTDIR` when ancestor is a file.
- Update `mnemofs_rmdir` return value to `-ENOTDIR` when path is not a directory.
- Better logs for file and dir operations including `mnemofs_open`, `mnemofs_close`, `mnemofs_read`, `mnemofs_write`, `mnemofs_seek`, `mnemofs_opendir`, `mnemofs_readdir`, `mnemofs_rewinddir`, `mnemofs_mkdir`, `mnemofs_rmdir`, `mnemofs_stat`.
- Renamed `mfs_lru_updatedinfo` to `mfs_lru_getupdatedinfo` to make it easier to understand.

The change is necessary to ensure proper return values of various file system operations and to improve readability of code through better logs and better identifiers.

## Impact

- Proper return value of various file system operations.
- Better logs for file and dir operations.
- Better readability of code.

## Testing

I confirm that changes are verified on local setup and works as intended:

- Build Host(s): OS (Linux), CPU(Intel), compiler(GCC 13).
- Target(s): arch(sim), sim:mnemofs.

Logs before:
```
nsh> custom_hello
binfs_stat: Entry
mnemofs_open: Mnemofs open on path "a.txt" with flags 7 and mode 50810.
mnemofs_open: Lock Acquired.
...
mnemofs_write: Lock acquired.
mnemofs_write: Mnemofs write 20 bytes at offset 0
lru_nodesearch: Node search ended without match.
...
mnemofs_write: Offset updated to 20 and size to 20
mnemofs_write: Lock released.
mnemofs_write: Mnemofs write exited with 20.
mnemofs_seek: Mnemofs seek.
mnemofs_seek: Lock acquired.
mnemofs_seek: Mnemofs seek from 20 offset to 4294967295 using whence 1.
mnemofs_seek: Final position 19.
mnemofs_seek: Lock released.
mnemofs_write: Mnemofs write.
mnemofs_write: Lock acquired.
...
mnemofs_close: Mnemofs close.
mnemofs_close: Lock Acquired.
mnemofs_close: Original refcount is 1.
...
mnemofs_close: File entry removed from the open files list.
mnemofs_close: Lock Released.
mnemofs_close: Mnemofs close exited with 0.
```

Logs after:
```
nsh> custom_hello
binfs_stat: Entry
mnemofs_open: [mnemofs | OPEN] Entry.
mnemofs_open: [mnemofs | OPEN] Requested path is a.txt.
mnemofs_open: [mnemofs | OPEN] Flags set as 0x7.
mnemofs_open: [mnemofs | OPEN] Mode set as 0x50810.
mnemofs_open: [mnemofs | OPEN] Mutex acquired.
mnemofs_open: [mnemofs | OPEN] Allocated file structure at 0x503000000250.
mnemofs_open: [mnemofs | OPEN] Allocated common file structure at 0x503000000280.
...
mfs_get_patharr: [mnemofs | MFS_GET_PATHARR] Looking at depth 1
mfs_get_patharr: [mnemofs | MFS_GET_PATHARR] Current String is "a.txt" (0x50137f24)
mfs_get_patharr: [mnemofs | MFS_GET_PATHARR] Name length is 5
mfs_get_patharr: [mnemofs | MFS_GET_PATHARR] Next String is ""
...
mnemofs_write: [mnemofs | WRITE] Mutex  released.
mnemofs_write: [mnemofs | WRITE] Exit | Return: 2.
mnemofs_seek: [mnemofs | SEEK] Entry.
mnemofs_seek: [mnemofs | SEEK] Offset: 0, Whence: 0
mnemofs_seek: [mnemofs | SEEK] Mutex acquired.
mnemofs_seek: [mnemofs | SEEK] File offset: 21, Command offset: 0, Whence 0.
mnemofs_seek: [mnemofs | SEEK] Proposed final position: 0
mnemofs_seek: [mnemofs | SEEK] Final position: 0
...
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F] File structure details.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]        List details.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Previous node 0x512000000150.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Next node 0x512000000150.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]        Common structure details.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Depth: 2
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                New Entry: true.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Offset: 21
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Flags: 0x7.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Reference Counter: 0
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                File Size: 21
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                Path details.
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                        Offset: 0
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                        Size: 0
MFS_EXTRA_LOG_F: [mnemofs | EXTRA_LOG_F]                        CTZ (0, 432).
...
mnemofs_close: [mnemofs | CLOSE] Mutex released.
mnemofs_close: [mnemofs | CLOSE] Exit | Return: 0.
```
