### PR TITLE
crashdump change to choice, add coredump to mtd support based on mtdout stream.

### DIFF
--- a/arch/renesas/src/rx65n/Kconfig
+++ b/arch/renesas/src/rx65n/Kconfig
@@ -149,7 +149,7 @@ config RX65N_CMT0
 config RX65N_CMT1
 	bool "CMT1"
 	default n
-	depends on BOARD_CRASHDUMP && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
 
 config RX65N_CMT2
 	bool "CMT2"
@@ -170,7 +170,7 @@ config RX65N_IRQ_GROUP
 config RX65N_SBRAM
 	bool "SBRAM"
 	default n
-	depends on BOARD_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM
 
 config RX65N_SAVE_CRASHDUMP
 	bool "SBRAM Save Crashdump"
@@ -541,7 +541,7 @@ config RX65N_CMT0
 config RX65N_CMT1
 	bool "CMT1"
 	default n
-	depends on BOARD_CRASHDUMP && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
 
 config RX65N_CMT2
 	bool "CMT2"
@@ -562,7 +562,7 @@ config RX65N_IRQ_GROUP
 config RX65N_SBRAM
 	bool "SBRAM"
 	default n
-	depends on BOARD_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM
 
 config RX65N_SAVE_CRASHDUMP
 	bool "SBRAM Save Crashdump"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4722,6 +4722,12 @@ config BOARD_COREDUMP_BLKDEV
 	---help---
 		Enable save coredump to block device when crash.
 
+config BOARD_COREDUMP_MTDDEV
+	bool "Enable Core Dump to mtd device"
+	depends on COREDUMP
+	---help---
+		Enable save coredump to mtd device when crash.
+
 config BOARD_CRASHDUMP_NONE
 	bool "No Board level crash dump"
 
@@ -4729,9 +4735,9 @@ endchoice # BOARD crashdump method
 
 config BOARD_COREDUMP_DEVPATH
 	string "Save Core Dump data with device PATH"
-	depends on BOARD_COREDUMP_BLKDEV
+	depends on BOARD_COREDUMP_BLKDEV || BOARD_COREDUMP_MTDDEV
 	---help---
-		Save coredump file into block device path.
+		Save coredump file into block/mtd device path.
 
 config BOARD_COREDUMP_FULL
 	bool "Core Dump all thread registers and stacks"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4728,6 +4728,12 @@ config BOARD_COREDUMP_MTDDEV
 	---help---
 		Enable save coredump to mtd device when crash.
 
+config BOARD_CRASHDUMP_CUSTOM
+	bool "Enable Core Dump with custom method"
+	---help---
+		Enable save coredump with custom method. only work with
+		board_crashdump api.
+
 config BOARD_CRASHDUMP_NONE
 	bool "No Board level crash dump"
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4693,9 +4693,9 @@ source "boards/arm/nrf91/common/Kconfig"
 endif
 endif
 
-config BOARD_CRASHDUMP
-	bool "Enable Board level logging of crash dumps"
-	default n
+choice
+	prompt "BOARD crashdump method"
+	default BOARD_CRASHDUMP_NONE
 	---help---
 		If selected up_assert will call out to board_crashdump, in the case
 		of an assertion failure, prior to calling exit. Or in the
@@ -4712,28 +4712,31 @@ config BOARD_CRASHDUMP
 
 config BOARD_COREDUMP_SYSLOG
 	bool "Enable Core dump to syslog"
-	default n
 	depends on COREDUMP
 	---help---
 		Enable put coredump to syslog when crash.
 
 config BOARD_COREDUMP_BLKDEV
 	bool "Enable Core Dump to block device"
-	default n
 	depends on COREDUMP
 	---help---
-		Enable save coredump at block device when crash.
+		Enable save coredump to block device when crash.
 
-config BOARD_COREDUMP_BLKDEV_PATH
-	string "Save Core Dump block device PATH"
+config BOARD_CRASHDUMP_NONE
+	bool "No Board level crash dump"
+
+endchoice # BOARD crashdump method
+
+config BOARD_COREDUMP_DEVPATH
+	string "Save Core Dump data with device PATH"
 	depends on BOARD_COREDUMP_BLKDEV
 	---help---
