### PR TITLE
arch: lc823450: Add missing license info to lc823450_symbols.ld

### DIFF
--- a/arch/arm/src/lc823450/lc823450_symbols.ld
+++ b/arch/arm/src/lc823450/lc823450_symbols.ld
@@ -1,5 +1,37 @@
-"Copyright (C) 2014-2015 ON Semiconductor. All rights reserved." = 0x0;
-;;;
+/****************************************************************************
+ * arch/arm/src/lc823450/lc823450_symbols.ld
+ *
+ *   Copyright (C) 2014-2015 ON Semiconductor. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 __pTransWork             = 0x02000014;
 __gTransInitSts          = 0x02000018;
 __Fsfs_Convert_ErrorCode = 0x0221ae07;


### PR DESCRIPTION
## Summary

- The file includes symbol information provided by ON Semiconductor.
- The license information is the same as lc823450_sdc.c

## Impact

- None

## Testing

- lc823450-xgevk:rndis (build only)
