### PR TITLE
can/sja100: leave critical section properly

### DIFF
--- a/drivers/can/sja1000.c
+++ b/drivers/can/sja1000.c
@@ -339,7 +339,6 @@ static int sja1000_setup(struct can_dev_s *dev)
   if (ret < 0)
     {
       canerr("ERROR: Failed to attach to IRQ Handler!\n");
-      return ret;
     }
 
 #ifdef CONFIG_ARCH_HAVE_MULTICPU


### PR DESCRIPTION

## Summary

can/sja100: leave critical section properly

leave critical section properly before return

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check


