### PR TITLE
fs: migrate to SPDX identifier

### DIFF
--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/Make.defs
+++ b/fs/Make.defs
@@ -1,5 +1,5 @@
 # ##############################################################################
-# fs/semaphore/CMakeLists.txt
+# fs/Make.defs
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,9 +19,3 @@
 # the License.
 #
 # ##############################################################################
-
-if(CONFIG_FS_NAMED_SEMAPHORES)
-
-  target_sources(fs PRIVATE sem_open.c sem_close.c sem_unlink.c)
-
-endif()

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/aio/CMakeLists.txt
+++ b/fs/aio/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/aio/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/aio/Make.defs
+++ b/fs/aio/Make.defs
@@ -1,15 +1,17 @@
 ############################################################################
 # fs/aio/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
 # ASF licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance with the
 # License.  You may obtain a copy of the License at
-
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the

--- a/fs/aio/aio_cancel.c
+++ b/fs/aio/aio_cancel.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_cancel.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_fsync.c
+++ b/fs/aio/aio_fsync.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_fsync.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_initialize.c
+++ b/fs/aio/aio_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_queue.c
+++ b/fs/aio/aio_queue.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_queue.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_read.c
+++ b/fs/aio/aio_read.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_read.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_signal.c
+++ b/fs/aio/aio_signal.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_signal.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aio_write.c
+++ b/fs/aio/aio_write.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aio_write.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/aio/aioc_contain.c
+++ b/fs/aio/aioc_contain.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/aio/aioc_contain.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/binfs/CMakeLists.txt
+++ b/fs/binfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/binfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/binfs/Make.defs
+++ b/fs/binfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/binfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/binfs/fs_binfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/cromfs/CMakeLists.txt
+++ b/fs/cromfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/cromfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/cromfs/Make.defs
+++ b/fs/cromfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/cromfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/cromfs/cromfs.h
+++ b/fs/cromfs/cromfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/cromfs/cromfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/cromfs/fs_cromfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/CMakeLists.txt
+++ b/fs/driver/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/driver/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/driver/Make.defs
+++ b/fs/driver/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/driver/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/driver/driver.h
+++ b/fs/driver/driver.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/driver.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_blockpartition.c
+++ b/fs/driver/fs_blockpartition.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_blockpartition.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_blockproxy.c
+++ b/fs/driver/fs_blockproxy.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_blockproxy.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_closeblockdriver.c
+++ b/fs/driver/fs_closeblockdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_closeblockdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_closemtddriver.c
+++ b/fs/driver/fs_closemtddriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_closemtddriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_findblockdriver.c
+++ b/fs/driver/fs_findblockdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_findblockdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_findmtddriver.c
+++ b/fs/driver/fs_findmtddriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_findmtddriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_mtdpartition.c
+++ b/fs/driver/fs_mtdpartition.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_mtdpartition.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_mtdproxy.c
+++ b/fs/driver/fs_mtdproxy.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_mtdproxy.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_openblockdriver.c
+++ b/fs/driver/fs_openblockdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_openblockdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_registerblockdriver.c
+++ b/fs/driver/fs_registerblockdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_registerblockdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_registerdriver.c
+++ b/fs/driver/fs_registerdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_registerdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_registermtddriver.c
+++ b/fs/driver/fs_registermtddriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_registermtddriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_registerpipedriver.c
+++ b/fs/driver/fs_registerpipedriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_registerpipedriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_unregisterblockdriver.c
+++ b/fs/driver/fs_unregisterblockdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_unregisterblockdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_unregisterdriver.c
+++ b/fs/driver/fs_unregisterdriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_unregisterdriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_unregistermtddriver.c
+++ b/fs/driver/fs_unregistermtddriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_unregistermtddriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/driver/fs_unregisterpipedriver.c
+++ b/fs/driver/fs_unregisterpipedriver.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/driver/fs_unregisterpipedriver.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/event/CMakeLists.txt
+++ b/fs/event/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/event/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/event/Make.defs
+++ b/fs/event/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/events/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/event/event.h
+++ b/fs/event/event.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/event/event.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/event/event_close.c
+++ b/fs/event/event_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/event/event_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/event/event_open.c
+++ b/fs/event/event_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/event/event_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fat/CMakeLists.txt
+++ b/fs/fat/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/fat/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/fat/Make.defs
+++ b/fs/fat/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/fat/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fat/fs_fat32.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fat/fs_fat32.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fat/fs_fat32attrib.c
+++ b/fs/fat/fs_fat32attrib.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fat/fs_fat32attrib.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fat/fs_fat32dirent.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fat/fs_fat32util.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fs_heap.c
+++ b/fs/fs_heap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fs_heap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fs_heap.h
+++ b/fs/fs_heap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fs_heap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/fs_initialize.c
+++ b/fs/fs_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/fs_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/hostfs/CMakeLists.txt
+++ b/fs/hostfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/hostfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/hostfs/Make.defs
+++ b/fs/hostfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/hostfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/hostfs/hostfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/hostfs/hostfs.h
+++ b/fs/hostfs/hostfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/hostfs/hostfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/CMakeLists.txt
+++ b/fs/inode/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/inode/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/inode/Make.defs
+++ b/fs/inode/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/inode/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_files.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_foreachinode.c
+++ b/fs/inode/fs_foreachinode.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_foreachinode.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inode.c
+++ b/fs/inode/fs_inode.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inode.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodeaddref.c
+++ b/fs/inode/fs_inodeaddref.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodeaddref.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodebasename.c
+++ b/fs/inode/fs_inodebasename.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodebasename.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodefind.c
+++ b/fs/inode/fs_inodefind.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodefind.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodefree.c
+++ b/fs/inode/fs_inodefree.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodefree.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodegetpath.c
+++ b/fs/inode/fs_inodegetpath.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodegetpath.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inoderelease.c
+++ b/fs/inode/fs_inoderelease.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inoderelease.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inoderemove.c
+++ b/fs/inode/fs_inoderemove.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inoderemove.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodereserve.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodesearch.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/inode/inode.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/littlefs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/littlefs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/littlefs/lfs_vfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/littlefs/lfs_vfs.h
+++ b/fs/littlefs/lfs_vfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/littlefs/lfs_vfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/CMakeLists.txt
+++ b/fs/mmap/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/mmap/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/mmap/Make.defs
+++ b/fs/mmap/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/mmap/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_anonmap.c
+++ b/fs/mmap/fs_anonmap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_anonmap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_anonmap.h
+++ b/fs/mmap/fs_anonmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_anonmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_mmap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_mmisc.c
+++ b/fs/mmap/fs_mmisc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_mmisc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_msync.c
+++ b/fs/mmap/fs_msync.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_msync.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_munmap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_rammap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mmap/fs_rammap.h
+++ b/fs/mmap/fs_rammap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mmap/fs_rammap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mnemofs/CMakeLists.txt
+++ b/fs/mnemofs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/mnemofs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/mnemofs/Make.defs
+++ b/fs/mnemofs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/mnemofs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/mnemofs/mnemofs.c
+++ b/fs/mnemofs/mnemofs.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs.c
- * mnemofs: Filesystem for NAND Flash storage devices.
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs.h
+++ b/fs/mnemofs/mnemofs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs.h
  *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mnemofs/mnemofs_blkalloc.c
