### PR TITLE
cmake(enhance):enhance NuttX cmake target_dependencies and link_library modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,10 @@ nuttx_export_kconfig(${CMAKE_BINARY_DIR}/.config)
 include(nuttx_generate_headers)
 include(nuttx_generate_outputs)
 include(nuttx_add_library)
+
+# add NuttX CMake extenstion after nuttx_add_library
+include(nuttx_extensions)
+
 include(nuttx_add_application)
 include(nuttx_add_romfs)
 include(nuttx_add_symtab)
@@ -377,9 +381,6 @@ include(menuconfig)
 
 include(ExternalProject)
 include(FetchContent)
-
-# add NuttX CMake extenstion at last
-include(nuttx_extensions)
 
 set(FETCHCONTENT_QUIET OFF)
 
@@ -581,6 +582,9 @@ if(NOT CONFIG_BUILD_KERNEL)
   endif()
 
 endif()
+
+# after we traverse all build directories unify all target dependencies
+process_all_target_dependencies()
 
 # Link step ##################################################################
 

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -154,6 +154,24 @@ function(nuttx_add_application)
       set(TARGET "apps_${NAME}")
       add_library(${TARGET} ${SRCS})
 
+      # Set apps global compile options & definitions hold by
+      # nuttx_apps_interface
+      target_compile_options(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_OPTIONS>>
+      )
+      target_compile_definitions(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_DEFINITIONS>>
+      )
+      target_include_directories(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_INCLUDE_DIRECTORIES>>
+      )
+
       nuttx_add_library_internal(${TARGET})
       # add to list of application libraries
 

--- a/cmake/nuttx_add_dependencies.cmake
+++ b/cmake/nuttx_add_dependencies.cmake
@@ -20,6 +20,9 @@
 #
 # ##############################################################################
 
+# global dependency maintenance target
+add_custom_target(nuttx_dep_map)
+
 include(nuttx_parse_function_args)
 
 # ~~~
@@ -55,16 +58,47 @@ function(nuttx_add_dependencies)
     ARGN
     ${ARGN})
 
-  get_target_property(NO_COMPILABLE_TARGET ${TARGET} NO_COMPILABLE_TARGET)
-  if(NO_COMPILABLE_TARGET)
-    return()
-  endif()
+  set_property(
+    TARGET nuttx_dep_map
+    APPEND
+    PROPERTY ALL_PROCESS_TARGET ${TARGET})
 
   foreach(dep ${DEPENDS})
-    # add dependencies
-    add_dependencies(${TARGET} ${dep})
-    # add export include directory
-    target_include_directories(${TARGET}
-                               PRIVATE ${NUTTX_APPS_BINDIR}/include/${dep})
+    set_property(
+      TARGET nuttx_dep_map
+      APPEND
+      PROPERTY ${TARGET} ${dep})
+  endforeach()
+endfunction()
+
+# After collecting all dependency mappings, process all targets uniformly
+function(process_all_target_dependencies)
+  # get all target need add deps
+  get_property(
+    all_process_target
+    TARGET nuttx_dep_map
+    PROPERTY ALL_PROCESS_TARGET)
+  foreach(target ${all_process_target})
+    if(TARGET ${target})
+      get_target_property(NO_COMPILABLE_TARGET ${target} NO_COMPILABLE_TARGET)
+      if(NOT NO_COMPILABLE_TARGET)
+        # treat `target` as mapping key
+        get_property(
+          all_deps
+          TARGET nuttx_dep_map
+          PROPERTY ${target})
+        foreach(dep ${all_deps})
+          if(TARGET ${dep})
+            # ensure build time order
+            add_dependencies(${target} ${dep})
+            # inherit public properties
+            nuttx_link_libraries(${target} ${dep})
+            # compatible with previous export headers
+            target_include_directories(
+              ${target} PRIVATE ${NUTTX_APPS_BINDIR}/include/${dep})
+          endif()
+        endforeach()
+      endif()
+    endif()
   endforeach()
 endfunction()

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -183,7 +183,22 @@ function(nuttx_add_library target)
   add_library(${target} ${ARGN})
   add_dependencies(${target} apps_context)
   set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
-
+  # Set apps global compile options & definitions hold by nuttx_apps_interface
+  target_compile_options(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_OPTIONS>>
+  )
+  target_compile_definitions(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_DEFINITIONS>>
+  )
+  target_include_directories(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_INCLUDE_DIRECTORIES>>
+  )
   nuttx_add_library_internal(${target})
 endfunction()
 


### PR DESCRIPTION
## Summary

After https://github.com/apache/nuttx/pull/14747, we have a preliminary extensions design : )
I have two enhance ideas here:

### 1.link_library


In the Nuttx CMake build system, we **cannot** call target_link_library
Why? 
this is because we need to consider different build MODES,
 different static libs need to be connected to the `kernel` or `user` blob,
 which results in the link target of nuttx to be manually controlled.
 [Refer to the implementation of add_library](https://github.com/apache/nuttx/blob/master/cmake/nuttx_add_library.cmake)
This creates a problem that goes against the intuition of using CMake. 
`target_link_library` cannot be called, otherwise the problem of multi defines will occur during linking.
ref: https://github.com/apache/nuttx/pull/14757 and  https://github.com/apache/nuttx-apps/pull/2846

So I enhance `target_link_library` to `nuttx_link_library`,  
It only inherits the public properties of the linked one without actually connecting it.


### 2.add_dependencies


The NuttX CMake build system executes sequentially when traversing all subdirectories.
This will also cause a problem, that is, when using` add_dependencies(targetA targetB)`, targetB may not have been traversed yet.

So I enhanced `nuttx_add_dependencies`, which only records dependencies and mappings when called, 
and actually executes dependencies after all targets are traversed.


### 3.other shortcut calls

set  scope is all the APPS include search path, compile_options, definitions.

```
nuttx_include_directories_for_all_apps()
nuttx_compile_options_for_all_apps()
nuttx_compile_definitions_for_all_apps()

```

## Impact

Enhanced functions, fully compatible with existing cases

## Testing

```
#  use extensions call in apps lvgl CMakeLists.txt

-  set_property(
-    TARGET nuttx
-    APPEND
-    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}
-             ${CMAKE_CURRENT_LIST_DIR}/lvgl)
-
-  set_property(
-    TARGET nuttx
-    APPEND
-    PROPERTY NUTTX_COMPILE_OPTIONS -DLV_USE_DEV_VERSION=1)
+
+  nuttx_include_directories_for_all_apps(${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/lvgl)
+  nuttx_compile_definitions_for_all_apps(LV_USE_DEV_VERSION=1)
```

test build with:
```
cmake -B build -DBOARD_CONFIG=qemu-armv7a:full -GNinja
```

build pass
