### PR TITLE
boards/xtensa/esp32s3: Treat return value that greater than zero as succ

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -243,7 +243,7 @@ int esp32s3_bringup(void)
 
 #ifdef CONFIG_ESP32S3_SPIFLASH
   ret = board_spiflash_init();
-  if (ret)
+  if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize SPI Flash\n");
     }


### PR DESCRIPTION
## Summary
Treat return value that greater than zero as succ.
`parse_mtd_partition()` may return value that greater than zero when succ.
e.g: board_spiflash_init() => init_storage_partition() => parse_mtd_partition() 

## Impact
boards/xtensa/esp32s3

## Testing
1. Selftest: `esp32s3-devkit:adb` with `CONFIG_TXTABLE_PARTITION` enabled.
2. NuttX CI



