### PR TITLE
boards/arm/stm32/nucleo-f4x1re/src/stm32_adc.c: fix typo

### DIFF
--- a/boards/arm/stm32/nucleo-f4x1re/src/stm32_adc.c
+++ b/boards/arm/stm32/nucleo-f4x1re/src/stm32_adc.c
@@ -34,7 +34,7 @@
 
 #include "chip.h"
 #include "arm_internal.h"
-#include "stm32_pwm.h"
+#include "stm32_adc.h"
 #include "nucleo-f4x1re.h"
 
 #include <arch/board/board.h>


### PR DESCRIPTION
## Summary
fix typo, should include ADC file, not PWM file

## Impact

fix typo

## Testing
 none


