### PR TITLE
fix compiler error when CONFIG_CLOCK_TIMEKEEPING=y

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -31,6 +31,7 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/clock.h>
+#include <nuttx/irq.h>
 #include <stdint.h>
 
 /****************************************************************************

--- a/sched/sched/sched_processtimer.c
+++ b/sched/sched/sched_processtimer.c
@@ -37,6 +37,10 @@
 #  include <nuttx/board.h>
 #endif
 
+#ifdef CONFIG_CLOCK_TIMEKEEPING
+#  include "clock/clock_timekeeping.h"
+#endif
+
 #include "sched/sched.h"
 #include "wdog/wdog.h"
 #include "clock/clock.h"


### PR DESCRIPTION

## Summary
reason:
when CONFIG_CLOCK_TIMEKEEPING=y, compiler error may report

In file included from /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/sched.h:42,
                 from /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/arch.h:89,
                 from boardctl.c:33:
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/irq.h:261:12: error: conflicting types for 'enter_critical_section'; have 'irqstate_t(void)' {aka 'long unsigned int(void)'}
  261 | irqstate_t enter_critical_section(void) noinstrument_function;
      |            ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/wqueue.h:37,
                 from /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/addrenv.h:39,
                 from /home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/sched.h:40:
/home/hujun5/downloads1/vela_sim/nuttx/include/nuttx/wdog.h:267:11: note: previous implicit declaration of 'enter_critical_section' with type 'int()'
  267 |   flags = enter_critical_section();
      |           ^~~~~~~~~~~~~~~~~~~~~~
hujun5@hujun5-OptiPlex-7070:~/downloads1/vela_sim/nuttx$ make -j12
sched/sched_processtimer.c: In function 'nxsched_process_timer':
sched/sched_processtimer.c:178:3: error: implicit declaration of function 'clock_update_wall_time' [-Werror=implicit-function-declaration]
  178 |   clock_update_wall_time();

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*


## Impact
CONFIG_CLOCK_TIMEKEEPING

## Testing
ci ostest


