### PR TITLE
build(bugfix):pac sim elf ONLY in Linux platform

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -330,15 +330,17 @@ else ifeq ($(CONFIG_HOST_MACOS),)
   LDFLAGS += -Wl,-no-pie
 endif
 
-define POSTBUILD
-	$(Q)echo "Pac SIM with dynamic libs..";
-	@ rm -rf sim-pac;
-	@ mkdir -p sim-pac/libs;
-	@ cp nuttx sim-pac/nuttx;
-	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
-	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
-	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
-	@ tar -czf nuttx.tgz sim-pac;
-	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
-	@ rm -rf sim-pac;
-endef
+ifeq ($(CONFIG_HOST_LINUX),y)
+  define POSTBUILD
+  	$(Q)echo "Pac SIM with dynamic libs..";
+  	@ rm -rf sim-pac;
+  	@ mkdir -p sim-pac/libs;
+  	@ cp nuttx sim-pac/nuttx;
+  	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
+  	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
+  	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
+  	@ tar -czf nuttx.tgz sim-pac;
+  	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
+  	@ rm -rf sim-pac;
+  endef
+endif


### PR DESCRIPTION
## Summary

avoid SIM compilation post build issues on other platforms

this should fix issue https://github.com/apache/nuttx/issues/14773#issuecomment-2476484040
## Impact

bugfix

## Testing

```
./tools/configure.sh -l sim:nsh
make -j12
```
```
LD:  nuttx
Pac SIM with dynamic libs..
'/lib/x86_64-linux-gnu/libpthread.so.0' -> 'sim-pac/libs/libpthread.so.0'
'/lib/x86_64-linux-gnu/librt.so.1' -> 'sim-pac/libs/librt.so.1'
'/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
```

