### PR TITLE
pthread_cond_broadcast use wait_count for judement

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -269,7 +269,7 @@ struct pthread_cond_s
 {
   sem_t sem;
   clockid_t clockid;
-  volatile int16_t lock_count;
+  uint16_t wait_count;
 };
 
 #ifndef __PTHREAD_COND_T_DEFINED

--- a/libs/libc/pthread/pthread_condinit.c
+++ b/libs/libc/pthread/pthread_condinit.c
@@ -74,7 +74,7 @@ int pthread_cond_init(FAR pthread_cond_t *cond,
   else
     {
       cond->clockid = attr ? attr->clockid : CLOCK_REALTIME;
-      cond->lock_count = 0;
+      cond->wait_count = 0;
     }
 
   sinfo("Returning %d\n", ret);

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -113,7 +113,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
       sinfo("Give up mutex...\n");
 
-      cond->lock_count--;
+      cond->wait_count++;
 
       /* Give up the mutex */
 

--- a/sched/pthread/pthread_condsignal.c
+++ b/sched/pthread/pthread_condsignal.c
@@ -41,6 +41,10 @@
  *
  * Description:
  *    A thread can signal on a condition variable.
+ *    pthread_cond_signal shall unblock a thread currently blocked on a
+ *    specified condition variable cond. We need own the mutex that threads
+ *    calling pthread_cond_wait or pthread_cond_timedwait have associated
+ *    with the condition variable during their wait.
  *
  * Input Parameters:
  *   None
@@ -64,10 +68,10 @@ int pthread_cond_signal(FAR pthread_cond_t *cond)
     }
   else
     {
-      if (cond->lock_count < 0)
+      if (cond->wait_count > 0)
         {
           sinfo("Signalling...\n");
-          cond->lock_count++;
+          cond->wait_count--;
           ret = -nxsem_post(&cond->sem);
         }
     }

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -88,7 +88,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
       sinfo("Give up mutex / take cond\n");
 
-      cond->lock_count--;
+      cond->wait_count++;
       ret = pthread_mutex_breaklock(mutex, &nlocks);
 
       status = -nxsem_wait_uninterruptible(&cond->sem);


### PR DESCRIPTION


## Summary
pthread_cond_broadcast use wait_count for judement
This commit fixes the comment from https://github.com/apache/nuttx/pull/14581

## Impact
pthread_cond

## Testing
ostest


