### PR TITLE
lpuart: fix build errors for SINGLEWIRE and INVERT without SERIAL_TERMIOS

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -2465,9 +2465,12 @@ static int imxrt_interrupt(int irq, void *context, void *arg)
 
 static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
-#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT) || defined(CONFIG_SERIAL_TERMIOS)
+#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT)    || \
+    defined(CONFIG_SERIAL_TERMIOS)           || \
+    defined(CONFIG_IMXRT_LPUART_SINGLEWIRE ) || \
+    defined(CONFIG_IMXRT_LPUART_INVERT )
   struct inode *inode = filep->f_inode;
-  struct uart_dev_s *dev   = inode->i_private;
+  struct uart_dev_s *dev = inode->i_private;
   irqstate_t flags;
 #endif
   int ret   = OK;
@@ -2664,7 +2667,6 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSSINGLEWIRE:
       {
         uint32_t regval;
-        irqstate_t flags;
         struct imxrt_uart_s *priv = (struct imxrt_uart_s *)dev;
 
         flags  = spin_lock_irqsave(&priv->lock);
@@ -2712,7 +2714,6 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint32_t ctrl;
         uint32_t stat;
         uint32_t regval;
-        irqstate_t flags;
         struct imxrt_uart_s *priv = (struct imxrt_uart_s *)dev;
 
         flags  = spin_lock_irqsave(&priv->lock);

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -3327,9 +3327,12 @@ static int s32k3xx_interrupt(int irq, void *context, void *arg)
 
 static int s32k3xx_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
-#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT) || defined(CONFIG_SERIAL_TERMIOS)
+#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT)      || \
+    defined(CONFIG_SERIAL_TERMIOS)             || \
+    defined(CONFIG_S32K3XX_LPUART_SINGLEWIRE ) || \
+    defined(CONFIG_S32K3XX_LPUART_INVERT )
   struct inode *inode = filep->f_inode;
-  struct uart_dev_s *dev   = inode->i_private;
+  struct uart_dev_s *dev = inode->i_private;
   irqstate_t flags;
 #endif
   int ret   = OK;
@@ -3526,7 +3529,6 @@ static int s32k3xx_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSSINGLEWIRE:
       {
         uint32_t regval;
-        irqstate_t flags;
         struct s32k3xx_uart_s *priv = (struct s32k3xx_uart_s *)dev->priv;
 
         flags  = spin_lock_irqsave(&priv->lock);
@@ -3554,7 +3556,6 @@ static int s32k3xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint32_t ctrl;
         uint32_t stat;
         uint32_t regval;
-        irqstate_t flags;
         struct s32k3xx_uart_s *priv = (struct s32k3xx_uart_s *)dev->priv;
 
         flags  = spin_lock_irqsave(&priv->lock);

--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -1576,9 +1576,12 @@ static int imx9_interrupt(int irq, void *context, void *arg)
 
 static int imx9_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
-#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT) || defined(CONFIG_SERIAL_TERMIOS)
+#if defined(CONFIG_SERIAL_TIOCSERGSTRUCT)   || \
+    defined(CONFIG_SERIAL_TERMIOS)          || \
+    defined(CONFIG_IMX9_LPUART_SINGLEWIRE ) || \
+    defined(CONFIG_IMX9_LPUART_INVERT )
   struct inode *inode = filep->f_inode;
-  struct uart_dev_s *dev   = inode->i_private;
+  struct uart_dev_s *dev = inode->i_private;
   irqstate_t flags;
 #endif
   int ret   = OK;
@@ -1773,7 +1776,6 @@ static int imx9_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSSINGLEWIRE:
       {
         uint32_t regval;
-        irqstate_t flags;
         struct imx9_uart_s *priv = (struct imx9_uart_s *)dev;
 
         flags  = spin_lock_irqsave(NULL);
@@ -1801,7 +1803,6 @@ static int imx9_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint32_t ctrl;
         uint32_t stat;
         uint32_t regval;
-        irqstate_t flags;
         struct imx9_uart_s *priv = (struct imx9_uart_s *)dev;
 
         flags  = spin_lock_irqsave(NULL);


### PR DESCRIPTION
## Summary

The features CONFIG_IMXRT_LPUART_SINGLEWIRE and CONFIG_IMXRT_LPUART_INVERT will get build errors when CONFIG_SERIAL_TERMIOS or CONFIG_SERIAL_TIOCSERGSTRUCT are not enabled.

This happens because INVERT and SINGLEWIRE rely on variables that are only declared when TERMIOS or TIOCSERGSTRUCT are enabled.

Fixed by making those vars available in all cases.

## Impact

arm/imxrt, arm/s32k3xx, arm64/imx9

## Testing