+++ b/fs/mnemofs/mnemofs_blkalloc.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_blkalloc.c
- * Block Allocator for mnemofs
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs_ctz.c
+++ b/fs/mnemofs/mnemofs_ctz.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_ctz.c
  *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mnemofs/mnemofs_fsobj.c
+++ b/fs/mnemofs/mnemofs_fsobj.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_fsobj.c
  *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mnemofs/mnemofs_journal.c
+++ b/fs/mnemofs/mnemofs_journal.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_journal.c
- * Journal of mnemofs.
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs_lru.c
+++ b/fs/mnemofs/mnemofs_lru.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_lru.c
- * LRU cache of mnemofs.
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs_master.c
+++ b/fs/mnemofs/mnemofs_master.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_master.c
- * Master node of mnemofs.
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs_rw.c
+++ b/fs/mnemofs/mnemofs_rw.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_rw.c
- * Read/Write utilities for mnemofs
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mnemofs/mnemofs_util.c
+++ b/fs/mnemofs/mnemofs_util.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * fs/mnemofs/mnemofs_util.c
- * Utilities for mnemofs
+ *
+ * SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/fs/mount/CMakeLists.txt
+++ b/fs/mount/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/mount/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/mount/Make.defs
+++ b/fs/mount/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/mount/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_automount.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_foreachmountpoint.c
+++ b/fs/mount/fs_foreachmountpoint.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_foreachmountpoint.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_gettype.c
+++ b/fs/mount/fs_gettype.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_gettype.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_mount.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_procfs_mount.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/fs_umount2.c
+++ b/fs/mount/fs_umount2.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/fs_umount2.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mount/mount.h
+++ b/fs/mount/mount.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mount/mount.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mqueue/CMakeLists.txt
+++ b/fs/mqueue/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/mqueue/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/mqueue/Make.defs
+++ b/fs/mqueue/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/mqueue/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/mqueue/mq_close.c
+++ b/fs/mqueue/mq_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mqueue/mq_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mqueue/mq_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mqueue/mq_unlink.c
+++ b/fs/mqueue/mq_unlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mqueue/mq_unlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/mqueue/mqueue.h
+++ b/fs/mqueue/mqueue.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/mqueue/mqueue.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nfs/CMakeLists.txt
+++ b/fs/nfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/nfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/nfs/Make.defs
+++ b/fs/nfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/nfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/nfs/nfs.h
+++ b/fs/nfs/nfs.h
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/nfs.h
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/nfs_mount.h
+++ b/fs/nfs/nfs_mount.h
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/nfs_mount.h
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/nfs_node.h
+++ b/fs/nfs/nfs_node.h
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/nfs_node.h
  *
