### PR TITLE
net: fix inet #14634 regression

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -68,6 +68,24 @@
  * matter.  It should, however, be valid in the current configuration.
  */
 
+#undef HAVE_INET_SOCKETS
+#undef HAVE_PFINET_SOCKETS
+#undef HAVE_PFINET6_SOCKETS
+
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
+#  define HAVE_INET_SOCKETS
+
+#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
+#    define HAVE_PFINET_SOCKETS
+#  endif
+
+#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
+#    define HAVE_PFINET6_SOCKETS
+#  endif
+#endif
+
 #if defined(HAVE_PFINET_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET
 #elif defined(HAVE_PFINET6_SOCKETS)

--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -35,30 +35,6 @@
 #include <nuttx/net/ip.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* Configuration */
-
-#undef HAVE_INET_SOCKETS
-#undef HAVE_PFINET_SOCKETS
-#undef HAVE_PFINET6_SOCKETS
-
-#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
-#  define HAVE_INET_SOCKETS
-
-#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
-#    define HAVE_PFINET_SOCKETS
-#  endif
-
-#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
-#    define HAVE_PFINET6_SOCKETS
-#  endif
-#endif
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -34,6 +34,7 @@
 #include <debug.h>
 
 #include <nuttx/net/net.h>
+#include <nuttx/net/netconfig.h>
 #include <nuttx/net/tcp.h>
 #include <nuttx/kmalloc.h>
 

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/net/net.h>
+#include <nuttx/net/netconfig.h>
 
 #include "inet/inet.h"
 #include "local/local.h"


### PR DESCRIPTION
## Summary

`HAVE_INET_SOCKETS` define wasn't included by netconfig.h causing renew to fail.
Thanks for pointing out @masayuki2009 

Moved preprocessor defintions to `include/nuttx/net/netconfig.h` so that `AF_INET` gets defined.

Btw could we impove CI coverage as well to test if we get a DHCP address using qemu?

## Impact

Fixes broken inet

## Testing

mr-canhubk344