### PR TITLE
virtio: fix compile error

### DIFF
--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -343,15 +343,18 @@ static int virtio_mmio_config_virtqueue(FAR struct metal_io_region *io,
     {
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_NUM, vq->vq_nentries);
 
-      addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.desc);
+      addr = (uint64_t)((uintptr_t)
+                        kasan_reset_tag((FAR void *)vq->vq_ring.desc));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_DESC_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_DESC_HIGH, addr >> 32);
 
-      addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.avail);
+      addr = (uint64_t)((uintptr_t)
+                        kasan_reset_tag((FAR void *)vq->vq_ring.avail));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_AVAIL_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_AVAIL_HIGH, addr >> 32);
 
-      addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.used);
+      addr = (uint64_t)((uintptr_t)
+                        kasan_reset_tag((FAR void *)vq->vq_ring.used));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_USED_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_USED_HIGH, addr >> 32);
 


### PR DESCRIPTION
## Summary

CC:  virtio/virtio-mmio.c virtio/virtio-mmio.c: In function 'virtio_mmio_config_virtqueue': virtio/virtio-mmio.c:346:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  346 |       addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.desc);
      |              ^
virtio/virtio-mmio.c:350:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  350 |       addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.avail);
      |              ^
virtio/virtio-mmio.c:354:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  354 |       addr = (uint64_t)kasan_reset_tag((FAR void *)vq->vq_ring.used)


## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


