### PR TITLE
nuttxgdb: minor fix to diagnose command and thread module

### DIFF
--- a/tools/gdb/nuttxgdb/diagnose.py
+++ b/tools/gdb/nuttxgdb/diagnose.py
@@ -76,8 +76,11 @@ class DiagnoseReport(gdb.Command):
                     result = command.diagnose()
                 except gdb.error as e:
                     result = {
+                        "title": f"Command {name} failed",
+                        "summary": "Command execution failed",
+                        "result": "info",
                         "command": name,
-                        "error": str(e),
+                        "message": str(e),
                     }
 
                     gdb.write(f"Failed: {e}\n")

--- a/tools/gdb/nuttxgdb/diagnose.py
+++ b/tools/gdb/nuttxgdb/diagnose.py
@@ -70,8 +70,20 @@ class DiagnoseReport(gdb.Command):
         for clz in commands:
             if hasattr(clz, "diagnose"):
                 command = clz()
-                gdb.write(f"Run command: {clz.__name__}\n")
-                results.append(command.diagnose())
+                name = clz.__name__.lower()
+                gdb.write(f"Run command: {name}\n")
+                try:
+                    result = command.diagnose()
+                except gdb.error as e:
+                    result = {
+                        "command": name,
+                        "error": str(e),
+                    }
+
+                    gdb.write(f"Failed: {e}\n")
+
+                result.setdefault("command", name)
+                results.append(result)
 
         gdb.write(f"Write report to {reportfile}\n")
         with open(reportfile, "w") as f:

--- a/tools/gdb/nuttxgdb/thread.py
+++ b/tools/gdb/nuttxgdb/thread.py
@@ -94,9 +94,6 @@ class Registers:
                 reginfo[name] = {
                     "rmt_nr": rmt_nr,  # The register number in remote-registers, Aka the one we saved in g_tcbinfo.
                     "tcb_reg_off": tcb_reg_off,
-                    "desc": registers.find(
-                        name
-                    ),  # Register descriptor. It's faster for frame.read_register
                 }
 
             Registers.reginfo = reginfo
@@ -142,8 +139,8 @@ class Registers:
 
         registers = {}
         frame = gdb.newest_frame()
-        for name, info in Registers.reginfo.items():
-            value = frame.read_register(info["desc"])
+        for name, _ in Registers.reginfo.items():
+            value = frame.read_register(name)
             registers[name] = value
 
         Registers.saved_regs = registers

--- a/tools/gdb/nuttxgdb/thread.py
+++ b/tools/gdb/nuttxgdb/thread.py
@@ -52,8 +52,6 @@ class Registers:
             # Switch to second inferior to get the original remote-register layout
             state = utils.suppress_cli_notifications(True)
             utils.switch_inferior(2)
-            arch = gdb.selected_inferior().architecture()
-            registers = arch.registers()
 
             natural_size = gdb.lookup_type("long").sizeof
             tcb_info = gdb.parse_and_eval("g_tcbinfo")
@@ -306,9 +304,10 @@ class Nxthread(gdb.Command):
     """Switch to a specified thread"""
 
     def __init__(self):
-        super().__init__("nxthread", gdb.COMMAND_USER)
         if not is_thread_command_supported():
-            gdb.execute("define thread\n nxthread \n end\n")
+            super().__init__("thread", gdb.COMMAND_USER)
+        else:
+            super().__init__("nxthread", gdb.COMMAND_USER)
 
     def invoke(self, args, from_tty):
         npidhash = gdb.parse_and_eval("g_npidhash")

--- a/tools/gdb/nuttxgdb/utils.py
+++ b/tools/gdb/nuttxgdb/utils.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import json
 import os
@@ -854,6 +855,14 @@ def gather_gdbcommands(modules=None, path=None) -> List[gdb.Command]:
             if isinstance(c, type) and issubclass(c, gdb.Command):
                 commands.append(c)
     return commands
+
+
+def get_elf_md5():
+    """Return the md5 checksum of the current ELF file"""
+    file = gdb.objfiles()[0].filename
+    with open(file, "rb") as f:
+        hash = hashlib.md5(f.read()).hexdigest()
+    return hash
 
 
 def jsonify(obj, indent=None):


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. For diagnose command, we catch any gdb error happened and report it in the final message.
2. Fix thread command not working on come circumstances.

`thread` is a GDB prefix command. Use `define` can only change it to a
user prefix command. In this case, `thread 3` is unable to pass
the argument 3 to python.

Use python code to register command to overwrite this behavior. It may
not work with future GDB, but all is good for now.
3. Optimize `memleak` command by caching the global variables information parsed from elf file. This can save seconds when run the command for multiple times.


## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

Tested with qemu arm64.
The thread command can work correctly.

```
(gdb) info threads
Index Tid  Pid  Cpu  Thread                Info                                                                             Frame
*0    0    0    0 '\000' Thread 0x404345e0     (Name: CPU0 IDLE, State: Running, Priority: 0, Stack: 16368) 0x402b1bcc  pl011_rxavailable() at /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:697
*1    1    0    1 '\001' Thread 0x40434738     (Name: CPU1 IDLE, State: Running, Priority: 0, Stack: 16368) 0x402b1bcc  pl011_rxavailable() at /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:697
 2    2    0    0 '\000' Thread 0x4044a000     (Name: hpwork, State: Waiting,Semaphore, Priority: 192, Stack: 16304) 0x402c32c0 nxsem_wait() at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
 3    3    3    1 '\001' Thread 0x4044e210     (Name: nsh_main, State: Waiting,Semaphore, Priority: 100, Stack: 16336) 0x402c32c0       nxsem_wait() at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
(gdb) info nxt
Index Tid  Pid  Cpu  Thread                Info                                                                             Frame
*0    0    0    0 '\000' Thread 0x404345e0     (Name: CPU0 IDLE, State: Running, Priority: 0, Stack: 16368) 0x402b1bcc  pl011_rxavailable() at /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:697
*1    1    0    1 '\001' Thread 0x40434738     (Name: CPU1 IDLE, State: Running, Priority: 0, Stack: 16368) 0x402b1bcc  pl011_rxavailable() at /home/neo/projects/nuttx/nuttx/drivers/serial/uart_pl011.c:697
 2    2    0    0 '\000' Thread 0x4044a000     (Name: hpwork, State: Waiting,Semaphore, Priority: 192, Stack: 16304) 0x402c32c0 nxsem_wait() at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
 3    3    3    1 '\001' Thread 0x4044e210     (Name: nsh_main, State: Waiting,Semaphore, Priority: 100, Stack: 16336) 0x402c32c0       nxsem_wait() at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
(gdb) t 3
(gdb) bt
#0  nxsem_wait (sem=sem@entry=0x40428588 <g_uart1port+40>) at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
#1  0x00000000402b2f40 in uart_read (filep=0x4044e708, buffer=0x404527af "", buflen=1) at 
...
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) t 2
(gdb) bt
#0  nxsem_wait (sem=sem@entry=0x40428a90 <g_hpwork+16>) at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:213
#1  0x00000000402c3340 in nxsem_wait_uninterruptible (sem=sem@entry=0x40428a90 <g_hpwork+16>) at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:252
#2  0x00000000402c52e0 in work_thread (argc=<optimized out>, argv=<optimized out>) at /home/neo/projects/nuttx/nuttx/sched/wqueue/kwork_thread.c:214
#3  0x00000000402c8904 in nxtask_start () at /home/neo/projects/nuttx/nuttx/sched/task/task_start.c:111
#4  0x0000000000000000 in ?? ()
Backtrace
```

