### PR TITLE
Clang/gcov: Enhance clang gcov dump

### DIFF
--- a/include/gcov.h
+++ b/include/gcov.h
@@ -161,6 +161,20 @@ extern void __gcov_filename_to_gcfn(FAR const char *filename,
                                                      FAR void *),
                                      FAR void *arg);
 
+/****************************************************************************
+ * Name: __gcov_dump_to_memory
+ *
+ * Description:
+ *   Dump gcov data directly to memory
+ *
+ * Parameters:
+ *   ptr - Memory Address
+ *   size - Memory block size
+ *
+ ****************************************************************************/
+
+size_t __gcov_dump_to_memory(FAR void *ptr, size_t size);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libbuiltin/compiler-rt/coverage.c
+++ b/libs/libbuiltin/compiler-rt/coverage.c
@@ -324,6 +324,15 @@ void __gcov_dump(void)
   _NX_CLOSE(fd);
 }
 
+size_t __gcov_dump_to_memory(FAR void *ptr, size_t size)
+{
+  struct lib_memoutstream_s stream;
+
+  lib_memoutstream(&stream, ptr, size);
+
+  return __llvm_profile_dump(&stream.common);
+}
+
 void __gcov_reset(void)
 {
 }


### PR DESCRIPTION
## Summary

1. Supports gcc standard output interface "__gcov_dump"
2. Add "__gcov_dump_to_memory" to dump gcov data directly to memory
3. mps/gcov: gcov app is enabled by default

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

Compile "`boards/arm/mps/mps3-an547/configs/gcov`", find the module that needs code coverage analysis, add the parameter` "-fprofile-instr-generate -fcoverage-mapping"`, run `qemu-system-arm -M mps3-an547 -nographic -kernel ./nuttx/nuttx`, execute the app that calls __llvm_profile_dump or nsh run `"gcov -d /tmp/xxx ",` if you set the dump to memory, read the memory in your own way, such as gdb. If you use the default dump to file, please dump the file to the host, and finally use the following command to run：
```
"llvm-profdata merge -sparse default.profraw -o result.profdata"
"llvm-cov show -format=html ./nuttx/nuttx -instr-profile=result.profdata -output-dir=./coverage/"
```
