### PR TITLE
stream_getc: use lib_stream_eof instead of EOF

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -50,6 +50,7 @@
 #define lib_stream_puts(stream, buf, len) \
         ((FAR struct lib_outstream_s *)(stream))->puts( \
         (FAR struct lib_outstream_s *)(stream), buf, len)
+#define lib_stream_eof(c) ((c) <= 0)
 #define lib_stream_getc(stream) \
         ((FAR struct lib_instream_s *)(stream))->getc( \
         (FAR struct lib_instream_s *)(stream))

--- a/libs/libc/hex2bin/lib_hex2bin.c
+++ b/libs/libc/hex2bin/lib_hex2bin.c
@@ -250,21 +250,21 @@ static int readstream(FAR struct lib_instream_s *instream,
   /* Skip until the beginning of line start code is encountered */
 
   ch = lib_stream_getc(instream);
-  while (ch != RECORD_STARTCODE && ch != EOF)
+  while (ch != RECORD_STARTCODE && !lib_stream_eof(ch))
     {
       ch = lib_stream_getc(instream);
     }
 
   /* Skip over the startcode */
 
-  if (ch != EOF)
+  if (!lib_stream_eof(ch))
     {
       ch = lib_stream_getc(instream);
     }
 
   /* Then read, verify, and buffer until the end of line is encountered */
 
-  while (ch != EOF && nbytes < (MAXRECORD_ASCSIZE - 1))
+  while (!lib_stream_eof(ch) && nbytes < (MAXRECORD_ASCSIZE - 1))
     {
       if (ch == '\n' || ch == '\r')
         {

--- a/libs/libc/misc/lib_kbddecode.c
+++ b/libs/libc/misc/lib_kbddecode.c
@@ -142,7 +142,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* No, ungotten characters.  Check for the beginning of an ESC sequence. */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream */
 
@@ -166,7 +166,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Check for ESC-[ */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the escape character now.  We will
        * return the EOF indication next time.
@@ -192,7 +192,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Get and verify the special keyboard data to decode */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Unget everything and return the ESC character.
        */
@@ -219,7 +219,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Check for the final semicolon */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Unget everything and return the ESC character.
        */

--- a/libs/libc/misc/lib_slcddecode.c
+++ b/libs/libc/misc/lib_slcddecode.c
@@ -180,7 +180,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* No, ungotten characters.  Get the next character from the buffer. */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream (or perhaps an I/O error) */
 
@@ -204,7 +204,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* Get the next character from the buffer */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the escape character now.  We will
        * return the EOF indication next time.
@@ -233,7 +233,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* Get the next character from the buffer */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the ESC now; return the following
        * characters later.
@@ -281,7 +281,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
       /* Get the next character from the buffer */
 
       ch = lib_stream_getc(stream);
-      if (ch == EOF)
+      if (lib_stream_eof(ch))
         {
           /* End of file/stream.  Return the ESC now; return the following
            * characters later.
@@ -314,7 +314,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
       /* Get the next character from the buffer */
 
       ch = lib_stream_getc(stream);
-      if (ch == EOF)
+      if (lib_stream_eof(ch))
         {
           /* End of file/stream.  Return the ESC now; return the following
            * characters later.

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -1149,7 +1149,7 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
                 {
                   size_t nchars = (size_t) (stream->nget - ngetstart);
 
-                  if (c != EOF)
+                  if (!lib_stream_eof(c))
                     {
                       /* One more character already read */
 

--- a/libs/libc/stdio/lib_vsscanf.c
+++ b/libs/libc/stdio/lib_vsscanf.c
@@ -41,7 +41,7 @@ int vsscanf(FAR const char *buf, FAR const IPTR char *fmt, va_list ap)
 
   /* Initialize a memory stream to freadm from the buffer */
 
-  lib_meminstream(&meminstream, buf, INT_MAX);
+  lib_meminstream(&meminstream, buf, strlen(buf));
 
   /* Then let lib_vscanf do the real work */
 

--- a/libs/libc/stream/lib_stdinstream.c
+++ b/libs/libc/stream/lib_stdinstream.c
@@ -52,6 +52,10 @@ static int stdinstream_getc(FAR struct lib_instream_s *self)
     {
       self->nget++;
     }
+  else
+    {
+      ret = _NX_GETERRVAL(ret);
+    }
 
   return ret;
 }

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -51,6 +51,10 @@ static int stdsistream_getc(FAR struct lib_sistream_s *self)
     {
       self->nget++;
     }
+  else
+    {
+      ret = _NX_GETERRVAL(ret);
+    }
 
   return ret;
 }


### PR DESCRIPTION
## Summary
EOF is libc definition, not the stream definition, we should use errno to handle the stream getc EOF case.
As we have lots of backend to support stream, which necessary to get errno.

first find in #14778, casing scanftest break  
at " %4c%n" case.
then scanf use INT_MAX cause meminstream EOF break.

## Impact
sscanf will do strlen firsttime, and then meminstream.
filestream/blkstream/mtdstream will able to handle the errno.

## Testing
CI-test, local sim:citest test.


