### PR TITLE
gdb/debug: add debugpy to debug python code

### DIFF
--- a/tools/gdb/nuttxgdb/debug.py
+++ b/tools/gdb/nuttxgdb/debug.py
@@ -1,0 +1,62 @@
+############################################################################
+# tools/gdb/nuttxgdb/debug.py
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import argparse
+
+import gdb
+
+from . import utils
+
+
+class DebugPy(gdb.Command):
+    """Start debugpy server, so we can debug python code from IDE like VSCode"""
+
+    def __init__(self):
+        debugpy = utils.import_check("debugpy", errmsg="Please pip install debugpy")
+        if not debugpy:
+            return
+
+        self.debugpy = debugpy
+        super().__init__("debugpy", gdb.COMMAND_USER)
+
+    def invoke(self, args, from_tty):
+        debugpy = self.debugpy
+        if debugpy.is_client_connected():
+            gdb.write("debugpy is already running.\n")
+            return
+
+        parser = argparse.ArgumentParser(description=DebugPy.__doc__)
+        parser.add_argument(
+            "-p",
+            "--port",
+            default=5678,
+            type=int,
+            help="Server listening port",
+        )
+
+        try:
+            args = parser.parse_args(gdb.string_to_argv(args))
+        except SystemExit:
+            return
+
+        debugpy.listen(args.port)
+        gdb.write(f"Waiting for connection at localhost:{args.port}\n")
+        debugpy.wait_for_client()
+        gdb.write("Debugger connected.\n")

--- a/tools/gdb/requirements.txt
+++ b/tools/gdb/requirements.txt
@@ -1,3 +1,13 @@
-matplotlib
-numpy
-pyelftools
+contourpy==1.3.0
+cycler==0.12.1
+debugpy==1.8.7
+fonttools==4.54.1
+kiwisolver==1.4.7
+matplotlib==3.9.2
+numpy==2.1.2
+packaging==24.1
+pillow==11.0.0
+pyelftools==0.31
+pyparsing==3.2.0
+python-dateutil==2.9.0.post0
+six==1.16.0


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The `nuttxgdb` is getting more features, we need a better way to debug python code.

In this PR, we include `debugpy` from https://github.com/microsoft/debugpy

Usage:
(gdb) debugpy
Waiting for connection at localhost:5678

In VSCode, add new configuration in launch.
```
{
  "name": "Python Debugger: Remote Attach",
  "type": "debugpy",
  "request": "attach",
  "connect": {
    "host": "localhost",
    "port": 5678
  }
}
```
and launch.

## Impact

No.

## Testing

Tested on locally.


