### PR TITLE
arch/stm32h5: Simplify PLL configuration.

### DIFF
--- a/arch/arm/src/stm32h5/stm32h5xx_rcc.c
+++ b/arch/arm/src/stm32h5/stm32h5xx_rcc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/stm32h5/stm32h5xx_rcc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -943,9 +945,9 @@ void stm32_stdclockconfig(void)
   regval  = getreg32(STM32_RCC_CR);
   regval |= RCC_CR_HSION;           /* Enable HSI */
 
-#if defined(STM32_CR_HSIDIV)
+#if defined(STM32_BOARD_HSIDIV)
   regval &= ~RCC_CR_HSIDIV_MASK;
-  regval |= STM32_CR_HSIDIV;
+  regval |= STM32_BOARD_HSIDIV;
 #else
   /* Use default (32 MHz) */
 #endif
@@ -958,7 +960,8 @@ void stm32_stdclockconfig(void)
     {
       /* Check if the HSIRDY flag is the set in the CR */
 
-      if ((getreg32(STM32_RCC_CR) & RCC_CR_HSIRDY) != 0)
+      if ((getreg32(STM32_RCC_CR) & RCC_CR_HSIRDY) != 0 &&
+          (getreg32(STM32_RCC_CR) & RCC_CR_HSIDIVF) != 0)
         {
           /* If so, then break-out with timeout > 0 */
 
@@ -966,19 +969,6 @@ void stm32_stdclockconfig(void)
         }
     }
 
-  /* Make sure HSIDIVF is also not 0 */
-
-  for (timeout = HSIRDY_TIMEOUT; timeout > 0; timeout--)
-    {
-      /* Check if the HSIRDY flag is the set in the CR */
-
-      if ((getreg32(STM32_RCC_CR) & RCC_CR_HSIDIVF) != 0)
-        {
-          /* If so, then break-out with timeout > 0 */
-
-          break;
-        }
-    }
 #endif
 
 #if defined(STM32_BOARD_USECSI)
@@ -1088,131 +1078,14 @@ void stm32_stdclockconfig(void)
       putreg32(regval, STM32_RCC_CFGR1);
 #endif
 
-      /* Configure PLL1 */
-
-      /* PLL1CFGR */
-
-      regval  = getreg32(STM32_RCC_PLL1CFGR);
-
-      /* Set the PLL1 source and main divider */
-
-      /* Use PLL1SRC defnitions to override USE_XXX */
-
-#ifdef STM32H5_PLL1SRC_HSI
-      regval |= RCC_PLL1CFGR_PLL1SRC_HSI;
-#elif defined(STM32H5_PLL1SRC_CSI)
-      regval |= RCC_PLL1CFGR_PLL1SRC_CSI;
-#elif defined(STM32H5_PLL1SRC_HSE)
-      regval |= RCC_PLL1CFGR_PLL1SRC_HSE;
-#elif defined(STM32_BOARD_USEHSI)
-      regval |= RCC_PLL1CFGR_PLL1SRC_HSI;
-#elif defined(STM32_BOARD_USECSI)
-      regval |= RCC_PLL1CFGR_PLL1SRC_CSI;
-#else /* if STM32_BOARD_USEHSE */
-      regval |= RCC_PLL1CFGR_PLL1SRC_HSE;
-#endif
-
-      /* Set RGE, FRACEN, VCOSEL, and M from board.h */
-
-      regval |= (STM32_PLL1CFGR_PLL1RGE | STM32_PLL1CFGR_PLL1FRACEN |
-                 STM32_PLL1CFGR_PLL1VCOSEL | STM32_PLL1CFGR_PLL1M);
-
-#ifdef STM32_PLL1CFGR_PLL1P_ENABLED
-      regval |= RCC_PLL1CFGR_PLL1PEN;
-#endif
-#ifdef STM32_PLL1CFGR_PLL1Q_ENABLED
-      regval |= RCC_PLL1CFGR_PLL1QEN;
-#endif
-#ifdef STM32_PLL1CFGR_PLL1R_ENABLED
-      regval |= RCC_PLL1CFGR_PLL1REN;
-#endif
-
-      putreg32(regval, STM32_RCC_PLL1CFGR);
-
-      /* PLL1DIVR and PLL1FRACR */
-
-      /* Get settings from board.h */
-
-      /* PLL1DIVR */
-
-      regval  = getreg32(STM32_RCC_PLL1DIVR);
-      regval = (STM32_PLL1DIVR_PLL1N | STM32_PLL1DIVR_PLL1P |
-                STM32_PLL1DIVR_PLL1Q | STM32_PLL1DIVR_PLL1R);
-      putreg32(regval, STM32_RCC_PLL1DIVR);
-
-      /* PLL1FRACR */
-
-      regval  = getreg32(STM32_RCC_PLL1FRACR);
-      regval |= STM32_PLL1FRACR_PLL1FRACN;
-      putreg32(regval, STM32_RCC_PLL1FRACR);
-
-      /* Enable PLL1 */
-
-      regval  = getreg32(STM32_RCC_CR);
-      regval |= RCC_CR_PLL1ON;
-      putreg32(regval, STM32_RCC_CR);
-
-      /* Wait until PLL1 is ready */
-
-      while ((getreg32(STM32_RCC_CR) & RCC_CR_PLL1RDY) == 0)
-        {
-        }
-
+#ifdef STM32_PLLCFG_PLL2CFG
       /* Configure PLL2 */
 
