### PR TITLE
arch/arm64/imx9: Fix usdhc dma receive

### DIFF
--- a/arch/arm64/src/imx9/imx9_usdhc.c
+++ b/arch/arm64/src/imx9/imx9_usdhc.c
@@ -1069,6 +1069,8 @@ static void imx9_recvdma(struct imx9_dev_s *priv)
     {
       /* In an aligned case, we have always received all blocks */
 
+      up_invalidate_dcache((uintptr_t)priv->buffer,
+                           (uintptr_t)priv->buffer + priv->remaining);
       priv->remaining = 0;
     }
 


### PR DESCRIPTION
Invalidate cache when dma transfer is ready

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Read operation gives sometimes invalid data, this fixes that issue

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


