### PR TITLE
cxd56xx: use small lock in arch/arm/src/cxd56xx/cxd56_clock.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_clock.c
+++ b/arch/arm/src/cxd56xx/cxd56_clock.c
@@ -150,6 +150,7 @@ static void cxd56_scu_peri_clock_gating(const struct scu_peripheral *p,
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_cxd56_clock_lock = SP_UNLOCKED;
 static struct power_domain g_digital;
 static struct power_domain g_analog;
 
@@ -323,9 +324,9 @@ static void enable_pwd(int pdid)
       release_pwd_reset(domain);
     }
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_cxd56_clock_lock);
   g_digital.refs[pdid]++;
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_cxd56_clock_lock, flags);
 }
 
 static void disable_pwd(int pdid)
@@ -337,9 +338,9 @@ static void disable_pwd(int pdid)
   stat = getreg32(CXD56_TOPREG_PWD_STAT);
   if (stat & domain)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_cxd56_clock_lock);
       g_digital.refs[pdid]--;
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_cxd56_clock_lock, flags);
       if (g_digital.refs[pdid] == 0)
         {
           putreg32(domain << 16, CXD56_TOPREG_PWD_CTL);
@@ -361,9 +362,9 @@ static void enable_apwd(int apdid)
       do_power_control(CXD56_TOPREG_ANA_PW_STAT, domain, domain);
     }
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_cxd56_clock_lock);
   g_analog.refs[apdid]++;
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_cxd56_clock_lock, flags);
 }
 
 static void disable_apwd(int apdid)
@@ -375,9 +376,9 @@ static void disable_apwd(int apdid)
   stat = getreg32(CXD56_TOPREG_ANA_PW_STAT);
   if (stat & domain)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_cxd56_clock_lock);
       g_analog.refs[apdid]--;
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_cxd56_clock_lock, flags);
       if (g_analog.refs[apdid] == 0)
         {
           putreg32(domain << 16, CXD56_TOPREG_ANA_PW_CTL);


### PR DESCRIPTION

## Summary

cxd56xx: use small lock in arch/arm/src/cxd56xx/cxd56_clock.c
## Impact
cxd56xx


## Testing
ci


