### PR TITLE
gprof: Add a configuration dependency

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1377,10 +1377,12 @@ config SCHED_GPROF
 		cause the linker to include the gmon.out file in the final
 		executable.
 		Add the "-pg" parameter to the Makefile when compiling to obtain
-		the function call graph of the specified module.
+		the function call graph of the specified module. If you do this,
+		please enable "CONFIG_FRAME_POINTER"
 
 config SCHED_GPROF_ALL
 	bool "Enable gprof call graph for all modules"
+	depends on FRAME_POINTER
 	depends on SCHED_GPROF
 	default n
 	---help---


### PR DESCRIPTION
arm-none-eabi-g++: error: -pg and -fomit-frame-pointer are incompatible

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
arm-none-eabi-g++: error: -pg and -fomit-frame-pointer are incompatible
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


