### PR TITLE
arch/arm64/src/common/arm64_fatal.c: Fix compilation warning with -We…

### DIFF
--- a/arch/arm64/src/common/arm64_fatal.c
+++ b/arch/arm64/src/common/arm64_fatal.c
@@ -78,7 +78,6 @@ static int default_fatal_handler(uint64_t *regs, uint64_t far, uint64_t esr);
 
 static const char *g_esr_class_str[] =
 {
-  [0 ... ESR_ELX_EC_MAX]   = "UNRECOGNIZED EC",
   [ESR_ELX_EC_UNKNOWN]     = "Unknown/Uncategorized",
   [ESR_ELX_EC_WFX]         = "WFI/WFE",
   [ESR_ELX_EC_CP15_32]     = "CP15 MCR/MRC",
@@ -126,7 +125,6 @@ static const char *g_esr_class_str[] =
 
 static const char *g_esr_desc_str[] =
 {
-  [0 ... ESR_ELX_EC_MAX] = "UNRECOGNIZED EC",
   [ESR_ELX_EC_UNKNOWN]   = "Unknown/Uncategorized",
   [ESR_ELX_EC_WFX]       = "Trapped WFI or WFE instruction execution",
   [ESR_ELX_EC_CP15_32]   = "Trapped MCR or MRC access with"
@@ -299,8 +297,18 @@ static const char *esr_get_desc_string(uint64_t esr)
 
 static void print_ec_cause(uint64_t esr)
 {
-  serr("%s\n", esr_get_class_string(esr));
-  serr("%s\n", esr_get_desc_string(esr));
+  const char *class_string = esr_get_class_string(esr);
+  const char *desc_string = esr_get_desc_string(esr);
+
+  if (class_string && desc_string)
+    {
+      serr("%s\n", class_string);
+      serr("%s\n", desc_string);
+    }
+  else
+    {
+      serr("UNRECOGNIZED EC\n");
+    }
 }
 
 static int default_fatal_handler(uint64_t *regs, uint64_t far, uint64_t esr)


### PR DESCRIPTION
…xtra

## Summary

When building with systems with -Wextra and -Werror , the following errors are generated for aarch64 compiler:

```
common/arm64_fatal.c:82:30: error: initialized field overwritten [-Werror=override-init]
   82 |   [ESR_ELX_EC_UNKNOWN]     = "Unknown/Uncategorized",
      |                              ^~~~~~~~~~~~~~~~~~~~~~~
common/arm64_fatal.c:82:30: note: (near initialization for 'g_esr_class_str[0]')
common/arm64_fatal.c:83:30: error: initialized field overwritten [-Werror=override-init]
   83 |   [ESR_ELX_EC_WFX]         = "WFI/WFE",
```
Even though there is in principle nothing wrong with the code itself, and the error is rather silly, I still would like to propose this small modification to the code, to avoid the warning. The functionality is the same.

## Impact

Removes compiler warning with -Wextra. Has no functional impacts.

## Testing

Tested on imx9 platform.