### PR TITLE
clang/cmake: Fix clang cmake can't find libgcc, align with makefile

### DIFF
--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -238,14 +238,31 @@ set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
 set(NUTTX_FIND_TOOLCHAIN_LIB_DEFINED true)
 
 if(CONFIG_BUILTIN_TOOLCHAIN)
-  function(nuttx_find_toolchain_lib)
-    execute_process(
-      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-              --print-file-name
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      OUTPUT_VARIABLE extra_lib_path)
-    nuttx_add_extra_library(${extra_lib_path})
-  endfunction()
+  if(ARGN)
+    function(nuttx_find_toolchain_lib)
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+                --print-file-name=${ARGN}
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE extra_lib_path)
+      nuttx_add_extra_library(${extra_lib_path})
+    endfunction()
+  else()
+    function(nuttx_find_toolchain_lib)
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+                --print-libgcc-file-name
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE libgcc_path)
+      get_filename_component(libgcc_name ${libgcc_path} NAME)
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+                --print-file-name=${libgcc_name}
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE libgcc)
+      nuttx_add_extra_library(${libgcc})
+    endfunction()
+  endif()
 else()
   function(nuttx_find_toolchain_lib)
     if(ARGN)


### PR DESCRIPTION
## Summary
makefile:
ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),y)
  COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
  ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
    ifeq ($(wildcard $(COMPILER_RT_LIB)),)
      # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
      # then go ahead and try "--print-file-name"
      COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
    endif
  endif
endif
## Impact
None
## Testing
None