### PR TITLE
libc/misc: do not sanitize backtrace_format

### DIFF
--- a/libs/libc/misc/lib_backtrace.c
+++ b/libs/libc/misc/lib_backtrace.c
@@ -459,6 +459,7 @@ void backtrace_symbols_fd(FAR void *const *buffer, int size, int fd)
  *
  ****************************************************************************/
 
+nosanitize_address
 int backtrace_format(FAR char *buffer, int size,
                      FAR void *backtrace[], int depth)
 {


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

We could call backtrace from mm module and access to kasan protected mm_node.backtrace field. Disable kasan check for backtrace_format.


## Impact

`memdump` can work correctly without being caught by kasan.

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

Tested with qemu arm64 with DEBUG_MM and mm backtrace enabled.

Now memdump will work correctly.


