### PR TITLE
arm64: remove g_running_tasks[this_cpu()] = NULL

### DIFF
--- a/arch/arm64/src/common/arm64_exit.c
+++ b/arch/arm64/src/common/arm64_exit.c
@@ -65,7 +65,7 @@ void up_exit(int status)
 
   /* Scheduler parameters will update inside syscall */
 
-  g_running_tasks[this_cpu()] = NULL;
+  g_running_tasks[this_cpu()] = this_task();
 
   /* Then switch contexts */
 

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -161,6 +161,5 @@ retry:
   rtcb->irqcount--;
 #endif
 
-  g_running_tasks[this_cpu()] = NULL;
   arm64_fullcontextrestore();
 }


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
arm64: remove g_running_tasks[this_cpu()] = NULL
reason:
We hope to keep g_running_tasks valid forever.

## Impact
arm64

## Testing
ci ostest
qemu-armv8a:nsh_smp


