### PR TITLE
Change the memory of struct filelist to be malloced

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -198,7 +198,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   spin_unlock_irqrestore(&list->fl_lock, flags);
 
-  if (tmp != NULL && tmp != &list->fl_prefile)
+  if (tmp != NULL)
     {
       fs_heap_free(tmp);
     }
@@ -363,14 +363,7 @@ static int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2,
 
 void files_initlist(FAR struct filelist *list)
 {
-  /* The first row will reuse pre-allocated files, which will avoid
-   * unnecessary allocator accesses during file initialization.
-   */
-
-  list->fl_rows = 1;
   list->fl_crefs = 1;
-  list->fl_files = &list->fl_prefile;
-  list->fl_prefile = list->fl_prefiles;
   spin_lock_init(&list->fl_lock);
 }
 
@@ -508,16 +501,11 @@ void files_putlist(FAR struct filelist *list)
           file_close(&list->fl_files[i][j]);
         }
 
-      if (i != 0)
-        {
-          fs_heap_free(list->fl_files[i]);
-        }
+      fs_heap_free(list->fl_files[i]);
+      list->fl_rows--;
     }
 
-  if (list->fl_files != &list->fl_prefile)
-    {
-      fs_heap_free(list->fl_files);
-    }
+  fs_heap_free(list->fl_files);
 }
 
 /****************************************************************************

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1263,7 +1263,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
   DEBUGASSERT(group != NULL);
 
-  count = files_countlist(&group->tg_filelist);
+  count = files_countlist(group->tg_filelist);
   if (count == 0)
     {
       return 0;
@@ -1303,7 +1303,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
 
   for (i = 0; i < count; i++)
     {
-      filep = files_fget(&group->tg_filelist, i);
+      filep = files_fget(group->tg_filelist, i);
 
       /* Is there an inode associated with the file descriptor? */
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -881,7 +881,7 @@ int nx_umount2(FAR const char *target, unsigned int flags);
  *
  ****************************************************************************/
 
-void files_initlist(FAR struct filelist *list);
+int files_initlist(FAR struct filelist **list);
 
 /****************************************************************************
  * Name: files_dumplist

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -496,15 +496,6 @@ struct filelist
   uint8_t           fl_rows;    /* The number of rows of fl_files array */
   uint8_t           fl_crefs;   /* The references to filelist */
   FAR struct file **fl_files;   /* The pointer of two layer file descriptors array */
-
-  /* Pre-allocated files to avoid allocator access during thread creation
-   * phase, For functional safety requirements, increase
-   * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK could also avoid allocator access
-   * caused by the file descriptor exceeding the limit.
-   */
-
-  FAR struct file  *fl_prefile;
-  struct file       fl_prefiles[CONFIG_NFILE_DESCRIPTORS_PER_BLOCK];
 };
 
 /* The following structure defines the list of files used for standard C I/O.

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -566,7 +566,7 @@ struct task_group_s
 
   /* File descriptors *******************************************************/
 
-  struct filelist tg_filelist;      /* Maps file descriptor to file         */
+  struct filelist *tg_filelist;      /* Maps file descriptor to file         */
 
   /* Virtual memory mapping info ********************************************/
 

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -168,7 +168,11 @@ int group_initialize(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   /* Initialize file descriptors for the TCB */
 
-  files_initlist(&group->tg_filelist);
+  ret = files_initlist(&group->tg_filelist);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Alloc task info for group  */
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -98,7 +98,7 @@ group_release(FAR struct task_group_s *group, uint8_t ttype)
 
   /* Free resources held by the file descriptor list */
 
-  files_putlist(&group->tg_filelist);
+  files_putlist(group->tg_filelist);
 
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Release all shared environment variables */

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -83,8 +83,8 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
 
   if (group != rtcb->group)
     {
-      files_duplist(&rtcb->group->tg_filelist,
-                    &group->tg_filelist, actions, cloexec);
+      files_duplist(rtcb->group->tg_filelist,
+                    group->tg_filelist, actions, cloexec);
     }
 
   if (ret >= 0 && actions != NULL)

--- a/sched/sched/sched_getfiles.c
+++ b/sched/sched/sched_getfiles.c
@@ -60,7 +60,7 @@ FAR struct filelist *nxsched_get_files_from_tcb(FAR struct tcb_s *tcb)
 
   if (group)
     {
-      return &group->tg_filelist;
+      return group->tg_filelist;
     }
 
   /* Higher level logic must handle the NULL gracefully */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

    The refs in the filelist cannot protect the handles in the prefiles
    The prefiles and its associated group are allocated together, and when
    the group leaves, they are released together.
    During a reboot process, the sync operation may encounter a "used after free"
    issue.

## Impact

    The filelist  will be freed when refence change to zero

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


