### PR TITLE
s32k1xx_serial: arch/arm/src/s32k1xx/s32k1xx_serial.c

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -179,6 +179,7 @@
 struct s32k1xx_uart_s
 {
   struct uart_dev_s dev;    /* Generic UART device */
+  spinlock_t lock;          /* Spinlock */
   uint32_t uartbase;        /* Base address of UART registers */
   uint32_t baud;            /* Configured baud */
   uint32_t ie;              /* Saved enabled interrupts */
@@ -450,6 +451,7 @@ static struct s32k1xx_uart_s g_lpuart0priv =
 #  endif
         .priv         = &g_lpuart0priv,
       },
+  .lock         = SP_UNLOCKED,
   .uartbase     = S32K1XX_LPUART0_BASE,
   .baud         = CONFIG_LPUART0_BAUD,
   .irq          = S32K1XX_IRQ_LPUART0,
@@ -515,6 +517,7 @@ static struct s32k1xx_uart_s g_lpuart1priv =
           .priv           = &g_lpuart1priv,
   },
 
+  .lock         = SP_UNLOCKED,
   .uartbase     = S32K1XX_LPUART1_BASE,
   .baud         = CONFIG_LPUART1_BAUD,
   .irq          = S32K1XX_IRQ_LPUART1,
@@ -577,6 +580,7 @@ static struct s32k1xx_uart_s g_lpuart2priv =
         .priv           = &g_lpuart2priv,
   },
 
+  .lock         = SP_UNLOCKED,
   .uartbase     = S32K1XX_LPUART2_BASE,
   .baud         = CONFIG_LPUART2_BAUD,
   .irq          = S32K1XX_IRQ_LPUART2,
@@ -669,10 +673,8 @@ static int s32k1xx_dma_nextrx(struct s32k1xx_uart_s *priv)
 static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
                                           uint32_t *ie)
 {
-  irqstate_t flags;
   uint32_t regval;
 
-  flags  = spin_lock_irqsave(NULL);
   regval = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
 
   /* Return the current Rx and Tx interrupt state */
@@ -684,7 +686,6 @@ static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
 
   regval &= ~LPUART_ALL_INTS;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -694,19 +695,16 @@ static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
 static inline void s32k1xx_restoreuartint(struct s32k1xx_uart_s *priv,
                                         uint32_t ie)
 {
-  irqstate_t flags;
   uint32_t regval;
 
   /* Enable/disable any interrupts that are currently disabled but should be
    * enabled/disabled.
    */
 
-  flags   = spin_lock_irqsave(NULL);
   regval  = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
   regval &= ~LPUART_ALL_INTS;
   regval |= ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1329,7 +1327,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
              * implement TCSADRAIN / TCSAFLUSH
              */
 
-            flags = spin_lock_irqsave(NULL);
+            flags = spin_lock_irqsave(&priv->lock);
             s32k1xx_disableuartint(priv, &ie);
             ret = dev->ops->setup(dev);
 
@@ -1337,7 +1335,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
 
             s32k1xx_restoreuartint(priv, ie);
             priv->ie = ie;
-            spin_unlock_irqrestore(NULL, flags);
+            spin_unlock_irqrestore(&priv->lock, flags);
           }
       }
       break;
@@ -1351,7 +1349,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint32_t regval;
         struct s32k1xx_uart_s *priv = (struct s32k1xx_uart_s *)dev->priv;
 
-        flags  = spin_lock_irqsave(NULL);
+        flags  = spin_lock_irqsave(&priv->lock);
         ctrl   = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
         stat   = s32k1xx_serialin(priv, S32K1XX_LPUART_STAT_OFFSET);
         regval = ctrl;
@@ -1387,7 +1385,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET, stat);
         s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, ctrl);
 
-        spin_unlock_irqrestore(NULL, flags);
+        spin_unlock_irqrestore(&priv->lock, flags);
       }
       break;
 #endif
@@ -1441,7 +1439,7 @@ static void s32k1xx_rxint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupts for data available at Rx */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1457,7 +1455,7 @@ static void s32k1xx_rxint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif
 
@@ -1890,7 +1888,7 @@ static void s32k1xx_txint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupt for TX complete */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1906,7 +1904,7 @@ static void s32k1xx_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif
 
@@ -2549,11 +2547,14 @@ void up_putc(int ch)
 #ifdef CONSOLE_DEV
   struct s32k1xx_uart_s *priv =
       (struct s32k1xx_uart_s *)CONSOLE_DEV.dev.priv;
+  irqstate_t flags;
   uint32_t ie;
 
+  flags = spin_lock_irqsave(&priv->lock);
   s32k1xx_disableuartint(priv, &ie);
   s32k1xx_lowputc(ch);
   s32k1xx_restoreuartint(priv, ie);
+  spin_unlock_irqrestore(&priv->lock, flags);
 #endif
 }
 


### PR DESCRIPTION

## Summary
s32k1xx_serial: arch/arm/src/s32k1xx/s32k1xx_serial.c
reason:
We hope to remove all instances of spin_lock_irqsave(NULL).


## Impact
s32k1xx_serial

## Testing

ci

