### PR TITLE
drivers/misc: fix rpmsg dev poll assert crash

### DIFF
--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -403,12 +403,13 @@ static int rpmsgdev_poll_handler(FAR struct rpmsg_endpoint *ept,
     }
   else
     {
-      DEBUGASSERT(dev->cfd != 0);
-
-      msg->header.result = file_poll(&dev->file, &dev->fd, false);
-      if (msg->header.result == OK)
+      if (dev->cfd != 0)
         {
-          dev->cfd = 0;
+          msg->header.result = file_poll(&dev->file, &dev->fd, false);
+          if (msg->header.result == OK)
+            {
+              dev->cfd = 0;
+            }
         }
     }
 


### PR DESCRIPTION

## Summary

when client read and poll wait buffer from server side and server side may poll notify more than one times, then rpmsgdev in client side will call "rpmsgdev_poll_setup(priv, 0, false);" twice which will cause assert crash in rpmsgdev_server.c

## Impact

rpmsgdev driver

## Testing

qemu


