### PR TITLE
binfmt: migrate to SPDX identifier

### DIFF
--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/binfmt.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/builtin.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/elf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/binfmt/nxflat.c
+++ b/binfmt/nxflat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * binfmt/nxflat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing
NONE
