### PR TITLE
arch/arm: migrate to SPDX identifier

### DIFF
--- a/arch/arm/src/tiva/CMakeLists.txt
+++ b/arch/arm/src/tiva/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # arch/arm/src/tiva/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/tiva/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13x0_rom.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x0_rom.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x0_rom.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup_rom.c file which has a fully compatible BSD
- * license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x0_rom.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x0_rom.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x0_rom.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup_rom.h file which has a fully compatible
- * BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x0_trim.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x0_trim.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x0_trim.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup.c file (revision 49363) which has a fully
- * compatible BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
@@ -1,15 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
- * Driver for the AUX System Interface
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI aux_sysif.c file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's aux_sysif.h file which has a fully compatible BSD
- * license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup_rom.c file which has a fully compatible BSD
- * license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's rom.h file which has a fully compatible
- * BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's rom.h file which has a fully compatible BSD
- * license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13x2_v1_trim.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_v1_trim.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_v1_trim.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup.c file (revision 49363) which has a fully
- * compatible BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/cc13xx/cc13x2_v2_trim.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_v2_trim.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_v2_trim.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's setup.c file (revision 49363) which has a fully
- * compatible BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/cc13xx/cc13xx_chipinfo.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_chipinfo.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_chipinfo.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enableclks.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enableclks.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_enableclks.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enableclks.h
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enableclks.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_enableclks.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.h
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpio.h
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/cc13xx/cc13xx_prcm.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_prcm.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_prcm.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is a port of TI's prcm.c file (revision 49363) which has a fully
- * compatible BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/cc13xx/cc13xx_prcm.h
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_prcm.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_prcm.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Includes definitions from TI's prcm.c file which has a fully compatible
- * BSD license:
- *
- *    Copyright (c) 2015-2017, Texas Instruments Incorporated
- *    All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/cc13xx/cc13xx_start.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13xx_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/chip.h
+++ b/arch/arm/src/tiva/chip.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/chip.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c
+++ b/arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/lmxx_tm4c_start.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/lmxx_tm4c_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_adclib.c
+++ b/arch/arm/src/tiva/common/tiva_adclib.c
@@ -1,15 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_adclib.c
  *
- *   Copyright (C) 2015 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
- *
- * The Tivaware sample code has a BSD compatible license that requires this
- * copyright notice:
- *
- * Copyright (c) 2005-2014 Texas Instruments Incorporated.
- * All rights reserved.
- * Software License Agreement
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2014 Texas Instruments Incorporated.
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/common/tiva_adclow.c
+++ b/arch/arm/src/tiva/common/tiva_adclow.c
@@ -1,17 +1,12 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_adclow.c
  *
- *   Copyright (C) 2016-2018 Gregory Nutt. All rights reserved.
- *   Copyright (C) 2015 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
- *           Gregory Nutt <gnutt@nuttx.org>
- *
- * The Tivaware sample code has a BSD compatible license that requires this
- * copyright notice:
- *
- * Copyright (c) 2005-2014 Texas Instruments Incorporated.
- * All rights reserved.
- * Software License Agreement
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016-2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2014 Texas Instruments Incorporated.
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/common/tiva_allocateheap.c
+++ b/arch/arm/src/tiva/common/tiva_allocateheap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_allocateheap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_can.c
+++ b/arch/arm/src/tiva/common/tiva_can.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_can.c
- * Classic (character-device) lower-half driver for the Tiva CAN modules.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/tiva/common/tiva_dumpgpio.c
+++ b/arch/arm/src/tiva/common/tiva_dumpgpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_dumpgpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_eeprom.c
+++ b/arch/arm/src/tiva/common/tiva_eeprom.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_eeprom.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_flash.c
+++ b/arch/arm/src/tiva/common/tiva_flash.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_flash.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_hciuart.c
+++ b/arch/arm/src/tiva/common/tiva_hciuart.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_hciuart.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_i2c.c
+++ b/arch/arm/src/tiva/common/tiva_i2c.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_i2c.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_idle.c
+++ b/arch/arm/src/tiva/common/tiva_idle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_idle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_irq.c
+++ b/arch/arm/src/tiva/common/tiva_irq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_irq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_lowputc.c
+++ b/arch/arm/src/tiva/common/tiva_lowputc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_lowputc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_mpuinit.c
+++ b/arch/arm/src/tiva/common/tiva_mpuinit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_mpuinit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_pwm.c
+++ b/arch/arm/src/tiva/common/tiva_pwm.c
@@ -1,14 +1,11 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_pwm.c
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
- *
- * The basic structure of this driver derives in spirit (if nothing more)
- * from the NuttX SAM PWM driver which has:
- *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileCopyrightText: 2013 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/common/tiva_qencoder.c
+++ b/arch/arm/src/tiva/common/tiva_qencoder.c
@@ -1,15 +1,12 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_qencoder.c
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
- *
- * The basic structure of this driver derives in spirit (if nothing more)
- * from the NuttX STM32 QEI driver which has:
- *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *            Diego Sanchez <dsanchez@nx-engineering.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Diego Sanchez <dsanchez@nx-engineering.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_serial.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_sock_can.c
+++ b/arch/arm/src/tiva/common/tiva_sock_can.c
@@ -1,6 +1,7 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_sock_can.c
- * SocketCAN driver implementation for Tiva. Based on the chardev driver.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/tiva/common/tiva_ssi.c
+++ b/arch/arm/src/tiva/common/tiva_ssi.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_ssi.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_timerisr.c
+++ b/arch/arm/src/tiva/common/tiva_timerisr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_timerisr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_timerlib.c
+++ b/arch/arm/src/tiva/common/tiva_timerlib.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_timerlib.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_timerlow32.c
+++ b/arch/arm/src/tiva/common/tiva_timerlow32.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_timerlow32.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/common/tiva_userspace.c
+++ b/arch/arm/src/tiva/common/tiva_userspace.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/common/tiva_userspace.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi2_refsys.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi2_refsys.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi2_refsys.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_batmon.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_batmon.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_batmon.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_ioc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_ioc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_ioc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_rtc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_rtc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_rtc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_sysctl.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_sysctl.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_sysctl.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_wuc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_wuc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_wuc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_wuc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_wuc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_wuc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi0_osc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi0_osc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi0_osc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_fcfg1.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_fcfg1.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_fcfg1.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_flash.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_flash.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_flash.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_gpio.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_gpio.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_gpio.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_i2c.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_i2c.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_i2c.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ioc.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ioc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_ioc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_prcm.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_prcm.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_prcm.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_timer.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_timer.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_timer.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_vims.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_vims.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_vims.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi2_refsys.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi2_refsys.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi2_refsys.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi3_refsys.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi3_refsys.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi3_refsys.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi4_aux.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi4_aux.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi4_aux.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_batmon.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_batmon.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_batmon.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_ioc.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_ioc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_ioc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_pmctl.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_pmctl.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_pmctl.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_smph.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_smph.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_sysif.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_sysif.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_sysif.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ccfg.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ccfg.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ccfg.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi0_osc.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi0_osc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi0_osc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a
- * compatible BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_fcfg1.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_fcfg1.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_fcfg1.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_gpio.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_gpio.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_gpio.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_i2c.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_i2c.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_i2c.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ioc.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ioc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ioc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_memorymap.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_memorymap.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_memorymap.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_prcm.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_prcm.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_prcm.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_smph.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_smph.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_timer.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_timer.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_timer.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_vims.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_vims.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_vims.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible
- * BSD license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/lm/lm3s_ethernet.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_ethernet.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_ethernet.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_flash.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_gpio.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_memorymap.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_pinmap.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_pinmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_pinmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_sysctrl.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm3s_timer.h
+++ b/arch/arm/src/tiva/hardware/lm/lm3s_timer.h
@@ -1,21 +1,13 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm3s_timer.h
  *
- * Originally:
- *
- *   Copyright (C) 2012, 2014 Max Nekludov. All rights reserved.
- *   Author: Max Nekludov <macscomp@gmail.com>
- *
- * Ongoing support and major revision to support the TM4C129 family
- * (essentially a full file replacement):
- *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Some bitfield definitions taken from a header file provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015, 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012, 2014 Max Nekludov. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Max Nekludov <macscomp@gmail.com>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/lm/lm4f_gpio.h
+++ b/arch/arm/src/tiva/hardware/lm/lm4f_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm4f_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm4f_memorymap.h
+++ b/arch/arm/src/tiva/hardware/lm/lm4f_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm4f_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm4f_pinmap.h
+++ b/arch/arm/src/tiva/hardware/lm/lm4f_pinmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm4f_pinmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm4f_sysctrl.h
+++ b/arch/arm/src/tiva/hardware/lm/lm4f_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm4f_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm4f_timer.h
+++ b/arch/arm/src/tiva/hardware/lm/lm4f_timer.h
@@ -1,21 +1,13 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm4f_timer.h
  *
