### PR TITLE
arch/arm64/imx9: Reset rx fifo in mode change

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -1021,13 +1021,10 @@ static void imx9_lpspi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
 
       imx9_lpspi_modifytcr(priv, clrbits, setbits);
 
-      while ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_RSR_OFFSET) &
-              LPSPI_RSR_RXEMPTY) != LPSPI_RSR_RXEMPTY)
-        {
-          /* Flush SPI read FIFO */
+      /* Reset SPI read FIFO */
 
-          imx9_lpspi_getreg32(priv, IMX9_LPSPI_RSR_OFFSET);
-        }
+      imx9_lpspi_modifyreg32(priv, IMX9_LPSPI_CR_OFFSET, 0,
+                                LPSPI_CR_RRF);
 
       /* Save the mode so that subsequent re-configurations will be faster */
 


### PR DESCRIPTION
instead of looping just reset rxfifo


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

This fix random hang issues

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


