### PR TITLE
sched/clock: call up_timer_gettime() to get higher resolution

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -334,10 +334,6 @@ extern "C"
 
 #ifdef __HAVE_KERNEL_GLOBALS
 EXTERN volatile clock_t g_system_ticks;
-
-#  ifndef CONFIG_SYSTEM_TIME64
-#    define clock_systime_ticks() g_system_ticks
-#  endif
 #endif
 
 /****************************************************************************
@@ -695,9 +691,7 @@ void clock_resynchronize(FAR struct timespec *rtc_diff);
  *
  ****************************************************************************/
 
-#if !defined(__HAVE_KERNEL_GLOBALS) || defined(CONFIG_SYSTEM_TIME64)
 clock_t clock_systime_ticks(void);
-#endif
 
 /****************************************************************************
  * Name: clock_systime_timespec

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -56,7 +56,7 @@
  * Public Data
  ****************************************************************************/
 
-#if !defined(CONFIG_SCHED_TICKLESS) && !defined(__HAVE_KERNEL_GLOBALS)
+#if !defined(__HAVE_KERNEL_GLOBALS)
   /* The system clock exists (CONFIG_SCHED_TICKLESS), but it not prototyped
    * globally in include/nuttx/clock.h.
    */

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -85,19 +85,13 @@ clock_t clock_systime_ticks(void)
 
   clock_systime_timespec(&ts);
   return clock_time2ticks(&ts);
-#elif defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
+#elif defined(CONFIG_ALARM_ARCH) || \
+      defined(CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_SCHED_TICKLESS)
   clock_t ticks = 0;
 
   up_timer_gettick(&ticks);
   return ticks;
-#elif defined(CONFIG_SCHED_TICKLESS)
-  struct timespec ts =
-    {
-      0
-    };
-
-  up_timer_gettime(&ts);
-  return clock_time2ticks(&ts);
 #elif defined(CONFIG_SYSTEM_TIME64)
   clock_t sample;
   clock_t verify;

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -77,12 +77,9 @@ int clock_systime_timespec(FAR struct timespec *ts)
       ts->tv_sec = 0;
       ts->tv_nsec = 0;
     }
-#elif defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
-  clock_t ticks = 0;
-
-  up_timer_gettick(&ticks);
-  clock_ticks2time(ts, ticks);
-#elif defined(CONFIG_SCHED_TICKLESS)
+#elif defined(CONFIG_ALARM_ARCH) || \
+      defined(CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_SCHED_TICKLESS)
   up_timer_gettime(ts);
 #else
   clock_ticks2time(ts, g_system_ticks);


### PR DESCRIPTION

## Summary

This is continue work of https://github.com/apache/nuttx/pull/15038

sched/clock: call up_timer_gettime() to get higher resolution
driver/timers: remove wall clock diff from lower half
Some SOC chipsets use global clock generator to unify the time of each MCU,
that means after MCUs is start-up, the timer will not start counting from 0.
this PR will record the wall timer of global timer and recalculate the ticks.

Impact
N/A

Testing
ci-check