- * Originally:
- *
- *   Copyright (C) 2012, 2014 Max Nekludov. All rights reserved.
- *   Author: Max Nekludov <macscomp@gmail.com>
- *
- * Ongoing support and major revision to support the TM4C129 family
- * (essentially a full file replacement):
- *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Some bitfield definitions taken from a header file provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015, 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012, 2014 Max Nekludov. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Max Nekludov <macscomp@gmail.com>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/lm/lm_i2c.h
+++ b/arch/arm/src/tiva/hardware/lm/lm_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/lm/lm_uart.h
+++ b/arch/arm/src/tiva/hardware/lm/lm_uart.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/lm/lm_uart.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_adc.h
+++ b/arch/arm/src/tiva/hardware/tiva_adc.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_adc.h
  *
- *   Copyright (C) 2015 Calvin Maguranis. All rights reserved.
- *   Author: Calvin Maguranis <c.maguranis@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 Calvin Maguranis. All rights reserved.
+ * SPDX-FileContributor: Calvin Maguranis <c.maguranis@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tiva_adi2_refsys.h
+++ b/arch/arm/src/tiva/hardware/tiva_adi2_refsys.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_adi2_refsys.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_adi3_refsys.h
+++ b/arch/arm/src/tiva/hardware/tiva_adi3_refsys.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_adi3_refsys.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_adi4_aux.h
+++ b/arch/arm/src/tiva/hardware/tiva_adi4_aux.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_adi4_aux.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_batmon.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_batmon.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_batmon.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_ioc.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_ioc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_ioc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_pmctl.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_pmctl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_pmctl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_rtc.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_rtc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_rtc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_sysctl.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_sysctl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_sysctl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aon_wuc.h
+++ b/arch/arm/src/tiva/hardware/tiva_aon_wuc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aon_wuc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aux_smph.h
+++ b/arch/arm/src/tiva/hardware/tiva_aux_smph.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aux_smph.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aux_sysif.h
+++ b/arch/arm/src/tiva/hardware/tiva_aux_sysif.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aux_sysif.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_aux_wuc.h
+++ b/arch/arm/src/tiva/hardware/tiva_aux_wuc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_aux_wuc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_can.h
+++ b/arch/arm/src/tiva/hardware/tiva_can.h
@@ -1,19 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_can.h
  *
- *   Copyright (C) 2006-2020 Texas Instruments Incorporated.
- *                           All rights reserved.
- *   Author: Matthew Trescott <matthewtrescott@gmail.com>
- *
- * From the TivaWare Peripheral Driver Library, with minor changes for
- * clarity and style.
- *
- * The TivaWare sample code has a BSD compatible license that requires this
- * copyright notice:
- *
- * Copyright (c) 2005-2020 Texas Instruments Incorporated.
- * All rights reserved.
- * Software License Agreement
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2006-2020 Texas Instruments Incorporated.
+ * SPDX-FileContributor: Matthew Trescott <matthewtrescott@gmail.com>
  *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tiva_ccfg.h
+++ b/arch/arm/src/tiva/hardware/tiva_ccfg.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ccfg.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_ddi.h
+++ b/arch/arm/src/tiva/hardware/tiva_ddi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ddi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_ddi0_osc.h
+++ b/arch/arm/src/tiva/hardware/tiva_ddi0_osc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ddi0_osc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_eeprom.h
+++ b/arch/arm/src/tiva/hardware/tiva_eeprom.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_eeprom.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_epi.h
+++ b/arch/arm/src/tiva/hardware/tiva_epi.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_epi.h
  *
