### PR TITLE
mm_grantable.c: Fix infinite loop due to memory fragmentation

### DIFF
--- a/mm/mm_gran/mm_grantable.c
+++ b/mm/mm_gran/mm_grantable.c
@@ -232,21 +232,7 @@ failure:
         {
           /* Handle full GAT quickly */
 
-          tmp = 32;
-        }
-      else if (c == r.sidx)
-        {
-          /* offset of first unused when matching for free */
-
-          v = ~v;
-#ifdef CONFIG_HAVE_BUILTIN_CTZ
-          tmp = __builtin_ctz(v);
-#else
-          tmp = (uint32_t)((lsb_mask(v)) * DEBRUJIN_NUM) >> 27;
-          DEBUGASSERT(tmp < sizeof(DEBRUJIN_LUT));
-          tmp = DEBRUJIN_LUT[tmp];
-#endif
-          tmp = tmp - 1; /* Ok, because v >= 1 */
+          tmp = 31;
         }
       else
         {


### PR DESCRIPTION
## Summary

The search algorithm does not work with the ctz approach at all, if there is a free range of granules that does not fit a specific allocation (i.e. the granule allocation is fragmented) it will cause an infinite loop as the algorithm will try to find free space from the same (free) starting granule, causing an infinite loop.

The clz approach works for all cases, it will find the last used granule and the search will continue from the next free granule.

Also, offsetting a full GAT must be sizeof(gat[0] - 1), which is 31 in this case. The reason is that the upper level search function increments the value by +1.

## Impact

Impact is on granule allocator only. The patch fixes an infinite loop caused by memory fragmentation.

## Testing
qemu-armv8a:knsh
IMX9