### PR TITLE
tools/ci/platforms/darwin.sh: Port NuttX CI Job to macOS-14

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -31,6 +31,7 @@
 
 set -e
 set -o xtrace
+osarch=$(uname -m)
 
 add_path() {
   PATH=$1:${PATH}
@@ -80,16 +81,29 @@ avr_gcc_toolchain() {
   command avr-gcc --version
 }
 
+autoconf_brew() {
+  if ! type autoconf > /dev/null 2>&1; then
+    brew install autoconf
+  fi
+
+  command autoconf --version
+}
+
 binutils() {
-  mkdir -p "${NUTTXTOOLS}"/bintools/bin
   add_path "${NUTTXTOOLS}"/bintools/bin
 
   if ! type objcopy > /dev/null 2>&1; then
     brew install binutils
+    mkdir -p "${NUTTXTOOLS}"/bintools/bin
     # It is possible we cached prebuilt but did brew install so recreate
     # symlink if it exists
-    rm -f "${NUTTXTOOLS}"/bintools/bin/objcopy
-    ln -s /usr/local/opt/binutils/bin/objcopy "${NUTTXTOOLS}"/bintools/bin/objcopy
+    if [ "X$osarch" == "Xarm64" ]; then
+      rm -f "${NUTTXTOOLS}"/bintools/bin/objcopy
+      ln -s /opt/homebrew/opt/binutils/bin/objcopy "${NUTTXTOOLS}"/bintools/bin/objcopy
+    else
+      rm -f "${NUTTXTOOLS}"/bintools/bin/objcopy
+      ln -s /usr/local/opt/binutils/bin/objcopy "${NUTTXTOOLS}"/bintools/bin/objcopy
+    fi
   fi
 
   command objcopy --version
@@ -105,7 +119,7 @@ bloaty() {
     # https://github.com/google/bloaty/pull/326
     git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
     mkdir -p "${NUTTXTOOLS}"/bloaty
-    cmake -B build/bloaty -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
+    cmake -B build/bloaty -GNinja -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
     cmake --build build/bloaty
     cmake --build build/bloaty --target install
     cd "${NUTTXTOOLS}"
@@ -205,7 +219,11 @@ python_tools() {
   echo "export PIP_USER=yes" >> "${NUTTXTOOLS}"/env.sh
   echo "export PYTHONUSERBASE=${NUTTXTOOLS}/pylocal" >> "${NUTTXTOOLS}"/env.sh
   add_path "${PYTHONUSERBASE}"/bin
-
+  
+  if [ "X$osarch" == "Xarm64" ]; then
+    python3 -m venv --system-site-packages /opt/homebrew
+  fi
+  
   # workaround for Cython issue
   # https://github.com/yaml/pyyaml/pull/702#issuecomment-1638930830
   pip3 install "Cython<3.0"
@@ -361,7 +379,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain ninja_brew python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="ninja_brew autoconf_brew arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   mkdir -p "${NUTTXTOOLS}"/homebrew
   export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew


### PR DESCRIPTION

## Summary

Now you can use any of these runners

macos-13
https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

or 

macos-14 (arm64)
https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md


added autoconf
needed to build kconfig_frontends on macos-14

bloaty
speeded build with cmake + ninja

if we upgrade to macos-14 we need to remember to clear the caches (macOS-tools-xxxxxxxx) first
https://github.com/apache/nuttx/actions/caches

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

tested only on github workflow with only [macos] because **sim01, sim02, sim03 are broken !!!**

macos-13
[github macos-13](https://github.com/simbit18/nuttx-testing-ci/actions/runs/11724256583/job/32657844203)

macos-14
[github macos-14](https://github.com/simbit18/nuttx_test_pr/actions/runs/11724364651/job/32658207677
)

