### PR TITLE
{bp-15160} binfmt/exec: initialize binary_s to empty to avoid invaild access

### DIFF
--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -88,6 +88,7 @@ static int exec_internal(FAR const char *filename,
   struct binary_s sbin;
 
   bin = &sbin;
+  memset(bin, 0, sizeof(*bin));
 #else
 
   /* Allocate the load information */


### PR DESCRIPTION
## Summary

binfmt/exec: initialize binary_s to empty to avoid invaild access

Included 
https://github.com/apache/nuttx/pull/15124

## Impact

RELEASE

## Testing

CI
