### PR TITLE
libbuitin/compiler_rt: Supports separate builtin rt.builtins or rt.profile

### DIFF
--- a/libs/libbuiltin/Kconfig
+++ b/libs/libbuiltin/Kconfig
@@ -5,36 +5,42 @@
 
 comment "Toolchain Library Support"
 
+config LIB_BUILTIN
+	bool
+
+config LIB_COMPILER_RT
+	bool
+
 choice
 	prompt "Builtin toolchain support"
 	default BUILTIN_TOOLCHAIN
 	---help---
-		Choose to compile libraries related to toolchain into the OS
+		Select the builtin library
 
 config BUILTIN_COMPILER_RT
-	bool "Builtin LLVM Compiler-rt"
+	bool "Builtin LLVM libclang_rt.builtins"
+	select LIB_BUILTIN
+	select LIB_COMPILER_RT
 	---help---
 		Compile the LLVM Compiler-rt library into the OS.
 
 config BUILTIN_TOOLCHAIN
-	bool "Link the toolchain library"
-	---help---
-		Use the toolchain library that comes with the compiler
+	bool "Link toolchain builtin library to the OS"
 
 endchoice
 
-if BUILTIN_COMPILER_RT
+config COVERAGE_COMPILER_RT
+	bool "Builtin libclang_rt.profile"
+	select LIB_BUILTIN
+	select LIB_COMPILER_RT
+	default n
 
-config COMPILER_RT_VERSION
+config LIB_COMPILER_RT_VERSION
 	string "Select LLVM Compiler-rt version"
+	depends on LIB_COMPILER_RT
 	default "17.0.1"
 
-config COMPILER_RT_HAS_BFLOAT16
+config LIB_COMPILER_RT_HAS_BFLOAT16
 	bool "Enable support for bfloat16 in Compiler-rt"
+	depends on LIB_COMPILER_RT
 	default n
-
-config COMPILER_RT_PROFILE
-	bool "Enable profiling support in Compiler-rt"
-	default n
-
-endif # BUILTIN_COMPILER_RT

--- a/libs/libbuiltin/Makefile
+++ b/libs/libbuiltin/Makefile
@@ -26,7 +26,7 @@ BINDIR ?= bin
 KBIN = libkbuiltin$(LIBEXT)
 KBINDIR = kbin
 
-ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
+ifeq ($(CONFIG_LIB_COMPILER_RT),y)
 include compiler-rt/Make.defs
 endif
 

--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -18,11 +18,11 @@
 #
 # ##############################################################################
 
-if(CONFIG_BUILTIN_COMPILER_RT)
+if(CONFIG_LIB_COMPILER_RT)
 
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/compiler-rt)
 
