### PR TITLE
Revert "SYSLOG_DEFAULT: wrap up_putc/up_nputs calls with critical sec…

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -268,10 +268,6 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
         {
           /* The following steps must be atomic with respect to serial
            * interrupt handling.
-           *
-           * This critical section is also used for the serialization
-           * with the up_putc-based syslog channels.
-           * See https://github.com/apache/nuttx/issues/14662
            */
 
           flags = enter_critical_section();


### PR DESCRIPTION
…tion"

## Summary

This reverts commit f2aeb5e56ff6ec7ba15958403289e462a8c84ab8.

Because regressions are reported:
* https://github.com/apache/nuttx/pull/14722#issuecomment-2470710236
* https://github.com/apache/nuttx/pull/14722#issuecomment-2470778673
* https://github.com/apache/nuttx/issues/14749

## Impact

## Testing

