### PR TITLE
sched/addrenv.c: Fix usage of atomic_fetch_sub

### DIFF
--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -421,7 +421,7 @@ void addrenv_take(FAR struct addrenv_s *addrenv)
 
 int addrenv_give(FAR struct addrenv_s *addrenv)
 {
-  return atomic_fetch_sub(&addrenv->refs, 1);
+  return atomic_fetch_sub(&addrenv->refs, 1) - 1;
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

addrenv_give should return the new reference counter (after subtraction) instead of the old one.

## Impact

Fix regression from: https://github.com/apache/nuttx/pull/14859
## Testing

rv-virt:knsh32

