### PR TITLE
minor code refactor

### DIFF
--- a/.github/linters/setup.cfg
+++ b/.github/linters/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W503,W605,E203
+ignore = W503,W605,E203,E704
 max-complexity = 27
 max-line-length = 125
 multi_line_output=3

--- a/arch/sim/src/sim/win/sim_hostfs.c
+++ b/arch/sim/src/sim/win/sim_hostfs.c
@@ -80,7 +80,7 @@ static void host_stat_convert(struct _stat *hostbuf,
  * Name: host_open
  ****************************************************************************/
 
-int host_open(const char *pathname, int flags, nuttx_mode_t mode)
+int host_open(const char *pathname, int flags, int mode)
 {
   int mapflags = 0;
   int ret;
@@ -382,7 +382,7 @@ int host_unlink(const char *pathname)
  * Name: host_mkdir
  ****************************************************************************/
 
-int host_mkdir(const char *pathname, nuttx_mode_t mode)
+int host_mkdir(const char *pathname, int mode)
 {
   /* Just call the host's mkdir routine */
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -1013,7 +1013,6 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
       {
         FAR struct note_syscall_enter_s *nsc;
         int i;
-        int j;
         uintptr_t arg;
 
         nsc = (FAR struct note_syscall_enter_s *)p;
@@ -1027,7 +1026,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         ret += lib_sprintf(s, "sys_%s(",
                            g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED]);
 
-        for (i = j = 0; i < nsc->nsc_argc; i++)
+        for (i = 0; i < nsc->nsc_argc; i++)
           {
             arg = nsc->nsc_args[i];
             if (i == 0)

--- a/drivers/reset/core.c
+++ b/drivers/reset/core.c
@@ -26,6 +26,7 @@
 
 #include <errno.h>
 #include <debug.h>
+#include <string.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>

--- a/drivers/sensors/bmi160_uorb.c
+++ b/drivers/sensors/bmi160_uorb.c
@@ -591,7 +591,7 @@ static int bmi160_register_accel(int devno,
   priv->dev.freq = BMI160_I2C_FREQ;
 
 #else /* CONFIG_SENSORS_BMI160_SPI */
-  priv->devl.spi = dev;
+  priv->dev.spi = dev;
 
   /* BMI160 detects communication bus is SPI by rising edge of CS. */
 

--- a/libs/libxx/.gitignore
+++ b/libs/libxx/.gitignore
@@ -1,2 +1,6 @@
 *.xz
 *.bz2
+/libcxx/libcxx
+/libcxxabi/libcxxabi
+/uClibc++/uClibc++
+/libstdc++/

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -34,7 +34,6 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/irq.h>
 #include <nuttx/init.h>
-#include <nuttx/irq.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/tls.h>
 #include <nuttx/signal.h>

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -107,6 +107,10 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
   if (tcb)
     {
+      /* Released tcb shouldn't on any list */
+
+      DEBUGASSERT(tcb->flink == NULL && tcb->blink == NULL);
+
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
       /* Release any timers that the task might hold.  We do this
        * before release the PID because it may still be trying to


### PR DESCRIPTION
## Summary

- sched/misc: Remove the dup inclusion of nuttx/irq.h in assert.c 
- sensors/bmi160_uorb.c: Fix the typo error 
- note/noteram_driver: Remove the unused variable j 
- sim/win: Replace nuttx_mode_t with int
- .github/linters: Ignore E704 warning 

## Impact

minor

## Testing

ci
