### PR TITLE
fs/partition/txtable: Fix panic when no txtable was found in last eraseblock

### DIFF
--- a/fs/partition/fs_txtable.c
+++ b/fs/partition/fs_txtable.c
@@ -133,7 +133,8 @@ int parse_txtable_partition(FAR struct partition_state_s *state,
       /* Parsing data of partition table */
 
       token = strtok_r(token, "\n", &save_ptr);
-      if (strncmp(token, TXTABLE_MAGIC, strlen(TXTABLE_MAGIC)) != 0)
+      if (token == NULL ||
+          strncmp(token, TXTABLE_MAGIC, strlen(TXTABLE_MAGIC)) != 0)
         {
           save_ptr = NULL;
           ret = -EFTYPE;


### PR DESCRIPTION
## Summary
Panic occured if no txtable was found in last eraseblock of MTD device and `CONFIG_TXTABLE_DEFAULT_PARTITION` was disabled

Backtrace
```
  sched_dumpstack
  /workspace/nuttx/libs/libc/sched/sched_dumpstack.c:71
  dump_assert_info
  /workspace/nuttx/sched/misc/assert.c:718
  xtensa_user_panic
  /workspace/nuttx/arch/xtensa/src/common/xtensa_assert.c:188 (discriminator 1)
  xtensa_user
  ??:?
  _xtensa_user_handler
  /workspace/nuttx/arch/xtensa/src/common/xtensa_user_handler.S:194
  ??
  ??:0
  parse_txtable_partition
  /workspace/nuttx/fs/partition/fs_txtable.c:136
  parse_partition
  /workspace/nuttx/fs/partition/fs_partition.c:165
  parse_mtd_partition
  /workspace/nuttx/fs/partition/fs_partition.c:291
```

## Impact
fs/partition/txtable:

## Testing
1. Selftest
2. NuttX CI

