### PR TITLE
smpcall: we directly call the function to handle local smpcall

### DIFF
--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -314,6 +314,22 @@ int nxsched_smp_call_async(cpu_set_t cpuset,
       sched_lock();
     }
 
+  if (CPU_ISSET(this_cpu(), &cpuset))
+    {
+      ret = data->func(data->arg);
+      if (data->cookie != NULL)
+        {
+          data->cookie->error = ret;
+          nxsem_post(&data->cookie->sem);
+          if (ret < 0)
+            {
+              goto out;
+            }
+        }
+
+      CPU_CLR(this_cpu(), &cpuset);
+    }
+
   cpucnt = CPU_COUNT(&cpuset);
   if (cpucnt == 0)
     {


### PR DESCRIPTION
## Summary
smpcall: we directly call the function to handle local smpcall
some arch do not support issuing interrupts to the local CPU.

This commit fixes the regression from https://github.com/apache/nuttx/pull/14656

## Impact
smpcall

## Testing
ci ostest
**Build Host:**
* OS: Ubuntu 20.04
* CPU: x86_64 
* Compiler: GCC 9.4.0

Configuring NuttX and compile:
$ ./tools/configure.sh -l qemu-armv8a:nsh_smp
$ make
Running with qemu
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx



