### PR TITLE
procfs:fix cmdline overflow bug

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -687,9 +687,9 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
 
   /* Show the task / thread argument list (skipping over the name) */
 
-  linesize   = nxtask_argvstr(tcb, procfile->line, remaining);
+  linesize   = nxtask_argvstr(tcb, procfile->line, sizeof(procfile->line));
   copysize   = procfs_memcpy(procfile->line, linesize, buffer,
-                             remaining, &offset);
+                             sizeof(procfile->line), &offset);
   totalsize += copysize;
   buffer    += copysize;
   remaining -= copysize;


### PR DESCRIPTION
## Summary
procfs:fix cmdline overflow bug
## Impact
procfs
## Testing

use a too long command, and us ps wiil crash, this pr fix it.


