### PR TITLE
tools/imx9: Add norimage support to bootloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ kwarning
 SAVEMake.defs
 SAVEconfig
 .aider*
+imx9-norimage.img
+

--- a/boards/arm64/imx9/imx93-evk/src/Makefile
+++ b/boards/arm64/imx9/imx93-evk/src/Makefile
@@ -50,4 +50,5 @@ ifeq ($(CONFIG_IMX9_BOOTLOADER),y)
 .PHONY: distclean
 distclean::
 	$(call DELFILE, ${TOPDIR}${DELIM}imx9-sdimage.img)
+	$(call DELFILE, ${TOPDIR}${DELIM}imx9-norimage.img)
 endif

--- a/tools/imx9/Config.mk
+++ b/tools/imx9/Config.mk
@@ -28,6 +28,7 @@
 
 ifeq ($(CONFIG_IMX9_BOOTLOADER),y)
 	MK_BASE_URL = https://raw.githubusercontent.com/nxp-imx/imx-mkimage/cbb99377cc2bb8f7cf213794c030e1c60423ef1f/src
+	MK_SCRIPTS_URL = https://raw.githubusercontent.com/nxp-imx/imx-mkimage/cbb99377cc2bb8f7cf213794c030e1c60423ef1f/scripts
 	BASE_PATH = $(TOPDIR)$(DELIM)tools$(DELIM)imx9$(DELIM)
 	FILE_1 = imx8qxb0.c
 	FILE_1_PATH = $(BASE_PATH)$(FILE_1)
@@ -40,11 +41,18 @@ ifeq ($(CONFIG_IMX9_BOOTLOADER),y)
 	AHAB = firmware-ele-imx-0.1.1
 	AHAB_BINARY = $(AHAB).bin
 	AHAB_PATH = $(BASE_PATH)$(AHAB_BINARY)
+	FSPI_HEADER = fspi_header
+	FSPI_HEADER_PATH = $(BASE_PATH)$(FSPI_HEADER)
+	FCB_TOOL = fspi_fcb_gen.sh
+	FCB_TOOL_PATH = $(BASE_PATH)$(FCB_TOOL)
+	EXTRAFLAGS +=  -mstrict-align
 
 define DOWNLOAD_FILES
 	$(call DOWNLOAD,$(MK_BASE_URL),$(FILE_1),$(FILE_1_PATH))
 	$(call DOWNLOAD,$(MK_BASE_URL),$(FILE_2),$(FILE_2_PATH))
 	$(call DOWNLOAD,$(MK_BASE_URL),$(FILE_3),$(FILE_3_PATH))
+	$(call DOWNLOAD,$(MK_SCRIPTS_URL),$(FSPI_HEADER),$(FSPI_HEADER_PATH))
+	$(call DOWNLOAD,$(MK_SCRIPTS_URL),$(FCB_TOOL),$(FCB_TOOL_PATH))
 	$(call DOWNLOAD,$(AHAB_BASE_URL),$(AHAB_BINARY),$(AHAB_PATH))
 	$(Q) chmod a+x $(BASE_PATH)$(AHAB_BINARY)
 	$(Q) (cd $(BASE_PATH) && ./$(AHAB_BINARY) --auto-accept)
@@ -71,6 +79,22 @@ define POSTBUILD
 	$(Q) rm flash.bin
 	$(Q) echo "imx9-sdimage.img" >> nuttx.manifest
 	$(Q) echo "Created imx9-sdimage.img"
+
+
+	$(Q) sh tools$(DELIM)imx9$(DELIM)fspi_fcb_gen.sh tools$(DELIM)imx9$(DELIM)/fspi_header
+	$(Q) tools$(DELIM)imx9$(DELIM)mkimage_imx9$(HOSTEXEEXT) -soc IMX9 -dev flexspi -append $(BASE_PATH)$(AHAB)$(DELIM)mx93a1-ahab-container.img -c -ap nuttx.bin a55 0x2049a000 -fcb fcb.bin 0x204F0000 -out flash.bin 1>/dev/null 2>&1
+	$(Q) mv flash.bin flash.tmp
+
+	$(Q) echo "Append FCB to flash.bin"
+	$(Q) dd if=fcb.bin of=flash.bin bs=1k seek=1
+	$(Q) dd if=flash.tmp of=flash.bin bs=1k seek=4
+	$(Q) rm flash.tmp
+	$(Q) rm fcb.bin
+
+	$(Q) cp flash.bin  imx9-norimage.img
+	$(Q) rm flash.bin
+	$(Q) echo "imx9-norimage.img" >> nuttx.manifest
+	$(Q) echo "Created imx9-norimage.img"
 	$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)imx9 -f Makefile.host clean
 endef
 endif

--- a/tools/imx9/Makefile.host
+++ b/tools/imx9/Makefile.host
@@ -44,6 +44,8 @@ endif
 	$(call DELFILE, imx8qxb0.c)
 	$(call DELFILE, mkimage_common.h)
 	$(call DELFILE, build_info.h)
+	$(call DELFILE, fspi_fcb_gen.sh)
+	$(call DELFILE, fspi_header)
 	$(call DELFILE, firmware-ele-imx-0.1.1.bin)
 	$(call DELDIR, firmware-ele-imx-0.1.1)
 	$(call CLEAN)


### PR DESCRIPTION
Fetch fspi header and fcb generation script,
using mkimage generate nor bootable image.
compile bootloader using -mstrict-align

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


