### PR TITLE
arch: cxd56xx: Fix compile error of cxd56_gnss.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -40,6 +40,7 @@
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/spi/spi.h>
+#include <nuttx/arch.h>
 
 #include <arch/chip/gnss.h>
 #include <arch/chip/pm.h>


### PR DESCRIPTION
## Summary
Fix error: 'g_rtc_enabled' undeclared (first use in this function).

## Impact
Only cxd56xx

## Testing
Build pass