- *   Copyright (C) 2012-2013, 2017 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/nfs_proto.h
+++ b/fs/nfs/nfs_proto.h
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/nfs_proto.h
  *
- *   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/nfs_util.c
+++ b/fs/nfs/nfs_util.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nfs/nfs_util.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -1,11 +1,11 @@
 /****************************************************************************
  * fs/nfs/nfs_vfsops.c
  *
- *   Copyright (C) 2012-2013, 2015, 2017-2018 Gregory Nutt. All rights
- *     reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012-2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/rpc.h
+++ b/fs/nfs/rpc.h
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/rpc.h
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/rpc_clnt.c
+++ b/fs/nfs/rpc_clnt.c
@@ -1,10 +1,11 @@
 /****************************************************************************
  * fs/nfs/rpc_clnt.c
  *
- *   Copyright (C) 2012-2013, 2018 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012-2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/nfs/xdr_subs.h
+++ b/fs/nfs/xdr_subs.h
@@ -1,12 +1,11 @@
 /****************************************************************************
  * fs/nfs/xdr_subs.h
- * Definitions for Sun RPC Version 2, from
- * "RPC: Remote Procedure Call Protocol Specification" RFC1057
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2012 Jose Pablo Rojas Vargas. All rights reserved.
- *   Author: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
- *           Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Jose Pablo Rojas Vargas. All rights reserved.
+ * SPDX-FileContributor: Jose Pablo Rojas Vargas <jrojas@nx-engineering.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Leveraged from OpenBSD:
  *

--- a/fs/notify/CMakeLists.txt
+++ b/fs/notify/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/notify/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/notify/Make.defs
+++ b/fs/notify/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/notify/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/notify/inotify.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/notify/notify.h
+++ b/fs/notify/notify.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/notify/notify.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/CMakeLists.txt
+++ b/fs/nxffs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/nxffs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/nxffs/Make.defs
+++ b/fs/nxffs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/nxffs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs.h
+++ b/fs/nxffs/nxffs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_block.c
+++ b/fs/nxffs/nxffs_block.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_block.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_blockstats.c
+++ b/fs/nxffs/nxffs_blockstats.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_blockstats.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -120,7 +122,7 @@ int nxffs_blockstats(FAR struct nxffs_volume_s *volume,
             {
               /* The block is marked as good */
 
