### PR TITLE
nuttxgdb list function enhancement

### DIFF
--- a/tools/gdb/nuttxgdb/lists.py
+++ b/tools/gdb/nuttxgdb/lists.py
@@ -349,6 +349,13 @@ class ForeachListEntry(gdb.Command):
         parser.add_argument(
             "-m", "--member", type=str, default=None, help="Member name in container"
         )
+        parser.add_argument(
+            "-e",
+            "--element",
+            type=str,
+            help="Only dump this element in array member struct.",
+            default=None,
+        )
         try:
             args = parser.parse_args(argv)
         except SystemExit:
@@ -365,6 +372,7 @@ class ForeachListEntry(gdb.Command):
                 else node
             )
             entry = entry.dereference()
+            entry = entry[args.element] if args.element else entry
             gdb.write(
                 f"{i} *({entry.type} *){hex(entry.address)} {entry.format_string(styling=True)}\n"
             )
@@ -409,5 +417,5 @@ class ForeachArray(gdb.Command):
         node = pointer
         len = args.length if args.length else utils.nitems(pointer)
         for i in range(len):
-            entry = node[i][args.element] if arg.element else node[i]
+            entry = node[i][args.element] if args.element else node[i]
             gdb.write(f"{i}: {entry.format_string(styling=True)}\n")

--- a/tools/gdb/nuttxgdb/lists.py
+++ b/tools/gdb/nuttxgdb/lists.py
@@ -372,3 +372,42 @@ class ForeachListEntry(gdb.Command):
             node = node[args.next]
             if node == pointer:
                 break
+
+
+class ForeachArray(gdb.Command):
+    """Dump array members."""
+
+    def __init__(self):
+        super().__init__("foreach array", gdb.COMMAND_DATA, gdb.COMPLETE_EXPRESSION)
+
+    def invoke(self, arg, from_tty):
+        argv = gdb.string_to_argv(arg)
+
+        parser = argparse.ArgumentParser(description="Iterate the items in array")
+        parser.add_argument("head", type=str, help="List head")
+        parser.add_argument(
+            "-l",
+            "--length",
+            type=int,
+            help="The array length",
+            default=None,
+        )
+        parser.add_argument(
+            "-e",
+            "--element",
+            type=str,
+            help="Only dump this element in array member struct.",
+            default=None,
+        )
+        try:
+            args = parser.parse_args(argv)
+        except SystemExit:
+            gdb.write("Invalid arguments\n")
+            return
+
+        pointer = gdb.parse_and_eval(args.head)
+        node = pointer
+        len = args.length if args.length else utils.nitems(pointer)
+        for i in range(len):
+            entry = node[i][args.element] if arg.element else node[i]
+            gdb.write(f"{i}: {entry.format_string(styling=True)}\n")

--- a/tools/gdb/nuttxgdb/lists.py
+++ b/tools/gdb/nuttxgdb/lists.py
@@ -202,7 +202,7 @@ def sq_is_empty(sq):
         return False
 
 
-def sq_check(sq) -> int:
+def sq_check(sq, verbose=True) -> int:
     """Check the consistency of a singly linked list"""
     nb = 0
     if sq.type == sq_queue_type.pointer():
@@ -212,7 +212,8 @@ def sq_check(sq) -> int:
         return nb
 
     if sq["head"] == 0:
-        gdb.write("sq_queue head is empty {}\n".format(sq.address))
+        if verbose:
+            gdb.write("sq_queue head is empty {}\n".format(sq.address))
         return nb
 
     nodes = set()
@@ -236,13 +237,14 @@ def sq_check(sq) -> int:
         gdb.write("sq_queue tail->flink is not null {}\n".format(sq["tail"]))
         return nb
 
-    gdb.write("sq_queue is consistent: {} node(s)\n".format(nb))
+    if verbose:
+        gdb.write("sq_queue is consistent: {} node(s)\n".format(nb))
     return nb
 
 
-def sq_count(sq):
+def sq_count(sq) -> int:
     """Count sq elements, abort if check failed"""
-    return sq_check(sq)
+    return sq_check(sq, verbose=False)
 
 
 def dq_for_every(dq, entry=None):

--- a/tools/gdb/nuttxgdb/lists.py
+++ b/tools/gdb/nuttxgdb/lists.py
@@ -214,13 +214,25 @@ def sq_check(sq):
         gdb.write("sq_queue head is empty {}\n".format(sq.address))
         return
 
+    nodes = set()
     entry = sq["head"].dereference()
     try:
         while entry.address:
             nb += 1
+            if int(entry.address) in nodes:
+                gdb.write("sq_queue is circular: {}\n".format(entry.address))
+                return
+            nodes.add(int(entry.address))
             entry = entry["flink"].dereference()
     except gdb.MemoryError:
         gdb.write("entry address is unaccessible {}\n".format(entry.address))
