### PR TITLE
nuttx/uorb.h: Add GNSS firmware version for `struct sensor_gnss`

### DIFF
--- a/include/nuttx/uorb.h
+++ b/include/nuttx/uorb.h
@@ -871,6 +871,7 @@ struct sensor_gnss          /* Type: GNSS */
   float course;
 
   uint32_t satellites_used; /* Number of satellites used */
+  uint32_t firmware_ver;    /* Version of GNSS firmware */
 };
 
 /* Ref: android14-release/hardware/libhardware/include_all/hardware/\


### PR DESCRIPTION
## Summary
Add GNSS firmware version for `struct sensor_gnss`.
e.g. Some test apps may need getting firmware version.

## Impact
uORB/Topic/sensor_gnss - New member `firmware_ver` added.

## Testing
Tested with tool "uorb_listener" with patch https://github.com/apache/nuttx-apps/pull/2826
```
uorb_listener -n 20 sensor_gnss
```


