### PR TITLE
wqueue remove enter_critical_section 

### DIFF
--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -3215,8 +3215,6 @@ static void sam_callback(void *arg)
       ret = work_cancel(LPWORK, &priv->cbwork);
       if (ret < 0)
         {
-          /* NOTE: Currently, work_cancel only returns success */
-
           lcderr("ERROR: Failed to cancel work: %d\n", ret);
         }
 
@@ -3225,8 +3223,6 @@ static void sam_callback(void *arg)
                        priv->cbarg, 0);
       if (ret < 0)
         {
-          /* NOTE: Currently, work_queue only returns success */
-
           lcderr("ERROR: Failed to schedule work: %d\n", ret);
         }
     }

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -3355,8 +3355,6 @@ static void sam_callback(void *arg)
       ret = work_cancel(LPWORK, &priv->cbwork);
       if (ret < 0)
         {
-          /* NOTE: Currently, work_cancel only returns success */
-
           mcerr("ERROR: Failed to cancel work: %d\n", ret);
         }
 
@@ -3365,8 +3363,6 @@ static void sam_callback(void *arg)
                        priv->cbarg, 0);
       if (ret < 0)
         {
-          /* NOTE: Currently, work_queue only returns success */
-
           mcerr("ERROR: Failed to schedule work: %d\n", ret);
         }
     }

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -659,8 +659,6 @@ static void automount_timeout(wdparm_t arg)
   ret = work_queue(LPWORK, &priv->work, automount_worker, priv, 0);
   if (ret < 0)
     {
-      /* NOTE: Currently, work_queue only returns success */
-
       ferr("ERROR: Failed to schedule work: %d\n", ret);
     }
 }
@@ -772,8 +770,6 @@ static int automount_interrupt(FAR const struct automount_lower_s *lower,
                    priv->lower->ddelay);
   if (ret < 0)
     {
-      /* NOTE: Currently, work_queue only returns success */
-
       ferr("ERROR: Failed to schedule work: %d\n", ret);
     }
   else
@@ -848,8 +844,6 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
                    priv->lower->ddelay);
   if (ret < 0)
     {
-      /* NOTE: Currently, work_queue only returns success */
-
       ferr("ERROR: Failed to schedule work: %d\n", ret);
     }
 

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -73,6 +73,8 @@ struct work_notifier_entry_s
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_notifier_lock = SP_UNLOCKED;
+
 /* This is a doubly linked list of free notifications. */
 
 static dq_queue_t g_notifier_free;
@@ -166,17 +168,21 @@ static void work_notifier_worker(FAR void *arg)
 
   /* Disable interrupts very briefly. */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_notifier_lock);
 
   /* Remove the notification from the pending list */
 
-  dq_rem(&notifier->entry, &g_notifier_pending);
+  notifier = work_notifier_find(notifier->key);
+  if (notifier != NULL)
+    {
+      dq_rem(&notifier->entry, &g_notifier_pending);
 
-  /* Put the notification to the free list */
+      /* Put the notification to the free list */
 
-  dq_addlast(&notifier->entry, &g_notifier_free);
+      dq_addlast(&notifier->entry, &g_notifier_free);
+    }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_notifier_lock, flags);
 }
 
 /****************************************************************************
@@ -213,14 +219,14 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
 
   /* Disable interrupts very briefly. */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_notifier_lock);
 
   /* Try to get the entry from the free list */
 
   notifier = (FAR struct work_notifier_entry_s *)
     dq_remfirst(&g_notifier_free);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_notifier_lock, flags);
 
   if (notifier == NULL)
     {
@@ -245,7 +251,7 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
 
       /* Disable interrupts very briefly. */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_notifier_lock);
 
       /* Generate a unique key for this notification */
 
@@ -262,7 +268,7 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
       dq_addlast(&notifier->entry, &g_notifier_pending);
       ret = notifier->key;
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_notifier_lock, flags);
     }
 
   return ret;
