### PR TITLE
trace: replace all *_wo_note to *_notrace to make api define more approachable

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1837,7 +1837,7 @@ void sched_note_filter_mode(FAR struct note_filter_named_mode_s *oldm,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = spin_lock_irqsave_wo_note(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldm != NULL)
     {
@@ -1873,7 +1873,7 @@ void sched_note_filter_mode(FAR struct note_filter_named_mode_s *oldm,
         }
     }
 
-  spin_unlock_irqrestore_wo_note(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 
 /****************************************************************************
@@ -1903,7 +1903,7 @@ void sched_note_filter_syscall(FAR struct note_filter_named_syscall_s *oldf,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = spin_lock_irqsave_wo_note(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -1939,7 +1939,7 @@ void sched_note_filter_syscall(FAR struct note_filter_named_syscall_s *oldf,
         }
     }
 
-  spin_unlock_irqrestore_wo_note(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 #endif
 
@@ -1970,7 +1970,7 @@ void sched_note_filter_irq(FAR struct note_filter_named_irq_s *oldf,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = spin_lock_irqsave_wo_note(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -2006,7 +2006,7 @@ void sched_note_filter_irq(FAR struct note_filter_named_irq_s *oldf,
         }
     }
 
-  spin_unlock_irqrestore_wo_note(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 #endif
 
@@ -2037,7 +2037,7 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
   irqstate_t falgs;
   FAR struct note_driver_s **driver;
 
-  falgs = spin_lock_irqsave_wo_note(&g_note_lock);
+  falgs = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -2073,7 +2073,7 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
         }
     }
 
-  spin_unlock_irqrestore_wo_note(&g_note_lock, falgs);
+  spin_unlock_irqrestore_notrace(&g_note_lock, falgs);
 }
 #endif
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -467,9 +467,9 @@ static ssize_t noteram_read(FAR struct file *filep, FAR char *buffer,
 
   if (ctx->mode == NOTERAM_MODE_READ_BINARY)
     {
-      flags = spin_lock_irqsave_wo_note(&drv->lock);
+      flags = spin_lock_irqsave_notrace(&drv->lock);
       ret = noteram_get(drv, (FAR uint8_t *)buffer, buflen);
-      spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+      spin_unlock_irqrestore_notrace(&drv->lock, flags);
     }
   else
     {
@@ -481,9 +481,9 @@ static ssize_t noteram_read(FAR struct file *filep, FAR char *buffer,
 
           /* Get the next note (removing it from the buffer) */
 
-          flags = spin_lock_irqsave_wo_note(&drv->lock);
+          flags = spin_lock_irqsave_notrace(&drv->lock);
           ret = noteram_get(drv, note, sizeof(note));
-          spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           if (ret <= 0)
             {
               return ret;
@@ -508,7 +508,7 @@ static int noteram_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
   int ret = -ENOSYS;
   FAR struct noteram_driver_s *drv = filep->f_inode->i_private;
-  irqstate_t flags = spin_lock_irqsave_wo_note(&drv->lock);
+  irqstate_t flags = spin_lock_irqsave_notrace(&drv->lock);
 
   /* Handle the ioctl commands */
 
@@ -600,7 +600,7 @@ static int noteram_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           break;
     }
 
-  spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   return ret;
 }
 
@@ -622,7 +622,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
   DEBUGASSERT(inode != NULL && inode->i_private != NULL);
   drv = inode->i_private;
 
-  flags = spin_lock_irqsave_wo_note(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   /* Ignore waits that do not include POLLIN */
 
@@ -655,7 +655,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (noteram_unread_length(drv) > 0)
         {
-          spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           poll_notify(&drv->pfd, 1, POLLIN);
           return ret;
         }
@@ -666,7 +666,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
     }
 
 errout:
-  spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   return ret;
 }
 
