### PR TITLE
net/netlink: fix netlink poll return value on success

### DIFF
--- a/net/netlink/netlink_notifier.c
+++ b/net/netlink/netlink_notifier.c
@@ -80,7 +80,7 @@ int netlink_notifier_setup(worker_t worker, FAR struct netlink_conn_s *conn,
   info.worker    = worker;
 
   conn->key      =  work_notifier_setup(&info);
-  return conn->key;
+  return conn->key < 0 ? conn->key : 0;
 }
 
 /****************************************************************************

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -687,7 +687,7 @@ static ssize_t netlink_recvmsg(FAR struct socket *psock,
     {
       conn = psock->s_conn;
 
-      /* No response is variable, but presumably, one is expected.  Check
+      /* No response is available, but presumably, one is expected.  Check
        * if the socket has been configured for non-blocking operation.
        */
 


### PR DESCRIPTION
## Summary

Make sure the return value is zero on success - as described in the
documentation of the function.

## Impact

It doesn't look like the "error" affected any code.



