### PR TITLE
v9fs/CMakeLists.txt:Fix the problem that virtio-9p is not compiled 

### DIFF
--- a/fs/v9fs/CMakeLists.txt
+++ b/fs/v9fs/CMakeLists.txt
@@ -23,7 +23,7 @@
 if(CONFIG_FS_V9FS)
   set(V9FS client.c transport.c v9fs.c)
 
-  if(CONFIG_DRIVERS_VIRTIO_9P)
+  if(CONFIG_V9FS_VIRTIO_9P)
     list(APPEND V9FS virtio_9p.c)
   endif()
 


### PR DESCRIPTION
## Summary

This PR is a fix for the problem that v9fs does not correctly include virtio-9p.c in the compilation when compiled with cmake.

**Change:**
  change `CONFIG_DRIVERS_VIRTIO_9P` -> `CONFIG_V9FS_VIRTIO_9P`


## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

After this PR, virtio-9p can be compiled normally under cmake


