### PR TITLE
CI: Run CI Job `other` only for Simple x86 PR

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -76,6 +76,8 @@ jobs:
             echo 'arch_contains_sim=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Arch: x86_64"* ]]; then
             echo 'arch_contains_x86_64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Arch: x86"* ]]; then
+            echo 'arch_contains_x86=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Arch: xtensa"* ]]; then
             echo 'arch_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
           fi
@@ -91,6 +93,8 @@ jobs:
             echo 'board_contains_sim=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Board: x86_64"* ]]; then
             echo 'board_contains_x86_64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: x86"* ]]; then
+            echo 'board_contains_x86=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Board: xtensa"* ]]; then
             echo 'board_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
           fi
@@ -119,12 +123,14 @@ jobs:
           arch_contains_arm64=${{ steps.get-arch.outputs.arch_contains_arm64 }}
           arch_contains_riscv=${{ steps.get-arch.outputs.arch_contains_riscv }}
           arch_contains_sim=${{ steps.get-arch.outputs.arch_contains_sim }}
+          arch_contains_x86=${{ steps.get-arch.outputs.arch_contains_x86 }}
           arch_contains_x86_64=${{ steps.get-arch.outputs.arch_contains_x86_64 }}
           arch_contains_xtensa=${{ steps.get-arch.outputs.arch_contains_xtensa }}
           board_contains_arm=${{ steps.get-arch.outputs.board_contains_arm }}
           board_contains_arm64=${{ steps.get-arch.outputs.board_contains_arm64 }}
           board_contains_riscv=${{ steps.get-arch.outputs.board_contains_riscv }}
           board_contains_sim=${{ steps.get-arch.outputs.board_contains_sim }}
+          board_contains_x86=${{ steps.get-arch.outputs.board_contains_x86 }}
           board_contains_x86_64=${{ steps.get-arch.outputs.board_contains_x86_64 }}
           board_contains_xtensa=${{ steps.get-arch.outputs.board_contains_xtensa }}
 
@@ -151,6 +157,7 @@ jobs:
               "$arch_contains_arm64" != "$board_contains_arm64" ||
               "$arch_contains_riscv" != "$board_contains_riscv" ||
               "$arch_contains_sim" != "$board_contains_sim" ||
+              "$arch_contains_x86" != "$board_contains_x86" ||
               "$arch_contains_x86_64" != "$board_contains_x86_64" ||
               "$arch_contains_xtensa" != "$board_contains_xtensa"
             ]]; then
@@ -218,6 +225,12 @@ jobs:
                 skip_build=1
               fi
 
+            # For "Arch / Board: x86": Build other
+            elif [[ "$arch_contains_x86" == "1" || "$board_contains_x86" == "1" ]]; then
+              if [[ "$board" != *"other"* ]]; then
+                skip_build=1
+              fi
+  
             # For "Arch / Board: x86_64": Build x86_64-01
             elif [[ "$arch_contains_x86_64" == "1" || "$board_contains_x86_64" == "1" ]]; then
               if [[ "$board" != *"x86_64-"* ]]; then


### PR DESCRIPTION
## Summary

Presently, Simple x86 PRs will run All CI Checks (across all Architectures), as reported here: https://github.com/apache/nuttx/pull/14885#issuecomment-2492555557

This PR fixes the CI Build Rules, so that Simple x86 PRs will run only One Single CI Job: `other`.

## Impact

When we create or update a Simple x86 PR: Only CI Job `other` shall be executed.

No impact on other PRs.

## Testing

We tested the updated Build Rules `arch.yml`:

- Arch x86 PR: Will build `other` only <br> https://github.com/lupyuen5/label-nuttx/actions/runs/11963675871

- Board x86 PR: Will build `other` only <br>  https://github.com/lupyuen5/label-nuttx/actions/runs/11963676750

- Arch x86, Board x86 PR: Will build `other` only <br>  https://github.com/lupyuen5/label-nuttx/actions/runs/11963708940

__Regression Test:__

- Arch x86_64 PR: Will build `x86_64-01` only <br> https://github.com/lupyuen5/label-nuttx/actions/runs/11963695329

- Board x86_64 PR: Will build `x86_64-01` only <br> https://github.com/lupyuen5/label-nuttx/actions/runs/11963678242

- Arch x86_64, Board x86_64 PR: Will build `x86_64-01` only <br> https://github.com/lupyuen5/label-nuttx/actions/runs/11963712490

- Merge PR: Will build all targets <br> https://github.com/lupyuen5/label-nuttx/actions/runs/11963606904

