### PR TITLE
armv6-m: fix the incorrect stub-function entry address of svc call

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -92,7 +92,7 @@ static void dispatch_syscall(void)
     " ldr r4, =g_stublookup\n"                      /* R4=The base of the stub lookup table */
     " lsl r0, r0, #2\n"                             /* R0=Offset of the stub for this syscall */
     " ldr r4, [r4, r0]\n"                           /* R4=Address of the stub for this syscall */
-    " blx r5\n"                                     /* Call the stub (modifies lr) */
+    " blx r4\n"                                     /* Call the stub (modifies lr) */
     " mov lr, r5\n"                                 /* Restore lr */
     " add sp, sp, #12\n"                            /* Destroy the stack frame */
     " pop {r4, r5}\n"                               /* Recover R4 and R5 */


### PR DESCRIPTION
## Summary

the stub-function entry address is stored in r4, we should branch to the stub-function with blx r4, not r5.
this patch using to fix the issue of: https://github.com/apache/nuttx/issues/14862

## Impact

1. impact on armv6-m platform

## Testing

1. has passed the ostest


