### PR TITLE
segger/stream_rtt: fix warning after stream update

### DIFF
--- a/drivers/segger/stream_rtt.c
+++ b/drivers/segger/stream_rtt.c
@@ -54,12 +54,12 @@ static void rttstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: rttstream_puts
  ****************************************************************************/
 
-static int rttstream_puts(FAR struct lib_outstream_s *self,
-                          FAR const void *buf, int len)
+static ssize_t rttstream_puts(FAR struct lib_outstream_s *self,
+                              FAR const void *buf, size_t len)
 {
   FAR struct lib_rttoutstream_s *stream =
                                 (FAR struct lib_rttoutstream_s *)self;
-  int ret;
+  ssize_t ret;
 
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(0);
   ret = SEGGER_RTT_Write(stream->channel, buf, len);
@@ -86,12 +86,12 @@ static int rttstream_getc(FAR struct lib_instream_s *self)
  * Name: rttstream_gets
  ****************************************************************************/
 
-static int rttstream_gets(FAR struct lib_instream_s *self,
-                          FAR void * buffer, int size)
+static ssize_t rttstream_gets(FAR struct lib_instream_s *self,
+                              FAR void * buffer, size_t size)
 {
   FAR struct lib_rttinstream_s *stream =
                                 (FAR struct lib_rttinstream_s *)self;
-  int ret;
+  ssize_t ret;
 
   DEBUGASSERT(stream);
   ret = SEGGER_RTT_Read(stream->channel, buffer, size);


### PR DESCRIPTION
## Summary
after this patch, stream decreased int, use more size_t off_t ssize_t
#14778 
and 
the segger/stream_rtt get warning after change, 
#14796 
as it's a stream implement outside of libs/libc/stream, it's not coverd in previous patch.

## Impact
fix warning.

## Testing
ci-test, local sim:segger.