- *   Copyright (C) 2009-2013 Max Neklyudov. All rights reserved.
- *   Author: Max Neklyudov <macscomp@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2009-2013 Max Neklyudov. All rights reserved.
+ * SPDX-FileContributor: Max Neklyudov <macscomp@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tiva_ethernet.h
+++ b/arch/arm/src/tiva/hardware/tiva_ethernet.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ethernet.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_fcfg1.h
+++ b/arch/arm/src/tiva/hardware/tiva_fcfg1.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_fcfg1.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_flash.h
+++ b/arch/arm/src/tiva/hardware/tiva_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_gpio.h
+++ b/arch/arm/src/tiva/hardware/tiva_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_i2c.h
+++ b/arch/arm/src/tiva/hardware/tiva_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_ioc.h
+++ b/arch/arm/src/tiva/hardware/tiva_ioc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ioc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_memorymap.h
+++ b/arch/arm/src/tiva/hardware/tiva_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_pinmap.h
+++ b/arch/arm/src/tiva/hardware/tiva_pinmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_pinmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_prcm.h
+++ b/arch/arm/src/tiva/hardware/tiva_prcm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_prcm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_pwm.h
+++ b/arch/arm/src/tiva/hardware/tiva_pwm.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_pwm.h
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tiva_qencoder.h
+++ b/arch/arm/src/tiva/hardware/tiva_qencoder.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_qencoder.h
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tiva_smph.h
+++ b/arch/arm/src/tiva/hardware/tiva_smph.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_smph.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_ssi.h
+++ b/arch/arm/src/tiva/hardware/tiva_ssi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_ssi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_sysctrl.h
+++ b/arch/arm/src/tiva/hardware/tiva_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_timer.h
+++ b/arch/arm/src/tiva/hardware/tiva_timer.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_timer.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_uart.h
+++ b/arch/arm/src/tiva/hardware/tiva_uart.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_uart.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_vims.h
+++ b/arch/arm/src/tiva/hardware/tiva_vims.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_vims.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tiva_wdt.h
+++ b/arch/arm/src/tiva/hardware/tiva_wdt.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tiva_wdt.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c123_gpio.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c123_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c123_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c123_i2c.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c123_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c123_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c123_sysctrl.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c123_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c123_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c123_timer.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c123_timer.h
@@ -1,21 +1,13 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c123_timer.h
  *
- * Originally:
- *
- *   Copyright (C) 2012, 2014 Max Nekludov. All rights reserved.
- *   Author: Max Nekludov <macscomp@gmail.com>
- *
- * Ongoing support and major revision to support the TM4C129 family
- * (essentially a full file replacement):
- *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Some bitfield definitions taken from a header file provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015, 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012, 2014 Max Nekludov. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Max Nekludov <macscomp@gmail.com>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c129_gpio.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c129_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c129_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c129_i2c.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c129_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c129_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c129_sysctrl.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c129_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c129_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c129_timer.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c129_timer.h
@@ -1,21 +1,13 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c129_timer.h
  *
- * Originally:
- *
- *   Copyright (C) 2012, 2014 Max Nekludov. All rights reserved.
- *   Author: Max Nekludov <macscomp@gmail.com>
- *
- * Ongoing support and major revision to support the TM4C129 family
- * (essentially a full file replacement):
- *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Some bitfield definitions taken from a header file provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015, 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012, 2014 Max Nekludov. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Max Nekludov <macscomp@gmail.com>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_ethernet.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_ethernet.h
@@ -1,13 +1,11 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c_ethernet.h
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Includes some register bit definitions provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_flash.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_flash.h
@@ -1,13 +1,11 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c_flash.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Based on register definitions provided by:
- *
- *   Copyright (C) 2014 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 TRD2 Inc. All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_memorymap.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_pinmap.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_pinmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c_pinmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/lm/lm3s_ethernet.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/lm/lm3s_gpio.c
+++ b/arch/arm/src/tiva/lm/lm3s_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/lm/lm3s_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/lm/lm3s_gpio.h
+++ b/arch/arm/src/tiva/lm/lm3s_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/lm/lm3s_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/lm/lm4f_gpio.c
+++ b/arch/arm/src/tiva/lm/lm4f_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/lm/lm4f_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/lm/lm4f_gpio.h
+++ b/arch/arm/src/tiva/lm/lm4f_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/lm/lm4f_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_adc.h
+++ b/arch/arm/src/tiva/tiva_adc.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_adc.h
  *
