### PR TITLE
[sensors]: Removed the unnecessary inclusion of spi header files

### DIFF
--- a/boards/arm/mx8mp/verdin-mx8mp/src/mx8mp_ina219.c
+++ b/boards/arm/mx8mp/verdin-mx8mp/src/mx8mp_ina219.c
@@ -31,7 +31,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/ina219.h>
 
 #include "mx8mp_i2c.h"

--- a/boards/arm/rp2040/common/src/rp2040_ina219.c
+++ b/boards/arm/rp2040/common/src/rp2040_ina219.c
@@ -45,7 +45,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/ina219.h>
 
 #include "rp2040_i2c.h"

--- a/boards/arm/stm32/common/src/stm32_apds9960.c
+++ b/boards/arm/stm32/common/src/stm32_apds9960.c
@@ -30,7 +30,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/apds9960.h>
 #include <arch/board/board.h>
 

--- a/boards/arm/stm32/common/src/stm32_ina219.c
+++ b/boards/arm/stm32/common/src/stm32_ina219.c
@@ -45,7 +45,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/ina219.h>
 
 #include "stm32.h"

--- a/boards/arm/stm32/common/src/stm32_veml6070.c
+++ b/boards/arm/stm32/common/src/stm32_veml6070.c
@@ -30,7 +30,6 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/veml6070.h>
 
 #include "stm32.h"

--- a/boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_apds9960.c
+++ b/boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_apds9960.c
@@ -30,7 +30,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/apds9960.h>
 #include <arch/board/board.h>
 

--- a/boards/xtensa/esp32/common/src/esp32_board_apds9960.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_apds9960.c
@@ -30,7 +30,6 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <nuttx/spi/spi.h>
 #include <nuttx/sensors/apds9960.h>
 #include <arch/board/board.h>
 


### PR DESCRIPTION
## Summary

- ina219
- apds9960
- veml6070

these sensors use i2c serial communication protocol


## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

Github

https://github.com/simbit18/nuttx_test_pr/actions/runs/12238181261


