### PR TITLE
arm/olimex-stm32-p407: Fix kmodule board profile

### DIFF
--- a/boards/arm/stm32/olimex-stm32-p407/scripts/memory.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/memory.ld
@@ -94,7 +94,7 @@ MEMORY
 
   /* 112Kb of contiguous SRAM */
 
-  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 8K
-  usram (rwx)      : ORIGIN = 0x20002000, LENGTH = 8K
-  xsram (rwx)      : ORIGIN = 0x20008000, LENGTH = 96K
+  ksram (rwx)      : ORIGIN = 0x20000000, LENGTH = 16K
+  usram (rwx)      : ORIGIN = 0x20004000, LENGTH = 16K
+  xsram (rwx)      : ORIGIN = 0x2000a000, LENGTH = 80K
 }


### PR DESCRIPTION
## Summary

Just increase the ksram and usram to avoid compilation issue.

## Impact

Fix kmodule build

## Testing

Local building only
