### PR TITLE
fs/shm/shmfs_alloc.c: Allocate zero-initialized memory in flat build

### DIFF
--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -51,24 +51,26 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
    * chunk in kernel heap
    */
 
-  object = fs_heap_zalloc(sizeof(struct shmfs_object_s));
+  size_t hdr_size = sizeof(struct shmfs_object_s);
+  size_t alloc_size = length;
+  size_t cachesize = up_get_dcache_linesize();
+
+  if (cachesize > 0)
+    {
+      hdr_size = ALIGN_UP(hdr_size, cachesize);
+      alloc_size = ALIGN_UP(alloc_size, cachesize);
+      object = fs_heap_memalign(cachesize, hdr_size + alloc_size);
+    }
+  else
+    {
+      object = fs_heap_malloc(hdr_size + alloc_size);
+    }
+
   if (object)
     {
-      size_t cachesize = up_get_dcache_linesize();
-      if (cachesize > 0)
-        {
-          object->paddr = fs_heap_memalign(cachesize,
-                                           ALIGN_UP(length, cachesize));
-        }
-      else
-        {
-          object->paddr = fs_heap_malloc(length);
-        }
-
-      if (object->paddr)
-        {
-           allocated = true;
-        }
+      memset(object, 0, hdr_size + alloc_size);
+      object->paddr = (void *)((uintptr_t)object + hdr_size);
+      allocated = true;
     }
 
 #elif defined(CONFIG_BUILD_PROTECTED)
@@ -76,23 +78,27 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
    * memory in user heap
    */
 
+  size_t alloc_size = length;
+
   object = fs_heap_zalloc(sizeof(struct shmfs_object_s));
   if (object)
     {
       size_t cachesize = up_get_dcache_linesize();
+
       if (cachesize > 0)
         {
-          object->paddr = kumm_memalign(cachesize,
-                                        ALIGN_UP(length, cachesize));
+          alloc_size = ALIGN_UP(alloc_size, cachesize);
+          object->paddr = kumm_memalign(cachesize, alloc_size);
         }
       else
         {
-          object->paddr = kumm_malloc(length);
+          object->paddr = kumm_malloc(alloc_size);
         }
 
       if (object->paddr)
         {
-           allocated = true;
+          memset(object->paddr, 0, alloc_size);
+          allocated = true;
         }
     }
 
@@ -152,9 +158,7 @@ void shmfs_free_object(FAR struct shmfs_object_s *object)
 {
   if (object)
     {
-#if defined(CONFIG_BUILD_FLAT)
-      fs_heap_free(object->paddr);
-#elif defined(CONFIG_BUILD_PROTECTED)
+#if defined(CONFIG_BUILD_PROTECTED)
       kumm_free(object->paddr);
 #elif defined(CONFIG_BUILD_KERNEL)
       size_t i;


### PR DESCRIPTION
POSIX requires that the shm objects are zero-initialized. This has been broken in some earlier commits (starting from 9af5fc5d09724a5d300bc07ce85b9ba5c01ffadd)

Also fix the flat build memory allocation to allocate both object data and payload in the same chunk (as the comment also suggests). This saves allocations and memory in a system with lots of shm objects.


## Summary

This PR fixes errors in applications, which run in "CONFIG_BUILD_FLAT", and assume that newly allocated shared memory is zero-initialized.

This also reduces memory consumption in smaller devices, when each shared memory object is allocated in a single chunk as originally.

The errors were introduced earlier when the SHM allocations were cache-line aligned.

## Impact

This corrects SHM allocation to return zero-initialized memory

## Testing

Tested on an MPFS board, using flat-mode build and several hundred shm objects allocated.


