### PR TITLE
fs: Fix mtd/sector512.c:554:19: error: incomplete definition of type 'struct partition_info_s'

### DIFF
--- a/drivers/sensors/adxl362_uorb.c
+++ b/drivers/sensors/adxl362_uorb.c
@@ -27,9 +27,9 @@
 #include <debug.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <sys/param.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/signal.h>

--- a/drivers/sensors/adxl372.c
+++ b/drivers/sensors/adxl372.c
@@ -32,6 +32,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>

--- a/drivers/sensors/adxl372_uorb.c
+++ b/drivers/sensors/adxl372_uorb.c
@@ -27,9 +27,9 @@
 #include <debug.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <sys/param.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/signal.h>

--- a/drivers/sensors/bmg160.c
+++ b/drivers/sensors/bmg160.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/fs/fs.h>

--- a/drivers/sensors/bmi270_base.h
+++ b/drivers/sensors/bmi270_base.h
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/sensors/bmi270.h>

--- a/drivers/sensors/bmm150_uorb.c
+++ b/drivers/sensors/bmm150_uorb.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <sys/param.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/mutex.h>
 #include <nuttx/signal.h>
 #include <nuttx/kthread.h>

--- a/drivers/sensors/l3gd20_uorb.c
+++ b/drivers/sensors/l3gd20_uorb.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <math.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>

--- a/drivers/sensors/lis3dh.c
+++ b/drivers/sensors/lis3dh.c
@@ -44,6 +44,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/random.h>

--- a/drivers/sensors/lis3dsh.c
+++ b/drivers/sensors/lis3dsh.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/random.h>

--- a/drivers/sensors/lis3mdl.c
+++ b/drivers/sensors/lis3mdl.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/random.h>

--- a/drivers/sensors/lsm330_spi.c
+++ b/drivers/sensors/lsm330_spi.c
@@ -32,6 +32,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>

--- a/drivers/sensors/mlx90393.c
+++ b/drivers/sensors/mlx90393.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 #include <string.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/fs/fs.h>

--- a/drivers/sensors/msa301.c
+++ b/drivers/sensors/msa301.c
@@ -28,6 +28,8 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
 #include <nuttx/mutex.h>

--- a/drivers/sensors/t67xx.c
+++ b/drivers/sensors/t67xx.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <time.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/i2c/i2c_master.h>

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -72,11 +72,12 @@
 #include <debug.h>
 #include <string.h>
 #include <limits.h>
-#include <nuttx/mutex.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/bits.h>
 #include <nuttx/compiler.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
 #include <nuttx/spi/spi.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/video/max7456.h>

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/compiler.h>
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/fs/uio.h>
 
 #include <sys/uio.h>
@@ -251,33 +252,6 @@ struct file_operations
 /* This structure provides information about the state of a block driver */
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
-struct geometry
-{
-  bool      geo_available;    /* true: The device is available */
-  bool      geo_mediachanged; /* true: The media has changed since last query */
-  bool      geo_writeenabled; /* true: It is okay to write to this device */
-  blkcnt_t  geo_nsectors;     /* Number of sectors on the device */
-  blksize_t geo_sectorsize;   /* Size of one sector */
-
-  /* NULL-terminated string representing the device model */
-
-  char      geo_model[NAME_MAX + 1];
-};
-
-struct partition_info_s
-{
-  size_t    numsectors;   /* Number of sectors in the partition */
-  size_t    sectorsize;   /* Size in bytes of a single sector */
-  off_t     startsector;  /* Offset to the first section/block of the
-                           * managed sub-region */
-
-  /* NULL-terminated string representing the name of the parent node of the
-   * partition.
-   */
-
-  char      parent[NAME_MAX + 1];
-};
-
 /* This structure is provided by block devices when they register with the
  * system.  It is used by file systems to perform filesystem transfers.  It
  * differs from the normal driver vtable in several ways -- most notably in

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -28,6 +28,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
+#include <stdbool.h>
 #include <sys/types.h>
 
 /****************************************************************************
@@ -756,6 +758,33 @@
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
+
+struct geometry
+{
+  bool      geo_available;    /* true: The device is available */
+  bool      geo_mediachanged; /* true: The media has changed since last query */
+  bool      geo_writeenabled; /* true: It is okay to write to this device */
+  blkcnt_t  geo_nsectors;     /* Number of sectors on the device */
+  blksize_t geo_sectorsize;   /* Size of one sector */
+
+  /* NULL-terminated string representing the device model */
+
+  char      geo_model[NAME_MAX + 1];
+};
+
+struct partition_info_s
+{
+  size_t    numsectors;   /* Number of sectors in the partition */
+  size_t    sectorsize;   /* Size in bytes of a single sector */
+  off_t     startsector;  /* Offset to the first section/block of the
+                           * managed sub-region */
+
+  /* NULL-terminated string representing the name of the parent node of the
+   * partition.
+   */
+
+  char      parent[NAME_MAX + 1];
+};
 
 struct pipe_peek_s
 {

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -30,14 +30,14 @@
 #include <nuttx/compiler.h>
 
 #ifdef CONFIG_LIBC_LZF
-#include <lzf.h>
+#  include <lzf.h>
 #endif
 #include <stdio.h>
 #ifndef CONFIG_DISABLE_MOUNTPOINT
-#include <nuttx/fs/fs.h>
-#ifdef CONFIG_MTD
-#include <nuttx/mtd/mtd.h>
-#endif
+#  include <nuttx/fs/fs.h>
+#  ifdef CONFIG_MTD
+#    include <nuttx/mtd/mtd.h>
+#  endif
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

by moving geometry and partition_info_s to include/fs/ioctl.h

## Impact

Fix ci error reported here:
https://github.com/apache/nuttx/actions/runs/11643419979/job/32424162668?pr=14605

## Testing

ci

