### PR TITLE
{bp-15091} build(CMAKE): fix pac sim elf ONLY in Linux platform

### DIFF
--- a/boards/sim/sim/sim/CMakeLists.txt
+++ b/boards/sim/sim/sim/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 add_subdirectory(src)
 
-if(NOT MSVC)
+if(CONFIG_HOST_LINUX)
   add_custom_target(
     nuttx_post_build
     DEPENDS nuttx


### PR DESCRIPTION
## Summary
avoid SIM compilation post build issues on other platforms

same fix for build with make
https://github.com/apache/nuttx/pull/14800

## Impact

RELEASE

## Testing

CI