### PR TITLE
cmake: don't include syslog files if CONFIG_SYSLOG=n

### DIFF
--- a/drivers/syslog/CMakeLists.txt
+++ b/drivers/syslog/CMakeLists.txt
@@ -17,11 +17,21 @@
 # the License.
 #
 # ##############################################################################
-# ##############################################################################
 
 # Include SYSLOG Infrastructure
 
-set(SRCS vsyslog.c syslog_channel.c syslog_putc.c syslog_write.c syslog_flush.c)
+set(SRCS)
+
+if(CONFIG_SYSLOG)
+  list(
+    APPEND
+    SRCS
+    vsyslog.c
+    syslog_channel.c
+    syslog_putc.c
+    syslog_write.c
+    syslog_flush.c)
+endif()
 
 if(CONFIG_SYSLOG_INTBUFFER)
   list(APPEND SRCS syslog_intbuffer.c)


### PR DESCRIPTION
## Summary
don't include syslog files if CONFIG_SYSLOG=n

## Impact
sync with make build system

## Testing
local build

