### PR TITLE
fix macos sim nsh break, fix no -mcmodel=medium in clang.

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -143,8 +143,8 @@ ifeq ($(CONFIG_SIM_M32),y)
   ARCHCFLAGS += -m32
   ARCHCXXFLAGS += -m32
 else
-  ARCHCFLAGS += -fno-pic -mcmodel=medium
-  ARCHCXXFLAGS += -fno-pic -mcmodel=medium
+  ARCHCFLAGS += -fno-pic -mcmodel=large
+  ARCHCXXFLAGS += -fno-pic -mcmodel=large
 endif
 
 # LLVM style architecture flags


### PR DESCRIPTION
## Summary
after #14466, add -mcmodel=medium witch is not supported in clang.
-mcmodel=large, should both support  gcc & clang.
case sim:nsh break in makefile.

## Impact
change from -mcmodel=medium to -mcmodel=large maybe cause larger codesize? not sure if it's a critical index.
sim:nsh in macos will ready to work with both make and cmake after fix.

## Testing
ci-test, local macos with cmake sim:nsh & makefile sim:nsh.

