### PR TITLE
Fix typo errors in include/nuttx/clock.h

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -391,7 +391,7 @@ EXTERN volatile clock_t g_system_ticks;
  *
  * Input Parameters:
  *   ts1 and ts2: The two timespecs to be added
- *   t23: The location to return the result (may be ts1 or ts2)
+ *   ts3: The location to return the result (may be ts1 or ts2)
  *
  * Returned Value:
  *   None
@@ -422,7 +422,7 @@ EXTERN volatile clock_t g_system_ticks;
  *
  * Input Parameters:
  *   ts1 and ts2: The two timespecs to be subtracted (ts1 - ts2)
- *   t23: The location to return the result (may be ts1 or ts2)
+ *   ts3: The location to return the result (may be ts1 or ts2)
  *
  * Returned Value:
  *   None


### PR DESCRIPTION

## Summary
Fix typo errors in include/nuttx/clock.h

## Impact
none

## Testing
ci ostest

