### PR TITLE
fs_automount:fix ci break

### DIFF
--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -813,7 +813,7 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   FAR char *devpath = lib_get_pathbuffer();
   if (devpath == NULL)
     {
-      return;
+      return NULL;
     }
 #endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
 
@@ -826,6 +826,9 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
+#ifdef CONFIG_FS_AUTOMOUNTER_DRIVER
+      lib_put_pathbuffer(devpath);
+#endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
       return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fixed CI Break caused by https://github.com/apache/nuttx/pull/14632

```
==================================================================================== Configuration/Tool: spresense/example_camera,CONFIG_ARM_TOOLCHAIN_GNU_EABI 2024-11-12 12:24:37
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
mount/fs_automount.c: In function 'automount_initialize': Error: mount/fs_automount.c:816:7: error: 'return' with no value, in function returning non-void [-Werror=return-type]
  816 |       return;
      |       ^~~~~~
In file included from mount/fs_automount.c:43:
/github/workspace/sources/nuttx/include/nuttx/fs/automount.h:176:11: note: declared here
  176 | FAR void *automount_initialize(FAR const struct automount_lower_s *lower);
      |           ^~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): spresense/example_camera

```
Create version.h
CPP:  nxfonts_convert.c-> nxfonts_convert_32bpp.i LN: platform/board to /home/crafcat7/SSD/vela/apps/platform/dummy
Register: camera
Register: nsh
Register: sh
Register: msconn
Register: msdis
CPP:  /home/crafcat7/SSD/vela/nuttx/boards/arm/cxd56xx/spresense/scripts/ramconfig-new.ld-> /home/crafcat7/SSD/vela/nuttx/boards/arm/cxd56xx/spresense/scriptsLD: nuttx
Memory region         Used Size  Region Size  %age Used
             ram:      220228 B      1536 KB     14.00%
         gnssram:          0 GB       640 KB      0.00%
Generating: nuttx.spk
tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk;
File nuttx.spk is successfully created.
Done.
```


