### PR TITLE
libxx: Map all output files to the bin directory

### DIFF
--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -31,6 +31,9 @@ include $(TOPDIR)/Make.defs
 # you know about the configuration problem.  Refer to the README.txt file
 # in the NuttX uClibc++ GIT repository for more information
 
+BIN = libxx$(LIBEXT)
+BINDIR = bin
+
 ifeq ($(CONFIG_UCLIBCXX),y)
 include uClibc++.defs
 else ifeq ($(CONFIG_LIBCXX),y)
@@ -49,29 +52,27 @@ endif
 
 # Object Files
 
-AOBJS = $(ASRCS:.S=$(OBJEXT))
-COBJS = $(CSRCS:.c=$(OBJEXT))
-CXXOBJS = $(CXXSRCS:.cxx=$(OBJEXT))
-CPPOBJS = $(CPPSRCS:.cpp=$(OBJEXT))
+AOBJS = $(addprefix $(BINDIR)$(DELIM), $(ASRCS:.S=$(OBJEXT)))
+COBJS = $(addprefix $(BINDIR)$(DELIM), $(CSRCS:.c=$(OBJEXT)))
+CXXOBJS = $(addprefix $(BINDIR)$(DELIM), $(CXXSRCS:.cxx=$(OBJEXT)))
+CPPOBJS = $(addprefix $(BINDIR)$(DELIM), $(CPPSRCS:.cpp=$(OBJEXT)))
 
 SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(CPPSRCS)
 OBJS = $(AOBJS) $(COBJS) $(CXXOBJS) $(CPPOBJS)
 
-BIN = libxx$(LIBEXT)
-
 all: $(BIN)
 .PHONY: depend clean distclean context
 
-$(AOBJS): %$(OBJEXT): %.S
+$(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
 
-$(COBJS): %$(OBJEXT): %.c
+$(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
-$(CXXOBJS): %$(OBJEXT): %.cxx
+$(CXXOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cxx
 	$(call COMPILEXX, $<, $@)
 
-$(CPPOBJS): %$(OBJEXT): %.cpp
+$(CPPOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.cpp
 	$(call COMPILEXX, $<, $@)
 
 $(BIN): $(OBJS)
@@ -90,10 +91,12 @@ makedepfile: $(CXXSRCS:.cxx=.ddx) $(CPPSRCS:.cpp=.ddp)
 depend: .depend
 
 clean:
+	$(Q) $(MAKE) -C bin clean
 	$(call DELFILE, $(BIN))
 	$(call CLEAN)
 
 distclean:: clean
+	$(Q) $(MAKE) -C bin distclean
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/libs/libxx/bin/Makefile
+++ b/libs/libxx/bin/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# libs/libxx/bin/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+include $(TOPDIR)/Make.defs
+
+all:
+.PHONY: clean distclean
+
+# Clean Targets:
+
+clean:
+	$(call DELFILE, *.o)
+	$(call DELFILE, *.su)
+
+# Deep clean -- removes all traces of the configuration
+
+distclean: clean
+	$(call DELFILE, *.dep)
+	$(call DELFILE, .depend)

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -37,6 +37,11 @@ libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(Q) patch -p0 < 0001-libcxx-fix-ld-errors.patch
 	$(Q) patch -p0 < 0001-Fix-build-error-about-__GLIBC__.patch
 	$(Q) touch $@
+	$(Q) mkdir $(BINDIR)/libcxx \
+	           $(BINDIR)/libcxx/src \
+	           $(BINDIR)/libcxx/src/experimental \
+	           $(BINDIR)/libcxx/src/filesystem \
+	           $(BINDIR)/libcxx/src/ryu
 endif
 
 $(TOPDIR)/include/libcxx: libcxx
@@ -50,6 +55,7 @@ distclean::
 ifeq ($(wildcard libcxx/.git),)
 	$(Q) $(DELFILE) libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(call DELDIR, libcxx)
+	$(call DELDIR, $(BINDIR)/libcxx)
 endif
 
 CXXFLAGS += ${DEFINE_PREFIX}_LIBCPP_BUILDING_LIBRARY
@@ -84,4 +90,3 @@ ifeq ($(CONFIG_CXX_LOCALIZATION),)
   LOCALE_CPPSRCS += libcxx/src/strstream.cpp
   CPPSRCS := $(filter-out $(LOCALE_CPPSRCS), $(CPPSRCS))
 endif
-


### PR DESCRIPTION
## Summary
libxx: Map all output files to the bin directory
1. There are files with the same name in libcxx, so the generated files must be separated by files
## Impact
No
## Testing
Mo
