### PR TITLE
fs/fat/fs_fat32util.c: fix potential exception due to dividing zero during mounting when fat is corrupted

### DIFF
--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -213,6 +213,11 @@ static int fat_checkbootrecord(struct fat_mountpt_s *fs)
   /* Get the sectors per cluster */
 
   fs->fs_fatsecperclus = FBR_GETSECPERCLUS(fs->fs_buffer);
+  if (fs->fs_fatsecperclus == 0)
+    {
+      fwarn("WARNING: sectors per cluster cannot be 0\n");
+      return -EINVAL;
+    }
 
   /* Calculate the number of clusters */
 


### PR DESCRIPTION
## Summary

Some bytes in boot sector might be corrupted for some reason. When this happens, the Nuttx system will crash due to dividing zero. It is better to return a mounting error, instead of crashing the system.

```
nsh> mount -t vfat /dev/mmcsd1 /mnt
nsh> dd if=/dev/mmcsd1 of=/mnt/file bs=32 count=1
32bytes copied, 0 usec, 4294967295 KB/s
nsh> hexdump /mnt/file
/mnt/file at 00000000:
0000: eb 58 90 4e 55 54 54 58 20 20 20 00 02 20 20 00 .X.NUTTX   ..  .
0010: 02 00 00 00 00 f8 00 00 3f 00 ff 00 00 00 00 00 ........?.......
nsh> dd if=/dev/mmcsd1 of=/dev/mmcsd1 bs=1 count=1 skip=11 seek=13
1bytes copied, 0 usec, 4294967295 KB/s
nsh> dd if=/dev/mmcsd1 of=/mnt/file bs=32 count=1
32bytes copied, 0 usec, 4294967295 KB/s
nsh> hexdump /mnt/file
/mnt/file at 00000000:
0000: eb 58 90 4e 55 54 54 58 20 20 20 00 02 00 20 00 .X.NUTTX   ... .
0010: 02 00 00 00 00 f8 00 00 3f 00 ff 00 00 00 00 00 ........?.......
nsh> umount /mnt
nsh> mount -t vfat /dev/mmcsd1 /mnt
[CPU0] xtensa_user_panic: User Exception: EXCCAUSE=0006 task: nsh_main
[CPU0] _assert: Current Version: NuttX  12.4.0 fc53a57fe5 Dec 11 2024 17:10:38 xtensa
[CPU0] _assert: Assertion failed user panic: at file: common/xtensa_assert.c:187 task(CPU0): nsh_main process: nsh_main 0x42011554
```

## Impact

A check of fs_fatsecperclus' value when read from device driver is added. Return an error if it is zero.
When "sector per cluster" byte is corrupted to zero, mounting the FAT will end up in failure instead of system exception.

## Testing

```
(reboot)
nsh> mount -t vfat /dev/mmcsd1 /mnt
nsh: mount: mount failed: 22
```


