### PR TITLE
sched/clock: call up_timer_gettime() to get higher resolution

### DIFF
--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -82,7 +82,9 @@ int clock_systime_timespec(FAR struct timespec *ts)
 
   up_timer_gettick(&ticks);
   clock_ticks2time(ts, ticks);
-#elif defined(CONFIG_SCHED_TICKLESS)
+#elif defined(CONFIG_ALARM_ARCH) || \
+      defined(CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_SCHED_TICKLESS)
   up_timer_gettime(ts);
 #else
   clock_ticks2time(ts, g_system_ticks);


### PR DESCRIPTION
## Summary

This is continue work of https://github.com/apache/nuttx/pull/15038

1. sched/clock: call up_timer_gettime() to get higher resolution
2. driver/timers: remove wall clock diff from lower half

Some SOC chipsets use global clock generator to unify the time of each MCU,
that means after MCUs is start-up, the timer will not start counting from 0.
this PR will record the wall timer of global timer and recalculate the ticks.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check