### PR TITLE
sim(feat):support sim elf and dynamic libs package in post build

### DIFF
--- a/boards/sim/sim/sim/CMakeLists.txt
+++ b/boards/sim/sim/sim/CMakeLists.txt
@@ -20,18 +20,20 @@
 
 add_subdirectory(src)
 
-add_custom_target(
-  nuttx_post_build
-  DEPENDS nuttx
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac
-  COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac/libs
-  COMMAND ${CMAKE_COMMAND} -E copy nuttx sim-pac/nuttx
-  COMMAND ldd sim-pac/nuttx | grep \"=> /\" | awk '{print $$3}' | xargs -I '{}'
-          cp -v '{}' sim-pac/libs
-  COMMAND readelf -l nuttx | grep "program interpreter" | awk -F':' '{print
-          $$2}' | cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tools/simlaunch.sh
-          sim-pac
-  COMMAND tar -czf nuttx.tgz sim-pac
-  COMMENT "Pac SIM with dynamic libs in nuttx.tgz")
+if(NOT MSVC)
+  add_custom_target(
+    nuttx_post_build
+    DEPENDS nuttx
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac
+    COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac/libs
+    COMMAND ${CMAKE_COMMAND} -E copy nuttx sim-pac/nuttx
+    COMMAND ldd sim-pac/nuttx | grep \"=> /\" | awk '{print $$3}' | xargs -I
+            '{}' cp -v '{}' sim-pac/libs
+    COMMAND readelf -l nuttx | grep "program interpreter" | awk -F':' '{print
+                $$2}' | cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tools/simlaunch.sh
+            sim-pac
+    COMMAND tar -czf nuttx.tgz sim-pac
+    COMMENT "Pac SIM with dynamic libs in nuttx.tgz")
+endif()

--- a/boards/sim/sim/sim/CMakeLists.txt
+++ b/boards/sim/sim/sim/CMakeLists.txt
@@ -19,3 +19,19 @@
 # ##############################################################################
 
 add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac
+  COMMAND ${CMAKE_COMMAND} -E make_directory sim-pac/libs
+  COMMAND ${CMAKE_COMMAND} -E copy nuttx sim-pac/nuttx
+  COMMAND ldd sim-pac/nuttx | grep \"=> /\" | awk '{print $$3}' | xargs -I '{}'
+          cp -v '{}' sim-pac/libs
+  COMMAND readelf -l nuttx | grep "program interpreter" | awk -F':' '{print
+          $$2}' | cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/tools/simlaunch.sh
+          sim-pac
+  COMMAND tar -czf nuttx.tgz sim-pac
+  COMMENT "Pac SIM with dynamic libs in nuttx.tgz")

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -323,3 +323,16 @@ else ifeq ($(CONFIG_HOST_MACOS),)
   ARCHPICFLAGS += -no-pie
   LDFLAGS += -Wl,-no-pie
 endif
+
+define POSTBUILD
+	$(Q)echo "Pac SIM with dynamic libs..";
+	@ rm -rf sim-pac;
+	@ mkdir -p sim-pac/libs;
+	@ cp nuttx sim-pac/nuttx;
+	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
+	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
+	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
+	@ tar -czf nuttx.tgz sim-pac;
+	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
+	@ rm -rf sim-pac;
+endef

--- a/tools/simlaunch.sh
+++ b/tools/simlaunch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# tools/simlaunch.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if ! command -v patchelf &> /dev/null; then
+    echo "patchelf does not installed:" 1>&2
+    echo "sudo apt-get update" 1>&2
+    echo "sudo apt-get install patchelf" 1>&2
+    exit 1
+fi
+
+CWD=`pwd`
+
+if [ ! -d ${CWD}/libs ]; then
+    echo "Directory for nuttx libs does not exist in ${CWD}." 1>&2
+    exit 1
+fi
+
+if [ ! -e ${CWD}/nuttx ]; then
+    echo "Nuttx elf does not exist in ${CWD}." 1>&2
+    exit 1
+fi
+
+INTERPRETER=$(find "${CWD}" -maxdepth 1 -type f -name '*ld-linux*')
+
+if [ ! -n "${INTERPRETER}" ]; then
+    echo "No dynamic interpreter exist in ${CWD}." 1>&2
+    exit 1
+fi
+
+CURRENT_INTERPRETER=$(readelf -l nuttx |grep "program interpreter" | awk -F':' '{print $2}'| cut -d"]" -f1 | awk '{$1=$1};1')
+
+if [ "$INTERPRETER" != "$CURRENT_INTERPRETER" ]; then
+    echo "Patch nuttx so interpreter to ${INTERPRETER}"
+    patchelf --set-interpreter "$INTERPRETER" nuttx
+fi
+
+export LD_LIBRARY_PATH=${CWD}/libs
+"${CWD}/nuttx"


### PR DESCRIPTION
## Summary

This will support the compatibility of sim products in different versions of host environments.

For example:
A sim elf compiled in ubuntu22 can run in ubuntu20.
This will be helpful when compiling in different dockers

use the dynamic library .so of the binding compilation environment,
and then modify the dynamic loader of elf at runtime to run sim elf across system versions

1. add post-build for sim build
2. collect dynamic .so and dynamic interpreter
3. add execution script for the entire package sim elf

## Impact

It is an enhanced function and should have no impact on previous

## Testing

Build sim in ubuntu22
Start elf in ubuntu20


