### PR TITLE
group_signal_handler: Remove a redundant check

### DIFF
--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -85,30 +85,69 @@ static int group_signal_handler(pid_t pid, FAR void *arg)
   tcb = nxsched_get_tcb(pid);
   DEBUGASSERT(tcb != NULL && tcb->group != NULL && info != NULL);
 
-  if (tcb)
+  /* Set this one as the default if we have not already set the
+   * default.
+   */
+
+  if (!info->dtcb)
     {
-      /* Set this one as the default if we have not already set the
-       * default.
+      info->dtcb = tcb;
+    }
+
+  /* Is the thread waiting for this signal (in this case, the signal is
+   * probably blocked).
+   */
+
+  ret = nxsig_ismember(&tcb->sigwaitmask, info->siginfo->si_signo);
+  if (ret == 1 && (!info->atcb || info->siginfo->si_signo == SIGCHLD))
+    {
+      /* Yes.. This means that the task is suspended, waiting for this
+       * signal to occur. Stop looking and use this TCB.  The
+       * requirement is this:  If a task group receives a signal and
+       * more than one thread is waiting on that signal, then one and
+       * only one indeterminate thread out of that waiting group will
+       * receive the signal.
        */
 
-      if (!info->dtcb)
+      ret = nxsig_tcbdispatch(tcb, info->siginfo);
+      if (ret < 0)
         {
-          info->dtcb = tcb;
+          return ret;
         }
 
-      /* Is the thread waiting for this signal (in this case, the signal is
-       * probably blocked).
+      /* Limit to one thread */
+
+      info->atcb = tcb;
+
+      if (info->ptcb != NULL && info->siginfo->si_signo != SIGCHLD)
+        {
+          return 1; /* Terminate the search */
+        }
+    }
+
+  /* Is this signal unblocked on this thread? */
+
+  if (!nxsig_ismember(&tcb->sigprocmask, info->siginfo->si_signo) &&
+      !info->ptcb && tcb != info->atcb)
+    {
+      /* Yes.. remember this TCB if we have not encountered any
+       * other threads that have the signal unblocked.
        */
 
-      ret = nxsig_ismember(&tcb->sigwaitmask, info->siginfo->si_signo);
-      if (ret == 1 && (!info->atcb || info->siginfo->si_signo == SIGCHLD))
+      if (!info->utcb)
         {
-          /* Yes.. This means that the task is suspended, waiting for this
-           * signal to occur. Stop looking and use this TCB.  The
-           * requirement is this:  If a task group receives a signal and
-           * more than one thread is waiting on that signal, then one and
-           * only one indeterminate thread out of that waiting group will
-           * receive the signal.
+          info->utcb = tcb;
+        }
+
+      /* Is there also a action associated with the task group? */
+
+      sigact = nxsig_find_action(tcb->group, info->siginfo->si_signo);
+      if (sigact)
+        {
+          /* Yes.. then use this thread.  The requirement is this:
+           * If a task group receives a signal then one and only one
+           * indeterminate thread in the task group which is not
+           * blocking the signal will receive the signal.
            */
 
           ret = nxsig_tcbdispatch(tcb, info->siginfo);
@@ -119,52 +158,10 @@ static int group_signal_handler(pid_t pid, FAR void *arg)
 
           /* Limit to one thread */
 
-          info->atcb = tcb;
-
-          if (info->ptcb != NULL && info->siginfo->si_signo != SIGCHLD)
+          info->ptcb = tcb;
+          if (info->atcb != NULL)
             {
               return 1; /* Terminate the search */
-            }
-        }
-
-      /* Is this signal unblocked on this thread? */
-
-      if (!nxsig_ismember(&tcb->sigprocmask, info->siginfo->si_signo) &&
-          !info->ptcb && tcb != info->atcb)
-        {
-          /* Yes.. remember this TCB if we have not encountered any
-           * other threads that have the signal unblocked.
-           */
-
-          if (!info->utcb)
-            {
-              info->utcb = tcb;
-            }
-
-          /* Is there also a action associated with the task group? */
-
-          sigact = nxsig_find_action(tcb->group, info->siginfo->si_signo);
-          if (sigact)
-            {
-              /* Yes.. then use this thread.  The requirement is this:
-               * If a task group receives a signal then one and only one
-               * indeterminate thread in the task group which is not
-               * blocking the signal will receive the signal.
-               */
-
-              ret = nxsig_tcbdispatch(tcb, info->siginfo);
-              if (ret < 0)
-                {
-                  return ret;
-                }
-
-              /* Limit to one thread */
-
-              info->ptcb = tcb;
-              if (info->atcb != NULL)
-                {
-                  return 1; /* Terminate the search */
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary

group_signal_handler: Remove a redundant check.
We know tcb is not NULL here as we have a DIAGASSERT on it immediately above.

## Impact

no functional changes are expected.

## Testing

 esp32s3-devkitc:smp
