### PR TITLE
{bp-15094} max32660_rtc: use small lock in arch/arm/src/max326xx/max32660/max32660 rtc

### DIFF
--- a/arch/arm/src/max326xx/max32660/max32660_rtc.c
+++ b/arch/arm/src/max326xx/max32660/max32660_rtc.c
@@ -80,6 +80,8 @@ static alm_callback_t g_alarmcb;
 static void *g_alarmarg;
 #endif
 
+static spinlock_t lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -459,7 +461,7 @@ int up_rtc_settime(const struct timespec *tp)
 
   /* Enable write access to RTC configuration registers */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&lock);
   max326_rtc_wrenable(true);
 
   /* We need to disable the RTC in order to write to the SEC and SSEC
@@ -483,7 +485,7 @@ int up_rtc_settime(const struct timespec *tp)
   max326_rtc_enable(true);
   max326_rtc_wrenable(false);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&lock, flags);
   return OK;
 }
 
@@ -522,7 +524,7 @@ int max326_rtc_setalarm(struct timespec *ts,
 
   /* Is there already something waiting on the ALARM? */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&lock);
   if (g_alarmcb == NULL)
     {
       /* Get the time as a fixed precision number.
@@ -617,7 +619,7 @@ int max326_rtc_setalarm(struct timespec *ts,
     }
 
 errout_with_lock:
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&lock, flags);
   return ret;
 }
 #endif
@@ -717,7 +719,7 @@ int max326_rtc_cancelalarm(void)
   uint32_t regval;
   int ret = -ENODATA;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&lock);
 
   if (g_alarmcb != NULL)
     {
@@ -745,7 +747,7 @@ int max326_rtc_cancelalarm(void)
       ret = OK;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&lock, flags);
   return ret;
 }
 #endif


### PR DESCRIPTION
## Summary
reason:
We hope to remove all instances of spin_lock_irqsave(NULL).

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

RELEASE

## Testing

CI
