### PR TITLE
syslog: allow microsecond on user specific time format

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -170,8 +170,10 @@ config SYSLOG_TIMESTAMP_FORMAT
 
 config SYSLOG_TIMESTAMP_FORMAT_MICROSECOND
 	bool "Append microseconds after seconds"
-	default y
-	depends on SYSLOG_TIMESTAMP_FORMAT = "%d/%m/%y %H:%M:%S"
+	default y if SYSLOG_TIMESTAMP_FORMAT = "%d/%m/%y %H:%M:%S"
+	---help---
+		Append microseconds after seconds in syslog timestamp.
+		Suggest SYSLOG_TIMESTAMP_FORMAT end with %S.
 
 config SYSLOG_TIMESTAMP_BUFFER
 	int "Formatted timestamp buffer size"


### PR DESCRIPTION
## Summary
FORMAT_MICROSECOND depends on format is not required.
We shall remove the depend on, and allow open microsecond in syslog

## Impact
able to open SYSLOG_TIMESTAMP_FORMAT_MICROSECOND with user specific time format

## Testing
CI-test, local arm-v8m board.

