### PR TITLE
GreenHills support: add thumb mode detection support for ghs compiler

### DIFF
--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -41,7 +41,8 @@
 
 #define SYS_syscall 0x00
 
-#if defined(__thumb__) || defined(__thumb2__)
+#if defined(__thumb__) || defined(__thumb2__) || \
+    defined(__THUMB_AWARE__) || defined(__THUMB2_AWARE__)
 #  define SYS_smhcall 0xab
 #else
 #  define SYS_smhcall 0x123456


### PR DESCRIPTION
## Summary

In the GreenHills compiler, the predefined macros for thumb mode detection are different from those in the GCC compiler. The judgment needs to be made through __THUMB_AWARE__ and __THUMB2_AWARE__.
If the wrong macros are used in GreenHills, it will be impossible to determine whether the current mode is thumb mode or not. Consequently, the wrong **SYS_smhcall** will be used, and then a compilation error will occur.

## Impact

Has no impact on current implementation

## Testing

1. has passed the ostest
2. has tested on GHS and GCC compiler