@@ -293,7 +299,7 @@ void work_notifier_teardown(int key)
 
   /* Disable interrupts very briefly. */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_notifier_lock);
 
   /* Find the entry matching this key in the g_notifier_pending list.  We
    * assume that there is only one.
@@ -302,21 +308,23 @@ void work_notifier_teardown(int key)
   notifier = work_notifier_find(key);
   if (notifier != NULL)
     {
+      /* Remove the notification from the pending list */
+
+      dq_rem(&notifier->entry, &g_notifier_pending);
+      spin_unlock_irqrestore(&g_notifier_lock, flags);
+
       /* Cancel the work, this may be waiting */
 
-      if (work_cancel_sync(notifier->info.qid, &notifier->work) != 1)
-        {
-          /* Remove the notification from the pending list */
+      work_cancel_sync(notifier->info.qid, &notifier->work);
 
-          dq_rem(&notifier->entry, &g_notifier_pending);
+      flags = spin_lock_irqsave(&g_notifier_lock);
 
-          /* Put the notification to the free list */
+      /* Put the notification to the free list */
 
-          dq_addlast(&notifier->entry, &g_notifier_free);
-        }
+      dq_addlast(&notifier->entry, &g_notifier_free);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_notifier_lock, flags);
 }
 
 /****************************************************************************
@@ -352,7 +360,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
    * the notifications have been sent.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_notifier_lock);
   sched_lock();
 
   /* Process the notification at the head of the pending list until the
@@ -397,7 +405,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
     }
 
   sched_unlock();
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_notifier_lock, flags);
 }
 
 #endif /* CONFIG_WQUEUE_NOTIFIER */

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -35,6 +35,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/queue.h>
 #include <nuttx/wqueue.h>
+#include <nuttx/spinlock.h>
 
 #ifdef CONFIG_SCHED_WORKQUEUE
 
@@ -58,6 +59,7 @@ struct kworker_s
   pid_t             pid;       /* The task ID of the worker thread */
   FAR struct work_s *work;     /* The work structure */
   sem_t             wait;      /* Sync waiting for worker done */
+  int16_t           wait_count;
 };
 
 /* This structure defines the state of one kernel-mode work queue */
@@ -67,8 +69,10 @@ struct kwork_wqueue_s
   struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
+  spinlock_t        lock;      /* Spinlock */
   uint8_t           nthreads;  /* Number of worker threads */
   bool              exit;      /* A flag to request the thread to exit */
+  int16_t           wait_count;
   struct kworker_s  worker[0]; /* Describes a worker thread */
 };
 
@@ -82,8 +86,10 @@ struct hp_wqueue_s
   struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
+  spinlock_t        lock;      /* Spinlock */
   uint8_t           nthreads;  /* Number of worker threads */
   bool              exit;      /* A flag to request the thread to exit */
+  int16_t           wait_count;
 
   /* Describes each thread in the high priority queue's thread pool */
 
@@ -101,8 +107,10 @@ struct lp_wqueue_s
   struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
+  spinlock_t        lock;      /* Spinlock */
   uint8_t           nthreads;  /* Number of worker threads */
   bool              exit;      /* A flag to request the thread to exit */
+  int16_t           wait_count;
 
   /* Describes each thread in the low priority queue's thread pool */
 


### PR DESCRIPTION
## Summary

    we use small lock to replace enter_critical_section to avoid busywait

    reason:
    We decouple semcount from business logic
    by using an independent counting variable,
    which allows us to remove critical sections in many cases.


## Impact
work queue

## Testing
Build Host:

OS: Ubuntu 20.04
CPU: x86_64
Compiler: GCC 9.4.0
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic
-machine virt,virtualization=on,gic-version=3
-net none -chardev stdio,id=con,mux=on -serial chardev:con
-mon chardev=con,mode=readline -kernel ./nuttx

