### PR TITLE
libc/libc.csv: Fix signature of getpass

### DIFF
--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -109,7 +109,7 @@
 "getoptindp","unistd.h","","FAR int *"
 "getoptoptp","unistd.h","","FAR int *"
 "getpriority","sys/resource.h","","int","int","id_t"
-"getpass","unistd.h","","FAR const char *"
+"getpass","unistd.h","","FAR const char *","FAR char *"
 "getpwnam_r","pwd.h","","int","FAR const char *","FAR struct passwd *","FAR char *","size_t","FAR struct passwd **"
 "getpwuid_r","pwd.h","","int","uid_t","FAR struct passwd *","FAR char *","size_t","FAR struct passwd **"
 "getrandom","sys/random.h","!defined(CONFIG_BUILD_KERNEL)","ssize_t","FAR void *","size_t","unsigned int"


### PR DESCRIPTION

## Summary

Add missing parameter type to getpass signature,
and add missing const qualifier to the return value.


## Impact

syscall
## Testing

Local machine


