### PR TITLE
arch/risc-v: Add ARCH_HAVE_RAMFUNCS option for ESP32-C3

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -89,6 +89,7 @@ config ARCH_CHIP_ESP32C3
 	select ARCH_HAVE_BOOTLOADER
 	select ARCH_HAVE_PERF_EVENTS
 	select ARCH_HAVE_DEBUG
+	select ARCH_HAVE_RAMFUNCS
 	---help---
 		Espressif ESP32-C3 (RV32IMC).
 
@@ -119,6 +120,7 @@ config ARCH_CHIP_ESP32C3_GENERIC
 	select ESPRESSIF_SOC_RTC_MEM_SUPPORTED
 	select ARCH_CHIP_ESPRESSIF
 	select ARCH_HAVE_DEBUG
+	select ARCH_HAVE_RAMFUNCS
 	---help---
 		ESP32-C3 chip with a single RISC-V IMC core, no embedded Flash memory
 


### PR DESCRIPTION


## Summary

`ARCH_HAVE_RAMFUNCS` has no actual effect on the ESP32-C3, but ESP32-C3 has RAM functions, so select it to mark that is OK, and then we can also suppress the RWX memory region warning with https://github.com/apache/nuttx/pull/14724


## Impact
Minor
## Testing

CI and local machine

