### PR TITLE
net/igc: Support Intel I226V.

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -818,6 +818,10 @@ config NET_IGC_I225LM
 	bool "Intel I225LM"
 	default n
 
+config NET_IGC_I226V
+	bool "Intel I226V"
+	default n
+
 endif # NET_IGC
 
 endif # NETDEVICES

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -213,12 +213,28 @@ static const struct igc_type_s g_igc_i225lm =
 };
 #endif
 
+#ifdef CONFIG_NET_IGC_I226V
+/* Intel I226V */
+
+static const struct igc_type_s g_igc_i226v =
+{
+  .desc_align = 128,
+  .mta_regs   = 128
+};
+#endif
+
 static const struct pci_device_id_s g_igc_id_table[] =
 {
 #ifdef CONFIG_NET_IGC_I225LM
   {
     PCI_DEVICE(0x8086, 0x15f2),
     .driver_data = (uintptr_t)&g_igc_i225lm
+  },
+#endif
+#ifdef CONFIG_NET_IGC_I226V
+  {
+    PCI_DEVICE(0x8086, 0x125c),
+    .driver_data = (uintptr_t)&g_igc_i226v
   },
 #endif
   { }


### PR DESCRIPTION
## Summary

This commit added the device ID to support Intel I226V Ethernet controller.

## Impact

Intel I226V Ethernet controller works fine after the device ID added.

## Testing

Tested on an Intel i9-13900 x86/64 machine with I226V.

