### PR TITLE
Fix the conflicting symbol specifications between can.h and lin.h

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -211,7 +211,7 @@ enum can_ioctl_state_e
 struct can_ioctl_state_s
 {
   uintptr_t priv;             /* This is private data. */
-  enum can_ioctl_state_e state;
+  enum can_ioctl_state_e can_st_type;
 };
 
 /* There are two forms of the I/F request structure.

--- a/include/nuttx/can.h
+++ b/include/nuttx/can.h
@@ -44,7 +44,6 @@
 #define CAN_EFF_FLAG 0x80000000  /* EFF/SFF is set in the MSB */
 #define CAN_RTR_FLAG 0x40000000  /* Remote transmission request */
 #define CAN_ERR_FLAG 0x20000000  /* Error message frame */
-#define CAN_EVT_FLAG 0x10000000  /* Lower_half use this flags to report state switch event */
 
 /* Valid bits in CAN ID for frame formats */
 

--- a/include/nuttx/lin.h
+++ b/include/nuttx/lin.h
@@ -44,31 +44,28 @@
 #define LIN_RTR_FLAG              CAN_RTR_FLAG  /* Describe the direction of sending and receiving */
 #define LIN_ERR_FLAG              CAN_ERR_FLAG  /* The flag indicate  this is LIN err_frame */
 
-/* Bit flags on can_frame.types
- *
- * Use can_frame.types to identify other special frame.
- *
- * LIN_TCF_FLAG : TxConfirmation message frame. Lower_half use this flag to
- *                confirm frame-transmit
- *
- * LIN_EVT_FLAG : Event message frame. Lower_half use this flag to report
- *                state switch event
- *
- * LIN_CACHE_RESP_FLAG: When slave response to master, slave node should send
- *                      frame immediately which already be cached in last
- *                      transmission in case of response interval over time.
- *
- * LIN_CHKSUM_EXT_FLAG: LIN checksum have two types, default type will be
- *                      classic checksum
- *
- * LIN_SINGLE_RESP_FLAG: Cache LIN frame only work once, then will be cleared
+/* When slave response to master, slave node should send  frame immediately
+ * which already be cached in last transmission in case of response interval
+ * over time
  */
 
-#define LIN_TCF_FLAG              CAN_TCF_FLAG
-#define LIN_EVT_FLAG              CAN_EVT_FLAG
-#define LIN_CACHE_RESP_FLAG       (1 << (CANFD_FLAGS_BITS + 2))
-#define LIN_CHKSUM_EXT_FLAG       (1 << (CANFD_FLAGS_BITS + 3))
-#define LIN_SINGLE_RESP_FLAG      (1 << (CANFD_FLAGS_BITS + 4))
+#define LIN_CACHE_RESPONSE        (1 << (LIN_ID_BITS))
+
+/* LIN checksum have two types, default type will be classic checksum */
+
+#define LIN_CHECKSUM_EXTENDED     (1 << (LIN_ID_BITS + 1))
+
+/* Cache LIN frame only work once. then will be clear */
+
+#define LIN_SINGLE_RESPONSE       (1 << (LIN_ID_BITS + 2))
+
+/* Lower_half use this flags to report state switch event */
+
+#define LIN_EVT_FLAG              (1 << (LIN_ID_BITS + 3))
+
+/* TxConfirmation frame. Lower_half use the flag to confirm frame-transmit */
+
+#define LIN_TCF_FLAG              (1 << (LIN_ID_BITS + 4))
 
 /* LIN Error Indications ****************************************************/
 
@@ -76,13 +73,14 @@
  * The error frame consists of err_flag（LIN_ERR_FLAG)、err_class
  * (defined in data[0]) and err_reason(defined in data[1] to data[4]).
  * The error frame is described using the following structure:
- * begin_packed_struct struct can_frame {
+ * struct can_frame {
  *    canid_t can_id;
  *    uint8_t can_dlc;
- *    uint16_t flags;
+ *    uint8_t __pad;
+ *    uint8_t __res0;
  *    uint8_t __res1;
  *    uint8_t data[CAN_MAX_DLEN] __attribute__((aligned(8)));
- *  } end_packed_struct;
+ *  };
  *
  * Error frame description format：
  *
@@ -113,7 +111,7 @@
 
 #define LIN_ERR_TX_UNSPEC         0x00     /* Unspecified error */
 #define LIN_ERR_TX_BREAK_TMO      (1 << 0) /* Bit 0: Master send break field, but detect break event timeout */
-#define LIN_ERR_TX_SYNC_TMO       (1 << 1) /* Bit 1: Master send sync timeout (receive back timeout) */ 
+#define LIN_ERR_TX_SYNC_TMO       (1 << 1) /* Bit 1: Master send sync timeout (receive back timeout) */
 #define LIN_ERR_TX_PID_TMO        (1 << 2) /* Bit 2: Master send pid timeout (receive back timeout) */
 #define LIN_ERR_TX_DATA_TMO       (1 << 3) /* Bit 3: Master/slave send data timeout (receive back timeout) */
 #define LIN_ERR_TX_CHECKSUM_TMO   (1 << 4) /* Bit 4: Master/slave send checksum timeout(receive back timeout) */
@@ -143,6 +141,7 @@
 #define LIN_ERR_CRTL_UNSPEC       0x00     /* Unspecified error */
 #define LIN_ERR_CRTL_RXOVERFLOW   (1 << 0) /* Hardware controller receive overflow */
 #define LIN_ERR_CTRL_FRAMEERROR   (1 << 1) /* Hardware controller frame error */
+#define LIN_ERR_CTRL_NOISE        (1 << 2) /* Hardware controller noise error */
 
 /* LIN States Indications ***************************************************/
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*
1.Fix the conflicting symbol specifications between can.h and lin.h
2.Add lin's error frame type noise type
3.Modify state to can_st_type, the definition is clearer
*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


