### PR TITLE
riscv: remove up_set_current_regs/up_current_regs

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -162,8 +162,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)up_current_regs()[REG_FP],
-                               (void *)up_current_regs()[REG_EPC],
+                               running_regs()[REG_FP],
+                               running_regs()[REG_EPC],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -110,22 +110,22 @@ int riscv_exception(int mcause, void *regs, void *args)
 
       /* Return to _exit function in privileged mode with argument SIGSEGV */
 
-      up_current_regs()[REG_EPC] = (uintptr_t)_exit;
-      up_current_regs()[REG_A0] = SIGSEGV;
-      up_current_regs()[REG_INT_CTX] |= STATUS_PPP;
+      running_regs()[REG_EPC] = _exit;
+      running_regs()[REG_A0] = (void *)SIGSEGV;
+      ((uintreg_t *)running_regs())[REG_INT_CTX] |= STATUS_PPP;
 
       /* Continue with kernel stack in use. The frame(s) in kernel stack
        * are no longer needed, so just set it to top
        */
 
-      up_current_regs()[REG_SP] = (uintptr_t)tcb->xcp.ktopstk;
+      running_regs()[REG_SP] = tcb->xcp.ktopstk;
     }
   else
 #endif
     {
       _alert("PANIC!!! Exception = %" PRIxREG "\n", cause);
       up_irq_save();
-      up_set_current_regs(regs);
+      up_set_interrupt_context(true);
       PANIC_WITH_REGS("panic", regs);
     }
 
@@ -197,7 +197,7 @@ int riscv_fillpage(int mcause, void *regs, void *args)
     {
       _alert("PANIC!!! virtual address not mappable: %" PRIxPTR "\n", vaddr);
       up_irq_save();
-      up_set_current_regs(regs);
+      up_set_interrupt_context(true);
       PANIC_WITH_REGS("panic", regs);
     }
 

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -32,7 +32,9 @@
  * Public Data
  ****************************************************************************/
 
-volatile uintreg_t *g_current_regs[CONFIG_SMP_NCPUS];
+/* g_interrupt_context store irq status */
+
+volatile bool g_interrupt_context[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions

--- a/arch/risc-v/src/common/riscv_registerdump.c
+++ b/arch/risc-v/src/common/riscv_registerdump.c
@@ -53,7 +53,7 @@ uintptr_t up_getusrsp(void *regs)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uintreg_t *regs = dumpregs ? dumpregs : up_current_regs();
+  volatile uintreg_t *regs = dumpregs ? dumpregs : running_regs();
 
   /* Are user registers available from interrupt processing? */
 

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -45,9 +45,9 @@ void *riscv_perform_syscall(uintreg_t *regs)
       (*running_task)->xcp.regs = regs;
     }
 
-  /* Set up the interrupt register set needed by swint() */
+  /* Set irq flag */
 
-  up_set_current_regs(regs);
+  up_set_interrupt_context(true);
 
   /* Run the system call handler (swint) */
 
@@ -77,7 +77,9 @@ void *riscv_perform_syscall(uintreg_t *regs)
       *running_task = tcb;
     }
 
-  up_set_current_regs(NULL);
+  /* Set irq flag */
+
+  up_set_interrupt_context(false);
 
   return tcb->xcp.regs;
 }


### PR DESCRIPTION

## Summary
reason:
up_set_current_regs initially had two functions:

1: To mark the entry into an interrupt state.
2: To record the context before an interrupt/exception. If we switch to a new task, we need to store the upcoming context regs by calling up_set_current_regs(regs).

Currently, we record the context in other ways, so the second function is obsolete. Therefore, we need to rename up_set_current_regs to better reflect its actual meaning, which is solely to mark an interrupt.

## Impact
riscv

## Testing
ci ostest

