### PR TITLE
xtensa: remove g_running_tasks[this_cpu()] = NULL

### DIFF
--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -66,9 +66,9 @@ void up_exit(int status)
 
   tcb = this_task();
 
-  /* Scheduler parameters will update inside syscall */
+  /* Update g_running_tasks */
 
-  g_running_tasks[this_cpu()] = NULL;
+  g_running_tasks[this_cpu()] = tcb;
 
   /* Then switch contexts */
 

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -63,7 +63,11 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   up_set_interrupt_context(true);
 
-  if (*running_task != NULL)
+  /* This judgment proves that (*running_task)->xcp.regs
+   * is invalid, and we can safely overwrite it.
+   */
+
+  if (!(XTENSA_IRQ_SWINT == irq && regs[REG_A2] == SYS_restore_context))
     {
       (*running_task)->xcp.regs = regs;
     }


### PR DESCRIPTION

## Summary
xtensa: remove g_running_tasks[this_cpu()] = NULL
reason:
We hope to keep g_running_tasks valid forever.


## Impact

xtensa

## Testing
esp32s3-devkit:smp
ci ostest 


