### PR TITLE
Fix timers/arch_alarm.c:109:3: error: 'now' may be used uninitialized

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -102,9 +102,9 @@ static void udelay_coarse(useconds_t microseconds)
 static void oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
                              FAR void *arg)
 {
-  clock_t now;
-  ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);
+  clock_t now = 0;
 
+  ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);
 #ifdef CONFIG_SCHED_TICKLESS
   nxsched_alarm_tick_expiration(now);
 #else
@@ -140,7 +140,7 @@ static void oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
 void up_alarm_set_lowerhalf(FAR struct oneshot_lowerhalf_s *lower)
 {
 #ifdef CONFIG_SCHED_TICKLESS
-  clock_t ticks;
+  clock_t ticks = 0;
 #endif
 
   g_oneshot_lower = lower;
@@ -318,7 +318,7 @@ int weak_function up_alarm_tick_start(clock_t ticks)
 
   if (g_oneshot_lower != NULL)
     {
-      clock_t now;
+      clock_t now = 0;
       clock_t delta;
 
       ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);


### PR DESCRIPTION
## Summary

and timers/arch_alarm.c:150:51: error: 'ticks' may be used uninitialized

## Impact

fix compiler warning

## Testing

ci

