### PR TITLE
tools/rp2040: Building picotool if necessary

### DIFF
--- a/tools/rp2040/Config.mk
+++ b/tools/rp2040/Config.mk
@@ -26,17 +26,33 @@
 
 # POSTBUILD -- Perform post build operations
 
-ifeq ($(CONFIG_RP2040_UF2_BINARY),y)
-ifdef PICO_SDK_PATH
-define POSTBUILD
-	$(Q)echo "Generating: nuttx.uf2"; \
+PICOTOOL_BIN_PATH?=$(PICO_SDK_PATH)$(DELIM)_deps$(DELIM)picotool$(DELIM)picotool
 
-	picotool$(HOSTEXEEXT) uf2 convert --quiet -t elf nuttx nuttx.uf2;
-	$(Q)([ $$? -eq 0 ] && echo nuttx.uf2 >> nuttx.manifest && echo "Done.")
+define GEN_PICO_UF2
+  $(Q)echo "Generating: nuttx.uf2"; \
+
+  $(Q)$1 uf2 convert --quiet -t elf nuttx nuttx.uf2;
+  $(Q)([ $$? -eq 0 ] && echo nuttx.uf2 >> nuttx.manifest && echo "Done.")
 endef
-else
-define POSTBUILD
-	$(Q) echo "PICO_SDK_PATH must be specified for flash boot"
-endef
-endif
+
+ifeq ($(CONFIG_RP2040_UF2_BINARY),y)
+  ifneq ($(shell which picotool),)
+    define POSTBUILD
+      $(call GEN_PICO_UF2, picotool)
+    endef
+  else ifdef PICO_SDK_PATH
+    define POSTBUILD
+      $(Q)(if ! $(PICOTOOL_BIN_PATH) help >&/dev/null; then \
+              echo "Building: picotool"; \
+              cd $(PICO_SDK_PATH); \
+              cmake . >&/dev/null; \
+              make picotoolBuild >&/dev/null; \
+           fi;)
+      $(call GEN_PICO_UF2, $(PICOTOOL_BIN_PATH))
+    endef
+  else
+    define POSTBUILD
+      $(Q) echo "PICO_SDK_PATH/picotool must be specified/installed for flash boot"
+    endef
+  endif
 endif


### PR DESCRIPTION
## Summary
1. The pre-installed "picotool" should not depend on `PICO_SDK_PATH`
2. Perhaps we should compile "picotool" from `PICO_SDK_PATH` if it was not found in `$PATH`

## Impact
boards/arm/rp2040/*

## Testing
1. Selftest
```bash
# Board: waveshare-rp2040-lcd-1.28:usbnsh

# a. The "picotool" is pre-installed or built from `PICO_SDK_PATH`

LD: nuttx 
Generating: nuttx.uf2 
Done.

# b. `PICO_SDK_PATH` is specified but "picotool" is not installed

LD: nuttx 
Building: picotool 
Generating: nuttx.uf2 
Done.

# c. Neither "picotool" nor `PICO_SDK_PATH` are installed/specified

LD: nuttx 
PICO_SDK_PATH/picotool must be specified/installed for flash boot
```
2. NuttX CI