-    set(COMPILER_RT_VERSION ${CONFIG_COMPILER_RT_VERSION})
+    set(COMPILER_RT_VERSION ${CONFIG_LIB_COMPILER_RT_VERSION})
 
     FetchContent_Declare(
       compiler-rt
@@ -52,427 +52,75 @@ if(CONFIG_BUILTIN_COMPILER_RT)
 
   endif()
 
-  nuttx_add_system_library(compiler-rt)
+  if(CONFIG_ARCH_ARM)
+    set(ARCH arm)
+  elseif(CONFIG_ARCH_RISCV)
+    set(ARCH riscv)
+  elseif(CONFIG_ARCH_X86_64)
+    set(ARCH x86_64)
+  elseif(CONFIG_ARCH_ARM64)
+    set(ARCH aarch64)
+  endif()
 
   list(APPEND INCDIR ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/include)
-  list(APPEND INCDIR ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins)
 
-  # Arithmetic operations
-  set(RT_BUILTIN_SRCS
-      absvdi2.c
-      absvsi2.c
-      absvti2.c
-      adddf3.c
-      addtf3.c
-      addvdi3.c
-      addvsi3.c
-      addvti3.c
-      muldc3.c
-      muldf3.c
-      muldi3.c
-      mulodi4.c
-      mulosi4.c
-      muloti4.c
-      mulsc3.c
-      mulsf3.c
-      multc3.c
-      multf3.c
-      multi3.c
-      mulvdi3.c
-      mulvsi3.c
-      mulvti3.c
-      mulxc3.c
-      negdf2.c
-      negdi2.c
-      negsf2.c
-      negti2.c
-      negvdi2.c
-      negvsi2.c
-      negvti2.c
-      subdf3.c
-      subsf3.c
-      subtf3.c
-      subvdi3.c
-      subvsi3.c
-      subvti3.c)
+  if(CONFIG_BUILTIN_COMPILER_RT)
 
-  # Floating point operations
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    floatdidf.c
-    floatdisf.c
-    floatditf.c
-    floatdixf.c
-    floatsidf.c
-    floatsisf.c
-    floatsitf.c
-    floattidf.c
-    floattisf.c
-    floattitf.c
-    floattixf.c
-    floatundidf.c
-    floatundisf.c
-    floatunditf.c
-    floatundixf.c
-    floatunsidf.c
-    floatunsisf.c
-    floatunsitf.c
-    floatuntidf.c
-    floatuntisf.c
-    floatuntitf.c
-    floatuntixf.c)
-
-  # Conversion and expansion operations
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    fixtfdi.c
-    fixtfsi.c
-    fixtfti.c
-    fixunsdfdi.c
-    fixunsdfsi.c
-    fixunsdfti.c
-    fixunssfdi.c
-    fixunssfsi.c
-    fixunssfti.c
-    fixunstfdi.c
-    fixunstfsi.c
-    fixunstfti.c
-    fixunsxfdi.c
-    fixunsxfsi.c
-    fixunsxfti.c
-    fixxfdi.c
-    fixxfti.c
-    extenddftf2.c
-    extendhfsf2.c
-    extendhftf2.c
-    extendsfdf2.c
-    extendsftf2.c
-    truncdfhf2.c
-    truncdfsf2.c
-    truncsfhf2.c
-    trunctfdf2.c
-    trunctfhf2.c
-    trunctfsf2.c)
-
-  # Bit manipulation operations
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    ashldi3.c
-    ashlti3.c
-    ashrdi3.c
-    ashrti3.c
-    clzti2.c
-    ctzdi2.c
-    ctzsi2.c
-    ctzti2.c
-    lshrdi3.c
-    lshrti3.c
-    popcountdi2.c
-    popcountsi2.c
-    popcountti2.c
-    paritydi2.c
-    paritysi2.c
-    parityti2.c)
-
-  # Division and modulo operations
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    divdc3.c
-    divdf3.c
-    divdi3.c
-    divmoddi4.c
-    divmodti4.c
-    divsc3.c
-    divsf3.c
-    divtc3.c
-    divtf3.c
-    divti3.c
-    divxc3.c
-    moddi3.c
-    modti3.c
-    udivdi3.c
-    udivmoddi4.c
-    udivmodti4.c
-    udivti3.c
-    umoddi3.c
-    umodti3.c)
-
-  # Atomic operations
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    atomic.c
-    atomic_flag_clear.c
-    atomic_flag_clear_explicit.c
-    atomic_flag_test_and_set.c
-    atomic_flag_test_and_set_explicit.c
-    atomic_signal_fence.c
-    atomic_thread_fence.c)
-
-  # Other function related files
-  list(
-    APPEND
-    RT_BUILTIN_SRCS
-    apple_versioning.c
-    clear_cache.c
-    cmpdi2.c
-    cmpti2.c
-    comparedf2.c
-    comparetf2.c
-    cpu_model.c
-    emutls.c
-    enable_execute_stack.c
-    eprintf.c
-    fp_mode.c
-    gcc_personality_v0.c
-    int_util.c
-    os_version_check.c
-    trampoline_setup.c
-    ucmpdi2.c
-    ucmpti2.c
-    powidf2.c
-    powisf2.c
-    powitf2.c
-    powixf2.c)
-
-  set(RT_BUILTIN_ARCH_SRCS)
-  # ARM-specific assembly files
-  if(CONFIG_ARCH_ARM)
-    set(RT_BUILTIN_ARCH arm)
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      adddf3vfp.S
-      addsf3.S
-      addsf3vfp.S
-      divmodsi4.S
-      divsi3.S
-      modsi3.S
-      subdf3vfp.S
-      subsf3vfp.S
-      muldf3vfp.S
-      mulsf3vfp.S
-      negdf2vfp.S
-      negsf2vfp.S)
-
-    # Floating-Point Operations
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      comparesf2.S
-      eqdf2vfp.S
-      eqsf2vfp.S
-      extendsfdf2vfp.S
-      fixdfsivfp.S
-      fixsfsivfp.S
-      fixunsdfsivfp.S
-      fixunssfsivfp.S
-      floatsidfvfp.S
-      floatsisfvfp.S
-      floatunssidfvfp.S
-      floatunssisfvfp.S
-      gedf2vfp.S
-      gesf2vfp.S
-      gtdf2vfp.S
-      gtsf2vfp.S
-      ledf2vfp.S
-      lesf2vfp.S
-      ltdf2vfp.S
-      ltsf2vfp.S
-      nedf2vfp.S
-      nesf2vfp.S
-      truncdfsf2vfp.S
-      unorddf2vfp.S
-      unordsf2vfp.S)
-
-    # Synchronization operations
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      sync_fetch_and_add_4.S
-      sync_fetch_and_add_8.S
-      sync_fetch_and_and_4.S
-      sync_fetch_and_and_8.S
-      sync_fetch_and_max_4.S
-      sync_fetch_and_max_8.S
-      sync_fetch_and_min_4.S
-      sync_fetch_and_min_8.S
-      sync_fetch_and_nand_4.S
-      sync_fetch_and_nand_8.S
-      sync_fetch_and_or_4.S
-      sync_fetch_and_or_8.S
-      sync_fetch_and_sub_4.S
-      sync_fetch_and_sub_8.S
-      sync_fetch_and_umax_4.S
-      sync_fetch_and_umax_8.S
-      sync_fetch_and_umin_4.S
-      sync_fetch_and_umin_8.S
-      sync_fetch_and_xor_4.S
-      sync_fetch_and_xor_8.S
-      sync_synchronize.S)
-
-    # Memory operations
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      aeabi_memcmp.S
-      aeabi_memcpy.S
-      aeabi_memmove.S
-      aeabi_memset.S
-      restore_vfp_d8_d15_regs.S
-      save_vfp_d8_d15_regs.S)
-
-    # Division and Modulus Operations
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      aeabi_idivmod.S
-      aeabi_ldivmod.S
-      aeabi_uidivmod.S
-      aeabi_uldivmod.S
-      udivmodsi4.S
-      udivsi3.S
-      umodsi3.S)
-
-    # Bitwise and Other Operations
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      bswapdi2.S
-      bswapsi2.S
-      chkstk.S
-      clzdi2.S
-      clzsi2.S)
-
-    # Branch and Control Flow
-    list(APPEND RT_BUILTIN_ARCH_SRCS switch16.S switch32.S switch8.S switchu8.S)
-
-  else()
-
-    # Other architectures
-    list(
-      APPEND
-      RT_BUILTIN_SRCS
-      addsf3.c
-      divsi3.c
-      modsi3.c
-      bswapdi2.c
-      bswapsi2.c
-      clzdi2.c
-      clzsi2.c
-      divmodsi4.c
-      udivmodsi4.c
-      udivsi3.c
-      umodsi3.c
-      comparesf2.c)
-
-  endif()
-
-  if(CONFIG_ARCH_ARM64)
-    set(ARCH "aarch64")
-    list(APPEND RT_BUILTIN_ARCH_SRCS chkstk.S lse.S fp_mode.c)
-  elseif(CONFIG_ARCH_RISCV)
-    set(ARCH "riscv")
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      muldi3.S
-      mulsi3.S
-      restore.S
-      save.S
-      fp_mode.c)
-  else()
-    list(APPEND RT_BUILTIN_SRCS muldi3.c)
-  endif()
-
-  if(CONFIG_ARCH_X86_64)
-    set(ARCH "x86_64")
-    list(
-      APPEND
-      RT_BUILTIN_ARCH_SRCS
-      chkstk2.S
-      chkstk.S
-      floatundidf.S
-      floatundisf.S
-      floatundixf.S
-      floatdidf.c
-      floatdisf.c
-      floatdixf.c)
-  else()
-    list(APPEND RT_BUILTIN_SRCS floatundidf.c floatundisf.c floatundixf.c)
-  endif()
-
-  if(CONFIG_COMPILER_RT_PROFILE)
+    nuttx_add_system_library(rt.buitlins)
 
     target_include_directories(
-      compiler-rt PRIVATE ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile)
+      rt.buitlins PRIVATE ${INCDIR}
+                          ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins)
 
