### PR TITLE
arch: cxd56xx: Fix not restart after TX error

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_i2c.c
+++ b/arch/arm/src/cxd56xx/cxd56_i2c.c
@@ -667,6 +667,7 @@ static int cxd56_i2c_transfer(struct i2c_master_s *dev,
       if (priv->error != OK)
         {
           ret = priv->error;
+          wostop = 0;
           break;
         }
 


### PR DESCRIPTION
## Summary

Fix a bug that I2C driver can not transfer after TX abort error. It caused by remaining NO_STOP flag status.

refs #17381

## Impact

I2C bus devices with SPRESENSE

## Testing

Tested on SPRESENSE
