### PR TITLE
xtensa/esp32s3: Update the reserved size for struct __lock

### DIFF
--- a/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
+++ b/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
@@ -43,12 +43,12 @@ struct __lock
 {
 #ifdef CONFIG_PRIORITY_INHERITANCE
 #  if CONFIG_SEM_PREALLOCHOLDERS > 0
-  int reserved[5];
+  int reserved[6];
 #  else
-  int reserved[8];
+  int reserved[9];
 #  endif
 #else
-  int reserved[4];
+  int reserved[5];
 #endif
 };
 


### PR DESCRIPTION
## Summary

* xtensa/esp32s3: Update the reserved size for struct __lock

After https://github.com/apache/nuttx/pull/15075, the static assertion at `nuttx/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c` was being triggered when building any of the ESP32-S3's defconfigs. This PR updates the reserved size to reflect the changes recently introduced.

## Impact

Fix building any of the ESP32-S3's defconfigs and closes https://github.com/apache/nuttx/issues/15137

## Testing

Internal CI testing + NuttX's upstream CI.