### PR TITLE
arm64: fix compile failed when build ELF apps

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -219,7 +219,7 @@ endif
 
 # Loadable module definitions
 
-CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden -mlong-calls # --target1-abs
+CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden # --target1-abs
 LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 
 # ELF module definitions


### PR DESCRIPTION
## Summary

arm64: fix compile failed when build ELF apps

aarch64-none-elf-gcc -c -D_LDBL_EQ_DBL -fno-common -Wall -Wstrict-prototypes -Wshadow -Wundef -Werror -Wno-attributes -Wno-unknown-pragmas -Wno-psabi "-O3" -fno-strict-aliasing -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstack-protector-all -fsanitize=kernel-address --param asan-globals=1 -ffunction-sections -fdata-sections "-g3" -mcpu=cortex-a53 -isystem /home/ligd/platform/trunk/nuttx/include -D__NuttX__  -pipe -I /home/ligd/platform/trunk/apps/crypto/mbedtls/include -I /home/ligd/platform/trunk/apps/crypto/mbedtls/mbedtls/include -I /home/ligd/platform/trunk/apps/crypto/openssl_mbedtls_wrapper/include -I /home/ligd/platform/trunk/apps/external/android/frameworks/native/libs/binder/include_rpc_unstable -I /home/ligd/platform/trunk/apps/external/android/frameworks/native/libs/binder/ndk/include_ndk -I /home/ligd/platform/trunk/apps/external/android/frameworks/native/libs/binder/ndk/include_platform -I /home/ligd/platform/trunk/apps/external/android/system/chre/chre/chre_api/include/chre_api -DCHRE_MESSAGE_TO_HOST_MAX_SIZE=2048 -I /home/ligd/platform/trunk/apps/external/android/system/core/libcutils/include -I /home/ligd/platform/trunk/apps/frameworks/graphics/uikit/include -I /home/ligd/platform/trunk/apps/frameworks/runtimes/feature/include -I /home/ligd/platform/trunk/apps/frameworks/runtimes/feature/src -I /home/ligd/platform/trunk/apps/frameworks/security/include -I /home/ligd/platform/trunk/apps/frameworks/system/dfx/include -I /home/ligd/platform/trunk/apps/frameworks/system/topics/include -I /home/ligd/platform/trunk/apps/frameworks/system/utils/include -I /home/ligd/platform/trunk/apps/graphics/lvgl -I /home/ligd/platform/trunk/apps/graphics/lvgl/lvgl -I "/home/ligd/platform/trunk/apps/system/argtable3/argtable3/src" -I /home/ligd/platform/trunk/apps/system/libuv/libuv/include -DUV_HANDLE_BACKTRACE=CONFIG_LIBUV_HANDLE_BACKTRACE -I /home/ligd/platform/trunk/apps/system/uorb/ -I /home/ligd/platform/trunk/nuttx/arch/arm64/src/board/include -I /home/ligd/platform/trunk/nuttx/arch/arm64/src/chip -I /home/ligd/platform/trunk/apps/vendor/bes/drivers/best1600_ep/miwear_drivers/display -I /home/ligd/platform/trunk/apps/vendor/bes/drivers/best1600_ep/miwear_drivers/boards -I /home/ligd/platform/trunk/apps/vendor/bes/drivers/best1600_ep/miwear_drivers/include -I "/home/ligd/platform/trunk/apps/include" -fvisibility=hidden -mlong-calls    modprint.c -o  modprint.c.home.ligd.platform.trunk.apps.examples.sotest.modprint.o

aarch64-none-elf-gcc: error: unrecognized command-line option '-mlong-calls'

## Impact

ARM64 ELF

## Testing

CI


