### PR TITLE
arch/arm64: Optimized SGI to avoid VM exit.

### DIFF
--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -378,9 +378,7 @@ static int arm64_gic_send_sgi(unsigned int sgi_id, uint64_t target_aff,
   uint32_t aff1;
   uint64_t sgi_val;
   uint32_t regval;
-  unsigned long base;
 
-  base = gic_get_rdist() + GICR_SGI_BASE_OFF;
   ASSERT(GIC_IS_SGI(sgi_id));
 
   /* Extract affinity fields from target */
@@ -394,7 +392,9 @@ static int arm64_gic_send_sgi(unsigned int sgi_id, uint64_t target_aff,
 
   ARM64_DSB();
 
-  regval = getreg32(IGROUPR(base, 0));
+  /* Read the IGROUPR0 value we set in `gicv3_cpuif_init` */
+
+  regval = IGROUPR_SGI_VAL;
 
   if (regval & BIT(sgi_id))
     {


### PR DESCRIPTION
## Summary

This patch is necessary to optimize the handling of SGI (Software Generated Interrupts) in a virtualized environment on ARM64 architecture. The original implementation required reading the IGROUPR0 register each time an SGI was sent, which, due to the GIC Redistributor being a purely emulated device, caused a VM exit. This VM exit leads to significant performance degradation. The patch addresses this issue by replacing the read operation with a predefined value set during the initialization in `gicv3_cpuif_init`, assuming that this value remains unmodified post-initialization.

## Impact

The change primarily affects the performance of virtualized environments by reducing the number of VM exits caused by SGI handling. Users running virtual machines on ARM64 hardware should experience improved performance, especially in scenarios with frequent SGI usage. There are no direct changes to the build process, hardware requirements, or documentation. Security and compatibility are not directly impacted by this change, but the overall system performance may be enhanced due to reduced VM exits.

## Testing

The change was verified on QEMU-virt/arm64.
