### PR TITLE
Fix poll notify

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -276,6 +276,7 @@ void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset)
 {
   int i;
   FAR struct pollfd *fds;
+  irqstate_t flags;
 
   DEBUGASSERT(afds != NULL && nfds >= 1);
 
@@ -284,6 +285,10 @@ void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset)
       fds = afds[i];
       if (fds != NULL)
         {
+          /* race condition protection when modifying fds->revents */
+
+          flags = enter_critical_section();
+
           /* The error event must be set in fds->revents */
 
           fds->revents |= eventset & (fds->events | POLLERR | POLLHUP);
@@ -293,6 +298,8 @@ void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset)
 
               fds->revents &= ~POLLOUT;
             }
+
+          leave_critical_section(flags);
 
           if ((fds->revents != 0 || (fds->events & POLLALWAYS) != 0) &&
               fds->cb != NULL)

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -325,6 +325,7 @@ struct uart_dev_s
   sem_t                xmitsem;      /* Wakeup user waiting for space in xmit.buffer */
   sem_t                recvsem;      /* Wakeup user waiting for data in recv.buffer */
   mutex_t              closelock;    /* Locks out new open while close is in progress */
+  mutex_t              polllock;     /* Manages exclusive access to fds[] */
 
   /* I/O buffers */
 


### PR DESCRIPTION

## Summary

Fix a race condition in poll_notify, revert seemingly unnecessary change in serial driver.

Originally, the race condition was found with an older nuttx version inside the poll_notify, and the same race condition exists also in the current upstream version.

This PR has the first patch, which protects from the RMW issue. Second patch is an optimization to the poll_notify, but also fixes another race which may cause callback being called twice.

For the serial driver, the issue has been circumvented in #13914, but the race condition should be fixed in poll_notify, as it exists for all the poll interfaces, and not just serial driver. I *believe* that the serial driver fix is unnecessary, so third patch is reverting that - it is not nice to add sched_locks around the drivers unnecessarily.

## Impact

Impacts the implementation of poll / poll_notify, fixing a read-modify-write race condition.

## Testing

The code has been inspected by 2 engineers, and desk-tested with real application using the poll interface. However, I don't have a possibility to run extensive testing which would show the exact issue which was fixed in #13914, so I'd appreciate if the solution is reviewed & tested by e.g. @CV-Bowen who fixed the race condition for serial driver.
