### PR TITLE
arm64: change name saved_reg to saved_regs

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -270,7 +270,7 @@ struct xcptcontext
 
   /* task context, for signal process */
 
-  uint64_t *saved_reg;
+  uint64_t *saved_regs;
 
 #ifdef CONFIG_ARCH_FPU
   uint64_t *fpu_regs;

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -138,7 +138,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * have been delivered.
        */
 
-      tcb->xcp.saved_reg = tcb->xcp.regs;
+      tcb->xcp.saved_regs = tcb->xcp.regs;
 
       /* create signal process context */
 

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -64,7 +64,7 @@ void arm64_sigdeliver(void)
 
   irqstate_t  flags;
   int16_t saved_irqcount;
-  flags = (rtcb->xcp.saved_reg[REG_SPSR] & SPSR_DAIF_MASK);
+  flags = (rtcb->xcp.saved_regs[REG_SPSR] & SPSR_DAIF_MASK);
 #endif
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -149,7 +149,7 @@ retry:
    */
 
   rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
-  rtcb->xcp.regs = rtcb->xcp.saved_reg;
+  rtcb->xcp.regs = rtcb->xcp.saved_regs;
 
   /* Then restore the correct state for this thread of execution. */
 


### PR DESCRIPTION

## Summary
arm64: change name saved_reg to saved_regs
reason:
saved_regs is more meaningful and used by all other arch

## Impact

none
## Testing
ci

