### PR TITLE
sensors/ms56xx: fix crc4 calculations

### DIFF
--- a/include/nuttx/sensors/msxxxx_crc4.h
+++ b/include/nuttx/sensors/msxxxx_crc4.h
@@ -43,42 +43,41 @@ static uint8_t msxxxx_crc4(FAR uint16_t *src,
                            uint8_t crcndx,
                            uint16_t crcmask)
 {
-  uint16_t cnt;
-  uint16_t n_rem;
-  uint16_t crc_read;
+  uint16_t cnt;       /* simple counter */
+  uint16_t n_rem;     /* crc reminder */
+  uint16_t crc_read;  /* original value of the crc */
   uint8_t n_bit;
 
   n_rem = 0x00;
-  crc_read = src[crcndx];
-  src[crcndx] &= ~crcmask;
+  crc_read = src[crcndx];   /* save read CRC */
+  src[crcndx] &= ~crcmask;  /* CRC byte is replaced by 0 */
 
-  for (cnt = 0; cnt < 16; cnt++)
+  for (cnt = 0; cnt < 16; cnt++)  /* operation is performed on bytes */
     {
       if (cnt % 2 == 1)
         {
-          n_rem ^= src[cnt >> 1] & 0x00ff;
+          n_rem ^= (uint16_t)((src[cnt >> 1]) & 0x00ff);
         }
       else
         {
-          n_rem ^= src[cnt >> 1] >> 8;
+          n_rem ^= (uint16_t)(src[cnt >> 1] >> 8);
         }
 
       for (n_bit = 8; n_bit > 0; n_bit--)
         {
-          if (n_rem & (0x8000) != 0)
+          if (n_rem & (0x8000))
             {
               n_rem = (n_rem << 1) ^ 0x3000;
             }
           else
             {
-              n_rem <<= 1;
+              n_rem = (n_rem << 1);
             }
         }
     }
-
-  n_rem = (n_rem >> 12) & 0x000f;
-  src[crcndx] = crc_read;
-  return n_rem ^ 0x00;
+  n_rem = (0x000f & (n_rem >> 12));  /* final 4-bit reminder is CRC code */
+  src[crcndx] = crc_read;            /* restore the crc_read to its original place */
+  return (n_rem ^ 0x00);
 }
 
 #endif /* __INCLUDE_NUTTX_SENSORS_MSXXXX_CRC4_H */


### PR DESCRIPTION
## Summary

Fix CRC4 calculations for msxxxx sensors, using implementation from [application note 520](https://www.amsys-sensor.com/downloads/notes/MS5XXX-C-code-example-for-MS56xx-MS57xx-MS58xx-AMSYS-an520e.pdf). Previous implementation returned the wrong value. 

## Impact

msxxxx sensors no longer report a CRC mismatch error and initialize properly.

## Testing

Tested with a raspberrypi pico w with a ms5611 barometer over i2c, device driver initialized properly.