- *   Copyright (C) 2015 TRD2 Inc. All rights reserved.
- *   Author: Calvin Maguranis <calvin.maguranis@trd2inc.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 TRD2 Inc. All rights reserved.
+ * SPDX-FileContributor: Calvin Maguranis <calvin.maguranis@trd2inc.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/tiva_can.h
+++ b/arch/arm/src/tiva/tiva_can.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_can.h
- * Classic (character-device) lower-half driver for the Tiva CAN modules.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/tiva/tiva_chipinfo.h
+++ b/arch/arm/src/tiva/tiva_chipinfo.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_chipinfo.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *
- * Technical content derives from a TI header file that has a compatible BSD
- * license:
- *
- *   Copyright (c) 2015-2017, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2015-2017, Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/tiva_eeprom.h
+++ b/arch/arm/src/tiva/tiva_eeprom.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_eeprom.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_enableclks.h
+++ b/arch/arm/src/tiva/tiva_enableclks.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_enableclks.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_enablepwr.h
+++ b/arch/arm/src/tiva/tiva_enablepwr.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_enablepwr.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_ethernet.h
+++ b/arch/arm/src/tiva/tiva_ethernet.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_ethernet.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_flash.h
+++ b/arch/arm/src/tiva/tiva_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_gpio.h
+++ b/arch/arm/src/tiva/tiva_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_hciuart.h
+++ b/arch/arm/src/tiva/tiva_hciuart.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_hciuart.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_i2c.h
+++ b/arch/arm/src/tiva/tiva_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_lowputc.h
+++ b/arch/arm/src/tiva/tiva_lowputc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_lowputc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_mpuinit.h
+++ b/arch/arm/src/tiva/tiva_mpuinit.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_mpuinit.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_periphrdy.h
+++ b/arch/arm/src/tiva/tiva_periphrdy.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_periphrdy.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_pwm.h
+++ b/arch/arm/src/tiva/tiva_pwm.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_pwm.h
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/tiva_qencoder.h
+++ b/arch/arm/src/tiva/tiva_qencoder.h
@@ -1,8 +1,9 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_qencoder.h
  *
