### PR TITLE
GDB Plugin Upgrade part3: fs related tools

### DIFF
--- a/tools/gdb/fs.py
+++ b/tools/gdb/fs.py
@@ -1,0 +1,59 @@
+############################################################################
+# tools/gdb/fs.py
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import gdb
+import utils
+
+FSNODEFLAG_TYPE_MASK = utils.get_symbol_value("FSNODEFLAG_TYPE_MASK")
+FSNODEFLAG_TYPE_MOUNTPT = utils.get_symbol_value("FSNODEFLAG_TYPE_MOUNTPT")
+
+
+def get_inode_name(inode):
+    ptr = inode["i_name"].cast(gdb.lookup_type("char").pointer())
+    return ptr.string()
+
+
+def foreach_inode(handler, root=None, path=""):
+    node = root if root else gdb.parse_and_eval("g_root_inode")["i_child"]
+    while node:
+        newpath = path + "/" + get_inode_name(node)
+        handler(node, newpath)
+        if node["i_child"]:
+            foreach_inode(handler, node["i_child"], newpath)
+        node = node["i_peer"]
+
+
+class Mount(gdb.Command):
+    def __init__(self):
+        super(Mount, self).__init__("mount", gdb.COMMAND_USER)
+
+    def mountpt_filter(self, node, path):
+        if node["i_flags"] & FSNODEFLAG_TYPE_MASK == FSNODEFLAG_TYPE_MOUNTPT:
+            statfs = node["u"]["i_mops"]["statfs"]
+            funcname = gdb.block_for_pc(int(statfs)).function.print_name
+            fstype = funcname.split("_")[0]
+            gdb.write("  %s type %s\n" % (path, fstype))
+
+    def invoke(self, args, from_tty):
+        foreach_inode(self.mountpt_filter)
+
+
+if not utils.get_symbol_value("CONFIG_DISABLE_MOUNTPOINT"):
+    Mount()

