### PR TITLE
sched/lockcount: replace all lockcount check to nxsched_islocked_tcb()

### DIFF
--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -77,7 +77,8 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
    * also disabled.
    */
 
-  if (rtcb->lockcount > 0 && rtcb->sched_priority < btcb->sched_priority)
+  if (nxsched_islocked_tcb(rtcb) &&
+      rtcb->sched_priority < btcb->sched_priority)
     {
       /* Yes.  Preemption would occur!  Add the new ready-to-run task to the
        * g_pendingtasks task list for now.
@@ -96,7 +97,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * is now the new active task!
        */
 
-      DEBUGASSERT(rtcb->lockcount == 0 && !is_idle_task(btcb));
+      DEBUGASSERT(!nxsched_islocked_tcb(rtcb) && !is_idle_task(btcb));
 
       btcb->task_state = TSTATE_TASK_RUNNING;
       btcb->flink->task_state = TSTATE_TASK_READYTORUN;

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -287,7 +287,7 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Did this task disable pre-emption? */
 
-  if (tcb->lockcount > 0)
+  if (nxsched_islocked_tcb(tcb))
     {
       /* Yes.. Save the start time */
 
@@ -345,7 +345,7 @@ void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   /* Did this task disable preemption? */
 
-  if (tcb->lockcount > 0)
+  if (nxsched_islocked_tcb(tcb))
     {
       /* Possibly re-enabling.. Check for the max elapsed time */
 

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -89,7 +89,7 @@ bool nxsched_merge_pending(void)
    * Do nothing if pre-emption is still disabled
    */
 
-  if (rtcb->lockcount == 0)
+  if (!nxsched_islocked_tcb(rtcb))
     {
       for (ptcb = (FAR struct tcb_s *)list_pendingtasks()->head;
            ptcb;

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -191,7 +191,7 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
     {
       FAR struct tcb_s *rtcb = this_task();
 
-      if (rtcb->lockcount > 0)
+      if (nxsched_islocked_tcb(rtcb))
         {
           /* Move all tasks with the higher priority from the ready-to-run
            * list to the pending list.


### PR DESCRIPTION
## Summary

sched/lockcount: replace all lockcount check to nxsched_islocked_tcb()

replace all lockcount check to nxsched_islocked_tcb()

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check