### PR TITLE
imx9/flexcan: Add disable/enable cycle

### DIFF
--- a/arch/arm64/src/imx9/imx9_flexcan.c
+++ b/arch/arm64/src/imx9/imx9_flexcan.c
@@ -1911,6 +1911,14 @@ static int imx9_initialize(struct imx9_driver_s *priv)
 
 static void imx9_reset(struct imx9_driver_s *priv)
 {
+  /* Make sure module is enabled */
+
+  if (!imx9_setenable(priv->base, true))
+    {
+      canerr("Enable fail\n");
+      return;
+    }
+
   modifyreg32(priv->base + IMX9_CAN_MCR_OFFSET, 0, CAN_MCR_SOFTRST);
 
   if (!imx9_waitmcr_change(priv->base, CAN_MCR_SOFTRST, false))
@@ -1919,7 +1927,7 @@ static void imx9_reset(struct imx9_driver_s *priv)
       return;
     }
 
-  /* Enable module */
+  /* Disable module */
 
   if (!imx9_setenable(priv->base, false))
     {
@@ -2050,6 +2058,10 @@ int imx9_caninitialize(int intf)
       irq_detach(priv->irq);
       return -EAGAIN;
     }
+
+  /* Disable */
+
+  imx9_setenable(priv->base, false);
 
   /* Initialize the driver structure */
 


### PR DESCRIPTION

## Summary

This corrects the imx9 can bus driver in case of warm reboot, where the flexcan block might be already initialized

## Impact

Impacts only imx9 canbus when doing warm reboot

## Testing

Tested on a imx93 board