### PR TITLE
{bp-15077} fs/tmpfs: Skip any slash at the beginning of relpath

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -889,6 +889,14 @@ static int tmpfs_find_object(FAR struct tmpfs_s *fs,
        * relpath.
        */
 
+      /* Skip any slash. */
+
+      while (*segment == '/')
+        {
+          segment++;
+          len--;
+        }
+
       next_segment = memchr(segment, '/', len);
       if (next_segment)
         {


### PR DESCRIPTION
## Summary
`tmpfs_stat()` fails when relpath start with slash.

Log

  Host
    $ adb -s 1234 pull /tmp/subdir
    adb: warning: skipping special file '/tmp/subdir/uname' (mode = 0o0)
    /tmp/subdir/: 0 files pulled. 1 file skipped.

  Device
    state_process_list (411): stat failed </tmp/subdir//uname> -1 22

Ref: https://github.com/apache/nuttx/blame/master/libs/libc/stdlib/lib_realpath.c#L111

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

tmpfs

## Testing
Selftest with esp32s3-devkit:adb with TMPFS enabled.
NuttX CI
