### PR TITLE
nuttxgdb/rpmsg.py:dump rpmsg_service message

### DIFF
--- a/tools/gdb/nuttxgdb/rpmsg.py
+++ b/tools/gdb/nuttxgdb/rpmsg.py
@@ -1,0 +1,105 @@
+############################################################################
+# tools/gdb/rpmsg.py
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import gdb
+
+from . import utils
+from .lists import NxList
+
+
+class RPMsgDump(gdb.Command):
+    """Dump rpmsg service"""
+
+    CALLBACK_HEADER = ["rpmsg_cb_s at", "ns_match", "ns_bind"]
+    ENDPOINT_HEADER = [
+        "endpoint_addr",
+        "name",
+        "addr",
+        "dest_addr",
+        "cb",
+        "ns_bound_cb",
+        "ns_unbind_cb",
+    ]
+
+    CALLBACK_FORAMTTER = "{:<20} {:<40} {:<40}"
+    ENDPOINT_FORMATTER = "{:<20} {:<20} {:<12} {:<12} {:<40} {:<40} {:<40}"
+
+    def __init__(self):
+        if utils.get_symbol_value("CONFIG_RPMSG"):
+            super(RPMsgDump, self).__init__("rpmsgdump", gdb.COMMAND_USER)
+
+    def print_headers(self, headers, formatter):
+        gdb.write(formatter.format(*headers) + "\n")
+        gdb.write(formatter.format(*["-" * len(header) for header in headers]) + "\n")
+
+    def dump_rdev_epts(self, endpoints_head):
+        gdb.write(f"dump_rdev_epts:{endpoints_head}\n")
+        self.print_headers(self.ENDPOINT_HEADER, self.ENDPOINT_FORMATTER)
+
+        output = []
+        for endpoint in NxList(endpoints_head, "struct rpmsg_endpoint", "node"):
+            output.append(
+                self.ENDPOINT_FORMATTER.format(
+                    f"{endpoint}",
+                    f"{endpoint['name'].string()}",
+                    f"{endpoint['addr']}",
+                    f"{endpoint['dest_addr']}",
+                    f"{endpoint['cb']}",
+                    f"{endpoint['ns_bound_cb']}",
+                    f"{endpoint['ns_unbind_cb']}",
+                )
+            )
+
+        gdb.write("\n".join(output) + "\n")
+
+    def dump_rdev_bitmap(self, rdev):
+        bitmap_values = [hex(bit) for bit in utils.ArrayIterator(rdev["bitmap"])]
+
+        gdb.write(
+            f"bitmap:{' '.join(bitmap_values):<20} bitmaplast: {rdev['bitmap']}\n"
+        )
+
+    def dump_rdev(self, rdev):
+        gdb.write(f"device:{rdev}\n")
+
+        self.dump_rdev_bitmap(rdev)
+        self.dump_rdev_epts(rdev["endpoints"])
+
+    def dump_rpmsg_cb(self):
+        gdb.write("g_rpmsg_cb:\n")
+        self.print_headers(self.CALLBACK_HEADER, self.CALLBACK_FORAMTTER)
+
+        output = []
+        for cb in NxList(gdb.parse_and_eval("g_rpmsg_cb"), "struct rpmsg_cb_s", "node"):
+            output.append(
+                self.CALLBACK_FORAMTTER.format(
+                    str(cb), str(cb["ns_match"]), str(cb["ns_bind"])
+                )
+            )
+        gdb.write("\n".join(output) + "\n")
+
+    def dump_rpmsg(self):
+        gdb.write("g_rpmsg:\n")
+        for rpmsg in NxList(gdb.parse_and_eval("g_rpmsg"), "struct rpmsg_s", "node"):
+            self.dump_rdev(rpmsg["rdev"])
+
+    def invoke(self, args, from_tty):
+        self.dump_rpmsg_cb()
+        self.dump_rpmsg()


### PR DESCRIPTION
(gdb)rpmsg_service
g_rpmsg_cb:
rpmsg_cb_s at        ns_match                                 ns_bind
-------------        --------                                 -------
0xf4e00ac0           0x44708225 <rpmsg_rtc_server_ns_match>   0x4470874c <rpmsg_rtc_server_ns_bind>
0xf4e27b20           0x440c8fd6 <syslog_rpmsg_ns_match>       0x440c966a <syslog_rpmsg_ns_bind>
0xf4e27af0           0x0                                      0x0
g_rpmsg:
Endpoint at          Name                 local Addr   dest Addr    cb                                       ns_bound_cb                              ns_unbind_cb
-----------          ----                 ----------   ---------    --                                       -----------                              ------------
0xf2302ac0           NS                   53           53           0x44699520 <rpmsg_virtio_ns_callback>    0x0                                      0x0
0xf3c0f920           rpmsg-ttysensor      1025         1028         0x44704457 <uart_rpmsg_ept_cb>           0x0                                      0x0
0xf301d058           rpmsg-sensor         1026         1029         0x440c1680 <sensor_rpmsg_ept_cb>         0x440c1871 <sensor_rpmsg_device_ns_bound> 0x44693a18 <rpmsg_destroy_ept>
0xf2302a6c           rpmsg-ping           1027         1036         0x440a10d2 <rpmsg_ping_ept_cb>           0x0                                      0x0

List update: rpmsg dump contains none initialized list, need to take care of it in NxList.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The function of rpmsg_service is implemented under GDB. By entering the command rpmsg_service, you can print out the contents of the two linked lists g_rpmsg and g_rpmsg_cb of the AP and sensor front-end. This allows us to see what devices are currently waiting to connect and what devices are already connected.

## Impact

The implementation of this function makes it easier for developers to view the connection status of the RPMsg service during debugging, allowing for better diagnosis and debugging. It mainly affects the debugging process and has no direct impact on the user interface and device functionality.

## Testing

It has been verified on a real device and the functionality is confirmed to work properly. Relevant log information has been recorded and analyzed to ensure the correctness of the implementation.


