### PR TITLE
crypto/se05x: Allow set_enable_pin to be NULL and fix error handling

### DIFF
--- a/drivers/crypto/pnt/pnt_se05x_api.c
+++ b/drivers/crypto/pnt/pnt_se05x_api.c
@@ -77,7 +77,7 @@ static bool set_enable_pin(FAR struct se05x_dev_s *se05x, bool state)
 {
   if (se05x->config->set_enable_pin == NULL)
     {
-      return FALSE;
+      return TRUE;
     }
 
   return se05x->config->set_enable_pin(state);
@@ -93,46 +93,48 @@ static bool set_enable_pin(FAR struct se05x_dev_s *se05x, bool state)
 
 int pnt_se05x_open(FAR struct se05x_dev_s *se05x)
 {
+  int ret;
   se05x->pnt = kmm_malloc(sizeof(struct pnt_handle));
-  int ret = se05x->pnt != NULL ? 0 : -EIO;
 
-  if (ret == 0)
+  if (se05x->pnt == NULL)
     {
-      memset(&(se05x->pnt->session), 0, sizeof(Se05xSession_t));
-
-      se05x->pnt->session.pScp03_enc_key = (FAR uint8_t *)scp03_enc_key;
-      se05x->pnt->session.pScp03_mac_key = (FAR uint8_t *)scp03_mac_key;
-      se05x->pnt->session.pScp03_dek_key = (FAR uint8_t *)scp03_dek_key;
-      se05x->pnt->session.scp03_enc_key_len = SCP03_KEY_SIZE;
-      se05x->pnt->session.scp03_mac_key_len = SCP03_KEY_SIZE;
-      se05x->pnt->session.scp03_dek_key_len = SCP03_KEY_SIZE;
-      ret = set_enable_pin(se05x, true) ? 0 : -EIO;
+      ret = -EIO;
+      goto errout;
     }
 
-  if (ret == 0)
+  memset(&(se05x->pnt->session), 0, sizeof(Se05xSession_t));
+
+  se05x->pnt->session.pScp03_enc_key = (FAR uint8_t *)scp03_enc_key;
+  se05x->pnt->session.pScp03_mac_key = (FAR uint8_t *)scp03_mac_key;
+  se05x->pnt->session.pScp03_dek_key = (FAR uint8_t *)scp03_dek_key;
+  se05x->pnt->session.scp03_enc_key_len = SCP03_KEY_SIZE;
+  se05x->pnt->session.scp03_mac_key_len = SCP03_KEY_SIZE;
+  se05x->pnt->session.scp03_dek_key_len = SCP03_KEY_SIZE;
+  if (!set_enable_pin(se05x, true))
     {
-      se05x->pnt->session.skip_applet_select = 0;
-      se05x->pnt->session.session_resume = 0;
-      smStatus_t status =
-          Se05x_API_SessionOpen(&(se05x->pnt->session), se05x);
-      ret = status == SM_OK ? 0 : -EIO;
+      ret = -EIO;
+      goto errout_with_alloc;
     }
 
-  /* if error */
-
-  if (ret < 0)
+  se05x->pnt->session.skip_applet_select = 0;
+  se05x->pnt->session.session_resume = 0;
+  if (Se05x_API_SessionOpen(&(se05x->pnt->session), se05x) != SM_OK)
     {
-      if (se05x->pnt->session.conn_context != NULL)
-        {
-          kmm_free(se05x->pnt->session.conn_context);
-        }
-
-      if (se05x->pnt != NULL)
-        {
-          kmm_free(se05x->pnt);
-        }
+      ret = -EIO;
+      goto errout_with_alloc;
     }
 
+  return OK;
+
+errout_with_alloc:
+  if (se05x->pnt->session.conn_context != NULL)
+    {
+      kmm_free(se05x->pnt->session.conn_context);
+    }
+
+  kmm_free(se05x->pnt);
+
+errout:
   return ret;
 }
 

--- a/drivers/crypto/se05x.c
+++ b/drivers/crypto/se05x.c
@@ -233,7 +233,8 @@ int se05x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   if (priv == NULL)
     {
       crypterr("ERROR: Failed to allocate instance\n");
-      return -ENOMEM;
+      ret = -ENOMEM;
+      goto errout;
     }
 
   priv->config = config;
@@ -241,14 +242,21 @@ int se05x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Check se05x availability */
 
-  pnt_se05x_open(priv);
+  ret = pnt_se05x_open(priv);
+  if (ret < 0)
+    {
+      crypterr("ERROR: Failed to open se05x driver: %d\n", ret);
+      ret = -ENODEV;
+      goto errout_with_alloc;
+    }
+
   struct se05x_uid_s uid;
   ret = pnt_se05x_get_uid(priv, &uid);
   if (ret < 0)
     {
-      crypterr("ERROR: Failed to register driver: %d\n", ret);
-      kmm_free(priv);
-      return -ENODEV;
+      crypterr("ERROR: Failed to probe se05x driver: %d\n", ret);
+      ret = -ENODEV;
+      goto errout_with_alloc_and_open;
     }
 
   pnt_se05x_close(priv);
@@ -259,10 +267,20 @@ int se05x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   if (ret < 0)
     {
       crypterr("ERROR: Failed to register driver: %d\n", ret);
-      kmm_free(priv);
+      ret =  -ENODEV;
+      goto errout_with_alloc;
     }
 
   nxmutex_init(&priv->mutex);
 
+  return OK;
+
+errout_with_alloc_and_open:
+  pnt_se05x_close(priv);
+
+errout_with_alloc:
+  kmm_free(priv);
+
+errout:
   return ret;
 }


### PR DESCRIPTION
## Summary

- set_enable_pin can be set to NULL for the boards where the enable pin(ENA) of the SE05x cannot be controlled. Before it resulted in se05x_register() function to return an error.
- Fixed error handling in se05x_register(). The return value of pnt_se05x_open() was not considered which could lead to heap problems. Also error labels are introduced for unwinding to reduce complexity.
 
## Impact

crypto/se05x

## Testing

ucans32k146:se05x

please ignore the 'Mixed case identifier found'. This is detected on the usage of external code.