--- a/tools/gdb/fs.py
+++ b/tools/gdb/fs.py
@@ -117,7 +117,7 @@ class Fdinfo(gdb.Command):
         output = []
         if CONFIG_FS_BACKTRACE:
             backtrace = utils.backtrace(
-                [file["f_backtrace"][i] for i in range(CONFIG_FS_BACKTRACE)]
+                file["f_backtrace"][i] for i in range(CONFIG_FS_BACKTRACE)
             )
 
             backtrace = [

--- a/tools/gdb/fs.py
+++ b/tools/gdb/fs.py
@@ -18,14 +18,21 @@
 #
 ############################################################################
 
+import argparse
+
 import gdb
 import utils
 
 FSNODEFLAG_TYPE_MASK = utils.get_symbol_value("FSNODEFLAG_TYPE_MASK")
 FSNODEFLAG_TYPE_MOUNTPT = utils.get_symbol_value("FSNODEFLAG_TYPE_MOUNTPT")
 
+CONFIG_PSEUDOFS_FILE = utils.get_symbol_value("CONFIG_PSEUDOFS_FILE")
+CONFIG_PSEUDOFS_ATTRIBUTES = utils.get_symbol_value("CONFIG_PSEUDOFS_ATTRIBUTES")
+
 
 def get_inode_name(inode):
+    if not inode:
+        return ""
     ptr = inode["i_name"].cast(gdb.lookup_type("char").pointer())
     return ptr.string()
 
@@ -55,5 +62,109 @@ class Mount(gdb.Command):
         foreach_inode(self.mountpt_filter)
 
 
+class ForeachInode(gdb.Command):
+    """Dump each inode info"""
+
+    def __init__(self):
+        super(ForeachInode, self).__init__("foreach_inode", gdb.COMMAND_USER)
+        self.level = 4096
+
+    def get_root_inode(self, addr_or_expr):
+        try:
+            return gdb.Value(int(addr_or_expr, 0)).cast(
+                gdb.lookup_type("struct inode").pointer()
+            )
+        except ValueError:
+            return utils.gdb_eval_or_none(addr_or_expr)
+
+    def parse_arguments(self, argv):
+        parser = argparse.ArgumentParser(description="foreach_inode command")
+        parser.add_argument(
+            "-L",
+            "--level",
+            type=int,
+            default=None,
+            help="Only render the tree to a specific depth",
+        )
+        parser.add_argument(
+            "addr_or_expr",
+            type=str,
+            nargs="?",
+            default=None,
+            help="set the start inode to be tranversed",
+        )
+        try:
+            args = parser.parse_args(argv)
+        except SystemExit:
+            return None
+        return {
+            "level": args.level if args.level else 4096,
+            "root_inode": (
+                self.get_root_inode(args.addr_or_expr)
+                if args.addr_or_expr
+                else utils.gdb_eval_or_none("g_root_inode")
+            ),
+        }
+
+    def print_inode_info(self, node, level, prefix):
+        if level > self.level:
+            return
+        while node:
+            if node["i_peer"]:
+                initial_indent = prefix + "├── "
+                subsequent_indent = prefix + "│   "
+                newprefix = prefix + "│   "
+            else:
+                initial_indent = prefix + "└── "
+                subsequent_indent = prefix + "    "
+                newprefix = prefix + "    "
+            gdb.write(
+                "%s [%s], %s, %s\n"
+                % (initial_indent, get_inode_name(node), node["i_ino"], node)
+            )
+            gdb.write(
+                "%s i_crefs: %s, i_flags: %s, i_private: %s\n"
+                % (
+                    subsequent_indent,
+                    node["i_crefs"],
+                    node["i_flags"],
+                    node["i_private"],
+                )
+            )
+            if CONFIG_PSEUDOFS_FILE:
+                gdb.write("%s i_size: %s\n" % (subsequent_indent, node["i_size"]))
+            if CONFIG_PSEUDOFS_ATTRIBUTES:
+                gdb.write(
+                    "%s i_mode: %s, i_owner: %s, i_group: %s\n"
+                    % (
+                        subsequent_indent,
+                        node["i_mode"],
+                        node["i_owner"],
+                        node["i_group"],
+                    )
+                )
+                gdb.write(
+                    "%s i_atime: %s, i_mtime: %s, i_ctime: %s\n"
+                    % (
+                        subsequent_indent,
+                        node["i_atime"],
+                        node["i_mtime"],
+                        node["i_ctime"],
+                    )
+                )
+            if node["i_child"]:
+                self.print_inode_info(node["i_child"], level + 1, newprefix)
+            node = node["i_peer"]
+
+    def invoke(self, args, from_tty):
+        arg = self.parse_arguments(args.split(" "))
+        if not arg:
+            return
+        self.level = arg["level"]
+        self.print_inode_info(arg["root_inode"], 1, "")
+
+
 if not utils.get_symbol_value("CONFIG_DISABLE_MOUNTPOINT"):
     Mount()
+
+ForeachInode()

--- a/tools/gdb/lists.py
+++ b/tools/gdb/lists.py
@@ -240,12 +240,12 @@ class ListCheck(gdb.Command):
             raise gdb.GdbError("Invalid argument type: {}".format(obj.type))
 
 
-class ListForEveryEntry(gdb.Command):
+class ForeachListEntry(gdb.Command):
     """Dump list members for a given list"""
 
     def __init__(self):
-        super(ListForEveryEntry, self).__init__(
-            "list_for_every_entry", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
+        super(ForeachListEntry, self).__init__(
+            "foreach_list_entry", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION
         )
 
     def invoke(self, arg, from_tty):
@@ -268,4 +268,4 @@ class ListForEveryEntry(gdb.Command):
 
 
 ListCheck()
-ListForEveryEntry()
+ForeachListEntry()

--- a/tools/gdb/memdump.py
+++ b/tools/gdb/memdump.py
@@ -989,7 +989,7 @@ class Memfrag(gdb.Command):
                 gdb.write(f"addr: {node['addr']}, size: {node['size']}\n")
 
         heapsize = gdb.parse_and_eval("*g_mmheap")["mm_heapsize"]
-        freesize = sum([node["size"] for node in info])
+        freesize = sum(node["size"] for node in info)
         remaining = freesize
         fragrate = 0
 

--- a/tools/gdb/thread.py
+++ b/tools/gdb/thread.py
@@ -412,10 +412,8 @@ class Ps(gdb.Command):
 
         sigmask = "{0:#0{1}x}".format(
             sum(
-                [
-                    int(tcb["sigprocmask"]["_elem"][i] << i)
-                    for i in range(get_macro("_SIGSET_NELEM"))
-                ]
+                int(tcb["sigprocmask"]["_elem"][i] << i)
+                for i in range(get_macro("_SIGSET_NELEM"))
             ),
             get_macro("_SIGSET_NELEM") * 8 + 2,
         )[

--- a/tools/gdb/utils.py
+++ b/tools/gdb/utils.py
@@ -21,11 +21,28 @@
 ############################################################################
 
 import re
+from typing import List
 
 import gdb
 
 g_symbol_cache = {}
 g_type_cache = {}
+
+
+def backtrace(addresses: List[gdb.Value]) -> List[str]:
+    """Convert addresses to backtrace"""
+    backtrace = []
+
+    for addr in addresses:
+        if not addr:
+            break
+
+        func = addr.format_string(symbols=True, address=False)
+        sym = gdb.find_pc_line(int(addr))
+        source = str(sym.symtab) + ":" + str(sym.line)
+        backtrace.append((int(addr), func, source))
+
+    return backtrace
 
 
 def lookup_type(name, block=None) -> gdb.Type:


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

In this PR, we introduces several fs related tools. 
This PR is based on part1/2 to minimize conflicts. I'll rebase once they are merged. For now please review commits by commits.

New tools added:
1. mount: similar to device side, mount lists all the mount point.
2. `foreach_inode` print all the inode and its information
```
go through each inode and print its structure info
in the form like below:
├── i_name: bin, i_ino: 51
│   i_parent: , i_peer: data, i_child: , i_crefs: 1, i_flags: 3
│   ......(other info)
│   ├── i_name: audio, i_ino: 5
│   │   i_parent: dev, i_peer: binder, i_child: mixer......
```
3. `fdinfo` print all the file opened in each task
```
(gdb) fdinfo
PID: 0
FD  OFLAGS  POS   PATH                  BACKTRACE
0   3       0     /dev/console          0x4028ff0c <sched_backtrace+48>                 /home/neo/projects/vela2/nuttx/sched/sched/sched_backtrace.c:105
                                        0x402888f8 <file_allocate_from_tcb+236>         /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:615
                                        0x402979d0 <nx_vopen+104>                       /home/neo/projects/vela2/nuttx/fs/vfs/fs_open.c:326
                                        0x40297ad4 <nx_open+116>                        /home/neo/projects/vela2/nuttx/fs/vfs/fs_open.c:449
                                        0x40291eb4 <group_setupidlefiles+28>            /home/neo/projects/vela2/nuttx/sched/group/group_setupidlefiles.c:75
                                        0x4028df94 <nx_start+628>                       /home/neo/projects/vela2/nuttx/sched/init/nx_start.c:651
                                        0x4028119c <arm64_boot_primary_c_routine+16>    /home/neo/projects/vela2/nuttx/arch/arm64/src/common/arm64_boot.c:205

1   3       0     /dev/console          0x4028ff0c <sched_backtrace+48>                 /home/neo/projects/vela2/nuttx/sched/sched/sched_backtrace.c:105
                                        0x40289574 <file_dup3+248>                      /home/neo/projects/vela2/nuttx/fs/vfs/fs_dup2.c:177
                                        0x40288b88 <nx_dup3_from_tcb+176>               /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:314
                                        0x40288c64 <nx_dup2_from_tcb+16>                /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:901
                                        0x40288c88 <nx_dup2+28>                         /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:924
                                        0x40291ec4 <group_setupidlefiles+44>            /home/neo/projects/vela2/nuttx/sched/group/group_setupidlefiles.c:84
                                        0x4028df94 <nx_start+628>                       /home/neo/projects/vela2/nuttx/sched/init/nx_start.c:651
                                        0x4028119c <arm64_boot_primary_c_routine+16>    /home/neo/projects/vela2/nuttx/arch/arm64/src/common/arm64_boot.c:205

2   3       0     /dev/console          0x4028ff0c <sched_backtrace+48>                 /home/neo/projects/vela2/nuttx/sched/sched/sched_backtrace.c:105
                                        0x40289574 <file_dup3+248>                      /home/neo/projects/vela2/nuttx/fs/vfs/fs_dup2.c:177
                                        0x40288b88 <nx_dup3_from_tcb+176>               /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:314
                                        0x40288c64 <nx_dup2_from_tcb+16>                /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:901
                                        0x40288c88 <nx_dup2+28>                         /home/neo/projects/vela2/nuttx/fs/inode/fs_files.c:924
                                        0x40291ed0 <group_setupidlefiles+56>            /home/neo/projects/vela2/nuttx/sched/group/group_setupidlefiles.c:117
                                        0x4028df94 <nx_start+628>                       /home/neo/projects/vela2/nuttx/sched/init/nx_start.c:651
                                        0x4028119c <arm64_boot_primary_c_routine+16>    /home/neo/projects/vela2/nuttx/arch/arm64/src/common/arm64_boot.c:205
```
4. `info shm` show the share memory usage
```
(gdb) info shm
  /var/shm/xms:bq-325-1044165565 memsize: 1536000, paddr: 0x41de3970
  /var/shm/xms:bq-325-2123092606 memsize: 1536000, paddr: 0x41f5a9a8
  /var/shm/xms:fakemq-325-1835096569 memsize: 12, paddr: 0x420d19e0
(gdb)
```

Also included an performance optimization that use generate instead of list where possible.

## Impact

New feature added.

## Testing

Tested on qemu arm64(info shm is not available because it's disabled).
