### PR TITLE
sched: replace up_cpu_index with this_cpu

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_irq.c
+++ b/arch/arm/src/rp23xx/rp23xx_irq.c
@@ -305,7 +305,7 @@ void up_disable_irq(int irq)
 
 #ifdef CONFIG_SMP
   if (irq >= RP23XX_IRQ_EXTINT && irq != RP23XX_SIO_IRQ_FIFO &&
-      up_cpu_index() != 0)
+      this_cpu() != 0)
     {
       /* Must be handled by Core 0 */
 
@@ -361,7 +361,7 @@ void up_enable_irq(int irq)
 
 #ifdef CONFIG_SMP
   if (irq >= RP23XX_IRQ_EXTINT && irq != RP23XX_SIO_IRQ_FIFO &&
-      up_cpu_index() != 0)
+      this_cpu() != 0)
     {
       /* Must be handled by Core 0 */
 

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -440,7 +440,7 @@ static inline void up_idtinit(void)
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
 static inline void x86_64_color_intstack(void)
 {
-  x86_64_stack_color((void *)up_get_intstackbase(up_cpu_index()),
+  x86_64_stack_color((void *)up_get_intstackbase(this_cpu()),
                      IRQ_STACK_SIZE);
 }
 #else


### PR DESCRIPTION

## Summary
sched: replace up_cpu_index with this_cpu
Make this_cpu is arch independent and up_cpu_index do that. In AMP mode, up_cpu_index() may return the index of the physical core.
## Impact
sched
## Testing
ci ostest

