### PR TITLE
cmake(enhance):Enhance romfs so that RAWS files can be added in any location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,8 +583,10 @@ if(NOT CONFIG_BUILD_KERNEL)
 
 endif()
 
-# after we traverse all build directories unify all target dependencies
+# after we traverse all build directories unify all target dependencies and all
+# romfs target
 process_all_target_dependencies()
+process_all_directory_romfs()
 
 # Link step ##################################################################
 


### PR DESCRIPTION
## Summary

1.make the generation sequence of etc romfs no longer bound to the board 
unify all add_raws calls after traversing all directories.
```
# nuttx/CMakeLists.txt
process_all_directory_romfs()
```

2.RCRAWS RCSRCS can be added from any directory

3.enable dynamic files, files generated during the compilation process,
    and ensure the correct time order
```
add_dynamic_rcraws(SRCS dyn_file DEPENDS gen_dyn_file_target)
```

## Impact

In order to be compatible with the old `nuttx_add_romfs`, we retain `nuttx_add_romfs`.

If you use this enhancement method, please **do not call nuttx_add_romfs**
Use `add_board_rcsrcs` and `add_board_rcraws` instead

## Testing

custom board build pass


