### PR TITLE
{bp-15120} libc/chdir: chdir/fchdir should not depend on environment variables

### DIFF
--- a/libs/libc/unistd/CMakeLists.txt
+++ b/libs/libc/unistd/CMakeLists.txt
@@ -66,7 +66,9 @@ set(SRCS
     lib_getpgid.c
     lib_lockf.c
     lib_flock.c
-    lib_getpass.c)
+    lib_getpass.c
+    lib_chdir.c
+    lib_fchdir.c)
 
 if(NOT CONFIG_SCHED_USER_IDENTITY)
   list(
@@ -83,7 +85,7 @@ if(NOT CONFIG_SCHED_USER_IDENTITY)
 endif()
 
 if(NOT CONFIG_DISABLE_ENVIRON)
-  list(APPEND SRCS lib_chdir.c lib_fchdir.c lib_restoredir.c)
+  list(APPEND SRCS lib_restoredir.c)
 endif()
 
 if(CONFIG_LIBC_EXECFUNCS)

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -33,6 +33,7 @@ CSRCS += lib_futimes.c lib_lutimes.c lib_gethostname.c lib_sethostname.c
 CSRCS += lib_fchownat.c lib_linkat.c lib_readlinkat.c lib_symlinkat.c
 CSRCS += lib_unlinkat.c lib_usleep.c lib_getpgrp.c lib_getpgid.c
 CSRCS += lib_lockf.c lib_flock.c lib_getpass.c
+CSRCS += lib_chdir.c lib_fchdir.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c
@@ -40,7 +41,7 @@ CSRCS += lib_seteuid.c lib_setegid.c lib_geteuid.c lib_getegid.c
 endif
 
 ifneq ($(CONFIG_DISABLE_ENVIRON),y)
-CSRCS += lib_chdir.c lib_fchdir.c lib_restoredir.c
+CSRCS += lib_restoredir.c
 endif
 
 ifeq ($(CONFIG_LIBC_EXECFUNCS),y)

--- a/libs/libc/unistd/lib_chdir.c
+++ b/libs/libc/unistd/lib_chdir.c
@@ -33,8 +33,6 @@
 
 #include "libc.h"
 
-#ifndef CONFIG_DISABLE_ENVIRON
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -74,9 +72,11 @@
 
 int chdir(FAR const char *path)
 {
-  struct stat buf;
+#ifndef CONFIG_DISABLE_ENVIRON
   FAR char *oldpwd;
+#endif /* !CONFIG_DISABLE_ENVIRON */
   FAR char *abspath;
+  struct stat buf;
   int ret;
 
   /* Verify that 'path' refers to a directory */
@@ -105,6 +105,8 @@ int chdir(FAR const char *path)
       return ERROR;
     }
 
+#ifndef CONFIG_DISABLE_ENVIRON
+
   /* Replace any preceding OLDPWD with the current PWD (this is to
    * support 'cd -' in NSH)
    */
@@ -120,8 +122,9 @@ int chdir(FAR const char *path)
   /* Set the cwd to the input 'path' */
 
   ret = setenv("PWD", abspath, TRUE);
+#endif /* !CONFIG_DISABLE_ENVIRON */
+
   lib_free(abspath);
 
   return ret;
 }
-#endif /* !CONFIG_DISABLE_ENVIRON */

--- a/libs/libc/unistd/lib_fchdir.c
+++ b/libs/libc/unistd/lib_fchdir.c
@@ -32,8 +32,6 @@
 #include <unistd.h>
 #include <nuttx/lib/lib.h>
 
-#ifndef CONFIG_DISABLE_ENVIRON
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -89,5 +87,3 @@ int fchdir(int fd)
   lib_put_pathbuffer(path);
   return ret;
 }
-
-#endif /* !CONFIG_DISABLE_ENVIRON */


### PR DESCRIPTION
## Summary
This PR will still allow basic shell operations such as cd/ls/pwd to be used even when the environment is disabled.

## Impact

RELEASE

## Testing

CI
