### PR TITLE
Revert "romfs:extend romfs to enable write"

### DIFF
--- a/fs/romfs/Kconfig
+++ b/fs/romfs/Kconfig
@@ -27,11 +27,4 @@ config FS_ROMFS_CACHE_FILE_NSECTORS
 	---help---
 		The number of file cache sector
 
-config FS_ROMFS_WRITEABLE
-	bool "Enable write extended feature in romfs"
-	default n
-	depends on FS_ROMFS_CACHE_NODE
-	---help---
-		Enable write extended feature in romfs
-
 endif

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -191,22 +191,12 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
       return ret;
     }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT))
+  ret = romfs_checkmount(rm);
+  if (ret < 0)
     {
-      if (list_is_empty(&rm->rm_sparelist))
-        {
-          ferr("ERROR: RW not enabled, only O_RDONLY supported\n");
-          ret = -EACCES;
-          goto errout_with_lock;
-        }
-
-      nxrmutex_unlock(&rm->rm_lock);
-      nxsem_wait_uninterruptible(&rm->rm_sem);
-      nxrmutex_lock(&rm->rm_lock);
+      ferr("ERROR: romfs_checkmount failed: %d\n", ret);
+      goto errout_with_lock;
     }
-  else
-#endif
 
   /* ROMFS is read-only.  Any attempt to open with any kind of write
    * access is not permitted.
@@ -219,13 +209,6 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
       goto errout_with_lock;
     }
 
-  ret = romfs_checkmount(rm);
-  if (ret < 0)
-    {
-      ferr("ERROR: romfs_checkmount failed: %d\n", ret);
-      goto errout_with_sem;
-    }
-
   /* Locate the directory entry for this path */
 
   ret = romfs_finddirentry(rm, &nodeinfo, relpath);
@@ -233,7 +216,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to find directory directory entry for '%s': %d\n",
            relpath, ret);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* The full path exists -- but is the final component a file
@@ -250,7 +233,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
       ret = -EISDIR;
       ferr("ERROR: '%s' is a directory\n", relpath);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
   else if (!IS_FILE(nodeinfo.rn_next))
     {
@@ -264,7 +247,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
       ret = -ENXIO;
       ferr("ERROR: '%s' is a special file\n", relpath);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Create an instance of the file private data to describe the opened
@@ -277,7 +260,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to allocate private data\n");
       ret = -ENOMEM;
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Initialize the file private data (only need to initialize
@@ -295,7 +278,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to locate start of file data: %d\n", ret);
       fs_heap_free(rf);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Configure buffering to support access to this file */
@@ -305,34 +288,14 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed configure buffering: %d\n", ret);
       fs_heap_free(rf);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Attach the private date to the struct file instance */
 
   filep->f_priv = rf;
+
   rm->rm_refs++;
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-
-  /* If the file is only created for read */
-
-  if ((oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT)) == O_CREAT)
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
-
-  nxrmutex_unlock(&rm->rm_lock);
-  return ret;
-
-errout_with_sem:
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT))
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
 
 errout_with_lock:
   nxrmutex_unlock(&rm->rm_lock);
@@ -369,13 +332,6 @@ static int romfs_close(FAR struct file *filep)
     }
 
   rm->rm_refs--;
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (filep->f_oflags & (O_WRONLY | O_APPEND | O_TRUNC))
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
-
   nxrmutex_unlock(&rm->rm_lock);
 
   /* Do not check if the mount is healthy.  We must support closing of
@@ -1173,53 +1129,16 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
       goto errout_with_mount;
     }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (data && strstr(data, "rw") && strstr(data, "forceformat"))
-    {
-      ret = romfs_mkfs(rm);
-      if (ret < 0)
-        {
-          ferr("ERROR: romfs_mkfs failed: %d\n", ret);
-          goto errout_with_buffer;
-        }
-    }
-#endif
-
   /* Then complete the mount by getting the ROMFS configuratrion from
    * the ROMF header
    */
 
