### PR TITLE
build.yml: disable the msys2 cache from the GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,7 @@ jobs:
         with:
           msystem: MSYS
           update: false
+          cache: false
           install: >-
             base-devel
             gcc


### PR DESCRIPTION
## Summary
You need to disable the msys2 cache from the GitHub action because we moved the Scheduled Merge Jobs to a new  [NuttX Mirror Repo](https://github.com/NuttX/nuttx) and approaching total cache storage limit !!!

[Nuttx caches](https://github.com/apache/nuttx/actions/caches)

[msys2 GitHub Action cache](https://github.com/msys2/setup-msys2?tab=readme-ov-file#cache)


## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
CI
[Github](https://github.com/simbit18/nuttx_test_pr/actions/runs/11974407888)



