### PR TITLE
libs/uClibc++: Fix the Download URL for uClibc++

### DIFF
--- a/libs/libxx/uClibc++/Make.defs
+++ b/libs/libxx/uClibc++/Make.defs
@@ -25,7 +25,7 @@ UCLIBCXX_VERSION=0.2.5
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard uClibc++/uClibc++/.git),)
 uClibc++-$(UCLIBCXX_VERSION).tar.bz2:
-	curl -O -L https://git.busybox.net/uClibc++/snapshot/$@
+	curl -O -L https://cxx.uclibc.org/src/$@
 
 uClibc++/uClibc++: uClibc++-$(UCLIBCXX_VERSION).tar.bz2
 	$(Q) tar -xf $<


### PR DESCRIPTION
## Summary

The SSL Cert for git.busybox.net has just expired today. This PR switches the uClibc++ download to cxx.uclibc.org.

## Impact

This PR will fix the build for sim:cxxtest.

## Testing

Tested OK on Ubuntu: https://gist.github.com/nuttxpr/4b41b2ab5839f15a7c796ef07fffe31b

```bash
$ tools/configure.sh sim:cxxtest
$ make
$ ./nuttx
```
