### PR TITLE
CI: Kill CI Test after 2 hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
             else
+                ( sleep 7200 ; echo Killing pytest after timeout... ; pkill -f pytest )&
                 ./cibuild.sh -c -A -N -R -S testlist/${{matrix.boards}}.dat
             fi
 


### PR DESCRIPTION
## Summary

CI Test will sometimes run for 6 hours (before getting auto-terminated by GitHub):
- https://github.com/apache/nuttx/issues/14808
- https://github.com/apache/nuttx/issues/14680

This is a problem because:
- It will increase our usage of GitHub Runners. Which may overrun the [GitHub Actions Budget](https://infra.apache.org/github-actions-policy.html) allocated by ASF.
- Suppose right after CI Test there's another build. If CI Test runs for all 6 hours, then the build after CI Test will never run.

For this PR: We assume that Every CI Job (e.g. risc-v-05) will complete normally within 2 hours. If any CI Job exceeds 2 hours: This PR will kill the CI Test Process `pytest` and allow the next build to run.

## Impact

CI Test will no longer run beyond 2 hours. When the CI Test is killed after 2 hours: The CI Job will be reported as a Failed Job, after the subsequent builds have completed.

## Testing

We tested at the NuttX Mirror Repo for CI Job risc-v-05. rv-virt:citest terminates after 2 hours, and allows the next build (rv-virt:citest64) to proceed. GitHub Actions reports CI Job risc-v-05 as a Failed Job.

https://github.com/NuttX/nuttx/actions/runs/11900221153/job/33160708989#step:7:306
```text
Configuration/Tool: rv-virt/citest
20:51:20
...
test_open_posix/test_openposix_.py::test_ltp_interfaces_sigpending_1_1 FAILED [ 15%]
test_open_posix/test_openposix_.py::test_ltp_interfaces_sigismember_3_1 FAILED [ 15%]
test_open_posix/test_openposix_.py::test_ltp_interfaces_sem_wait_11_1 FAILED [ 15%]
test_open_posix/test_openposix_.py::test_ltp_interfaces_pthread_rwlockattr_destroy_2_1 FAILED [ 16%]
Killing pytest after timeout...
Terminated
...
Configuration/Tool: rv-virt/citest64
22:51:28
```
