### PR TITLE
[ci] macOS platforms: added LLVM toolchain for Arm

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -37,6 +37,24 @@ add_path() {
   PATH=$1:${PATH}
 }
 
+arm_clang_toolchain() {
+  add_path "${NUTTXTOOLS}"/clang-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/clang-arm-none-eabi/bin/clang" ]; then
+    local basefile
+    basefile=LLVMEmbeddedToolchainForArm-17.0.1-Darwin
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM clang toolchain prebuilt by ARM
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/${basefile}.dmg
+    sudo hdiutil attach ${basefile}.dmg
+    sudo cp -R /Volumes/${basefile}/${basefile} "${NUTTXTOOLS}"/${basefile}
+    sudo mv ${basefile} clang-arm-none-eabi
+    rm ${basefile}.dmg
+  fi
+
+  command clang --version
+}
+
 arm_gcc_toolchain() {
   add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
 
@@ -414,7 +432,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="ninja_brew autoconf_brew arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain xtensa_esp32s2_gcc_toolchain xtensa_esp32s3_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="ninja_brew autoconf_brew arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain xtensa_esp32s2_gcc_toolchain xtensa_esp32s3_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   mkdir -p "${NUTTXTOOLS}"/homebrew
   export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew

--- a/tools/ci/platforms/darwin_arm64.sh
+++ b/tools/ci/platforms/darwin_arm64.sh
@@ -37,6 +37,24 @@ add_path() {
   PATH=$1:${PATH}
 }
 
+arm_clang_toolchain() {
+  add_path "${NUTTXTOOLS}"/clang-arm-none-eabi/bin
+
+  if [ ! -f "${NUTTXTOOLS}/clang-arm-none-eabi/bin/clang" ]; then
+    local basefile
+    basefile=LLVM-ET-Arm-19.1.1-Darwin-universal
+    cd "${NUTTXTOOLS}"
+    # Download the latest ARM clang toolchain prebuilt by ARM
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-19.1.1/${basefile}.dmg
+    sudo hdiutil attach ${basefile}.dmg
+    sudo cp -R /Volumes/${basefile}/${basefile} "${NUTTXTOOLS}"/${basefile}
+    sudo mv ${basefile} clang-arm-none-eabi
+    rm ${basefile}.dmg
+  fi
+
+  command clang --version
+}
+
 arm_gcc_toolchain() {
   add_path "${NUTTXTOOLS}"/gcc-arm-none-eabi/bin
 
@@ -414,7 +432,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="ninja_brew autoconf_brew arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain xtensa_esp32s2_gcc_toolchain xtensa_esp32s3_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="ninja_brew autoconf_brew arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty elf_toolchain gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang zig xtensa_esp32_gcc_toolchain xtensa_esp32s2_gcc_toolchain xtensa_esp32s3_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
 
   mkdir -p "${NUTTXTOOLS}"/homebrew
   export HOMEBREW_CACHE=${NUTTXTOOLS}/homebrew


### PR DESCRIPTION
## Summary

added LLVM toolchain for Arm on Apple Intel
release-17.0.1

added LLVM toolchain for Arm on Apple Silicon
release-19.1.1


## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

github  [macOS-14,  macOS-13 (arm-08)]
https://github.com/simbit18/nuttx_test_pr/actions/runs/12277626847/job/34257527992

```
====================================================================================
Configuration/Tool: nucleo-f207zg/nsh,CONFIG_ARM_TOOLCHAIN_CLANG
2024-12-11 14:35:07
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_CLANG
  Building NuttX...
chip/stm32_gpio.c:43:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   43 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
  Normalize nucleo-f207zg/nsh
====================================================================================
```


