### PR TITLE
Remove "dumprun" functions from various LCD drivers

### DIFF
--- a/boards/arm/sam34/sam4e-ek/src/sam_ili9325.c
+++ b/boards/arm/sam34/sam4e-ek/src/sam_ili9325.c
@@ -538,39 +538,6 @@ static void sam_set_cursor(uint16_t col, uint16_t row)
 }
 
 /****************************************************************************
- * Name:  sam_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void sam_dumprun(const char *msg, uint16_t *run,
-                        size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  sam_disable_backlight
  *
  * Description:

--- a/boards/arm/sam34/sam4e-ek/src/sam_ili9341.c
+++ b/boards/arm/sam34/sam4e-ek/src/sam_ili9341.c
@@ -572,39 +572,6 @@ static inline sam_color_t sam_gram_read(void)
 }
 
 /****************************************************************************
- * Name:  sam_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void sam_dumprun(const char *msg, uint16_t *run,
-                        size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  sam_disable_backlight
  *
  * Description:

--- a/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
@@ -692,39 +692,6 @@ static int sam_setwindow(struct sam_dev_s *priv, sam_color_t row,
 }
 
 /****************************************************************************
- * Name:  sam_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void sam_dumprun(const char *msg, uint16_t *run,
-                        size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  sam_disable_backlight
  *
  * Description:

--- a/boards/arm/stm32/shenzhou/src/stm32_ili93xx.c
+++ b/boards/arm/stm32/shenzhou/src/stm32_ili93xx.c
@@ -809,39 +809,6 @@ static void stm32_setcursor(struct stm32_dev_s *priv,
 }
 
 /****************************************************************************
- * Name:  stm32_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void stm32_dumprun(const char *msg,
-                          uint16_t *run, size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  stm32_putrun
  *
  * Description:

--- a/boards/arm/stm32/stm3210e-eval/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm3210e-eval/src/stm32_lcd.c
@@ -670,39 +670,6 @@ static void stm3210e_setcursor(uint16_t col, uint16_t row)
 }
 
 /****************************************************************************
- * Name:  stm3210e_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void stm3210e_dumprun(const char *msg, uint16_t *run,
-                             size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  stm3210e_putrun
  *
  * Description:

--- a/boards/arm/stm32/stm3220g-eval/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm3220g-eval/src/stm32_lcd.c
@@ -509,39 +509,6 @@ static void stm3220g_setcursor(uint16_t col, uint16_t row)
 }
 
 /****************************************************************************
- * Name:  stm3220g_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void stm3220g_dumprun(const char *msg,
-                             uint16_t *run, size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  stm3220g_putrun
  *
  * Description:

--- a/boards/arm/stm32/stm3240g-eval/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm3240g-eval/src/stm32_lcd.c
@@ -508,39 +508,6 @@ static void stm3240g_setcursor(uint16_t col, uint16_t row)
 }
 
 /****************************************************************************
- * Name:  stm3240g_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void stm3240g_dumprun(const char *msg,
-                             uint16_t *run, size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_DEBUG, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_DEBUG, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_DEBUG, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  stm3240g_putrun
  *
  * Description:

--- a/drivers/lcd/mio283qt2.c
+++ b/drivers/lcd/mio283qt2.c
@@ -476,40 +476,6 @@ static void mio283qt2_setarea(FAR struct mio283qt2_lcd_s *lcd,
 }
 
 /****************************************************************************
- * Name:  mio283qt2_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void mio283qt2_dumprun(FAR const char *msg,
-                              FAR uint16_t *run,
-                              size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_INFO, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_INFO, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_INFO, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  mio283qt2_putrun
  *
  * Description:

--- a/drivers/lcd/mio283qt9a.c
+++ b/drivers/lcd/mio283qt9a.c
@@ -379,40 +379,6 @@ static void mio283qt9a_setarea(FAR struct mio283qt9a_lcd_s *lcd,
 }
 
 /****************************************************************************
- * Name:  mio283qt9a_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void mio283qt9a_dumprun(FAR const char *msg,
-                               FAR uint16_t *run,
-                               size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_INFO, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_INFO, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_INFO, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
-
-/****************************************************************************
  * Name:  mio283qt9a_putrun
  *
  * Description:

--- a/drivers/lcd/ra8875.c
+++ b/drivers/lcd/ra8875.c
@@ -245,14 +245,6 @@ static void ra8875_clearmem(FAR struct ra8875_lcd_s *lcd);
 
 /* LCD Data Transfer Methods */
 
-#if 0 /* Sometimes useful */
-static void ra8875_dumprun(FAR const char *msg,
-                           FAR uint16_t *run,
-                           size_t npixels);
-#else
-#  define ra8875_dumprun(m,r,n)
-#endif
-
 #ifdef CONFIG_DEBUG_LCD
 static void ra8875_showrun(FAR struct ra8875_dev_s *priv, fb_coord_t row,
                             fb_coord_t col, size_t npixels, bool put);

--- a/drivers/lcd/ssd1289.c
+++ b/drivers/lcd/ssd1289.c
@@ -281,13 +281,6 @@ static void ssd1289_setcursor(FAR struct ssd1289_lcd_s *lcd,
 
 /* LCD Data Transfer Methods */
 
-#if 0 /* Sometimes useful */
-static void ssd1289_dumprun(FAR const char *msg, FAR uint16_t *run,
-                            size_t npixels);
-#else
-#  define ssd1289_dumprun(m,r,n)
-#endif
-
 #ifdef CONFIG_DEBUG_LCD
 static void ssd1289_showrun(FAR struct ssd1289_dev_s *priv, fb_coord_t row,
                             fb_coord_t col, size_t npixels, bool put);
@@ -482,39 +475,6 @@ static void ssd1289_setcursor(FAR struct ssd1289_lcd_s *lcd,
   ssd1289_putreg(lcd, SSD1289_YADDR, column);    /* 0-319 */
 #endif
 }
-
-/****************************************************************************
- * Name:  ssd1289_dumprun
- *
- * Description:
- *   Dump the contexts of the run buffer:
- *
- *  run     - The buffer in containing the run read to be dumped
- *  npixels - The number of pixels to dump
- *
- ****************************************************************************/
-
-#if 0 /* Sometimes useful */
-static void ssd1289_dumprun(FAR const char *msg,
-                            FAR uint16_t *run, size_t npixels)
-{
-  int i;
-  int j;
-
-  syslog(LOG_INFO, "\n%s:\n", msg);
-  for (i = 0; i < npixels; i += 16)
-    {
-      up_putc(' ');
-      syslog(LOG_INFO, " ");
-      for (j = 0; j < 16; j++)
-        {
-          syslog(LOG_INFO, " %04x", *run++);
-        }
-
-      up_putc('\n');
-    }
-}
-#endif
 
 /****************************************************************************
  * Name:  ssd1289_showrun


### PR DESCRIPTION
## Summary

* It seems that they assume up_putc() and syslog() outputs to the same device. Depending on the system and configurations, it's wrong.

* They are wrapped with "#if 0" and unused.

Fixes https://github.com/apache/nuttx/issues/14694

## Impact

## Testing
