### PR TITLE
arch/xtensa: use arch atomic when enable iram heap

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -573,7 +573,3 @@ SHLDFLAGS = -shared -Bsymbolic -Bdynamic -G
 ifeq ($(CONFIG_SIM_M32),y)
   SHLDFLAGS += -melf_i386
 endif
-
-ifeq ($(CONFIG_LIBC_ARCH_ATOMIC),y)
-  ARCHCFLAGS += -D__STDC_NO_ATOMICS__
-endif

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -859,6 +859,7 @@ config ESP32_RTC_HEAP
 config ESP32_IRAM_HEAP
 	bool "Use the rest of IRAM as a separate heap"
 	select ARCH_HAVE_EXTRA_HEAPS
+	select LIBC_ARCH_ATOMIC
 	default n
 
 endmenu # Memory Configuration

--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -29,7 +29,7 @@
 
 #include <stdbool.h>
 
-#ifdef __has_include
+#if defined(__has_include) && !defined(CONFIG_LIBC_ARCH_ATOMIC)
 #  if __has_include(<atomic>) && defined(__cplusplus)
 extern "C++"
 {


### PR DESCRIPTION
## Summary

This PR fixed EPS32 issue after enable https://github.com/apache/nuttx/pull/14465
Use arch atomic when enable iram heap.
S32C1I instructions may target cached, cache-bypass, and data RAM memory locations. S32C1I instructions are not permitted to access memory addresses in data ROM, instruction memory or the address region allocated to the XLMI port. Attempts to direct the S32C1I at these addresses will cause an exception.

## Impact

ESP32 iram heap

## Testing

esp32-devkit:sotest boot success