### PR TITLE
{bp-15118} net/tcp_timer: fix tcp RTO abnormally large after retransmission occurs

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -599,7 +599,8 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
               /* Exponential backoff. */
 
-              conn->timer = TCP_RTO << (conn->nrtx > 4 ? 4: conn->nrtx);
+              conn->rto = TCP_RTO << (conn->nrtx > 4 ? 4: conn->nrtx);
+              tcp_update_retrantimer(conn, conn->rto);
               conn->nrtx++;
 
               /* Ok, so we need to retransmit. We do this differently


### PR DESCRIPTION
## Summary

when tcp retransmission only double conn->timer in Karn(tcp_timer.c L602), after retransmission in Jacobson M is is now rtt test will become a negative value.
```
  signed char m;
  m = conn->rto - conn->timer; // M is now rtt test

  /* This is taken directly from VJs original code in his paper */

  m = m - (conn->sa >> 3);
  conn->sa += m;              //conn->sa is a negative value
  if (m < 0)
	{
	  m = -m;
	}

  m = m - (conn->sv >> 2);
  conn->sv += m;
  conn->rto = (conn->sa >> 3) + conn->sv; //rto
```
For example,we lost one ack packet, we will set conn->timer = 6 by backoff，conn->rto still 3. After retransmission we will Do RTT estimation, then will get
```
conn->sa = 253
conn->rto = 46
```
Then if any packets lost it will wait for a long time before triggering a retransmission.

Test method.
We can reproduce this issue by adding drop ACK packets in tcp_input, and debug conn->rto after Jacobson.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

RELEASE

## Testing

CI