### PR TITLE
cmake(bugfix):fix libcxx build error cause by layout changed

### DIFF
--- a/libs/libxx/libcxx/CMakeLists.txt
+++ b/libs/libxx/libcxx/CMakeLists.txt
@@ -84,6 +84,10 @@ if(CONFIG_LIBCXX)
     add_compile_definitions(__GLIBCXX__)
   endif()
 
+  if(CONFIG_LIBCXXABI)
+    add_compile_definitions(LIBCXX_BUILDING_LIBCXXABI)
+  endif()
+
   set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS ON)

--- a/libs/libxx/libcxxabi/CMakeLists.txt
+++ b/libs/libxx/libcxxabi/CMakeLists.txt
@@ -75,7 +75,14 @@ if(CONFIG_LIBCXXABI)
     cxa_thread_atexit.cpp
     cxa_vector.cpp
     cxa_virtual.cpp)
+  add_compile_definitions(_LIBCPP_BUILDING_LIBRARY)
+  if(CONFIG_LIBSUPCXX_TOOLCHAIN)
+    add_compile_definitions(__GLIBCXX__)
+  endif()
 
+  if(CONFIG_LIBSUPCXX)
+    add_compile_definitions(__GLIBCXX__)
+  endif()
   # C++ STL files
   list(APPEND SRCS stdlib_exception.cpp stdlib_new_delete.cpp
        stdlib_stdexcept.cpp stdlib_typeinfo.cpp)
@@ -120,6 +127,6 @@ if(CONFIG_LIBCXXABI)
 
   target_sources(libcxxabi PRIVATE ${TARGET_SRCS})
   target_include_directories(
-    libcxxabi BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR}/libcxxabi/include
-                             ${CMAKE_CURRENT_LIST_DIR}/libcxx/src)
+    libcxxabi BEFORE PRIVATE ${NUTTX_DIR}/libs/libxx/libcxx/libcxx/src
+                             ${CMAKE_CURRENT_LIST_DIR}/libcxxabi/include)
 endif()


### PR DESCRIPTION
## Summary

PR https://github.com/apache/nuttx/pull/14668 caused a build error after adjusting the layout.
This commit fixes this problem

```
/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_exception.h:47:10: error: 'unexpected_handler' in namespace 'std' does not name a type
   47 |     std::unexpected_handler unexpectedHandler;
      |          ^~~~~~~~~~~~~~~~~~
/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_exception.h:85:10: error: 'unexpected_handler' in namespace 'std' does not name a type
   85 |     std::unexpected_handler unexpectedHandler;
      |          ^~~~~~~~~~~~~~~~~~
/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_exception.h:121:65: error: static assertion failed: propagationCount has wrong negative offset
  121 |                       sizeof(_Unwind_Exception) + sizeof(void*) ==
      |                                                                 ^
/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_exception.h:121:65: note: the comparison reduces to '(124 == 128)'
/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_exception.h:125:65: error: static assertion failed: propagationCount has wrong negative offset
  125 |                       sizeof(_Unwind_Exception) + sizeof(void*) ==
      |

/home/data/vela/github/nuttx/libs/libxx/libcxxabi/libcxxabi/src/cxa_default_handlers.cpp:20:10: fatal error: include/atomic_support.h: No such file or directory
   20 | #include "include/atomic_support.h" // from libc++
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

## Impact

bugfix

## Testing

enable CONFIG_LIBCXX
enable CONFIG_LIBCXXABI

```
cmake -B build -DBOARD_CONFIG=qemu-armv7a:nsh -GNinja
```

build pass

