### PR TITLE
timers: Replace DEBUGASSERT with the error code, reopen from #12484

### DIFF
--- a/include/nuttx/timers/oneshot.h
+++ b/include/nuttx/timers/oneshot.h
@@ -269,7 +269,10 @@ int oneshot_max_delay(FAR struct oneshot_lowerhalf_s *lower,
   clock_t tick;
   int ret;
 
-  DEBUGASSERT(lower->ops->tick_max_delay);
+  if (lower->ops->tick_max_delay == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->tick_max_delay(lower, &tick);
   clock_ticks2time(ts, tick);
@@ -283,7 +286,10 @@ int oneshot_start(FAR struct oneshot_lowerhalf_s *lower,
 {
   clock_t tick;
 
-  DEBUGASSERT(lower->ops->tick_start);
+  if (lower->ops->tick_start == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   tick = clock_time2ticks(ts);
   return lower->ops->tick_start(lower, callback, arg, tick);
@@ -296,7 +302,10 @@ int oneshot_cancel(FAR struct oneshot_lowerhalf_s *lower,
   clock_t tick;
   int ret;
 
-  DEBUGASSERT(lower->ops->tick_cancel);
+  if (lower->ops->tick_cancel == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->tick_cancel(lower, &tick);
   clock_ticks2time(ts, tick);
@@ -311,7 +320,10 @@ int oneshot_current(FAR struct oneshot_lowerhalf_s *lower,
   clock_t tick;
   int ret;
 
-  DEBUGASSERT(lower->ops->tick_current);
+  if (lower->ops->tick_current == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->tick_current(lower, &tick);
   clock_ticks2time(ts, tick);
@@ -326,7 +338,10 @@ int oneshot_tick_max_delay(FAR struct oneshot_lowerhalf_s *lower,
   struct timespec ts;
   int ret;
 
-  DEBUGASSERT(lower->ops->max_delay);
+  if (lower->ops->max_delay == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->max_delay(lower, &ts);
   *ticks = clock_time2ticks(&ts);
@@ -340,7 +355,10 @@ int oneshot_tick_start(FAR struct oneshot_lowerhalf_s *lower,
 {
   struct timespec ts;
 
-  DEBUGASSERT(lower->ops->start);
+  if (lower->ops->start == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   clock_ticks2time(&ts, ticks);
   return lower->ops->start(lower, callback, arg, &ts);
@@ -353,7 +371,10 @@ int oneshot_tick_cancel(FAR struct oneshot_lowerhalf_s *lower,
   struct timespec ts;
   int ret;
 
-  DEBUGASSERT(lower->ops->cancel);
+  if (lower->ops->cancel == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->cancel(lower, &ts);
   *ticks = clock_time2ticks(&ts);
@@ -368,7 +389,10 @@ int oneshot_tick_current(FAR struct oneshot_lowerhalf_s *lower,
   struct timespec ts;
   int ret;
 
-  DEBUGASSERT(lower->ops->current);
+  if (lower->ops->current == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->current(lower, &ts);
   *ticks = clock_time2ticks(&ts);

--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -32,6 +32,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
 #include <nuttx/fs/ioctl.h>
+#include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <sys/types.h>
@@ -95,10 +96,10 @@
 /* Method access helper macros **********************************************/
 
 #define TIMER_START(l) \
-  ((l)->ops->start ? (l)->ops->start(l) : -ENOSYS)
+  ((l)->ops->start ? (l)->ops->start(l) : -ENOTSUP)
 
 #define TIMER_STOP(l) \
-  ((l)->ops->stop ? (l)->ops->stop(l) : -ENOSYS)
+  ((l)->ops->stop ? (l)->ops->stop(l) : -ENOTSUP)
 
 #define TIMER_GETSTATUS(l,s) \
   ((l)->ops->getstatus ? (l)->ops->getstatus(l,s) : timer_getstatus(l,s))
@@ -256,7 +257,10 @@ int timer_getstatus(FAR struct timer_lowerhalf_s *lower,
 {
   int ret;
 
-  DEBUGASSERT(lower->ops->tick_getstatus);
+  if (lower->ops->tick_getstatus == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->tick_getstatus(lower, status);
   if (ret >= 0)
@@ -272,7 +276,11 @@ static inline
 int timer_settimeout(FAR struct timer_lowerhalf_s *lower,
                      uint32_t timeout)
 {
-  DEBUGASSERT(lower->ops->tick_setttimeout);
+  if (lower->ops->tick_setttimeout == NULL)
+    {
+      return -ENOTSUP;
+    }
+
   return lower->ops->tick_setttimeout(lower, USEC2TICK(timeout));
 }
 
@@ -282,7 +290,10 @@ int timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
 {
   int ret;
 
-  DEBUGASSERT(lower->ops->tick_maxtimeout);
+  if (lower->ops->tick_maxtimeout == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->tick_maxtimeout(lower, maxtimeout);
   if (ret >= 0)
@@ -299,7 +310,10 @@ int timer_tick_getstatus(FAR struct timer_lowerhalf_s *lower,
 {
   int ret;
 
-  DEBUGASSERT(lower->ops->getstatus);
+  if (lower->ops->getstatus == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->getstatus(lower, status);
   if (ret >= 0)
@@ -315,7 +329,11 @@ static inline
 int timer_tick_settimeout(FAR struct timer_lowerhalf_s *lower,
                           uint32_t timeout)
 {
-  DEBUGASSERT(lower->ops->settimeout);
+  if (lower->ops->settimeout == NULL)
+    {
+      return -ENOTSUP;
+    }
+
   return lower->ops->settimeout(lower, TICK2USEC(timeout));
 }
 
@@ -325,7 +343,10 @@ int timer_tick_maxtimeout(FAR struct timer_lowerhalf_s *lower,
 {
   int ret;
 
-  DEBUGASSERT(lower->ops->maxtimeout);
+  if (lower->ops->maxtimeout == NULL)
+    {
+      return -ENOTSUP;
+    }
 
   ret = lower->ops->maxtimeout(lower, maxtimeout);
   if (ret >= 0)
@@ -408,8 +429,8 @@ void timer_unregister(FAR void *handle);
  *   arg      - Argument provided when the callback is called.
  *
  * Returned Value:
- *   Zero (OK), if the callback was successfully set, or -ENOSYS if the lower
- *   half driver does not support the operation.
+ *   Zero (OK), if the callback was successfully set, or -ENOTSUP if the
+ *   lower half driver does not support the operation.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
If the timer driver is not support both getstatus and tick_getstatus, 
we should not raise a panic, return -ENOSYS will prefer.

#7494 
#13606 
#14514 

## Impact
when timer driver no support for get status, will no longer panic, just return a -ENOSYS.

## Testing
CI-test & local stm32h7

