### PR TITLE
arm/isr: move up_set_interrupt_context() to chip define

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -244,6 +244,16 @@ static inline_function bool up_interrupt_context(void)
 #endif
 }
 
+noinstrument_function
+static inline_function void up_set_interrupt_context(bool flag)
+{
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+  g_interrupt_context[up_cpu_index()] = flag;
+#else
+  g_interrupt_context[0] = flag;
+#endif
+}
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -476,6 +476,12 @@ static inline_function bool up_interrupt_context(void)
   return (bool)CP15_GET(TPIDRPRW);
 }
 
+noinstrument_function
+static inline_function void up_set_interrupt_context(bool flag)
+{
+  CP15_SET(TPIDRPRW, flag);
+}
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -471,6 +471,12 @@ static inline_function bool up_interrupt_context(void)
   return (bool)CP15_GET(TPIDRPRW);
 }
 
+noinstrument_function
+static inline_function void up_set_interrupt_context(bool flag)
+{
+  CP15_SET(TPIDRPRW, flag);
+}
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -471,6 +471,12 @@ static inline_function bool up_interrupt_context(void)
   return (bool)CP15_GET(TPIDRPRW);
 }
 
+noinstrument_function
+static inline_function void up_set_interrupt_context(bool flag)
+{
+  CP15_SET(TPIDRPRW, flag);
+}
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/arch/arm/include/tlsr82/irq.h
+++ b/arch/arm/include/tlsr82/irq.h
@@ -273,6 +273,16 @@ static inline_function bool up_interrupt_context(void)
 #endif
 }
 
+noinstrument_function
+static inline_function void up_set_interrupt_context(bool flag)
+{
+#ifdef CONFIG_ARCH_HAVE_MULTICPU
+  g_interrupt_context[up_cpu_index()] = flag;
+#else
+  g_interrupt_context[0] = flag;
+#endif
+}
+
 #define up_switch_context(tcb, rtcb)                        \
   do {                                                      \
     if (!up_interrupt_context())                            \

--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -34,9 +34,7 @@
 
 /* g_interrupt_context store irq status */
 
-#if defined(CONFIG_ARCH_ARM)
 volatile bool g_interrupt_context[CONFIG_SMP_NCPUS];
-#endif
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -410,14 +410,6 @@ uint32_t *arm_prefetchabort(uint32_t *regs, uint32_t ifar, uint32_t ifsr);
 uint32_t *arm_syscall(uint32_t *regs);
 uint32_t *arm_undefinedinsn(uint32_t *regs);
 
-/* IRQ Flag */
-
-noinstrument_function
-static inline_function void up_set_interrupt_context(bool flag)
-{
-  CP15_SET(TPIDRPRW, flag);
-}
-
 /* Exception handling logic common to other ARM7 and ARM9 family. */
 
 #else /* ARM7 | ARM9 */
@@ -438,14 +430,6 @@ void arm_dataabort(uint32_t *regs);
 void arm_prefetchabort(uint32_t *regs);
 uint32_t *arm_syscall(uint32_t *regs);
 void arm_undefinedinsn(uint32_t *regs);
-
-/* IRQ Flag */
-
-noinstrument_function
-static inline_function void up_set_interrupt_context(bool flag)
-{
-  g_interrupt_context[this_cpu()] = flag;
-}
 
 #endif /* CONFIG_ARCH_ARMV[6-8]M */
 


### PR DESCRIPTION
## Summary

arm/isr: move up_set_interrupt_context() to chip define

up_set_interrupt_context() is chip specific implement, move this function to correct place

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

## Testing

ci-check
