### PR TITLE
GreenHills support: fix the naked_function attr cannot handle warning with old version GHS compiler

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -240,7 +240,11 @@
  * the function prolog and epilog.
  */
 
-#  define naked_function __attribute__((naked,no_instrument_function))
+#  if !defined(__ghs__) || __GHS_VERSION_NUMBER >= 202354
+#    define naked_function __attribute__((naked,no_instrument_function))
+#  else
+#    define naked_function
+#  endif
 
 /* The always_inline_function attribute informs GCC that the function should
  * always be inlined, regardless of the level of optimization.  The


### PR DESCRIPTION
## Summary

With greenhills version older than 202354, the __attribute__((naked)) cannot handled by greenhills compiler, and will report warning:

```
"/home/guoshichao/work_profile/vela_os/vela_car_6/nuttx/arch/arm/src/armv7-m/arm_svcall.c", line 79: warning #1097-D:
          unknown attribute "naked"
  static void dispatch_syscall(void) naked_function;
                                     ^
```
We need to ignore these warning when we build with old version GHS compiler

## Impact

Has no impact on other toolchain

## Testing

1. has passed the ostest
2. has tested in ghs and gcc compiler


