### PR TITLE
Use pathbuffer reduce stack

### DIFF
--- a/drivers/input/aw86225.c
+++ b/drivers/input/aw86225.c
@@ -45,6 +45,7 @@
 #include <nuttx/input/aw86225.h>
 #include <nuttx/input/ff.h>
 #include <nuttx/irq.h>
+#include <nuttx/lib/lib.h>
 
 #include "aw86225_reg.h"
 #include "aw86225_internal.h"
@@ -367,14 +368,21 @@ static int aw86225_i2c_write_bits(FAR struct aw86225 *aw86225,
 static int aw86225_request_firmware(FAR struct aw86225_firmware *fw,
                                     FAR const char *filename)
 {
-  char file_path[PATH_MAX];
+  FAR char *file_path;
   struct file file;
   size_t file_size;
   int ret;
 
-  snprintf(file_path, sizeof(file_path), "%s/%s", CONFIG_FF_RTP_FILE_PATH,
+  file_path = lib_get_pathbuffer();
+  if (file_path == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  snprintf(file_path, PATH_MAX, "%s/%s", CONFIG_FF_RTP_FILE_PATH,
            filename);
   ret = file_open(&file, file_path, O_RDONLY);
+  lib_put_pathbuffer(file_path);
   if (ret < 0)
     {
       ierr("open file failed");

--- a/drivers/mtd/dhara.c
+++ b/drivers/mtd/dhara.c
@@ -31,6 +31,7 @@
 #include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/lib/lib.h>
 
 #include <dhara/map.h>
 #include <dhara/nand.h>
@@ -783,7 +784,8 @@ err:
 
 int dhara_initialize(int minor, FAR struct mtd_dev_s *mtd)
 {
-  char path[PATH_MAX];
+  FAR char *path;
+  int ret;
 
 #ifdef CONFIG_DEBUG_FEATURES
   /* Sanity check */
@@ -794,8 +796,16 @@ int dhara_initialize(int minor, FAR struct mtd_dev_s *mtd)
     }
 #endif
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   /* Do the real work by dhara_mtdblock_initialize_by_path */
 
-  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
-  return dhara_initialize_by_path(path, mtd);
+  snprintf(path, PATH_MAX, "/dev/mtdblock%d", minor);
+  ret = dhara_initialize_by_path(path, mtd);
+  lib_put_pathbuffer(path);
+  return ret;
 }

--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -29,6 +29,7 @@
 #include <nuttx/circbuf.h>
 #include <nuttx/sensors/sensor.h>
 #include <nuttx/sensors/gnss.h>
+#include <nuttx/lib/lib.h>
 
 #include <fcntl.h>
 #include <poll.h>
@@ -713,12 +714,19 @@ int gnss_register(FAR struct gnss_lowerhalf_s *lower, int devno,
 {
   FAR struct gnss_upperhalf_s *upper;
   FAR struct gnss_sensor_s *dev;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   upper = kmm_zalloc(sizeof(struct gnss_upperhalf_s));
   if (upper == NULL)
     {
+      return -ENOMEM;
+    }
+
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      kmm_free(upper);
       return -ENOMEM;
     }
 
@@ -812,6 +820,7 @@ int gnss_register(FAR struct gnss_lowerhalf_s *lower, int devno,
       goto driver_err;
     }
 
+  lib_put_pathbuffer(path);
   return ret;
 
 driver_err:
@@ -830,6 +839,7 @@ gnss_err:
   nxmutex_destroy(&upper->lock);
   nxmutex_destroy(&upper->bufferlock);
   nxsem_destroy(&upper->buffersem);
+  lib_put_pathbuffer(path);
   kmm_free(upper);
   return ret;
 }
@@ -851,7 +861,13 @@ gnss_err:
 void gnss_unregister(FAR struct gnss_lowerhalf_s *lower, int devno)
 {
   FAR struct gnss_upperhalf_s *upper = lower->priv;
-  char path[PATH_MAX];
+  FAR char *path;
+
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return;
+    }
 
   sensor_unregister(&upper->dev[GNSS_IDX].lower, devno);
   sensor_unregister(&upper->dev[GNSS_SATELLITE_IDX].lower, devno);
@@ -862,5 +878,6 @@ void gnss_unregister(FAR struct gnss_lowerhalf_s *lower, int devno)
   unregister_driver(path);
   nxsem_destroy(&upper->buffersem);
   circbuf_uninit(&upper->buffer);
+  lib_put_pathbuffer(path);
   kmm_free(upper);
 }

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -39,6 +39,7 @@
 #include <nuttx/circbuf.h>
 #include <nuttx/mutex.h>
 #include <nuttx/sensors/sensor.h>
+#include <nuttx/lib/lib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -1238,16 +1239,25 @@ void sensor_remap_vector_raw16(FAR const int16_t *in, FAR int16_t *out,
 
 int sensor_register(FAR struct sensor_lowerhalf_s *lower, int devno)
 {
-  char path[PATH_MAX];
+  FAR char *path;
+  int ret;
 
   DEBUGASSERT(lower != NULL);
+
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
 
   snprintf(path, PATH_MAX, DEVNAME_FMT,
            g_sensor_meta[lower->type].name,
            lower->uncalibrated ? DEVNAME_UNCAL : "",
            devno);
-  return sensor_custom_register(lower, path,
-                                g_sensor_meta[lower->type].esize);
+  ret = sensor_custom_register(lower, path,
+                               g_sensor_meta[lower->type].esize);
+  lib_put_pathbuffer(path);
+  return ret;
 }
 
 /****************************************************************************
@@ -1379,13 +1389,20 @@ rpmsg_err:
 
 void sensor_unregister(FAR struct sensor_lowerhalf_s *lower, int devno)
 {
-  char path[PATH_MAX];
+  FAR char *path;
+
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return;
+    }
 
   snprintf(path, PATH_MAX, DEVNAME_FMT,
            g_sensor_meta[lower->type].name,
            lower->uncalibrated ? DEVNAME_UNCAL : "",
            devno);
   sensor_custom_unregister(lower, path);
+  lib_put_pathbuffer(path);
 }
 
 /****************************************************************************

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -42,6 +42,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/spawn.h>
 #include <nuttx/spinlock.h>
+#include <nuttx/lib/lib.h>
 
 #ifdef CONFIG_FDSAN
 #  include <android/fdsan.h>
@@ -381,6 +382,7 @@ void files_initlist(FAR struct filelist *list)
 #ifdef CONFIG_SCHED_DUMP_ON_EXIT
 void files_dumplist(FAR struct filelist *list)
 {
+  FAR char *path;
   int count = files_countlist(list);
   int i;
 
@@ -392,10 +394,15 @@ void files_dumplist(FAR struct filelist *list)
         "PID", "FD", "FLAGS", "TYPE", "POS", "PATH"
         );
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return;
+    }
+
   for (i = 0; i < count; i++)
     {
       FAR struct file *filep = files_fget(list, i);
-      char path[PATH_MAX];
 
 #if CONFIG_FS_BACKTRACE > 0
       char buf[BACKTRACE_BUFFER_SIZE(CONFIG_FS_BACKTRACE)];
@@ -431,6 +438,8 @@ void files_dumplist(FAR struct filelist *list)
             );
       fs_putfilep(filep);
     }
+
+  lib_put_pathbuffer(path);
 }
 #endif
 

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -39,6 +39,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/fs/automount.h>
+#include <nuttx/lib/lib.h>
 
 #ifdef CONFIG_FS_AUTOMOUNTER_DRIVER
 #  include <stdio.h>
@@ -807,7 +808,11 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   FAR struct automounter_state_s *priv;
   int ret;
 #ifdef CONFIG_FS_AUTOMOUNTER_DRIVER
-  char devpath[PATH_MAX];
+  FAR char *devpath = lib_get_pathbuffer();
+  if (devpath == NULL)
+    {
+      return;
+    }
 #endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
 
   finfo("lower=%p\n", lower);
@@ -851,10 +856,11 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
 
   /* Register driver */
 
-  snprintf(devpath, sizeof(devpath),
+  snprintf(devpath, PATH_MAX,
            CONFIG_FS_AUTOMOUNTER_VFS_PATH "%s", lower->mountpoint);
 
   ret = register_driver(devpath, &g_automount_fops, 0444, priv);
+  lib_put_pathbuffer(devpath);
   if (ret < 0)
     {
       ferr("ERROR: Failed to register automount driver: %d\n", ret);
@@ -911,12 +917,17 @@ void automount_uninitialize(FAR void *handle)
 #ifdef CONFIG_FS_AUTOMOUNTER_DRIVER
   if (priv->registered)
     {
-      char devpath[PATH_MAX];
+      FAR char *devpath = lib_get_pathbuffer();
+      if (devpath == NULL)
+        {
+          return;
+        }
 
-      snprintf(devpath, sizeof(devpath),
+      snprintf(devpath, PATH_MAX,
                CONFIG_FS_AUTOMOUNTER_VFS_PATH "%s", lower->mountpoint);
 
       unregister_driver(devpath);
+      lib_put_pathbuffer(devpath);
     }
 
   nxmutex_destroy(&priv->lock);

--- a/fs/partition/fs_partition.c
+++ b/fs/partition/fs_partition.c
@@ -91,9 +91,15 @@ static void register_partition(FAR struct partition_s *part, FAR void *arg)
     {
       FAR struct partition_register_s *reg = arg;
       FAR struct partition_state_s *state = reg->state;
-      char path[PATH_MAX];
+      FAR char *path;
 
-      snprintf(path, sizeof(path), "%s/%s", reg->dir, part->name);
+      path = lib_get_pathbuffer();
+      if (path == NULL)
+        {
+          return;
+        }
+
+      snprintf(path, PATH_MAX, "%s/%s", reg->dir, part->name);
       if (state->blk != NULL)
         {
           register_partition_with_inode(path, 0660, state->blk,
@@ -106,6 +112,8 @@ static void register_partition(FAR struct partition_s *part, FAR void *arg)
                                       part->firstblock, part->nblocks);
         }
 #endif
+
+      lib_put_pathbuffer(path);
     }
 }
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -57,6 +57,7 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/queue.h>
+#include <nuttx/lib/lib.h>
 
 #include "fs_heap.h"
 
@@ -1250,7 +1251,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 {
   FAR struct task_group_s *group = tcb->group;
   FAR struct file *filep;
-  char path[PATH_MAX];
+  FAR char *path;
   size_t remaining;
   size_t linesize;
   size_t copysize;
@@ -1286,6 +1287,12 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
   remaining -= copysize;
 
   if (totalsize >= buflen)
+    {
+      return totalsize;
+    }
+
+  path = lib_get_pathbuffer();
+  if (path == NULL)
     {
       return totalsize;
     }
@@ -1334,10 +1341,12 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
       if (totalsize >= buflen)
         {
+          lib_put_pathbuffer(path);
           return totalsize;
         }
     }
 
+  lib_put_pathbuffer(path);
   return totalsize;
 }
 

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -280,7 +280,7 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
   FAR struct inode *inode;
   FAR struct rpmsgfs_mountpt_s *fs;
   FAR struct rpmsgfs_ofile_s  *hf;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -296,11 +296,18 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
 
   DEBUGASSERT(fs != NULL);
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   /* Take the lock */
 
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
@@ -315,7 +322,7 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Try to open the file in the host file system */
 
@@ -368,6 +375,7 @@ errout_with_buffer:
 
 errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   if (ret == -EINVAL)
     {
       ret = -EIO;
@@ -865,7 +873,7 @@ static int rpmsgfs_opendir(FAR struct inode *mountpt,
 {
   FAR struct rpmsgfs_mountpt_s *fs;
   FAR struct rpmsgfs_dir_s *rdir;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -881,6 +889,13 @@ static int rpmsgfs_opendir(FAR struct inode *mountpt,
       return -ENOMEM;
     }
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      fs_heap_free(rdir);
+      return -ENOMEM;
+    }
+
   /* Take the lock */
 
   ret = nxmutex_lock(&fs->fs_lock);
@@ -891,7 +906,7 @@ static int rpmsgfs_opendir(FAR struct inode *mountpt,
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host's opendir function */
 
@@ -904,12 +919,14 @@ static int rpmsgfs_opendir(FAR struct inode *mountpt,
 
   *dir = (FAR struct fs_dirent_s *)rdir;
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return OK;
 
 errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);
 
 errout_with_rdir:
+  lib_put_pathbuffer(path);
   fs_heap_free(rdir);
   return ret;
 }
@@ -1242,7 +1259,7 @@ static int rpmsgfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 static int rpmsgfs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -1253,21 +1270,29 @@ static int rpmsgfs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 
   fs = mountpt->i_private;
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host fs to perform the unlink */
 
   ret = rpmsgfs_client_unlink(fs->handle, path);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return ret;
 }
 
@@ -1282,7 +1307,7 @@ static int rpmsgfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
                          mode_t mode)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -1293,21 +1318,29 @@ static int rpmsgfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host FS to do the mkdir */
 
   ret = rpmsgfs_client_mkdir(fs->handle, path, mode);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return ret;
 }
 
@@ -1321,7 +1354,7 @@ static int rpmsgfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 int rpmsgfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -1334,21 +1367,29 @@ int rpmsgfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 
   /* Take the lock */
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host FS to do the mkdir */
 
   ret = rpmsgfs_client_rmdir(fs->handle, path);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return ret;
 }
 
@@ -1363,9 +1404,22 @@ int rpmsgfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
                    FAR const char *newrelpath)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char oldpath[PATH_MAX];
-  char newpath[PATH_MAX];
+  FAR char *oldpath;
+  FAR char *newpath;
   int ret;
+
+  oldpath = lib_get_pathbuffer();
+  if (oldpath == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  newpath = lib_get_pathbuffer();
+  if (newpath == NULL)
+    {
+      lib_put_pathbuffer(oldpath);
+      return -ENOMEM;
+    }
 
   /* Sanity checks */
 
@@ -1378,21 +1432,25 @@ int rpmsgfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(oldpath);
+      lib_put_pathbuffer(newpath);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  strlcpy(oldpath, fs->fs_root, sizeof(oldpath));
-  strlcat(oldpath, oldrelpath, sizeof(oldpath));
-  strlcpy(newpath, fs->fs_root, sizeof(newpath));
-  strlcat(newpath, newrelpath, sizeof(newpath));
+  strlcpy(oldpath, fs->fs_root, PATH_MAX);
+  strlcat(oldpath, oldrelpath, PATH_MAX);
+  strlcpy(newpath, fs->fs_root, PATH_MAX);
+  strlcat(newpath, newrelpath, PATH_MAX);
 
   /* Call the host FS to do the mkdir */
 
   ret = rpmsgfs_client_rename(fs->handle, oldpath, newpath);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(oldpath);
+  lib_put_pathbuffer(newpath);
   return ret;
 }
 
@@ -1407,7 +1465,7 @@ static int rpmsgfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
                         FAR struct stat *buf)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -1418,21 +1476,29 @@ static int rpmsgfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host FS to do the stat operation */
 
   ret = rpmsgfs_client_stat(fs->handle, path, buf);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return ret;
 }
 
