### PR TITLE
spinlock: use spin_lock_init replace spin_initialize

### DIFF
--- a/arch/risc-v/src/esp32c3/esp_coex_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp_coex_adapter.c
@@ -236,7 +236,7 @@ void *esp_coex_common_spin_lock_create_wrapper(void)
       DEBUGPANIC();
     }
 
-  spin_initialize(lock, SP_UNLOCKED);
+  spin_lock_init(lock);
 
   return lock;
 }

--- a/arch/risc-v/src/esp32c6/esp_coex_adapter.c
+++ b/arch/risc-v/src/esp32c6/esp_coex_adapter.c
@@ -236,7 +236,7 @@ void *esp_coex_common_spin_lock_create_wrapper(void)
       DEBUGPANIC();
     }
 
-  spin_initialize(lock, SP_UNLOCKED);
+  spin_lock_init(lock);
 
   return lock;
 }

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -241,7 +241,8 @@ int up_cpu_start(int cpu)
        * try to lock it but spins until the APP CPU starts and unlocks it.
        */
 
-      spin_initialize(&g_appcpu_interlock, SP_LOCKED);
+      spin_lock_init(&g_appcpu_interlock);
+      spin_lock(&g_appcpu_interlock);
 
       /* Unstall the APP CPU */
 
@@ -288,6 +289,10 @@ int up_cpu_start(int cpu)
       /* And wait until the APP CPU starts and releases the spinlock. */
 
       spin_lock(&g_appcpu_interlock);
+
+      /* prev cpu boot done */
+
+      spin_unlock(&g_appcpu_interlock);
       DEBUGASSERT(g_appcpu_started);
     }
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -920,7 +920,7 @@ static void *esp_spin_lock_create(void)
       DEBUGPANIC();
     }
 
-  spin_initialize(lock, SP_UNLOCKED);
+  spin_lock_init(lock);
 
   return lock;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
@@ -879,7 +879,7 @@ static void *esp_spin_lock_create(void)
       DEBUGPANIC();
     }
 
-  spin_initialize(lock, SP_UNLOCKED);
+  spin_lock_init(lock);
 
   return lock;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -226,7 +226,8 @@ int up_cpu_start(int cpu)
        * try to lock it but spins until the APP CPU starts and unlocks it.
        */
 
-      spin_initialize(&g_appcpu_interlock, SP_LOCKED);
+      spin_lock_init(&g_appcpu_interlock);
+      spin_lock(&g_appcpu_interlock);
 
       /* OpenOCD might have already enabled clock gating and taken APP CPU
        * out of reset.  Don't reset the APP CPU if that's the case as this
@@ -272,6 +273,10 @@ int up_cpu_start(int cpu)
       /* And wait until the APP CPU starts and releases the spinlock. */
 
       spin_lock(&g_appcpu_interlock);
+
+      /* prev cpu boot done */
+
+      spin_unlock(&g_appcpu_interlock);
       DEBUGASSERT(g_appcpu_started);
     }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -923,7 +923,7 @@ static void *esp_spin_lock_create(void)
       DEBUGPANIC();
     }
 
-  spin_initialize(lock, SP_UNLOCKED);
+  spin_lock_init(lock);
 
   return lock;
 }

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -496,26 +496,6 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 #endif
 
 /****************************************************************************
- * Name: spin_initialize
- *
- * Description:
- *   Initialize a non-reentrant spinlock object to its initial,
- *   unlocked state.
- *
- * Input Parameters:
- *   lock  - A reference to the spinlock object to be initialized.
- *   state - Initial state of the spinlock {SP_LOCKED or SP_UNLOCKED)
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-/* void spin_initialize(FAR spinlock_t *lock, spinlock_t state); */
-
-#define spin_initialize(l,s) do { SP_DMB(); *(l) = (s); } while (0)
-
-/****************************************************************************
  * Name: spin_lock_irqsave_wo_note
  *
  * Description:

--- a/libs/libc/pthread/pthread_spinlock.c
+++ b/libs/libc/pthread/pthread_spinlock.c
@@ -94,7 +94,7 @@ int pthread_spin_init(FAR pthread_spinlock_t *lock, int pshared)
   DEBUGASSERT(lock != NULL);
   if (lock != NULL)
     {
-      spin_initialize(&lock->sp_lock, SP_UNLOCKED);
+      spin_lock_init(&lock->sp_lock);
       lock->sp_holder = IMPOSSIBLE_THREAD;
       ret             = OK;
     }

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -304,7 +304,7 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name)
       kasan_poison(base, size);
     }
 
-  spin_initialize(&pool->lock, SP_UNLOCKED);
+  spin_lock_init(&pool->lock);
   if (pool->wait && pool->expandsize == 0)
     {
       nxsem_init(&pool->waitsem, 0, 0);


### PR DESCRIPTION

## Summary
spinlock: use spin_lock_init replace spin_initialize
reason:
1: spin_lock_init and spin_initialize have similar functionalities.
 2: spin_lock and spin_unlock should be called in matching pairs.

## Impact
spinlock

## Testing
ci ostest


