### PR TITLE
float.h: Define FLT_ROUNDS if not defined by toolchain previously

### DIFF
--- a/include/nuttx/lib/float.h
+++ b/include/nuttx/lib/float.h
@@ -42,6 +42,12 @@
 
 #define FLT_RADIX 2
 
+/* Addition rounds to 0: zero, 1: nearest, 2: +inf, 3: -inf, -1: unknown.  */
+
+#ifndef FLT_ROUNDS  /* May be defined in a toolchain header */
+#  define FLT_ROUNDS 1
+#endif
+
 /* Number of base-FLT_RADIX digits in the floating-point significand, p. */
 
 #ifndef FLT_MANT_DIG  /* May be defined in a toolchain header */


### PR DESCRIPTION
## Summary

* float.h: Define FLT_ROUNDS if not defined by toolchain previously

This value is necessary to build third-party applications on NuttX.
If not defined previously by the toolchain, define it at NuttX's `lib/float.h`.

## Impact

None for current NuttX's applications. Enables building third-party apps that rely on this macro.

## Testing

Internal CI testing + NuttX's CI