### PR TITLE
nuttxgdb net module update

### DIFF
--- a/tools/gdb/nuttxgdb/net.py
+++ b/tools/gdb/nuttxgdb/net.py
@@ -60,7 +60,12 @@ def inet_ntop(domain, addr):
     """Convert a network address to a string"""
 
     addr_len = 16 if domain == AF_INET6 else 4
-    return socket.inet_ntop(domain, utils.get_bytes(addr, addr_len))
+    if socket:
+        return socket.inet_ntop(domain, utils.get_bytes(addr, addr_len))
+    else:
+        separator = "." if domain == AF_INET else ""
+        fmt = "%d" if domain == AF_INET else "%02x"
+        return separator.join([fmt % byte for byte in utils.get_bytes(addr, addr_len)])
 
 
 def socket_for_each_entry(proto):
@@ -111,7 +116,7 @@ class NetStats(gdb.Command):
     """
 
     def __init__(self):
-        if utils.get_symbol_value("CONFIG_NET") and socket:
+        if utils.get_symbol_value("CONFIG_NET"):
             super().__init__("netstats", gdb.COMMAND_USER)
 
     def iob_stats(self):

--- a/tools/gdb/nuttxgdb/net.py
+++ b/tools/gdb/nuttxgdb/net.py
@@ -20,6 +20,8 @@
 #
 ############################################################################
 
+from enum import Enum
+
 import gdb
 
 from . import utils
@@ -251,3 +253,66 @@ class NetStats(gdb.Command):
         if utils.get_symbol_value("CONFIG_NET_UDP") and "udp" in args:
             self.udp_stats()
             gdb.write("\n")
+
+
+class NetCheckResult(Enum):
+    PASS = 0
+    WARN = 1
+    FAILED = 2
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+
+class NetCheck(gdb.Command):
+    """Network check"""
+
+    def __init__(self):
+        if utils.get_symbol_value("CONFIG_NET"):
+            super().__init__("netcheck", gdb.COMMAND_USER)
+
+    def diagnose(self, *args, **kwargs):
+        result, message = NetCheckResult.PASS, []
+
+        if utils.get_symbol_value("CONFIG_MM_IOB"):
+            ret, msg = self.check_iob()
+            result = max(result, ret)
+            message.extend(msg)
+
+            return {
+                "title": "Netcheck Report",
+                "summary": "Net status check",
+                "result": "pass" if result else "fail",
+                "command": "netcheck",
+                "data": message,
+            }
+
+    def check_iob(self):
+        result = NetCheckResult.PASS
+        message = []
+        try:
+            nfree = gdb.parse_and_eval("g_iob_sem")["semcount"]
+            nthrottle = (
+                gdb.parse_and_eval("g_throttle_sem")["semcount"]
+                if utils.get_symbol_value("CONFIG_IOB_THROTTLE") > 0
+                else 0
+            )
+
+            if nfree < 0 or nthrottle < 0:
+                result = max(result, NetCheckResult.WARN)
+                message.append(
+                    "[WARNING] IOB used up: free %d throttle %d" % (nfree, nthrottle)
+                )
+
+        except gdb.error as e:
+            result = max(result, NetCheckResult.FAILED)
+            message.append("[FAILED] Failed to check IOB: %s" % e)
+
+        finally:
+            return result, message
+
+    def invoke(self, args, from_tty):
+        if utils.get_symbol_value("CONFIG_MM_IOB"):
+            result, message = self.check_iob()
+            gdb.write("IOB check: %s\n" % result.name)
+            gdb.write("\n".join(message))


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. 
Make netstats work without socket import

    We may get normal IPv4 address print like 10.10.0.1:5001 and a longer
    IPv6 like fc000000000000000000000000000001:5001
2.
Add command 'netcheck' for checks on network stack

## Impact
No impact.

## Testing

Tested on qemu using same setup as https://github.com/apache/nuttx/pull/14913. 
Do `telnet localhost 10023` on host to have a real connection to check by this tool.

```
(gdb) netcheck
IOB check: PASS
(gdb)

```

