### PR TITLE
sched/sched: change the judgment condition for nxsched_set_affinity

### DIFF
--- a/sched/sched/sched_setaffinity.c
+++ b/sched/sched/sched_setaffinity.c
@@ -126,8 +126,8 @@ int nxsched_set_affinity(pid_t pid, size_t cpusetsize,
    * First... is the task in an assigned task list?
    */
 
-  if (tcb->task_state >= FIRST_ASSIGNED_STATE &&
-      tcb->task_state <= LAST_ASSIGNED_STATE)
+  if (tcb->task_state >= FIRST_READY_TO_RUN_STATE &&
+      tcb->task_state <= LAST_READY_TO_RUN_STATE)
     {
       /* Yes... is the CPU associated with the assigned task in the new
        * affinity mask?


### PR DESCRIPTION
## Summary
reason:
In smp, It's possible that in a scenario where CONFIG_SMP_DEFAULT_CPUSET is set to 1, when taskA is created with a relatively low priority, it gets added to the g_readytorun queue with an affinity of 0x1. Meanwhile, CPUs 1~n are in an idle state.
Subsequently, when we attempt to change the affinity property of taskA using nxsched_set_affinity, the scheduling mechanism might not be triggered due to the lack of a proper condition check. This can result in taskA remaining unscheduled and therefore unable to run.

## Impact
nxsched_set_affinity

## Testing
Build Host:

OS: Ubuntu 20.04
CPU: x86_64
Compiler: GCC 9.4.0
Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic
-machine virt,virtualization=on,gic-version=3
-net none -chardev stdio,id=con,mux=on -serial chardev:con
-mon chardev=con,mode=readline -kernel ./nuttx
