### PR TITLE
video/fb: fix integer overflow issue

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1732,7 +1732,7 @@ int fb_register_device(int display, int plane,
   char devname[16];
   int nplanes;
   int ret;
-  size_t i;
+  ssize_t i;
 
   /* Allocate a framebuffer state instance */
 


### PR DESCRIPTION
## Summary

Reported by code static check:
```bash
overflow_const: Expression i - 1UL, which is equal to 18446744073709551615, where i is known to be equal to 0, underflows the type that receives it, an unsigned integer 64 bits wide.
```

Use `ssize_t` type to preserve sign.

## Impact

None.

## Testing

sim/fb

