### PR TITLE
drivers/pipes: return after short write if buffer is full

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -504,7 +504,6 @@ ssize_t pipecommon_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct inode      *inode    = filep->f_inode;
   FAR struct pipe_dev_s *dev      = inode->i_private;
   ssize_t                nwritten = 0;
-  ssize_t                last;
   int                    ret;
 
   DEBUGASSERT(dev);
@@ -544,97 +543,32 @@ ssize_t pipecommon_write(FAR struct file *filep, FAR const char *buffer,
       return ret;
     }
 
-  /* Loop until all of the bytes have been written */
+  /* REVISIT:  "If all file descriptors referring to the read end of a
+   * pipe have been closed, then a write will cause a SIGPIPE signal to
+   * be generated for the calling process.  If the calling process is
+   * ignoring this signal, then write(2) fails with the error EPIPE."
+   */
 
-  last = 0;
-  for (; ; )
+  if (dev->d_nreaders <= 0 && PIPE_IS_POLICY_0(dev->d_flags))
     {
-      /* REVISIT:  "If all file descriptors referring to the read end of a
-       * pipe have been closed, then a write will cause a SIGPIPE signal to
-       * be generated for the calling process.  If the calling process is
-       * ignoring this signal, then write(2) fails with the error EPIPE."
-       */
+      nxrmutex_unlock(&dev->d_bflock);
+      return -EPIPE;
+    }
 
-      if (dev->d_nreaders <= 0 && PIPE_IS_POLICY_0(dev->d_flags))
+  /* Would the next write overflow the circular buffer? */
+
+  while (circbuf_is_full(&dev->d_buffer))
+    {
+      if (filep->f_oflags & O_NONBLOCK)
         {
+          /* If O_NONBLOCK was set, then return EGAIN. */
+
           nxrmutex_unlock(&dev->d_bflock);
-          return nwritten == 0 ? -EPIPE : nwritten;
-        }
-
-      /* Would the next write overflow the circular buffer? */
-
-      if (!circbuf_is_full(&dev->d_buffer))
-        {
-          /* Loop until all of the bytes have been written */
-
-          nwritten += circbuf_write(&dev->d_buffer,
-                                    buffer + nwritten, len - nwritten);
-
-          if ((size_t)nwritten == len)
-            {
-              /* Notify all poll/select waiters that they can read from the
-               * FIFO when buffer used exceeds poll threshold.
-               */
-
-              if (circbuf_used(&dev->d_buffer) > dev->d_pollinthrd)
-                {
-                  poll_notify(dev->d_fds, CONFIG_DEV_PIPE_NPOLLWAITERS,
-                              POLLIN);
-                }
-
-              /* Yes.. Notify all of the waiting readers that more data is
-               * available.
-               */
-
-              pipecommon_wakeup(&dev->d_rdsem);
-
-              /* Return the number of bytes written */
-
-              nxrmutex_unlock(&dev->d_bflock);
-              return len;
-            }
+          return -EAGAIN;
         }
       else
         {
-          /* There is not enough room for the next byte.  Was anything
-           * written in this pass?
-           */
-
-          if (last < nwritten)
-            {
-              /* Notify all poll/select waiters that they can read from the
-               * FIFO.
-               */
-
-              poll_notify(dev->d_fds, CONFIG_DEV_PIPE_NPOLLWAITERS, POLLIN);
-
-              /* Yes.. Notify all of the waiting readers that more data is
-               * available.
-               */
-
-              pipecommon_wakeup(&dev->d_rdsem);
-            }
-
-          last = nwritten;
-
-          /* If O_NONBLOCK was set, then return partial bytes written or
-           * EGAIN.
-           */
-
-          if (filep->f_oflags & O_NONBLOCK)
-            {
-              if (nwritten == 0)
-                {
-                  nwritten = -EAGAIN;
-                }
-
-              nxrmutex_unlock(&dev->d_bflock);
-              return nwritten;
-            }
-
-          /* There is more to be written.. wait for data to be removed from
-           * the pipe
-           */
+          /* Wait for data to be removed from the pipe. */
 
           nxrmutex_unlock(&dev->d_bflock);
           ret = nxsem_wait(&dev->d_wrsem);
@@ -644,10 +578,35 @@ ssize_t pipecommon_write(FAR struct file *filep, FAR const char *buffer,
                * received or if the task was canceled.
                */
 
-              return nwritten == 0 ? (ssize_t)ret : nwritten;
+              return (ssize_t)ret;
             }
         }
     }
+
+  /* Write data to buffer. */
+
+  nwritten = circbuf_write(&dev->d_buffer, buffer, len);
+
+  /* Notify all poll/select waiters that they can read from the
+   * FIFO when buffer used exceeds poll threshold.
+   */
+
+  if (circbuf_used(&dev->d_buffer) > dev->d_pollinthrd)
+    {
+      poll_notify(dev->d_fds, CONFIG_DEV_PIPE_NPOLLWAITERS,
+                  POLLIN);
+    }
+
+  /* Yes.. Notify all of the waiting readers that more data is
+   * available.
+   */
+
+  pipecommon_wakeup(&dev->d_rdsem);
+
+  /* Return the number of bytes written */
+
+  nxrmutex_unlock(&dev->d_bflock);
+  return nwritten;
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

The write should return even in case of O_NONBLOCK if at least some bytes were written.

The previous state where always all bytes were written was breaking a common combination with poll, because poll would signal POLLOUT and some bytes would really be consumed but write could still block afterwards. That would prevent from execution returning to the poll loop again.

None the less it is also the standard C library behavior for the write function.

## Impact

This could have impack on any code that uses pipes and fifos and relies on this non-standard behavior or `write` always writing all bytes. But it is non-standard behavior and thus considered to be a bug in my eyes.

## Testing

Tested with the following code that after this change works:
```C
// Must be longer than CONFIG_DEV_PIPE_SIZE
const char *text =
        "Lorem ipsum odor amet, consectetuer adipiscing elit. Eget litora laoreet ornare elementum pellentesque class penatibus eleifend morbi. Conubia cras accumsan blandit at fames mauris varius. Nisl c
const size_t tlen = strlen(text);
printf("tlen %zd\n", tlen);
int fds[2];
assert(pipe2(fds, 0) == 0);
struct pollfd pfd[2] = {
        {
                .fd = fds[0],
                .events = POLLIN | POLLHUP,
        },
        {
                .fd = fds[1],
                .events = POLLOUT,
        },
};
size_t off = 0;
while (true) {
        if (poll(pfd, 2, -1) == -1) {
                printf("Poll fail %s\n", strerror(errno));
                exit(1);
        }
        if (pfd[1].revents & POLLOUT) {
                ssize_t wlen = write(fds[1], text + off, tlen - off);
                if (wlen < 0) {
                        printf("Write fail %s\n", strerror(errno));
                        exit(1);
                }
                printf("Written %zd\n", wlen);
                off += wlen;
                if (off >= tlen)
                        close(fds[1]);
                continue;
        }
        if (pfd[0].revents & POLLIN) {
                char buf[BUFSIZ];
                ssize_t rlen = read(fds[0], buf, BUFSIZ);
                if (rlen < 0) {
                        printf("Read fail %s\n", strerror(errno));
                        exit(1);
                }
                fwrite(buf, 1, rlen, stdout);
        }
        if (pfd[0].revents & POLLHUP) {
                putc('\n', stdout);
                exit(0);
        }
}
```
