### PR TITLE
drivers/timers: export arch timer api to support higher resolution

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -187,14 +187,13 @@ void up_alarm_set_lowerhalf(FAR struct oneshot_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
 void weak_function up_timer_getmask(FAR clock_t *mask)
 {
   *mask = 0;
 
   if (g_oneshot_lower != NULL)
     {
-      clock_t maxticks;
+      clock_t maxticks = 0;
 
       ONESHOT_TICK_MAX_DELAY(g_oneshot_lower, &maxticks);
 
@@ -210,9 +209,7 @@ void weak_function up_timer_getmask(FAR clock_t *mask)
         }
     }
 }
-#endif
 
-#if defined(CONFIG_SCHED_TICKLESS) || defined(CONFIG_CLOCK_TIMEKEEPING)
 int weak_function up_timer_gettick(FAR clock_t *ticks)
 {
   int ret = -EAGAIN;
@@ -236,7 +233,6 @@ int weak_function up_timer_gettime(struct timespec *ts)
 
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: up_alarm_cancel

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -243,7 +243,6 @@ void up_timer_set_lowerhalf(FAR struct timer_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
 void weak_function up_timer_getmask(FAR clock_t *mask)
 {
   uint32_t maxticks;
@@ -262,9 +261,7 @@ void weak_function up_timer_getmask(FAR clock_t *mask)
       *mask = next;
     }
 }
-#endif
 
-#if defined(CONFIG_SCHED_TICKLESS) || defined(CONFIG_CLOCK_TIMEKEEPING)
 int weak_function up_timer_gettick(FAR clock_t *ticks)
 {
   int ret = -EAGAIN;
@@ -291,7 +288,6 @@ int weak_function up_timer_gettime(struct timespec *ts)
 
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: up_timer_cancel

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1928,17 +1928,9 @@ void up_timer_initialize(void);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
 int up_timer_gettime(FAR struct timespec *ts);
-#endif
-
-#if defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT) || defined(CONFIG_CLOCK_TIMEKEEPING)
 int up_timer_gettick(FAR clock_t *ticks);
-#endif
-
-#ifdef CONFIG_CLOCK_TIMEKEEPING
 void up_timer_getmask(FAR clock_t *mask);
-#endif
 
 /****************************************************************************
  * Name: up_alarm_cancel


### PR DESCRIPTION
## Summary

drivers/timers: export arch timer api to support higher resolution

Before:
`[  384.149000] [CPU0] [ 5] Hello World!`
After:
`[  384.149947] [CPU0] [ 5] Hello World!`

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check