### PR TITLE
in smp_call handle we only change TCB_FLAG_CPU_LOCKED bit of tcb->flag

### DIFF
--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -44,7 +44,6 @@ struct backtrace_arg_s
   int size;
   int skip;
   cpu_set_t saved_affinity;
-  uint16_t saved_flags;
   bool need_restore;
 };
 
@@ -74,7 +73,7 @@ static int sched_backtrace_handler(FAR void *cookie)
   if (arg->need_restore)
     {
       tcb->affinity = arg->saved_affinity;
-      tcb->flags = arg->saved_flags;
+      tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
   leave_critical_section(flags);
@@ -127,7 +126,6 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
               else
                 {
                   arg.pid = tcb->pid;
-                  arg.saved_flags = tcb->flags;
                   arg.saved_affinity = tcb->affinity;
                   arg.need_restore = true;
 

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -46,7 +46,6 @@ struct reprioritize_arg_s
 {
   pid_t pid;
   cpu_set_t saved_affinity;
-  uint16_t saved_flags;
   int  sched_priority;
   bool need_restore;
 };
@@ -76,7 +75,7 @@ static int reprioritize_handler(FAR void *cookie)
   if (arg->need_restore)
     {
       tcb->affinity = arg->saved_affinity;
-      tcb->flags = arg->saved_flags;
+      tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
   if (nxsched_reprioritize_rtr(tcb, arg->sched_priority))
@@ -237,7 +236,6 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
               else
                 {
                   arg.pid = tcb->pid;
-                  arg.saved_flags = tcb->flags;
                   arg.saved_affinity = tcb->affinity;
                   arg.need_restore = true;
 

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -45,7 +45,6 @@ struct suspend_arg_s
 {
   pid_t pid;
   cpu_set_t saved_affinity;
-  uint16_t saved_flags;
   bool need_restore;
 };
 
@@ -74,7 +73,7 @@ static int nxsched_suspend_handler(FAR void *cookie)
   if (arg->need_restore)
     {
       tcb->affinity = arg->saved_affinity;
-      tcb->flags = arg->saved_flags;
+      tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
   nxsched_remove_readytorun(tcb);
@@ -158,7 +157,6 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
           else
             {
               arg.pid = tcb->pid;
-              arg.saved_flags = tcb->flags;
               arg.saved_affinity = tcb->affinity;
               arg.need_restore = true;
 

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -54,7 +54,6 @@ struct sig_arg_s
 {
   pid_t pid;
   cpu_set_t saved_affinity;
-  uint16_t saved_flags;
   bool need_restore;
 };
 
@@ -84,7 +83,7 @@ static int sig_handler(FAR void *cookie)
   if (arg->need_restore)
     {
       tcb->affinity = arg->saved_affinity;
-      tcb->flags = arg->saved_flags;
+      tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
   if (tcb->sigdeliver)
@@ -178,7 +177,6 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
                     }
                   else
                     {
-                      arg.saved_flags    = stcb->flags;
                       arg.saved_affinity = stcb->affinity;
                       arg.need_restore   = true;
 

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -49,7 +49,6 @@ struct restart_arg_s
 {
   pid_t pid;
   cpu_set_t saved_affinity;
-  uint16_t saved_flags;
   bool need_restore;
 };
 
@@ -80,7 +79,7 @@ static int restart_handler(FAR void *cookie)
   if (arg->need_restore)
     {
       tcb->affinity = arg->saved_affinity;
-      tcb->flags = arg->saved_flags;
+      tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
   nxsched_remove_readytorun(tcb);
@@ -238,7 +237,6 @@ static int nxtask_restart(pid_t pid)
       else
         {
           arg.pid = tcb->pid;
-          arg.saved_flags = tcb->flags;
           arg.saved_affinity = tcb->affinity;
           arg.need_restore = true;
 


### PR DESCRIPTION

## Summary
in smp_call handle we only change TCB_FLAG_CPU_LOCKED bit of tcb->flag
change unrelated changes to tcb->flag fields, may cause error

## Impact

smp call

## Testing
ci ostest


