### PR TITLE
arch/arm64: syscall SYS_switch_context and SYS_restore_context use tcb as parm

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -407,14 +407,15 @@ static inline void up_irq_restore(irqstate_t flags)
 #define up_update_task(t)      modify_sysreg(t, ~1ul, tpidr_el1)
 #define up_interrupt_context() (read_sysreg(tpidr_el1) & 1)
 
-#define up_switch_context(tcb, rtcb)                              \
-  do {                                                            \
-    if (!up_interrupt_context())                                  \
-      {                                                           \
-        sys_call2(SYS_switch_context, (uintptr_t)&rtcb->xcp.regs, \
-                  (uintptr_t)tcb->xcp.regs);                      \
-      }                                                           \
-  } while (0)
+#define up_switch_context(tcb, rtcb)                                      \
+  do                                                                      \
+    {                                                                     \
+      if (!up_interrupt_context())                                        \
+        {                                                                 \
+          sys_call2(SYS_switch_context, (uintptr_t)rtcb, (uintptr_t)tcb); \
+        }                                                                 \
+    }                                                                     \
+  while (0)
 
 /****************************************************************************
  * Name: up_getusrpc

--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -76,5 +76,5 @@ void up_exit(int status)
 
   /* Then switch contexts */
 
-  arm64_fullcontextrestore(tcb->xcp.regs);
+  arm64_fullcontextrestore(tcb);
 }

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -112,10 +112,10 @@
 
 /* Context switching */
 
-#define arm64_fullcontextrestore(restoreregs) \
+#define arm64_fullcontextrestore(next) \
   do \
     { \
-      sys_call1(SYS_restore_context, (uintptr_t)restoreregs); \
+      sys_call1(SYS_restore_context, (uintptr_t)next); \
     } \
   while (1)
 

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -160,5 +160,5 @@ retry:
   leave_critical_section(flags);
   rtcb->irqcount--;
 #endif
-  arm64_fullcontextrestore(rtcb->xcp.regs);
+  arm64_fullcontextrestore(rtcb);
 }


### PR DESCRIPTION

sys_call2(SYS_switch_context, (uintptr_t)rtcb, (uintptr_t)tcb) 
sys_call1(SYS_restore_context, (uintptr_t)next)


## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


