### PR TITLE
xtensa/esp32: encrypted MTD for partition offset

### DIFF
--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -778,7 +778,7 @@ static int partition_get_offset(const char *label, size_t size)
   int partion_offset;
   const struct partition_info_priv *info;
   DEBUGASSERT(label != NULL);
-  struct mtd_dev_s *mtd = esp32_spiflash_get_mtd();
+  struct mtd_dev_s *mtd = esp32_spiflash_encrypt_get_mtd();
   if (!mtd)
     {
       ferr("ERROR: Failed to get SPI flash MTD\n");

--- a/arch/xtensa/src/esp32s3/esp32s3_partition.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_partition.c
@@ -648,7 +648,7 @@ static int partition_get_offset(const char *label, size_t size)
   int partion_offset;
   const struct partition_info_priv_s *info;
   DEBUGASSERT(label != NULL);
-  struct mtd_dev_s *mtd = esp32s3_spiflash_mtd();
+  struct mtd_dev_s *mtd = esp32s3_spiflash_encrypt_mtd();
   if (!mtd)
     {
       ferr("ERROR: Failed to get SPI flash MTD\n");


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Non-encrypted mtd can not be used for encrypted device.

Even without SPI Flash encryption,
encrypted MTD also can be used to read no-encrypted data.

## Impact

For non-encrypted device, the performance impact is slightly only for partiton offset.
The encrypted/non-encrypted read/write are still using encrypted/non-encrypted MTD.

## Testing

Same behavior as esp32_partition_init(...).
Tested by using os cases.