### PR TITLE
debug symbol level: Use config instead

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2495,6 +2495,7 @@ config DEBUG_SYMBOLS
 
 config DEBUG_SYMBOLS_LEVEL
 	string "Custom symbols level"
+	depends on DEBUG_SYMBOLS
 	default "-g"
 	---help---
 		This string represents the custom symbol level that will be

--- a/arch/tricore/src/common/ToolchainGnuc.defs
+++ b/arch/tricore/src/common/ToolchainGnuc.defs
@@ -166,7 +166,7 @@ ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
 endif
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  ARCHOPTIMIZATION += -g
+  ARCHOPTIMIZATION += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 LDFLAGS += --no-warn-rwx-segments

--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -76,7 +76,7 @@ ARCHOPTIMIZATION += --tradeoff=2
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION += --debug-info=default
   ARCHOPTIMIZATION += --keep-temporary-files
-  LDFLAGS          += -g
+  LDFLAGS          += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 # merge source code with assembly output

--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -21,7 +21,7 @@
 ############################################################################
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  ARCHOPTIMIZATION = -g3
+  ARCHOPTIMIZATION = $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 ifneq ($(CONFIG_DEBUG_NOOPT),y)

--- a/tools/D.defs
+++ b/tools/D.defs
@@ -25,7 +25,7 @@ DC := ldmd2
 DFLAGS := -i
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  DFLAGS += -g
+  DFLAGS += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 ifeq ($(CONFIG_DEBUG_NOOPT),y)

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -25,7 +25,7 @@ RUSTC := rustc --edition 2021
 RUSTFLAGS :=
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  RUSTFLAGS += -g
+  RUSTFLAGS += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 ifeq ($(CONFIG_DEBUG_NOOPT),y)

--- a/tools/Swift.defs
+++ b/tools/Swift.defs
@@ -27,7 +27,7 @@ SWIFTC := swiftc
 SWIFTFLAGS := -enable-experimental-feature Embedded -wmo
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
-  SWIFTFLAGS += -g
+  SWIFTFLAGS += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
 endif
 
 ifeq ($(CONFIG_DEBUG_NOOPT),y)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use config instead

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


