### PR TITLE
libm: Do not link the toolchain's libm unless explicitly selected

### DIFF
--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -45,7 +45,7 @@ execute_process(
 
 list(APPEND EXTRA_LIB ${extra_library})
 
-if(NOT CONFIG_LIBM)
+if(CONFIG_LIBM_TOOLCHAIN)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
             --print-file-name=libm.a

--- a/arch/tricore/src/cmake/platform.cmake
+++ b/arch/tricore/src/cmake/platform.cmake
@@ -46,7 +46,7 @@ if(CONFIG_TRICORE_TOOLCHAIN_GNU)
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE extra_library)
   list(APPEND EXTRA_LIB ${extra_library})
-  if(NOT CONFIG_LIBM)
+  if(CONFIG_LIBM_TOOLCHAIN)
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
               --print-file-name=libm.a


### PR DESCRIPTION
## Summary

* libm: Do not link the toolchain's libm unless explicitly selected

Fix CMake-based build system to include the toolchain's libm only when `CONFIG_LIBM_TOOLCHAIN` is selected. Before this PR, if the user selected `CONFIG_LIBM_NEWLIB`, for instance, the build system would still link the toolchain's libm functions instead of the ones provided by newlib.

## Impact

Fix error of not using newlib's libm.

## Testing

Internal CI testing + rv-virt:nsh.

To test it using `rv-virt:nsh` (`cmake -B build -DBOARD_CONFIG=rv-virt:nsh -GNinja`), enable `CONFIG_LIBM_NEWLIB` and use the following application:
```
nooptimiziation_function
int main(int argc, FAR char *argv[])
{
  double x = 1.0;
  double y = 2.0;
  double z = 3.0;

  double result = fma(x, y, z);
  printf("result: %f\n", result);

  return 0;
}
```

Build with CMake (`cmake --build build`) and check `build/nuttx.map` content for the `fma` function. Before this commit, one can check that the toolchain's libm was being used instead of the newlib's.