### PR TITLE
Documentation: Remove CONFIG_ARMV7M_USEBASEPRI from code base

### DIFF
--- a/Documentation/guides/renode.rst
+++ b/Documentation/guides/renode.rst
@@ -7,19 +7,8 @@ framework dedicated for complex embedded systems.
 
 This page contains notes on running some of NuttX boards on Renode.
 
-ARM-v7m
-=======
-
-Renode doesn't correctly handle ``SVC`` instruction escalation to HardFault
-when ``PRIMASK=1`` which crashs NuttX in the first ``up_exit()`` call.
-We can work around this problem by enabling BASEPRI::
-
-  CONFIG_ARMV7M_USEBASEPRI=y
-
 stm32f4discovery
 ================
-
-``CONFIG_ARMV7M_USEBASEPRI=y`` must be set.
 
 Renode doesn't support CCM memory, so we have to disable it
 with ``CONFIG_MM_REGIONS=1``.
@@ -54,8 +43,6 @@ Doesn't work. No BASEPRI implementation for ``Cotex-M0`` in NuttX.
 
 nrf52840-dk
 ===========
-
-``CONFIG_ARMV7M_USEBASEPRI=y`` must be set.
 
 At default Renode uses UART with EasyDMA enabled (UARTE) which is not supported
 by Nuttx yet. We can get around this by creating our own machine description
@@ -101,7 +88,7 @@ Known issues:
 stm32f746g-disco
 ================
 
-``CONFIG_ARMV7M_USEBASEPRI=y`` and ``CONFIG_ARMV7M_BASEPRI_WAR=y`` must be set.
+``CONFIG_ARMV7M_BASEPRI_WAR=y`` must be set.
 
 Renode script::
 
@@ -130,8 +117,6 @@ Known issues:
 
 nucleo-h743zi
 =============
-
-``CONFIG_ARMV7M_USEBASEPRI=y`` must be set.
 
 Renode doesn't support ``PWR_CSR1_ACTVOSRDY`` bit so we have to disable
 it with ``CONFIG_STM32H7_PWR_IGNORE_ACTVOSRDY=y``.

--- a/Documentation/guides/zerolatencyinterrupts.rst
+++ b/Documentation/guides/zerolatencyinterrupts.rst
@@ -216,8 +216,6 @@ Configuration Options
 
 ``CONFIG_ARCH_HIPRI_INTERRUPT``
 
-If ``CONFIG_ARMV7M_USEBASEPRI`` is selected, then interrupts will be
-disabled by setting the *BASEPRI* register to
 ``NVIC_SYSH_DISABLE_PRIORITY`` so that most interrupts will not have
 execution priority. *SVCall* must have execution priority in all
 cases.

--- a/Documentation/platforms/arm/stm32f3/boards/stm32f3discovery/index.rst
+++ b/Documentation/platforms/arm/stm32f3/boards/stm32f3discovery/index.rst
@@ -109,8 +109,7 @@ Debugging
 If you are going to use a debugger, you should make sure that the following
 settings are selection in your configuration file::
 
-  CONFIG_DEBUG_SYMBOLS=y     : Enable debug symbols in the build
-  CONFIG_ARMV7M_USEBASEPRI=y : Use the BASEPRI register to disable interrupts
+  CONFIG_DEBUG_SYMBOLS=y : Enable debug symbols in the build
 
 STM32 ST-LINK Utility
 ---------------------

--- a/Documentation/platforms/arm/stm32l1/boards/stm32ldiscovery/index.rst
+++ b/Documentation/platforms/arm/stm32l1/boards/stm32ldiscovery/index.rst
@@ -225,8 +225,7 @@ Debugging
 If you are going to use a debugger, you should make sure that the following
 settings are selection in your configuration file::
 
-    CONFIG_DEBUG_SYMBOLS=y     : Enable debug symbols in the build
-    CONFIG_ARMV7M_USEBASEPRI=y : Use the BASEPRI register to disable interrupts
+    CONFIG_DEBUG_SYMBOLS=y : Enable debug symbols in the build
 
 STM32 ST-LINK Utility
 ---------------------


### PR DESCRIPTION
## Summary

since the basepri is always used without any configuration

## Impact

continue clean up from https://github.com/apache/nuttx/pull/15073

## Testing

ci

