### PR TITLE
spelling: fix spelling typo premption -> preemption

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -79,8 +79,8 @@
   ((drv)->ops->cpu_resume && ((drv)->ops->cpu_resume(drv, tcb, cpu), true))
 #define note_cpu_resumed(drv, tcb)                                           \
   ((drv)->ops->cpu_resumed && ((drv)->ops->cpu_resumed(drv, tcb), true))
-#define note_premption(drv, tcb, locked)                                     \
-  ((drv)->ops->premption && ((drv)->ops->premption(drv, tcb, locked), true))
+#define note_preemption(drv, tcb, locked)                                    \
+  ((drv)->ops->preemption && ((drv)->ops->preemption(drv, tcb, locked), true))
 #define note_csection(drv, tcb, enter)                                       \
   ((drv)->ops->csection && ((drv)->ops->csection(drv, tcb, enter), true))
 #define note_spinlock(drv, tcb, spinlock, type)                              \
@@ -1051,7 +1051,7 @@ void sched_note_cpu_resumed(FAR struct tcb_s *tcb)
 #endif /* CONFIG_SCHED_INSTRUMENTATION_SWITCH */
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
+void sched_note_preemption(FAR struct tcb_s *tcb, bool locked)
 {
   struct note_preempt_s note;
   FAR struct note_driver_s **driver;
@@ -1064,7 +1064,7 @@ void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
           continue;
         }
 
-      if (note_premption(*driver, tcb, locked))
+      if (note_preemption(*driver, tcb, locked))
         {
           continue;
         }

