### PR TITLE
Replace __attribute__((packed)) with [begin|end]_packed_struct

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_gt911.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_gt911.c
@@ -85,19 +85,18 @@ struct gt911_dev_s
 
 /* This structure describes the frame of touchpoint */
 
-struct gt911_touchpoint_s
+begin_packed_struct struct gt911_touchpoint_s
 {
   uint8_t id;                               /* Not used */
   uint16_t x;                               /* Touch X-axis */
   uint16_t y;                               /* Touch Y-axis */
   uint16_t pressure;                        /* Touch pressure */
   uint8_t  reserved;                        /* Not used */
-}
-__attribute__((packed));
+} end_packed_struct;
 
 /* This structure describes the frame of touchpoint */
 
-struct gt911_data_s
+begin_packed_struct struct gt911_data_s
 {
   uint8_t touchpoints     : 4;              /* Touch point number */
   uint8_t has_key         : 1;              /* 1: key is inpressed */
@@ -106,8 +105,7 @@ struct gt911_data_s
   uint8_t buffer_status   : 1;              /* 1: input data is valid */
 
   struct gt911_touchpoint_s touchpoint[0];
-}
-__attribute__((packed));
+} end_packed_struct;
 
 /****************************************************************************
  * Private Data

--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_tt21100.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_tt21100.c
@@ -76,7 +76,7 @@ struct tt21100_dev_s
 
 /* This structure describes the frame of touchpoint */
 
-struct tt21100_touchpoint_s
+begin_packed_struct struct tt21100_touchpoint_s
 {
   uint8_t  type       : 3;                  /* Touch object type */
   uint8_t  reserved   : 5;                  /* Reserved */
@@ -92,12 +92,11 @@ struct tt21100_touchpoint_s
 
   uint16_t major_axis_length;               /* Touch length of major axis */
   uint8_t  orientation;                     /* The angle between vertical axis and major axis */
-}
-__attribute__((packed));
+} end_packed_struct;
 
 /* This structure describes the frame of touch action */
 
-struct tt21100_touch_s
+begin_packed_struct struct tt21100_touch_s
 {
   uint8_t  data_num       : 5;              /* Touchpoint data frame number */
   uint8_t  large_object   : 1;              /* Large object detected */
@@ -108,19 +107,17 @@ struct tt21100_touch_s
   uint8_t  report_counter : 2;              /* Report issue counter */
 
   struct tt21100_touchpoint_s touchpoint[0];  /* Touchpoint data */
-}
-__attribute__((packed));
+} end_packed_struct;
 
 /* This structure describes the frame of TT21100 report */
 
-struct tt21100_data_s
+begin_packed_struct struct tt21100_data_s
 {
   uint16_t  length;                         /* Report frame length */
   uint8_t   id;                             /* Report ID */
   uint16_t  time_stamp;                     /* Report Timestamp */
   struct tt21100_touch_s touch;             /* Report Tocuh data */
-}
-__attribute__((packed));
+} end_packed_struct;
 
 /****************************************************************************
  * Private Function Prototypes

--- a/drivers/net/ksz9477_reg.h
+++ b/drivers/net/ksz9477_reg.h
@@ -134,13 +134,12 @@
  * Public Types
  ****************************************************************************/
 
-struct ksz9477_transfer_s
+begin_packed_struct struct ksz9477_transfer_s
 {
   uint16_t len;
   uint16_t reg;
   uint32_t data;
-}
-__attribute__((packed));
+} end_packed_struct;
 
 #ifndef __ASSEMBLY__
 

--- a/include/nuttx/lin.h
+++ b/include/nuttx/lin.h
@@ -76,13 +76,13 @@
  * The error frame consists of err_flag（LIN_ERR_FLAG)、err_class
  * (defined in data[0]) and err_reason(defined in data[1] to data[4]).
  * The error frame is described using the following structure:
- * struct can_frame {
+ * begin_packed_struct struct can_frame {
  *    canid_t can_id;
  *    uint8_t can_dlc;
  *    uint16_t flags;
  *    uint8_t __res1;
  *    uint8_t data[CAN_MAX_DLEN] __attribute__((aligned(8)));
- *  }__attribute__((packed));
+ *  } end_packed_struct;
  *
  * Error frame description format：
  *

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -327,7 +327,7 @@ struct sockaddr_storage
 
   /* Following fields are implementation-defined */
 
-  struct __attribute__((packed))
+  begin_packed_struct struct
   {
     char ss_pad1[SS_PAD1SIZE]; /* 6-byte pad; this is to make implementation-defined
                                 * pad up to alignment field that follows explicit in
@@ -337,7 +337,7 @@ struct sockaddr_storage
                                 * value minus size of ss_family ss_pad1, ss_align
                                 * fields is 112. */
   }
-  ss_data[1];
+  end_packed_struct ss_data[1];
 };
 
 /* The sockaddr structure is used to define a socket address which is used


### PR DESCRIPTION
## Summary

since the different compiler express the packed structure in the different way.

## Impact

fix ci error reported here:
https://github.com/apache/nuttx/actions/runs/11643419979/job/32424162791?pr=14605

## Testing

ci