-              stats-> ngood++;
+              stats->ngood++;
             }
           else
             {
@@ -197,7 +199,7 @@ int nxffs_blockstats(FAR struct nxffs_volume_s *volume,
             {
               /* The block is marked as good */
 
-              stats-> ngood++;
+              stats->ngood++;
             }
           else
             {

--- a/fs/nxffs/nxffs_cache.c
+++ b/fs/nxffs/nxffs_cache.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_cache.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_dirent.c
+++ b/fs/nxffs/nxffs_dirent.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_dirent.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_dump.c
+++ b/fs/nxffs/nxffs_dump.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_dump.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_initialize.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_inode.c
+++ b/fs/nxffs/nxffs_inode.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_inode.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_ioctl.c
+++ b/fs/nxffs/nxffs_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_pack.c
+++ b/fs/nxffs/nxffs_pack.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_pack.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_read.c
+++ b/fs/nxffs/nxffs_read.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_read.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_reformat.c
+++ b/fs/nxffs/nxffs_reformat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_reformat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_stat.c
+++ b/fs/nxffs/nxffs_stat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_stat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_truncate.c
+++ b/fs/nxffs/nxffs_truncate.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_truncate.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_unlink.c
+++ b/fs/nxffs/nxffs_unlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_unlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_util.c
+++ b/fs/nxffs/nxffs_util.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_util.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/nxffs/nxffs_write.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/CMakeLists.txt
+++ b/fs/partition/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/partition/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/partition/Make.defs
+++ b/fs/partition/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/partition/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/partition/fs_gpt.c
+++ b/fs/partition/fs_gpt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/fs_gpt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/fs_mbr.c
+++ b/fs/partition/fs_mbr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/fs_mbr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/fs_partition.c
+++ b/fs/partition/fs_partition.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/fs_partition.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/fs_ptable.c
+++ b/fs/partition/fs_ptable.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/fs_ptable.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/fs_txtable.c
+++ b/fs/partition/fs_txtable.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/fs_txtable.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/partition/partition.h
+++ b/fs/partition/partition.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/partition/partition.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/CMakeLists.txt
+++ b/fs/procfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/procfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/procfs/Make.defs
+++ b/fs/procfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/procfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfscpuinfo.c
+++ b/fs/procfs/fs_procfscpuinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfscpuinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfscpuload.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfscritmon.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsfdt.c
+++ b/fs/procfs/fs_procfsfdt.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsfdt.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsiobinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsmeminfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfspressure.c
+++ b/fs/procfs/fs_procfspressure.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfspressure.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsproc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfstcbinfo.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsuptime.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsutil.c
+++ b/fs/procfs/fs_procfsutil.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsutil.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_procfsversion.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/procfs/fs_skeleton.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/romfs/CMakeLists.txt
+++ b/fs/romfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/romfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/romfs/Make.defs
+++ b/fs/romfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/romfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/romfs/fs_romfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/romfs/fs_romfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/romfs/fs_romfsutil.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/rpmsgfs/CMakeLists.txt
+++ b/fs/rpmsgfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/rpmsgfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/rpmsgfs/Make.defs
+++ b/fs/rpmsgfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/rpmsgfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/rpmsgfs/rpmsgfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/rpmsgfs/rpmsgfs.h
+++ b/fs/rpmsgfs/rpmsgfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/rpmsgfs/rpmsgfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/rpmsgfs/rpmsgfs_client.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/rpmsgfs/rpmsgfs_server.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/semaphore/Make.defs
+++ b/fs/semaphore/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/semaphore/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/semaphore/sem_close.c
+++ b/fs/semaphore/sem_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/semaphore/sem_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/semaphore/sem_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/semaphore/sem_unlink.c
+++ b/fs/semaphore/sem_unlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/semaphore/sem_unlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/semaphore/semaphore.h
+++ b/fs/semaphore/semaphore.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/semaphore/semaphore.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/shm/CMakeLists.txt
+++ b/fs/shm/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/shm/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/shm/Make.defs
+++ b/fs/shm/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/shm/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/shm/shm_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/shm/shm_unlink.c
+++ b/fs/shm/shm_unlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/shm/shm_unlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/shm/shmfs.c
+++ b/fs/shm/shmfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/shm/shmfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/shm/shmfs.h
+++ b/fs/shm/shmfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/shm/shmfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/shm/shmfs_alloc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/smartfs/CMakeLists.txt
+++ b/fs/smartfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/smartfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/smartfs/Make.defs
+++ b/fs/smartfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/smartfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/smartfs/smartfs.h
+++ b/fs/smartfs/smartfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/smartfs/smartfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/smartfs/smartfs_procfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/smartfs/smartfs_smart.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/smartfs/smartfs_utils.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/socket/CMakeLists.txt
+++ b/fs/socket/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/socket/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/socket/Make.defs
+++ b/fs/socket/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/socket/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/socket/accept.c
+++ b/fs/socket/accept.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/socket/accept.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/socket/socket.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/socket/socketpair.c
+++ b/fs/socket/socketpair.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/socket/socketpair.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/CMakeLists.txt
+++ b/fs/spiffs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/spiffs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/spiffs/Make.defs
+++ b/fs/spiffs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/spiffs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/CMakeLists.txt
+++ b/fs/spiffs/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/spiffs/src/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/spiffs/src/spiffs.h
+++ b/fs/spiffs/src/spiffs.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_cache.c
+++ b/fs/spiffs/src/spiffs_cache.c
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_cache.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_cache.h
+++ b/fs/spiffs/src/spiffs_cache.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_cache.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/spiffs_check.c
+++ b/fs/spiffs/src/spiffs_check.c
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_check.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_check.h
+++ b/fs/spiffs/src/spiffs_check.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_check.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/spiffs_core.c
+++ b/fs/spiffs/src/spiffs_core.c
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_core.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_core.h
+++ b/fs/spiffs/src/spiffs_core.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_core.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_gc.c
+++ b/fs/spiffs/src/spiffs_gc.c
@@ -1,8 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_gc.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/spiffs/src/spiffs_gc.h
+++ b/fs/spiffs/src/spiffs_gc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_gc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/spiffs_mtd.c
+++ b/fs/spiffs/src/spiffs_mtd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_mtd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/spiffs_mtd.h
+++ b/fs/spiffs/src/spiffs_mtd.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_mtd.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -1,9 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_vfs.c
- * Interface between SPIFFS and the NuttX VFS
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * Includes logic taken from 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license.

--- a/fs/spiffs/src/spiffs_volume.c
+++ b/fs/spiffs/src/spiffs_volume.c
@@ -1,9 +1,8 @@
 /****************************************************************************
  * fs/spiffs/src/spiffs_volume.c
- * SPIFFS Utility Functions for Volume and File Object Support
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt
  *
  * This is a port of version 0.3.7 of SPIFFS by Peter Andersion.  That
  * version was originally released under the MIT license but is here re-

--- a/fs/tmpfs/CMakeLists.txt
+++ b/fs/tmpfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/tmpfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/tmpfs/Make.defs
+++ b/fs/tmpfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/tmpfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/tmpfs/fs_tmpfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/tmpfs/fs_tmpfs.h
+++ b/fs/tmpfs/fs_tmpfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/tmpfs/fs_tmpfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/unionfs/CMakeLists.txt
+++ b/fs/unionfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/unionfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/unionfs/Make.defs
+++ b/fs/unionfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/unionfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/unionfs/fs_unionfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/userfs/CMakeLists.txt
+++ b/fs/userfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/userfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/userfs/Make.defs
+++ b/fs/userfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/userfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/userfs/fs_userfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/userfs/userfs.h
+++ b/fs/userfs/userfs.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/userfs/userfs.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/CMakeLists.txt
+++ b/fs/v9fs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/v9fs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/v9fs/Make.defs
+++ b/fs/v9fs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/v9fs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/v9fs/client.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/client.h
+++ b/fs/v9fs/client.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/v9fs/client.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/transport.c
+++ b/fs/v9fs/transport.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/v9fs/transport.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/v9fs.c
+++ b/fs/v9fs/v9fs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/v9fs/v9fs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/v9fs/virtio_9p.c
+++ b/fs/v9fs/virtio_9p.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/v9fs/virtio_9p.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/vfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/vfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_chstat.c
+++ b/fs/vfs/fs_chstat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_chstat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_close.c
+++ b/fs/vfs/fs_close.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_close.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_dir.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_dup.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_dup2.c
+++ b/fs/vfs/fs_dup2.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_dup2.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_epoll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_eventfd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_fchstat.c
+++ b/fs/vfs/fs_fchstat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_fchstat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_fcntl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_fstat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_fstatfs.c
+++ b/fs/vfs/fs_fstatfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_fstatfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_fsync.c
+++ b/fs/vfs/fs_fsync.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_fsync.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_ioctl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_link.c
+++ b/fs/vfs/fs_link.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_link.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_lock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_lseek.c
+++ b/fs/vfs/fs_lseek.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_lseek.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_mkdir.c
+++ b/fs/vfs/fs_mkdir.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_mkdir.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_open.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_poll.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_pread.c
+++ b/fs/vfs/fs_pread.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_pread.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_pseudofile.c
+++ b/fs/vfs/fs_pseudofile.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_pseudofile.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_pwrite.c
+++ b/fs/vfs/fs_pwrite.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_pwrite.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_read.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_readlink.c
+++ b/fs/vfs/fs_readlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_readlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_rename.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_rmdir.c
+++ b/fs/vfs/fs_rmdir.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_rmdir.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_select.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_sendfile.c
+++ b/fs/vfs/fs_sendfile.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_sendfile.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_signalfd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_stat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_statfs.c
+++ b/fs/vfs/fs_statfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_statfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_symlink.c
+++ b/fs/vfs/fs_symlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_symlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_syncfs.c
+++ b/fs/vfs/fs_syncfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_syncfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_timerfd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_truncate.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_uio.c
+++ b/fs/vfs/fs_uio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_uio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_unlink.c
+++ b/fs/vfs/fs_unlink.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_unlink.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/fs_write.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/vfs/lock.h
+++ b/fs/vfs/lock.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/vfs/lock.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/fs/zipfs/CMakeLists.txt
+++ b/fs/zipfs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # fs/zipfs/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/fs/zipfs/Make.defs
+++ b/fs/zipfs/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # fs/zipfs/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/fs/zipfs/zip_vfs.c
+++ b/fs/zipfs/zip_vfs.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * fs/zipfs/zip_vfs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
NONE
