### PR TITLE
modlib:need add ctors to init_array and dtors to fini_array

### DIFF
--- a/libs/libc/modlib/gnu-elf.ld
+++ b/libs/libc/modlib/gnu-elf.ld
@@ -36,13 +36,16 @@ SECTIONS
   .init_array :
     {
       _sinit = .;
-      *(.init_array)
+      KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+      KEEP(*(.init_array .ctors))
       _einit = .;
     }
 
   .fini_array :
     {
-      *(.fini_array)
+      KEEP (*(.dtors))
+      KEEP (*(.fini_array))
+      KEEP (*(SORT(.fini_array.*)))
     }
 
   .rodata :


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

modlib:need add ctors to init_array and dtors to fini_array

## Impact

modlib

## Testing

esp32 with qemu run module, and pass it

