### PR TITLE
nuttxgdb: add error hint to gdbinit

### DIFF
--- a/tools/gdb/nuttxgdb/__init__.py
+++ b/tools/gdb/nuttxgdb/__init__.py
@@ -49,10 +49,18 @@ def register_commands(event):
     gdb.write('"handle SIGUSR1 "nostop" "pass" "noprint"\n')
 
     def init_gdb_commands(m: str):
-        module = importlib.import_module(f"{__package__}.{m}")
+        try:
+            module = importlib.import_module(f"{__package__}.{m}")
+        except Exception:
+            gdb.write(f"\x1b[31;1mIgnore module: {m}\n\x1b[m")
+            return
+
         for c in module.__dict__.values():
             if isinstance(c, type) and issubclass(c, gdb.Command):
-                c()
+                try:
+                    c()
+                except Exception:
+                    gdb.write(f"\x1b[31;1mIgnore command: {c}\n\x1b[m")
 
     # import utils module
     utils = importlib.import_module(f"{__package__}.utils")

--- a/tools/gdb/nuttxgdb/__init__.py
+++ b/tools/gdb/nuttxgdb/__init__.py
@@ -25,6 +25,12 @@ from os import path
 
 import gdb
 
+if __name__ == "__main__":
+    import sys
+
+    gdb.write("Use nuttx/tools/gdb/gdbinit.py instead")
+    sys.exit(1)
+
 here = path.dirname(path.abspath(__file__))
 
 

--- a/tools/gdb/nuttxgdb/__init__.py
+++ b/tools/gdb/nuttxgdb/__init__.py
@@ -51,16 +51,16 @@ def register_commands(event):
     def init_gdb_commands(m: str):
         try:
             module = importlib.import_module(f"{__package__}.{m}")
-        except Exception:
-            gdb.write(f"\x1b[31;1mIgnore module: {m}\n\x1b[m")
+        except Exception as e:
+            gdb.write(f"\x1b[31;1mIgnore module: {m}, error: {e}\n\x1b[m")
             return
 
         for c in module.__dict__.values():
             if isinstance(c, type) and issubclass(c, gdb.Command):
                 try:
                     c()
-                except Exception:
-                    gdb.write(f"\x1b[31;1mIgnore command: {c}\n\x1b[m")
+                except Exception as e:
+                    gdb.write(f"\x1b[31;1mIgnore command: {c}, e: {e}\n\x1b[m")
 
     # import utils module
     utils = importlib.import_module(f"{__package__}.utils")
@@ -79,6 +79,7 @@ def register_commands(event):
 
 
 if len(gdb.objfiles()) == 0:
+    gdb.write("No objectfile, defer to register NuttX commands.\n")
     gdb.events.new_objfile.connect(register_commands)
 else:
     register_commands(None)

--- a/tools/gdb/nuttxgdb/__init__.py
+++ b/tools/gdb/nuttxgdb/__init__.py
@@ -21,6 +21,7 @@
 ############################################################################
 
 import importlib
+import traceback
 from os import path
 
 import gdb
@@ -53,6 +54,7 @@ def register_commands(event):
             module = importlib.import_module(f"{__package__}.{m}")
         except Exception as e:
             gdb.write(f"\x1b[31;1mIgnore module: {m}, error: {e}\n\x1b[m")
+            traceback.print_exc()
             return
 
         for c in module.__dict__.values():


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Minor update to gdbinit.
1. Guide user to source `gdb/gdbinit.py` instead of the original `gdb/__init__.py`
2. Ignore commands that has error and continue to register the remaining commands. This normally happen when some modules are disabled.
3. Show backtrace of why the command failed to register.

## Impact

No.

## Testing

Tested with qemu arm64.
```
(gdb) source nuttx/tools/gdb/nuttxgdb/__init__.py
Use nuttx/tools/gdb/gdbinit.py instead%
```
Now it will exit and print error message.

Manually introduce an error in fs.py and it can correctly report.
```
Ignore module: fs, error: unterminated string literal (detected at line 33) (fs.py, line 33)
Traceback (most recent call last):
  File "/home/neo/projects/nuttx/nuttx/tools/gdb/nuttxgdb/__init__.py", line 54, in init_gdb_commands
    module = importlib.import_module(f"{__package__}.{m}")
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/neo/projects/nuttx/nuttx/tools/gdb/nuttxgdb/fs.py", line 33
    I'm an error.
     ^
SyntaxError: unterminated string literal (detected at line 33)
Load macro: /home/neo/projects/nuttx/build/8df01f54a9bf37445496eac21bd282fa.json

 if use thread command, please don't use 'continue', use 'c' instead !!!
 if use thread command, please don't use 'step', use 's' instead !!!
Build version:  "9f9cc7ecebd-dirty Nov 24 2024 19:24:07"

Remote debugging using :1127
0x00000000402cb73c in up_idle () at /home/neo/projects/nuttx/nuttx/arch/arm64/src/common/arm64_idle.c:63
63      }

```



