### PR TITLE
fs/littlefs: Add a kconfig to override littlefs version

### DIFF
--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -22,11 +22,10 @@
 
 if(CONFIG_FS_LITTLEFS)
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/littlefs)
-    set(LITTLEFS_VERSION 2.4.0)
 
     FetchContent_Declare(
       littlefs
-      URL https://github.com/ARMmbed/littlefs/archive/v${LITTLEFS_VERSION}.tar.gz
+      URL https://github.com/ARMmbed/littlefs/archive/v${CONFIG_FS_LITTLEFS_VERSION}.tar.gz
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/littlefs
           BINARY_DIR

--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -127,4 +127,10 @@ config FS_LITTLEFS_ATTR_UPDATE
 	---help---
 		Enable support for attributes when create a file.
 
+config FS_LITTLEFS_VERSION
+	string "LITTLEFS version to use"
+	default "2.5.1"
+	---help---
+		The LITTLEFS version to use.
+
 endif

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -47,15 +47,14 @@ CFLAGS += -DLFS_NAME_MAX=$(CONFIG_FS_LITTLEFS_NAME_MAX)
 CFLAGS += -DLFS_FILE_MAX=$(CONFIG_FS_LITTLEFS_FILE_MAX)
 CFLAGS += -DLFS_ATTR_MAX=$(CONFIG_FS_LITTLEFS_ATTR_MAX)
 
-LITTLEFS_VERSION ?= 2.5.1
-LITTLEFS_TARBALL = v$(LITTLEFS_VERSION).tar.gz
+LITTLEFS_TARBALL = v$(CONFIG_FS_LITTLEFS_VERSION).tar.gz
 
 $(LITTLEFS_TARBALL):
 	$(call DOWNLOAD,https://github.com/ARMmbed/littlefs/archive,$(LITTLEFS_TARBALL),littlefs/$(LITTLEFS_TARBALL))
 
 .littlefsunpack: $(LITTLEFS_TARBALL)
 	$(Q) tar zxf littlefs/$(LITTLEFS_TARBALL) -C littlefs
-	$(Q) mv littlefs/littlefs-$(LITTLEFS_VERSION) littlefs/littlefs
+	$(Q) mv littlefs/littlefs-$(CONFIG_FS_LITTLEFS_VERSION) littlefs/littlefs
 	$(Q) git apply littlefs/lfs_util.patch
 	$(Q) git apply littlefs/lfs_getpath.patch
 	$(Q) git apply littlefs/lfs_getsetattr.patch


### PR DESCRIPTION
## Summary

Hopefully, It's more user-friendly than the current method, which is just an overridable make variable. It would also help to make some features (and their associated local patches) conditional on littlefs version in future.

Also, update CMakeLists.txt to use the same littlefs version as Makefile.

## Impact

this changes littlefs version for cmake users.

## Testing

esp32s3-devkit:toywasm

