### PR TITLE
MPFS boot enhancements

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -46,6 +46,14 @@ config MPFS_BOOTLOADER
 	---help---
 		This NuttX image is used as a bootloader, which will boot only on one hart, putting the others in WFI
 
+config MPFS_CLKINIT
+	bool "Initialize system clocks"
+	depends on MPFS_BOOTLOADER
+	default y
+	---help---
+		This initilizes the system clocks at mpfs_start.c file. The option may be also turned off
+		if some other entity has already set them up.
+
 config MPFS_BOARD_PMP
 	bool "Enable board specific PMP configuration"
 	depends on ARCH_USE_MPU && MPFS_BOOTLOADER

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -27,12 +27,16 @@ CMN_ASRCS += mpfs_head.S
 endif
 
 # Specify our C code within this directory to be included
-CHIP_CSRCS  = mpfs_allocateheap.c mpfs_clockconfig.c
+CHIP_CSRCS  = mpfs_allocateheap.c
 CHIP_CSRCS += mpfs_irq.c mpfs_irq_dispatch.c
 CHIP_CSRCS += mpfs_lowputc.c mpfs_serial.c
 CHIP_CSRCS += mpfs_start.c mpfs_timerisr.c
 CHIP_CSRCS += mpfs_gpio.c mpfs_systemreset.c
 CHIP_CSRCS += mpfs_plic.c mpfs_dsn.c
+
+ifeq ($(CONFIG_MPFS_CLKINIT),y)
+CHIP_CSRCS += mpfs_clockconfig.c
+endif
 
 ifeq ($(CONFIG_MPFS_DMA),y)
 CHIP_CSRCS += mpfs_dma.c

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -49,6 +49,14 @@ __start:
   csrw CSR_MIE, zero
   csrw CSR_MIP, zero
 
+  /* Clear all IPIs (above doesn't clear them) */
+
+  csrr a0, CSR_MHARTID
+  slli t1, a0, 2
+  li   t0, MPFS_CLINT_BASE
+  add  t1, t1, t0
+  sw   zero, 0(t1)
+
   /* Initialize the Machine Trap Vector */
 
   la   t0, __trap_vec

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -121,7 +121,7 @@ void __mpfs_start(uint64_t mhartid)
 
   /* Setup PLL if not already provided */
 
-#ifdef CONFIG_MPFS_BOOTLOADER
+#ifdef CONFIG_MPFS_CLKINIT
   mpfs_clockconfig();
 #endif
 


### PR DESCRIPTION
## Summary

rmpfs IPI (Inter-processor Interrupts) are not cleared at boot currently. It's possible they're set at boot time, which then breaks the boot logic; harts1-4 should stay at wfi loop until they're released by an IPI. 

In addition, clocks don't need to be reset if they're already set. Let the use configure whether the system clocks are already set or not.

## Impact

If there's a chain of NuttX OS:es, for example, one NuttX that jumps to the next, the IPI fired at the 1st NuttX will make the follow-up NuttX proceed before it's released. Thus, clear the IPIs in like manner the interrupts are turned off at boot.

## Testing

Various mpfs based products with more than one NuttX OSs following each other. The 1st one sets the clokcs, while the 2nd doesn't alter them.
