### PR TITLE
arm64: remove up_set_current_regs/up_current_regs

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -438,7 +438,6 @@ static inline void up_irq_restore(irqstate_t flags)
  * interrupt context and 0 indicates being in a thread context.
  ****************************************************************************/
 
-#define up_current_regs()      (this_task()->xcp.regs)
 #define up_this_task()         ((struct tcb_s *)(read_sysreg(tpidr_el1) & ~1ul))
 #define up_update_task(t)      modify_sysreg(t, ~1ul, tpidr_el1)
 #define up_interrupt_context() (read_sysreg(tpidr_el1) & 1)
@@ -458,7 +457,7 @@ static inline void up_irq_restore(irqstate_t flags)
  ****************************************************************************/
 
 #define up_getusrpc(regs) \
-    (((uintptr_t *)((regs) ? (regs) : up_current_regs()))[REG_ELR])
+    (((uintptr_t *)((regs) ? (regs) : running_regs()))[REG_ELR])
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -143,8 +143,8 @@ int up_backtrace(struct tcb_s *tcb,
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)up_current_regs()[REG_X29],
-                               (void *)up_current_regs()[REG_ELR],
+                               running_regs()[REG_X29],
+                               running_regs()[REG_ELR],
                                &buffer[ret], size - ret, &skip);
             }
         }
@@ -160,8 +160,8 @@ int up_backtrace(struct tcb_s *tcb,
     {
       ret = backtrace(tcb->stack_base_ptr,
                       tcb->stack_base_ptr + tcb->adj_stack_size,
-                      (void *)up_current_regs()[REG_X29],
-                      (void *)up_current_regs()[REG_ELR],
+                      running_regs()[REG_X29],
+                      running_regs()[REG_ELR],
                       buffer, size, &skip);
     }
 

--- a/arch/arm64/src/common/arm64_registerdump.c
+++ b/arch/arm64/src/common/arm64_registerdump.c
@@ -63,7 +63,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint64_t *regs = dumpregs ? dumpregs : up_current_regs();
+  volatile uint64_t *regs = dumpregs ? dumpregs : running_regs();
 
   _alert("stack = %p\n", regs);
   _alert("x0:   0x%-16"PRIx64"  x1:   0x%"PRIx64"\n",

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -244,7 +244,7 @@
 #  define this_cpu()                 (0)
 #endif
 
-#define running_regs()               ((void *)(g_running_tasks[this_cpu()]->xcp.regs))
+#define running_regs()               ((FAR void **)(g_running_tasks[this_cpu()]->xcp.regs))
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION

## Summary

arm64: remove up_set_current_regs/up_current_regs
reason:
up_set_current_regs initially had two functions:

1: To mark the entry into an interrupt state.
2: To record the context before an interrupt/exception. If we switch to a new task, we need to store the upcoming context regs by calling up_set_current_regs(regs).

Currently, we record the context in other ways, so the second function is obsolete. Therefore, we need to rename up_set_current_regs to better reflect its actual meaning, which is solely to mark an interrupt.
## Impact
arm64 arch
## Testing

ostest

qemu-armv8a:nsh_smp
