### PR TITLE
nuttxgdb minor fix

### DIFF
--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -81,6 +81,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mm_node_handler_t handler,
            node = (FAR struct mm_allocnode_s *)((FAR char *)node + nodesize))
         {
           nodesize = MM_SIZEOF_NODE(node);
+          DEBUGASSERT(nodesize >= MM_SIZEOF_ALLOCNODE);
           minfo("region=%d node=%p size=%zu preceding=%u (%c %c)\n",
                 region, node, nodesize, (unsigned int)node->preceding,
                 MM_PREVNODE_IS_FREE(node) ? 'F' : 'A',

--- a/tools/gdb/gdbinit.py
+++ b/tools/gdb/gdbinit.py
@@ -30,6 +30,8 @@ if __name__ == "__main__":
         sys.path.insert(0, here)
 
     if "nuttxgdb" in sys.modules:
-        del sys.modules["nuttxgdb"]
+        for key in list(sys.modules.keys()):
+            if key.startswith("nuttxgdb"):
+                del sys.modules[key]
 
     import nuttxgdb  # noqa: F401

--- a/tools/gdb/nuttxgdb/mm.py
+++ b/tools/gdb/nuttxgdb/mm.py
@@ -466,6 +466,9 @@ class MMNode(gdb.Value, p.MMFreeNode):
 
     @property
     def nextnode(self) -> MMNode:
+        if not self.nodesize:
+            return None
+
         addr = int(self.address) + self.nodesize
         type = utils.lookup_type("struct mm_freenode_s").pointer()
         # Use gdb.Value for better performance
@@ -551,7 +554,7 @@ class MMHeap(Value, p.MMHeap):
     def nodes(self) -> Generator[MMNode, None, None]:
         for start, end in self.regions:
             node = start
-            while node.address <= end.address:
+            while node and node.address <= end.address:
                 yield node
                 node = node.nextnode
 

--- a/tools/gdb/nuttxgdb/thread.py
+++ b/tools/gdb/nuttxgdb/thread.py
@@ -514,7 +514,7 @@ class Ps(gdb.Command):
             int(tcb["stack_base_ptr"]),
             int(tcb["stack_alloc_ptr"]),
             int(tcb["adj_stack_size"]),
-            utils.get_sp(tcb),
+            utils.get_sp(tcb if tcb["task_state"] != TSTATE_TASK_RUNNING else None),
             4,
         )
 

--- a/tools/gdb/nuttxgdb/thread.py
+++ b/tools/gdb/nuttxgdb/thread.py
@@ -366,7 +366,11 @@ class Nxthread(gdb.Command):
                         g_registers.restore()
 
         else:
-            if arg[0].isnumeric() and pidhash[int(arg[0])] != 0:
+            if (
+                arg[0].isnumeric()
+                and int(arg[0]) < npidhash
+                and pidhash[int(arg[0])] != 0
+            ):
                 if pidhash[int(arg[0])]["task_state"] == gdb.parse_and_eval(
                     "TSTATE_TASK_RUNNING"
                 ):


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. Unload all existing nuttxgdb modules when souce gdbinit.py. This allows to make changes in .py take effect immediately.
2. Fix memdump busy loop when nodesize is zero due to corruption. This will happen on C code too.
3. Fix thread command. Make sure pid is a valid number and take task that is running into consideration when fetch registers.

## Impact

Mainly bug fix. No impact.

## Testing

Tested on qemu: `tools/configure.sh lm3s6965-ek:qemu-flat`.

Make sure g3 is used: `+CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"` 

Turn on `+CONFIG_DEBUG_MM=y` to use memdump.

```
qemu-system-arm -semihosting \                      -M lm3s6965evb \                                                                                                       -device loader,file=nuttx.bin,addr=0x00000000 \
        -nic user,id=user0,hostfwd=tcp::10023-:23 \
        -serial mon:stdio -nographic -s
```

```
gdb-multiarch nuttx/nuttx -ex "tar rem:1234" -ex "source ~/projects/vela/nuttx/tools/pynuttx/gdbinit.py"


(gdb) ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED   LOAD COMMAND
    0     0   0   0 FIFO     KTHREAD   - Running            0000000000000000    1008     456 45.24%   Dis. Idle_Task
    1     0   0 224 RR       KTHREAD   - Waiting  Semaphore 0000000000000000    1984     352 17.74%   Dis. hpwork 0x20000098 0x200000bc
    2     2   0 100 RR       TASK      - Waiting  Semaphore 0000000000000000    2008    1272 63.35%   Dis. nsh_main
    3     3   0 100 RR       TASK      - Waiting  Semaphore 0000000000000000    1960    1480 75.51%   Dis. NTP_daemon 0.pool.ntp.org;1.pool.ntp.org;2.pool.ntp.org
    4     4   0 100 RR       TASK      - Waiting  Semaphore 0000000000000000    2016     616 30.56%   Dis. telnetd
(gdb) stack-usage
Pid  | Name       | Entry      | Base                 | Size       | CurUsage   | MaxUsage
0    | Idle_Task  | 0x10e5     | 0x20004f0c           | 1008       | 40,3.97%   | 456,45.24%
1    | hpwork     | 0x1ee1     | 0x20005c58           | 1984       | 80,4.03%   | 352,17.74%
2    | nsh_main   | 0x84c9     | 0x20006938           | 2008       | 392,19.52% | 1272,63.35%
3    | NTP_daemon | 0x8c81     | 0x20007c80           | 1960       | 856,43.67% | 1480,75.51%
4    | telnetd    | 0x21f91    | 0x20009ca8           | 2016       | 408,20.24% | 616,30.56%
(gdb)
```
```
