### PR TITLE
wm8776: use small lock in drivers/audio/wm8776.c

### DIFF
--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -494,7 +494,7 @@ static void  wm8776_senddone(FAR struct i2s_dev_s *i2s,
    * against that possibility.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   /* Add the completed buffer to the end of our doneq.  We do not yet
    * decrement the reference count.
@@ -512,7 +512,7 @@ static void  wm8776_senddone(FAR struct i2s_dev_s *i2s,
   /* REVISIT:  This can be overwritten */
 
   priv->result = result;
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   /* Now send a message to the worker thread, informing it that there are
    * buffers in the done queue that need to be cleaned up.
@@ -547,13 +547,13 @@ static void wm8776_returnbuffers(FAR struct wm8776_dev_s *priv)
    * use interrupt controls to protect against that possibility.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   while (dq_peek(&priv->doneq) != NULL)
     {
       /* Take the next buffer from the queue of completed transfers */
 
       apb = (FAR struct ap_buffer_s *)dq_remfirst(&priv->doneq);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&priv->lock, flags);
 
       audinfo("Returning: apb=%p curbyte=%d nbytes=%d flags=%04x\n",
               apb, apb->curbyte, apb->nbytes, apb->flags);
@@ -588,10 +588,10 @@ static void wm8776_returnbuffers(FAR struct wm8776_dev_s *priv)
 #else
       priv->dev.upper(priv->dev.priv, AUDIO_CALLBACK_DEQUEUE, apb, OK);
 #endif
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&priv->lock);
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -644,9 +644,9 @@ static int wm8776_sendbuffer(FAR struct wm8776_dev_s *priv)
        * to avoid a possible race condition.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&priv->lock);
       priv->inflight++;
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&priv->lock, flags);
 
       shift  = (priv->bpsamp == 8) ? 14 - 3 : 14 - 4;
       shift -= (priv->nchannels > 1) ? 1 : 0;

--- a/drivers/audio/wm8776.h
+++ b/drivers/audio/wm8776.h
@@ -36,6 +36,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/fs/ioctl.h>
+#include <nuttx/spinlock_type.h>
 
 #ifdef CONFIG_AUDIO
 
@@ -107,6 +108,7 @@ struct wm8776_dev_s
 #endif
   bool                    reserved;         /* True: Device is reserved */
   volatile int            result;           /* The result of the last transfer */
+  spinlock_t              lock;             /* Spinlock */
 };
 
 #endif /* CONFIG_AUDIO */


### PR DESCRIPTION

## Summary
wm8776: use small lock in drivers/audio/wm8776.c
reason:
We hope to remove all instances of spin_lock_irqsave(NULL).


## Impact
wm8776


## Testing
ci

