### PR TITLE
semaphore: Fix a few regressions

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -880,7 +880,7 @@ void nxsem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem)
 {
   /* Check our assumptions */
 
-  DEBUGASSERT(atomic_load(NXSEM_COUNT(sem)) <= 0);
+  DEBUGASSERT((int16_t)atomic_load(NXSEM_COUNT(sem)) <= 0);
 
   /* Adjust the priority of every holder as necessary */
 

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -85,7 +85,7 @@ void nxsem_recover(FAR struct tcb_s *tcb)
   if (tcb->task_state == TSTATE_WAIT_SEM)
     {
       FAR sem_t *sem = tcb->waitobj;
-      DEBUGASSERT(sem != NULL && atomic_load(NXSEM_COUNT(sem)) < 0);
+      DEBUGASSERT(sem != NULL && (int16_t)atomic_load(NXSEM_COUNT(sem)) < 0);
 
       /* Restore the correct priority of all threads that hold references
        * to this semaphore.

--- a/sched/semaphore/sem_reset.c
+++ b/sched/semaphore/sem_reset.c
@@ -81,7 +81,7 @@ int nxsem_reset(FAR sem_t *sem, int16_t count)
    * out counts to any waiting threads.
    */
 
-  while (atomic_load(NXSEM_COUNT(sem)) < 0 && count > 0)
+  while ((int16_t)atomic_load(NXSEM_COUNT(sem)) < 0 && count > 0)
     {
       /* Give out one counting, waking up one of the waiting threads
        * and, perhaps, kicking off a lot of priority inheritance

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -85,7 +85,7 @@ static int nxsem_wait_slow(FAR sem_t *sem)
 
   /* Check if the lock is available */
 
-  if (atomic_fetch_sub(NXSEM_COUNT(sem), 1) > 0)
+  if ((int16_t)atomic_fetch_sub(NXSEM_COUNT(sem), 1) > 0)
     {
       /* It is, let the task take the semaphore. */
 

--- a/sched/semaphore/sem_waitirq.c
+++ b/sched/semaphore/sem_waitirq.c
@@ -87,7 +87,7 @@ void nxsem_wait_irq(FAR struct tcb_s *wtcb, int errcode)
    * and already changed the task's state.
    */
 
-  DEBUGASSERT(sem != NULL && atomic_load(NXSEM_COUNT(sem)) < 0);
+  DEBUGASSERT(sem != NULL && (int16_t)atomic_load(NXSEM_COUNT(sem)) < 0);
 
   /* Restore the correct priority of all threads that hold references
    * to this semaphore.


### PR DESCRIPTION
## Summary

Regressions caused by signedness issues in
"sem: change sem wait to atomic operation".
(https://github.com/apache/nuttx/pull/14465)

An alternative would be to make these atomic macros propagate signedness using the typeof() GCC/clang extension. I'm not inclined to do so because typeof is not so portable though. As we can unlikely require "real" C11 atomics in the foreseeable future, maybe we should use a different set of names from C11 to avoid confusions.

## Impact

## Testing

esp32s3-devkit:smp ostest, with a few unrelated local changes.
