### PR TITLE
sched: add header irq.h to exit.c

### DIFF
--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 #include <errno.h>
 
+#include <nuttx/irq.h>
 #include <nuttx/fs/fs.h>
 
 #include "task/task.h"


### PR DESCRIPTION
## Summary

It's found that in some board config/build, the macro expansion of `enter_critical_section` is not correct.
Add irq.h to avoid macro expansion problem in exit.c

## Impact

none

## Testing

sim build & run


