### PR TITLE
arch/arm64/imx9/lspi: improve spi initialization

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -134,6 +134,7 @@ struct imx9_lpspidev_s
   sem_t             txsem;      /* Wait for TX DMA to complete */
   void             *txbuf;      /* Driver DMA safe buffer for TX */
   void             *rxbuf;      /* Driver DMA safe buffer for RX */
+  int               refcount;   /* SPIn initialization counter */
 #endif
 };
 
@@ -1553,6 +1554,10 @@ static void imx9_lpspi_bus_initialize(struct imx9_lpspidev_s *priv)
 {
   uint32_t reg = 0;
 
+  /* Make sure bus is disabled */
+
+  imx9_lpspi_modifyreg32(priv, IMX9_LPSPI_CR_OFFSET, LPSPI_CR_MEN, 0);
+
   /* Enable power and reset the peripheral */
 
   imx9_lpspi_clock_enable(priv);
@@ -1802,8 +1807,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI1 pins: SCK, MISO, and MOSI */
 
@@ -1817,10 +1821,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI1_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI1_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1834,8 +1834,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI2 pins: SCK, MISO, and MOSI */
 
@@ -1849,10 +1848,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI2_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI2_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1866,8 +1861,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI3 pins: SCK, MISO, and MOSI */
 
@@ -1881,10 +1875,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI3_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI3_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1898,8 +1888,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI4 pins: SCK, MISO, and MOSI */
 
@@ -1913,10 +1902,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI4_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI4_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1930,8 +1915,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI5 pins: SCK, MISO, and MOSI */
 
@@ -1945,10 +1929,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI5_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI5_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1962,8 +1942,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI6 pins: SCK, MISO, and MOSI */
 
@@ -1977,10 +1956,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI6_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI6_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -1994,8 +1969,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI7 pins: SCK, MISO, and MOSI */
 
@@ -2009,10 +1983,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI7_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI7_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
@@ -2026,8 +1996,7 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 
       /* Only configure if the bus is not already configured */
 
-      if ((imx9_lpspi_getreg32(priv, IMX9_LPSPI_CR_OFFSET)
-           & LPSPI_CR_MEN) == 0)
+      if (priv->refcount == 0)
         {
           /* Configure SPI6 pins: SCK, MISO, and MOSI */
 
@@ -2041,17 +2010,24 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #if defined(GPIO_LPSPI8_DC) && defined(CONFIG_SPI_CMDDATA)
           imx9_iomux_configure(GPIO_LPSPI8_DC);
 #endif
-
-          /* Set up default configuration: Master, 8-bit, etc. */
-
-          imx9_lpspi_bus_initialize(priv);
         }
     }
   else
 #endif
     {
+      leave_critical_section(flags);
       spierr("ERROR: Unsupported SPI bus: %d\n", bus);
+      return NULL;
     }
+
+  /* Set up default configuration: Master, 8-bit, etc. */
+
+  if (priv->refcount == 0)
+    {
+      imx9_lpspi_bus_initialize(priv);
+    }
+
+  priv->refcount++;
 
 #ifdef CONFIG_IMX9_LPSPI_DMA
   if (priv->rxch && priv->txch)
@@ -2084,8 +2060,36 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 #endif
 
   leave_critical_section(flags);
-
   return (struct spi_dev_s *)priv;
+}
+
+/****************************************************************************
+ * Name: imx9_lpspibus_uninitialize
+ *
+ * Description:
+ *   Unitialize the selected SPI bus
+ *
+ * Input Parameters:
+ *   dev -      Device-specific state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void imx9_lpspi_uninitialize(struct spi_dev_s *dev)
+{
+  struct imx9_lpspidev_s  *priv = (struct imx9_lpspidev_s *)dev;
+
+  if (priv->refcount > 0)
+    {
+      priv->refcount--;
+      if (priv->refcount == 0)
+        {
+          imx9_lpspi_modifyreg32(priv,
+                                 IMX9_LPSPI_CR_OFFSET, LPSPI_CR_MEN, 0);
+        }
+    }
 }
 
 #endif /* CONFIG_IMX9_LPSPI */

--- a/arch/arm64/src/imx9/imx9_lpspi.h
+++ b/arch/arm64/src/imx9/imx9_lpspi.h
@@ -68,6 +68,22 @@ struct spi_dev_s; /* Forward reference */
 struct spi_dev_s *imx9_lpspibus_initialize(int bus);
 
 /****************************************************************************
+ * Name: imx9_lpspibus_uninitialize
+ *
+ * Description:
+ *   Unitialize the selected SPI bus if refcount is 1
+ *
+ * Input Parameters:
+ *   dev -      Device-specific state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void imx9_lpspi_uninitialize(struct spi_dev_s *dev);
+
+/****************************************************************************
  * Name:  imx9_lpspi1/2/...select and imx9_lpspi1/2/...status
  *
  * Description:


### PR DESCRIPTION
Hardware initialization is based refcount, not
spi enable bit and add interface to unitialize bus

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


