### PR TITLE
{bp-15144} arch/arm64/imx9: Fix usdhc dma receive

### DIFF
--- a/arch/arm64/src/imx9/imx9_usdhc.c
+++ b/arch/arm64/src/imx9/imx9_usdhc.c
@@ -1069,6 +1069,8 @@ static void imx9_recvdma(struct imx9_dev_s *priv)
     {
       /* In an aligned case, we have always received all blocks */
 
+      up_invalidate_dcache((uintptr_t)priv->buffer,
+                           (uintptr_t)priv->buffer + priv->remaining);
       priv->remaining = 0;
     }
 


### PR DESCRIPTION
## Summary
Invalidate cache when dma transfer is ready

## Impact

RELEASE

## Testing

CI