### PR TITLE
risc-v: Accelerate schedule by percpu

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -704,6 +704,29 @@ int up_cpu_index(void) noinstrument_function;
 #endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************
+ * Schedule acceleration macros
+ ****************************************************************************/
+
+/* If RISCV_PERCPU_SCRATCH is not enabled, we can use the scratch register
+ * to store the current task pointer.
+ */
+
+#ifndef CONFIG_RISCV_PERCPU_SCRATCH
+#define up_this_task() \
+  ({ \
+    struct tcb_s *t; \
+    t = (struct tcb_s *)READ_CSR(CSR_SCRATCH); \
+    t; \
+  })
+
+#define up_update_task(t) WRITE_CSR(CSR_SCRATCH, (uintptr_t)t)
+#else
+/* TODO: Implement up_this_task()/up_update_task() if RISCV_PERCPU_SCRATCH
+ * enabled.
+ */
+#endif
+
+/****************************************************************************
  * Name: up_this_cpu
  *
  * Description:

--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -37,6 +37,8 @@
 #include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
+#include <arch/irq.h>
+
 #include "sched/sched.h"
 #include "init/init.h"
 #include "riscv_internal.h"
@@ -69,6 +71,8 @@
 
 void riscv_cpu_boot(int cpu)
 {
+  struct tcb_s *tcb;
+
   /* Clear IPI for CPU(cpu) */
 
   riscv_ipi_clear(cpu);
@@ -100,8 +104,9 @@ void riscv_cpu_boot(int cpu)
 
   _info("CPU%d Started\n", this_cpu());
 
+  tcb = current_task(this_cpu());
+
 #ifdef CONFIG_STACK_COLORATION
-  struct tcb_s *tcb = this_task();
 
   /* If stack debug is enabled, then fill the stack with a
    * recognizable value that we can use later to test for high
@@ -110,6 +115,8 @@ void riscv_cpu_boot(int cpu)
 
   riscv_stack_color(tcb->stack_alloc_ptr, 0);
 #endif
+
+  up_update_task(tcb);
 
   /* TODO: Setup FPU */
 


### PR DESCRIPTION
## Summary

Fetch TCB info in percpu scratch register for better performance.

Similar to https://github.com/apache/nuttx/commit/948ac9b4cc4407120b671c5237dd7ff64b37e94e

## Impact

RISC-V arch level code

## Testing
ostest
