### PR TITLE
libc/machine/CMakeLists: should alaways build arch_atomic.c

### DIFF
--- a/libs/libc/machine/CMakeLists.txt
+++ b/libs/libc/machine/CMakeLists.txt
@@ -22,9 +22,7 @@
 
 add_subdirectory(${CONFIG_ARCH})
 
-if(CONFIG_LIBC_ARCH_ATOMIC)
-  target_sources(c PRIVATE arch_atomic.c)
-endif()
+target_sources(c PRIVATE arch_atomic.c)
 
 if(CONFIG_MM_KASAN)
   target_sources(c PRIVATE arch_libc.c)


### PR DESCRIPTION
## Summary

 **Why is this change necessary?**
  This issue comes from https://github.com/apache/nuttx/pull/14570. In the previous Atomic implementation https://github.com/apache/nuttx/pull/13044, we have removed the CONFIG_LIBC_ARCH_ATOMIC macro, so arch_atomic.c should always be compiled.

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.


## Testing

We can compile the nucleo-f072rb/nsh configuration through cmake

```
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcswcs.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcwidth.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcswidth.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_wctype.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_iswctype.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_towlower.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_towupper.c.obj
[ 99%] Linking C static library libc.a
[ 99%] Built target c
[ 99%] Building C object CMakeFiles/nuttx.dir/empty.c.obj
[ 99%] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       40152 B       128 KB     30.63%
            sram:        1968 B        16 KB     12.01%
[ 99%] Built target nuttx
[100%] Generating System.map
[100%] Generating nuttx.bin
[100%] Built target nuttx-bin
[100%] Built target systemmap
```

