### PR TITLE
libc/puts: newline was omitted for empty string

### DIFF
--- a/libs/libc/stdio/lib_puts.c
+++ b/libs/libc/stdio/lib_puts.c
@@ -57,7 +57,7 @@ int puts(FAR const IPTR char *s)
   /* Write the string without its trailing '\0' */
 
   nwritten = fputs_unlocked(s, stream);
-  if (nwritten > 0)
+  if (nwritten >= 0)
     {
       /* Followed by a newline */
 


### PR DESCRIPTION
`puts("");` did not print a newline. The standard
behavior is to print a newline even if the string
is empty.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

From `man 3 puts` on Linux:

> puts() writes the string s and a trailing newline to stdout.

## Impact

Tests that have `puts("")` may fail if they compare stdout against an expected result.

## Testing

`sim:nsh`

```c
puts("");
```

Should print a newline to `stdout`. Currently, nothing is printed.

Edit: Only an issue for the `CONFIG_FILE_STREAM` implementation. When disabled, a newline is included correctly.