### PR TITLE
sched/clock: cleanup g_system_ticks reference if arch timer is enabled

### DIFF
--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -75,7 +75,8 @@ extern struct timespec  g_basetime;
 int  clock_basetime(FAR struct timespec *tp);
 
 void clock_initialize(void);
-#ifndef CONFIG_SCHED_TICKLESS
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
 void clock_timer(void);
 #else
 #  define clock_timer()

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -49,12 +49,9 @@
  * Public Data
  ****************************************************************************/
 
-#ifndef CONFIG_SCHED_TICKLESS
-#ifdef CONFIG_SYSTEM_TIME64
-volatile uint64_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
-#else
-volatile uint32_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
-#endif
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
+volatile clock_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
 #endif
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
@@ -305,7 +302,9 @@ void clock_synchronize(FAR const struct timespec *tp)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_RTC) && !defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_CLOCK_TIMEKEEPING)
+#if defined(CONFIG_RTC) && !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_CLOCK_TIMEKEEPING) && !defined(CONFIG_ALARM_ARCH) && \
+    !defined(CONFIG_TIMER_ARCH)
 void clock_resynchronize(FAR struct timespec *rtc_diff)
 {
   struct timespec rtc_time;
@@ -393,7 +392,8 @@ skip:
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SCHED_TICKLESS
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
 void clock_timer(void)
 {
   /* Increment the per-tick system counter */


### PR DESCRIPTION
## Summary

sched/clock: cleanup g_system_ticks reference if arch timer is enabled

continue work of: https://github.com/apache/nuttx/pull/15139

Signed-off-by: chao an <anchao@lixiang.com>

## Impact

N/A

## Testing

ci-check