### PR TITLE
sched/semaphore: change semcount type to int

### DIFF
--- a/arch/risc-v/src/common/espressif/platform_include/sys/lock.h
+++ b/arch/risc-v/src/common/espressif/platform_include/sys/lock.h
@@ -39,7 +39,7 @@
 
 struct __lock
 {
-  int reserved[4];
+  int reserved[6];
 };
 
 typedef _LOCK_T _lock_t;

--- a/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
+++ b/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
@@ -41,12 +41,12 @@ struct __lock
 {
 #ifdef CONFIG_PRIORITY_INHERITANCE
 #  if CONFIG_SEM_PREALLOCHOLDERS > 0
-  int reserved[5];
+  int reserved[7];
 #  else
-  int reserved[8];
+  int reserved[10];
 #  endif
 #else
-  int reserved[4];
+  int reserved[6];
 #endif
 };
 

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -104,7 +104,7 @@ struct semholder_s
 
 struct sem_s
 {
-  volatile int16_t semcount;     /* >0 -> Num counts available */
+  volatile int semcount;         /* >0 -> Num counts available */
                                  /* <0 -> Num tasks waiting for semaphore */
 
   /* If priority inheritance is enabled, then we have to keep track of which

--- a/sched/semaphore/sem_destroy.c
+++ b/sched/semaphore/sem_destroy.c
@@ -60,7 +60,7 @@
 
 int nxsem_destroy(FAR sem_t *sem)
 {
-  short old;
+  int old;
 
   DEBUGASSERT(sem != NULL);
 

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -259,7 +259,7 @@ int nxsem_post(FAR sem_t *sem)
 #if !defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_PRIORITY_PROTECT)
   if (sem->flags & SEM_TYPE_MUTEX)
     {
-      short old = 0;
+      int old = 0;
       if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem), &old, 1,
                                                 memory_order_release,
                                                 memory_order_relaxed))

--- a/sched/semaphore/sem_reset.c
+++ b/sched/semaphore/sem_reset.c
@@ -60,7 +60,7 @@
 int nxsem_reset(FAR sem_t *sem, int16_t count)
 {
   irqstate_t flags;
-  short semcount;
+  int semcount;
 
   DEBUGASSERT(sem != NULL && count >= 0);
 

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -64,7 +64,7 @@ static int nxsem_trywait_slow(FAR sem_t *sem)
 {
   FAR struct tcb_s *rtcb;
   irqstate_t flags;
-  short semcount;
+  int semcount;
   int ret;
 
   /* The following operations must be performed with interrupts disabled
@@ -153,7 +153,7 @@ int nxsem_trywait(FAR sem_t *sem)
 #if !defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_PRIORITY_PROTECT)
   if (sem->flags & SEM_TYPE_MUTEX)
     {
-      short old = 1;
+      int old = 1;
       if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem), &old, 0,
                                                 memory_order_acquire,
                                                 memory_order_relaxed))

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -259,7 +259,7 @@ int nxsem_wait(FAR sem_t *sem)
 #if !defined(CONFIG_PRIORITY_INHERITANCE) && !defined(CONFIG_PRIORITY_PROTECT)
   if (sem->flags & SEM_TYPE_MUTEX)
     {
-      short old = 1;
+      int old = 1;
       if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem), &old, 0,
                                                 memory_order_acquire,
                                                 memory_order_relaxed))

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -40,7 +40,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NXSEM_COUNT(s) ((FAR atomic_short *)&(s)->semcount)
+#define NXSEM_COUNT(s) ((FAR atomic_int *)&(s)->semcount)
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary

Fix the issue introduced by bug #14465.
Some memory on the ESP32 requires aligned access,
so the semcount type has been changed to int.

## Impact

semaphore

## Testing

bes board test pass