### PR TITLE
i486/Toolchain.defs: move toolchain releated option to Toolchain.defs

### DIFF
--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -69,3 +69,4 @@ CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden
 
 LDELFFLAGS = -r -e main
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)modlib$(DELIM)gnu-elf.ld)
+EXEEXT = .elf

--- a/arch/x86/src/i486/Toolchain.defs
+++ b/arch/x86/src/i486/Toolchain.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/x86/qemu/qemu-i486/scripts/Make.defs
+# arch/x86/src/i486/Toolchain.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,4 @@
 #
 ############################################################################
 
-include $(TOPDIR)/.config
-include $(TOPDIR)/tools/Config.mk
-include $(TOPDIR)/arch/x86/src/i486/Toolchain.defs
-
-ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)qemu.ld
+include $(TOPDIR)/arch/x86_64/src/common/Toolchain.defs


### PR DESCRIPTION
## Summary
Toolchain related options should be in Toolchain.defs

## Impact
Only core refactor and minor changes, should be no impact

## Testing
qmeu-i486:nsh


