### PR TITLE
virtio: Add virtio version check

### DIFF
--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -821,6 +821,12 @@ static int virtio_mmio_init_device(FAR struct virtio_mmio_device_s *vmdev,
     }
 
   vdev->id.version = metal_io_read32(&vmdev->cfg_io, VIRTIO_MMIO_VERSION);
+  if (vdev->id.version < 1 || vdev->id.version > 2)
+    {
+      vrterr("Version %d not supported!\n", vdev->id.version);
+      return -ENODEV;
+    }
+
   vdev->id.device = metal_io_read32(&vmdev->cfg_io, VIRTIO_MMIO_DEVICE_ID);
   if (vdev->id.device == 0)
     {


### PR DESCRIPTION
## Summary
In the source code of qemu or linux, there is a check for the virtio version
```
    /* Check device version */
    priv->version = readl(priv->base + VIRTIO_MMIO_VERSION);
    if (priv->version < 1 || priv->version > 2) {
    	debug("(%s): version %d not supported!\n",
    	udev->name, priv->version);
    	return 0;
    }
    /* Check device ID */
    uc_priv->device = readl(priv->base + VIRTIO_MMIO_DEVICE_ID);
    if (uc_priv->device == 0) {
    	/*
    	* virtio-mmio device with an ID 0 is a (dummy) placeholder
    	* with no function. End probing now with no error reported.
    	*/
    	return 0;
    }
```

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


