### PR TITLE
addrenv: Ensure that the transmission parameter of addrenv_switch is not NULL

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -93,7 +93,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -93,7 +93,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */

--- a/arch/arm/src/dm320/dm320_decodeirq.c
+++ b/arch/arm/src/dm320/dm320_decodeirq.c
@@ -98,7 +98,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              addrenv_switch(NULL);
+              addrenv_switch(tcb);
             }
 #endif
 

--- a/arch/arm/src/imx1/imx_decodeirq.c
+++ b/arch/arm/src/imx1/imx_decodeirq.c
@@ -115,7 +115,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              addrenv_switch(NULL);
+              addrenv_switch(tcb);
             }
 #endif
         }

--- a/arch/arm/src/lpc31xx/lpc31_decodeirq.c
+++ b/arch/arm/src/lpc31xx/lpc31_decodeirq.c
@@ -103,7 +103,7 @@ uint32_t *arm_decodeirq(uint32_t *regs)
                * thread at the head of the ready-to-run list.
                */
 
-              addrenv_switch(NULL);
+              addrenv_switch(tcb);
             }
 #endif
 

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -94,7 +94,7 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -61,6 +61,7 @@
 uint32_t *avr_doirq(int irq, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -93,6 +94,8 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
 
   if (regs != up_current_regs())
     {
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
@@ -106,7 +109,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -114,7 +117,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -61,6 +61,7 @@
 uint8_t *hc_doirq(int irq, uint8_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -99,6 +100,8 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
       up_restorefpu(up_current_regs());
 #endif
 
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -106,7 +109,7 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -114,7 +117,7 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -61,6 +61,7 @@
 uint32_t *mips_doirq(int irq, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -99,6 +100,8 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
 
   if (regs != up_current_regs())
     {
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
@@ -112,7 +115,7 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -120,7 +123,7 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/mips/src/pic32mx/pic32mx_decodeirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_decodeirq.c
@@ -164,7 +164,7 @@ uint32_t *pic32mx_decodeirq(uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(this_task());
 #endif
     }
 #endif

--- a/arch/mips/src/pic32mz/pic32mz_decodeirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_decodeirq.c
@@ -164,7 +164,7 @@ uint32_t *pic32mz_decodeirq(uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(this_task());
 #endif
     }
 #endif

--- a/arch/misoc/src/lm32/lm32_doirq.c
+++ b/arch/misoc/src/lm32/lm32_doirq.c
@@ -48,6 +48,7 @@
 uint32_t *lm32_doirq(int irq, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -84,6 +85,8 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
 
   if (regs != up_current_regs())
     {
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
@@ -97,7 +100,7 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -105,7 +108,7 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -48,6 +48,7 @@
 uint32_t *minerva_doirq(int irq, uint32_t * regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -89,6 +90,8 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
       up_restorefpu(up_current_regs());
 #endif
 
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously running
        * task is closed down gracefully (data caches dump, MMU flushed) and
@@ -96,7 +99,7 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
        * the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -104,7 +107,7 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -61,6 +61,7 @@
 uint32_t *renesas_doirq(int irq, uint32_t * regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -102,6 +103,8 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
           up_restorefpu(up_current_regs());
 #endif
 
+          tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
           /* Make sure that the address environment for the previously
            * running task is closed down gracefully (data caches dump,
@@ -109,7 +112,7 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
            * thread at the head of the ready-to-run list.
            */
 
-          addrenv_switch(NULL);
+          addrenv_switch(tcb);
 #endif
 
           /* Record the new "running" task when context switch occurred.
@@ -117,7 +120,7 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = this_task();
+          g_running_tasks[this_cpu()] = tcb;
         }
 
       /* Get the current value of regs... it may have changed because

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -107,7 +107,7 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -65,7 +65,7 @@ void *riscv_perform_syscall(uintreg_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
       /* Update scheduler parameters */
 

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -61,6 +61,7 @@
 uint32_t *sparc_doirq(int irq, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -100,6 +101,8 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
       up_restorefpu(up_current_regs());
 #endif
 
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -107,7 +110,7 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -115,7 +118,7 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -47,6 +47,7 @@
 IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -87,6 +88,8 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   if (regs != up_current_regs())
     {
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -94,7 +97,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Record the new "running" task when context switch occurred.
@@ -102,7 +105,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      g_running_tasks[this_cpu()] = tcb;
 
       __mtcr(CPU_PCXI, (uintptr_t)up_current_regs());
       __isync();

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -94,6 +94,8 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
 
   if (regs != up_current_regs())
     {
+      tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -101,21 +103,20 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */
 
       cpu = this_cpu();
       nxsched_suspend_scheduler(*running_task);
-      nxsched_resume_scheduler(this_task());
+      nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      tcb = current_task(cpu);
       g_running_tasks[cpu] = tcb;
 
       /* Restore the cpu lock */

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -92,7 +92,7 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
        * thread at the head of the ready-to-run list.
        */
 
-      addrenv_switch(NULL);
+      addrenv_switch(tcb);
 #endif
 
       /* Update scheduler parameters */

--- a/arch/z80/src/common/z80_doirq.c
+++ b/arch/z80/src/common/z80_doirq.c
@@ -47,6 +47,7 @@
 FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
   if (*running_task != NULL)
     {
@@ -85,6 +86,8 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
 
       if (newregs != regs)
         {
+          tcb = this_task();
+
 #ifdef CONFIG_ARCH_ADDRENV
           /* Make sure that the address environment for the previously
            * running task is closed down gracefully and set up the
@@ -92,7 +95,7 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
            * ready-to-run list.
            */
 
-          addrenv_switch(NULL);
+          addrenv_switch(tcb);
 #endif
 
           /* Record the new "running" task when context switch occurred.
@@ -100,7 +103,7 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = this_task();
+          g_running_tasks[this_cpu()] = tcb;
         }
 
       regs = newregs;

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -129,16 +129,6 @@ int addrenv_switch(FAR struct tcb_s *tcb)
   int cpu;
   int ret;
 
-  /* NULL for the tcb means to use the TCB of the task at the head of the
-   * ready to run list.
-   */
-
-  if (!tcb)
-    {
-      tcb = this_task();
-    }
-
-  DEBUGASSERT(tcb);
   next = tcb->addrenv_curr;
 
   /* Does the group have an address environment? */


### PR DESCRIPTION

## Summary
 Ensure that the transmission parameter of addrenv_switch is not NULL
reason:
avoid obtaining this_task multiple times.

## Impact
addrenv

## Testing
ci ostest


