### PR TITLE
SYSLOG_DEFAULT: wrap up_putc/up_nputs calls with critical section

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -268,6 +268,10 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
         {
           /* The following steps must be atomic with respect to serial
            * interrupt handling.
+           *
+           * This critical section is also used for the serialization
+           * with the up_putc-based syslog channels.
+           * See https://github.com/apache/nuttx/issues/14662
            */
 
           flags = enter_critical_section();


### PR DESCRIPTION
## Summary

This would avoid the undesirable intertactions with the serial driver described in https://github.com/apache/nuttx/issues/14662.

Although I'm not entirely happy with this fix because it assumes the particular implementations of up_putc/up_nputc and its association to the serial devices, I haven't come up with better ideas for now.

An alternative is to place some serializations inside the target specific serial (and/or whatever provides up_putc api) implementaitons. But it isn't too attractive to put potentially complex logic into the low-level machinaries, especially when we have a lot of similar copies of it.

Another alternative is to deprecate up_putc. (at least for the purpose of syslog.) But it seems at least some of users are relying on what the current implementation provides heavily.

This commit also removes g_lowputs_lock because the critical section would serve the purpose of the lock as well.

## Impact

SYSLOG_DEFAULT

## Testing

Tested on esp32s3-devkitc with a several unrelated local patches.
