### PR TITLE
net: inet.h match inet_sockif.c definition

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/netconfig.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2011, 2014-2015, 2017-2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007, 2011, 2014-2015, 2017-2019 Gregory Nutt.
+ * All rights reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  * SPDX-FileContributor: Adam Dunkels <adam@dunkels.com>
@@ -67,9 +68,9 @@
  * matter.  It should, however, be valid in the current configuration.
  */
 
-#if defined(CONFIG_NET_IPv4)
+#if defined(HAVE_PFINET_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET
-#elif defined(CONFIG_NET_IPv6)
+#elif defined(HAVE_PFINET6_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET6
 #elif defined(CONFIG_NET_LOCAL)
 #  define NET_SOCK_FAMILY  AF_LOCAL

--- a/libs/libc/net/lib_indextoname.c
+++ b/libs/libc/net/lib_indextoname.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
 #include <nuttx/net/netconfig.h>
 
 /****************************************************************************

--- a/libs/libc/net/lib_nametoindex.c
+++ b/libs/libc/net/lib_nametoindex.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
 #include <nuttx/net/netconfig.h>
 
 /****************************************************************************

--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -47,11 +47,13 @@
 #if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
 #  define HAVE_INET_SOCKETS
 
-#  if defined(CONFIG_NET_IPv4)
+#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
 #    define HAVE_PFINET_SOCKETS
 #  endif
 
-#  if defined(CONFIG_NET_IPv6)
+#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
 #    define HAVE_PFINET6_SOCKETS
 #  endif
 #endif

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -76,7 +76,7 @@ net_sockif(sa_family_t family, int type, int protocol)
 
   switch (family)
     {
-#ifdef HAVE_INET_SOCKETS
+#if defined(HAVE_PFINET_SOCKETS) || defined(HAVE_PFINET6_SOCKETS)
 #  ifdef HAVE_PFINET_SOCKETS
     case PF_INET:
 #  endif


### PR DESCRIPTION

## Summary
When using the minimal CONFIG_NET configuration for SocketCAN. 
Ifup would fail with the following error code.
Fixes `psock_socket: ERROR: socket address family unsupported: 2`
This was caused because AF_INET got defined but `inet_sockif()` would return `NULL` because either `ICMP`, `TCP` or `UDP` dependency didn't met. This patch changes the `ifdef` logic for `AF_INET` and `AF_INET6` to include those checks so that other `SOCK_FAMILY` will work with minimal IPv4 or IPv6 config.

## Impact
Net

## Testing

Tested on MR-CANHUBK344 net config

