### PR TITLE
risc-v: Move CSR register manipulation macros to csr.h

### DIFF
--- a/arch/risc-v/include/csr.h
+++ b/arch/risc-v/include/csr.h
@@ -736,6 +736,91 @@
 #define ISELECT_EIE62         0xfe
 #define ISELECT_EIE63         0xff
 
+#ifndef __ASSEMBLY__
+
+/* Read the value of a CSR register */
+
+#define READ_CSR(reg) \
+  ({ \
+     uintreg_t __regval; \
+     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(__regval)); \
+     __regval; \
+  })
+
+/* Read the value of a CSR register and set the specified bits */
+
+#define READ_AND_SET_CSR(reg, bits) \
+  ({ \
+     uintreg_t __regval; \
+     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(__regval) : "rK"(bits)); \
+     __regval; \
+  })
+
+/* Write a value to a CSR register */
+
+#define WRITE_CSR(reg, val) \
+  ({ \
+     __asm__ __volatile__("csrw " __STR(reg) ", %0" :: "rK"(val)); \
+  })
+
+/* Set the specified bits in a CSR register */
+
+#define SET_CSR(reg, bits) \
+  ({ \
+     __asm__ __volatile__("csrs " __STR(reg) ", %0" :: "rK"(bits)); \
+  })
+
+/* Clear the specified bits in a CSR register */
+
+#define CLEAR_CSR(reg, bits) \
+  ({ \
+     __asm__ __volatile__("csrc " __STR(reg) ", %0" :: "rK"(bits)); \
+  })
+
+/* Swap the value of a CSR register with the specified value */
+
+#define SWAP_CSR(reg, val) \
+  ({ \
+     uintptr_t regval; \
+     __asm__ __volatile__("csrrw %0, " __STR(reg) ", %1" : "=r"(regval) \
+                                                         : "rK"(val)); \
+     regval; \
+  })
+
+/* Write a value to an indirect CSR register */
+
+#define WRITE_INDIRECT_CSR_REG0(reg, val) \
+  ({ \
+     WRITE_CSR(CSR_ISELECT, reg); \
+     WRITE_CSR(CSR_IREG, val); \
+  })
+
+/* Read the value of an indirect CSR register */
+
+#define READ_INDIRECT_CSR_REG0(reg, val) \
+  ({ \
+     WRITE_CSR(CSR_ISELECT, reg); \
+     READ_CSR(CSR_IREG, val); \
+  })
+
+/* Set the specified bits in an indirect CSR register */
+
+#define SET_INDIRECT_CSR_REG0(reg, val) \
+  ({ \
+     WRITE_CSR(CSR_ISELECT, reg); \
+     SET_CSR(CSR_IREG, val); \
+  })
+
+/* Clear the specified bits in an indirect CSR register */
+
+#define CLEAR_INDIRECT_CSR_REG0(reg, val) \
+  ({ \
+     WRITE_CSR(CSR_ISELECT, reg); \
+     CLEAR_CSR(CSR_IREG, val); \
+  })
+
+#endif /* __ASSEMBLY__ */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -163,67 +163,6 @@ static inline void putreg64(uint64_t v, const volatile uintreg_t a)
   __asm__ __volatile__("sd %0, 0(%1)" : : "r" (v), "r" (a));
 }
 
-#define READ_CSR(reg) \
-  ({ \
-     uintreg_t __regval; \
-     __asm__ __volatile__("csrr %0, " __STR(reg) : "=r"(__regval)); \
-     __regval; \
-  })
-
-#define READ_AND_SET_CSR(reg, bits) \
-  ({ \
-     uintreg_t __regval; \
-     __asm__ __volatile__("csrrs %0, " __STR(reg) ", %1": "=r"(__regval) : "rK"(bits)); \
-     __regval; \
-  })
-
-#define WRITE_CSR(reg, val) \
-  ({ \
-     __asm__ __volatile__("csrw " __STR(reg) ", %0" :: "rK"(val)); \
-  })
-
-#define SET_CSR(reg, bits) \
-  ({ \
-     __asm__ __volatile__("csrs " __STR(reg) ", %0" :: "rK"(bits)); \
-  })
-
-#define CLEAR_CSR(reg, bits) \
-  ({ \
-     __asm__ __volatile__("csrc " __STR(reg) ", %0" :: "rK"(bits)); \
-  })
-
-#define SWAP_CSR(reg, val) \
-  ({ \
-     uintptr_t regval; \
-     __asm__ __volatile__("csrrw %0, " __STR(reg) ", %1" : "=r"(regval) \
-                                                         : "rK"(val)); \
-     regval; \
-  })
-
-#define WRITE_INDIRECT_CSR_REG0(reg, val) \
-  ({ \
-     WRITE_CSR(CSR_ISELECT, reg); \
-     WRITE_CSR(CSR_IREG, val); \
-  })
-
-#define READ_INDIRECT_CSR_REG0(reg, val) \
-  ({ \
-     WRITE_CSR(CSR_ISELECT, reg); \
-     READ_CSR(CSR_IREG, val); \
-  })
-
-#define SET_INDIRECT_CSR_REG0(reg, val) \
-  ({ \
-     WRITE_CSR(CSR_ISELECT, reg); \
-     SET_CSR(CSR_IREG, val); \
-  })
-
-#define CLEAR_INDIRECT_CSR_REG0(reg, val) \
-  ({ \
-     WRITE_CSR(CSR_ISELECT, reg); \
-     CLEAR_CSR(CSR_IREG, val); \
-  })
-
 #define riscv_append_pmp_region(a, b, s) \
   riscv_config_pmp_region(riscv_next_free_pmp_region(), a, b, s)
 


### PR DESCRIPTION


## Summary

This patch allow public arch level code use them, make it possible to access system register in common code, such as percpu.

## Impact

RISC-V Only
## Testing

GitHub CI and local machine