-      /* PLL2CFGR */
-
-      regval  = getreg32(STM32_RCC_PLL2CFGR);
-
-      /* Set the PLL2 source and main divider */
-
-#ifdef STM32H5_PLL2SRC_HSI
-      regval |= RCC_PLL2CFGR_PLL2SRC_HSI;
-#elif defined(STM32H5_PLL2SRC_CSI)
-      regval |= RCC_PLL2CFGR_PLL2SRC_CSI;
-#elif defined(STM32H5_PLL2SRC_HSE)
-      regval |= RCC_PLL2CFGR_PLL2SRC_HSE;
-#elif defined(STM32_BOARD_USEHSI)
-      regval |= RCC_PLL2CFGR_PLL2SRC_HSI;
-#elif defined(STM32_BOARD_USECSI)
-      regval |= RCC_PLL2CFGR_PLL2SRC_CSI;
-#else /* if STM32_BOARD_USEHSE */
-      regval |= RCC_PLL2CFGR_PLL2SRC_HSE;
-#endif
-
-      /* Set RGE, FRACEN, VCOSEL, and M from board.h */
-
-      regval |= (STM32_PLL2CFGR_PLL2RGE | STM32_PLL2CFGR_PLL2FRACEN |
-                 STM32_PLL2CFGR_PLL2VCOSEL | STM32_PLL2CFGR_PLL2M);
-
-#ifdef STM32_PLL2CFGR_PLL2P_ENABLED
-      regval |= RCC_PLL2CFGR_PLL2PEN;
-#endif
-#ifdef STM32_PLL2CFGR_PLL2Q_ENABLED
-      regval |= RCC_PLL2CFGR_PLL2QEN;
-#endif
-#ifdef STM32_PLL2CFGR_PLL2R_ENABLED
-      regval |= RCC_PLL2CFGR_PLL2REN;
-#endif
-
+      regval = STM32_PLLCFG_PLL2CFG;
       putreg32(regval, STM32_RCC_PLL2CFGR);
 
-      /* PLL2DIVR and PLL2FRACR */
-
-      /* Get settings from board.h */
-
-      /* PLL2DIVR */
-
-      regval  = getreg32(STM32_RCC_PLL2DIVR);
-      regval = (STM32_PLL2DIVR_PLL2N | STM32_PLL2DIVR_PLL2P |
-                STM32_PLL2DIVR_PLL2Q | STM32_PLL2DIVR_PLL2R);
+      regval = STM32_PLLCFG_PLL2DIVR;
       putreg32(regval, STM32_RCC_PLL2DIVR);
-
-      /* PLL2FRACR */
-
-      regval  = getreg32(STM32_RCC_PLL2FRACR);
-      regval |= STM32_PLL2FRACR_PLL2FRACN;
-      putreg32(regval, STM32_RCC_PLL2FRACR);
 
       /* Enable PLL2 */
 
@@ -1220,67 +1093,20 @@ void stm32_stdclockconfig(void)
       regval |= RCC_CR_PLL2ON;
       putreg32(regval, STM32_RCC_CR);
 
-      /* Wait until PLL2 is ready */
+#ifdef STM32_PLLCFG_PLL2FRACR
+      regval = STM32_PLLCFG_PLL2FRACR;
+      putreg32(regval, STM32_RCC_PLL2FRACR);
+#endif
+#endif
 
-      while ((getreg32(STM32_RCC_CR) & RCC_CR_PLL2RDY) == 0)
-        {
-        }
-
+#ifdef STM32_PLLCFG_PLL3CFG
       /* Configure PLL3 */
 
-      /* PLL3CFGR */
-
-      regval  = getreg32(STM32_RCC_PLL3CFGR);
-
-      /* Set the PLL3 source and main divider */
-
-#ifdef STM32H5_PLL3SRC_HSI
-      regval |= RCC_PLL3CFGR_PLL3SRC_HSI;
-#elif defined(STM32H5_PLL3SRC_CSI)
-      regval |= RCC_PLL3CFGR_PLL3SRC_CSI;
-#elif defined(STM32H5_PLL3SRC_HSE)
-      regval |= RCC_PLL3CFGR_PLL3SRC_HSE;
-#elif defined(STM32_BOARD_USEHSI)
-      regval |= RCC_PLL3CFGR_PLL3SRC_HSI;
-#elif defined(STM32_BOARD_USECSI)
-      regval |= RCC_PLL3CFGR_PLL3SRC_CSI;
-#else /* if STM32_BOARD_USEHSE */
-      regval |= RCC_PLL3CFGR_PLL3SRC_HSE;
-#endif
-
-      /* Set RGE, FRACEN, VCOSEL, and M from board.h */
-
-      regval |= (STM32_PLL3CFGR_PLL3RGE | STM32_PLL3CFGR_PLL3FRACEN |
-                 STM32_PLL3CFGR_PLL3VCOSEL | STM32_PLL3CFGR_PLL3M);
-
-#ifdef STM32_PLL3CFGR_PLL3P_ENABLED
-      regval |= RCC_PLL3CFGR_PLL3PEN;
-#endif
-#ifdef STM32_PLL3CFGR_PLL3Q_ENABLED
-      regval |= RCC_PLL3CFGR_PLL3QEN;
-#endif
-#ifdef STM32_PLL3CFGR_PLL3R_ENABLED
-      regval |= RCC_PLL3CFGR_PLL3REN;
-#endif
-
+      regval = STM32_PLLCFG_PLL3CFG;
       putreg32(regval, STM32_RCC_PLL3CFGR);
 
