### PR TITLE
CI: Disable the failed macOS Builds

### DIFF
--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -33,6 +33,16 @@
 # macOS matter compilation is not currently supported
 -Darwin,sim:matter
 
+# macOS doesn't support cxxabi.h
+-Darwin,sim:libcxxtest
+
+# macOS doesn't support pipe2()
+-Darwin,sim:lua
+
+# macOS doesn't support --wrap flag
+# ld: unknown option: --wrap
+-Darwin,sim:note
+
 # Boards build by CMake
 CMake,sim:dynconns
 CMake,sim:fb

--- a/tools/ci/testlist/sim-03.dat
+++ b/tools/ci/testlist/sim-03.dat
@@ -24,6 +24,15 @@
 -Darwin,sim:usbdev
 -Darwin,sim:usbhost
 
+# macOS fails to patch quickjs-libc.c
+-Darwin,sim:quickjs
+
+# macOS fails at uintmax_t: 'unsigned long long' vs 'unsigned long'
+-Darwin,sim:rpproxy_virtio
+
+# macOS fails at uintmax_t: 'unsigned long long' vs 'unsigned long'
+-Darwin,sim:rpserver_virtio
+
 # Boards build by CMake
 CMake,sim:ostest
 CMake,sim:ostest_oneholder


### PR DESCRIPTION
## Summary

This PR disables the failed macOS Builds from CI Checks sim-02 and sim-03, so that the macOS CI Checks will complete successfully in the NuttX Mirror Repo:

- `sim:libcxxtest`: macOS doesn't support cxxabi.h

- `sim:lua`: macOS doesn't support pipe2()

- `sim:note`: macOS doesn't support `ld --wrap`

- `sim:quickjs`: macOS fails to patch quickjs-libc.c

- `sim:rpproxy_virtio`: macOS fails at uintmax_t `unsigned long long` vs `unsigned long`

- `sim:rpserver_virtio`: macOS fails at uintmax_t `unsigned long long` vs `unsigned long`

## Impact

With this PR, macOS CI Checks will complete successfully in the [NuttX Mirror Repo](https://github.com/NuttX/nuttx/actions/workflows/build.yml).

## Testing

The macOS CI Checks completed successfully in our Test Repo:
https://github.com/lupyuen5/label-nuttx/actions/runs/11828738112