--- a/drivers/note/notelog_driver.c
+++ b/drivers/note/notelog_driver.c
@@ -61,8 +61,8 @@ static void notelog_cpu_resumed(FAR struct note_driver_s *drv,
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-static void notelog_premption(FAR struct note_driver_s *drv,
-                              FAR struct tcb_s *tcb, bool locked);
+static void notelog_preemption(FAR struct note_driver_s *drv,
+                               FAR struct tcb_s *tcb, bool locked);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
 static void notelog_csection(FAR struct note_driver_s *drv,
@@ -103,7 +103,7 @@ static const struct note_driver_ops_s g_notelog_ops =
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-  notelog_premption,     /* premption */
+  notelog_preemption,    /* preemption */
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
   notelog_csection,      /* csection */
@@ -255,8 +255,8 @@ static void notelog_cpu_resumed(FAR struct note_driver_s *drv,
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-static void notelog_premption(FAR struct note_driver_s *drv,
-                              FAR struct tcb_s *tcb, bool locked)
+static void notelog_preemption(FAR struct note_driver_s *drv,
+                               FAR struct tcb_s *tcb, bool locked)
 {
 #ifdef CONFIG_SMP
   syslog(LOG_INFO, "CPU%d: Task %s TCB@%p preemption %s\n",

--- a/drivers/note/notesnap_driver.c
+++ b/drivers/note/notesnap_driver.c
@@ -86,8 +86,8 @@ static void notesnap_cpu_resumed(FAR struct note_driver_s *drv,
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-static void notesnap_premption(FAR struct note_driver_s *drv,
-                               FAR struct tcb_s *tcb, bool locked);
+static void notesnap_preemption(FAR struct note_driver_s *drv,
+                                FAR struct tcb_s *tcb, bool locked);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
 static void notesnap_csection(FAR struct note_driver_s *drv,
@@ -133,7 +133,7 @@ static const struct note_driver_ops_s g_notesnap_ops =
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-  notesnap_premption,
+  notesnap_preemption,
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
   notesnap_csection,
@@ -302,8 +302,8 @@ static void notesnap_cpu_resumed(FAR struct note_driver_s *drv,
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-static void notesnap_premption(FAR struct note_driver_s *drv,
-                               FAR struct tcb_s *tcb, bool locked)
+static void notesnap_preemption(FAR struct note_driver_s *drv,
+                                FAR struct tcb_s *tcb, bool locked)
 {
   notesnap_common(drv, tcb, locked ? NOTE_PREEMPT_LOCK :
                   NOTE_PREEMPT_UNLOCK, 0);

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -112,7 +112,7 @@ static const struct note_driver_ops_s g_note_sysview_ops =
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-  NULL,                       /* premption */
+  NULL,                       /* preemption */
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
   NULL,                       /* csection */

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -214,9 +214,9 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Convert the for maximum time pre-emption disabled */
 
-  if (g_premp_max[cpu] > 0)
+  if (g_preemp_max[cpu] > 0)
     {
-      perf_convert(g_premp_max[cpu], &maxtime);
+      perf_convert(g_preemp_max[cpu], &maxtime);
     }
   else
     {
@@ -226,7 +226,7 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   /* Reset the maximum */
 
-  g_premp_max[cpu] = 0;
+  g_preemp_max[cpu] = 0;
 
   /* Generate output for maximum time pre-emption disabled */
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -774,9 +774,9 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
   /* Convert the for maximum time pre-emption disabled */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-  if (tcb->premp_max > 0)
+  if (tcb->preemp_max > 0)
     {
-      perf_convert(tcb->premp_max, &maxtime);
+      perf_convert(tcb->preemp_max, &maxtime);
     }
   else
     {
@@ -786,14 +786,14 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   /* Reset the maximum */
 
-  tcb->premp_max = 0;
+  tcb->preemp_max = 0;
 
   /* Generate output for maximum time pre-emption disabled */
 
   linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%lu.%09lu %p,",
                              (unsigned long)maxtime.tv_sec,
                              (unsigned long)maxtime.tv_nsec,
-                             tcb->premp_max_caller);
+                             tcb->preemp_max_caller);
   copysize = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                            &offset);
 

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -71,8 +71,8 @@ struct note_driver_ops_s
 #  endif
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-  CODE void (*premption)(FAR struct note_driver_s *drv,
-                         FAR struct tcb_s *tcb, bool locked);
+  CODE void (*preemption)(FAR struct note_driver_s *drv,
+                          FAR struct tcb_s *tcb, bool locked);
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
   CODE void (*csection)(FAR struct note_driver_s *drv,

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -702,10 +702,10 @@ struct tcb_s
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-  clock_t premp_start;                   /* Time when preemption disabled   */
-  clock_t premp_max;                     /* Max time preemption disabled    */
-  void   *premp_caller;                  /* Caller of preemption disabled   */
-  void   *premp_max_caller;              /* Caller of max preemption        */
+  clock_t preemp_start;                  /* Time when preemption disabled   */
+  clock_t preemp_max;                    /* Max time preemption disabled    */
+  void   *preemp_caller;                 /* Caller of preemption disabled   */
+  void   *preemp_max_caller;             /* Caller of max preemption        */
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
@@ -867,7 +867,7 @@ extern "C"
 /* Maximum time with pre-emption disabled or within critical section. */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-EXTERN clock_t g_premp_max[CONFIG_SMP_NCPUS];
+EXTERN clock_t g_preemp_max[CONFIG_SMP_NCPUS];
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION  >= 0 */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -630,9 +630,9 @@ void sched_note_cpu_resumed(FAR struct tcb_s *tcb);
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-void sched_note_premption(FAR struct tcb_s *tcb, bool locked);
+void sched_note_preemption(FAR struct tcb_s *tcb, bool locked);
 #else
-#  define sched_note_premption(t,l)
+#  define sched_note_preemption(t,l)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1252,7 +1252,7 @@ config SCHED_INSTRUMENTATION_PREEMPTION
 		Enables additional hooks for changes to pre-emption state.  Board-
 		specific logic must provide this additional logic.
 
-			void sched_note_premption(FAR struct tcb_s *tcb, bool state);
+			void sched_note_preemption(FAR struct tcb_s *tcb, bool state);
 
 config SCHED_INSTRUMENTATION_CSECTION
 	bool "Critical section monitor hooks"

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -93,7 +93,7 @@
 /* Maximum time with pre-emption disabled or within critical section. */
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-clock_t g_premp_max[CONFIG_SMP_NCPUS];
+clock_t g_preemp_max[CONFIG_SMP_NCPUS];
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
@@ -182,28 +182,28 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
     {
       /* Disabling.. Save the thread start time */
 
-      tcb->premp_start  = current;
-      tcb->premp_caller = caller;
+      tcb->preemp_start  = current;
+      tcb->preemp_caller = caller;
     }
   else
     {
       /* Re-enabling.. Check for the max elapsed time */
 
-      clock_t elapsed = current - tcb->premp_start;
+      clock_t elapsed = current - tcb->preemp_start;
       int cpu         = this_cpu();
 
-      if (elapsed > tcb->premp_max)
+      if (elapsed > tcb->preemp_max)
         {
-          tcb->premp_max        = elapsed;
-          tcb->premp_max_caller = tcb->premp_caller;
+          tcb->preemp_max        = elapsed;
+          tcb->preemp_max_caller = tcb->preemp_caller;
           CHECK_PREEMPTION(tcb->pid, elapsed);
         }
 
       /* Check for the global max elapsed time */
 
-      if (elapsed > g_premp_max[cpu])
+      if (elapsed > g_preemp_max[cpu])
         {
-          g_premp_max[cpu] = elapsed;
+          g_preemp_max[cpu] = elapsed;
         }
     }
 }
@@ -291,7 +291,7 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
     {
       /* Yes.. Save the start time */
 
-      tcb->premp_start = current;
+      tcb->preemp_start = current;
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */
 
@@ -349,11 +349,11 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
     {
       /* Possibly re-enabling.. Check for the max elapsed time */
 
-      elapsed = current - tcb->premp_start;
-      if (elapsed > tcb->premp_max)
+      elapsed = current - tcb->preemp_start;
+      if (elapsed > tcb->preemp_max)
         {
-          tcb->premp_max        = elapsed;
-          tcb->premp_max_caller = tcb->premp_caller;
+          tcb->preemp_max        = elapsed;
+          tcb->preemp_max_caller = tcb->preemp_caller;
           CHECK_PREEMPTION(tcb->pid, elapsed);
         }
 
@@ -361,9 +361,9 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
        * re-open in nxsched_resume_critmon.
        */
 
-      if (elapsed > g_premp_max[cpu])
+      if (elapsed > g_preemp_max[cpu])
         {
-          g_premp_max[cpu] = elapsed;
+          g_preemp_max[cpu] = elapsed;
         }
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -110,7 +110,7 @@ int sched_lock(void)
           nxsched_critmon_preemption(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-          sched_note_premption(rtcb, true);
+          sched_note_preemption(rtcb, true);
 #endif
         }
 
@@ -164,7 +164,7 @@ int sched_lock(void)
           nxsched_critmon_preemption(rtcb, true, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-          sched_note_premption(rtcb, true);
+          sched_note_preemption(rtcb, true);
 #endif
         }
     }

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -95,7 +95,7 @@ int sched_unlock(void)
           nxsched_critmon_preemption(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-          sched_note_premption(rtcb, false);
+          sched_note_preemption(rtcb, false);
 #endif
 
           /* Release any ready-to-run tasks that have collected in
@@ -220,7 +220,7 @@ int sched_unlock(void)
           nxsched_critmon_preemption(rtcb, false, return_address(0));
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_PREEMPTION
-          sched_note_premption(rtcb, false);
+          sched_note_preemption(rtcb, false);
 #endif
 
           /* Release any ready-to-run tasks that have collected in


### PR DESCRIPTION
## Summary

spelling: fix spelling typo premption -> preemption
spelling: fix spelling typo premp -> preemp

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check

