### PR TITLE
arch/arm64/imx9: Clear DMA channel interrupts on init

### DIFF
--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -864,6 +864,10 @@ void weak_function arm64_dma_initialize(void)
 
       putreg32(0, IMX9_EDMA_TCD(base, chan) + IMX9_EDMA_CH_CSR_OFFSET);
 
+      /* Clear interrupt if any */
+
+      putreg32(1, IMX9_EDMA_TCD(base, chan) + IMX9_EDMA_CH_INT_OFFSET);
+
       /* Set all TCD CSR, biter and citer entries to 0 so that
        * will be 0 when DONE is not set so that imx9_dmach_getcount
        * reports 0.


### PR DESCRIPTION
Avoid spurious interrupts on reboot

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

On warm reboot it is possible that there is old interrupt pending.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


