### PR TITLE
Support enabling/disabling attr attribute in littlefs for nuttx

### DIFF
--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -119,4 +119,12 @@ config FS_LITTLEFS_ATTR_MAX
 
 		Note: Many of tools to generate LITTLEFS images use 1022
 		for this by default.
+
+config FS_LITTLEFS_ATTR_UPDATE
+	bool "LITTLEFS update attributes"
+	depends on FS_LITTLEFS_ATTR_MAX > 0
+	default y
+	---help---
+		Enable support for attributes when create a file.
+
 endif

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -772,7 +772,7 @@ static int littlefs_fstat(FAR const struct file *filep, FAR struct stat *buf)
                                                  &attr, sizeof(attr)));
   if (ret < 0)
     {
-      if (ret != -ENODATA)
+      if (ret != -ENODATA && ret != -ENOENT)
         {
           goto errout;
         }

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -114,8 +114,6 @@ static int     littlefs_dup(FAR const struct file *oldp,
                             FAR struct file *newp);
 static int     littlefs_fstat(FAR const struct file *filep,
                               FAR struct stat *buf);
-static int     littlefs_fchstat(FAR const struct file *filep,
-                                FAR const struct stat *buf, int flags);
 static int     littlefs_truncate(FAR struct file *filep,
                                  off_t length);
 
@@ -148,9 +146,13 @@ static int     littlefs_rename(FAR struct inode *mountpt,
                                FAR const char *newrelpath);
 static int     littlefs_stat(FAR struct inode *mountpt,
                              FAR const char *relpath, FAR struct stat *buf);
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
+static int     littlefs_fchstat(FAR const struct file *filep,
+                                FAR const struct stat *buf, int flags);
 static int     littlefs_chstat(FAR struct inode *mountpt,
                                FAR const char *relpath,
                                FAR const struct stat *buf, int flags);
+#endif
 
 /****************************************************************************
  * Public Data
@@ -178,7 +180,11 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */
   littlefs_fstat,         /* fstat */
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   littlefs_fchstat,       /* fchstat */
+#else
+  NULL,
+#endif
 
   littlefs_opendir,       /* opendir */
   littlefs_closedir,      /* closedir */
@@ -194,7 +200,11 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_rmdir,         /* rmdir */
   littlefs_rename,        /* rename */
   littlefs_stat,          /* stat */
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   littlefs_chstat         /* chstat */
+#else
+  NULL,
+#endif
 };
 
 /****************************************************************************
@@ -347,6 +357,7 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
       goto errout;
     }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   if (oflags & LFS_O_CREAT)
     {
       struct littlefs_attr_s attr;
@@ -366,6 +377,7 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
           goto errout_with_file;
         }
     }
+#endif
 
   /* In append mode, we need to set the file pointer to the end of the
    * file.
@@ -788,6 +800,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
 static int littlefs_fchstat(FAR const struct file *filep,
                             FAR const struct stat *buf, int flags)
 {
@@ -865,6 +878,7 @@ errout:
   nxmutex_unlock(&fs->lock);
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: littlefs_truncate
@@ -1700,6 +1714,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
 static int littlefs_chstat(FAR struct inode *mountpt,
                            FAR const char *relpath,
                            FAR const struct stat *buf, int flags)
@@ -1773,3 +1788,4 @@ errout:
   nxmutex_unlock(&fs->lock);
   return ret;
 }
+#endif


### PR DESCRIPTION
## Summary

This PR is mainly from the discussion of https://github.com/apache/nuttx/pull/14479
In the current littlefs for NuttX, because the attr function is introduced, we can get/set file attributes through the interface `lfs_file_getattr` / `lfs_file_setattr` . But this requires that the mkfs tool also needs to write the file attributes when creating the file, otherwise the fstat interface will return -2

**Changes**
Therefore, in littlefs_fstat we ignore the error message for -ENOENT, and when it returns we assume that it is a file with no attributes set.
At the same time, a new macro `CONFIG_FS_LITTLEFS_ATTR_UPDATE` is introduced to determine whether to write the file attributes each time the file is created, which depends on `FS_LITTLEFS_ATTR_MAX` > 0

## Impact

**Is a new feature added?:** NO
**Impact on build:** NO
**Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation:** NO,This patch does not introduce any new features
**Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh

If we fstat a file without write attributes, it will not return -2. The result is as follows
```
nsh> cd test
nsh> hello
File size: 5 bytes
File permissions: 777
Last access time: 0
Last modification time: 0
```

