### PR TITLE
fix: remove duplicated statistics of upd.drop

### DIFF
--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -82,9 +82,6 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
   if (conn->readahead && conn->readahead->io_pktlen > conn->rcvbufs)
     {
       netdev_iob_release(dev);
-#ifdef CONFIG_NET_STATISTICS
-      g_netstats.udp.drop++;
-#endif
       return 0;
     }
 #endif


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
*The valule of g_netstats.udp.drop has been increased in net_dataevent() function,
while it is increased in udp_datahandler().*

## Impact

*The statistical count of lost packets is twice the actual count of lost packets..*

## Testing
**


