### PR TITLE
irq/irq.h: Remove extern of non-existent global

### DIFF
--- a/sched/irq/irq.h
+++ b/sched/irq/irq.h
@@ -123,7 +123,6 @@ extern volatile spinlock_t g_cpu_irqlock;
 
 /* Used to keep track of which CPU(s) hold the IRQ lock. */
 
-extern volatile spinlock_t g_cpu_irqsetlock;
 extern volatile cpu_set_t g_cpu_irqset;
 
 /* Handles nested calls to enter_critical section from interrupt handlers */


### PR DESCRIPTION
## Summary

Remove dead code (g_cpu_irqsetlock does not exist any more)
## Impact

Absolutely none.
## Testing

None.

