### PR TITLE
libs/uClibc++: Fix the Download URL for uClibc++ (CMake)

### DIFF
--- a/libs/libxx/uClibc++/CMakeLists.txt
+++ b/libs/libxx/uClibc++/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_UCLIBCXX)
       uClibc++
       DOWNLOAD_NAME "uClibc++-${UCLIBCXX_VERSION}.tar.bz2"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://git.busybox.net/uClibc++/snapshot/uClibc++-${UCLIBCXX_VERSION}.tar.bz2"
+      URL "https://cxx.uclibc.org/src/uClibc++-${UCLIBCXX_VERSION}.tar.bz2"
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/uClibc++
           BINARY_DIR


### PR DESCRIPTION
## Summary

The SSL Cert for git.busybox.net has just expired today. This PR switches the uClibc++ download to cxx.uclibc.org for CMake.

## Impact

This PR will fix the CMake build for sim:cxxtest.

## Testing

Tested OK on Ubuntu: https://gist.github.com/nuttxpr/2117937562cdace45c6830796d264964

```bash
$ cmake -B build -DBOARD_CONFIG=sim:cxxtest
$ cmake --build build
$ ./build/nuttx 
```
