### PR TITLE
kasan/globals: fix compile error

### DIFF
--- a/tools/kasan_global.py
+++ b/tools/kasan_global.py
@@ -266,9 +266,12 @@ def create_kasan_file(config: Config, region_list=[]):
             file.write("\n};")
 
         # Record kasan region pointer location
-        file.write("\nconst unsigned long g_global_region[] = {\n")
+        file.write("struct kasan_global_region_s;\n")
+        file.write("const struct kasan_global_region_s *g_global_region[] = {\n")
         for i in range(len(region_list)):
-            file.write("\n(const unsigned long)&globals_region%d," % (i))
+            file.write(
+                "\n(const struct kasan_global_region_s *)&globals_region%d," % (i)
+            )
         file.write("0x00\n};")
 
 


### PR DESCRIPTION
## Summary

../../../mm/kasan/global.c:58:44: error: type of 'g_global_region' does not match original declaration [-Werror=lto-type-mismatch]
   58 | extern const struct kasan_global_region_s *g_global_region[];
      |                                            ^
kasan_globals.tmp:3:21: note: 'g_global_region' was previously declared here
    3 | const unsigned long g_global_region[] = {
      |                     ^
lto1: all warnings being treated as errors

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


