### PR TITLE
arch: cxd56xx: Fix cxd56xx for SMP

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -672,6 +672,7 @@ config ARCH_CHIP_CXD56XX
 	select ARCH_HAVE_MATH_H
 	select ARCH_HAVE_I2CRESET
 	select ARCH_HAVE_CUSTOM_VECTORS
+	select LIBC_ARCH_ATOMIC if SMP
 	---help---
 		Sony CXD56XX (ARM Cortex-M4) architectures
 


### PR DESCRIPTION
## Summary

- In https://github.com/apache/nuttx/pull/14465, atomic_compare_exchange_weak_explicit() was newly introduced in semaphore. However, cxd56xx has an issue with the API if SMP is enabled (see up_testset2 in cxd56_testset.c).
- This commit fixes the issue by using LIBC_ARCH_ATOMIC.

## Impact

- Only cxd56xx SoCs in SMP mode.

## Testing

- Tested with spresense:smp, spresense:wifi_smp
- NOTE: If DEBUG_ASSERTIONS is enabled assert would be happend. I think this might be another issue.
