### PR TITLE
[cmake] windows native: fixed FAILED: System.map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ endif()
 # Generate system map using the compiler toolchain. Conventionally, the tool
 # which dump symbols are called nm, though, some compiler toolchain may have a
 # different name.
-if(NOT WIN32)
+if(NOT CMAKE_HOST_WIN32)
   add_custom_command(
     OUTPUT System.map
     COMMAND


### PR DESCRIPTION
## Summary

fixed

```
[1025/1027] Generating System.map
FAILED: System.map C:/nuttxgit/nuttx/build/System.map cmd.exe /C "cd /D C:\nuttxgit\nuttx\build && arm-none-eabi-nm nuttx | grep -v '(compiled)|($)|( [aUw] )|(..ng$)|(LASH[RL]DI)' | sort > System.map"
```

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
local 

```
C:\nuttxgit\nuttx>cmake -B build -DBOARD_CONFIG=nucleo-l152re:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.27.1
--   Ninja:  1.11.1
--   Board:  nucleo-l152re
--   Config: nsh
--   Appdir: C:/nuttxgit/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: C:/nuttxgit/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (10.3s)
-- Generating done (2.1s)
-- Build files have been written to: C:/nuttxgit/nuttx/build

C:\nuttxgit\nuttx>cmake --build build
[27/1026] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32/stm32_gpio.c.obj
C:/nuttxgit/nuttx/arch/arm/src/stm32/stm32_gpio.c:43:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   43 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1024/1026] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       56132 B       512 KB     10.71%
            sram:        3760 B        80 KB      4.59%
[1026/1026] Generating nuttx.bin

```

