### PR TITLE
{bp-15182} sensors: fix Make.defs for bmm150

### DIFF
--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -174,10 +174,6 @@ else
 endif
 endif
 
-ifeq ($(CONFIG_SENSORS_BMM150),y)
-  CSRCS += bmm150.c
-endif
-
 ifeq ($(CONFIG_SENSORS_BMP180),y)
   CSRCS += bmp180_base.c
 ifeq ($(CONFIG_SENSORS_BMP180_UORB),y)


### PR DESCRIPTION

## Summary

Build fails when enabling CONFIG_SENSORS_BMM150. This happens because "bmm150.c" is added to the CSRCS but that file does not exist.

Solved it by removing the part that adds bmm150.c. The driver is available in bmm150_uorb.c and that is correctly added to CSRCS on

[nuttx/drivers/sensors/Make.defs](https://github.com/apache/nuttx/blob/fce4f2b3ee849edeb224bf2815f8633df25edfc8/drivers/sensors/Make.defs#L299)

Line 299 in [fce4f2b](https://github.com/apache/nuttx/commit/fce4f2b3ee849edeb224bf2815f8633df25edfc8)
 CSRCS += bmm150_uorb.c

## Impact

RELEASE

## Testing

CI