### PR TITLE
drivers/audio/wm8994.c: Include nuttx/arch.h to fix compilation (up_m…

### DIFF
--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -38,6 +38,7 @@
 #include <fixedmath.h>
 #include <debug.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/clock.h>


### PR DESCRIPTION
…delay prototype)

Fix the compilation error:

  audio/wm8994.c: In function 'wm8994_audio_output':
  Error: audio/wm8994.c:1898:3: error: implicit declaration of function 'up_mdelay' [-Werror=implicit-function-declaration]
   1898 |   up_mdelay(40);
        |   ^~~~~~~~~


