### PR TITLE
armv7-a/armv7-r/armv8-r: percpu reg store this_task

### DIFF
--- a/arch/arm/include/armv7-a/cp15.h
+++ b/arch/arm/include/armv7-a/cp15.h
@@ -273,4 +273,6 @@
      value;                             \
   })                                    \
 
+#define CP15_MODIFY(v,m,a) CP15_SET(a, ((CP15_GET(a) & ~(m)) | ((uintptr_t)(v) & (m))))
+
 #endif /* __ARCH_ARM_SRC_ARMV7_A_CP15_H */

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -471,16 +471,14 @@ static inline_function uint32_t up_getsp(void)
 }
 
 noinstrument_function
-static inline_function bool up_interrupt_context(void)
-{
-  return (bool)CP15_GET(TPIDRPRW);
-}
-
-noinstrument_function
 static inline_function void up_set_interrupt_context(bool flag)
 {
-  CP15_SET(TPIDRPRW, flag);
+  CP15_MODIFY(flag, 1ul, TPIDRPRW);
 }
+
+#define up_this_task()         ((struct tcb_s *)(CP15_GET(TPIDRPRW) & ~1ul))
+#define up_update_task(t)      CP15_MODIFY(t, ~1ul, TPIDRPRW)
+#define up_interrupt_context() (CP15_GET(TPIDRPRW) & 1)
 
 /****************************************************************************
  * Public Data

--- a/arch/arm/include/armv7-r/cp15.h
+++ b/arch/arm/include/armv7-r/cp15.h
@@ -216,4 +216,6 @@
      value;                             \
   })                                    \
 
+#define CP15_MODIFY(v,m,a) CP15_SET(a, ((CP15_GET(a) & ~(m)) | ((uintptr_t)(v) & (m))))
+
 #endif /* __ARCH_ARM_SRC_ARMV7_R_CP15_H */

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -466,16 +466,14 @@ static inline_function uint32_t up_getsp(void)
 }
 
 noinstrument_function
-static inline_function bool up_interrupt_context(void)
-{
-  return (bool)CP15_GET(TPIDRPRW);
-}
-
-noinstrument_function
 static inline_function void up_set_interrupt_context(bool flag)
 {
-  CP15_SET(TPIDRPRW, flag);
+  CP15_MODIFY(flag, 1ul, TPIDRPRW);
 }
+
+#define up_this_task()         ((struct tcb_s *)(CP15_GET(TPIDRPRW) & ~1ul))
+#define up_update_task(t)      CP15_MODIFY(t, ~1ul, TPIDRPRW)
+#define up_interrupt_context() (CP15_GET(TPIDRPRW) & 1)
 
 /****************************************************************************
  * Public Data

--- a/arch/arm/include/armv8-r/cp15.h
+++ b/arch/arm/include/armv8-r/cp15.h
@@ -235,4 +235,6 @@
      _value;                             \
   })                                    \
 
+#define CP15_MODIFY(v,m,a) CP15_SET(a, ((CP15_GET(a) & ~(m)) | ((uintptr_t)(v) & (m))))
+
 #endif /* __ARCH_ARM_SRC_ARMV8_R_CP15_H */

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -466,16 +466,14 @@ static inline_function uint32_t up_getsp(void)
 }
 
 noinstrument_function
-static inline_function bool up_interrupt_context(void)
-{
-  return (bool)CP15_GET(TPIDRPRW);
-}
-
-noinstrument_function
 static inline_function void up_set_interrupt_context(bool flag)
 {
-  CP15_SET(TPIDRPRW, flag);
+  CP15_MODIFY(flag, 1ul, TPIDRPRW);
 }
+
+#define up_this_task()         ((struct tcb_s *)(CP15_GET(TPIDRPRW) & ~1ul))
+#define up_update_task(t)      CP15_MODIFY(t, ~1ul, TPIDRPRW)
+#define up_interrupt_context() (CP15_GET(TPIDRPRW) & 1)
 
 /****************************************************************************
  * Public Data

--- a/arch/arm/src/armv7-a/arm_scu.c
+++ b/arch/arm/src/armv7-a/arm_scu.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <arch/irq.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 #include "cp15_cacheops.h"
@@ -54,6 +55,14 @@
 void arm_enable_smp(int cpu)
 {
   uint32_t regval;
+
+  /* We need to confirm that current_task has been initialized. */
+
+  while (!current_task(this_cpu()));
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(current_task(cpu));
 
   /* Handle actions unique to CPU0 which comes up first */
 

--- a/arch/arm/src/armv7-r/arm_scu.c
+++ b/arch/arm/src/armv7-r/arm_scu.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <arch/irq.h>
+#include <sched/sched.h>
 
 #include "arm_internal.h"
 #include "cp15_cacheops.h"
@@ -54,6 +55,14 @@
 void arm_enable_smp(int cpu)
 {
   uint32_t regval;
+
+  /* We need to confirm that current_task has been initialized. */
+
+  while (!current_task(this_cpu()));
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(current_task(cpu));
 
   /* Handle actions unique to CPU0 which comes up first */
 


### PR DESCRIPTION

## Summary

This is continue work of https://github.com/apache/nuttx/pull/13726

We can utilize percpu storage to hold information about the current running task. If we intend to implement this feature, we would need to define two macros that help us manage this percpu information effectively.

up_this_task: This macro is designed to read the contents of the percpu register to retrieve information about the current running task.This allows us to quickly access
task-specific data without having to disable interrupts, access global variables and obtain the current cpu index.

up_update_task: This macro is responsible for updating the contents of the percpu register.It is typically called during
initialization or when a context switch occurs to ensure that the percpu register reflects the information of the newly running task.

## Impact
armv7-a/armv7-r/armv8-r:

## Testing
ci ostest 
make distclean -j20; ./tools/configure.sh -l qemu-armv7a:smp;make -j12


