### PR TITLE
nuttxgdb utils module update

### DIFF
--- a/tools/gdb/nuttxgdb/fs.py
+++ b/tools/gdb/nuttxgdb/fs.py
@@ -159,9 +159,7 @@ class Fdinfo(gdb.Command):
 
         output = []
         if CONFIG_FS_BACKTRACE:
-            backtrace = utils.backtrace(
-                file["f_backtrace"][i] for i in range(CONFIG_FS_BACKTRACE)
-            )
+            backtrace = utils.backtrace(utils.ArrayIterator(file["f_backtrace"]))
 
             backtrace = [
                 backtrace_formatter.format(

--- a/tools/gdb/nuttxgdb/fs.py
+++ b/tools/gdb/nuttxgdb/fs.py
@@ -159,19 +159,16 @@ class Fdinfo(gdb.Command):
 
         output = []
         if CONFIG_FS_BACKTRACE:
-            backtrace = utils.backtrace(utils.ArrayIterator(file["f_backtrace"]))
+            backtrace = utils.Backtrace(
+                utils.ArrayIterator(file["f_backtrace"]), formatter=backtrace_formatter
+            )
 
-            backtrace = [
-                backtrace_formatter.format(
-                    hex(addr),
-                    func,
-                    source,
-                )
-                for addr, func, source in backtrace
-            ]
-
-            output.append(formatter.format(fd, oflags, pos, path, backtrace[0]))
-            output.extend(formatter.format("", "", "", "", bt) for bt in backtrace[1:])
+            output.append(
+                formatter.format(fd, oflags, pos, path, backtrace.formatted[0])
+            )
+            output.extend(
+                formatter.format("", "", "", "", bt) for bt in backtrace.formatted[1:]
+            )
             output.append("")  # separate each backtrace
         else:
             output = [formatter.format(fd, oflags, pos, path, "")]

--- a/tools/gdb/nuttxgdb/gcore.py
+++ b/tools/gdb/nuttxgdb/gcore.py
@@ -129,8 +129,8 @@ class NXGcore(gdb.Command):
             os.remove(section)
 
         gdb.execute(f"file {tmpfile.name}")
-        gdb.execute(f"gcore {corefile}")
-        gdb.execute(f"file {elffile}")
+        gdb.execute(f'gcore "{corefile}"')
+        gdb.execute(f'file "{elffile}"')
         tmpfile.close()
 
         print(f"Please run gdbserver.py to parse {corefile}")

--- a/tools/gdb/nuttxgdb/macros.py
+++ b/tools/gdb/nuttxgdb/macros.py
@@ -135,7 +135,7 @@ def fetch_macro_info(file):
     cache = path.join(path.dirname(path.abspath(file)), f"{hash}.macro")
     if not path.isfile(cache):
         start = time.time()
-        os.system(f"readelf -wm {file} > {cache}")
+        os.system(f'readelf -wm "{file}" > "{cache}"')
         print(f"readelf took {time.time() - start:.1f} seconds")
         print(f"Cache macro info to {cache}")
     else:

--- a/tools/gdb/nuttxgdb/memdump.py
+++ b/tools/gdb/nuttxgdb/memdump.py
@@ -112,15 +112,13 @@ def mm_dumpnode(node, count, align, simple, detail, alive):
         )
 
         if node.type.has_key("backtrace"):
-            max = node["backtrace"].type.range()[1]
             firstrow = True
-            for x in range(0, max):
-                backtrace = int(node["backtrace"][x])
-                if backtrace == 0:
+            for backtrace in utils.ArrayIterator(node["backtrace"]):
+                if int(backtrace) == 0:
                     break
 
                 if simple:
-                    gdb.write(" %0#*x" % (align, backtrace))
+                    gdb.write(" %0#*x" % (align, int(backtrace)))
                 else:
                     if firstrow:
                         firstrow = False
@@ -132,8 +130,8 @@ def mm_dumpnode(node, count, align, simple, detail, alive):
                         "  [%0#*x] %-20s %s:%d\n"
                         % (
                             align,
-                            backtrace,
-                            node["backtrace"][x].format_string(
+                            int(backtrace),
+                            backtrace.format_string(
                                 raw=False, symbols=True, address=False
                             ),
                             gdb.find_pc_line(backtrace).symtab,

--- a/tools/gdb/nuttxgdb/net.py
+++ b/tools/gdb/nuttxgdb/net.py
@@ -95,8 +95,10 @@ def tcp_ofoseg_bufsize(conn):
 
     total = 0
     if utils.get_symbol_value("CONFIG_NET_TCP_OUT_OF_ORDER"):
-        for i in range(conn["nofosegs"]):
-            total += conn["ofosegs"][i]["data"]["io_pktlen"]
+        total = sum(
+            seg["data"]["io_pktlen"]
+            for seg in utils.ArrayIterator(conn["ofosegs"], conn["nofosegs"])
+        )
     return total
 
 

--- a/tools/gdb/nuttxgdb/profile.py
+++ b/tools/gdb/nuttxgdb/profile.py
@@ -1,0 +1,62 @@
+############################################################################
+# tools/gdb/nuttxgdb/profile.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import gdb
+
+from .utils import import_check
+
+
+class Profile(gdb.Command):
+    """Profile a gdb command
+
+    Usage: profile <gdb command>
+    """
+
+    def __init__(self):
+        self.cProfile = import_check(
+            "cProfile", errmsg="cProfile module not found, try gdb-multiarch.\n"
+        )
+        if not self.cProfile:
+            return
+
+        super().__init__("profile", gdb.COMMAND_USER)
+
+    def invoke(self, args, from_tty):
+        self.cProfile.run(f"gdb.execute('{args}')", sort="cumulative")
+
+
+class Time(gdb.Command):
+    """Time a gdb command
+
+    Usage: time <gdb command>
+    """
+
+    def __init__(self):
+        super().__init__("time", gdb.COMMAND_USER)
+
+    def invoke(self, args, from_tty):
+        import time
+
+        start = time.time()
+        gdb.execute(args)
+        end = time.time()
+        gdb.write(f"Time elapsed: {end - start:.6f}s\n")

--- a/tools/gdb/nuttxgdb/stack.py
+++ b/tools/gdb/nuttxgdb/stack.py
@@ -137,10 +137,9 @@ def fetch_stacks():
     stacks = dict()
 
     for tcb in utils.get_tcbs():
-        if (
-            tcb["task_state"] == gdb.parse_and_eval("TSTATE_TASK_RUNNING")
-            and not utils.in_interrupt_context()
-        ):
+        # We have no way to detect if we are in an interrupt context for now.
+        # Originally we use `and not utils.in_interrupt_context()`
+        if tcb["task_state"] == gdb.parse_and_eval("TSTATE_TASK_RUNNING"):
             sp = utils.get_sp()
         else:
             sp = utils.get_sp(tcb=tcb)

--- a/tools/gdb/nuttxgdb/thread.py
+++ b/tools/gdb/nuttxgdb/thread.py
@@ -234,8 +234,7 @@ class Nxinfothreads(gdb.Command):
                 % ("Index", "Tid", "Pid", "Thread", "Info", "Frame")
             )
 
-        for i in range(0, npidhash):
-            tcb = pidhash[i]
+        for i, tcb in enumerate(utils.ArrayIterator(pidhash, npidhash)):
             if not tcb:
                 continue
 
@@ -326,11 +325,11 @@ class Nxthread(gdb.Command):
                 gdb.write("Please specify a command following the thread ID list\n")
 
             elif arg[1] == "all":
-                for i in range(0, npidhash):
-                    if pidhash[i] == 0:
+                for i, tcb in enumerate(utils.ArrayIterator(pidhash, npidhash)):
+                    if tcb == 0:
                         continue
                     try:
-                        gdb.write(f"Thread {i} {pidhash[i]['name'].string()}\n")
+                        gdb.write(f"Thread {i} {tcb['name'].string()}\n")
                     except gdb.error and UnicodeDecodeError:
                         gdb.write(f"Thread {i}\n")
 

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -100,7 +100,7 @@ def container_of(
     """Return pointer to containing data structure"""
     if isinstance(typeobj, str):
         typeobj = lookup_type(typeobj)
-    return gdb.Value(int(ptr.address) - offset_of(typeobj, member)).cast(
+    return gdb.Value(int(ptr.dereference().address) - offset_of(typeobj, member)).cast(
         typeobj.pointer()
     )
 

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -94,8 +94,12 @@ def offset_of(typeobj: gdb.Type, field: str) -> Union[int, None]:
     return None
 
 
-def container_of(ptr: gdb.Value, typeobj: gdb.Type, member: str) -> gdb.Value:
+def container_of(
+    ptr: gdb.Value, typeobj: Union[gdb.Type, str], member: str
+) -> gdb.Value:
     """Return pointer to containing data structure"""
+    if isinstance(typeobj, str):
+        typeobj = lookup_type(typeobj)
     return gdb.Value(int(ptr.address) - offset_of(typeobj, member)).cast(
         typeobj.pointer()
     )
@@ -112,9 +116,7 @@ class ContainerOf(gdb.Function):
         super().__init__("container_of")
 
     def invoke(self, ptr, typename, elementname):
-        return container_of(
-            ptr, gdb.lookup_type(typename.string()).pointer(), elementname.string()
-        )
+        return container_of(ptr, typename.string(), elementname.string())
 
 
 ContainerOf()

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -196,7 +196,7 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
     # in order to use the list command to set the scope.
     if len(gdb.inferiors()) == 1:
         gdb.execute(
-            f"add-inferior -exec {gdb.objfiles()[0].filename} -no-connection",
+            f'add-inferior -exec "{gdb.objfiles()[0].filename}" -no-connection',
             to_string=True,
         )
         g_symbol_cache = {}

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -96,7 +96,9 @@ def offset_of(typeobj: gdb.Type, field: str) -> Union[int, None]:
 
 def container_of(ptr: gdb.Value, typeobj: gdb.Type, member: str) -> gdb.Value:
     """Return pointer to containing data structure"""
-    return gdb.Value(ptr.address - offset_of(typeobj, member)).cast(typeobj.pointer())
+    return gdb.Value(int(ptr.address) - offset_of(typeobj, member)).cast(
+        typeobj.pointer()
+    )
 
 
 class ContainerOf(gdb.Function):

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -339,6 +339,12 @@ def nitems(array):
     return array_size
 
 
+def sizeof(t: Union[str, gdb.Type]):
+    if type(t) is str:
+        t = gdb.lookup_type(t)
+
+    return t.sizeof
+
 # Machine Specific Helper Functions
 
 

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -345,6 +345,7 @@ def sizeof(t: Union[str, gdb.Type]):
 
     return t.sizeof
 
+
 # Machine Specific Helper Functions
 
 
@@ -911,22 +912,3 @@ class Addr2Line(gdb.Command):
                     except gdb.error as e:
                         gdb.write(f"Ignore {arg}: {e}\n")
             self.print_backtrace(addresses)
-
-
-class Profile(gdb.Command):
-    """Profile a gdb command
-
-    Usage: profile <gdb command>
-    """
-
-    def __init__(self):
-        self.cProfile = import_check(
-            "cProfile", errmsg="cProfile module not found, try gdb-multiarch.\n"
-        )
-        if not self.cProfile:
-            return
-
-        super().__init__("profile", gdb.COMMAND_USER)
-
-    def invoke(self, args, from_tty):
-        self.cProfile.run(f"gdb.execute('{args}')", sort="cumulative")

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -211,7 +211,6 @@ def get_symbol_value(name, locspec="nx_start", cacheable=True):
         # Try to expand macro by reading elf
         global g_macro_ctx
         if not g_macro_ctx:
-            gdb.write("No macro context found, trying to load from ELF\n")
             if len(gdb.objfiles()) > 0:
                 g_macro_ctx = MacroCtx(gdb.objfiles()[0].filename)
             else:

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -519,32 +519,6 @@ def in_interrupt_context(cpuid=0):
         return not g_current_regs or not g_current_regs[cpuid]
 
 
-def get_arch_sp_name():
-    if is_target_arch("arm") or is_target_arch("aarch64"):
-        # arm and arm variants
-        return "sp"
-    elif is_target_arch("i386", exact=True):
-        return "esp"
-    elif is_target_arch("i386:x86-64", exact=True):
-        return "rsp"
-    else:
-        # Default to use sp, add more archs if needed
-        return "sp"
-
-
-def get_arch_pc_name():
-    if is_target_arch("arm") or is_target_arch("aarch64"):
-        # arm and arm variants
-        return "pc"
-    elif is_target_arch("i386", exact=True):
-        return "eip"
-    elif is_target_arch("i386:x86-64", exact=True):
-        return "rip"
-    else:
-        # Default to use pc, add more archs if needed
-        return "pc"
-
-
 def get_register_byname(regname, tcb=None):
     frame = gdb.selected_frame()
 
@@ -572,11 +546,11 @@ def get_register_byname(regname, tcb=None):
 
 
 def get_sp(tcb=None):
-    return get_register_byname(get_arch_sp_name(), tcb)
+    return get_register_byname("sp", tcb)
 
 
 def get_pc(tcb=None):
-    return get_register_byname(get_arch_pc_name(), tcb)
+    return get_register_byname("pc", tcb)
 
 
 def get_tcbs():

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -763,10 +763,13 @@ class Hexdump(gdb.Command):
             address = int(argv[0], 0)
             size = int(argv[1], 0)
         else:
-            var = gdb.parse_and_eval(f"{argv[0]}")
-            address = int(var.address)
-            size = int(var.type.sizeof)
-            gdb.write(f"{argv[0]} {hex(address)} {int(size)}\n")
+            try:
+                var = gdb.parse_and_eval(f"{argv[0]}")
+                address = int(var.cast(long_type))
+                size = int(argv[1]) if argv[1] else int(var.type.sizeof)
+                gdb.write(f"{argv[0]} {hex(address)} {int(size)}\n")
+            except Exception as e:
+                gdb.write(f"Invalid {argv[0]}: {e}\n")
 
         hexdump(address, size)
 
@@ -843,7 +846,7 @@ class Addr2Line(gdb.Command):
                 self.print_backtrace(addr, pid)
         else:
             addresses = []
-            for arg in shlex.split(args):
+            for arg in shlex.split(args.replace(",", " ")):
                 if is_decimal(arg):
                     addresses.append(int(arg))
                 elif is_hexadecimal(arg):

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -561,6 +561,16 @@ def get_tcb(pid):
     return tcb
 
 
+def get_tid(tcb):
+    """get tid from tcb"""
+    if not tcb:
+        return None
+    try:
+        return tcb["group"]["tg_pid"]
+    except gdb.error:
+        return None
+
+
 def get_task_name(tcb):
     try:
         name = tcb["name"].cast(gdb.lookup_type("char").pointer())

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -37,6 +37,7 @@ from .macros import fetch_macro_info, try_expand
 g_symbol_cache = {}
 g_type_cache = {}
 g_macro_ctx = None
+g_backtrace_cache = {}
 
 
 class Backtrace:
@@ -70,10 +71,21 @@ class Backtrace:
         self,
         address: List[Union[gdb.Value, int]] = [],
         formatter="{:<5} {:<36} {}\n",
+        break_null=True,
     ):
         self.formatter = formatter  # Address, Function, Source
         self._formatted = None  # Cached formatted backtrace
-        self.backtrace = [res for addr in address if (res := self.convert(addr))]
+        self.backtrace = []
+        for addr in address:
+            if break_null and not addr:
+                break
+            self.append(addr)
+
+    def __eq__(self, value: Backtrace) -> bool:
+        return self.backtrace == value.backtrace
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.backtrace))
 
     def append(self, addr: Union[gdb.Value, int]) -> None:
         """Append an address to the backtrace"""
@@ -84,7 +96,10 @@ class Backtrace:
     def convert(self, addr: Union[gdb.Value, int]) -> Tuple[int, str, str]:
         """Convert an address to function and source"""
         if not addr:
-            return
+            return None
+
+        if int(addr) in g_backtrace_cache:
+            return g_backtrace_cache[int(addr)]
 
         if type(addr) is int:
             addr = gdb.Value(addr)
@@ -95,7 +110,9 @@ class Backtrace:
         func = addr.format_string(symbols=True, address=False)
         sym = gdb.find_pc_line(int(addr))
         source = str(sym.symtab) + ":" + str(sym.line)
-        return (int(addr), func, source)
+        result = (int(addr), func, source)
+        g_backtrace_cache[int(addr)] = result
+        return result
 
     @property
     def formatted(self):
@@ -884,7 +901,7 @@ class Addr2Line(gdb.Command):
     def print_backtrace(self, addresses, pid=None):
         if pid:
             gdb.write(f"\nBacktrace of {pid}\n")
-        backtraces = Backtrace(addresses, formatter=self.formatter)
+        backtraces = Backtrace(addresses, formatter=self.formatter, break_null=False)
         gdb.write(str(backtraces))
 
     def invoke(self, args, from_tty):


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR mainly update the utils module and minor bug fixes.
1. Added `Backtrace` to better handle converting addresses to symbols.
2. Enhancement to `offset_of` and `container_of`, now support string as argumment
3. added helper `sizeof`, both str and gdb.Type are accepted.
4. Added enum function to map C enum to python Enum class
```
    in C:
    enum color_e {
        RED = 1,
        GREEN = 2,
    };
    in python:
    COLOR = utils.enum("enum color_e", "COLOR")
    print(COLOR.GREEN.value) # --> 2
    RED = COLOR(1)
```
6. Added `ArrayIterator` to access array elements
7. Added crash log parsing for `addr2line` command, now you can use `addr2line -f crash.log` or `addr2line -f crash.log -p 123 ` for specified PID.
8. Moved profiling commands to `profile.py`

## Impact

No.

## Testing

I tested addr2line on qemu arm64.
```
(gdb) addr2line -f crash.log
Address              Symbol                           Source

Backtrace of 0
0x402cf900           <sched_backtrace+88>             /home/neo/projects/nuttx/nuttx/sched/sched/sched_backtrace.c:106
0x402cd854           <sched_dumpstack+68>             /home/neo/projects/nuttx/nuttx/libs/libc/sched/sched_dumpstack.c:71
0x402c0510           <dump_running_task+420>          /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:667
0x402c0978           <_assert+544>                    /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:718
0x402b35bc           <uart_check_special+132>         /home/neo/projects/nuttx/nuttx/drivers/serial/serial.c:2272
0x402b39fc           <uart_recvchars+520>             /home/neo/projects/nuttx/nuttx/drivers/serial/serial_io.c:282
0x402b1978           <pl011_irq_handler+148>          /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:838
0x402bfb70           <irq_dispatch+60>                /home/neo/projects/nuttx/nuttx/sched/irq/irq_dispatch.c:145
0x402b14e0           <arm64_doirq+96>                 /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_doirq.c:75
0x402b0908           <arm64_decodeirq+80>             /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_gicv3.c:808
0x402afd60           <arm64_irq_handler+32>           /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_vectors.S:227
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63
0x402af6c4           <arm64_boot_primary_c_routine+16> /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_boot.c:212
0x402cf900           <sched_backtrace+88>             /home/neo/projects/nuttx/nuttx/sched/sched/sched_backtrace.c:106
0x402cd854           <sched_dumpstack+68>             /home/neo/projects/nuttx/nuttx/libs/libc/sched/sched_dumpstack.c:71
0x402c0360           <dump_backtrace+32>              /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:452
0x402c11d4           <nxsched_foreach+160>            /home/neo/projects/nuttx/nuttx/sched/sched/sched_foreach.c:69
0x402c0ad0           <_assert+888>                    /home/neo/projects/nuttx/nuttx/sched/misc/assert.c:790
0x402b35bc           <uart_check_special+132>         /home/neo/projects/nuttx/nuttx/drivers/serial/serial.c:2272
0x402b39fc           <uart_recvchars+520>             /home/neo/projects/nuttx/nuttx/drivers/serial/serial_io.c:282
0x402b1978           <pl011_irq_handler+148>          /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:838
0x402bfb70           <irq_dispatch+60>                /home/neo/projects/nuttx/nuttx/sched/irq/irq_dispatch.c:145
0x402b14e0           <arm64_doirq+96>                 /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_doirq.c:75
0x402b0908           <arm64_decodeirq+80>             /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_gicv3.c:808
0x402afd60           <arm64_irq_handler+32>           /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_vectors.S:227
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63
0x402af6c4           <arm64_boot_primary_c_routine+16> /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_boot.c:212

Backtrace of 1
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63

Backtrace of 2
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63

Backtrace of 3
0x402cbcc0           <up_idle+8>                      /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63
(gdb)

```



