### PR TITLE
macos: fix “sed: -I or -i may not be used with stdin”

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -799,6 +799,7 @@ endif
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
 	$(call DELFILE, .config.orig)
+	$(call DELFILE, .config.backup)
 	$(call DELFILE, .gdbinit)
 
 # Application housekeeping targets.  The APPDIR variable refers to the user

--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -57,7 +57,7 @@ process_file() {
             fi
         else
             local key_config="$(echo "$line" | cut -d= -f1)="
-            sed -i "/$key_config/d" $output_file
+            sed -i.backup "/$key_config/d" $output_file
             echo "$line" >> $output_file
         fi
     done < "$input_file"


### PR DESCRIPTION
## Summary

fixed this error for macos after the PR #14552

```
====================================================================================
Configuration/Tool: stm32f4discovery/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2024-11-04 05:53:44
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
sed: -I or -i may not be used with stdin
```
https://github.com/NuttX/nuttx/actions/runs/11658534293/job/32457779415


tools/Unix.mk
added $(call DELFILE, .config.backup)

tools/process-config.sh
sed-i -> sed -i.backup

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
ci


