### PR TITLE
Fix compilation errors

### DIFF
--- a/include/gcov.h
+++ b/include/gcov.h
@@ -137,7 +137,7 @@ extern void __gcov_info_to_gcda(FAR const struct gcov_info *info,
                                 FAR void (*filename)(FAR const char *,
                                                      FAR void *),
                                 FAR void (*dump)(FAR const void *,
-                                                 unsigned int, FAR void *),
+                                                 size_t, FAR void *),
                                 FAR void *(*allocate)(unsigned int,
                                                       FAR void *),
                                 FAR void *arg);

--- a/libs/libbuiltin/libgcc/gcov.c
+++ b/libs/libbuiltin/libgcc/gcov.c
@@ -205,6 +205,11 @@ static int gcov_process_path(FAR char *prefix, int strip,
 
   prefix_count = token_count;
   token = strtok(path, "/");
+  if (token == NULL)
+    {
+      return -EINVAL;
+    }
+
   while (token != NULL)
     {
       filename = token;
@@ -315,9 +320,22 @@ void __gcov_dump(void)
   FAR struct gcov_info *info;
   FAR const char *strip = getenv("GCOV_PREFIX_STRIP");
   FAR const char *prefix = getenv("GCOV_PREFIX");
-  FAR char *prefix2 = strdup(prefix);
   FAR char new_path[PATH_MAX];
+  FAR char *prefix2;
   int ret;
+
+  if (prefix == NULL)
+    {
+      syslog(LOG_ERR, "No path prefix specified");
+      return;
+    }
+
+  prefix2 = strdup(prefix);
+  if (prefix2 == NULL)
+    {
+      syslog(LOG_ERR, "gcov alloc failed!");
+      return;
+    }
 
   for (info = __gcov_info_start; info; info = info->next)
     {
@@ -401,7 +419,7 @@ void __gcov_filename_to_gcfn(FAR const char *filename,
 void __gcov_info_to_gcda(FAR const struct gcov_info *info,
                          FAR void (*filename_fn)(FAR const char *,
                                                  FAR void *),
-                         FAR void (*dump_fn)(FAR const void *, unsigned int,
+                         FAR void (*dump_fn)(FAR const void *, size_t,
                                              FAR void *),
                          FAR void *(*allocate_fn)(unsigned int, FAR void *),
                          FAR void *arg)


### PR DESCRIPTION
## Summary

    CC:  gcov.c gcov.c: In function 'gcov_stdout_dump':
    gcov.c:146:50: error: passing argument 3 of '__gcov_info_to_gcda' from incompatible pointer type [-Werror=incompatible-pointer-types]
      146 |       __gcov_info_to_gcda(info, stdout_filename, stdout_dump, NULL, &arg);
          |                                                  ^~~~~~~~~~~
          |                                                  |
          |                                                  void (*)(const void *, size_t,  void *) {aka void (*)(const void *, long unsigned int,  void *)}
    In file included from gcov.c:25:
    /mnt/vela/github/NX/nuttx/include/gcov.h:139:44: note: expected 'void (*)(const void *, unsigned int,  void *)' but argument is of type 'void (*)(const void *, size_t,  void *)' {aka 'void (*)(const void *, long unsigned int,  void *)'}
      139 |                                 FAR void (*dump)(FAR const void *,
          |                                     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
      140 |                                                  unsigned int, FAR void *),
          |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~
    libgcc/gcov.c: In function 'gcov_process_path.constprop':
    libgcc/gcov.c:230:29: error: 'filename' may be used uninitialized [-Werror=maybe-uninitialized]
      230 |       tokens[token_count++] = filename;
          |       ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
    libgcc/gcov.c:188:13: note: 'filename' was declared here
      188 |   FAR char *filename;

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


