### PR TITLE
arch/arm64/imx9: Boot, move mmu init to correct place

### DIFF
--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -124,10 +124,6 @@ void arm64_el_init(void)
 
 void arm64_chip_boot(void)
 {
-  /* MAP IO and DRAM, enable MMU. */
-
-  arm64_mmu_init(true);
-
 #ifdef CONFIG_IMX9_BOOTLOADER
   imx9_mix_powerup();
 
@@ -143,6 +139,10 @@ void arm64_chip_boot(void)
   imx9_dram_init();
 #endif
 #endif
+
+  /* MAP IO and DRAM, enable MMU. */
+
+  arm64_mmu_init(true);
 
   /* Do UART early initialization & pin muxing */
 


### PR DESCRIPTION
MMU init must be after ddrinit.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Initialization order is wrong, mmu init must be after dram init.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


