### PR TITLE
netdb:Add macro to control DNS using TCP transmission

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -237,6 +237,13 @@ config NETDB_DNSSERVER_IPv4ADDR
 		Default DNS server IPv4 address in host byte order.  Default value
 		10.0.0.1.  This may be changed via dns_add_nameserver().
 
+config NETDB_DNS_STREAM
+	bool "DNS supports TCP transmission"
+	depends on LIBC_NETDB
+	default n
+	---help---
+		Enable support for DNS Name resolution over TCP.
+
 if NETDB_DNSSERVER_IPv6
 
 config NETDB_DNSSERVER_IPv6ADDR_1

--- a/libs/libc/netdb/lib_dns.h
+++ b/libs/libc/netdb/lib_dns.h
@@ -170,7 +170,11 @@ void dns_restorelock(unsigned int count);
  *
  ****************************************************************************/
 
+#ifndef CONFIG_NETDB_DNS_STREAM
+int dns_bind(sa_family_t family);
+#else
 int dns_bind(sa_family_t family, bool stream);
+#endif
 
 /****************************************************************************
  * Name: dns_query

--- a/libs/libc/netdb/lib_dnsbind.c
+++ b/libs/libc/netdb/lib_dnsbind.c
@@ -63,16 +63,28 @@
  *
  ****************************************************************************/
 
+#ifndef CONFIG_NETDB_DNS_STREAM
+int dns_bind(sa_family_t family)
+#else
 int dns_bind(sa_family_t family, bool stream)
+#endif
 {
+#ifdef CONFIG_NETDB_DNS_STREAM
   int stype = stream ? SOCK_STREAM : SOCK_DGRAM;
+#endif
+
   struct timeval tv;
   int sd;
   int ret;
 
   /* Create a new socket */
 
+#ifndef CONFIG_NETDB_DNS_STREAM
+  sd = socket(family, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+#else
   sd = socket(family, stype | SOCK_CLOEXEC, 0);
+#endif
+
   if (sd < 0)
     {
       ret = -get_errno();


### PR DESCRIPTION
## Summary

When dns uses tcp for transmission, it is easy to exceed RECV_BUFFER_SIZE, causing resolution failure. Therefore a macro was added to limit whether this feature is enabled or not.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


