### PR TITLE
GDB Plugin Upgrade part2: memory leak detection and other memory tools

### DIFF
--- a/tools/gdb/lists.py
+++ b/tools/gdb/lists.py
@@ -218,12 +218,12 @@ def dq_check(dq):
     gdb.write("dq_queue is consistent: {} node(s)\n".format(nb))
 
 
-class Nxlistcheck(gdb.Command):
+class ListCheck(gdb.Command):
     """Verify a list consistency"""
 
     def __init__(self):
-        super(Nxlistcheck, self).__init__(
-            "listcheck", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
+        super(ListCheck, self).__init__(
+            "list_check", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
         )
 
     def invoke(self, arg, from_tty):
@@ -240,23 +240,22 @@ class Nxlistcheck(gdb.Command):
             raise gdb.GdbError("Invalid argument type: {}".format(obj.type))
 
 
-Nxlistcheck()
-
-
-class Nxlistforentry(gdb.Command):
+class ListForEveryEntry(gdb.Command):
     """Dump list members for a given list"""
 
     def __init__(self):
-        super(Nxlistforentry, self).__init__(
-            "listforentry", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
+        super(ListForEveryEntry, self).__init__(
+            "list_for_every_entry", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
         )
 
     def invoke(self, arg, from_tty):
         argv = gdb.string_to_argv(arg)
 
         if len(argv) != 3:
-            gdb.write("listforentry takes three arguments" "head, type, member\n")
-            gdb.write("eg: listforentry &g_list 'struct type' 'node '\n")
+            gdb.write(
+                "list_for_every_entry takes three arguments" "head, type, member\n"
+            )
+            gdb.write("eg: list_for_every_entry &g_list 'struct type' 'node '\n")
             return
 
         i = 0
@@ -268,4 +267,5 @@ class Nxlistforentry(gdb.Command):
             i += 1
 
 
-Nxlistforentry()
+ListCheck()
+ListForEveryEntry()

--- a/tools/gdb/lists.py
+++ b/tools/gdb/lists.py
@@ -23,16 +23,16 @@
 import gdb
 import utils
 
-list_node = utils.CachedType("struct list_node")
-sq_queue = utils.CachedType("sq_queue_t")
-dq_queue = utils.CachedType("dq_queue_t")
+list_node_type = utils.lookup_type("struct list_node")
+sq_queue_type = utils.lookup_type("sq_queue_t")
+dq_queue_type = utils.lookup_type("dq_queue_t")
 
 
 def list_for_each(head):
     """Iterate over a list"""
-    if head.type == list_node.get_type().pointer():
+    if head.type == list_node_type.pointer():
         head = head.dereference()
-    elif head.type != list_node.get_type():
+    elif head.type != list_node_type:
         raise TypeError("Must be struct list_node not {}".format(head.type))
 
     if head["next"] == 0:
@@ -59,9 +59,9 @@ def list_check(head):
     """Check the consistency of a list"""
     nb = 0
 
-    if head.type == list_node.get_type().pointer():
+    if head.type == list_node_type.pointer():
         head = head.dereference()
-    elif head.type != list_node.get_type():
+    elif head.type != list_node_type:
         raise gdb.GdbError("argument must be of type (struct list_node [*])")
     c = head
     try:
@@ -123,9 +123,9 @@ def list_check(head):
 
 def sq_for_every(sq, entry):
     """Iterate over a singly linked list"""
-    if sq.type == sq_queue.get_type().pointer():
+    if sq.type == sq_queue_type.pointer():
         sq = sq.dereference()
-    elif sq.type != sq_queue.get_type():
+    elif sq.type != sq_queue_type:
         gdb.write("Must be struct sq_queue not {}".format(sq.type))
         return
 
@@ -141,9 +141,9 @@ def sq_for_every(sq, entry):
 
 def sq_is_empty(sq):
     """Check if a singly linked list is empty"""
-    if sq.type == sq_queue.get_type().pointer():
+    if sq.type == sq_queue_type.pointer():
         sq = sq.dereference()
-    elif sq.type != sq_queue.get_type():
+    elif sq.type != sq_queue_type:
         return False
 
     if sq["head"] == 0:
@@ -155,9 +155,9 @@ def sq_is_empty(sq):
 def sq_check(sq):
     """Check the consistency of a singly linked list"""
     nb = 0
-    if sq.type == sq_queue.get_type().pointer():
+    if sq.type == sq_queue_type.pointer():
         sq = sq.dereference()
-    elif sq.type != sq_queue.get_type():
+    elif sq.type != sq_queue_type:
         gdb.write("Must be struct sq_queue not {}".format(sq.type))
         return
 
@@ -179,9 +179,9 @@ def sq_check(sq):
 
 def dq_for_every(dq, entry):
     """Iterate over a doubly linked list"""
-    if dq.type == dq_queue.get_type().pointer():
+    if dq.type == dq_queue_type.pointer():
         dq = dq.dereference()
-    elif dq.type != dq_queue.get_type():
+    elif dq.type != dq_queue_type:
         gdb.write("Must be struct dq_queue not {}".format(dq.type))
         return
 
@@ -197,9 +197,9 @@ def dq_for_every(dq, entry):
 def dq_check(dq):
     """Check the consistency of a doubly linked list"""
     nb = 0
-    if dq.type == dq_queue.get_type().pointer():
+    if dq.type == dq_queue_type.pointer():
         dq = dq.dereference()
-    elif dq.type != dq_queue.get_type():
+    elif dq.type != dq_queue_type:
         gdb.write("Must be struct dq_queue not {}".format(dq.type))
         return
 
@@ -232,9 +232,9 @@ class Nxlistcheck(gdb.Command):
             raise gdb.GdbError("nx-list-check takes one argument")
 
         obj = gdb.parse_and_eval(argv[0])
-        if obj.type == list_node.get_type().pointer():
+        if obj.type == list_node_type.pointer():
             list_check(obj)
-        elif obj.type == sq_queue.get_type().pointer():
+        elif obj.type == sq_queue_type.pointer():
             sq_check(obj)
         else:
             raise gdb.GdbError("Invalid argument type: {}".format(obj.type))

--- a/tools/gdb/macros.py
+++ b/tools/gdb/macros.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/macros.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -26,14 +28,14 @@
 # then parse and evaluate it by ourselves.
 #
 # There might be two ways to achieve this, one is to leverage the C preprocessor
-# to directly preprocess all the macros instereted into python constants
+# to directly preprocess all the macros interpreted into python constants
 # gcc -E -x c -P <file_with_macros> -I/path/to/nuttx/include
 #
 # While the other way is to leverage the dwarf info stored in the ELF file,
 # with -g3 switch, we have a `.debug_macro` section containing all the information
 # about the macros.
 #
-# Currently, we using the second method.
+# Currently, we are using the second method.
 
 import os
 import re
@@ -184,9 +186,9 @@ def do_expand(expr, macro_map):
 
 
 # NOTE: Implement a fully functional parser which can
-# preprocessing all the C marcos according to ISO 9899 standard
+# preprocess all the C macros according to ISO 9899 standard
 # may be an overkill, what we really care about are those
-# macros that can be evaluted to an constant value.
+# macros that can be evaluated to a constant value.
 #
 # #define A (B + C + D)
 # #define B 1
@@ -202,7 +204,7 @@ def do_expand(expr, macro_map):
 # use case for it in our GDB plugin.
 #
 # However, you can switch to the correct stack frame that has this macro defined
-# and let GDB expand and evaluate it for you if you really want to evalue some very
+# and let GDB expand and evaluate it for you if you really want to evaluate some very
 # complex macros.
 
 

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -20,7 +20,6 @@
 
 import argparse
 import bisect
-import math
 import time
 
 import gdb
@@ -794,8 +793,15 @@ class Memmap(gdb.Command):
             print("pip install matplotlib numpy")
             return False
 
+        try:
+            import math as math
+        except ImportError:
+            print("Please consider to use gdb-multiarch")
+            return False
+
         self.np = np
         self.plt = plt
+        self.math = math
         self.initialized = True
         return True
 
@@ -804,7 +810,7 @@ class Memmap(gdb.Command):
         start = mallinfo[0]["addr"]
         size = mallinfo[-1]["addr"] - start
 
-        order = math.ceil(size**0.5)
+        order = self.math.ceil(size**0.5)
         img = self.np.zeros([order, order])
 
         for node in mallinfo:
@@ -812,7 +818,7 @@ class Memmap(gdb.Command):
             size = node["size"]
             start_index = addr - start
             end_index = start_index + size
-            img.flat[start_index:end_index] = 1 + math.log2(node["sequence"] + 1)
+            img.flat[start_index:end_index] = 1 + self.math.log2(node["sequence"] + 1)
 
         self.plt.imsave(output_file, img, cmap=self.plt.get_cmap("Greens"))
 

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -759,8 +759,11 @@ class Memleak(gdb.Command):
         if arg is None:
             return
 
-        if CONFIG_MM_BACKTRACE <= 0:
-            gdb.write("Better use CONFIG_MM_BACKTRACE=16 or 8 get more information\n")
+        if CONFIG_MM_BACKTRACE < 0:
+            gdb.write("Need to set CONFIG_MM_BACKTRACE to 8 or 16 better.\n")
+            return
+        elif CONFIG_MM_BACKTRACE == 0:
+            gdb.write("CONFIG_MM_BACKTRACE is 0, no backtrace available\n")
 
         start = last = time.time()
         white_dict = self.collect_white_dict()

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/memdump.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -469,7 +471,7 @@ class Memdump(gdb.Command):
                 return
 
         title_dict = {
-            PID_MM_ALLOC: "Dump all used memory node info, use '\x1b[33;1m*\x1b[m' mark pid is not exist:\n",
+            PID_MM_ALLOC: "Dump all used memory node info, use '\x1b[33;1m*\x1b[m' mark pid does not exist:\n",
             PID_MM_FREE: "Dump all free memory node info:\n",
             PID_MM_BIGGEST: f"Dump biggest allocated top {biggest_top}\n",
             PID_MM_ORPHAN: "Dump allocated orphan nodes\n",
@@ -789,10 +791,10 @@ class Memleak(gdb.Command):
 
         gdb.write("\n")
         if len(white_dict) == 0:
-            gdb.write("All node have references, no memory leak!\n")
+            gdb.write("All nodes have references, no memory leak!\n")
             return
 
-        gdb.write("Leak catch!, use '\x1b[33;1m*\x1b[m' mark pid is not exist:\n")
+        gdb.write("Leak catch!, use '\x1b[33;1m*\x1b[m' mark pid does not exist:\n")
 
         if CONFIG_MM_BACKTRACE > 0 and not arg["detail"]:
             gdb.write("%6s" % ("CNT"))

--- a/tools/gdb/requirements.txt
+++ b/tools/gdb/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+numpy

--- a/tools/gdb/requirements.txt
+++ b/tools/gdb/requirements.txt
@@ -1,2 +1,3 @@
 matplotlib
 numpy
+pyelftools

--- a/tools/gdb/stack.py
+++ b/tools/gdb/stack.py
@@ -57,7 +57,7 @@ class Stack(object):
             gdb.write("An overflow detected, dumping the stack:\n")
 
             ptr_4bytes = gdb.Value(self._stack_base).cast(
-                gdb.lookup_type("unsigned int").pointer()
+                utils.lookup_type("unsigned int").pointer()
             )
 
             for i in range(0, self._stack_size // 4):
@@ -80,7 +80,7 @@ class Stack(object):
 
     def check_max_usage(self):
         ptr_4bytes = gdb.Value(self._stack_base).cast(
-            gdb.lookup_type("unsigned int").pointer()
+            utils.lookup_type("unsigned int").pointer()
         )
 
         spare = 0

--- a/tools/gdb/stack.py
+++ b/tools/gdb/stack.py
@@ -143,7 +143,7 @@ def fetch_stacks():
             )
 
         except gdb.GdbError as e:
-            gdb.write(f"Failed to construction stack object for tcb: {e}")
+            gdb.write(f"Failed to construct stack object for tcb: {e}")
 
     return stacks
 

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/thread.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -504,8 +504,8 @@ def register_commands():
     Ps()
 
     # Disable thread commands for core dump and gdb-stub.
-    # In which case the recogoized threads count is less or equal to the number of cpus
-    ncpus = utils.get_symbol_value("CONFIG_SMP_NCPUS")
+    # In which case the recognized threads count is less or equal to the number of cpus
+    ncpus = utils.get_symbol_value("CONFIG_SMP_NCPUS") or 1
     nthreads = len(gdb.selected_inferior().threads())
     if nthreads <= ncpus:
         Nxsetregs()

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -499,18 +499,6 @@ class Ps(gdb.Command):
             self.parse_and_show_info(tcb)
 
 
-# We can't use a user command to rename continue it will recursion
-
-gdb.execute("define c\n nxcontinue \n end\n")
-gdb.execute("define s\n nxstep \n end\n")
-gdb.write(
-    "\n\x1b[31;1m if use thread command, please don't use 'continue', use 'c' instead !!!\x1b[m\n"
-)
-gdb.write(
-    "\x1b[31;1m if use thread command, please don't use 'step', use 's' instead !!!\x1b[m\n"
-)
-
-
 def register_commands():
     Nxsetregs()
     Ps()
@@ -525,6 +513,16 @@ def register_commands():
         Nxthread()
         Nxcontinue()
         Nxstep()
+
+        # We can't use a user command to rename continue it will recursion
+        gdb.execute("define c\n nxcontinue \n end\n")
+        gdb.execute("define s\n nxstep \n end\n")
+        gdb.write(
+            "\n\x1b[31;1m if use thread command, please don't use 'continue', use 'c' instead !!!\x1b[m\n"
+        )
+        gdb.write(
+            "\x1b[31;1m if use thread command, please don't use 'step', use 's' instead !!!\x1b[m\n"
+        )
 
 
 register_commands()

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -93,12 +93,12 @@ class Nxsetregs(gdb.Command):
 
         if arg[0] != "":
             regs = gdb.parse_and_eval(f"{arg[0]}").cast(
-                gdb.lookup_type("char").pointer()
+                utils.lookup_type("char").pointer()
             )
         else:
             gdb.execute("set $_current_regs=tcbinfo_current_regs()")
             current_regs = gdb.parse_and_eval("$_current_regs")
-            regs = current_regs.cast(gdb.lookup_type("char").pointer())
+            regs = current_regs.cast(utils.lookup_type("char").pointer())
 
         if regs == 0:
             gdb.write("regs is NULL\n")
@@ -114,7 +114,7 @@ class Nxsetregs(gdb.Command):
             gdb.execute("select-frame 0")
             if tcbinfo["reg_off"]["p"][i] != UINT16_MAX:
                 value = gdb.Value(regs + tcbinfo["reg_off"]["p"][i]).cast(
-                    gdb.lookup_type("uintptr_t").pointer()
+                    utils.lookup_type("uintptr_t").pointer()
                 )[0]
                 gdb.execute(f"set ${reg.name} = {value}")
 
@@ -162,9 +162,9 @@ class Nxinfothreads(gdb.Command):
             statename = f'\x1b{"[32;1m" if statename == "Running" else "[33;1m"}{statename}\x1b[m'
 
             if tcb["task_state"] == gdb.parse_and_eval("TSTATE_WAIT_SEM"):
-                mutex = tcb["waitobj"].cast(gdb.lookup_type("sem_t").pointer())
+                mutex = tcb["waitobj"].cast(utils.lookup_type("sem_t").pointer())
                 if mutex["flags"] & SEM_TYPE_MUTEX:
-                    mutex = tcb["waitobj"].cast(gdb.lookup_type("mutex_t").pointer())
+                    mutex = tcb["waitobj"].cast(utils.lookup_type("mutex_t").pointer())
                     statename = f"Waiting,Mutex:{mutex['holder']}"
 
             try:

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -145,6 +145,16 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
     return value
 
 
+def import_check(module, name="", errmsg=""):
+    try:
+        module = __import__(module, fromlist=[name])
+    except ImportError:
+        gdb.write(errmsg if errmsg else f"Error to import {module}\n")
+        return None
+
+    return getattr(module, name) if name else module
+
+
 def hexdump(address, size):
     inf = gdb.inferiors()[0]
     mem = inf.read_memory(address, size)

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -141,9 +141,12 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
     # If there is a current stack frame, GDB uses the macros in scope at that frame’s source code line.
     # Otherwise, GDB uses the macros in scope at the current listing location.
     # Reference: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Macros.html#Macros
-    if not gdb.selected_frame():
-        gdb.execute(f"list {locspec}", to_string=True)
-        return gdb_eval_or_none(name)
+    try:
+        if not gdb.selected_frame():
+            gdb.execute(f"list {locspec}", to_string=True)
+            return gdb_eval_or_none(name)
+    except gdb.error:
+        pass
 
     # Try current frame
     value = gdb_eval_or_none(name)

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -1,6 +1,8 @@
 ############################################################################
 # tools/gdb/utils.py
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -323,7 +325,7 @@ target_arch = None
 
 def is_target_arch(arch, exact=False):
     """
-    For non exactly match, this function will
+    For non extact match, this function will
     return True if the target architecture contains
     keywords of an ARCH family. For example, x86 is
     contained in i386:x86_64.
@@ -410,7 +412,7 @@ def get_arch_pc_name():
 def get_register_byname(regname, tcb=None):
     frame = gdb.selected_frame()
 
-    # If no tcb is given then we can directly used the register from
+    # If no tcb is given then we can directly use the register from
     # the cached frame by GDB
     if not tcb:
         return int(frame.read_register(regname))

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -23,7 +23,9 @@
 import re
 
 import gdb
-from macros import fetch_macro_info, try_expand
+from macros import fetch_macro_info
+
+g_symbol_cache = {}
 
 
 class CachedType:
@@ -132,17 +134,53 @@ def gdb_eval_or_none(expresssion):
         return None
 
 
-def get_symbol_value(name):
+def get_symbol_value(name, locspec="nx_start", cacheable=True):
     """Return the value of a symbol value etc: Variable, Marco"""
+    global g_symbol_cache
 
-    expr = None
+    # If there is a current stack frame, GDB uses the macros in scope at that frame’s source code line.
+    # Otherwise, GDB uses the macros in scope at the current listing location.
+    # Reference: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Macros.html#Macros
+    if not gdb.selected_frame():
+        gdb.execute(f"list {locspec}", to_string=True)
+        return gdb_eval_or_none(name)
 
-    try:
-        gdb.execute("set $_%s = %s" % (name, name))
-        expr = "$_%s" % (name)
-    except gdb.error:
-        expr = try_expand(name, macroctx.macro_map)
-    return gdb_eval_or_none(expr)
+    # Try current frame
+    value = gdb_eval_or_none(name)
+    if value:
+        return value
+
+    # Check if the symbol is already cached
+    if cacheable and (name, locspec) in g_symbol_cache:
+        return g_symbol_cache[(name, locspec)]
+
+    # There's current frame and no definition found. We need second inferior without a valid frame
+    # in order to use the list command to set the scope.
+    if len(gdb.inferiors()) == 1:
+        gdb.execute(
+            f"add-inferior -exec {gdb.objfiles()[0].filename} -no-connection",
+            to_string=True,
+        )
+        g_symbol_cache = {}
+
+    suppressed = "on" in gdb.execute("show suppress-cli-notifications", to_string=True)
+    if not suppressed:
+        # Disable notifications
+        gdb.execute("set suppress-cli-notifications on")
+
+    # Switch to inferior 2 and set the scope firstly
+    gdb.execute("inferior 2", to_string=True)
+    gdb.execute(f"list {locspec}", to_string=True)
+    value = gdb_eval_or_none(name)
+    if cacheable:
+        g_symbol_cache[(name, locspec)] = value
+
+    # Switch back to inferior 1
+    gdb.execute("inferior 1", to_string=True)
+
+    if not suppressed:
+        gdb.execute("set suppress-cli-notifications off")
+    return value
 
 
 def hexdump(address, size):

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -166,7 +166,9 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
         )
         g_symbol_cache = {}
 
-    suppressed = "on" in gdb.execute("show suppress-cli-notifications", to_string=True)
+    suppressed = "is on" in gdb.execute(
+        "show suppress-cli-notifications", to_string=True
+    )
     if not suppressed:
         # Disable notifications
         gdb.execute("set suppress-cli-notifications on")

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -123,9 +123,14 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
         )
         g_symbol_cache = {}
 
-    suppressed = "is on" in gdb.execute(
-        "show suppress-cli-notifications", to_string=True
-    )
+    try:
+        suppressed = "is on" in gdb.execute(
+            "show suppress-cli-notifications", to_string=True
+        )
+    except gdb.error:
+        # Treat as suppressed if the command is not available
+        suppressed = True
+
     if not suppressed:
         # Disable notifications
         gdb.execute("set suppress-cli-notifications on")


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR is based on https://github.com/apache/nuttx/pull/14843 to minimize conflicts. I will rebase once that one is merged. The changes are from commit 679e38df843b869207cc6c6701851a1206a2312b.

In this PR, @anjiahao1 introduces a powerful tool to automatically detect memory leak based on offline core dump or online gdb connection. There are follow up commits that optimizes memleak detection speed.

The memfrag from @Gary-Hobson is used to calculate memory fragmentation rate, so we can have a relatively unified number to check the fragmentation rate.

The memmap from @Gary-Hobson  can visually show the memory status.

This PR also includes miscellaneous bug fixes for utils module such as compatibility for older version of GDB etc.


## Impact

New feature and bug fixes.

## Testing


I tested on qemu arm64 with below additional configuration. Note that `-g3` is needed in order to parse the macro values which are needed by the tool.

```patch
+CONFIG_MM_BACKTRACE=16
+CONFIG_MM_BACKTRACE_DEFAULT=y
+CONFIG_MM_BACKTRACE_SKIP=1
+CONFIG_MM_HEAP_MEMPOOL_BACKTRACE_SKIP=3
+CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256
+CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"
+CONFIG_DEBUG_MM=y
```

1. compile and launch

```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm64/qemu/qemu-armv8a/configs/nsh_smp nuttx

 qemu-system-aarch64 -smp 4 -cpu cortex-a53 -semihosting -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel build/nuttx -gdb tcp::1127
```
2. Connect GDB and do analysis
`gdb-multiarch build/nuttx -ex "tar rem:1127" -ex "source nuttx/tools/gdb/__init__.py"`
3. execute `memleak` command
```bash
(gdb) memleak
Searching for leaked memory, please wait a moment
Searching in global variables 0x40433000 ~ 0x40448000
Searching in grey memory
Search all memory use 0.03 seconds

Leak catch!, use '*' mark pid is not exist:
   CNT   PID        Size    Sequence            Address Callstack
     2     0         160           0         0x40454b80
*    1     4         256          34         0x40459290  [0x000000000402c09d8] <mm_malloc+48>       /home/neo/projects/nuttx/nuttx/mm/mm_heap/mm_malloc.c:186
                                                         [0x000000000402c153c] <malloc+28>          /home/neo/projects/nuttx/nuttx/mm/umm_heap/umm_malloc.c:66
                                                         [0x000000000402f15bc] <hello_main+16>      /home/neo/projects/nuttx/apps/examples/hello/hello_main.c:39
                                                         [0x000000000402d3458] <nxtask_startup+48>  /home/neo/projects/nuttx/nuttx/libs/libc/sched/task_startup.c:72
                                                         [0x000000000402cdf90] <nxtask_start+208>   /home/neo/projects/nuttx/nuttx/sched/task/task_start.c:75

Alloc 3 count,have 2 some backtrace leak, total leak memory is 256 bytes
Finished in 0.06 seconds
(gdb)

```

Note the leak is generated by example in hello_main.c:
```patch
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -35,6 +35,6 @@
 
 int main(int argc, FAR char *argv[])
 {
-  printf("Hello, World!!\n");
+  printf("Hello, World!!: %p\n", malloc(123));
   return 0;
 }
```