@@ -698,11 +698,11 @@ static void noteram_add(FAR struct note_driver_s *driver,
   unsigned int space;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave_wo_note(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   if (drv->ni_overwrite == NOTERAM_MODE_OVERWRITE_OVERFLOW)
     {
-      spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+      spin_unlock_irqrestore_notrace(&drv->lock, flags);
       return;
     }
 
@@ -716,7 +716,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
           /* Stop recording if not in overwrite mode */
 
           drv->ni_overwrite = NOTERAM_MODE_OVERWRITE_OVERFLOW;
-          spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           return;
         }
 
@@ -737,7 +737,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
   memcpy(drv->ni_buffer + head, note, space);
   memcpy(drv->ni_buffer, buf + space, notelen - space);
   drv->ni_head = noteram_next(drv, head, NOTE_ALIGN(notelen));
-  spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   poll_notify(&drv->pfd, 1, POLLIN);
 }
 

--- a/drivers/note/noterpmsg_driver.c
+++ b/drivers/note/noterpmsg_driver.c
@@ -180,7 +180,7 @@ static bool noterpmsg_transfer(FAR struct noterpmsg_driver_s *drv,
 static void noterpmsg_work(FAR void *priv)
 {
   FAR struct noterpmsg_driver_s *drv = priv;
-  irqstate_t flags = spin_lock_irqsave_wo_note(&drv->lock);
+  irqstate_t flags = spin_lock_irqsave_notrace(&drv->lock);
 
   if (!noterpmsg_transfer(drv, false))
     {
@@ -188,7 +188,7 @@ static void noterpmsg_work(FAR void *priv)
                  NOTE_RPMSG_WORK_DELAY);
     }
 
-  spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
 }
 
 static void noterpmsg_add(FAR struct note_driver_s *driver,
@@ -199,7 +199,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
   irqstate_t flags;
   size_t space;
 
-  flags = spin_lock_irqsave_wo_note(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   space = CONFIG_DRIVERS_NOTERPMSG_BUFSIZE - noterpmsg_length(drv);
   if (space < notelen)
@@ -236,7 +236,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
                  NOTE_RPMSG_WORK_DELAY);
     }
 
-  spin_unlock_irqrestore_wo_note(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
 }
 
 static int noterpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -80,7 +80,7 @@
   do \
     { \
       g_cpu_irqset = 0; \
-      spin_unlock_wo_note(&g_cpu_irqlock); \
+      spin_unlock_notrace(&g_cpu_irqlock); \
     } \
   while (0)
 #endif

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -218,7 +218,7 @@ static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
 #define spin_lock_init(l) do { *(l) = SP_UNLOCKED; } while (0)
 
 /****************************************************************************
- * Name: spin_lock_wo_note
+ * Name: spin_lock_notrace
  *
  * Description:
  *   If this CPU does not already hold the spinlock, then loop until the
@@ -240,7 +240,7 @@ static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
  ****************************************************************************/
 
 #ifdef CONFIG_SPINLOCK
