### PR TITLE
libcxx/CMakeLists.txt: Remove unnecessary flags.

### DIFF
--- a/libs/libxx/libcxx/CMakeLists.txt
+++ b/libs/libxx/libcxx/CMakeLists.txt
@@ -88,13 +88,6 @@ if(CONFIG_LIBCXX)
     add_compile_definitions(LIBCXX_BUILDING_LIBCXXABI)
   endif()
 
-  set(CMAKE_CXX_STANDARD 20)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS ON)
-
-  set(SRCS)
-  set(SRCSTMP)
-
   file(GLOB SRCS ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/*.cpp)
   file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/experimental/*.cpp)
   list(APPEND SRCS ${SRCSTMP})


### PR DESCRIPTION
## Summary

## Impact

build libcxx with cmake.

## Testing

ci-test

