### PR TITLE
cmake(bugfix):add missing source file for driver/serial and keep romfs cmake intermediate 

### DIFF
--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -155,8 +155,6 @@ function(nuttx_add_romfs)
             copy_directory ${PATH} romfs_${NAME} \; fi
     COMMAND genromfs -f ${IMGNAME} -d romfs_${NAME} -V ${NAME}
     COMMAND xxd -i ${IMGNAME} romfs_${NAME}.${EXTENSION}
-    COMMAND ${CMAKE_COMMAND} -E remove ${IMGNAME}
-    COMMAND ${CMAKE_COMMAND} -E remove_directory romfs_${NAME}
     COMMAND if ! [ -z "${NONCONST}" ]\; then sed -E -i'' -e
             "s/^unsigned/const unsigned/g" romfs_${NAME}.${EXTENSION} \; fi
     DEPENDS ${DEPENDS})

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -50,6 +50,10 @@ if(CONFIG_RPMSG_UART)
   list(APPEND SRCS uart_rpmsg.c)
 endif()
 
+if(CONFIG_UART_HOSTFS)
+  list(APPEND SRCS uart_hostfs.c)
+endif()
+
 # Pseudo-terminal support
 
 if(CONFIG_PSEUDOTERM)


### PR DESCRIPTION
## Summary

[Bugfix]
1. add missing driver/serial CMake build source
2.  keeping intermediate products of romfs target in the binary directory helps debugging

## Impact

bugfix

## Testing
CI check


