### PR TITLE
fs/littlefs: make CONFIG_FS_LITTLEFS_VERSION include the "v" prefix

### DIFF
--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CONFIG_FS_LITTLEFS)
 
     FetchContent_Declare(
       littlefs
-      URL https://github.com/ARMmbed/littlefs/archive/v${CONFIG_FS_LITTLEFS_VERSION}.tar.gz
+      URL https://github.com/ARMmbed/littlefs/archive/${CONFIG_FS_LITTLEFS_VERSION}.tar.gz
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/littlefs
           BINARY_DIR

--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -129,7 +129,7 @@ config FS_LITTLEFS_ATTR_UPDATE
 
 config FS_LITTLEFS_VERSION
 	string "LITTLEFS version to use"
-	default "2.5.1"
+	default "v2.5.1"
 	---help---
 		The LITTLEFS version to use.
 

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -47,14 +47,14 @@ CFLAGS += -DLFS_NAME_MAX=$(CONFIG_FS_LITTLEFS_NAME_MAX)
 CFLAGS += -DLFS_FILE_MAX=$(CONFIG_FS_LITTLEFS_FILE_MAX)
 CFLAGS += -DLFS_ATTR_MAX=$(CONFIG_FS_LITTLEFS_ATTR_MAX)
 
-LITTLEFS_TARBALL = v$(CONFIG_FS_LITTLEFS_VERSION).tar.gz
+LITTLEFS_TARBALL = $(CONFIG_FS_LITTLEFS_VERSION).tar.gz
 
 $(LITTLEFS_TARBALL):
 	$(call DOWNLOAD,https://github.com/ARMmbed/littlefs/archive,$(LITTLEFS_TARBALL),littlefs/$(LITTLEFS_TARBALL))
 
 .littlefsunpack: $(LITTLEFS_TARBALL)
 	$(Q) tar zxf littlefs/$(LITTLEFS_TARBALL) -C littlefs
-	$(Q) mv littlefs/littlefs-$(CONFIG_FS_LITTLEFS_VERSION) littlefs/littlefs
+	$(Q) mv littlefs/littlefs-* littlefs/littlefs
 	$(Q) git apply littlefs/lfs_util.patch
 	$(Q) git apply littlefs/lfs_getpath.patch
 	$(Q) git apply littlefs/lfs_getsetattr.patch


### PR DESCRIPTION
## Summary

fs/littlefs: make CONFIG_FS_LITTLEFS_VERSION include the "v" prefix
To allow other tags/branches like "devel" and even sha256 hash.

## Impact

littlefs

## Testing

build tested
(although i haven't tested CMakeFiles.txt locally because i couldn't find a defconfig working on macOS.)