-  ret = romfs_fsconfigure(rm, data);
+  ret = romfs_fsconfigure(rm);
   if (ret < 0)
     {
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-      if (data && strstr(data, "rw") && strstr(data, "autoformat"))
-        {
-          ret = romfs_mkfs(rm);
-          if (ret < 0)
-            {
-              ferr("ERROR: romfs_format failed: %d\n", ret);
-              goto errout_with_buffer;
-            }
-
-          ret = romfs_fsconfigure(rm, data);
-          if (ret < 0)
-            {
-              ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
-              goto errout_with_buffer;
-            }
-        }
-      else
-#endif
-        {
-          ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
-          goto errout_with_buffer;
-        }
+      ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
+      goto errout_with_buffer;
     }
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  nxsem_init(&rm->rm_sem, 0, 1);
-#endif
 
   /* Mounted! */
 
@@ -1227,7 +1146,10 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   return 0;
 
 errout_with_buffer:
-  fs_heap_free(rm->rm_devbuffer);
+  if (!rm->rm_xipbase)
+    {
+      fs_heap_free(rm->rm_buffer);
+    }
 
 errout_with_mount:
   nxrmutex_destroy(&rm->rm_lock);
@@ -1315,14 +1237,13 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
       /* Release the mountpoint private data */
 
-      fs_heap_free(rm->rm_devbuffer);
+      if (!rm->rm_xipbase)
+        {
+          fs_heap_free(rm->rm_buffer);
+        }
 
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
       romfs_freenode(rm->rm_root);
-#endif
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-      nxsem_destroy(&rm->rm_sem);
-      romfs_free_sparelist(&rm->rm_sparelist);
 #endif
       nxrmutex_destroy(&rm->rm_lock);
       fs_heap_free(rm);
@@ -1381,10 +1302,9 @@ static int romfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Everything else follows in units of sectors */
 
-  buf->f_blocks  = rm->rm_hwnsectors;
-  buf->f_bfree   = buf->f_blocks -
-                   SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
-  buf->f_bavail  = buf->f_bfree;
+  buf->f_blocks  = SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
+  buf->f_bfree   = 0;
+  buf->f_bavail  = 0;
   buf->f_namelen = NAME_MAX;
 
 errout_with_lock:

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -28,7 +28,6 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/list.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -119,20 +118,6 @@
  * Public Types
  ****************************************************************************/
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-/* This structure represents the spare list.  An instance of this
- * structure is retained as file header and file data size on each mountpoint
- * that is mounted with a romfs filesystem.
- */
-
-struct romfs_sparenode_s
-{
-  struct list_node node;
-  uint32_t start;
-  uint32_t end;
-};
-#endif
-
 /* This structure represents the overall mountpoint state.  An instance of
  * this structure is retained as inode private data on each mountpoint that
  * is mounted with a romfs filesystem.
@@ -156,11 +141,6 @@ struct romfs_mountpt_s
   uint32_t rm_cachesector;        /* Current sector in the rm_buffer */
   FAR uint8_t *rm_xipbase;        /* Base address of directly accessible media */
   FAR uint8_t *rm_buffer;         /* Device sector buffer, allocated if rm_xipbase==0 */
-  FAR uint8_t *rm_devbuffer;      /* Device sector buffer, allocated for write if rm_xipbase != 0 */
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  struct list_node rm_sparelist;  /* The list of spare space */
-  sem_t            rm_sem;        /* The semaphore to assume write safe */
-#endif
 };
 
 /* This structure represents on open file under the mountpoint.  An instance
@@ -186,7 +166,6 @@ struct romfs_nodeinfo_s
   uint32_t rn_next;                        /* Offset of the next file header+flags */
   uint32_t rn_size;                        /* Size (if file) */
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
-  uint32_t rn_origoffset;                  /* Offset of origin file header */
   FAR struct romfs_nodeinfo_s **rn_child;  /* The node array for link to lower level */
   uint16_t rn_count;                       /* The count of node in rn_child level */
   uint8_t  rn_namesize;                    /* The length of name of the entry */
@@ -216,7 +195,7 @@ int  romfs_hwread(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
 int  romfs_filecacheread(FAR struct romfs_mountpt_s *rm,
                          FAR struct romfs_file_s *rf, uint32_t sector);
 int  romfs_hwconfigure(FAR struct romfs_mountpt_s *rm);
-int  romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data);
+int  romfs_fsconfigure(FAR struct romfs_mountpt_s *rm);
 int  romfs_fileconfigure(FAR struct romfs_mountpt_s *rm,
                          FAR struct romfs_file_s *rf);
 int  romfs_checkmount(FAR struct romfs_mountpt_s *rm);
