### PR TITLE
binfmt/modlib: reduce size of binary_s if CONFIG_LIBC_MODLIB is disabled

### DIFF
--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -68,8 +68,14 @@ struct binary_s
 
   main_t entrypt;                      /* Entry point into a program module */
   FAR void *mapped;                    /* Memory-mapped, address space */
+
+#ifdef CONFIG_LIBC_MODLIB
   struct module_s mod;                 /* Module context */
+#endif
+
+#ifdef CONFIG_PIC
   FAR void *picbase;                   /* Position-independent */
+#endif
 
 #ifdef CONFIG_ARCH_ADDRENV
   /* Address environment.


### PR DESCRIPTION
## Summary

binfmt/modlib: reduce size of binary_s if CONFIG_LIBC_MODLIB is disabled

Test on nsh/sim

before:
sizeof(struct binary_s): 216

after:
sizeof(struct binary_s): 56(-160)

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

nsh/sim