### PR TITLE
Revert "sim/make: fix macos sim:nsh make break, no -mcmodel in clang"

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -149,8 +149,8 @@ ifeq ($(CONFIG_SIM_M32),y)
   ARCHCFLAGS += -m32
   ARCHCXXFLAGS += -m32
 else
-  ARCHCFLAGS += -fno-pic -mcmodel=large
-  ARCHCXXFLAGS += -fno-pic -mcmodel=large
+  ARCHCFLAGS += -fno-pic -mcmodel=medium
+  ARCHCXXFLAGS += -fno-pic -mcmodel=medium
 endif
 
 # LLVM style architecture flags


### PR DESCRIPTION
This reverts commit 56c920ce5d65145368e364eb1a679d93d2cf74d1.

## Summary


## Impact


## Testing
ci test