- *   Copyright (C) 2016 Young Mu. All rights reserved.
- *   Author: Young Mu <young.mu@aliyun.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2016 Young Mu. All rights reserved.
+ * SPDX-FileContributor: Young Mu <young.mu@aliyun.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tiva/tiva_ssi.h
+++ b/arch/arm/src/tiva/tiva_ssi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_ssi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_start.h
+++ b/arch/arm/src/tiva/tiva_start.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_start.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_sysctrl.h
+++ b/arch/arm/src/tiva/tiva_sysctrl.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_sysctrl.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_timer.h
+++ b/arch/arm/src/tiva/tiva_timer.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_timer.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tiva_userspace.h
+++ b/arch/arm/src/tiva/tiva_userspace.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tiva_userspace.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tm4c/tm4c129_sysctrl.c
+++ b/arch/arm/src/tiva/tm4c/tm4c129_sysctrl.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tm4c/tm4c129_sysctrl.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tm4c/tm4c_ethernet.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tm4c/tm4c_gpio.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tm4c/tm4c_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tiva/tm4c/tm4c_gpio.h
+++ b/arch/arm/src/tiva/tm4c/tm4c_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tiva/tm4c/tm4c_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/Make.defs
+++ b/arch/arm/src/tlsr82/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/tlsr82/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/tlsr82/Toolchain.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/chip.h
+++ b/arch/arm/src/tlsr82/chip.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/chip.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S
+++ b/arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_adc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_adc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_aes.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_aes.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_aes.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_analog.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_analog.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_analog.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_clock.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_clock.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_clock.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_dma.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_dma.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_dma.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_gpio.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_irq.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_irq.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_irq.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_mspi.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_mspi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_mspi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_pwm.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_pwm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_pwm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_register.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_register.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_register.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_spi.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_spi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_spi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_timer.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_timer.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_timer.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/hardware/tlsr82_uart.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_uart.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/hardware/tlsr82_uart.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/Make.defs
+++ b/arch/arm/src/tlsr82/tc32/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/tlsr82/tc32/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/div_mod.S
+++ b/arch/arm/src/tlsr82/tc32/div_mod.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/div_mod.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32.h
+++ b/arch/arm/src/tlsr82/tc32/tc32.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_backtrace.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_doirq.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_doirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_doirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_exception.S
+++ b/arch/arm/src/tlsr82/tc32/tc32_exception.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_exception.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_fullcontextrestore.S
+++ b/arch/arm/src/tlsr82/tc32/tc32_fullcontextrestore.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_fullcontextrestore.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_initialstate.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_initialstate.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_initialstate.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_saveusercontext.S
+++ b/arch/arm/src/tlsr82/tc32/tc32_saveusercontext.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_saveusercontext.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_switchcontext.S
+++ b/arch/arm/src/tlsr82/tc32/tc32_switchcontext.S
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_switchcontext.S
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_syscall.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_syscall.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_syscall.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tc32/tc32_udelay.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_udelay.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tc32/tc32_udelay.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_adc.c
+++ b/arch/arm/src/tlsr82/tlsr82_adc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_adc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/tlsr82_adc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_adc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_aes.c
+++ b/arch/arm/src/tlsr82/tlsr82_aes.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_aes.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_analog.c
+++ b/arch/arm/src/tlsr82/tlsr82_analog.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_analog.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_analog.h
+++ b/arch/arm/src/tlsr82/tlsr82_analog.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_analog.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_clock.c
+++ b/arch/arm/src/tlsr82/tlsr82_clock.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_clock.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_clock.h
+++ b/arch/arm/src/tlsr82/tlsr82_clock.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_clock.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_cpu.c
+++ b/arch/arm/src/tlsr82/tlsr82_cpu.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_cpu.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_cpu.h
+++ b/arch/arm/src/tlsr82/tlsr82_cpu.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_cpu.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_flash.c
+++ b/arch/arm/src/tlsr82/tlsr82_flash.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_flash.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_flash.h
+++ b/arch/arm/src/tlsr82/tlsr82_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_flash_mtd.c
+++ b/arch/arm/src/tlsr82/tlsr82_flash_mtd.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_flash_mtd.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_flash_mtd.h
+++ b/arch/arm/src/tlsr82/tlsr82_flash_mtd.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_flash_mtd.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_gpio.c
+++ b/arch/arm/src/tlsr82/tlsr82_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_gpio.h
+++ b/arch/arm/src/tlsr82/tlsr82_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_gpio_cfg.c
+++ b/arch/arm/src/tlsr82/tlsr82_gpio_cfg.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_gpio_cfg.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_gpio_cfg.h
+++ b/arch/arm/src/tlsr82/tlsr82_gpio_cfg.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_gpio_cfg.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_gpio_default.h
+++ b/arch/arm/src/tlsr82/tlsr82_gpio_default.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_gpio_default.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_irq.c
+++ b/arch/arm/src/tlsr82/tlsr82_irq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_irq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_mspi.c
+++ b/arch/arm/src/tlsr82/tlsr82_mspi.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_mspi.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_mspi.h
+++ b/arch/arm/src/tlsr82/tlsr82_mspi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_mspi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_pwm.c
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_pwm.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_pwm.h
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_pwm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_serial.c
+++ b/arch/arm/src/tlsr82/tlsr82_serial.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_serial.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_serial.h
+++ b/arch/arm/src/tlsr82/tlsr82_serial.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_serial.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_spi_console.c
+++ b/arch/arm/src/tlsr82/tlsr82_spi_console.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_spi_console.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_spi_console.h
+++ b/arch/arm/src/tlsr82/tlsr82_spi_console.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_spi_console.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_start.c
+++ b/arch/arm/src/tlsr82/tlsr82_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_timer.c
+++ b/arch/arm/src/tlsr82/tlsr82_timer.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_timer.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_timer.h
+++ b/arch/arm/src/tlsr82/tlsr82_timer.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_timer.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_timer_isr.c
+++ b/arch/arm/src/tlsr82/tlsr82_timer_isr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_timer_isr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.c
+++ b/arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this args for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.h
+++ b/arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_watchdog.c
+++ b/arch/arm/src/tlsr82/tlsr82_watchdog.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_watchdog.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tlsr82/tlsr82_watchdog.h
+++ b/arch/arm/src/tlsr82/tlsr82_watchdog.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tlsr82/tlsr82_watchdog.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/CMakeLists.txt
+++ b/arch/arm/src/tms570/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # arch/arm/src/tms570/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/tms570/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/chip.h
+++ b/arch/arm/src/tms570/chip.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/chip.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_esm.h
+++ b/arch/arm/src/tms570/hardware/tms570_esm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_esm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_flash.h
+++ b/arch/arm/src/tms570/hardware/tms570_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_gio.h
+++ b/arch/arm/src/tms570/hardware/tms570_gio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_gio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_iomm.h
+++ b/arch/arm/src/tms570/hardware/tms570_iomm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_iomm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_memorymap.h
+++ b/arch/arm/src/tms570/hardware/tms570_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_pbist.h
+++ b/arch/arm/src/tms570/hardware/tms570_pbist.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_pbist.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_pcr.h
+++ b/arch/arm/src/tms570/hardware/tms570_pcr.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_pcr.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_pinmux.h
+++ b/arch/arm/src/tms570/hardware/tms570_pinmux.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_pinmux.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_rti.h
+++ b/arch/arm/src/tms570/hardware/tms570_rti.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_rti.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_sci.h
+++ b/arch/arm/src/tms570/hardware/tms570_sci.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_sci.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_sys.h
+++ b/arch/arm/src/tms570/hardware/tms570_sys.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_sys.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_sys2.h
+++ b/arch/arm/src/tms570/hardware/tms570_sys2.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_sys2.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570_vim.h
+++ b/arch/arm/src/tms570/hardware/tms570_vim.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570_vim.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570ls04x03x_memorymap.h
+++ b/arch/arm/src/tms570/hardware/tms570ls04x03x_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570ls04x03x_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/hardware/tms570ls04x03x_pinmux.h
+++ b/arch/arm/src/tms570/hardware/tms570ls04x03x_pinmux.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/hardware/tms570ls04x03x_pinmux.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_boot.c
+++ b/arch/arm/src/tms570/tms570_boot.c
@@ -1,15 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_boot.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * This is primarily original code.  However, some logic in this file was
- * inspired/leveraged from TI's Project0 which has a compatible BSD license
- * and credit should be given in any case:
- *
- *   Copyright (c) 2012, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tms570/tms570_boot.h
+++ b/arch/arm/src/tms570/tms570_boot.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_boot.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_clockconfig.c
+++ b/arch/arm/src/tms570/tms570_clockconfig.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_clockconfig.c
  *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Some logic in this file was inspired/leveraged from TI's Project0 which
