### PR TITLE
xtensa: remove up_set_current_regs/up_current_regs

### DIFF
--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -65,14 +65,7 @@
 
 void xtensa_panic(int xptcode, uint32_t *regs)
 {
-  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
-
-  if (*running_task != NULL)
-    {
-      (*running_task)->xcp.regs = regs;
-    }
-
-  up_set_current_regs(regs);
+  up_set_interrupt_context(true);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 
@@ -171,7 +164,14 @@ void xtensa_panic(int xptcode, uint32_t *regs)
 
 void xtensa_user_panic(int exccause, uint32_t *regs)
 {
-  up_set_current_regs(regs);
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
+
+  up_set_interrupt_context(true);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -65,6 +65,13 @@
 
 void xtensa_panic(int xptcode, uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
+
   up_set_interrupt_context(true);
 
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -277,8 +277,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
                                  rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                                 (void *)up_current_regs()[REG_A1],
-                                 (void *)up_current_regs()[REG_A0],
+                                 running_regs()[REG_A1],
+                                 running_regs()[REG_A0],
                                  &buffer[ret], size - ret, &skip);
         }
       else

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -32,17 +32,9 @@
  * Public Data
  ****************************************************************************/
 
-/* g_current_regs[] holds a reference to the current interrupt level
- * register storage structure.  It is non-NULL only during interrupt
- * processing.  Access to g_current_regs[] must be through the
- * [get/set]_current_regs for portability.
- */
+/* g_interrupt_context store irq status */
 
-/* For the case of architectures with multiple CPUs, then there must be one
- * such value for each processor that can receive an interrupt.
- */
-
-volatile uint32_t *g_current_regs[CONFIG_SMP_NCPUS];
+volatile bool g_interrupt_context[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -57,13 +57,11 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   /* Nested interrupts are not supported */
 
-  DEBUGASSERT(up_current_regs() == NULL);
+  DEBUGASSERT(!up_interrupt_context());
 
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * current_regs is also used to manage interrupt level context switches.
-   */
+  /* Set irq flag */
 
-  up_set_current_regs(regs);
+  up_set_interrupt_context(true);
 
   if (*running_task != NULL)
     {
@@ -104,11 +102,9 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
       *running_task = tcb;
     }
 
-  /* Set current_regs to NULL to indicate that we are no longer in an
-   * interrupt handler.
-   */
+  /* Set irq flag */
 
-  up_set_current_regs(NULL);
+  up_set_interrupt_context(false);
 #endif
 
   board_autoled_off(LED_INIRQ);

--- a/arch/xtensa/src/common/xtensa_registerdump.c
+++ b/arch/xtensa/src/common/xtensa_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uintptr_t *regs = dumpregs ? dumpregs : up_current_regs();
+  volatile uintptr_t *regs = dumpregs ? dumpregs : running_regs();
 
   _alert("   PC: %08lx    PS: %08lx\n",
          (unsigned long)regs[REG_PC], (unsigned long)regs[REG_PS]);


### PR DESCRIPTION
## Summary
reason:
up_set_current_regs initially had two functions:

1: To mark the entry into an interrupt state.
2: To record the context before an interrupt/exception. If we switch to a new task, we need to store the upcoming context regs by calling up_set_current_regs(regs).

Currently, we record the context in other ways, so the second function is obsolete. Therefore, we need to rename up_set_current_regs to better reflect its actual meaning, which is solely to mark an interrupt.

## Impact

xteansa

## Testing
ci ostest


