### PR TITLE
arm/phy6222: Fix the garbled Linker Script

### DIFF
--- a/boards/arm/phy62xx/phy6222/scripts/flash.ld
+++ b/boards/arm/phy62xx/phy6222/scripts/flash.ld
@@ -1,4 +1,3 @@
-  GNU nano 7.2                                           /awork/nuttx/NuttX/nuttx/boards/arm/nuc1xx/nutiny-nuc120/scripts/nutiny-nuc120.ld                                                    
 /****************************************************************************
  * boards/arm/nuc1xx/nutiny-nuc120/scripts/nutiny-nuc120.ld
  *
@@ -20,7 +19,6 @@
  * under the License.
  *
  ****************************************************************************/
-
 
 MEMORY
 {


### PR DESCRIPTION
## Summary

The Linker Script for phy6222 was garbled due to the SPDX Update. This PR removes the garbled text.
- https://github.com/apache/nuttx/pull/14704

## Impact

This PR will fix the build error for phy6222: https://github.com/NuttX/nuttx/actions/runs/11760431178/job/32760999540#step:7:1092

## Testing

None
