### PR TITLE
cmake(bugfix):remove no need target_link_library in static target

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -219,13 +219,6 @@ function(nuttx_add_application)
     # interface include and libraries
     foreach(dep ${DEPENDS})
       nuttx_add_dependencies(TARGET ${TARGET} DEPENDS ${dep})
-      if(TARGET ${dep})
-        get_target_property(dep_type ${dep} TYPE)
-        if(${dep_type} STREQUAL "STATIC_LIBRARY")
-          target_link_libraries(${TARGET} PRIVATE ${dep})
-        endif()
-      endif()
-
     endforeach()
   endif()
 endfunction()


### PR DESCRIPTION
## Summary

the `link_library` of the static target will cause PRIVATE to be inherited to nuttx, resulting in duplicate linking and definition problems. because all target static libraries will eventually be linked, there is no need to specify it explicitly.

```shell

# if app2 target call target_link_library(app1)
# casue dup link be like
ld --start-group libapp1.a libapp2.a libarch.a libboard.a --end-group libapp1.a 

``` 
If the static definition exceeds the linker group, there is a risk of multiple definition errors.

## Impact

should be compatible with all cmake build configurations

## Testing

cmake -B build -DBOARD_CONFIG=qemu-armv7a:nsh

build pass