@@ -233,10 +212,6 @@ int  romfs_datastart(FAR struct romfs_mountpt_s *rm,
                      FAR uint32_t *start);
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
 void romfs_freenode(FAR struct romfs_nodeinfo_s *node);
-#endif
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-int romfs_mkfs(FAR struct romfs_mountpt_s *rm);
-void romfs_free_sparelist(FAR struct list_node *list);
 #endif
 
 #undef EXTERN

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -397,218 +397,6 @@ static inline int romfs_searchdir(FAR struct romfs_mountpt_s *rm,
   return -ENOENT;
 }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-/****************************************************************************
- * Name: romfs_alloc_sparenode
- *
- * Description:
- *   Allocate the spare node
- *
- ****************************************************************************/
-
-static FAR struct romfs_sparenode_s *
-romfs_alloc_sparenode(uint32_t start, uint32_t end)
-{
-  FAR struct romfs_sparenode_s *node;
-  node = fs_heap_malloc(sizeof(struct romfs_sparenode_s));
-  if (node == NULL)
-    {
-      ferr("romfs_alloc_sparenode: no memory\n");
-      return NULL;
-    }
-
-  node->start = start;
-  node->end = end;
-  return node;
-}
-
-/****************************************************************************
- * Name: romfs_init_sparelist
- *
- * Description:
- *   Init the sparelist
- *
- ****************************************************************************/
-
-static int romfs_init_sparelist(FAR struct romfs_mountpt_s *rm, bool rw)
-{
-  FAR struct romfs_sparenode_s *node;
-
-  list_initialize(&rm->rm_sparelist);
-  if (!rw)
-    {
-      return 0;
-    }
-
-  node = romfs_alloc_sparenode(0, rm->rm_hwsectorsize *
-                               rm->rm_hwnsectors);
-  if (node == NULL)
-    {
-      return -ENOMEM;
-    }
-
-  list_add_head(&rm->rm_sparelist, &node->node);
-  rm->rm_volsize = 0;
-  return 0;
-}
-
-/****************************************************************************
- * Name: romfs_alloc_spareregion
- *
- * Description:
- *   Allocate the spare region
- *
- ****************************************************************************/
-
-static int romfs_alloc_spareregion(FAR struct list_node *list,
-                                   uint32_t start, uint32_t end)
-{
-  FAR struct romfs_sparenode_s *node;
-
-  list_for_every_entry(list, node, struct romfs_sparenode_s, node)
-    {
-      /* Find the node that start ~ end
-       * is in node->start ~ node->end
-       */
-
-      if (start == node->start && end == node->end)
-        {
-          /* Delete the node */
-
-          list_delete(&node->node);
-          fs_heap_free(node);
-          return 0;
-        }
-      else if (start == node->start)
-        {
-          /* Update the node */
-
-          node->start = end;
-          return 0;
-        }
-      else if (end == node->end)
-        {
-          /* Update the node */
-
-          node->end = start;
-          return 0;
-        }
-      else if (start > node->start && end < node->end)
-        {
-          /* Split the node */
-
-          FAR struct romfs_sparenode_s *new;
-          new = romfs_alloc_sparenode(end, node->end);
-          if (new == NULL)
-            {
-              return -ENOMEM;
-            }
-
-          node->end = start;
-          list_add_after(&node->node, &new->node);
-          return 0;
-        }
-    }
-
-  /* Not found */
-
-  ferr("No space for start %" PRIu32 ", end %" PRIu32 "\n", start, end);
-  return -ENOENT;
-}
-
-/****************************************************************************
- * Name: romfs_devmemcpy
- ****************************************************************************/
-
-static void romfs_devmemcpy(FAR struct romfs_mountpt_s *rm,
-                            int ndx, FAR const void *buf, size_t len)
-{
-  memcpy(rm->rm_devbuffer + ndx, buf, len);
-}
-
-/****************************************************************************
- * Name: romfs_devstrcpy
- ****************************************************************************/
-
-static void romfs_devstrcpy(FAR struct romfs_mountpt_s *rm,
-                            int ndx, FAR const char *buf)
-{
-  strcpy((FAR char *)rm->rm_devbuffer + ndx, buf);
-}
-
-/****************************************************************************
- * Name: romfs_devwrite32
- *
- * Description:
- *   Write the big-endian 32-bit value to the mount device buffer
- *
- ****************************************************************************/
-
-static void romfs_devwrite32(FAR struct romfs_mountpt_s *rm,
-                             int ndx, uint32_t value)
-{
-  /* Write the 32-bit value to the specified index in the buffer */
-
-  rm->rm_devbuffer[ndx]     = (uint8_t)(value >> 24) & 0xff;
-  rm->rm_devbuffer[ndx + 1] = (uint8_t)(value >> 16) & 0xff;
-  rm->rm_devbuffer[ndx + 2] = (uint8_t)(value >> 8) & 0xff;
-  rm->rm_devbuffer[ndx + 3] = (uint8_t)(value & 0xff);
-}
-
-/****************************************************************************
- * Name: romfs_hwwrite
- *
- * Description:
- *   Write the specified number of sectors to the block device
- *
- ****************************************************************************/
-
-static int romfs_hwwrite(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
-                         uint32_t sector, unsigned int nsectors)
-{
-  FAR struct inode *inode = rm->rm_blkdriver;
-  ssize_t ret = -ENODEV;
-
-  if (inode->u.i_bops->write)
-    {
-      ret = inode->u.i_bops->write(inode, buffer, sector, nsectors);
-    }
-
-  if (ret == (ssize_t)nsectors)
-    {
-      ret = 0;
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: romfs_devcachewrite
- *
- * Description:
- *   Write the specified sector for specified offset into the sector cache.
- *
- ****************************************************************************/
-
-static int romfs_devcachewrite(FAR struct romfs_mountpt_s *rm,
-                               uint32_t sector)
-{
-  int ret;
-
-  ret = romfs_hwwrite(rm, rm->rm_devbuffer, sector, 1);
-  if (ret >= 0)
-    {
-      rm->rm_cachesector = sector;
-    }
-  else
-    {
-      rm->rm_cachesector = (uint32_t)-1;
-    }
-
-  return ret;
-}
-#endif
-
 /****************************************************************************
  * Name: romfs_cachenode
  *
@@ -619,16 +407,16 @@ static int romfs_devcachewrite(FAR struct romfs_mountpt_s *rm,
 
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
 static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
-                           uint32_t origoffset, uint32_t offset,
-                           uint32_t next, uint32_t size,
-                           FAR const char *name,
+                           uint32_t offset, uint32_t next,
+                           uint32_t size, FAR const char *name,
                            FAR struct romfs_nodeinfo_s **pnodeinfo)
 {
   FAR struct romfs_nodeinfo_s **child;
   FAR struct romfs_nodeinfo_s *nodeinfo;
   char childname[NAME_MAX + 1];
-  uint16_t count = 0;
+  uint32_t linkoffset;
   uint32_t info;
+  uint8_t num = 0;
   size_t nsize;
   int ret;
 
@@ -641,90 +429,72 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
 
   *pnodeinfo              = nodeinfo;
   nodeinfo->rn_offset     = offset;
-  nodeinfo->rn_origoffset = origoffset;
   nodeinfo->rn_next       = next;
   nodeinfo->rn_namesize   = nsize;
   memcpy(nodeinfo->rn_name, name, nsize + 1);
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (!list_is_empty(&rm->rm_sparelist))
-    {
-      uint32_t totalsize = ROMFS_ALIGNUP(ROMFS_FHDR_NAME + nsize + 1);
-      if (offset == origoffset)
-        {
-          totalsize += ROMFS_ALIGNUP(size);
-        }
-
-      rm->rm_volsize += totalsize;
-      ret = romfs_alloc_spareregion(&rm->rm_sparelist, origoffset,
-                                    origoffset + totalsize);
-      if (ret < 0)
-        {
-          return ret;
-        }
-    }
-#endif
-
-  if (!IS_DIRECTORY(next) || (strcmp(name, ".") == 0) ||
-      (strcmp(name, "..") == 0))
+  if (!IS_DIRECTORY(next))
     {
       nodeinfo->rn_size = size;
       return 0;
     }
 
-  origoffset = offset;
   child = nodeinfo->rn_child;
 
   do
     {
-      /* Fetch the directory entry at this offset */
+      /* Parse the directory entry at this offset (which may be re-directed
+       * to some other entry if HARLINKED).
+       */
 
-      ret = romfs_parsedirentry(rm, origoffset, &offset, &next, &info,
+      ret = romfs_parsedirentry(rm, offset, &linkoffset, &next, &info,
                                 &size);
       if (ret < 0)
         {
           return ret;
         }
 
-      ret = romfs_parsefilename(rm, origoffset, childname);
+      ret = romfs_parsefilename(rm, offset, childname);
       if (ret < 0)
         {
           return ret;
         }
 
-      if (child == NULL || nodeinfo->rn_count == count - 1)
+      if (strcmp(childname, ".") != 0 && strcmp(childname, "..") != 0)
         {
-          FAR void *tmp;
-
-          tmp = fs_heap_realloc(nodeinfo->rn_child,
-                (count + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
-          if (tmp == NULL)
+          if (child == NULL || nodeinfo->rn_count == num - 1)
             {
-              return -ENOMEM;
+              FAR void *tmp;
+
+              tmp = fs_heap_realloc(nodeinfo->rn_child,
+                    (num + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
+              if (tmp == NULL)
+                {
+                  return -ENOMEM;
+                }
+
+              nodeinfo->rn_child = tmp;
+              memset(nodeinfo->rn_child + num, 0, NODEINFO_NINCR *
+                     sizeof(*nodeinfo->rn_child));
+              num += NODEINFO_NINCR;
             }
 
-          nodeinfo->rn_child = tmp;
-          memset(nodeinfo->rn_child + count, 0, NODEINFO_NINCR *
-                  sizeof(*nodeinfo->rn_child));
-          count += NODEINFO_NINCR;
-        }
+          child = &nodeinfo->rn_child[nodeinfo->rn_count++];
+          if (IS_DIRECTORY(next))
+            {
+              linkoffset = info;
+            }
 
-      child = &nodeinfo->rn_child[nodeinfo->rn_count++];
-      if (IS_DIRECTORY(next))
-        {
-          offset = info;
-        }
-
-      ret = romfs_cachenode(rm, origoffset, offset, next, size,
-                            childname, child);
-      if (ret < 0)
-        {
-          nodeinfo->rn_count--;
-          return ret;
+          ret = romfs_cachenode(rm, linkoffset, next, size,
+                                childname, child);
+          if (ret < 0)
+            {
+              nodeinfo->rn_count--;
+              return ret;
+            }
         }
 
       next &= RFNEXT_OFFSETMASK;
-      origoffset = next;
+      offset = next;
     }
   while (next != 0);
 
@@ -891,16 +661,6 @@ int romfs_hwconfigure(FAR struct romfs_mountpt_s *rm)
   rm->rm_hwnsectors   = geo.geo_nsectors;
   rm->rm_cachesector  = (uint32_t)-1;
 
-  /* Allocate the device cache buffer for normal sector accesses */
-
-  rm->rm_devbuffer = fs_heap_malloc(rm->rm_hwsectorsize);
-  if (!rm->rm_devbuffer)
-    {
-      return -ENOMEM;
-    }
-
-  /* Determine if block driver supports the XIP mode of operation */
-
   if (inode->u.i_bops->ioctl)
     {
       ret = inode->u.i_bops->ioctl(inode, BIOC_XIPBASE,
@@ -917,32 +677,16 @@ int romfs_hwconfigure(FAR struct romfs_mountpt_s *rm)
         }
     }
 
-  /* The device cache buffer for normal sector accesses */
+  /* Allocate the device cache buffer for normal sector accesses */
 
-  rm->rm_buffer = rm->rm_devbuffer;
+  rm->rm_buffer = fs_heap_malloc(rm->rm_hwsectorsize);
+  if (!rm->rm_buffer)
+    {
+      return -ENOMEM;
+    }
+
   return 0;
 }
-
-/****************************************************************************
- * Name: romfs_free_sparelist
- *
- * Description:
- *   Free the sparelist
- *
- ****************************************************************************/
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-void romfs_free_sparelist(FAR struct list_node *list)
-{
-  FAR struct romfs_sparenode_s *node;
-  FAR struct romfs_sparenode_s *tmp;
-
-  list_for_every_entry_safe(list, node, tmp, struct romfs_sparenode_s, node)
-    {
-      list_delete(&node->node);
-      fs_heap_free(node);
-    }
-}
-#endif
 
 /****************************************************************************
  * Name: romfs_fsconfigure
@@ -955,20 +699,19 @@ void romfs_free_sparelist(FAR struct list_node *list)
  *
  ****************************************************************************/
 
-int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data)
+int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm)
 {
   FAR const char *name;
-  int             ret;
-  uint32_t        rootoffset;
+  int16_t         ndx;
 
   /* Then get information about the ROMFS filesystem on the devices managed
    * by this block driver. Read sector zero which contains the volume header.
    */
 
-  ret = romfs_devcacheread(rm, 0);
-  if (ret < 0)
+  ndx = romfs_devcacheread(rm, 0);
+  if (ndx < 0)
     {
-      return ret;
+      return ndx;
     }
 
   /* Verify the magic number at that identifies this as a ROMFS filesystem */
@@ -980,33 +723,22 @@ int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data)
 
   /* Then extract the values we need from the header and return success */
 
-  rm->rm_volsize = romfs_devread32(rm, ROMFS_VHDR_SIZE);
+  rm->rm_volsize    = romfs_devread32(rm, ROMFS_VHDR_SIZE);
 
   /* The root directory entry begins right after the header */
 
-  name = (FAR const char *)&rm->rm_buffer[ROMFS_VHDR_VOLNAME];
-  rootoffset = ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME + strlen(name) + 1);
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  ret = romfs_init_sparelist(rm, data && strstr(data, "rw"));
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
-
+  name              = (FAR const char *)&rm->rm_buffer[ROMFS_VHDR_VOLNAME];
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
-  ret = romfs_cachenode(rm, 0, rootoffset, RFNEXT_DIRECTORY,
-                        0, "", &rm->rm_root);
-  if (ret < 0)
+  ndx               = romfs_cachenode(rm, ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME +
+                                                        strlen(name) + 1),
+                                      RFNEXT_DIRECTORY, 0, "", &rm->rm_root);
+  if (ndx < 0)
     {
-#  ifdef CONFIG_FS_ROMFS_WRITEABLE
-      romfs_free_sparelist(&rm->rm_sparelist);
-#  endif
       romfs_freenode(rm->rm_root);
-      return ret;
+      return ndx;
     }
 #else
-  rm->rm_rootoffset = rootoffset;
+  rm->rm_rootoffset = ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME + strlen(name) + 1);
 #endif
 
   /* and return success */
