### PR TITLE
arm64/toolchain: Cmake alignment makefile writing

### DIFF
--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -71,13 +71,9 @@ set(NO_LTO "-fno-lto")
 
 if(CONFIG_ARCH_ARMV8A)
   add_compile_options(-march=armv8-a)
-endif()
-
-if(CONFIG_ARCH_ARMV8R)
+elseif(CONFIG_ARCH_ARMV8R)
   add_compile_options(-march=armv8-r)
-endif()
-
-if(CONFIG_ARCH_CORTEX_A53)
+elseif(CONFIG_ARCH_CORTEX_A53)
   add_compile_options(-mcpu=cortex-a53)
 elseif(CONFIG_ARCH_CORTEX_A57)
   add_compile_options(-mcpu=cortex-a57)


### PR DESCRIPTION
## Summary

They should be a relationship of choice:
ifeq ($(CONFIG_ARCH_CORTEX_A53),y)
  ARCHCPUFLAGS += -mcpu=cortex-a53
else ifeq ($(CONFIG_ARCH_CORTEX_A55),y)
  ARCHCPUFLAGS += -mcpu=cortex-a55
else ifeq ($(CONFIG_ARCH_CORTEX_A57),y)
  ARCHCPUFLAGS += -mcpu=cortex-a57
else ifeq ($(CONFIG_ARCH_CORTEX_A72),y)
  ARCHCPUFLAGS += -mcpu=cortex-a72
else ifeq ($(CONFIG_ARCH_CORTEX_R82),y)
  ARCHCPUFLAGS += -mcpu=cortex-r82
else ifeq ($(CONFIG_ARCH_ARMV8A),y)
  ARCHCPUFLAGS += -march=armv8-a
else ifeq ($(CONFIG_ARCH_ARMV8R),y)
  ARCHCPUFLAGS += -march=armv8-r
endif

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


