### PR TITLE
arch/x86_64/intel64: up_disable_irq should work from any CPU

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -165,8 +165,10 @@ void x86_64_ap_boot(void)
 
   irq_attach(SMP_IPI_CALL_IRQ, x86_64_smp_call_handler, NULL);
   irq_attach(SMP_IPI_SCHED_IRQ, x86_64_smp_sched_handler, NULL);
-  up_enable_irq(SMP_IPI_CALL_IRQ);
-  up_enable_irq(SMP_IPI_SCHED_IRQ);
+
+  /* NOTE: IPC interrupts don't use IOAPIC but interrupts are sent
+   * directly to CPU, so we don't use up_enable_irq() API here.
+   */
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a


### PR DESCRIPTION
## Summary

- arch/x86_64/intel64: up_disable_irq should work from any CPU
  simplify interrupt logic and allow any CPU to disable interrupt, not only CPU that enabled it.

## Impact

up_disable_irq works from any CPU, not just the one that previously enabled a given interrupt

## Testing

qemu