-static inline_function void spin_lock_wo_note(FAR volatile spinlock_t *lock)
+static inline_function void spin_lock_notrace(FAR volatile spinlock_t *lock)
 {
 #ifdef CONFIG_TICKET_SPINLOCK
   unsigned short ticket =
@@ -290,7 +290,7 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 
   /* Lock without trace note */
 
-  spin_lock_wo_note(lock);
+  spin_lock_notrace(lock);
 
   /* Notify that we have the spinlock */
 
@@ -299,7 +299,7 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
- * Name: spin_trylock_wo_note
+ * Name: spin_trylock_notrace
  *
  * Description:
  *   Try once to lock the spinlock.  Do not wait if the spinlock is already
@@ -322,7 +322,7 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 
 #ifdef CONFIG_SPINLOCK
 static inline_function bool
-spin_trylock_wo_note(FAR volatile spinlock_t *lock)
+spin_trylock_notrace(FAR volatile spinlock_t *lock)
 {
 #ifdef CONFIG_TICKET_SPINLOCK
   unsigned short ticket =
@@ -387,7 +387,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
 
   /* Try lock without trace note */
 
-  locked = spin_trylock_wo_note(lock);
+  locked = spin_trylock_notrace(lock);
   if (locked)
     {
       /* Notify that we have the spinlock */
@@ -406,7 +406,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
- * Name: spin_unlock_wo_note
+ * Name: spin_unlock_notrace
  *
  * Description:
  *   Release one count on a non-reentrant spinlock.
@@ -427,7 +427,7 @@ static inline_function bool spin_trylock(FAR volatile spinlock_t *lock)
 
 #ifdef CONFIG_SPINLOCK
 static inline_function void
-spin_unlock_wo_note(FAR volatile spinlock_t *lock)
+spin_unlock_notrace(FAR volatile spinlock_t *lock)
 {
   SP_DMB();
 #ifdef CONFIG_TICKET_SPINLOCK
@@ -463,7 +463,7 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 {
   /* Unlock without trace note */
 
-  spin_unlock_wo_note(lock);
+  spin_unlock_notrace(lock);
 
   /* Notify that we are unlocking the spinlock */
 
@@ -496,7 +496,7 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 #endif
 
 /****************************************************************************
- * Name: spin_lock_irqsave_wo_note
+ * Name: spin_lock_irqsave_notrace
  *
  * Description:
  *   This function is no trace version of spin_lock_irqsave()
@@ -505,7 +505,7 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 
 #ifdef CONFIG_SPINLOCK
 static inline_function
-irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
+irqstate_t spin_lock_irqsave_notrace(FAR volatile spinlock_t *lock)
 {
   irqstate_t ret;
   ret = up_irq_save();
@@ -515,7 +515,7 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
       int me = this_cpu();
       if (0 == g_irq_spin_count[me])
         {
-          spin_lock_wo_note(&g_irq_spin);
+          spin_lock_notrace(&g_irq_spin);
         }
 
       g_irq_spin_count[me]++;
@@ -523,13 +523,13 @@ irqstate_t spin_lock_irqsave_wo_note(FAR volatile spinlock_t *lock)
     }
   else
     {
-      spin_lock_wo_note(lock);
+      spin_lock_notrace(lock);
     }
 
   return ret;
 }
 #else
-#  define spin_lock_irqsave_wo_note(l) ((void)(l), up_irq_save())
+#  define spin_lock_irqsave_notrace(l) ((void)(l), up_irq_save())
 #endif
 
 /****************************************************************************
@@ -577,7 +577,7 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 
   /* Lock without trace note */
 
-  flags = spin_lock_irqsave_wo_note(lock);
+  flags = spin_lock_irqsave_notrace(lock);
 
   /* Notify that we have the spinlock */
 
@@ -590,7 +590,7 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 #endif
 
 /****************************************************************************
- * Name: spin_trylock_irqsave_wo_note
+ * Name: spin_trylock_irqsave_notrace
  *
  * Description:
  *   Try once to lock the spinlock.  Do not wait if the spinlock is already
@@ -613,14 +613,14 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
  ****************************************************************************/
 
 #ifdef CONFIG_SPINLOCK
-#  define spin_trylock_irqsave_wo_note(l, f) \
+#  define spin_trylock_irqsave_notrace(l, f) \
 ({ \
   f = up_irq_save(); \
-  spin_trylock_wo_note(l) ? \
+  spin_trylock_notrace(l) ? \
   true : ({ up_irq_restore(f); false; }); \
 })
 #else
-#  define spin_trylock_irqsave_wo_note(l, f) \
+#  define spin_trylock_irqsave_notrace(l, f) \
 ({ \
   (void)(l); \
   f = up_irq_save(); \
@@ -665,7 +665,7 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
- * Name: spin_unlock_irqrestore_wo_note
+ * Name: spin_unlock_irqrestore_notrace
  *
  * Description:
  *   This function is no trace version of spin_unlock_irqrestore()
@@ -674,7 +674,7 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 
 #ifdef CONFIG_SPINLOCK
 static inline_function
-void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
+void spin_unlock_irqrestore_notrace(FAR volatile spinlock_t *lock,
                                     irqstate_t flags)
 {
   if (NULL == lock)
@@ -685,18 +685,18 @@ void spin_unlock_irqrestore_wo_note(FAR volatile spinlock_t *lock,
 
       if (0 == g_irq_spin_count[me])
         {
-          spin_unlock_wo_note(&g_irq_spin);
+          spin_unlock_notrace(&g_irq_spin);
         }
     }
   else
     {
-      spin_unlock_wo_note(lock);
+      spin_unlock_notrace(lock);
     }
 
   up_irq_restore(flags);
 }
 #else
-#  define spin_unlock_irqrestore_wo_note(l, f) ((void)(l), up_irq_restore(f))
+#  define spin_unlock_irqrestore_notrace(l, f) ((void)(l), up_irq_restore(f))
 #endif
 
 /****************************************************************************
@@ -735,7 +735,7 @@ void spin_unlock_irqrestore(FAR volatile spinlock_t *lock,
 {
   /* Unlock without trace note */
 
-  spin_unlock_irqrestore_wo_note(lock, flags);
+  spin_unlock_irqrestore_notrace(lock, flags);
 
   /* Notify that we are unlocking the spinlock */
 

--- a/libs/libc/machine/arch_atomic.c
+++ b/libs/libc/machine/arch_atomic.c
@@ -46,11 +46,11 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   void weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
                                                                      \
     *(FAR type *)ptr = value;                                        \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
   }
 
 #define LOAD(fn, n, type)                                             \
@@ -58,11 +58,11 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR const volatile void *ptr, \
                                         int memorder)                 \
   {                                                                   \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock);  \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock);  \
                                                                       \
     type ret = *(FAR type *)ptr;                                      \
                                                                       \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);         \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);         \
     return ret;                                                       \
   }
 
@@ -71,13 +71,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     type ret = *tmp;                                                 \
     *tmp = value;                                                    \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -89,7 +89,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         int success, int failure)    \
   {                                                                  \
     bool ret = false;                                                \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmpmem = (FAR type *)mem;                              \
     FAR type *tmpexp = (FAR type *)expect;                           \
                                                                      \
@@ -103,7 +103,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmpexp = *tmpmem;                                           \
       }                                                              \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -112,13 +112,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         int memorder)                \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *(FAR type *)ptr = 1;                                            \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -127,13 +127,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp + value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -142,13 +142,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp - value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -157,13 +157,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp & value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -172,13 +172,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp | value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -187,13 +187,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp ^ value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -202,12 +202,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp + value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -216,12 +216,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp - value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -230,12 +230,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp | value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -244,12 +244,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp & value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -258,12 +258,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp ^ value;                                             \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -272,12 +272,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = ~(*tmp & value);                                          \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -288,7 +288,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         type newvalue)               \
   {                                                                  \
     bool ret = false;                                                \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     if (*tmp == oldvalue)                                            \
@@ -297,7 +297,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmp = newvalue;                                             \
       }                                                              \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -307,7 +307,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         type oldvalue,               \
                                         type newvalue)               \
   {                                                                  \
-    irqstate_t irqstate = spin_lock_irqsave_wo_note(&g_atomic_lock); \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
@@ -316,7 +316,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmp = newvalue;                                             \
       }                                                              \
                                                                      \
