### PR TITLE
update stream relative, fix mtd&blk stream readback before block update. decrese int use in stream to handle FS_LARGEFILE

### DIFF
--- a/boards/arm/sama5/sama5d4-ek/src/at25_main.c
+++ b/boards/arm/sama5/sama5d4-ek/src/at25_main.c
@@ -182,7 +182,7 @@ int at25_main(int argc, char *argv[])
   /* The HEX file load was successful, write the data to FLASH */
 
   printf("Successfully loaded the Intel HEX file into memory...\n");
-  printf("  Writing %d bytes to the AT25 Serial FLASH\n",
+  printf("  Writing %" PRIdOFF " bytes to the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   remaining = memoutstream.common.nput;
@@ -215,7 +215,7 @@ int at25_main(int argc, char *argv[])
    * the same.
    */
 
-  printf("  Verifying %d bytes in the AT25 Serial FLASH\n",
+  printf("  Verifying %" PRIdOFF " bytes in the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   /* Open the AT25 device for writing */
@@ -254,7 +254,7 @@ int at25_main(int argc, char *argv[])
         {
           if (memcmp(g_iobuffer, src, nread) != 0)
             {
-              fprintf(stderr, "ERROR: Verify failed at offset %d\n",
+              fprintf(stderr, "ERROR: Verify failed at offset %"PRIdOFF"\n",
                       memoutstream.common.nput - remaining);
               close(fd);
               return EXIT_FAILURE;
@@ -266,7 +266,7 @@ int at25_main(int argc, char *argv[])
     }
   while (remaining > 0);
 
-  printf("  Successfully verified %d bytes in the AT25 Serial FLASH\n",
+  printf("Successfully verified %"PRIdOFF" bytes in the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   close(fd);

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -74,19 +74,19 @@
 /* These are the generic representations of a streams used by the NuttX */
 
 struct lib_instream_s;
-typedef CODE int  (*lib_getc_t)(FAR struct lib_instream_s *self);
-typedef CODE int  (*lib_gets_t)(FAR struct lib_instream_s *self,
-                                FAR void *buf, int len);
+typedef CODE int     (*lib_getc_t)(FAR struct lib_instream_s *self);
+typedef CODE ssize_t (*lib_gets_t)(FAR struct lib_instream_s *self,
+                                   FAR void *buf, size_t len);
 
 struct lib_outstream_s;
-typedef CODE void (*lib_putc_t)(FAR struct lib_outstream_s *self, int ch);
-typedef CODE int  (*lib_puts_t)(FAR struct lib_outstream_s *self,
-                                FAR const void *buf, int len);
-typedef CODE int  (*lib_flush_t)(FAR struct lib_outstream_s *self);
+typedef CODE void    (*lib_putc_t)(FAR struct lib_outstream_s *self, int ch);
+typedef CODE ssize_t (*lib_puts_t)(FAR struct lib_outstream_s *self,
+                                   FAR const void *buf, size_t len);
+typedef CODE int     (*lib_flush_t)(FAR struct lib_outstream_s *self);
 
 struct lib_instream_s
 {
-  int                    nget;    /* Total number of characters gotten.  Written
+  off_t                  nget;    /* Total number of characters gotten.  Written
                                    * by get method, readable by user */
   lib_getc_t             getc;    /* Get one character from the instream */
   lib_gets_t             gets;    /* Get the string from the instream */
@@ -94,7 +94,7 @@ struct lib_instream_s
 
 struct lib_outstream_s
 {
-  int                    nput;    /* Total number of characters put.  Written
+  off_t                  nput;    /* Total number of characters put.  Written
                                    * by put method, readable by user */
   lib_putc_t             putc;    /* Put one character to the outstream */
   lib_puts_t             puts;    /* Writes the string to the outstream */
@@ -104,23 +104,24 @@ struct lib_outstream_s
 /* Seek-able streams */
 
 struct lib_sistream_s;
-typedef CODE int   (*lib_sigetc_t)(FAR struct lib_sistream_s *self);
-typedef CODE int   (*lib_sigets_t)(FAR struct lib_sistream_s *self,
-                                   FAR void *buf, int len);
-typedef CODE off_t (*lib_siseek_t)(FAR struct lib_sistream_s *self,
-                                   off_t offset, int whence);
+typedef CODE int     (*lib_sigetc_t)(FAR struct lib_sistream_s *self);
+typedef CODE ssize_t (*lib_sigets_t)(FAR struct lib_sistream_s *self,
+                                     FAR void *buf, size_t len);
+typedef CODE off_t   (*lib_siseek_t)(FAR struct lib_sistream_s *self,
+                                     off_t offset, int whence);
 
 struct lib_sostream_s;
-typedef CODE void  (*lib_soputc_t)(FAR struct lib_sostream_s *self, int ch);
-typedef CODE int   (*lib_soputs_t)(FAR struct lib_sostream_s *self,
-                                   FAR const void *buf, int len);
-typedef CODE int   (*lib_soflush_t)(FAR struct lib_sostream_s *self);
-typedef CODE off_t (*lib_soseek_t)(FAR struct lib_sostream_s *self,
-                                   off_t offset, int whence);
+typedef CODE void    (*lib_soputc_t)(FAR struct lib_sostream_s *self,
+                                     int ch);
+typedef CODE ssize_t (*lib_soputs_t)(FAR struct lib_sostream_s *self,
+                                     FAR const void *buf, size_t len);
+typedef CODE int     (*lib_soflush_t)(FAR struct lib_sostream_s *self);
+typedef CODE off_t   (*lib_soseek_t)(FAR struct lib_sostream_s *self,
+                                     off_t offset, int whence);
 
 struct lib_sistream_s
 {
-  int                    nget;    /* Total number of characters gotten.  Written
+  off_t                  nget;    /* Total number of characters gotten.  Written
                                    * by get method, readable by user */
   lib_sigetc_t           getc;    /* Get one character from the instream */
   lib_gets_t             gets;    /* Get the string from the instream */
@@ -129,7 +130,7 @@ struct lib_sistream_s
 
 struct lib_sostream_s
 {
-  int                    nput;    /* Total number of characters put.  Written
+  off_t                  nput;    /* Total number of characters put.  Written
                                    * by put method, readable by user */
   lib_soputc_t           putc;    /* Put one character to the outstream */
   lib_soputs_t           puts;    /* Writes the string to the outstream */
@@ -157,7 +158,7 @@ struct lib_memsistream_s
 {
   struct lib_sistream_s  common;
   FAR const char        *buffer;  /* Address of first byte in the buffer */
-  size_t                 offset;  /* Current buffer offset in bytes */
+  off_t                  offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
@@ -165,7 +166,7 @@ struct lib_memsostream_s
 {
   struct lib_sostream_s  common;
   FAR char              *buffer;  /* Address of first byte in the buffer */
-  size_t                 offset;  /* Current buffer offset in bytes */
+  off_t                  offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
@@ -231,7 +232,7 @@ struct lib_bufferedoutstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   char                        buffer[CONFIG_STREAM_OUT_BUFFER_SIZE];
 };
 
@@ -239,7 +240,7 @@ struct lib_hexdumpstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   char                        buffer[CONFIG_STREAM_HEXDUMP_BUFFER_SIZE + 1];
 };
 
@@ -247,9 +248,9 @@ struct lib_base64outstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   unsigned char               bytes[3];
-  int                         nbytes;
+  size_t                      nbytes;
   char                        buffer[CONFIG_STREAM_BASE64_BUFFER_SIZE + 1];
 };
 
@@ -269,7 +270,7 @@ struct lib_syslograwstream_s
   struct lib_outstream_s common;
 #ifdef CONFIG_SYSLOG_BUFFER
   char buffer[CONFIG_SYSLOG_BUFSIZE];
-  int  offset;
+  off_t offset;
 #endif
   int last_ch;
 };
@@ -282,7 +283,7 @@ struct lib_lzfoutstream_s
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
   lzf_state_t                 state;
-  size_t                      offset;
+  off_t                       offset;
   char                        in[LZF_STREAM_BLOCKSIZE];
   char                        out[LZF_MAX_HDR_SIZE + LZF_STREAM_BLOCKSIZE];
 };
@@ -354,13 +355,13 @@ extern struct lib_outstream_s g_lowoutstream;
  ****************************************************************************/
 
 void lib_meminstream(FAR struct lib_meminstream_s *stream,
-                     FAR const char *bufstart, int buflen);
+                     FAR const char *bufstart, size_t buflen);
 void lib_memoutstream(FAR struct lib_memoutstream_s *stream,
-                      FAR char *bufstart, int buflen);
+                      FAR char *bufstart, size_t buflen);
 void lib_memsistream(FAR struct lib_memsistream_s *stream,
-                     FAR const char *bufstart, int buflen);
+                     FAR const char *bufstart, size_t buflen);
 void lib_memsostream(FAR struct lib_memsostream_s *stream,
-                     FAR char *bufstart, int buflen);
+                     FAR char *bufstart, size_t buflen);
 
 /****************************************************************************
  * Name: lib_stdinstream, lib_stdoutstream

--- a/libs/libc/obstack/lib_obstack_vprintf.c
+++ b/libs/libc/obstack/lib_obstack_vprintf.c
@@ -42,8 +42,8 @@ struct obstack_stream
  * Private Functions
  ****************************************************************************/
 
-static int obstack_puts(FAR struct lib_outstream_s *self,
-    FAR const void *buf, int len)
+static ssize_t obstack_puts(FAR struct lib_outstream_s *self,
+                            FAR const void *buf, size_t len)
 {
   FAR struct obstack_stream *stream = (FAR struct obstack_stream *)self;
 

--- a/libs/libc/stream/lib_base64outstream.c
+++ b/libs/libc/stream/lib_base64outstream.c
@@ -82,18 +82,18 @@ static void base64stream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: base64stream_puts
  ****************************************************************************/
 
-static int base64stream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t base64stream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_base64outstream_s *stream = (FAR void *)self;
   FAR const unsigned char *input = (FAR const unsigned char *)buf;
-  int remaining = len;
+  size_t remaining = len;
 
   if (stream->nbytes)
     {
       /* Flush the first three bytes */
 
-      int n = 3 - stream->nbytes;
+      size_t n = 3 - stream->nbytes;
       if (n > remaining)
         {
           n = remaining;
@@ -118,8 +118,9 @@ static int base64stream_puts(FAR struct lib_outstream_s *self,
 
   while (remaining >= 3)
     {
-      int outlen;
-      int n = (STREAM_BASE64_BUFFER_SIZE - stream->pending) / 4 * 3;
+      size_t outlen;
+      size_t n = (STREAM_BASE64_BUFFER_SIZE - stream->pending) / 4 * 3;
+
       if (n > remaining)
         {
           n = remaining / 3 * 3;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -104,11 +104,14 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
         }
       else if (remain < sectorsize)
         {
-          /* Set content to all 0 before caching,
-           * so no random content will be flushed
-           */
+          /* Read sector back to keep as more as possible old data */
 
-          memset(stream->cache, 0, sectorsize);
+          ret = inode->u.i_bops->read(inode, stream->cache, sector, 1);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -65,8 +65,8 @@ static int blkoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: blkoutstream_puts
  ****************************************************************************/
 
-static int blkoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_blkoutstream_s *stream =
                                  (FAR struct lib_blkoutstream_s *)self;
@@ -74,12 +74,12 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
   FAR struct inode *inode = stream->inode;
   FAR const unsigned char *ptr = buf;
   size_t remain = len;
-  int ret;
+  ssize_t ret;
 
   while (remain > 0)
     {
-      size_t sector = self->nput / sectorsize;
-      size_t offset = self->nput % sectorsize;
+      off_t sector = self->nput / sectorsize;
+      off_t offset = self->nput % sectorsize;
 
       if (offset > 0)
         {

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -174,6 +174,7 @@ void lib_blkoutstream_close(FAR struct lib_blkoutstream_s *stream)
 
       if (stream->cache != NULL)
         {
+          blkoutstream_flush(&stream->common);
           lib_free(stream->cache);
           stream->cache = NULL;
         }

--- a/libs/libc/stream/lib_bufferedoutstream.c
+++ b/libs/libc/stream/lib_bufferedoutstream.c
@@ -63,12 +63,12 @@ static int bufferedoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: bufferedoutstream_puts
  ****************************************************************************/
 
-static int bufferedoutstream_puts(FAR struct lib_outstream_s *self,
-                                 FAR const void *buf, int len)
+static ssize_t bufferedoutstream_puts(FAR struct lib_outstream_s *self,
+                                      FAR const void *buf, size_t len)
 {
   FAR struct lib_bufferedoutstream_s *stream =
     (FAR struct lib_bufferedoutstream_s *)self;
-  int ret = len;
+  size_t ret = len;
 
   if (stream->pending + len <= CONFIG_STREAM_OUT_BUFFER_SIZE)
     {

--- a/libs/libc/stream/lib_fileoutstream.c
+++ b/libs/libc/stream/lib_fileoutstream.c
@@ -42,12 +42,12 @@
  * Name: rawoutstream_puts
  ****************************************************************************/
 
-static int fileoutstream_puts(FAR struct lib_outstream_s *self,
-                              FAR const void *buf, int len)
+static ssize_t fileoutstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_fileoutstream_s *stream =
                                   (FAR struct lib_fileoutstream_s *)self;
-  int nwritten;
+  ssize_t nwritten;
 
   do
     {

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -100,7 +100,7 @@ static int hexdumpstream_flush(FAR struct lib_outstream_s *self)
 static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
-  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  size_t outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
   const uint8_t byte = ch;
 
   bin2hex(&byte, 1, stream->buffer + stream->pending,
@@ -120,15 +120,15 @@ static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: hexdumpstream_puts
  ****************************************************************************/
 
-static int hexdumpstream_puts(FAR struct lib_outstream_s *self,
-                           FAR const void *buf, int len)
+static ssize_t hexdumpstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
   const unsigned char *p = buf;
-  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
-  int line = outlen / 2;
-  int remain = len;
-  int ret;
+  size_t outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  size_t line = outlen / 2;
+  size_t remain = len;
+  ssize_t ret;
 
   while (remain > 0)
     {

--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -40,8 +40,8 @@
  ****************************************************************************/
 
 static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch);
-static int lowoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len);
+static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len);
 
 /****************************************************************************
  * Public Data
@@ -79,8 +79,8 @@ static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: lowoutstream_puts
  ****************************************************************************/
 
-static int lowoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   DEBUGASSERT(self);
 

--- a/libs/libc/stream/lib_lzfcompress.c
+++ b/libs/libc/stream/lib_lzfcompress.c
@@ -64,8 +64,8 @@ static int lzfoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: lzfoutstream_puts
  ****************************************************************************/
 
-static int lzfoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t lzfoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_lzfoutstream_s *stream =
                                  (FAR struct lib_lzfoutstream_s *)self;
@@ -74,7 +74,7 @@ static int lzfoutstream_puts(FAR struct lib_outstream_s *self,
   size_t total = len;
   size_t copyin;
   size_t outlen;
-  int ret;
+  ssize_t ret;
 
   while (total > 0)
     {

--- a/libs/libc/stream/lib_meminstream.c
+++ b/libs/libc/stream/lib_meminstream.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 
 #include "libc.h"
@@ -41,7 +42,7 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
 {
   FAR struct lib_meminstream_s *stream =
                                        (FAR struct lib_meminstream_s *)self;
-  int ret;
+  int ret = -EINVAL;
 
   DEBUGASSERT(self);
 
@@ -52,10 +53,6 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
       ret = stream->buffer[self->nget];
       self->nget++;
     }
-  else
-    {
-      ret = EOF;
-    }
 
   return ret;
 }
@@ -64,12 +61,12 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
  * Name: meminstream_gets
  ****************************************************************************/
 
-static int meminstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t meminstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_meminstream_s *stream =
                                        (FAR struct lib_meminstream_s *)self;
-  int ret;
+  ssize_t ret = -EINVAL;
 
   DEBUGASSERT(self);
 
@@ -81,10 +78,6 @@ static int meminstream_gets(FAR struct lib_instream_s *self,
             stream->buflen - self->nget : len;
       self->nget += ret;
       memcpy(buffer, stream->buffer, ret);
-    }
-  else
-    {
-      ret = EOF;
     }
 
   return ret;
@@ -112,7 +105,7 @@ static int meminstream_gets(FAR struct lib_instream_s *self,
  ****************************************************************************/
 
 void lib_meminstream(FAR struct lib_meminstream_s *stream,
-                     FAR const char *bufstart, int buflen)
+                     FAR const char *bufstart, size_t buflen)
 {
   stream->common.getc = meminstream_getc;
   stream->common.gets = meminstream_gets;

--- a/libs/libc/stream/lib_memoutstream.c
+++ b/libs/libc/stream/lib_memoutstream.c
@@ -36,12 +36,12 @@
  * Name: memoutstream_puts
  ****************************************************************************/
 
-static int memoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t memoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_memoutstream_s *stream =
                                 (FAR struct lib_memoutstream_s *)self;
-  int ncopy;
+  size_t ncopy;
 
   DEBUGASSERT(self);
 
@@ -94,7 +94,7 @@ static void memoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  ****************************************************************************/
 
 void lib_memoutstream(FAR struct lib_memoutstream_s *outstream,
-                      FAR char *bufstart, int buflen)
+                      FAR char *bufstart, size_t buflen)
 {
   outstream->common.putc  = memoutstream_putc;
   outstream->common.puts  = memoutstream_puts;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -77,8 +77,8 @@ static int mtdoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: mtdoutstream_puts
  ****************************************************************************/
 
-static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t mtdoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_mtdoutstream_s *stream =
     (FAR struct lib_mtdoutstream_s *)self;
@@ -87,7 +87,7 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
   size_t erasesize = stream->geo.erasesize;
   size_t nblkpererase = erasesize / stream->geo.blocksize;
   size_t remain = len;
-  int ret;
+  ssize_t ret;
 
   if (self->nput + len > erasesize * stream->geo.neraseblocks)
     {
@@ -96,8 +96,8 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 
   while (remain > 0)
     {
-      size_t sblock = self->nput / erasesize;
-      size_t offset = self->nput % erasesize;
+      off_t sblock = self->nput / erasesize;
+      off_t offset = self->nput % erasesize;
 
       if (offset > 0)
         {

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -240,6 +240,7 @@ void lib_mtdoutstream_close(FAR struct lib_mtdoutstream_s *stream)
 
       if (stream->cache != NULL)
         {
+          mtdoutstream_flush(&stream->common);
           lib_free(stream->cache);
           stream->cache = NULL;
         }

--- a/libs/libc/stream/lib_nullinstream.c
+++ b/libs/libc/stream/lib_nullinstream.c
@@ -36,15 +36,15 @@
 static int nullinstream_getc(FAR struct lib_instream_s *self)
 {
   UNUSED(self);
-  return EOF;
+  return -EINVAL;
 }
 
-static int nullinstream_gets(FAR struct lib_instream_s *self,
-                             FAR void *buffer, int len)
+static ssize_t nullinstream_gets(FAR struct lib_instream_s *self,
+                                 FAR void *buffer, size_t len)
 {
   UNUSED(buffer);
   UNUSED(len);
-  return EOF;
+  return -EINVAL;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_nulloutstream.c
+++ b/libs/libc/stream/lib_nulloutstream.c
@@ -41,8 +41,8 @@ static void nulloutstream_putc(FAR struct lib_outstream_s *self, int ch)
   self->nput++;
 }
 
-static int nulloutstream_puts(FAR struct lib_outstream_s *self,
-                              FAR const void *buffer, int len)
+static ssize_t nulloutstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buffer, size_t len)
 {
   UNUSED(buffer);
   UNUSED(len);

--- a/libs/libc/stream/lib_rawinstream.c
+++ b/libs/libc/stream/lib_rawinstream.c
@@ -59,26 +59,22 @@ static int rawinstream_getc(FAR struct lib_instream_s *self)
       self->nget++;
       return ch;
     }
-
-  /* Return EOF on any failure to read from the incoming byte stream. The
-   * only expected error is EINTR meaning that the read was interrupted
-   * by a signal.  A Zero return value would indicate an end-of-file
-   * condition.
-   */
-
-  return EOF;
+  else
+    {
+      return _NX_GETERRVAL(nread);
+    }
 }
 
 /****************************************************************************
  * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawinstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t rawinstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_rawinstream_s *stream =
                                        (FAR struct lib_rawinstream_s *)self;
-  int nread;
+  ssize_t nread;
 
   DEBUGASSERT(self && stream->fd >= 0);
 

--- a/libs/libc/stream/lib_rawoutstream.c
+++ b/libs/libc/stream/lib_rawoutstream.c
@@ -42,12 +42,12 @@
  * Name: rawoutstream_puts
  ****************************************************************************/
 
-static int rawoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t rawoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_rawoutstream_s *stream =
                                 (FAR struct lib_rawoutstream_s *)self;
-  int nwritten = 0;
+  ssize_t nwritten = 0;
 
   do
     {

--- a/libs/libc/stream/lib_rawsistream.c
+++ b/libs/libc/stream/lib_rawsistream.c
@@ -59,26 +59,22 @@ static int rawsistream_getc(FAR struct lib_sistream_s *self)
       self->nget++;
       return ch;
     }
-
-  /* Return EOF on any failure to read from the incoming byte stream. The
-   * only expected error is EINTR meaning that the read was interrupted
-   * by a signal.  A Zero return value would indicated an end-of-file
-   * confition.
-   */
-
-  return EOF;
+  else
+    {
+      return _NX_GETERRVAL(nread);
+    }
 }
 
 /****************************************************************************
  * Name: rawsistream_gets
  ****************************************************************************/
 
-static int rawsistream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t rawsistream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_rawsistream_s *stream =
                                        (FAR struct lib_rawsistream_s *)self;
-  int nread;
+  ssize_t nread;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -108,7 +104,13 @@ static off_t rawsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                                        (FAR struct lib_rawsistream_s *)self;
 
   DEBUGASSERT(self);
-  return _NX_SEEK(stream->fd, offset, whence);
+  offset = _NX_SEEK(stream->fd, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_rawsostream.c
+++ b/libs/libc/stream/lib_rawsostream.c
@@ -47,7 +47,7 @@ static void rawsostream_putc(FAR struct lib_sostream_s *self, int ch)
   FAR struct lib_rawsostream_s *stream =
                                        (FAR struct lib_rawsostream_s *)self;
   char buffer = ch;
-  int nwritten;
+  ssize_t nwritten;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -79,12 +79,12 @@ static void rawsostream_putc(FAR struct lib_sostream_s *self, int ch)
  * Name: rawsostream_puts
  ****************************************************************************/
 
-static int rawsostream_puts(FAR struct lib_sostream_s *self,
-                            FAR const void *buffer, int len)
+static ssize_t rawsostream_puts(FAR struct lib_sostream_s *self,
+                                FAR const void *buffer, size_t len)
 {
   FAR struct lib_rawsostream_s *stream =
                                        (FAR struct lib_rawsostream_s *)self;
-  int nwritten;
+  ssize_t nwritten;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -125,7 +125,13 @@ static off_t rawsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                                        (FAR struct lib_rawsostream_s *)self;
 
   DEBUGASSERT(self);
-  return _NX_SEEK(stream->fd, offset, whence);
+  offset = _NX_SEEK(stream->fd, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_stdinstream.c
+++ b/libs/libc/stream/lib_stdinstream.c
@@ -60,12 +60,12 @@ static int stdinstream_getc(FAR struct lib_instream_s *self)
  * Name: stdinstream_gets
  ****************************************************************************/
 
-static int stdinstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t stdinstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_stdinstream_s *stream =
                                        (FAR struct lib_stdinstream_s *)self;
-  int nread = 0;
+  ssize_t nread = 0;
 
   DEBUGASSERT(self);
 

--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -71,12 +71,12 @@ static void stdoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: stdoutstream_puts
  ****************************************************************************/
 
-static int stdoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buffer, int len)
+static ssize_t stdoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buffer, size_t len)
 {
   FAR struct lib_stdoutstream_s *stream =
                                (FAR struct lib_stdoutstream_s *)self;
-  int result;
+  ssize_t result;
 
   DEBUGASSERT(self && stream->handle);
 

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -59,12 +59,12 @@ static int stdsistream_getc(FAR struct lib_sistream_s *self)
  * Name: stdsistream_gets
  ****************************************************************************/
 
-static int stdsistream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t stdsistream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_stdsistream_s *stream =
                                         (FAR struct lib_stdsistream_s *)self;
-  int nread = 0;
+  ssize_t nread = 0;
 
   DEBUGASSERT(self);
 
@@ -94,7 +94,13 @@ static off_t stdsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                                         (FAR struct lib_stdsistream_s *)self;
 
   DEBUGASSERT(self);
-  return fseek(stream->handle, offset, whence);
+  offset = fseek(stream->handle, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_stdsostream.c
+++ b/libs/libc/stream/lib_stdsostream.c
@@ -70,12 +70,12 @@ static void stdsostream_putc(FAR struct lib_sostream_s *self, int ch)
  * Name: stdsostream_puts
  ****************************************************************************/
 
-static int stdsostream_puts(FAR struct lib_sostream_s *self,
-                            FAR const void *buffer, int len)
+static ssize_t stdsostream_puts(FAR struct lib_sostream_s *self,
+                                FAR const void *buffer, size_t len)
 {
   FAR struct lib_stdsostream_s *stream =
                                         (FAR struct lib_stdsostream_s *)self;
-  int result;
+  ssize_t result;
 
   DEBUGASSERT(self && stream->handle);
 
@@ -129,7 +129,13 @@ static off_t stdsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                                         (FAR struct lib_stdsostream_s *)self;
 
   DEBUGASSERT(stream != NULL && stream->handle != NULL);
-  return fseek(stream->handle, offset, whence);
+  offset = fseek(stream->handle, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -102,15 +102,15 @@ static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
  * Name: syslograwstream_addstring
  ****************************************************************************/
 
-static int
+static ssize_t
 syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
-                          FAR const char *buff, int len)
+                          FAR const char *buff, size_t len)
 {
-  int ret = 0;
+  ssize_t ret = 0;
 
   do
     {
-      int remain = CONFIG_SYSLOG_BUFSIZE - stream->offset;
+      size_t remain = CONFIG_SYSLOG_BUFSIZE - stream->offset;
       remain = remain > len - ret ? len - ret : remain;
       memcpy(stream->buffer + stream->offset, buff + ret, remain);
       stream->offset += remain;
@@ -183,8 +183,8 @@ static void syslograwstream_putc(FAR struct lib_outstream_s *self, int ch)
     }
 }
 
-static int syslograwstream_puts(FAR struct lib_outstream_s *self,
-                                FAR const void *buff, int len)
+static ssize_t syslograwstream_puts(FAR struct lib_outstream_s *self,
+                                    FAR const void *buff, size_t len)
 {
   FAR struct lib_syslograwstream_s *stream = (FAR void *)self;
 
@@ -202,7 +202,7 @@ static int syslograwstream_puts(FAR struct lib_outstream_s *self,
 
   return syslograwstream_addstring(stream, buff, len);
 #else
-  int ret;
+  ssize_t ret;
 
   /* Try writing until the write was successful or until an
    * irrecoverable error occurs.

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -49,8 +49,8 @@ static void syslogstream_putc(FAR struct lib_outstream_s *self, int ch)
   stream->common.nput++;
 }
 
-static int syslogstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buff, int len)
+static ssize_t syslogstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buff, size_t len)
 {
   FAR struct lib_syslogstream_s *stream =
                                        (FAR struct lib_syslogstream_s *)self;
@@ -61,7 +61,7 @@ static int syslogstream_puts(FAR struct lib_outstream_s *self,
       return 0;
     }
 
-  syslog(stream->priority, "%.*s", len, (FAR const char *)buff);
+  syslog(stream->priority, "%.*s", (int)len, (FAR const char *)buff);
   return len;
 }
 

--- a/libs/libc/stream/lib_zeroinstream.c
+++ b/libs/libc/stream/lib_zeroinstream.c
@@ -38,8 +38,8 @@ static int zeroinstream_getc(FAR struct lib_instream_s *self)
   return 0;
 }
 
-static int zeroinstream_gets(FAR struct lib_instream_s *self,
-                             FAR void *buffer, int len)
+static ssize_t zeroinstream_gets(FAR struct lib_instream_s *self,
+                                 FAR void *buffer, size_t len)
 {
   self->nget += len;
   memset(buffer, 0, len);


### PR DESCRIPTION
## Summary
int is not reliable when we use same code for cross platform.
replace with off_t,size_t,ssize_t should prefer.

offset int -> offset, len int -> size_t, ret int -> ssize_t

Also we should readback sector/block before operate to new sector/block,
for user only update partial case.

## Impact
stream will able to support FS_LARGEFILE better cover >4GB devices.
if user use blk/mtd stream to update partial, the old data will be kept back.

## Testing
CI-test, local arm-v8m prject, qemu-armv8a, ubutun sim:nsh

