### PR TITLE
samv7: fix bytes to words calculation in user signature read

### DIFF
--- a/arch/arm/src/samv7/sam_us.c
+++ b/arch/arm/src/samv7/sam_us.c
@@ -177,7 +177,7 @@ int sam_read_user_signature(void *buffer, size_t buflen)
 
   /* sam_eefc_readsequence requires read length in bit words. */
 
-  nwords = (buflen + sizeof(uint32_t) / sizeof(uint32_t));
+  nwords = (buflen + sizeof(uint32_t)) / sizeof(uint32_t);
   sam_eefc_readsequence(FCMD_STUS, FCMD_SPUS, g_page_buffer, nwords);
 
   /* Copy local buffer to void *buffer provided by the user. */


### PR DESCRIPTION
## Summary
EEFC read sequence requires read length in words instead of bytes, therefore bytes given by the user has to be recalculated to words. The calculation however had a mistake in brackets and was just adding 1 to buflen instead of recalculating it to 4 byte words. This caused global array `g_page_buffer` to overflow for some reads.

This fixes the calculation.

## Impact

Read sequence now uses correct number of words to be read, avoiding potential overflow in `g_page_buffer` array.

## Testing

Tested on custom SAMv7 board. Previous overflow was causing an inconsistency in affecting other global variables.


