### PR TITLE
{bp-15143} xtensa/esp32s3: Update the reserved size for struct __lock

### DIFF
--- a/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
+++ b/arch/xtensa/src/common/espressif/platform_include/sys/lock.h
@@ -43,12 +43,12 @@ struct __lock
 {
 #ifdef CONFIG_PRIORITY_INHERITANCE
 #  if CONFIG_SEM_PREALLOCHOLDERS > 0
-  int reserved[5];
+  int reserved[6];
 #  else
-  int reserved[8];
+  int reserved[9];
 #  endif
 #else
-  int reserved[4];
+  int reserved[5];
 #endif
 };
 


### PR DESCRIPTION
## Summary
After https://github.com/apache/nuttx/pull/15075, the static assertion at `nuttx/arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c` was being triggered when building any of the ESP32-S3's defconfigs. This commit updates the reserved size to reflect the changes introduced by the related PR.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

RELEASE

## Testing

CI

