### PR TITLE
Reapply "SYSLOG_DEFAULT: wrap up_putc/up_nputs calls with critical section" with a fix

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -268,6 +268,10 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
         {
           /* The following steps must be atomic with respect to serial
            * interrupt handling.
+           *
+           * This critical section is also used for the serialization
+           * with the up_putc-based syslog channels.
+           * See https://github.com/apache/nuttx/issues/14662
            */
 
           flags = enter_critical_section();


### PR DESCRIPTION
## Summary

Reapply "SYSLOG_DEFAULT: wrap up_putc/up_nputs calls with critical section" with a fix.

original change https://github.com/apache/nuttx/pull/14722
a revert https://github.com/apache/nuttx/pull/14751

## Impact

## Testing

- esp32-devkitc:wifi_smp (smp)
- esp32s3-devkit:smp (ostest, smp)
   (with https://github.com/apache/nuttx/pull/14755 and a few other unrelated local patches)
