### PR TITLE
xtensa/esp32: Remove duplicate board Make.defs

### DIFF
--- a/boards/xtensa/esp32/esp32-2432S028/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-2432S028/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/esp32-audio-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-audio-kit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_USERLED),y)

--- a/boards/xtensa/esp32/esp32-devkitc/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/esp32-lyrat/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-lyrat/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_USERLED),y)

--- a/boards/xtensa/esp32/esp32-pico-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-pico-kit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/esp32-sparrow-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-sparrow-kit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)

--- a/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/Make.defs
+++ b/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/ttgo_eink5_v2/src/Make.defs
+++ b/boards/xtensa/esp32/ttgo_eink5_v2/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/Make.defs
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32/ttgo_t_display_esp32/src/Make.defs
+++ b/boards/xtensa/esp32/ttgo_t_display_esp32/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s2/esp32s2-kaluga-1/src/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-kaluga-1/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s2_boot.c esp32s2_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s2_boot.c esp32s2_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s2/franzininho-wifi/src/Make.defs
+++ b/boards/xtensa/esp32s2/franzininho-wifi/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s2_boot.c esp32s2_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-box/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-eye/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-eye/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-lhcbit/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-lhcbit/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)

--- a/boards/xtensa/esp32s3/esp32s3-meadow/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-meadow/src/Make.defs
@@ -20,8 +20,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 CSRCS = esp32s3_boot.c esp32s3_bringup.c
 
 ifeq ($(CONFIG_BOARDCTL),y)


### PR DESCRIPTION
## Summary

Remove duplicate board Make.defs.

In PR https://github.com/apache/nuttx/pull/14805 we found board Make.defs
will be included twice, so remove one of them.

## Impact

ESP32 board

## Testing

esp32-devkitc:sotest build success.