-    spin_unlock_irqrestore_wo_note(&g_atomic_lock, irqstate);        \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -181,7 +181,7 @@ irqstate_t enter_critical_section(void)
                * no longer blocked by the critical section).
                */
 
-              spin_lock_wo_note(&g_cpu_irqlock);
+              spin_lock_notrace(&g_cpu_irqlock);
               cpu_irqlock_set(cpu);
             }
 
@@ -232,7 +232,7 @@ irqstate_t enter_critical_section(void)
 
           DEBUGASSERT((g_cpu_irqset & (1 << cpu)) == 0);
 
-          spin_lock_wo_note(&g_cpu_irqlock);
+          spin_lock_notrace(&g_cpu_irqlock);
 
           /* Then set the lock count to 1.
            *

--- a/sched/sched/sched_process_delivered.c
+++ b/sched/sched/sched_process_delivered.c
@@ -73,7 +73,7 @@ void nxsched_process_delivered(int cpu)
 
   if ((g_cpu_irqset & (1 << cpu)) == 0)
     {
-      spin_lock_wo_note(&g_cpu_irqlock);
+      spin_lock_notrace(&g_cpu_irqlock);
 
       g_cpu_irqset |= (1 << cpu);
     }


### PR DESCRIPTION
## Summary

trace: replace all *_wo_note to *_notrace to make api define more approachable

Follow the linux naming style:

https://github.com/torvalds/linux/blob/master/include/linux/preempt.h#L237-L242
https://github.com/torvalds/linux/blob/master/include/linux/srcu.h#L221

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check
