### PR TITLE
Various improvements for e1000 and igc

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -812,6 +812,13 @@ config NET_IGC_RXSPARE
 	int "Intel IGC spare RX buffers"
 	default 8
 
+config NET_IGC_INT_INTERVAL
+	int "Intel IGC interrupt interval"
+	default 100
+	range 1 8191
+	---help---
+		Minimum Inter-interrupt Interval in 1 us increments.
+
 endif # NET_IGC
 
 endif # NETDEVICES

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -777,11 +777,27 @@ menuconfig NET_E1000
 
 if NET_E1000
 
+config NET_E1000_TXDESC
+	int "Intel E1000 TX descriptors"
+	default 256
+
+config NET_E1000_RXDESC
+	int "Intel E1000 RX descriptors"
+	default 256
+
 config NET_E1000_RXSPARE
 	int "Intel E1000 spare RX buffers"
 	default 8
 
 endif # NET_E1000
+
+config NET_IGC_TXDESC
+	int "Intel IGC TX descriptors"
+	default 256
+
+config NET_IGC_RXDESC
+	int "Intel IGC RX descriptors"
+	default 256
 
 menuconfig NET_IGC
 	bool "Intel IGC support"

--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -46,6 +46,14 @@
  * Pre-processor Definitions
  *****************************************************************************/
 
+#if CONFIG_NET_E1000_TXDESC % 2 != 0
+#  error CONFIG_NET_E1000_TXDESC must be multiple of 2
+#endif
+
+#if CONFIG_NET_E1000_RXDESC % 2 != 0
+#  error CONFIG_NET_E1000_RXDESC must be multiple of 2
+#endif
+
 /* Packet buffer size */
 
 #define E1000_PKTBUF_SIZE       2048
@@ -53,8 +61,8 @@
 
 /* TX and RX descriptors */
 
-#define E1000_TX_DESC           256
-#define E1000_RX_DESC           256
+#define E1000_TX_DESC           CONFIG_NET_E1000_TXDESC
+#define E1000_RX_DESC           CONFIG_NET_E1000_RXDESC
 
 /* After RX packet is done, we provide free netpkt to the RX descriptor ring.
  * The upper-half network logic is responsible for freeing the RX packets

--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -572,6 +572,11 @@ static int e1000_transmit(FAR struct netdev_lowerhalf_s *dev,
       return -EINVAL;
     }
 
+  if (!IFF_IS_RUNNING(dev->netdev.d_flags))
+    {
+      return -ENETDOWN;
+    }
+
   /* Store TX packet reference */
 
   priv->tx_pkt[priv->tx_now] = pkt;

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -526,6 +526,11 @@ static int igc_transmit(FAR struct netdev_lowerhalf_s *dev,
       return -EINVAL;
     }
 
+  if (!IFF_IS_RUNNING(dev->netdev.d_flags))
+    {
+      return -ENETDOWN;
+    }
+
   /* Store TX packet reference */
 
   priv->tx_pkt[priv->tx_now] = pkt;

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -46,6 +46,14 @@
  * Pre-processor Definitions
  *****************************************************************************/
 
+#if CONFIG_NET_IGC_TXDESC % 2 != 0
+#  error CONFIG_NET_IGC_TXDESC must be multiple of 2
+#endif
+
+#if CONFIG_NET_IGC_RXDESC % 2 != 0
+#  error CONFIG_NET_IGC_RXDESC must be multiple of 2
+#endif
+
 /* Packet buffer size */
 
 #define IGC_PKTBUF_SIZE        2048
@@ -53,8 +61,8 @@
 
 /* TX and RX descriptors */
 
-#define IGC_TX_DESC            256
-#define IGC_RX_DESC            256
+#define IGC_TX_DESC            CONFIG_NET_IGC_TXDESC
+#define IGC_RX_DESC            CONFIG_NET_IGC_RXDESC
 
 /* After RX packet is done, we provide free netpkt to the RX descriptor ring.
  * The upper-half network logic is responsible for freeing the RX packets

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -91,10 +91,6 @@
 #define IGC_IO_BAR             2
 #define IGC_MSIX_BAR           3
 
-/* Minimum Inter-interrupt Interval in 1 us increments */
-
-#define IGC_INTERRUPT_INTERVAL 100
-
 /* For MSI-X we allocate all interrupts to MSI-X vector 0 */
 
 #define IGC_GPIE_MSIX_SINGLE   (IGC_GPIE_NSICR | IGC_GPIE_EIAME | \
@@ -1185,7 +1181,7 @@ static int igc_initialize(FAR struct igc_driver_s *priv)
 
   /* Configure Interrupt Throttle */
 
-  igc_putreg_mem(priv, IGC_EITR0, (IGC_INTERRUPT_INTERVAL << 2));
+  igc_putreg_mem(priv, IGC_EITR0, (CONFIG_NET_IGC_INT_INTERVAL << 2));
 
   /* Get MAC if valid */
 


### PR DESCRIPTION
## Summary

-  drivers/net/{e1000|igc}: configure RX/TX descriptors from Kconfig
        configure E1000/IGC RX/TX descriptors from Kconfig
- drivers/net/igc: make Interrupt Throttle configurable
- drivers/net/{e1000|igc}: fix link status crash
     netdev_lower_carrier_xxx API can't be used in interrupt context
- drivers/net/{e1000|igc}: reset TX ring when disconnected
- drivers/net/{e1000|igc}: limit no packet is transmit after carrier off
- drivers/net/{e1000|igc}: limit no packet is transmit after carrier off

## Impact

1. moved some hardcoded values to Kconfig
2. fixed various issues when repeatedly pluggin and unplugging the eth cable

## Testing

intel hardware


