### PR TITLE
sched/wqueue: fix work_notifier_setup() false failure

### DIFF
--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -66,7 +66,7 @@ struct work_notifier_entry_s
 
   /* Additional payload needed to manage the notification */
 
-  uint32_t key;                 /* Unique ID for the notification */
+  int key;                      /* Unique ID for the notification */
 };
 
 /****************************************************************************
@@ -100,7 +100,7 @@ static dq_queue_t g_notifier_pending;
  *
  ****************************************************************************/
 
-static FAR struct work_notifier_entry_s *work_notifier_find(uint32_t key)
+static FAR struct work_notifier_entry_s *work_notifier_find(int key)
 {
   FAR struct work_notifier_entry_s *notifier;
   FAR dq_entry_t *entry;
@@ -134,11 +134,11 @@ static FAR struct work_notifier_entry_s *work_notifier_find(uint32_t key)
  *
  ****************************************************************************/
 
-static uint32_t work_notifier_key(void)
+static int work_notifier_key(void)
 {
-  static uint32_t notifier_key;
+  static int notifier_key;
 
-  if (++notifier_key == 0)
+  if (++notifier_key <= 0)
     {
       notifier_key = 1;
     }

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -295,7 +295,7 @@ void work_notifier_teardown(int key)
 
   flags = enter_critical_section();
 
-  /* Find the entry matching this PID in the g_notifier_pending list.  We
+  /* Find the entry matching this key in the g_notifier_pending list.  We
    * assume that there is only one.
    */
 
@@ -349,7 +349,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
   irqstate_t flags;
 
   /* Don't let any newly started threads block this thread until all of
-   * the notifications and been sent.
+   * the notifications have been sent.
    */
 
   flags = enter_critical_section();
@@ -376,7 +376,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
       notifier = (FAR struct work_notifier_entry_s *)entry;
       info     = &notifier->info;
 
-      /* Check if this is the a notification request for the event that
+      /* Check if this is a notification request for the event that
        * just occurred.
        */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Be consistent with the datatype used for the 'key'. As the API in
in the .h file uses int, I chose to replace uint32_t with int
everywhere.

This change ensures that work_notifier_setup() will not return a
negative value indicating error to the caller, when in fact the
notifier was correctly setup. This would happen when
work_notifier_setup() had been called 0x8000000 times, and that
many keys allocated.

## Impact

work_notifier_setup() is used in TCP, UDP, Netlink and IOB code.


