### PR TITLE
gcov.c: Add necessary instrumentation functions

### DIFF
--- a/libs/libbuiltin/libgcc/gcov.c
+++ b/libs/libbuiltin/libgcc/gcov.c
@@ -319,6 +319,10 @@ void __gcov_execve(void)
 {
 }
 
+void __gcov_execl(void)
+{
+}
+
 void __gcov_execv(void)
 {
 }


### PR DESCRIPTION
## Summary

(.text.ltp_interfaces_sem_unlink_2_2_main+0xd8): undefined reference to `__gcov_execlk'

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


