### PR TITLE
GreenHills Support: add __ARM_ARCH, __ARM_FEATURE_DSP macro definition when build with ghs compiler

### DIFF
--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -43,6 +43,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 6
+#endif
+
 /* Configuration ************************************************************/
 
 /* If this is a kernel build,

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -42,6 +42,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 7
+#endif
+
 /* IRQ Stack Frame Format:
  *
  * Context is always saved/restored in the same way:

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -42,6 +42,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 7
+#endif
+
 /* Configuration ************************************************************/
 
 /* If this is a kernel build, how many nested system calls should we

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -42,6 +42,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 7
+#endif
+
 /* IRQ Stack Frame Format:
  *
  * Context is always saved/restored in the same way:

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -42,6 +42,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 8
+#endif
+
 /* Configuration ************************************************************/
 
 /* If this is a kernel build, how many nested system calls should we

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -42,6 +42,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 8
+#endif
+
 /* IRQ Stack Frame Format:
  *
  * Context is always saved/restored in the same way:

--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -75,6 +75,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#if defined(__ghs__) && defined(__ARM_DSP__)
+#  define __ARM_FEATURE_DSP 1
+#endif
+
 #ifndef __ASSEMBLY__
 
 #ifndef up_switch_context

--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -49,6 +49,10 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+#ifdef __ghs__
+#  define __ARM_ARCH 8
+#endif
+
 #define up_getsp()          (uintptr_t)__builtin_frame_address(0)
 
 /* MPIDR_EL1, Multiprocessor Affinity Register */


### PR DESCRIPTION
## Summary
when we build mbedtls in vela with ghs compiler, the mbedtls need to access __ARM_ARCH and __ARM_FEATURE_DSP, and to construct the inline asm code based on these two macros.
With ghs compiler, these two macros are not defined, and will be evaluated as 0 by default, and thus will using to wrong inline asm code, in order to handle this issue, we need to add conversion between the ghs and gcc with __ARM_ARCH, __ARM_FEATURE_DSP

## Impact

Has no impact with current gcc toolchain and other toolchain

## Testing

1. has passed the ostest
2. has tested with ghs and gcc compiler


