### PR TITLE
Minor improve blkoutstream and mtdoutstream

### DIFF
--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -78,7 +78,7 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
 
   while (remain > 0)
     {
-      size_t sblock = self->nput / sectorsize;
+      size_t sector = self->nput / sectorsize;
       size_t offset = self->nput % sectorsize;
 
       if (offset > 0)
@@ -93,28 +93,27 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
           self->nput += copyin;
           remain     -= copyin;
 
-          if (offset == stream->geo.geo_sectorsize)
+          if (offset == sectorsize)
             {
-              ret = inode->u.i_bops->write(inode, stream->cache, sblock, 1);
+              ret = inode->u.i_bops->write(inode, stream->cache, sector, 1);
               if (ret < 0)
                 {
                   return ret;
                 }
             }
         }
-      else if (remain < stream->geo.geo_sectorsize)
+      else if (remain < sectorsize)
         {
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;
         }
-      else if (remain >= stream->geo.geo_sectorsize)
+      else if (remain >= sectorsize)
         {
-          size_t copyin = (remain / stream->geo.geo_sectorsize) *
-                                    stream->geo.geo_sectorsize;
+          size_t copyin = (remain / sectorsize) * sectorsize;
 
-          ret = inode->u.i_bops->write(inode, ptr, sblock,
-                                       remain / stream->geo.geo_sectorsize);
+          ret = inode->u.i_bops->write(inode, ptr, sector,
+                                       remain / sectorsize);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -104,6 +104,11 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
         }
       else if (remain < sectorsize)
         {
+          /* Set content to all 0 before caching,
+           * so no random content will be flushed
+           */
+
+          memset(stream->cache, 0, sectorsize);
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -108,12 +108,12 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
           self->nput += remain;
           remain      = 0;
         }
-      else if (remain >= sectorsize)
+      else
         {
-          size_t copyin = (remain / sectorsize) * sectorsize;
+          size_t nsector = remain / sectorsize;
+          size_t copyin = nsector * sectorsize;
 
-          ret = inode->u.i_bops->write(inode, ptr, sector,
-                                       remain / sectorsize);
+          ret = inode->u.i_bops->write(inode, ptr, sector, nsector);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -104,9 +104,12 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 #ifdef CONFIG_MTD_BYTE_WRITE
   if (inode->u.i_mtd->write != NULL)
     {
-      if (self->nput % erasesize == 0)
+      size_t sblock = (self->nput + erasesize - 1) / erasesize;
+      size_t eblock = (self->nput + len + erasesize - 1) / erasesize;
+
+      if (sblock != eblock)
         {
-          ret = MTD_ERASE(inode->u.i_mtd, self->nput / erasesize, 1);
+          ret = MTD_ERASE(inode->u.i_mtd, sblock, eblock - sblock);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -102,10 +102,9 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 #ifdef CONFIG_MTD_BYTE_WRITE
   if (stream->inode->u.i_mtd->write != NULL)
     {
-      if (self->nput % stream->geo.erasesize == 0)
+      if (self->nput % erasesize == 0)
         {
-          ret = MTD_ERASE(inode->u.i_mtd,
-                          self->nput / stream->geo.erasesize, 1);
+          ret = MTD_ERASE(inode->u.i_mtd, self->nput / erasesize, 1);
           if (ret < 0)
             {
               return ret;
@@ -162,7 +161,7 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
                * so no random content will be flushed
                */
 
-              memset(stream->cache, 0, stream->geo.erasesize);
+              memset(stream->cache, 0, erasesize);
               memcpy(stream->cache, ptr, remain);
               self->nput += remain;
               remain      = 0;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -295,7 +295,7 @@ int lib_mtdoutstream_open(FAR struct lib_mtdoutstream_s *stream,
   if (node->u.i_mtd->write == NULL)
 #endif
     {
-      stream->cache = lib_zalloc(stream->geo.erasesize);
+      stream->cache = lib_malloc(stream->geo.erasesize);
       if (stream->cache == NULL)
         {
           close_mtddriver(node);


### PR DESCRIPTION
## Summary

- libc/blkoutstream: Replace stream->geo.geo_sectorsize with sectorsize 
- libc/blkoutstream: Remove the redundant check and compute 
- libc/blkoutstream: Zero the cache to avoid random data
- libc/mtdoutstream: Replace stream->geo.erasesize with erasesize 
- libc/mtdoutstream: Remove the redundant check and compute 
- libc/mtdoutstream: Fix the in insufficient erase in byte write case

## Impact

blkoutstream and mtdoutstream

## Testing

internal test

