### PR TITLE
mm/map: Remove MM_MAP_COUNT_MAX Kconfig and related check

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -98,12 +98,6 @@ config MM_REGIONS
 		that the memory manager must handle and enables the API
 		mm_addregion(heap, start, end);
 
-config MM_MAP_COUNT_MAX
-	int "The maximum number of memory map areas for each task"
-	default 1024
-	---help---
-		The maximum number of memory map areas for each task.
-
 config MM_FILL_ALLOCATIONS
 	bool "Fill allocations with debug value"
 	default n

--- a/mm/map/mm_map.c
+++ b/mm/map/mm_map.c
@@ -222,19 +222,8 @@ int mm_map_add(FAR struct mm_map_s *mm, FAR struct mm_map_entry_s *entry)
       return ret;
     }
 
-  /* Too many mappings? */
-
-  if (mm->map_count >= CONFIG_MM_MAP_COUNT_MAX)
-    {
-      kmm_free(new_entry);
-      nxrmutex_unlock(&mm->mm_map_mutex);
-      return -ENOMEM;
-    }
-
   mm->map_count++;
-
   sq_addfirst((sq_entry_t *)new_entry, &mm->mm_map_sq);
-
   nxrmutex_unlock(&mm->mm_map_mutex);
 
   return OK;


### PR DESCRIPTION
## Summary

since it's not necessary to limit the number of map entries.

## Impact

remove the artificial limitation

## Testing

ci

