### PR TITLE
arm/cxd56xx: Add g_ prefix to rtc spin lock

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -113,7 +113,7 @@ struct rtc_backup_s
  * Private Data
  ****************************************************************************/
 
-static spinlock_t lock = SP_UNLOCKED;
+static spinlock_t g_rtc_lock = SP_UNLOCKED;
 
 /* Callback to use when the alarm expires */
 
@@ -436,7 +436,7 @@ int up_rtc_settime(const struct timespec *tp)
   irqstate_t flags;
   uint64_t count;
 
-  flags = spin_lock_irqsave(&lock);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
 #ifdef RTC_DIRECT_CONTROL
   /* wait until previous write request is completed */
@@ -459,7 +459,7 @@ int up_rtc_settime(const struct timespec *tp)
   g_rtc_save->offset = (int64_t)count - (int64_t)cxd56_rtc_count();
 #endif
 
-  spin_unlock_irqrestore(&lock, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   rtc_dumptime(tp, "Setting time");
 
@@ -487,12 +487,12 @@ uint64_t cxd56_rtc_count(void)
    * 1st post -> 2nd pre, and should be operated in atomic.
    */
 
-  flags = spin_lock_irqsave(&lock);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   val = (uint64_t)getreg32(CXD56_RTC0_RTPOSTCNT) << 15;
   val |= getreg32(CXD56_RTC0_RTPRECNT);
 
-  spin_unlock_irqrestore(&lock, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return val;
 }
@@ -514,12 +514,12 @@ uint64_t cxd56_rtc_almcount(void)
   uint64_t val;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&lock);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   val = (uint64_t)getreg32(CXD56_RTC0_SETALMPOSTCNT(0)) << 15;
   val |= (getreg32(CXD56_RTC0_SETALMPRECNT(0)) & 0x7fff);
 
-  spin_unlock_irqrestore(&lock, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return val;
 }
@@ -561,7 +561,7 @@ int cxd56_rtc_setalarm(struct alm_setalarm_s *alminfo)
     {
       /* The set the alarm */
 
-      flags = spin_lock_irqsave(&lock);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       cbinfo->ac_cb  = alminfo->as_cb;
       cbinfo->ac_arg = alminfo->as_arg;
@@ -592,7 +592,7 @@ int cxd56_rtc_setalarm(struct alm_setalarm_s *alminfo)
 
       while (RTCREG_ALM_BUSY_MASK & getreg32(CXD56_RTC0_ALMOUTEN(id)));
 
-      spin_unlock_irqrestore(&lock, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
 
       rtc_dumptime(&alminfo->as_time, "New Alarm time");
       ret = OK;
@@ -634,7 +634,7 @@ int cxd56_rtc_cancelalarm(enum alm_id_e alarmid)
     {
       /* Unset the alarm */
 
-      flags = spin_lock_irqsave(&lock);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       cbinfo->ac_cb = NULL;
 
@@ -667,7 +667,7 @@ int cxd56_rtc_cancelalarm(enum alm_id_e alarmid)
           putreg32(mask, CXD56_RTC0_ALMCLR);
         }
 
-      spin_unlock_irqrestore(&lock, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
 
       ret = OK;
     }


### PR DESCRIPTION
## Summary

arm/cxd56xx: Add g_ prefix to rtc spin lock

continue work of a68b00206bb5205f2b8372867b49665cac54fd00

```
| commit a68b00206bb5205f2b8372867b49665cac54fd00
| Author: hujun5 <hujun5@xiaomi.com>
| Date:   Mon Dec 9 20:48:09 2024 +0800
|
|     cxd56_rtc.c: use small lock in arch/arm/src/cxd56xx/cxd56_rtc.c
|
|     reason:
|     We hope to remove all instances of spin_lock_irqsave(NULL).
|
|     Signed-off-by: hujun5 <hujun5@xiaomi.com>
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check