### PR TITLE
riscv: Suppress LOAD RWX linker warning

### DIFF
--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -265,6 +265,12 @@ if(CONFIG_RISCV_TOOLCHAIN STREQUAL GNU_RVG)
     string(REGEX MATCH "([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
                  "${GCC_VERSION_OUTPUT}")
     set(GCCVER ${CMAKE_MATCH_1})
+
+    if(GCCVER GREATER_EQUAL 12)
+      if(CONFIG_ARCH_RAMFUNCS OR NOT CONFIG_BOOT_RUNFROMFLASH)
+        add_link_options(-Wl,--no-warn-rwx-segments)
+      endif()
+    endif()
   endif()
 
   if(CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI)

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -386,6 +386,13 @@ ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
     ifeq ($(GCCVER),)
       export GCCVER := $(shell $(CC) --version | grep gcc | sed -E "s/.* ([0-9]+\.[0-9]+).*/\1/" | cut -d'.' -f1)
     endif
+    ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)
+      ifeq ($(CONFIG_ARCH_RAMFUNCS),y)
+        LDFLAGS += --no-warn-rwx-segments
+      else ifeq ($(CONFIG_BOOT_RUNFROMFLASH),)
+        LDFLAGS += --no-warn-rwx-segments
+      endif
+    endif
   endif
 endif
 


### PR DESCRIPTION

## Summary

Suppress the warning message "nuttx has a LOAD segment with RWX permissions" in case of RAM boot mode is selected. RAM MODE: BOOT_RUNFROMEXTSRAM/BOOT_RUNFROMISRAM/BOOT_RUNFROMSDRAM/BOOT_COPYTORAM

Similar to https://github.com/apache/nuttx/pull/14474

## Impact

RISC-V GCC 12+

## Testing

Local machine

