### PR TITLE
remove sched_lock in pthread_cond_broadcast

### DIFF
--- a/sched/pthread/pthread_condbroadcast.c
+++ b/sched/pthread/pthread_condbroadcast.c
@@ -68,13 +68,6 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
     }
   else
     {
-      /* Disable pre-emption until all of the waiting threads have been
-       * restarted. This is necessary to assure that the sval behaves as
-       * expected in the following while loop
-       */
-
-      sched_lock();
-
       /* Loop until all of the waiting threads have been restarted. */
 
       while (cond->wait_count > 0)
@@ -92,10 +85,6 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
 
           cond->wait_count--;
         }
-
-      /* Now we can let the restarted threads run */
-
-      sched_unlock();
     }
 
   sinfo("Returning %d\n", ret);


### PR DESCRIPTION
## Summary
remove sched_lock in pthread_cond_broadcast
reason:
Since pthread_cond_broadcast is already protected by a mutex, even if sem_post causes a context switch, it will not affect the count of wait_count.
## Impact
pthread cond_wait

## Testing
ci ostest


