### PR TITLE
st7789: add configuration option to set default background color

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -756,6 +756,15 @@ config LCD_ST7789_INVCOLOR
 		Invert colors of the LCD display. This is useful for implementations
 		that assume that that colors are inverted by default.
 
+config LCD_ST7789_DEFAULT_COLOR
+	hex "ST7789 Default Background Color"
+	default 0xffff
+	range 0 0xffff
+	---help---
+		This sets the default color of ST7789 display during its initialization.
+		It is the color that is filled to the display and remains there unless
+		higher layer (framebuffer/lcd) overwrites it.
+
 config LCD_ST7789_BGR
 	bool "ST7789 Use BGR Instead Of RGB"
 	default n

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -992,7 +992,7 @@ FAR struct lcd_dev_s *st7789_lcdinitialize(FAR struct spi_dev_s *spi)
   st7789_setorientation(priv);
 #endif
   st7789_display(priv, true);
-  st7789_fill(priv, 0xffff);
+  st7789_fill(priv, CONFIG_LCD_ST7789_DEFAULT_COLOR);
 
   return &priv->dev;
 }


### PR DESCRIPTION
## Summary
ST7789 fills the display with 0xffff color during its initialization. This color may or may not be overwritten by a higher layer (framebuffer or lcd driver for example). The color remains on the display until application UI is started if not overwritten by the higher layer before.

This commit adds configuration option `LCD_ST7789_DEFAULT_COLOR` that allows to set the default background color. This may avoid shining display with, for example, white color for an extensive amount of time. The default value is set to `0xffff` previously hard-coded in the driver, therefore current implementations will not notice the change.

## Impact
New configuration option, none to current implementations.

## Testing
Tested with SPI connected ST7789 on SAMv7 MCU based custom board.


