### PR TITLE
arm64: syscall SYS_switch_context and SYS_restore_context use 0 para

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -447,8 +447,9 @@ static inline void up_irq_restore(irqstate_t flags)
     {                                                                     \
       if (!up_interrupt_context())                                        \
         {                                                                 \
-          sys_call2(SYS_switch_context, (uintptr_t)rtcb, (uintptr_t)tcb); \
+          sys_call0(SYS_switch_context);                                  \
         }                                                                 \
+      UNUSED(rtcb);                                                       \
     }                                                                     \
   while (0)
 

--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -57,18 +57,11 @@
 
 void up_exit(int status)
 {
-  struct tcb_s *tcb = this_task();
   UNUSED(status);
 
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
-
-  /* Now, perform the context switch to the new ready-to-run task at the
-   * head of the list.
-   */
-
-  tcb = this_task();
 
   /* Scheduler parameters will update inside syscall */
 
@@ -76,5 +69,5 @@ void up_exit(int status)
 
   /* Then switch contexts */
 
-  arm64_fullcontextrestore(tcb);
+  arm64_fullcontextrestore();
 }

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -112,10 +112,10 @@
 
 /* Context switching */
 
-#define arm64_fullcontextrestore(next) \
+#define arm64_fullcontextrestore() \
   do \
     { \
-      sys_call1(SYS_restore_context, (uintptr_t)next); \
+      sys_call0(SYS_restore_context); \
     } \
   while (1)
 

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -162,5 +162,5 @@ retry:
 #endif
 
   g_running_tasks[this_cpu()] = NULL;
-  arm64_fullcontextrestore(rtcb);
+  arm64_fullcontextrestore();
 }


### PR DESCRIPTION


## Summary
arm64: syscall SYS_switch_context and SYS_restore_context use 0 para
reason:
simplify context switch
sys_call0(SYS_switch_context)
sys_call0(SYS_restore_context)

size nuttx
before 
   text    data     bss     dec     hex filename
504644   54968   81085  640697   9c6b9 nuttx

after
   text    data     bss     dec     hex filename
504360   54968   81085  640413   9c59d nuttx

size reduce -284
## Impact
arm64




## Testing
ostest
qemu-armv8a:nsh_smp


