### PR TITLE
msys2: fix make[3]: warning: jobserver unavailable: using -j1.

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -139,7 +139,11 @@ function run_builds {
     ncpus=$(grep -c ^processor /proc/cpuinfo)
   fi
 
-  options+="-j ${ncpus}"
+  if [ "X$osname" == "Xmsys2" ]; then
+    export MAKEFLAGS="-j"
+  else
+    options+="-j ${ncpus}"
+  fi
 
   for build in "${builds[@]}"; do
     "${nuttx}"/tools/testbuild.sh ${options} -e "-Wno-cpp -Werror" "${build}"


### PR DESCRIPTION
## Summary

fixed this warning for msys2

```
====================================================================================
Configuration/Tool: nucleo-l152re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2024-11-05 06:12:26
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.

```
## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
We tested on the local platform MSYS2 and GitHub
https://github.com/simbit18/nuttx_test_pr/actions/runs/11681580122/job/32526983618#step:9:574



