### PR TITLE
{bp-15151} sched/clock: cleanup g_system_ticks reference if arch timer is enabled

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -334,10 +334,6 @@ extern "C"
 
 #ifdef __HAVE_KERNEL_GLOBALS
 EXTERN volatile clock_t g_system_ticks;
-
-#  ifndef CONFIG_SYSTEM_TIME64
-#    define clock_systime_ticks() g_system_ticks
-#  endif
 #endif
 
 /****************************************************************************
@@ -695,9 +691,7 @@ void clock_resynchronize(FAR struct timespec *rtc_diff);
  *
  ****************************************************************************/
 
-#if !defined(__HAVE_KERNEL_GLOBALS) || defined(CONFIG_SYSTEM_TIME64)
 clock_t clock_systime_ticks(void);
-#endif
 
 /****************************************************************************
  * Name: clock_systime_timespec

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -56,7 +56,7 @@
  * Public Data
  ****************************************************************************/
 
-#if !defined(CONFIG_SCHED_TICKLESS) && !defined(__HAVE_KERNEL_GLOBALS)
+#if !defined(__HAVE_KERNEL_GLOBALS)
   /* The system clock exists (CONFIG_SCHED_TICKLESS), but it not prototyped
    * globally in include/nuttx/clock.h.
    */

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -75,7 +75,8 @@ extern struct timespec  g_basetime;
 int  clock_basetime(FAR struct timespec *tp);
 
 void clock_initialize(void);
-#ifndef CONFIG_SCHED_TICKLESS
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
 void clock_timer(void);
 #else
 #  define clock_timer()

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -49,12 +49,9 @@
  * Public Data
  ****************************************************************************/
 
-#ifndef CONFIG_SCHED_TICKLESS
-#ifdef CONFIG_SYSTEM_TIME64
-volatile uint64_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
-#else
-volatile uint32_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
-#endif
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
+volatile clock_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
 #endif
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
@@ -305,7 +302,9 @@ void clock_synchronize(FAR const struct timespec *tp)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_RTC) && !defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_CLOCK_TIMEKEEPING)
+#if defined(CONFIG_RTC) && !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_CLOCK_TIMEKEEPING) && !defined(CONFIG_ALARM_ARCH) && \
+    !defined(CONFIG_TIMER_ARCH)
 void clock_resynchronize(FAR struct timespec *rtc_diff)
 {
   struct timespec rtc_time;
@@ -393,7 +392,8 @@ skip:
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SCHED_TICKLESS
+#if !defined(CONFIG_SCHED_TICKLESS) && \
+    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
 void clock_timer(void)
 {
   /* Increment the per-tick system counter */

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -85,19 +85,13 @@ clock_t clock_systime_ticks(void)
 
   clock_systime_timespec(&ts);
   return clock_time2ticks(&ts);
-#elif defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
+#elif defined(CONFIG_ALARM_ARCH) || \
+      defined(CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_SCHED_TICKLESS)
   clock_t ticks = 0;
 
   up_timer_gettick(&ticks);
   return ticks;
-#elif defined(CONFIG_SCHED_TICKLESS)
-  struct timespec ts =
-    {
-      0
-    };
-
-  up_timer_gettime(&ts);
-  return clock_time2ticks(&ts);
 #elif defined(CONFIG_SYSTEM_TIME64)
   clock_t sample;
   clock_t verify;

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -77,12 +77,9 @@ int clock_systime_timespec(FAR struct timespec *ts)
       ts->tv_sec = 0;
       ts->tv_nsec = 0;
     }
-#elif defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
-  clock_t ticks = 0;
-
-  up_timer_gettick(&ticks);
-  clock_ticks2time(ts, ticks);
-#elif defined(CONFIG_SCHED_TICKLESS)
+#elif defined(CONFIG_ALARM_ARCH) || \
+      defined(CONFIG_TIMER_ARCH) || \
+      defined(CONFIG_SCHED_TICKLESS)
   up_timer_gettime(ts);
 #else
   clock_ticks2time(ts, g_system_ticks);


### PR DESCRIPTION
## Summary

sched/clock: cleanup g_system_ticks reference if arch timer is enabled

Included: 
https://github.com/apache/nuttx/pull/15139

## Impact

RELEASE

## Testing

CI
