### PR TITLE
remove redundant scheduling records

### DIFF
--- a/arch/arm/src/armv7-a/arm_smpcall.c
+++ b/arch/arm/src/armv7-a/arm_smpcall.c
@@ -68,16 +68,7 @@
 
 int arm_smp_sched_handler(int irq, void *context, void *arg)
 {
-  struct tcb_s *tcb;
-  int cpu = this_cpu();
-
-  tcb = current_task(cpu);
-  nxsched_suspend_scheduler(tcb);
-  nxsched_process_delivered(cpu);
-  tcb = current_task(cpu);
-  nxsched_resume_scheduler(tcb);
-
-  UNUSED(tcb);
+  nxsched_process_delivered(this_cpu());
   return OK;
 }
 

--- a/arch/arm/src/armv7-r/arm_smpcall.c
+++ b/arch/arm/src/armv7-r/arm_smpcall.c
@@ -68,16 +68,7 @@
 
 int arm_smp_sched_handler(int irq, void *context, void *arg)
 {
-  struct tcb_s *tcb;
-  int cpu = this_cpu();
-
-  tcb = current_task(cpu);
-  nxsched_suspend_scheduler(tcb);
-  nxsched_process_delivered(cpu);
-  tcb = current_task(cpu);
-  nxsched_resume_scheduler(tcb);
-
-  UNUSED(tcb);
+  nxsched_process_delivered(this_cpu());
   return OK;
 }
 

--- a/arch/arm64/src/common/arm64_smpcall.c
+++ b/arch/arm64/src/common/arm64_smpcall.c
@@ -67,17 +67,7 @@
 
 int arm64_smp_sched_handler(int irq, void *context, void *arg)
 {
-  struct tcb_s *tcb;
-  int cpu = this_cpu();
-
-  tcb = current_task(cpu);
-  nxsched_suspend_scheduler(tcb);
-  nxsched_process_delivered(cpu);
-  tcb = current_task(cpu);
-  nxsched_resume_scheduler(tcb);
-
-  UNUSED(tcb);
-
+  nxsched_process_delivered(this_cpu());
   return OK;
 }
 

--- a/arch/x86_64/src/intel64/intel64_smpcall.c
+++ b/arch/x86_64/src/intel64/intel64_smpcall.c
@@ -94,11 +94,8 @@ int x86_64_smp_sched_handler(int irq, void *c, void *arg)
   struct tcb_s *tcb;
   int cpu = this_cpu();
 
-  tcb = current_task(cpu);
-  nxsched_suspend_scheduler(tcb);
   nxsched_process_delivered(cpu);
   tcb = current_task(cpu);
-  nxsched_resume_scheduler(tcb);
   x86_64_restorestate(tcb->xcp.regs);
 
   return OK;


### PR DESCRIPTION

## Summary
remove redundant scheduling records
reason:
Since the scheduling records have already been moved to the interrupt exit in this submission, we need to delete the original records' locations. This commit fixes the regression from https://github.com/apache/nuttx/pull/13651
## Impact
scheduling records


## Testing
ci ostest

