### PR TITLE
fix some build error

### DIFF
--- a/arch/arm/src/goldfish/goldfish_boot.c
+++ b/arch/arm/src/goldfish/goldfish_boot.c
@@ -104,7 +104,7 @@ int up_cpu_start(int cpu)
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify of the start event */
 
-  sched_note_cpu_start(this_task_inirq(), cpu);
+  sched_note_cpu_start(this_task(), cpu);
 #endif
 
   return psci_cpu_on(cpu, (uintptr_t)__start);

--- a/arch/arm/src/qemu/qemu_boot.c
+++ b/arch/arm/src/qemu/qemu_boot.c
@@ -36,6 +36,11 @@
 #  include <nuttx/fdt.h>
 #endif
 
+#ifdef CONFIG_SCHED_INSTRUMENTATION
+#  include <sched/sched.h>
+#  include <nuttx/sched_note.h>
+#endif
+
 #include <nuttx/syslog/syslog_rpmsg.h>
 
 /****************************************************************************
@@ -99,7 +104,7 @@ int up_cpu_start(int cpu)
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify of the start event */
 
-  sched_note_cpu_start(this_task_inirq(), cpu);
+  sched_note_cpu_start(this_task(), cpu);
 #endif
 
   return psci_cpu_on(cpu, (uintptr_t)__start);


### PR DESCRIPTION
## Summary

hujun5@hujun5-OptiPlex-7070:~/downloads1/vela_sim/nuttx$ make -j12 chip/qemu_boot.c: In function 'up_cpu_start':
chip/qemu_boot.c:102:3: warning: implicit declaration of function 'sched_note_cpu_start' [-Wimplicit-function-declaration]
  102 |   sched_note_cpu_start(this_task(), cpu);
      |   ^~~~~~~~~~~~~~~~~~~~
chip/qemu_boot.c:102:24: warning: implicit declaration of function 'this_task' [-Wimplicit-function-declaration]
  102 |   sched_note_cpu_start(this_task(), cpu);
      |                        ^~~~~~~~~
## Impact
none

## Testing
ci

