### PR TITLE
boards/stm32f103-minimum: fix unaligned pointer to .data section in ld.script

### DIFF
--- a/boards/arm/stm32/stm32f103-minimum/scripts/ld.script
+++ b/boards/arm/stm32/stm32f103-minimum/scripts/ld.script
@@ -88,7 +88,7 @@ SECTIONS
         _etbss = ABSOLUTE(.);
     } > flash
 
-    _eronly = ABSOLUTE(.);
+    _eronly = LOADADDR(.data);
 
     /* The STM32F103C8T6 has 20Kb of SRAM beginning at the following address */
 


### PR DESCRIPTION

This patch fix _eronly value which is used during boot process to initialize .data section to sram.

Since .data section is 4 byte aligned in flash, also _eronly must follow this alignment to stay coherent with the start address of .data.

If one of the sections preceeding .data has a size which is not 4 byte aligned, the _eronly value does not match with .data physical address resulting in wrong copy of data section to sram and thus an almost immediate hardfault.

## Summary

This is a bugfix in linkerscript of stm32f103-minimum board.
_eronly is wrongly set and this caused data section to be copied to sram with additional garbage padding.
This happens when, for example, the .text section size is not a multiple of 4bytes (.text preceeds .data in elf map)
Similar bug has been fixed in e7ed720699e8698d83c2e582f46306d8d2fb69a6

## Impact

Currently this has no impact.
**There might be other boards with the same exact problem** and this seems to have originated in commit 2925c28f8f6168045be48196ca8f2db526fa969b , when ALIGN(4) has been added to some sections.

## Testing

### Test setup:
* arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009
* Dev system: ubuntu 22.04 64 bit
* nuttx master: e2a9c842607ba8286eefb108591d47f12ed2d8b1
* Board: stm32f103 "blupill"
* NuttX configuration: tools/configure.sh -l stm32f103-minimum:nsh

### Code to trigger the bug:
```
diff --git a/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c b/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
index 7849cb9e51..3a2fc17b8b 100644
--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
@@ -240,6 +240,8 @@ static int g_sensor_devno;
  *
  ****************************************************************************/
 
+const char msg[] = "as";
+
 int stm32_bringup(void)
 {
 #ifdef CONFIG_ONESHOT
@@ -578,5 +580,7 @@ int stm32_bringup(void)
   usbdev_adb_initialize();
 #endif
 
+  syslog(LOG_ERR, "msg: %s\n", msg);
+
   return ret;
 }
```

**Please note that in the code snippet, msg[] might be increased or decreased in order to have an unaligned .text size**

### Result (BUG)
uart:
�ABC

gdb:
Thread #1 (Suspended : Signal : SIGINT:Interrupt)
	stack_dump() at assert.c:182 0x800111c
	dump_stackinfo() at assert.c:232 0x8001392
	dump_stacks() at assert.c:329 0x8001392
	dump_running_task() at assert.c:653 0x8001392
	dump_assert_info() at assert.c:707 0x8001392
	_assert() at assert.c:892 0x8001392
	__assert() at lib_assert.c:38 0x8003fc6
	irq_unexpected_isr() at irq_unexpectedisr.c:56 0x80010c4
	arm_doirq() at arm_doirq.c:90 0x8000ba8
	exception_common() at arm_exception.S:214 0x80008e8

$ arm-none-eabi-readelf -a nuttx
...
Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x001000 0x08000000 0x08000000 0x0c3e7 0x0c3e7 R E 0x1000
  LOAD           0x00e000 0x20000000 0x0800c3e8 0x001a0 0x00f28 RW  0x1000
...
  1781: 0800c3e7     0 NOTYPE  GLOBAL DEFAULT  ABS _eronly

**Note that _eronly is wrongly set to 0x0800c3e7 instead of 0x0800c3e8**

### Result (BUGFIX)
uart:
ABCDF
msg: as

NuttShell (NSH) NuttX-12.6.0-RC1
nsh>

arm-none-eabi-readelf -a nuttx

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x001000 0x08000000 0x08000000 0x0c3e7 0x0c3e7 R E 0x1000
  LOAD           0x00e000 0x20000000 0x0800c3e8 0x001a0 0x00f28 RW  0x1000

  1781: 0800c3e8     0 NOTYPE  GLOBAL DEFAULT  ABS _eronly



