### PR TITLE
use spin_lock_wo_note replace spin_lock in csection

### DIFF
--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -181,7 +181,7 @@ irqstate_t enter_critical_section(void)
                * no longer blocked by the critical section).
                */
 
-              spin_lock(&g_cpu_irqlock);
+              spin_lock_wo_note(&g_cpu_irqlock);
               cpu_irqlock_set(cpu);
             }
 
@@ -232,7 +232,7 @@ irqstate_t enter_critical_section(void)
 
           DEBUGASSERT((g_cpu_irqset & (1 << cpu)) == 0);
 
-          spin_lock(&g_cpu_irqlock);
+          spin_lock_wo_note(&g_cpu_irqlock);
 
           /* Then set the lock count to 1.
            *


### PR DESCRIPTION
## Summary

use spin_lock_wo_note replace spin_lock in csection
reason:
spin_lock_wo_note/spin_unlock_wo_note  should be called in matching pairs.
This commit fixes the regression from https://github.com/apache/nuttx/pull/13933

leave_critical_section use cpu_irqlock_clear which alse use spin_unlock_wo_note


![image](https://github.com/user-attachments/assets/9638eb84-5895-4b82-8208-a3d323010fe4)

in https://github.com/apache/nuttx/pull/13933
I overlooked some changes, resulting in a mismatch in spinlock calls
## Impact

critical section

## Testing
ci ostest