-      /* PLL3DIVR and PLL3FRACR */
-
-      /* Get settings from board.h */
-
-      /* PLL3DIVR */
-
-      regval  = getreg32(STM32_RCC_PLL3DIVR);
-      regval = (STM32_PLL3DIVR_PLL3N | STM32_PLL3DIVR_PLL3P |
-                STM32_PLL3DIVR_PLL3Q | STM32_PLL3DIVR_PLL3R);
+      regval = STM32_PLLCFG_PLL3DIVR;
       putreg32(regval, STM32_RCC_PLL3DIVR);
-
-      /* PLL3FRACR */
-
-      regval  = getreg32(STM32_RCC_PLL3FRACR);
-      regval |= STM32_PLL3FRACR_PLL3FRACN;
-      putreg32(regval, STM32_RCC_PLL3FRACR);
 
       /* Enable PLL3 */
 
@@ -1288,11 +1114,41 @@ void stm32_stdclockconfig(void)
       regval |= RCC_CR_PLL3ON;
       putreg32(regval, STM32_RCC_CR);
 
-      /* Wait until PLL3 is ready */
+#ifdef STM32_PLLCFG_PLL3FRACR
+      regval = STM32_PLLCFG_PLL3FRACR;
+      putreg32(regval, STM32_RCC_PLL3FRACR);
+#endif
+#endif
 
-      while ((getreg32(STM32_RCC_CR) & RCC_CR_PLL3RDY) == 0)
+#ifdef STM32_PLLCFG_PLL1CFG
+      /* Configure PLL1
+       * No need for Read modify write. Either reset val = 0 or register is
+       * fully defined in board.h
+       */
+
+      regval = STM32_PLLCFG_PLL1CFG;
+      putreg32(regval, STM32_RCC_PLL1CFGR);
+
+      regval = STM32_PLLCFG_PLL1DIVR;
+      putreg32(regval, STM32_RCC_PLL1DIVR);
+
+#ifdef STM32_PLLCFG_PLL1FRACR
+      regval = STM32_PLLCFG_PLL1FRACR;
+      putreg32(regval, STM32_RCC_PLL1FRACR);
+#endif
+
+      /* Enable PLL1 */
+
+      regval  = getreg32(STM32_RCC_CR);
+      regval |= RCC_CR_PLL1ON;
+      putreg32(regval, STM32_RCC_CR);
+
+      /* Wait until PLL1 is ready, since it is used for system clock */
+
+      while ((getreg32(STM32_RCC_CR) & RCC_CR_PLL1RDY) == 0)
         {
         }
+#endif
 
       /* Determine wait states based on sysclk frequency and VOS
        * Determine WRHIGHFREQ based on wait states


### PR DESCRIPTION
The PLL clock configuration was simplified on the assumption the clocks are correctly set in the board.h file. Instead of seperate conditions for register components, assume the relevant PLL registers are fully defined in board.h. This should result in easier to understand defines in board.h and simpler code flow in the standard clock configuration function.

Changes were mad in the board file alongside changing the arch files. Changes to board/stm32h5:
  - PLL1 has been configured to use integer instead of fractional mode to reach the 250 MHz target. PLL2 and PLL3 configurations were removed since they are currently unused in the H5 configuration.
  - PLL1 output was verified by testing for changes in serial baud rate.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change is primarily to make it easier to configure PLL clocks when working with peripherals. It followed the H7 `board.h` practice of fully defining each register.

## Impact

This makes PLL clock setup easier in `board.h`, and will make it easier for peripherals to be configured based off the PLL configuration. This change continues to assume clocks must be set up properly in `board.h`

## Testing

Changes in the system clock would be detected by a change in baud rate on the serial com port. After the changes, the serial com port continued to work at the intended baud rate and the board booted to the nutshell. 

Host OS: Ubuntu 24.04 on WSL 2 (Windows 11)
Compiler: arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009

Target:
- Arch: STM32H5
- Chip: STM32H563ZIT6U
- Board: Nucleo-H563ZI
- Config: nucleo-h563zi:nsh
