### PR TITLE
arm64: fix compile failed 'tpidr_el1' undeclared

### DIFF
--- a/arch/arm64/include/arch.h
+++ b/arch/arm64/include/arch.h
@@ -34,8 +34,9 @@
 #ifndef __ASSEMBLY__
 #  include <stdint.h>
 #  include <stddef.h>
-#  include <nuttx/macro.h>
 #endif
+
+#include <nuttx/irq.h>
 
 /****************************************************************************
  * Pre-processor Prototypes
@@ -52,41 +53,6 @@
 #define ARCH_SPGTS          (ARCH_PGT_MAX_LEVELS - 1)
 
 #endif /* CONFIG_ARCH_ADDRENV */
-
-/****************************************************************************
- * Name:
- *   read_/write_/zero_/modify_ sysreg
- *
- * Description:
- *
- *   ARMv8 Architecture Registers access method
- *   All the macros need a memory clobber
- *
- ****************************************************************************/
-
-#define read_sysreg(reg)                            \
-  ({                                                \
-    uint64_t __val;                                 \
-    __asm__ volatile ("mrs %0, " STRINGIFY(reg)     \
-                    : "=r" (__val) :: "memory");    \
-    __val;                                          \
-  })
-
-#define write_sysreg(__val, reg)                    \
-  ({                                                \
-    __asm__ volatile ("msr " STRINGIFY(reg) ", %0"  \
-                      : : "r" (__val) : "memory");  \
-  })
-
-#define zero_sysreg(reg)                            \
-  ({                                                \
-    __asm__ volatile ("msr " STRINGIFY(reg) ", xzr" \
-                      ::: "memory");                \
-  })
-
-#define modify_sysreg(v,m,a)                        \
-  write_sysreg((read_sysreg(a) & ~(m)) |            \
-               ((uintptr_t)(v) & (m)), a)
 
 /****************************************************************************
  * Inline functions


### PR DESCRIPTION
## Summary

```
time/lib_localtime.c: In function 'tz_lock':
time/lib_localtime.c:396:7: error: 'tpidr_el1' undeclared (first use in this function)
  396 |   if (up_interrupt_context() || (sched_idletask() && OSINIT_IDLELOOP()))
      |       ^~~~~~~~~~~~~~~~~~~~
```

## Impact

arm64

## Testing

ci

