### PR TITLE
riscv/riscv_ipi.h: Do not write to CSR_MIP.MSIP as it is read-only

### DIFF
--- a/arch/risc-v/src/common/riscv_ipi.h
+++ b/arch/risc-v/src/common/riscv_ipi.h
@@ -46,10 +46,13 @@ static inline void riscv_ipi_send(int cpu)
 
 static inline void riscv_ipi_clear(int cpu)
 {
-#if defined(RISCV_IPI) && !defined(CONFIG_ARCH_USE_S_MODE)
-  putreg32(0, (uintptr_t)RISCV_IPI + (4 * riscv_cpuid_to_hartid(cpu)));
-#endif
+#if defined(CONFIG_ARCH_USE_S_MODE)
   CLEAR_CSR(CSR_IP, IP_SIP);
+#elif defined(RISCV_IPI)
+  putreg32(0, (uintptr_t)RISCV_IPI + (4 * riscv_cpuid_to_hartid(cpu)));
+#else
+#  error "No IPI support for this SoC"
+#endif
 }
 
 #endif /* __ARCH_RISCV_SRC_COMMON_RISCV_IPI_H */


### PR DESCRIPTION
## Summary

From the RISV-V Privileged Spec v1.10 (3.1.14 MIP/MIE):

Only the bits corresponding to lower-privilege software interrupts (USIP, SSIP), timer interrupts (UTIP, STIP), and external interrupts (UEIP, SEIP) in mip are writable through this CSR address; the remaining bits are read-only.

Thus, it is futile to write to the M-mode status bit via the CSR, only access via RISCV_IPI is valid.

## Impact

RISC-V SMP only.

## Testing

rv-virt:smp64
rv-virt:smp
rv-virt:ksmp64