-    target_compile_options(
-      compiler-rt
-      PRIVATE -DCOMPILER_RT_HAS_UNAME
-              -Wno-cleardeprecated-pragma
-              -Wno-deprecated-pragma
-              -Wno-incompatible-pointer-types
-              -Wno-shadow
-              -Wno-strict-prototypes
-              -Wno-undef
-              -Wno-unknown-warning-option)
+    target_compile_options(rt.buitlins PRIVATE -Wno-undef -Wno-macro-redefined)
 
-    set(RT_PROFILE_SRCS
-        GCDAProfiling.c
-        InstrProfiling.c
-        InstrProfilingBuffer.c
-        InstrProfilingFile.c
-        InstrProfilingInternal.c
-        InstrProfilingMerge.c
-        InstrProfilingMergeFile.c
-        InstrProfilingNameVar.c
-        InstrProfilingUtil.c
-        InstrProfilingValue.c
-        InstrProfilingVersionVar.c
-        InstrProfilingWriter.c
-        InstrProfilingRuntime.cpp)
+    set(SRCSTMP)
+    set(RT_BUILTINS_SRCS)
+    file(GLOB RT_BUILTINS_SRCS
+         ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/*.c)
 
-    foreach(src ${RT_PROFILE_SRCS})
-      string(PREPEND src ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile/)
-      list(APPEND COMPILER_RT_SRCS ${src})
-    endforeach()
+    file(GLOB SRCSTMP
+         ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${ARCH}/*.S)
+    list(APPEND RT_BUILTINS_SRCS ${SRCSTMP})
 
-    list(APPEND COMPILER_RT_SRCS InstrProfilingPlatform.c)
+    file(GLOB SRCSTMP
+         ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${ARCH}/*.c)
+    list(APPEND RT_BUILTINS_SRCS ${SRCSTMP})
+
+    if(NOT CONFIG_LIB_COMPILER_RT_HAS_BFLOAT16)
+      set(RT_BUILTINS_BFLOAT16_SRCS
+          ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/truncdfbf2.c
+          ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/truncsfbf2.c)
+      list(REMOVE_ITEM RT_BUILTINS_SRCS ${RT_BUILTINS_BFLOAT16_SRCS})
+    endif()
+
+    target_sources(rt.buitlins PRIVATE ${RT_BUILTINS_SRCS})
 
   endif()
 
-  list(APPEND INCDIR
-       ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${RT_BUILTIN_ARCH})
+  if(CONFIG_COVERAGE_COMPILER_RT)
 
-  foreach(src ${RT_BUILTIN_SRCS})
-    string(PREPEND src ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/)
-    list(APPEND COMPILER_RT_SRCS ${src})
-  endforeach()
+    nuttx_add_system_library(rt.profile)
 
-  foreach(src ${RT_BUILTIN_ARCH_SRCS})
-    string(
-      PREPEND src
-      ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins/${RT_BUILTIN_ARCH}/)
-    list(APPEND COMPILER_RT_SRCS ${src})
-  endforeach()
+    target_include_directories(
+      rt.profile PRIVATE ${INCDIR}
+                         ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile)
 
-  # Add the sources to the target
-  target_sources(compiler-rt PRIVATE ${COMPILER_RT_SRCS})
+    target_compile_options(
+      rt.profile PRIVATE -DCOMPILER_RT_HAS_UNAME -Wno-undef
+                         -Wno-strict-prototypes -Wno-shadow)
 
-  target_compile_options(
-    compiler-rt
-    PRIVATE -Wno-shift-count-negative
-            -Wno-constant-conversion
-            -Wshift-count-overflow
-            -Wno-undef
-            -Wno-incompatible-pointer-types
-            -Wno-visibility
-            -Wno-macro-redefined)
+    set(SRCSTMP)
+    set(RT_PROFILE_SRCS InstrProfilingPlatform.c)
 
-  target_include_directories(compiler-rt PRIVATE ${INCDIR})
+    file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile/*.c)
+    list(APPEND RT_PROFILE_SRCS ${SRCSTMP})
+
+    file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/profile/*.cpp)
+    list(APPEND RT_PROFILE_SRCS ${SRCSTMP})
+
+    target_sources(rt.profile PRIVATE ${RT_PROFILE_SRCS})
+
+  endif()
+
 endif()

--- a/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
+++ b/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
@@ -60,37 +60,37 @@ void __llvm_profile_register_names_function(void *NamesStart,
 COMPILER_RT_VISIBILITY
 const __llvm_profile_data *__llvm_profile_begin_data(void)
 {
-  return &__start__llvm_prf_data;
+  return (const __llvm_profile_data *)__start__llvm_prf_data;
 }
 
 COMPILER_RT_VISIBILITY
 const __llvm_profile_data *__llvm_profile_end_data(void)
 {
-  return &__end__llvm_prf_data;
+  return (const __llvm_profile_data *)__end__llvm_prf_data;
 }
 
 COMPILER_RT_VISIBILITY
 const char *__llvm_profile_begin_names(void)
 {
-  return &__start__llvm_prf_names;
+  return (const char *)__start__llvm_prf_names;
 }
 
 COMPILER_RT_VISIBILITY
 const char *__llvm_profile_end_names(void)
 {
-  return &__end__llvm_prf_names;
+  return (const char *)__end__llvm_prf_names;
 }
 
 COMPILER_RT_VISIBILITY
 char *__llvm_profile_begin_counters(void)
 {
-  return &__start__llvm_prf_cnts;
+  return (char *)__start__llvm_prf_cnts;
 }
 
 COMPILER_RT_VISIBILITY
 char *__llvm_profile_end_counters(void)
 {
-  return &__end__llvm_prf_cnts;
+  return (char *)__end__llvm_prf_cnts;
 }
 
 COMPILER_RT_VISIBILITY

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -74,8 +74,8 @@ ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
 
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
-FLAGS += -Wno-shift-count-negative -Wno-constant-conversion -Wshift-count-overflow
-FLAGS += -Wno-undef -Wno-incompatible-pointer-types -Wno-visibility -Wno-macro-redefined
+
+FLAGS += -Wno-undef -Wno-macro-redefined
 
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/*.c)
 ASRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/$(ARCH)/*.S)
@@ -94,10 +94,9 @@ endif
 ifeq ($(CONFIG_COVERAGE_COMPILER_RT),y)
 
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/profile
-FLAGS += -Wno-cleardeprecated-pragma -Wno-deprecated-pragma -Wno-incompatible-pointer-types
-FLAGS += -Wno-shadow -Wno-strict-prototypes -Wno-undef -Wno-unknown-warning-option
+
+FLAGS += -Wno-undef -Wno-strict-prototypes  -Wno-shadow
 FLAGS += -DCOMPILER_RT_HAS_UNAME
-FLAGS += -fno-profile-generate
 
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/profile/*.c)
 CPPSRCS += $(wildcard compiler-rt/compiler-rt/lib/profile/*.cpp)

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -20,7 +20,7 @@
 
 include $(TOPDIR)/Make.defs
 
-COMPILER_RT_VERSION=$(CONFIG_COMPILER_RT_VERSION)
+COMPILER_RT_VERSION=$(CONFIG_LIB_COMPILER_RT_VERSION)
 
 ifeq ($(CONFIG_ARCH_ARM),y)
   ARCH = arm
@@ -67,26 +67,32 @@ distclean::
 	$(call DELDIR, compiler-rt/compiler-rt)
 
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/include
+
+################# Builtin Library #################
+
+ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
+
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
 FLAGS += -Wno-shift-count-negative -Wno-constant-conversion -Wshift-count-overflow
 FLAGS += -Wno-undef -Wno-incompatible-pointer-types -Wno-visibility -Wno-macro-redefined
 
-################# Builtin Library #################
-
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/*.c)
 ASRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/$(ARCH)/*.S)
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/$(ARCH)/*.c)
 
-ifeq ($(CONFIG_COMPILER_RT_HAS_BFLOAT16),)
+ifeq ($(CONFIG_LIB_COMPILER_RT_HAS_BFLOAT16),)
   BFLOAT16_SRCS := compiler-rt/compiler-rt/lib/builtins/truncdfbf2.c
   BFLOAT16_SRCS += compiler-rt/compiler-rt/lib/builtins/truncsfbf2.c
   CSRCS := $(filter-out $(BFLOAT16_SRCS), $(CSRCS))
 endif
 
+endif
+
 ################# Profile Library #################
 
-ifeq ($(CONFIG_COMPILER_RT_PROFILE),y)
+ifeq ($(CONFIG_COVERAGE_COMPILER_RT),y)
+
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/profile
 FLAGS += -Wno-cleardeprecated-pragma -Wno-deprecated-pragma -Wno-incompatible-pointer-types
 FLAGS += -Wno-shadow -Wno-strict-prototypes -Wno-undef -Wno-unknown-warning-option

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -68,7 +68,7 @@ ifeq ($(CONFIG_BUILD_FLAT),y)
 
 KERNDEPDIRS += libs$(DELIM)libc mm
 
-ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+ifeq ($(CONFIG_LIB_BUILTIN),y)
 KERNDEPDIRS += libs$(DELIM)libbuiltin
 else
 CLEANDIRS += libs$(DELIM)libbuiltin
@@ -90,7 +90,7 @@ else
 
 USERDEPDIRS += libs$(DELIM)libc mm
 
-ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+ifeq ($(CONFIG_LIB_BUILTIN),y)
 USERDEPDIRS += libs$(DELIM)libbuiltin
 else
 CLEANDIRS += libs$(DELIM)libbuiltin

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -52,7 +52,7 @@ NUTTXLIBS += staging$(DELIM)libarch$(LIBEXT)
 
 # Add toolchain library support
 
-ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+ifeq ($(CONFIG_LIB_BUILTIN),y)
 NUTTXLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
 endif
 

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -54,7 +54,7 @@ USERLIBS  += staging$(DELIM)libmm$(LIBEXT) staging$(DELIM)libarch$(LIBEXT)
 
 # Add toolchain library support
 
-ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+ifeq ($(CONFIG_LIB_BUILTIN),y)
 NUTTXLIBS += staging$(DELIM)libkbuiltin$(LIBEXT)
 USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
 endif

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -54,7 +54,7 @@ USERLIBS  += staging$(DELIM)libmm$(LIBEXT) staging$(DELIM)libarch$(LIBEXT)
 
 # Add toolchain library support
 
-ifeq ($(CONFIG_BUILTIN_TOOLCHAIN),)
+ifeq ($(CONFIG_LIB_BUILTIN),y)
 NUTTXLIBS += staging$(DELIM)libkbuiltin$(LIBEXT)
 USERLIBS += staging$(DELIM)libbuiltin$(LIBEXT)
 endif


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
1.  Organize make.defs and eliminate compilation warnings'
2.  Supports separate builtin rt.builtins or rt.profile
## Impact
None
## Testing
1. enable CONFIG_COMPILER_RT_BUILTINS to builtin rt.builtins instead of the toolchain's own
2. enable CONFIG_COMPILER_RT_PROFILE to builtin rt.profile instead of the toolchain's own