@@ -1448,49 +1180,3 @@ int romfs_datastart(FAR struct romfs_mountpt_s *rm,
   return -EINVAL; /* Won't get here */
 #endif
 }
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-
-/****************************************************************************
- * Name: romfs_mkfs
- *
- * Description:
- *   Format the romfs filesystem
- *
- ****************************************************************************/
-
-int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
-{
-  /* Write the magic number at that identifies this as a ROMFS filesystem */
-
-  romfs_devmemcpy(rm, ROMFS_VHDR_ROM1FS, ROMFS_VHDR_MAGIC, ROMFS_VHDR_SIZE);
-
-  /* Init the ROMFS volume size */
-
-  romfs_devwrite32(rm, ROMFS_VHDR_SIZE, 0x60);
-
-  /* Write the volume name */
-
-  romfs_devstrcpy(rm, ROMFS_VHDR_VOLNAME, "romfs");
-
-  /* Write the root node . */
-
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_NEXT, 0x40 | RFNEXT_DIRECTORY);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_INFO, 0x20);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_SIZE, 0);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_CHKSUM, 0);
-  romfs_devstrcpy(rm, 0x20 + ROMFS_FHDR_NAME, ".");
-
-  /* Write the root node .. */
-
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_NEXT, RFNEXT_HARDLINK);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_INFO, 0x20);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_SIZE, 0);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_CHKSUM, 0);
-  romfs_devstrcpy(rm, 0x40 + ROMFS_FHDR_NAME, "..");
-
-  /* Write the buffer to sector zero */
-
-  return romfs_devcachewrite(rm, 0);
-}
-#endif


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This reverts commit ac6fff747a7a6122e61de373350148331a94692f. 
This reverts commit c83e3f651b967c64b5652a6bd2e96bcae48417b4. 
This reverts commit 133db24d072457331134b683ad7b84c8a002feb9. 
This reverts commit 5c1248ec38964e7886b23e65f732241c5d870d69. 
This reverts commit 2cc850b6dcbad904282f1a326f52bff054251591. 
This reverts commit 49cad84508e7db903068180fe4ebdfaef335efac.

Remove the patch sets about writable romfs

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

romfs , remove  the code configed by FS_ROMFS_WRITEABLE

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

test about romfs 

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


