### PR TITLE
remove redundant judgments *running_task != NULL

### DIFF
--- a/arch/avr/src/avr/avr_doirq.c
+++ b/arch/avr/src/avr/avr_doirq.c
@@ -61,10 +61,7 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 
-  if (*running_task != NULL)
-    {
-      avr_copystate((*running_task)->xcp.regs, regs);
-    }
+  avr_copystate((*running_task)->xcp.regs, regs);
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -104,7 +101,7 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      *running_task = this_task();
     }
 
   regs = up_current_regs();   /* Cast removes volatile attribute */

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -63,10 +63,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb;
 
-  if (*running_task != NULL)
-    {
-      avr_copystate((*running_task)->xcp.regs, regs);
-    }
+  avr_copystate((*running_task)->xcp.regs, regs);
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -117,7 +114,7 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -63,10 +63,7 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb;
 
-  if (*running_task != NULL)
-    {
-      hc_copystate((*running_task)->xcp.regs);
-    }
+  hc_copystate((*running_task)->xcp.regs);
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -117,7 +114,7 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/or1k/src/common/or1k_doirq.c
+++ b/arch/or1k/src/common/or1k_doirq.c
@@ -45,10 +45,7 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 
-  if (*running_task != NULL)
-    {
-      or1k_copyfullstate((*running_task)->xcp.regs, regs);
-    }
+  or1k_copyfullstate((*running_task)->xcp.regs, regs);
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -86,7 +83,7 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = this_task();
+      *running_task = this_task();
     }
 
   regs = up_current_regs();

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -63,10 +63,7 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb;
 
-  if (*running_task != NULL)
-    {
-      renesas_copystate((*running_task)->xcp.regs, regs);
-    }
+  renesas_copystate((*running_task)->xcp.regs, regs);
 
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -120,7 +117,7 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = tcb;
+          *running_task = tcb;
         }
 
       /* Get the current value of regs... it may have changed because

--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -67,10 +67,7 @@ void *sim_doirq(int irq, void *context)
     {
       struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 
-      if (*running_task != NULL)
-        {
-          sim_copyfullstate((*running_task)->xcp.regs, regs);
-        }
+      sim_copyfullstate((*running_task)->xcp.regs, regs);
 
       up_set_current_regs(regs);
 
@@ -91,7 +88,7 @@ void *sim_doirq(int irq, void *context)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = this_task();
+          *running_task = this_task();
         }
 
       regs = up_current_regs();

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -91,10 +91,7 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
   DEBUGASSERT(up_current_regs() == NULL);
   up_set_current_regs(regs);
 
-  if (*running_task != NULL)
-    {
-      x86_savestate((*running_task)->xcp.regs);
-    }
+  x86_savestate((*running_task)->xcp.regs);
 
   /* Deliver the IRQ */
 

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -69,10 +69,7 @@ void xtensa_panic(int xptcode, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 
-  if (*running_task != NULL)
-    {
-      (*running_task)->xcp.regs = regs;
-    }
+  (*running_task)->xcp.regs = regs;
 
   up_set_interrupt_context(true);
 
@@ -175,10 +172,7 @@ void xtensa_user_panic(int exccause, uint32_t *regs)
 {
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
 
-  if (*running_task != NULL)
-    {
-      (*running_task)->xcp.regs = regs;
-    }
+  (*running_task)->xcp.regs = regs;
 
   up_set_interrupt_context(true);
 

--- a/arch/z16/src/common/z16_doirq.c
+++ b/arch/z16/src/common/z16_doirq.c
@@ -63,10 +63,7 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
       struct tcb_s **running_task = &g_running_tasks[this_cpu()];
       FAR chipreg_t *savestate;
 
-      if (*running_task != NULL)
-        {
-          z16_copystate((*running_task)->xcp.regs, regs)
-        }
+      z16_copystate((*running_task)->xcp.regs, regs)
 
       /* Nested interrupts are not supported in this implementation.  If
        * you want to implement nested interrupts, you would have to (1)
@@ -100,7 +97,7 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = this_task();
+          *running_task = this_task();
         }
 
       /* Restore the previous value of g_current_regs.  NULL would indicate

--- a/arch/z16/src/z16f/z16f_sysexec.c
+++ b/arch/z16/src/z16f/z16f_sysexec.c
@@ -52,10 +52,7 @@ void z16f_sysexec(FAR chipreg_t *regs)
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   uint16_t excp;
 
-  if (*running_task != NULL)
-    {
-      z16_copystate((*running_task)->xcp.regs, regs)
-    }
+  z16_copystate((*running_task)->xcp.regs, regs)
 
   /* Save that register reference so that it can be used for built-in
    * diagnostics.

--- a/arch/z80/src/common/z80_doirq.c
+++ b/arch/z80/src/common/z80_doirq.c
@@ -49,10 +49,7 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
   struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb;
 
-  if (*running_task != NULL)
-    {
-      z80_copystate((*running_task)->xcp.regs, regs)
-    }
+  z80_copystate((*running_task)->xcp.regs, regs)
 
   board_autoled_on(LED_INIRQ);
 
@@ -103,7 +100,7 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = tcb;
+          *running_task = tcb;
         }
 
       regs = newregs;


### PR DESCRIPTION

## Summary

remove redundant judgments *running_task != NULL
reason:
In irq, g_running_tasks is always valid.
## Impact

arch

## Testing
ci ostest


