### PR TITLE
arch/risc-v/src/mpfs/mpfs_irq.c: Default global interrupt priorities

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -63,6 +63,13 @@ void up_irqinitialize(void)
   riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
+  /* Set priority for all global interrupts to 1 (lowest) */
+
+  for (int id = 1; id <= NR_IRQS; id++)
+    {
+      putreg32(1, MPFS_PLIC_PRIORITY + (4 * id));
+    }
+
   /* Attach the common interrupt handler */
 
   riscv_exception_attach();


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

On MPFS PolarFire, when we recently rebased to use the latest from NuttX, some of the functionality was broken. After reviewing, we noticed mpfs_irq.c no longer defaults the global interrupt priorities (removed in https://github.com/apache/nuttx/pull/14397), and this creates issues where interrupts are missed. Adding this back in.  

## Impact

## Testing

Tested with SMP on MPFS PolarFire. 


