### PR TITLE
arch/x86_64/intel64: fix revoke_low_memory

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -436,17 +436,20 @@ g_cpu_count:
 
 __revoke_low_memory:
 	/* Revoke the lower 128MB memory mapping */
+	movq    $X86_64_LOAD_OFFSET,%rcx
 	lea     g_pd_low, %edi
+	add     %rcx, %rdi
 	lea     g_pt_low, %esi
+	add     %rcx, %rsi
 
 	/* for ecx = 0...64 : Loop and setup 64x 2MB page directories */
 	mov     $64,   %ecx
 npd_loop:
-	mov     %esi,   %edx
-	or      $(X86_PAGE_WR | X86_PAGE_PRESENT), %edx
-	mov     %edx, 0(%edi)
-	add     $(PAGE_SIZE), %esi
-	add     $(X86_PAGE_ENTRY_SIZE), %edi
+	mov     %rsi,   %rdx
+	or      $(X86_PAGE_WR | X86_PAGE_PRESENT), %rdx
+	mov     %rdx, 0(%rdi)
+	add     $(PAGE_SIZE), %rsi
+	add     $(X86_PAGE_ENTRY_SIZE), %rdi
 
 	/* end for ecx */
 	dec     %ecx

--- a/arch/x86_64/src/intel64/intel64_lowsetup.c
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.c
@@ -90,12 +90,4 @@ void intel64_lowsetup(void)
   /* reload the GDTR with mapped high memory address */
 
   setgdt((void *)g_gdt64, (uintptr_t)(&g_gdt64_low_end - &g_gdt64_low) - 1);
-
-#ifndef CONFIG_SMP
-  /* Revoke the lower memory if not SMP, otherwise this is done in
-   * x86_64_ap_boot() after the initialization of the last AP is finished.
-   */
-
-  __revoke_low_memory();
-#endif
 }

--- a/arch/x86_64/src/intel64/intel64_start.c
+++ b/arch/x86_64/src/intel64/intel64_start.c
@@ -172,6 +172,14 @@ void __nxstart(void)
   acpi_init(g_acpi_rsdp);
 #endif
 
+#ifndef CONFIG_SMP
+  /* Revoke the lower memory if not SMP, otherwise this is done in
+   * x86_64_ap_boot() after the initialization of the last AP is finished.
+   */
+
+  __revoke_low_memory();
+#endif
+
   /* Initialize CPU data (BSP and APs) */
 
   x86_64_cpu_init();


### PR DESCRIPTION
## Summary

- arch/x86_64/intel64: fix revoke_low_memory
    Fix revoke_low_memory, problem found by Xiangzhen Ouyang.
    g_pt_low mapping is removed during revoke_low_memory so we can't access this memory area with 1:1 mapping.
    This logic has been broken for a long time, but for some reason it worked without any crash at boot.

## Impact

fix broken code

## Testing

qemu and intel HW