+        return
+
+    if int(sq["tail"]) not in nodes:
+        gdb.write("sq_queue tail is not in the list {}\n".format(sq["tail"]))
+        return
+    if sq["tail"]["flink"] != 0:
+        gdb.write("sq_queue tail->flink is not null {}\n".format(sq["tail"]))
         return
 
     gdb.write("sq_queue is consistent: {} node(s)\n".format(nb))
@@ -257,13 +269,26 @@ def dq_check(dq):
     if dq["head"] == 0:
         gdb.write("dq_queue head is empty {}\n".format(dq.address))
         return
+
+    nodes = set()
     entry = dq["head"].dereference()
     try:
         while entry.address:
             nb += 1
+            if int(entry.address) in nodes:
+                gdb.write("dq_queue is circular: {}\n".format(entry.address))
+                return
+            nodes.add(int(entry.address))
             entry = entry["flink"].dereference()
     except gdb.MemoryError:
         gdb.write("entry address is unaccessible {}\n".format(entry.address))
+        return
+
+    if int(dq["tail"]) not in nodes:
+        gdb.write("dq_queue tail is not in the list {}\n".format(dq["tail"]))
+        return
+    if dq["tail"]["flink"] != 0:
+        gdb.write("dq_queue tail->flink is not null {}\n".format(dq["tail"]))
         return
 
     gdb.write("dq_queue is consistent: {} node(s)\n".format(nb))

--- a/tools/gdb/nuttxgdb/lists.py
+++ b/tools/gdb/nuttxgdb/lists.py
@@ -285,6 +285,8 @@ class ListCheck(gdb.Command):
             list_check(obj)
         elif obj.type == sq_queue_type.pointer():
             sq_check(obj)
+        elif obj.type == dq_queue_type.pointer():
+            dq_check(obj)
         else:
             raise gdb.GdbError("Invalid argument type: {}".format(obj.type))
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR includes minor bug fixes to list iterator and introduced more powerful iteration commands.
1. `foreach list` command now can iterate any type of `list`. E.g
```
    (gdb) foreach list -n next &g_msgfree
    0: {prev = 0x40286200 <g_msgpool+280>, next = 0x4028628c <g_msgpool+420>}
    1: {prev = 0x40286e30 <g_msgfree>, next = 0x40286318 <g_msgpool+560>}

    (gdb) foreach list "(struct list_node *) 0x40286e30"
    0: {prev = 0x40286200 <g_msgpool+280>, next = 0x4028628c <g_msgpool+420>}
    1: {prev = 0x40286e30 <g_msgfree>, next = 0x40286318 <g_msgpool+560>}

    (gdb) foreach list g_active_tcp_connections.head -n flink -c "struct tcp_conn_s" -m "sconn"
                                                                                      13:14:07 [1047/1047]
    0 @ *(struct tcp_conn_s *)0x40441510 {
      sconn = {
        node = {
          flink = 0x40441658 <g_tcp_connections+984>,
          blink = 0x0
        },
        list = 0x40443754 <g_cbprealloc+1488>,
        list_tail = 0x40443754 <g_cbprealloc+1488>,
        s_error = 0,
        s_options = 0,
        s_rcvtimeo = 0,
        s_sndtimeo = 0,
        s_boundto = 0 '\000',
        s_flags = 105 'i',
        s_tos = 0 '\000',
        s_ttl = 64 '@'
      },
      u = {
        ipv4 = {
          laddr = 16777343,
          raddr = 16777343
        },
        ipv6 = {
          laddr = {127, 256, 127, 256, 0, 0, 0, 0},
          raddr = {0, 0, 0, 0, 0, 0, 0, 0}
        }
      },
      rcvseq = "h\374\375\064",
      sndseq = "h\374\375\063",
      crefs = 1 '\001',
      domain = 2 '\002',
      sa = 0 '\000',
      sv = 12 '\f',
      rto = 12 '\f',
      tcpstateflags = 4 '\004',
```
Note that https://github.com/apache/nuttx/pull/14912 is needed to fix the issue of `container_of`.

2. Added `foreach array`, just like list.
```
    E.g.

    (gdb) foreach array g_mmheap->mm_nodelist
    0: {preceding = 0, size = 0, pid = 0, seqno = 0, backtrace = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, flink = 0x41692cb8, blink = 0x0}
    1: {preceding = 0, size = 0, pid = 0, seqno = 0, backtrace = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, flink = 0x40c378a0, blink = 0x40605f58}

    (gdb) foreach array g_mmheap->mm_nodelist -e "flink"
    0: 0x41692cb8
    1: 0x40c378a0

``` 

## Impact

No impact.

## Testing

Tested on qemu
1. compile
`tools/configure.sh lm3s6965-ek:qemu-flat`

Make sure `+CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"`

2. Run
```
qemu-system-arm -semihosting \
        -M lm3s6965evb \
        -device loader,file=nuttx.bin,addr=0x00000000 \
        -nic user,id=user0,hostfwd=tcp::10023-:23 \
        -serial mon:stdio -nographic -s
```

3. Connect
```
gdb-multiarch nuttx -ex "source tools/gdb/gdbinit.py" -ex "tar rem:1234"
```

4. Run the example commands above.


