### PR TITLE
x86_64: fix compile warning

### DIFF
--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -213,3 +213,13 @@ endif()
 if(CONFIG_ARCH_X86_64_AVX512VBMI)
   add_compile_options(-mavx512vbmi)
 endif()
+
+if(CONFIG_ARCH_TOOLCHAIN_GNU AND NOT CONFIG_ARCH_TOOLCHAIN_CLANG)
+  if(NOT GCCVER)
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+                    OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+" GCC_VERSION_REGEX
+                 "${GCC_VERSION_OUTPUT}")
+    set(GCCVER ${CMAKE_MATCH_1})
+  endif()
+endif()

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -137,6 +137,14 @@ NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
+  ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),)
+    ifeq ($(GCCVER),)
+      export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
+    endif
+  endif
+endif
+
 ifeq ($(CONFIG_ARCH_X86_64_SSE3),y)
   ARCHCPUFLAGS += -msse3
 endif


### PR DESCRIPTION
## Summary

x86_64: fix compile warning

In function ‘void* std::__1::__libcpp_operator_new(_Args ...) [with _Args = {long unsigned int}]’,
    inlined from ‘void* std::__1::__libcpp_allocate(size_t, size_t)’ at /home/ligd/platform/trunk/nuttx/include/libcxx/new:294:31,
    inlined from ‘_Tp* std::__1::allocator<_Tp>::allocate(size_t) [with _Tp = char]’ at /home/ligd/platform/trunk/nuttx/include/libcxx/__memory/allocator.h:114:62,
    inlined from ‘constexpr std::__1::__allocation_result<typename std::__1::allocator_traits<_Alloc>::pointer> std::__1::__allocate_at_least(_Alloc&, size_t) [with _Alloc = allocator<char>]’ at /home/ligd/platform/trunk/nuttx/include/libcxx/__memory/allocate_at_least.h:55:27,
    inlined from ‘void std::__1::basic_string<_CharT, _Traits, _Allocator>::__grow_by_and_replace(size_type, size_type, size_type, size_type, size_type, size_type, const value_type*) [with _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]’ at /home/ligd/platform/trunk/nuttx/include/libcxx/string:2325:49,
    inlined from ‘std::__1::basic_string<_CharT, _Traits, _Allocator>& std::__1::basic_string<_CharT, _Traits, _Allocator>::__assign_external(const value_type*, size_type) [with _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]’ at /home/ligd/platform/trunk/nuttx/include/libcxx/string:2431:26,
    inlined from ‘std::__1::basic_string<_CharT, _Traits, _Allocator>& std::__1::basic_string<_CharT, _Traits, _Allocator>::assign(const value_type*, size_type) [with _CharT = char; _Traits = std::__1::char_traits<char>; _Allocator = std::__1::allocator<char>]’ at /home/ligd/platform/trunk/nuttx/include/libcxx/string:2444:35:
/home/ligd/platform/trunk/nuttx/include/libcxx/new:270:24: warning: argument 1 value ‘18446744073709551599’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
  270 |   return ::operator new(__args...);


## Impact

x86-64

## Testing

CI


