### PR TITLE
Enable DEV_PIPE_NPOLLWAITERS default value 4 for adapte APP

### DIFF
--- a/drivers/pipes/Kconfig
+++ b/drivers/pipes/Kconfig
@@ -40,4 +40,10 @@ config DEV_PIPE_VFS_PATH
 	---help---
 		The path to where pipe device will exist in the VFS namespace.
 
+config DEV_PIPE_NPOLLWAITERS
+	int "number of threads for waiting POLL events"
+	default 4
+	---help---
+		Maximum number of threads that can be waiting for POLL events
+
 endif # PIPES


### PR DESCRIPTION
Such as DBus, it maybe more than 1 thread to poll one dev, if that will make poll fail

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


