### PR TITLE
fix some comment in https://github.com/apache/nuttx/pull/14764

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -279,16 +279,6 @@ FAR struct iob_s *iob_alloc_with_data(FAR void *data, uint16_t size,
 int iob_navail(bool throttled);
 
 /****************************************************************************
- * Name: iob_qentry_navail
- *
- * Description:
- *   Return the number of available IOB chains.
- *
- ****************************************************************************/
-
-int iob_qentry_navail(void);
-
-/****************************************************************************
  * Name: iob_free
  *
  * Description:

--- a/mm/iob/iob.h
+++ b/mm/iob/iob.h
@@ -75,27 +75,27 @@ extern FAR struct iob_qentry_s *g_iob_freeqlist;
 extern FAR struct iob_qentry_s *g_iob_qcommitted;
 #endif
 
-/* Counting semaphores that tracks the number of free IOBs/qentries */
+/* semaphores that IOBs need wait */
 
 extern sem_t g_iob_sem;
 
 /* Counts free I/O buffers */
 
-extern volatile int16_t g_iob_count;
+extern int16_t g_iob_count;
 
 #if CONFIG_IOB_THROTTLE > 0
 extern sem_t g_throttle_sem;
 
-/* Counts available I/O buffers when throttled */
+/* Wait Counts for throttle */
 
-extern volatile int16_t g_throttle_count;
+extern int16_t g_throttle_wait;
 #endif
 #if CONFIG_IOB_NCHAINS > 0
 extern sem_t g_qentry_sem;
 
-/* Counts free I/O buffer queue containers */
+/* Wait Counts for qentry */
 
-extern volatile int16_t g_qentry_count;
+extern int16_t g_qentry_wait;
 #endif
 
 extern volatile spinlock_t g_iob_lock;

--- a/mm/iob/iob_free_qentry.c
+++ b/mm/iob/iob_free_qentry.c
@@ -68,17 +68,16 @@ FAR struct iob_qentry_s *iob_free_qentry(FAR struct iob_qentry_s *iobq)
    * iob_tryalloc_qentry()).
    */
 
-  if (g_qentry_count < 0)
+  if (g_qentry_wait > 0)
     {
       iobq->qe_flink   = g_iob_qcommitted;
       g_iob_qcommitted = iobq;
-      g_qentry_count++;
+      g_qentry_wait--;
       spin_unlock_irqrestore(&g_iob_lock, flags);
       nxsem_post(&g_qentry_sem);
     }
   else
     {
-      g_qentry_count++;
       iobq->qe_flink   = g_iob_freeqlist;
       g_iob_freeqlist  = iobq;
       spin_unlock_irqrestore(&g_iob_lock, flags);

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -93,26 +93,25 @@ FAR struct iob_qentry_s *g_iob_qcommitted;
 
 sem_t g_iob_sem = SEM_INITIALIZER(0);
 
-/* Counting semaphores that tracks the number of free IOBs/qentries */
+/* Counting that tracks the number of free IOBs/qentries */
 
-volatile int16_t g_iob_count = CONFIG_IOB_NBUFFERS;
+int16_t g_iob_count = CONFIG_IOB_NBUFFERS;
 
 #if CONFIG_IOB_THROTTLE > 0
 
 sem_t g_throttle_sem = SEM_INITIALIZER(0);
 
-/* Counts available I/O buffers when throttled */
+/* Wait Counts for throttle */
 
-volatile int16_t g_throttle_count = CONFIG_IOB_NBUFFERS -
-                                    CONFIG_IOB_THROTTLE;
+int16_t g_throttle_wait = 0;
 #endif
 
 #if CONFIG_IOB_NCHAINS > 0
 sem_t g_qentry_sem = SEM_INITIALIZER(0);
 
-/* Counts free I/O buffer queue containers */
+/* Wait Counts for qentry */
 
-volatile int16_t g_qentry_count = CONFIG_IOB_NCHAINS;
+int16_t g_qentry_wait = 0;
 #endif
 
 volatile spinlock_t g_iob_lock = SP_UNLOCKED;

--- a/mm/iob/iob_navail.c
+++ b/mm/iob/iob_navail.c
@@ -71,30 +71,3 @@ int iob_navail(bool throttled)
 
   return ret;
 }
-
-/****************************************************************************
- * Name: iob_qentry_navail
- *
- * Description:
- *   Return the number of available IOB chains.
- *
- ****************************************************************************/
-
-int iob_qentry_navail(void)
-{
-  int ret;
-
-#if CONFIG_IOB_NCHAINS > 0
-  /* Get the value of the IOB chain qentry counting semaphores */
-
-  ret = g_qentry_count;
-  if (ret < 0)
-    {
-      ret = 0;
-    }
-#else
-  ret = 0;
-#endif
-
-  return ret;
-}

--- a/mm/iob/iob_statistics.c
+++ b/mm/iob/iob_statistics.c
@@ -68,12 +68,8 @@ void iob_getstats(FAR struct iob_stats_s *stats)
     }
 
 #if CONFIG_IOB_THROTTLE > 0
-  stats->nthrottle = g_throttle_count;
+  stats->nthrottle = (g_iob_count - CONFIG_IOB_THROTTLE);
   if (stats->nthrottle < 0)
-    {
-      stats->nthrottle = -stats->nthrottle;
-    }
-  else
 #endif
     {
       stats->nthrottle = 0;


### PR DESCRIPTION
## Summary
mm/iob: fix some comment in https://github.com/apache/nuttx/pull/14764

reason:
Since we decoupled counting and sem count,
we changed the meanings of three key global variables:

g_iob_count: A positive number indicates the available number
  of IOBs, while a negative number indicates the number of waiters in iob_alloc (when throttle == false).
g_throttle_wait: Represents the number of waiters in
  iob_alloc (when throttle == true), and it will not be negative.
g_qentry_wait: Represents the number of waiters for
  qentry, and it will not be negative.
## Impact
iob 

## Testing
iob test


