### PR TITLE
Remove FAR from 32/64bit arch

### DIFF
--- a/Documentation/platforms/arm/goldfish/goldfish_timer.rst
+++ b/Documentation/platforms/arm/goldfish/goldfish_timer.rst
@@ -26,11 +26,11 @@ To read the current time, the kernel must execute an IO_READ(TIME_LOW), which re
 
 ::
 
-    static int goldfish_timer_current(FAR struct oneshot_lowerhalf_s *lower_,
-                                      FAR struct timespec *ts)
+    static int goldfish_timer_current(struct oneshot_lowerhalf_s *lower_,
+                                      struct timespec *ts)
     {
-      FAR struct goldfish_timer_lowerhalf_s *lower =
-        (FAR struct goldfish_timer_lowerhalf_s *)lower_;
+      struct goldfish_timer_lowerhalf_s *lower =
+        (struct goldfish_timer_lowerhalf_s *)lower_;
       irqstate_t flags;
       uint32_t l32;
       uint32_t h32;
@@ -65,13 +65,13 @@ When the corresponding value is reached, the device will raise its IRQ. Note tha
 
 ::
 
-    static int goldfish_timer_start(FAR struct oneshot_lowerhalf_s *lower_,
-                                    FAR oneshot_callback_t callback,
-                                    FAR void *arg,
-                                    FAR const struct timespec *ts)
+    static int goldfish_timer_start(struct oneshot_lowerhalf_s *lower_,
+                                    oneshot_callback_t callback,
+                                    void *arg,
+                                    const struct timespec *ts)
     {
-      FAR struct goldfish_timer_lowerhalf_s *lower =
-        (FAR struct goldfish_timer_lowerhalf_s *)lower_;
+      struct goldfish_timer_lowerhalf_s *lower =
+        (struct goldfish_timer_lowerhalf_s *)lower_;
       irqstate_t flags;
       uint64_t nsec;
       uint32_t l32;
@@ -108,10 +108,10 @@ Note: Currently, the alarm is used only on ARM-based systems. On MIPS-based syst
 ::
 
     static int goldfish_timer_interrupt(int irq,
-                                        FAR void *context,
-                                        FAR void *arg)
+                                        void *context,
+                                        void *arg)
     {
-      FAR struct goldfish_timer_lowerhalf_s *lower = arg;
+      struct goldfish_timer_lowerhalf_s *lower = arg;
       oneshot_callback_t callback = NULL;
       irqstate_t flags;
       void *cbarg;

--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -56,7 +56,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 {
   int cpu = this_cpu();
   struct tcb_s **running_task = &g_running_tasks[cpu];
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
   uint32_t cmd;
 
   /* Nested interrupts are not supported */

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -158,7 +158,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 {
   int cpu = this_cpu();
   struct tcb_s **running_task = &g_running_tasks[cpu];
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
   uint32_t cmd;
 #ifdef CONFIG_BUILD_PROTECTED
   uint32_t cpsr;

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -158,7 +158,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 {
   int cpu = this_cpu();
   struct tcb_s **running_task = &g_running_tasks[cpu];
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
   uint32_t cmd;
 #ifdef CONFIG_BUILD_PROTECTED
   uint32_t cpsr;

--- a/arch/arm/src/goldfish/goldfish_timer.c
+++ b/arch/arm/src/goldfish/goldfish_timer.c
@@ -36,7 +36,7 @@
 void up_timer_initialize(void)
 {
 #if defined(CONFIG_GOLDFISH_TIMER) && defined(CONFIG_LIBC_FDT)
-  FAR struct oneshot_lowerhalf_s *lower;
+  struct oneshot_lowerhalf_s *lower;
   const void *fdt = fdt_get();
 
   DEBUGASSERT(fdt != NULL);

--- a/arch/arm/src/moxart/moxart_16550.c
+++ b/arch/arm/src/moxart/moxart_16550.c
@@ -69,7 +69,7 @@ void uart_decodeirq(int irq, void *context)
 }
 
 #ifdef CONFIG_SERIAL_UART_ARCH_IOCTL
-int uart_ioctl(FAR struct u16550_s *priv, int cmd, unsigned long arg)
+int uart_ioctl(struct u16550_s *priv, int cmd, unsigned long arg)
 {
   int          ret = -ENOTTY;
   uint32_t     vmode;

--- a/arch/arm/src/s32k1xx/s32k1xx_flexio_i2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexio_i2c.c
@@ -421,7 +421,7 @@ static int s32k1xx_flexio_i2c_interrupt(int irq, void *context, void *arg)
   return OK;
 }
 
-static int set_expiretime(int expire_time, FAR struct timespec *set_time)
+static int set_expiretime(int expire_time, struct timespec *set_time)
 {
   struct timespec curr_time;
 

--- a/arch/arm/src/samv7/sam_lin_sock.c
+++ b/arch/arm/src/samv7/sam_lin_sock.c
@@ -796,7 +796,7 @@ static int sam_lin_netdev_ioctl(struct net_driver_s *dev, int cmd,
 }
 #endif /* CONFIG_NETDEV_IOCTL */
 
-static int sam_interrupt(int irq, void *context, FAR void *arg)
+static int sam_interrupt(int irq, void *context, void *arg)
 {
   struct sam_lin_s *priv = (struct sam_lin_s *)arg;
   uint32_t pending;

--- a/arch/arm64/src/goldfish/goldfish_rtc.c
+++ b/arch/arm64/src/goldfish/goldfish_rtc.c
@@ -35,7 +35,7 @@
 
 int up_rtc_initialize(void)
 {
-  FAR struct rtc_lowerhalf_s *rtc_lowerhalf =
+  struct rtc_lowerhalf_s *rtc_lowerhalf =
             pl031_initialize(CONFIG_GOLDFISH_RTC_PL031_BASE,
                              CONFIG_GOLDFISH_RTC_PL031_IRQ);
 

--- a/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
@@ -613,7 +613,7 @@ static int esp_temperature_sensor_fetch(struct sensor_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp_temperature_sensor_thread(int argc, FAR char **argv)
+static int esp_temperature_sensor_thread(int argc, char **argv)
 {
   struct esp_temp_priv_s *priv =
       (struct esp_temp_priv_s *)((uintptr_t)strtoul(argv[1], NULL, 16));
@@ -784,7 +784,7 @@ int esp_temperature_sensor_initialize(struct esp_temp_sensor_config_t cfg)
   int ret = 0;
   struct esp_temp_priv_s *priv = &esp_temp_priv;
 #ifdef CONFIG_ESPRESSIF_TEMP_UORB_POLL
-  FAR char *argv[2];
+  char *argv[2];
   char arg1[32];
 #endif
 

--- a/arch/risc-v/src/common/espressif/esp_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_timer.c
@@ -511,7 +511,7 @@ IRAM_ATTR static int esp_timer_isr(int irq, void *context, void *arg)
 int esp_timer_initialize(uint32_t timer_id)
 {
   struct esp_timer_lowerhalf_s *lower = NULL;
-  FAR char *devpath;
+  char *devpath;
   uint32_t group_num;
   uint32_t timer_num;
 

--- a/arch/sim/src/sim/sim_heap.c
+++ b/arch/sim/src/sim/sim_heap.c
@@ -675,7 +675,7 @@ size_t mm_heapfree(struct mm_heap_s *heap)
  *
  ****************************************************************************/
 
-size_t mm_heapfree_largest(FAR struct mm_heap_s *heap)
+size_t mm_heapfree_largest(struct mm_heap_s *heap)
 {
   return SIZE_MAX;
 }

--- a/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
@@ -612,7 +612,7 @@ static int esp_temperature_sensor_fetch(struct sensor_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp_temperature_sensor_thread(int argc, FAR char **argv)
+static int esp_temperature_sensor_thread(int argc, char **argv)
 {
   struct esp_temp_priv_s *priv =
       (struct esp_temp_priv_s *)((uintptr_t)strtoul(argv[1], NULL, 16));
@@ -783,7 +783,7 @@ int esp_temperature_sensor_initialize(struct esp_temp_sensor_config_t cfg)
   int ret = 0;
   struct esp_temp_priv_s *priv = &esp_temp_priv;
 #ifdef CONFIG_ESPRESSIF_TEMP_UORB_POLL
-  FAR char *argv[2];
+  char *argv[2];
   char arg1[32];
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -75,7 +75,7 @@
 static bool spiram_inited = false;
 
 #ifdef CONFIG_SMP
-static int pause_cpu_handler(FAR void *cookie);
+static int pause_cpu_handler(void *cookie);
 static struct smp_call_data_s g_call_data =
 SMP_CALL_INITIALIZER(pause_cpu_handler, NULL);
 #endif
@@ -91,7 +91,7 @@ SMP_CALL_INITIALIZER(pause_cpu_handler, NULL);
 #ifdef CONFIG_SMP
 static volatile bool g_cpu_wait = true;
 static volatile bool g_cpu_pause = false;
-static int pause_cpu_handler(FAR void *cookie)
+static int pause_cpu_handler(void *cookie)
 {
   g_cpu_pause = true;
   while (g_cpu_wait);

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.c
@@ -118,7 +118,7 @@ static uint32_t page0_page = INVALID_PHY_PAGE;
 #endif
 
 #ifdef CONFIG_SMP
-static int pause_cpu_handler(FAR void *cookie);
+static int pause_cpu_handler(void *cookie);
 static struct smp_call_data_s g_call_data =
 SMP_CALL_INITIALIZER(pause_cpu_handler, NULL);
 #endif
@@ -289,7 +289,7 @@ static int IRAM_ATTR esp_mmu_map_region(uint32_t vaddr, uint32_t paddr,
 #ifdef CONFIG_SMP
 static volatile bool g_cpu_wait = true;
 static volatile bool g_cpu_pause = false;
-static int pause_cpu_handler(FAR void *cookie)
+static int pause_cpu_handler(void *cookie)
 {
   g_cpu_pause = true;
   while (g_cpu_wait);

--- a/boards/arm/mps/mps3-an547/src/mps3_bringup.c
+++ b/boards/arm/mps/mps3-an547/src/mps3_bringup.c
@@ -105,7 +105,7 @@ static int mps3_bringup(void)
 
 #ifdef CONFIG_BOARDCTL_BOOT_IMAGE
 
-int board_boot_image(FAR const char *path, uint32_t hdr_size)
+int board_boot_image(const char *path, uint32_t hdr_size)
 {
   struct mod_loadinfo_s loadinfo;
   struct module_s mod;

--- a/boards/arm/rp23xx/common/src/rp23xx_uniqueid.c
+++ b/boards/arm/rp23xx/common/src/rp23xx_uniqueid.c
@@ -134,7 +134,7 @@ void rp23xx_uniqueid_initialize(void)
  *
  ****************************************************************************/
 
-int board_uniqueid(FAR uint8_t *uniqueid)
+int board_uniqueid(uint8_t *uniqueid)
 {
   memcpy(uniqueid, g_uniqueid, CONFIG_BOARDCTL_UNIQUEID_SIZE);
   return OK;

--- a/libs/libc/machine/arm64/arch_elf.c
+++ b/libs/libc/machine/arm64/arch_elf.c
@@ -184,8 +184,8 @@ aarch64_insn_encode_immediate(enum insn_imm_type_e type,
 static uint64_t do_reloc(enum reloc_op_e op,
                          uintptr_t place, uint64_t val)
 {
-  val = (uint64_t)kasan_reset_tag((FAR const void *)val);
-  place = (uint64_t)kasan_reset_tag((FAR const void *)place);
+  val = (uint64_t)kasan_reset_tag((const void *)val);
+  place = (uint64_t)kasan_reset_tag((const void *)place);
 
   switch (op)
     {

--- a/libs/libc/machine/sim/arch_elf64.c
+++ b/libs/libc/machine/sim/arch_elf64.c
@@ -143,14 +143,14 @@ bool up_checkarch(const Elf64_Ehdr *ehdr)
  ****************************************************************************/
 
 int up_relocate(const Elf64_Rel *rel, const Elf64_Sym *sym, uintptr_t addr,
-                FAR void *arch_data)
+                void *arch_data)
 {
   berr("Not implemented\n");
   return -ENOSYS;
 }
 
 int up_relocateadd(const Elf64_Rela *rel, const Elf64_Sym *sym,
-                   uintptr_t addr, FAR void *arch_data)
+                   uintptr_t addr, void *arch_data)
 {
   unsigned int relotype;
   uint64_t value;


### PR DESCRIPTION
## Summary

since these arch doesn't distinguish between near and far pointers

## Impact

minor code refactor only

## Testing

ci