### PR TITLE
arm64/lto: Fix link error after opening lto

### DIFF
--- a/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
+++ b/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld
@@ -144,7 +144,6 @@ SECTIONS
        *(.exit.text)
        *(.exit.data)
        *(.exitcall.exit)
-       *(.eh_frame)
   }
 
   /* Stabs debugging sections.  */


### PR DESCRIPTION
## Summary

```
CPP:  /mnt/vela/github/NX/nuttx/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld-> /mnt/vela/github/NX/nutLD: nuttx
Please update the link script, section ['.kasan.global'] cannot be found
`.eh_frame' referenced in section `.text.frame_dummy' of /mnt/vela/github/Toolchains/arm64-gcc-13/bin/../lib/gcc/aarch64-none-elf/13.2.1/crtbegin.o: defined in discarded section `.eh_frame' of /mnt/vela/github/Toolchains/arm64-gcc-13/bin/../lib/gcc/aarch64-none-elf/13.2.1/crtbegin.o
`.eh_frame' referenced in section `.text.frame_dummy' of /mnt/vela/github/Toolchains/arm64-gcc-13/bin/../lib/gcc/aarch64-none-elf/13.2.1/crtbegin.o: defined in discarded section `.eh_frame' of /mnt/vela/github/Toolchains/arm64-gcc-13/bin/../lib/gcc/aarch64-none-elf/13.2.1/crtbegin.o
```

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


