### PR TITLE
Revert "drivers/pm: pm_smp remove sched_lock", should do sched_lock before pm ops and WFI.

### DIFF
--- a/drivers/power/pm/pm_idle.c
+++ b/drivers/power/pm/pm_idle.c
@@ -148,11 +148,10 @@ void pm_idle(pm_idle_handler_t handler)
 
   /* If sched lock before irq save, and irq handler do post, scheduler will
    * be delayed after WFI until next sched unlock. which is not acceptable.
-   * per cpu sched_lock/unlock is not available here, all post/wait api will
-   * not allow in pm_callbacks.
    */
 
   flags = up_irq_save();
+  sched_lock();
 
   oldstate = pm_querystate(domain);
   newstate = pm_checkstate(domain);
@@ -203,11 +202,10 @@ void pm_idle(pm_idle_handler_t handler)
 
   /* If there is pending irq, enable irq make handlers finish all
    * execution will be better decrease scheduler context switch times.
-   * per cpu sched_lock/unlock is not available here, all post/wait api will
-   * not allow in pm_callbacks.
    */
 
   up_irq_restore(flags);
+  sched_unlock();
 }
 
 #else


### PR DESCRIPTION
## Summary
This reverts commit 731af5b42fb20d62b57e79eb52b3fbbeac38eecb.

Now we already support sched_lock for per cpu/tcb,
And as we should support post like API in pm callbacks, should do sched_lock to avoide scheduler problems.

Before percpu/tcb lock ready, when smp case, multi-core do sched_lock will cause a dead lock. This pr revert the workaround patch.

## Impact
pm_idle behavior as expect do sched_lock/sched_unlock.

## Testing
CI-test, qemu-armv8a.
