### PR TITLE
xtensa: use up_interrupt_context() to determine if in interrupt context

### DIFF
--- a/arch/xtensa/src/common/xtensa_switchcontext.c
+++ b/arch/xtensa/src/common/xtensa_switchcontext.c
@@ -59,7 +59,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
   /* Are we in an interrupt handler? */
 
-  if (!up_current_regs())
+  if (!up_interrupt_context())
     {
       /* Switch context to the context of the task at the head of the
        * ready to run list.


### PR DESCRIPTION
## Summary

`up_interrupt_context` is more smp friendly

## Impact

context switch

## Testing

`esp32s3-devkit:smp` ostest


