### PR TITLE
Disable SYSLOG_DEFAULT by default

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -267,7 +267,7 @@ config SYSLOG_STREAM
 
 config SYSLOG_CONSOLE
 	bool "Log to /dev/console"
-	default !ARCH_LOWPUTC && !SYSLOG_CHAR && !RAMLOG_SYSLOG && !SYSLOG_RPMSG && !SYSLOG_RTT
+	default !SYSLOG_CHAR && !RAMLOG_SYSLOG && !SYSLOG_RPMSG && !SYSLOG_RTT
 	depends on DEV_CONSOLE
 	select SYSLOG_REGISTER
 	---help---
@@ -275,10 +275,16 @@ config SYSLOG_CONSOLE
 
 config SYSLOG_DEFAULT
 	bool "Default SYSLOG device"
-	default ARCH_LOWPUTC && !SYSLOG_CHAR && !RAMLOG_SYSLOG && !SYSLOG_RPMSG && !SYSLOG_RTT && !SYSLOG_CONSOLE
+	default n
+	depends on EXPERIMENTAL
 	---help---
 		syslog() interfaces will be present, but all output will go to the
 		up_putc(ARCH_LOWPUTC == y) or bit-bucket(ARCH_LOWPUTC == n).
+
+		CAVEAT: The current implementation of this functionality might
+		interfere the other activities on the console device, especially
+		with SMP. (Thus marked EXPERIMENTAL.)
+		See https://github.com/apache/nuttx/issues/14662.
 
 endif
 


### PR DESCRIPTION
## Summary

Disable SYSLOG_DEFAULT by default because the implementation is problematic.
See https://github.com/apache/nuttx/issues/14662 for the discussion. Also, make it depend on EXPERIMENTAL to discourage it.

Instead, enable SYSLOG_CONSOLE for a bit more cases.

An alternative would be to introduce/extend some serialization mechanism (eg. enter_critical_section, which is currently used by the serial driver to interact with interrupts) to cover up_putc users including SYSLOG_DEFAULT. While it works, it doesn't sound attractive to me to introduce this kind of complexity to up_putc, which is supposed to be a very low-level machinary used early in the boot. Also, the implementation of such serialization can be complex because how up_putc works is basically device-specific and how it corresponds to other devices on the system (eg. uarts) isn't obvious to the upper layers.

## Impact

this would affect many board configurations.

## Testing

tested for esp32s3-devkitc, with a few unrelated patches.