- * has a compatible BSD license:
- *
- *   Copyright (c) 2012, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015,2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tms570/tms570_clockconfig.h
+++ b/arch/arm/src/tms570/tms570_clockconfig.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_clockconfig.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_esm.c
+++ b/arch/arm/src/tms570/tms570_esm.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_esm.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from the TI "Project0" sample code which has a compatible 3-
- * clause BSD license:
- *
- * Copyright (c) 2012, Texas Instruments Incorporated
- * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tms570/tms570_esm.h
+++ b/arch/arm/src/tms570/tms570_esm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_esm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_gio.c
+++ b/arch/arm/src/tms570/tms570_gio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_gio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_gio.h
+++ b/arch/arm/src/tms570/tms570_gio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_gio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_gioirq.c
+++ b/arch/arm/src/tms570/tms570_gioirq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_gioirq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_irq.c
+++ b/arch/arm/src/tms570/tms570_irq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_irq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_irq.h
+++ b/arch/arm/src/tms570/tms570_irq.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_irq.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_lowputc.c
+++ b/arch/arm/src/tms570/tms570_lowputc.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_lowputc.c
  *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Includes some logic from TI sample which has a compatible three-clause
- * BSD license and:
- *
- *   Copyright (c) 2012, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015,2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tms570/tms570_lowputc.h
+++ b/arch/arm/src/tms570/tms570_lowputc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_lowputc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_selftest.c
+++ b/arch/arm/src/tms570/tms570_selftest.c
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_selftest.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Most logic in this file was leveraged from TI's Project0 which has a
- * compatible BSD license:
- *
- *   Copyright (c) 2012, Texas Instruments Incorporated
- *   All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 Texas Instruments Incorporated
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/tms570/tms570_selftest.h
+++ b/arch/arm/src/tms570/tms570_selftest.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_selftest.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_serial.c
+++ b/arch/arm/src/tms570/tms570_serial.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_serial.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/tms570/tms570_timerisr.c
+++ b/arch/arm/src/tms570/tms570_timerisr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/tms570/tms570_timerisr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/CMakeLists.txt
+++ b/arch/arm/src/xmc4/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # arch/arm/src/xmc4/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # arch/arm/src/xmc4/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/chip.h
+++ b/arch/arm/src/xmc4/chip.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/chip.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/hardware/xmc4_eru_pinmap.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_eru_pinmap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_eru_pinmap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/hardware/xmc4_pinmux.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_pinmux.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_pinmux.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/hardware/xmc4_posif.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_posif.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_posif.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/hardware/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_vadc.h
@@ -1,6 +1,8 @@
 /******************************************************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_vadc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_allocateheap.c
+++ b/arch/arm/src/xmc4/xmc4_allocateheap.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_allocateheap.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_ccu4.c
+++ b/arch/arm/src/xmc4/xmc4_ccu4.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_ccu4.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_ccu4.h
+++ b/arch/arm/src/xmc4/xmc4_ccu4.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_ccu4.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_clockconfig.h
+++ b/arch/arm/src/xmc4/xmc4_clockconfig.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_clockconfig.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_clrpend.c
+++ b/arch/arm/src/xmc4/xmc4_clrpend.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_clrpend.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_config.h
+++ b/arch/arm/src/xmc4/xmc4_config.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_config.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_dma.h
+++ b/arch/arm/src/xmc4/xmc4_dma.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_dma.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_ecat.c
+++ b/arch/arm/src/xmc4/xmc4_ecat.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_ecat.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_ecat.h
+++ b/arch/arm/src/xmc4/xmc4_ecat.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_ecat.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_flash.c
+++ b/arch/arm/src/xmc4/xmc4_flash.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_flash.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_flash.h
+++ b/arch/arm/src/xmc4/xmc4_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_gpio.c
+++ b/arch/arm/src/xmc4/xmc4_gpio.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_gpio.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_gpio.h
+++ b/arch/arm/src/xmc4/xmc4_gpio.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_gpio.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_i2c.c
+++ b/arch/arm/src/xmc4/xmc4_i2c.c
@@ -1,6 +1,8 @@
 /*****************************************************************************
  * arch/arm/src/xmc4/xmc4_i2c.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_i2c.h
+++ b/arch/arm/src/xmc4/xmc4_i2c.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_i2c.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_idle.c
+++ b/arch/arm/src/xmc4/xmc4_idle.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_idle.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_irq.c
+++ b/arch/arm/src/xmc4/xmc4_irq.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_irq.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_lowputc.c
+++ b/arch/arm/src/xmc4/xmc4_lowputc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_lowputc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_lowputc.h
+++ b/arch/arm/src/xmc4/xmc4_lowputc.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_lowputc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_mpuinit.c
+++ b/arch/arm/src/xmc4/xmc4_mpuinit.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_mpuinit.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_mpuinit.h
+++ b/arch/arm/src/xmc4/xmc4_mpuinit.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_mpuinit.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_pwm.c
+++ b/arch/arm/src/xmc4/xmc4_pwm.c
@@ -1,6 +1,8 @@
 /*****************************************************************************
  * arch/arm/src/xmc4/xmc4_pwm.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_pwm.h
+++ b/arch/arm/src/xmc4/xmc4_pwm.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_pwm.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_serial.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_spi.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_spi.h
+++ b/arch/arm/src/xmc4/xmc4_spi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_spi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_start.c
+++ b/arch/arm/src/xmc4/xmc4_start.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_start.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_start.h
+++ b/arch/arm/src/xmc4/xmc4_start.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_start.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_tickless.c
+++ b/arch/arm/src/xmc4/xmc4_tickless.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_tickless.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_timerisr.c
+++ b/arch/arm/src/xmc4/xmc4_timerisr.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_timerisr.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_userspace.c
+++ b/arch/arm/src/xmc4/xmc4_userspace.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_userspace.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_userspace.h
+++ b/arch/arm/src/xmc4/xmc4_userspace.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_userspace.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/xmc4/xmc4_usic.h
+++ b/arch/arm/src/xmc4/xmc4_usic.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_usic.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

## Impact
SBOM

## Testing

CI