### PR TITLE
arm64: fix compile error in arm64

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -30,6 +30,14 @@
 #                   reliable code generation.
 #
 
+ifeq ($(CONFIG_ARCH_ARMV8A),y)
+  ARCHCPUFLAGS += -march=armv8-a
+endif
+
+ifeq ($(CONFIG_ARCH_ARMV8R),y)
+  ARCHCPUFLAGS += -march=armv8-r
+endif
+
 ifeq ($(CONFIG_ARCH_CORTEX_A53),y)
   ARCHCPUFLAGS += -mcpu=cortex-a53
 else ifeq ($(CONFIG_ARCH_CORTEX_A55),y)
@@ -40,10 +48,6 @@ else ifeq ($(CONFIG_ARCH_CORTEX_A72),y)
   ARCHCPUFLAGS += -mcpu=cortex-a72
 else ifeq ($(CONFIG_ARCH_CORTEX_R82),y)
   ARCHCPUFLAGS += -mcpu=cortex-r82
-else ifeq ($(CONFIG_ARCH_ARMV8A),y)
-  ARCHCPUFLAGS += -march=armv8-a
-else ifeq ($(CONFIG_ARCH_ARMV8R),y)
-  ARCHCPUFLAGS += -march=armv8-r
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)


### PR DESCRIPTION
## Summary

arm64: fix compile error in arm64

/home/mi/ssd/vela-trunk/nuttx/include/string.h:192:36: error: inlining failed in call to 'always_inline' 'memcpy': target specific option mismatch
  192 | fortify_function(memcpy) FAR void *memcpy(FAR void *dest,
      |                                    ^~~~~~

This was introduced by:
https://github.com/apache/nuttx/pull/12049

## Impact

CI

## Testing

CI


