### PR TITLE
tools/ci/platforms/darwin.sh: bump bloaty version

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -131,7 +131,8 @@ bloaty() {
     # Due to issues with latest MacOS versions use pinned commit.
     # https://github.com/google/bloaty/pull/326
     # https://github.com/google/bloaty/pull/347
-    git checkout 6b78e080efcb63fa4ef9d2c1f062e3d5bf158e94
+    # https://github.com/google/bloaty/pull/385
+    git checkout 8026607280ef139bc0ea806e88cfe4fd0af60bad
     mkdir -p "${NUTTXTOOLS}"/bloaty
     cmake -B build/bloaty -GNinja -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty
     cmake --build build/bloaty


### PR DESCRIPTION
## Summary

hopefully this can fix build failure on macos-13. (see below)

```
 [470/495] Linking CXX executable bloaty
FAILED: bloaty
: && /Applications/Xcode_15.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -W -Wall -Wno-sign-compare -fdiagnostics-color=always -O2 -g1 -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=13.7 -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/bloaty.dir/src/main.cc.o -o bloaty  liblibbloaty.a  third_party/protobuf/cmake/libprotoc.a  third_party/re2/libre2.a  third_party/capstone/libcapstone.a  /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/lib/libz.tbd  third_party/abseil-cpp/absl/strings/libabsl_strings.a  third_party/protobuf/cmake/libprotobuf.a  /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/lib/libz.tbd  third_party/abseil-cpp/absl/strings/libabsl_strings_internal.a  third_party/abseil-cpp/absl/base/libabsl_base.a  third_party/abseil-cpp/absl/base/libabsl_spinlock_wait.a  third_party/abseil-cpp/absl/numeric/libabsl_int128.a  third_party/abseil-cpp/absl/base/libabsl_throw_delegate.a  third_party/abseil-cpp/absl/types/libabsl_bad_optional_access.a  third_party/abseil-cpp/absl/base/libabsl_raw_logging_internal.a  third_party/abseil-cpp/absl/base/libabsl_log_severity.a && :
ld: Undefined symbols:
  absl::debugging_internal::Demangle(char const*, char*, int), referenced from:
      bloaty::ItaniumDemangle(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bloaty::DataSource) in liblibbloaty.a[2](bloaty.cc.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Impact

## Testing

i tested "cibuild.sh -i" with macOS 15.2, x86-64, Xcode 16.1.