### PR TITLE
com/can: Remove unnecessary judgment logic

### DIFF
--- a/drivers/can/can_sender.c
+++ b/drivers/can/can_sender.c
@@ -148,17 +148,6 @@ FAR struct can_msg_s *can_get_msg(FAR struct can_txcache_s *cd_sender)
   list_for_every_entry(&cd_sender->tx_sending, tmp_node,
                        struct can_msg_node_s, list)
     {
-      if (tmp_node->msg.cm_hdr.ch_id == msg->cm_hdr.ch_id)
-        {
-          /* In order to prevent messages with the same ID from being
-           * sent out of order, as long as there is a message with the
-           * same ID that has not been sent in H/W, no data will be
-           * written to H/W
-           */
-
-          return NULL;
-        }
-
       if (tmp_node->msg.cm_hdr.ch_id > msg->cm_hdr.ch_id)
         {
           break;


### PR DESCRIPTION

## Summary
The feature of preventing the same ID frame rotation should be done in the lowerhalf or hardware, otherwise it may cause some problems. The CAN protocol stack only ensures that message is written into the hardware in the order of application layer packets, and does not care hardware sending order. This patch just remove this feature from CAN stack.

## Impact
When the application layer sends frames faster than Hardware and the can_id of frames is the same, the CAN protocol stack will directly hand over frames to Hardware and no longer prevent it from being sent.

## Testing
The application layer sends CAN frames with same can_id, constructs a scenario where the sending queue is full, and manually adds log information to record the frame in sending queue. Print the frame.can_id information for each frame as follows:
pending_list lentgth is :3 , and tx mailbox count is : 3
frame in tx mailbox is : 0x193, 0x193, 0x193


