### PR TITLE
arch/arm64: bug fix,arm64_fatal_handler need regs parms

### DIFF
--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -190,6 +190,7 @@ reserved_syscall:
     mov    sp, x0
     b      arm64_exit_exception
 2:
+    mov    x0, sp
     adrp   x5, arm64_fatal_handler
     add    x5, x5, #:lo12:arm64_fatal_handler
     br     x5


### PR DESCRIPTION
fix the bug

#0  udelay_coarse (microseconds=63000) at timers/arch_alarm.c:65
#1  up_ndelay (nanoseconds=nanoseconds@entry=250000000) at timers/arch_alarm.c:429
#2  0x00000000402b130c in up_udelay (microseconds=microseconds@entry=250000) at timers/arch_alarm.c:414
#3  0x00000000402b136c in up_mdelay (milliseconds=milliseconds@entry=250) at timers/arch_alarm.c:399
#4  0x000000004029db88 in reset_board () at misc/assert.c:787
#5  _assert (filename=filename@entry=0x40e29d18 "common/arm64_fatal.c", linenum=linenum@entry=549, msg=0x0, regs=regs@entry=0x0) at misc/assert.c:814
#6  0x00000000402d84e8 in __assert (filename=filename@entry=0x40e29d18 "common/arm64_fatal.c", linenum=linenum@entry=549, msg=<optimized out>) at assert/lib_assert.c:38
#7  0x00000000402907a4 in arm64_fatal_handler (regs=<optimized out>) at common/arm64_fatal.c:549
#8  0x0000000040d27278 in _vector_table () at common/arm64_vector_table.S:178
#9  0x000000004036f938 in up_backtrace (tcb=<optimized out>, buffer=0x4191c248, size=16, skip=0) at common/arm64_backtrace.c:131
#10 0x000000004036144c in sched_backtrace (tid=tid@entry=27, buffer=buffer@entry=0x4191c248, size=size@entry=16, skip=skip@entry=0) at sched/sched_backtrace.c:107
#11 0x00000000402dbaec in sched_dumpstack (tid=27) at sched/sched_dumpstack.c:71
#12 0x000000004029d870 in dump_running_task (regs=0x411bc0a0 <g_last_regs>, rtcb=0x418182a0) at misc/assert.c:639
#13 dump_assert_info (regs=0x411bc0a0 <g_last_regs>, msg=0x40e29d30 "panic", linenum=563, filename=0x40e29d18 "common/arm64_fatal.c", rtcb=0x418182a0) at misc/assert.c:687
#14 _assert (filename=filename@entry=0x40e29d18 "common/arm64_fatal.c", linenum=linenum@entry=563, msg=msg@entry=0x40e29d30 "panic", regs=0x411bc0a0 <g_last_regs>, regs@entry=0x0) at misc/assert.c:874
#15 0x0000000040290754 in arm64_fatal_handler (regs=0x0) at common/arm64_fatal.c:563
#16 0x0000000040d27278 in _vector_table () at common/arm64_vector_table.S:178
#17 0x0000000040370bac in hello_main (argc=argc@entry=1, argv=argv@entry=0x4191a940) at hello_main.c:40
#18 0x00000000402dbbd8 in nxtask_startup (entrypt=0x40370b80 <hello_main>, argc=1, argv=0x4191a940) at sched/task_startup.c:72
#19 0x00000000402a1d60 in nxtask_start () at task/task_start.c:116
#20 0x0000000000000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


