### PR TITLE
risc-v/mpfs: make cache clearing optional

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -54,6 +54,13 @@ config MPFS_CLKINIT
 		This initilizes the system clocks at mpfs_start.c file. The option may be also turned off
 		if some other entity has already set them up.
 
+config MPFS_L2_CLEAR
+	bool "Clear the L2 cache at boot"
+	depends on MPFS_BOOTLOADER
+	default y
+	---help---
+		L2 should be zero-initialized on the first boot so that the ECC will be happy.
+
 config MPFS_BOARD_PMP
 	bool "Enable board specific PMP configuration"
 	depends on ARCH_USE_MPU && MPFS_BOOTLOADER

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -181,6 +181,7 @@ __start:
 
 .continue_boot:
 
+#ifdef CONFIG_MPFS_L2_CLEAR
   /* L2 needs to be zeroed before ECC (error correction) is enabled later. */
 
   la  a4, __l2lim_start
@@ -190,6 +191,7 @@ __start:
   sd   x0, 0(a4)
   add  a4, a4, 8
   blt  a4, a5, .clear_l2lim
+#endif /* CONFIG_MPFS_L2_CLEAR */
 #endif
 
   /* Set stack pointer to the idle thread stack */


### PR DESCRIPTION
L2 needs to be zeroed to make the ECC happy. However, if there's more than one bootloader in the chain, the cache doesn't need to be wiped every time. One time is enough. Thus, make this optional so that it's initialized only when really needed.

## Summary

L2 is well cleaned at the start. However, chaining NuttX OSs will cause the L2 being wiped too many times. Only one time is needed, so provide a compile flag that may be used to coordinate this effort.

## Impact

This concerns MPFS related bootloaders. However, by default, it's set on so no changes to existing systems unless manually turned off in the defconfig.

## Testing

mpfs/Polarfire derived product


