### PR TITLE
{bp-15184} arm64/imx9: tpm: fix TPM_FILTER_CHXFVAL_MASK macro

### DIFF
--- a/arch/arm64/src/imx9/hardware/imx9_tpm.h
+++ b/arch/arm64/src/imx9/hardware/imx9_tpm.h
@@ -160,7 +160,7 @@
 
 /* FILTER */
 
-#define TPM_FILTER_CHXFVAL_MASK(ch)   (0xf << ((ch) * 4))) /* Channel filter value */
+#define TPM_FILTER_CHXFVAL_MASK(ch)   (0xf << ((ch) * 4)) /* Channel filter value */
 
 /* QDCTRL */
 


### PR DESCRIPTION
## Summary

Macro contains one closing bracket too much

## Impact

RELEASE

## Testing

CI
