### PR TITLE
fix compile error

### DIFF
--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -62,7 +62,7 @@ void up_exit(int status)
 
   /* Scheduler parameters will update inside syscall */
 
-  g_running_tasks[this_cpu()] = tcb;
+  g_running_tasks[this_cpu()] = this_task();
 
   /* Then switch contexts */
 


### PR DESCRIPTION

## Summary
CC:  mqueue.c common/riscv_exit.c: In function 'up_exit': common/riscv_exit.c:65:33: error: 'tcb' undeclared (first use in this function); did you mean 'tcb_s'?
   65 |   g_running_tasks[this_cpu()] = tcb;
      |                                 ^~~
      |                                 tcb_s

## Impact
riscv
## Testing
ci

