### PR TITLE
boards/nucleo-f302r8: fix LED1 pin

### DIFF
--- a/boards/arm/stm32/nucleo-f302r8/include/board.h
+++ b/boards/arm/stm32/nucleo-f302r8/include/board.h
@@ -130,7 +130,7 @@
  *
  * And one can be controlled by software:
  *
- * User LD2: green LED is a user LED connected to the I/O PA5 of the
+ * User LD2: green LED is a user LED connected to the I/O PB13 of the
  *           STM32F302R8T6.
  *
  * If CONFIG_ARCH_LEDS is not defined, then the user can control the LED in

--- a/boards/arm/stm32/nucleo-f302r8/src/nucleo-f302r8.h
+++ b/boards/arm/stm32/nucleo-f302r8/src/nucleo-f302r8.h
@@ -43,7 +43,7 @@
  *
  * And one can be controlled by software:
  *
- * User LD2: green LED is a user LED connected to the I/O PA5 of the
+ * User LD2: green LED is a user LED connected to the I/O PB13 of the
  *           STM32F302R8T6.
  *
  * If CONFIG_ARCH_LEDS is not defined, then the user can control the LED in
@@ -51,7 +51,7 @@
  */
 
 #define GPIO_LED1      (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|\
-                        GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN5)
+                        GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN13)
 
 #define LED_DRIVER_PATH "/dev/userleds"
 


### PR DESCRIPTION
## Summary
- boards/nucleo-f302r8: fix LED1 pin
nucleo-f302r8 uses PB13 for LED1 not PA5

## Impact
LED1 works now

## Testing
nucleo-f302r8 



