### PR TITLE
GreenHills support: fix the naked_function function non-compatible issue with arm_svcall

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -32,6 +32,7 @@
 #include <syscall.h>
 
 #include <arch/irq.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
@@ -82,23 +83,22 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " push {r4, r5}\n"            /* Save R4 and R5 */
-    " sub sp, sp, #12\n"          /* Create a stack frame to hold 3 parms */
-    " str r4, [sp, #0]\n"         /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"         /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"         /* Move parameter 6 (if any) into position */
-    " mov r5, lr\n"               /* Save lr in R5 */
-    " ldr r4, =g_stublookup\n"    /* R4=The base of the stub lookup table */
-    " lsl r0, r0, #2\n"           /* R0=Offset of the stub for this syscall */
-    " ldr r4, [r4, r0]\n"         /* R4=Address of the stub for this syscall */
-    " blx r5\n"                   /* Call the stub (modifies lr) */
-    " mov lr, r5\n"               /* Restore lr */
-    " add sp, sp, #12\n"          /* Destroy the stack frame */
-    " pop {r4, r5}\n"             /* Recover R4 and R5 */
-    " mov r2, r0\n"               /* R2=Save return value in R2 */
-    " mov r0, %0\n"               /* R0=SYS_syscall_return */
-    " svc %1\n"::"i"(SYS_syscall_return),
-                 "i"(SYS_syscall) /* Return from the SYSCALL */
+    " push {r4, r5}\n"                              /* Save R4 and R5 */
+    " sub sp, sp, #12\n"                            /* Create a stack frame to hold 3 parms */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " mov r5, lr\n"                                 /* Save lr in R5 */
+    " ldr r4, =g_stublookup\n"                      /* R4=The base of the stub lookup table */
+    " lsl r0, r0, #2\n"                             /* R0=Offset of the stub for this syscall */
+    " ldr r4, [r4, r0]\n"                           /* R4=Address of the stub for this syscall */
+    " blx r5\n"                                     /* Call the stub (modifies lr) */
+    " mov lr, r5\n"                                 /* Restore lr */
+    " add sp, sp, #12\n"                            /* Destroy the stack frame */
+    " pop {r4, r5}\n"                               /* Recover R4 and R5 */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -33,8 +33,8 @@
 
 #include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
-#include <nuttx/addrenv.h>
 
 #include "addrenv.h"
 #include "arm.h"
@@ -124,20 +124,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"         /* Restore lr */
-    " add sp, sp, #16\n"           /* Destroy the stack frame */
-    " mov r2, r0\n"                /* R2=Save return value in R2 */
-    " mov r0, %0\n"                /* R0=SYS_syscall_return */
-    " svc %1\n"::"i"(SYS_syscall_return),
-                 "i"(SYS_syscall)  /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                             /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                            /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                            /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                            /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                           /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                       /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                    /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                      /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                           /* Restore lr */
+    " add sp, sp, #16\n"                             /* Destroy the stack frame */
+    " mov r2, r0\n"                                  /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n"  /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"             /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -32,6 +32,7 @@
 #include <syscall.h>
 
 #include <arch/irq.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
@@ -87,26 +88,25 @@ static void dispatch_syscall(void)
        *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
        */
 
-      " mov ip, sp\n"                /* Calculate (orig_SP - new_SP) */
+      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
       " sub ip, ip, #20\n"
       " and ip, ip, #7\n"
       " add ip, ip, #20\n"
       " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"          /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"          /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"          /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"         /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"         /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"     /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"  /* R12=The address of the stub for this syscall */
-      " blx ip\n"                    /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"         /* Restore lr */
-      " ldr r2, [sp, #16]\n"         /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"            /* Restore SP */
-      " mov r2, r0\n"                /* R2=Save return value in R2 */
-      " mov r0, %0\n"                /* R0=SYS_syscall_return */
-      " svc %1\n"::"i"(SYS_syscall_return),
-                   "i"(SYS_syscall)  /* Return from the SYSCALL */
+      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
+      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
+      " blx ip\n"                                     /* Call the stub (modifies lr) */
+      " ldr lr, [sp, #12]\n"                          /* Restore lr */
+      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
+      " add sp, sp, r2\n"                             /* Restore SP */
+      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -31,6 +31,7 @@
 #include <syscall.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
 
 #include "arm.h"
@@ -120,20 +121,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"         /* Restore lr */
-    " add sp, sp, #16\n"           /* Destroy the stack frame */
-    " mov r2, r0\n"                /* R2=Save return value in R2 */
-    " mov r0, %0\n"                /* R0=SYS_syscall_return */
-    " svc %1\n"::"i"(SYS_syscall_return),
-                 "i"(SYS_syscall)  /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                            /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                     /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                          /* Restore lr */
+    " add sp, sp, #16\n"                            /* Destroy the stack frame */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -32,6 +32,7 @@
 #include <syscall.h>
 
 #include <arch/irq.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
@@ -87,26 +88,25 @@ static void dispatch_syscall(void)
        *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
        */
 
-      " mov ip, sp\n"                /* Calculate (orig_SP - new_SP) */
+      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
       " sub ip, ip, #20\n"
       " and ip, ip, #7\n"
       " add ip, ip, #20\n"
       " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"          /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"          /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"          /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"         /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"         /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"     /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"  /* R12=The address of the stub for this syscall */
-      " blx ip\n"                    /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"         /* Restore lr */
-      " ldr r2, [sp, #16]\n"         /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"            /* Restore SP */
-      " mov r2, r0\n"                /* R2=Save return value in R2 */
-      " mov r0, %0\n"                /* R0=SYS_syscall_return */
-      " svc %1\n"::"i"(SYS_syscall_return),
-                   "i"(SYS_syscall)  /* Return from the SYSCALL */
+      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
+      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
+      " blx ip\n"                                     /* Call the stub (modifies lr) */
+      " ldr lr, [sp, #12]\n"                          /* Restore lr */
+      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
+      " add sp, sp, r2\n"                             /* Restore SP */
+      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -31,6 +31,7 @@
 #include <syscall.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/macro.h>
 #include <nuttx/sched.h>
 
 #include "arm.h"
@@ -120,20 +121,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"         /* Restore lr */
-    " add sp, sp, #16\n"           /* Destroy the stack frame */
-    " mov r2, r0\n"                /* R2=Save return value in R2 */
-    " mov r0, %0\n"                /* R0=SYS_syscall_return */
-    " svc %1\n"::"i"(SYS_syscall_return),
-                 "i"(SYS_syscall)  /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                            /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                     /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                          /* Restore lr */
+    " add sp, sp, #16\n"                            /* Destroy the stack frame */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif


### PR DESCRIPTION
## Summary

when build with greenhills_202354(support  naked_function attribute), the naked_function should only contains the basic asm statements, so if the naked_function contains the statements that using to accept params from C lang runtime, then following build error will reported:
```
error #101112: Only basic asm expressions are allowed for functions
with __attribute__((naked)): dispatch_syscall
```

## Impact

has no impact on other toolchain

## Testing

1. has passed the ostest
2. has tested on ghs and gcc toolchains