@@ -1447,7 +1513,7 @@ static int rpmsgfs_chstat(FAR struct inode *mountpt, FAR const char *relpath,
                           FAR const struct stat *buf, int flags)
 {
   FAR struct rpmsgfs_mountpt_s *fs;
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
   /* Sanity checks */
@@ -1458,20 +1524,28 @@ static int rpmsgfs_chstat(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return -ENOMEM;
+    }
+
   ret = nxmutex_lock(&fs->fs_lock);
   if (ret < 0)
     {
+      lib_put_pathbuffer(path);
       return ret;
     }
 
   /* Append to the host's root directory */
 
-  rpmsgfs_mkpath(fs, relpath, path, sizeof(path));
+  rpmsgfs_mkpath(fs, relpath, path, PATH_MAX);
 
   /* Call the host FS to do the chstat operation */
 
   ret = rpmsgfs_client_chstat(fs->handle, path, buf, flags);
 
   nxmutex_unlock(&fs->fs_lock);
+  lib_put_pathbuffer(path);
   return ret;
 }

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1601,12 +1601,8 @@ int v9fs_client_init(FAR struct v9fs_client_s *client,
                      FAR const char *data)
 {
   FAR const char *options;
+  FAR char *aname;
   char transport[NAME_MAX];
-  char aname[PATH_MAX] =
-    {
-      0
-    };
-
   char uname[NAME_MAX] =
     {
       0
@@ -1614,6 +1610,14 @@ int v9fs_client_init(FAR struct v9fs_client_s *client,
 
   size_t length;
   int ret;
+
+  aname = lib_get_pathbuffer();
+  if (aname == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  aname[0] = '\0';
 
   /* Parse commandline */
 
@@ -1655,6 +1659,7 @@ int v9fs_client_init(FAR struct v9fs_client_s *client,
   ret = v9fs_transport_create(&client->transport, transport, data);
   if (ret < 0)
     {
+      lib_put_pathbuffer(aname);
       return ret;
     }
 
@@ -1662,6 +1667,7 @@ int v9fs_client_init(FAR struct v9fs_client_s *client,
   if (client->fids == NULL)
     {
       v9fs_transport_destroy(client->transport);
+      lib_put_pathbuffer(aname);
       return -ENOMEM;
     }
 
@@ -1685,12 +1691,14 @@ int v9fs_client_init(FAR struct v9fs_client_s *client,
 
   client->root_fid = ret;
   client->tag_id = 1;
+  lib_put_pathbuffer(aname);
   return 0;
 
 out:
   v9fs_transport_destroy(client->transport);
   nxmutex_destroy(&client->lock);
   idr_destroy(client->fids);
+  lib_put_pathbuffer(aname);
   return ret;
 }
 

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -32,6 +32,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
+#include <nuttx/lib/lib.h>
 
 #include "inode/inode.h"
 #include "fs_heap.h"
@@ -581,8 +582,14 @@ int dir_allocate(FAR struct file *filep, FAR const char *relpath)
 {
   FAR struct fs_dirent_s *dir;
   FAR struct inode *inode = filep->f_inode;
-  char path_prefix[PATH_MAX];
+  FAR char *path_prefix;
   int ret;
+
+  path_prefix = lib_get_pathbuffer();
+  if (path_prefix == NULL)
+    {
+      return -ENOMEM;
+    }
 
   /* Is this a node in the pseudo filesystem? Or a mountpoint? */
 
@@ -594,6 +601,7 @@ int dir_allocate(FAR struct file *filep, FAR const char *relpath)
       ret = open_mountpoint(inode, relpath, &dir);
       if (ret < 0)
         {
+          lib_put_pathbuffer(path_prefix);
           return ret;
         }
     }
@@ -603,20 +611,23 @@ int dir_allocate(FAR struct file *filep, FAR const char *relpath)
       ret = open_pseudodir(inode, &dir);
       if (ret < 0)
         {
+          lib_put_pathbuffer(path_prefix);
           return ret;
         }
     }
 
-  inode_getpath(inode, path_prefix, sizeof(path_prefix));
+  inode_getpath(inode, path_prefix, PATH_MAX);
   ret = fs_heap_asprintf(&dir->fd_path, "%s%s/", path_prefix, relpath);
   if (ret < 0)
     {
       dir->fd_path = NULL;
+      lib_put_pathbuffer(path_prefix);
       return ret;
     }
 
   filep->f_inode = &g_dir_inode;
   filep->f_priv  = dir;
   inode_addref(&g_dir_inode);
+  lib_put_pathbuffer(path_prefix);
   return ret;
 }

--- a/libs/libc/locale/lib_catalog.c
+++ b/libs/libc/locale/lib_catalog.c
@@ -177,6 +177,7 @@ nl_catd catopen(FAR const char *name, int oflag)
   FAR const char *lang;
   FAR const char *p;
   FAR const char *z;
+  FAR char *buf;
 
   if (strchr(name, '/'))
     {
@@ -195,9 +196,15 @@ nl_catd catopen(FAR const char *name, int oflag)
       lang = "";
     }
 
+  buf = lib_get_pathbuffer();
+  if (buf == NULL)
+    {
+      set_errno(ENOMEM);
+      return MAP_FAILED;
+    }
+
   for (p = path; *p; p = z)
     {
-      char buf[PATH_MAX];
       nl_catd catd;
       size_t i;
 
@@ -261,7 +268,7 @@ nl_catd catopen(FAR const char *name, int oflag)
               l = 1;
             }
 
-          if (v == NULL || i + l >= sizeof(buf))
+          if (v == NULL || i + l >= PATH_MAX)
             {
               break;
             }
@@ -286,10 +293,12 @@ nl_catd catopen(FAR const char *name, int oflag)
         catd = catmap(i ? buf : name);
         if (catd != MAP_FAILED)
           {
+            lib_put_pathbuffer(buf);
             return catd;
           }
       }
 
+  lib_put_pathbuffer(buf);
   set_errno(ENOENT);
   return MAP_FAILED;
 }

--- a/libs/libc/locale/lib_catalog.c
+++ b/libs/libc/locale/lib_catalog.c
@@ -36,6 +36,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <nuttx/lib/lib.h>
+
 #ifdef CONFIG_LIBC_LOCALE_CATALOG
 
 /****************************************************************************

--- a/libs/libc/locale/lib_gettext.c
+++ b/libs/libc/locale/lib_gettext.c
@@ -549,9 +549,9 @@ FAR char *dcngettext(FAR const char *domainname,
 {
   FAR struct mofile_s *mofile;
   FAR const char *lang;
-  char path[PATH_MAX];
   FAR char *notrans;
   FAR char *trans;
+  FAR char *path;
 
   notrans = (FAR char *)(n == 1 ? msgid1 : msgid2);
 
@@ -576,6 +576,12 @@ FAR char *dcngettext(FAR const char *domainname,
       lang = "C";
     }
 
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      return notrans;
+    }
+
   snprintf(path, PATH_MAX,
            CONFIG_LIBC_LOCALE_PATH"/%s/%s/%s.mo",
            lang, g_catname[category], domainname);
@@ -598,6 +604,7 @@ FAR char *dcngettext(FAR const char *domainname,
       if (mofile == NULL)
         {
           nxmutex_unlock(&g_lock);
+          lib_put_pathbuffer(path);
           return notrans;
         }
 
@@ -606,6 +613,7 @@ FAR char *dcngettext(FAR const char *domainname,
       if (mofile->map == MAP_FAILED)
         {
           nxmutex_unlock(&g_lock);
+          lib_put_pathbuffer(path);
           lib_free(mofile);
           return notrans;
         }
@@ -651,6 +659,7 @@ FAR char *dcngettext(FAR const char *domainname,
     }
 
   nxmutex_unlock(&g_lock); /* Leave look before search */
+  lib_put_pathbuffer(path);
 
   trans = molookup(mofile->map, mofile->size, msgid1);
   if (trans == NULL)

--- a/libs/libc/misc/lib_fchmodat.c
+++ b/libs/libc/misc/lib_fchmodat.c
@@ -66,20 +66,33 @@
 
 int fchmodat(int dirfd, FAR const char *path, mode_t mode, int flags)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
   if ((flags & AT_SYMLINK_NOFOLLOW) != 0)
     {
-      return lchmod(fullpath, mode);
+      ret = lchmod(fullpath, mode);
+    }
+  else
+    {
+      ret = chmod(fullpath, mode);
     }
 
-  return chmod(fullpath, mode);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/misc/lib_fstatat.c
+++ b/libs/libc/misc/lib_fstatat.c
@@ -67,20 +67,33 @@
 int fstatat(int dirfd, FAR const char *path, FAR struct stat *buf,
             int flags)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
   if ((flags & AT_SYMLINK_NOFOLLOW) != 0)
     {
-      return lstat(fullpath, buf);
+      ret = lstat(fullpath, buf);
+    }
+  else
+    {
+      ret = stat(fullpath, buf);
     }
 
-  return stat(fullpath, buf);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/misc/lib_glob.c
+++ b/libs/libc/misc/lib_glob.c
@@ -417,10 +417,16 @@ int glob(FAR const char *pat, int flags,
   size_t i;
   size_t offs = (flags & GLOB_DOOFFS) ? g->gl_offs : 0;
   int error = 0;
-  char buf[PATH_MAX];
+  FAR char *buf;
 
   head.next = NULL;
   head.name[0] = '\0';
+
+  buf = lib_get_pathbuffer();
+  if (buf == NULL)
+    {
+      return -ENOMEM;
+    }
 
   if (!errfunc)
     {
@@ -442,6 +448,7 @@ int glob(FAR const char *pat, int flags,
 
       if (!p)
         {
+          lib_put_pathbuffer(buf);
           return GLOB_NOSPACE;
         }
 
@@ -453,6 +460,7 @@ int glob(FAR const char *pat, int flags,
       lib_free(p);
     }
 
+  lib_put_pathbuffer(buf);
   if (error == GLOB_NOSPACE)
     {
       freelist(&head);

--- a/libs/libc/misc/lib_memfd.c
+++ b/libs/libc/misc/lib_memfd.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <nuttx/lib/lib.h>
 
 #if defined(CONFIG_LIBC_MEMFD_TMPFS) || defined(CONFIG_LIBC_MEMFD_SHMFS)
 /****************************************************************************
@@ -54,10 +55,17 @@ int memfd_create(FAR const char *name, unsigned int flags)
   set_errno(ENOSYS);
   return -1;
 #else
-  char path[PATH_MAX];
+  FAR char *path;
   int ret;
 
-  snprintf(path, sizeof(path), LIBC_MEM_FD_VFS_PATH_FMT, name);
+  path = lib_get_pathbuffer();
+  if (path == NULL)
+    {
+      set_errno(ENOMEM);
+      return -1;
+    }
+
+  snprintf(path, PATH_MAX, LIBC_MEM_FD_VFS_PATH_FMT, name);
 #  ifdef CONFIG_LIBC_MEMFD_SHMFS
   ret = shm_open(path, O_RDWR | flags, 0660);
   if (ret >= 0)
@@ -73,6 +81,7 @@ int memfd_create(FAR const char *name, unsigned int flags)
     }
 #  endif
 
+  lib_put_pathbuffer(path);
   return ret;
 #endif
 }

--- a/libs/libc/misc/lib_mkdirat.c
+++ b/libs/libc/misc/lib_mkdirat.c
@@ -64,15 +64,25 @@
 
 int mkdirat(int dirfd, FAR const char *path, mode_t mode)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return mkdir(fullpath, mode);
+  ret = mkdir(fullpath, mode);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/misc/lib_mkfifo.c
+++ b/libs/libc/misc/lib_mkfifo.c
@@ -114,17 +114,27 @@ int mkfifo(FAR const char *pathname, mode_t mode)
 
 int mkfifoat(int dirfd, FAR const char *path, mode_t mode)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return mkfifo(fullpath, mode);
+  ret = mkfifo(fullpath, mode);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }
 
 #endif /* CONFIG_PIPES && CONFIG_DEV_FIFO_SIZE > 0 */

--- a/libs/libc/misc/lib_openat.c
+++ b/libs/libc/misc/lib_openat.c
@@ -65,13 +65,21 @@
 
 int openat(int dirfd, FAR const char *path, int oflags, ...)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   mode_t mode = 0;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
@@ -85,5 +93,7 @@ int openat(int dirfd, FAR const char *path, int oflags, ...)
       va_end(ap);
     }
 
-  return open(fullpath, oflags, mode);
+  ret = open(fullpath, oflags, mode);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -41,8 +41,8 @@
 
 struct pathbuffer_s
 {
-  mutex_t lock;             /* Lock for the buffer */
-  unsigned int free_bitmap; /* Bitmap of free buffer */
+  mutex_t lock;              /* Lock for the buffer */
+  unsigned long free_bitmap; /* Bitmap of free buffer */
   char buffer[CONFIG_LIBC_MAX_PATHBUFFER][PATH_MAX];
 };
 
@@ -87,7 +87,7 @@ FAR char *lib_get_pathbuffer(void)
   /* Try to find a free buffer */
 
   nxmutex_lock(&g_pathbuffer.lock);
-  index = ffs(g_pathbuffer.free_bitmap) - 1;
+  index = ffsl(g_pathbuffer.free_bitmap) - 1;
   if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
     {
       g_pathbuffer.free_bitmap &= ~(1u << index);

--- a/libs/libc/misc/lib_utimensat.c
+++ b/libs/libc/misc/lib_utimensat.c
@@ -66,20 +66,33 @@
 int utimensat(int dirfd, FAR const char *path,
               const struct timespec times[2], int flags)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
   if ((flags & AT_SYMLINK_NOFOLLOW) != 0)
     {
-      return lutimens(fullpath, times);
+      ret = lutimens(fullpath, times);
+    }
+  else
+    {
+      ret = utimens(fullpath, times);
     }
 
-  return utimens(fullpath, times);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/unistd/lib_access.c
+++ b/libs/libc/unistd/lib_access.c
@@ -137,15 +137,25 @@ int access(FAR const char *path, int amode)
 
 int faccessat(int dirfd, FAR const char *path, int amode, int flags)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return access(fullpath, amode);
+  ret = access(fullpath, amode);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }

--- a/libs/libc/unistd/lib_readlinkat.c
+++ b/libs/libc/unistd/lib_readlinkat.c
@@ -70,17 +70,27 @@
 ssize_t readlinkat(int dirfd, FAR const char *path, FAR char *buf,
                    size_t bufsize)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return readlink(fullpath, buf, bufsize);
+  ret = readlink(fullpath, buf, bufsize);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }
 
 #endif /* CONFIG_PSEUDOFS_SOFTLINKS */

--- a/libs/libc/unistd/lib_symlinkat.c
+++ b/libs/libc/unistd/lib_symlinkat.c
@@ -67,17 +67,27 @@
 
 int symlinkat(FAR const char *path1, int dirfd, FAR const char *path2)
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path2, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path2, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return symlink(path1, fullpath);
+  ret = symlink(path1, fullpath);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }
 
 #endif /* CONFIG_PSEUDOFS_SOFTLINKS */

--- a/libs/libc/unistd/lib_utimes.c
+++ b/libs/libc/unistd/lib_utimes.c
@@ -53,15 +53,25 @@ int utimes(FAR const char *path, const struct timeval tv[2])
 
 int futimesat(int dirfd, FAR const char *path, const struct timeval tv[2])
 {
-  char fullpath[PATH_MAX];
+  FAR char *fullpath;
   int ret;
 
-  ret = lib_getfullpath(dirfd, path, fullpath, sizeof(fullpath));
+  fullpath = lib_get_pathbuffer();
+  if (fullpath == NULL)
+    {
+      set_errno(ENOMEM);
+      return ERROR;
+    }
+
+  ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
   if (ret < 0)
     {
+      lib_put_pathbuffer(fullpath);
       set_errno(-ret);
       return ERROR;
     }
 
-  return utimes(fullpath, tv);
+  ret = utimes(fullpath, tv);
+  lib_put_pathbuffer(fullpath);
+  return ret;
 }


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
Benefit from the lib_pathbuffer feature introduced in https://github.com/apache/nuttx/pull/12969, we can further optimize the stack usage size in the NuttX kernel.
**Changes**
In this change, we replaced the declarations related to xxx[PATH_MAX] in the NuttX directory with the lib_pathbuffer method

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh

By default
```
LIBC_MAX_PATHBUFFER = 2
LIBC_PATHBUFFER_MALLOC = y
```
So when there is not enough memory on the stack, it will be requested from the heap
