### PR TITLE
arch/arm64/imx9/imx9_flexspi: Replace memcpy by while loop

### DIFF
--- a/arch/arm64/src/imx9/imx9_flexspi_nor.c
+++ b/arch/arm64/src/imx9/imx9_flexspi_nor.c
@@ -788,16 +788,13 @@ static ssize_t imx9_flexspi_nor_read(struct mtd_dev_s *dev,
     }
 
   src = priv->ahb_base + offset;
-  DEBUGASSERT(((uintptr_t)src & (ARMV8A_DCACHE_LINESIZE - 1)) == 0);
 
-  up_invalidate_dcache((uintptr_t)buffer,
-                       (uintptr_t)buffer +
-                       ALIGN_UP(nbytes, ARMV8A_DCACHE_LINESIZE));
+  int n = nbytes;
 
-  memcpy(buffer, src, nbytes);
-
-  up_clean_dcache((uintptr_t)buffer, (uintptr_t)buffer +
-                  ALIGN_UP(nbytes, ARMV8A_DCACHE_LINESIZE));
+  while (n-- > 0)
+    {
+      *buffer++ = *src++;
+    }
 
   finfo("return nbytes: %d\n", (int)nbytes);
   return (ssize_t)nbytes;


### PR DESCRIPTION
libc memcpy cannot access fspi memory space correctly remove unnecessary debugassert and cache operations

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


