### PR TITLE
pthread: remove enter_critical_section in pthread_barrier_wait

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -368,6 +368,8 @@ struct pthread_barrier_s
 {
   sem_t        sem;
   unsigned int count;
+  unsigned int wait_count;
+  mutex_t      mutex;
 };
 
 #ifndef __PTHREAD_BARRIER_T_DEFINED

--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -87,6 +87,8 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
     {
       sem_init(&barrier->sem, 0, 0);
       barrier->count = count;
+      barrier->wait_count = 0;
+      nxmutex_init(&barrier->mutex);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
reason:
We decouple semcount from business logic by using an independent counting variable, which allows us to remove critical sections in many cases.

## Impact
pthread_barrier_wait

## Testing
Build Host:

OS: Ubuntu 20.04
CPU: x86_64
Compiler: GCC 9.4.0
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic
-machine virt,virtualization=on,gic-version=3
-net none -chardev stdio,id=con,mux=on -serial chardev:con
-mon chardev=con,mode=readline -kernel ./nuttx