-		Save coredump file block device path.
+		Save coredump file into block device path.
 
 config BOARD_COREDUMP_FULL
 	bool "Core Dump all thread registers and stacks"
 	default y
-	depends on BOARD_COREDUMP_SYSLOG || BOARD_COREDUMP_BLKDEV
+	depends on !BOARD_CRASHDUMP_NONE
 	---help---
 		Enable to support for the dump all task registers and stacks.
 
@@ -4741,7 +4744,7 @@ config BOARD_COREDUMP_COMPRESSION
 	bool "Enable Core Dump compression"
 	default y
 	select LIBC_LZF
-	depends on BOARD_COREDUMP_SYSLOG || BOARD_COREDUMP_BLKDEV
+	depends on !BOARD_CRASHDUMP_NONE
 	---help---
 		Enable LZF compression algorithm for core dump content
 

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -820,7 +820,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_BOARD_CRASHDUMP
+#ifdef CONFIG_BOARD_CRASHDUMP_CUSTOM
 struct tcb_s;
 void board_crashdump(uintptr_t sp, FAR struct tcb_s *tcb,
                      FAR const char *filename, int lineno,

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -293,7 +293,7 @@ struct lib_lzfoutstream_s
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 struct lib_blkoutstream_s
 {
-  struct lib_outstream_s common;
+  struct lib_sostream_s  common;
   FAR struct inode      *inode;
   struct geometry        geo;
   FAR unsigned char     *cache;
@@ -303,7 +303,7 @@ struct lib_blkoutstream_s
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_MTD)
 struct lib_mtdoutstream_s
 {
-  struct lib_outstream_s common;
+  struct lib_sostream_s  common;
   FAR struct inode      *inode;
   struct mtd_geometry_s  geo;
   FAR unsigned char     *cache;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -45,7 +45,7 @@
  * Name: blkoutstream_flush
  ****************************************************************************/
 
-static int blkoutstream_flush(FAR struct lib_outstream_s *self)
+static int blkoutstream_flush(FAR struct lib_sostream_s *self)
 {
   FAR struct lib_blkoutstream_s *stream =
                                  (FAR struct lib_blkoutstream_s *)self;
@@ -62,10 +62,80 @@ static int blkoutstream_flush(FAR struct lib_outstream_s *self)
 }
 
 /****************************************************************************
+ * Name: blkoutstream_seek
+ ****************************************************************************/
+
+static off_t blkoutstream_seek(FAR struct lib_sostream_s *self,
+                               off_t offset, int whence)
+{
+  FAR struct lib_blkoutstream_s *stream =
+                                 (FAR struct lib_blkoutstream_s *)self;
+  size_t sectorsize = stream->geo.geo_sectorsize;
+  off_t streamsize = sectorsize * stream->geo.geo_nsectors;
+  FAR struct inode *inode = stream->inode;
+  off_t sector;
+  off_t ret;
+
+  switch (whence)
+    {
+      case SEEK_SET:
+        break;
+      case SEEK_END:
+        offset += streamsize;
+        break;
+      case SEEK_CUR:
+        offset += self->nput;
+        break;
+      default:
+        return -ENOTSUP;
+    }
+
+  /* Seek to negative value or value larger than maximum size shall fail. */
+
+  if (offset < 0 || offset > streamsize)
+    {
+      return -EINVAL;
+    }
+
+  if (self->nput % sectorsize)
+    {
+      sector = self->nput / sectorsize;
+      if (offset >= sector * sectorsize &&
+          offset < (sector + 1) * sectorsize)
+        {
+          /* Inside same sector */
+
+          goto out;
+        }
+
+      ret = inode->u.i_bops->write(stream->inode, stream->cache,
+                                   sector, 1);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+  if (offset % sectorsize)
+    {
+      ret = inode->u.i_bops->read(inode, stream->cache,
+                                  offset / sectorsize, 1);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+out:
+  self->nput = offset;
+  return offset;
+}
+
+/****************************************************************************
  * Name: blkoutstream_puts
  ****************************************************************************/
 
-static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
+static ssize_t blkoutstream_puts(FAR struct lib_sostream_s *self,
                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_blkoutstream_s *stream =
@@ -140,7 +210,7 @@ static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
  * Name: blkoutstream_putc
  ****************************************************************************/
 
-static void blkoutstream_putc(FAR struct lib_outstream_s *self, int ch)
+static void blkoutstream_putc(FAR struct lib_sostream_s *self, int ch)
 {
   char tmp = ch;
   blkoutstream_puts(self, &tmp, 1);
@@ -240,6 +310,7 @@ int lib_blkoutstream_open(FAR struct lib_blkoutstream_s *stream,
   stream->common.putc  = blkoutstream_putc;
   stream->common.puts  = blkoutstream_puts;
   stream->common.flush = blkoutstream_flush;
+  stream->common.seek  = blkoutstream_seek;
 
   return OK;
 }

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -322,8 +322,7 @@ static inline void nx_start_application(void)
   board_late_initialize();
 #endif
 
-#if defined(CONFIG_BOARD_COREDUMP_SYSLOG) || \
-    defined(CONFIG_BOARD_COREDUMP_BLKDEV)
+#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   coredump_initialize();
 #endif
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -765,14 +765,13 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
   usbtrace_enumerate(assert_tracecallback, NULL);
 #endif
 
-#ifdef CONFIG_BOARD_CRASHDUMP
-  board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
-#endif
-
-#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   /* Flush previous SYSLOG data before possible long time coredump */
 
   syslog_flush();
+
+#ifdef CONFIG_BOARD_CRASHDUMP_CUSTOM
+  board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
+#elif !defined(CONFIG_BOARD_CRASHDUMP_NONE)
 
   /* Dump core information */
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -769,9 +769,7 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
   board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
 #endif
 
-#if defined(CONFIG_BOARD_COREDUMP_SYSLOG) || \
-    defined(CONFIG_BOARD_COREDUMP_BLKDEV)
-
+#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   /* Flush previous SYSLOG data before possible long time coredump */
 
   syslog_flush();

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -47,7 +47,8 @@
 #  define ELF_PAGESIZE    1024
 #endif
 
-#ifdef CONFIG_BOARD_COREDUMP_BLKDEV
+#if defined(CONFIG_BOARD_COREDUMP_BLKDEV) || \
+    defined(CONFIG_BOARD_COREDUMP_MTDDEV)
 #  define CONFIG_BOARD_COREDUMP_DEV
 #endif
 
@@ -92,6 +93,8 @@ static struct lib_hexdumpstream_s g_hexstream;
 
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
 static struct lib_blkoutstream_s g_devstream;
+#elif defined(CONFIG_BOARD_COREDUMP_MTDDEV)
+static struct lib_mtdoutstream_s g_devstream;
 #endif
 
 #ifdef CONFIG_BOARD_MEMORY_RANGE
@@ -867,6 +870,12 @@ int coredump_initialize(void)
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
   ret = lib_blkoutstream_open(&g_devstream,
                               CONFIG_BOARD_COREDUMP_DEVPATH);
+#elif defined(CONFIG_BOARD_COREDUMP_MTDDEV)
+  ret = lib_mtdoutstream_open(&g_devstream,
+                              CONFIG_BOARD_COREDUMP_DEVPATH);
+#endif
+
+#ifdef CONFIG_BOARD_COREDUMP_DEV
   if (ret < 0)
     {
       _alert("%s Coredump device not found %d\n",


### PR DESCRIPTION
## Summary
Pervious coredump to device based on blk geo information, and not easy to extend,
we changed it to seek api, so the coredump to device should more common, and also possible to mtd directly.
for the small device should be more effeciency.  As we don't have to use blk/bch/ftl/mtd. both code size and memory will be decreasd.
Also as we removed the geo information requirments, the alloc of g_blockinfo can be removed.

should work with 
https://github.com/apache/nuttx-apps/pull/2871
if want using coredump to blk/mtd -> reboot -> restore to filesystem -> adb/ymodem/.. this kind of workflow.

Kept the compatible with 
```C
board_crashdump
```
API  by BOARD_CRASHDUMP_CUSTOM, and it's a choice which exclusive with coredump syslog/blk/mtd.
Should compatible with the current running project/defconfig.

## Impact
the coredump infomation position has changed, we now able to put more data in coredump section.
support coredump to mtd (especially norflash)
board_crashdump will not be call if using coredump syslog/blk/mtd.
if we further have more storage device type, will be easier to add support.

## Testing
CI-test & local arm-v8m board, local arm-v7a board.


