### PR TITLE
xtensa: syscall SYS_switch_context and SYS_restore_context use 0 para

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -105,11 +105,9 @@
 
 /* Context switching via system calls ***************************************/
 
-#define xtensa_context_restore(regs)\
-  sys_call1(SYS_restore_context, (uintptr_t)regs)
+#define xtensa_context_restore() sys_call0(SYS_restore_context)
 
-#define xtensa_switchcontext(saveregs, restoreregs)\
-  sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs)
+#define xtensa_switchcontext() sys_call0(SYS_switch_context)
 
 /* Interrupt codes from other CPUs: */
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -54,25 +54,17 @@
 
 void up_exit(int status)
 {
-  struct tcb_s *tcb = this_task();
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
 
-  /* Now, perform the context switch to the new ready-to-run task at the
-   * head of the list.
-   */
-
-  tcb = this_task();
-
   /* Update g_running_tasks */
 
-  g_running_tasks[this_cpu()] = tcb;
+  g_running_tasks[this_cpu()] = this_task();
 
   /* Then switch contexts */
 
-  xtensa_context_restore(tcb->xcp.regs);
+  xtensa_context_restore();
 
   /* xtensa_context_restore() should not return but could if the
    * software interrupts are disabled.

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -159,5 +159,8 @@ retry:
   leave_critical_section((regs[REG_PS]));
   rtcb->irqcount--;
 #endif
-  xtensa_context_restore(regs);
+
+  rtcb->xcp.regs = rtcb->xcp.saved_regs;
+  xtensa_context_restore();
+  UNUSED(regs);
 }

--- a/arch/xtensa/src/common/xtensa_switchcontext.c
+++ b/arch/xtensa/src/common/xtensa_switchcontext.c
@@ -65,7 +65,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        * ready to run list.
        */
 
-      xtensa_switchcontext(&rtcb->xcp.regs, tcb->xcp.regs);
+      xtensa_switchcontext();
 
       /* xtensa_switchcontext forces a context switch to the task at the
        * head of the ready-to-run list.  It does not 'return' in the

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -188,7 +188,7 @@ void IRAM_ATTR xtensa_appcpu_start(void)
    * be the CPUs NULL task.
    */
 
-  xtensa_context_restore(tcb->xcp.regs);
+  xtensa_context_restore();
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -173,7 +173,7 @@ void xtensa_appcpu_start(void)
    * be the CPUs NULL task.
    */
 
-  xtensa_context_restore(tcb->xcp.regs);
+  xtensa_context_restore();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
xtensa: syscall SYS_switch_context and SYS_restore_context use 0 para
reason:
simplify context switch
sys_call0(SYS_switch_context)
sys_call0(SYS_restore_context)

size nuttx

before
   text    data     bss     dec     hex filename
 187620    1436  169296  358352   577d0 nuttx
after
   text    data     bss     dec     hex filename
 187576    1452  169280  358308   577a4 nuttx

size reduce -44

## Impact
xtensa
## Testing
ci ostest 
esp32s3-devkit:smp


