### PR TITLE
{bp-15185} windows native: fixed FAILED: System.map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ endif()
 # Generate system map using the compiler toolchain. Conventionally, the tool
 # which dump symbols are called nm, though, some compiler toolchain may have a
 # different name.
-if(NOT WIN32)
+if(NOT CMAKE_HOST_WIN32)
   add_custom_command(
     OUTPUT System.map
     COMMAND


### PR DESCRIPTION
## Summary
fixed

[1025/1027] Generating System.map
FAILED: System.map C:/nuttxgit/nuttx/build/System.map cmd.exe /C "cd /D C:\nuttxgit\nuttx\build && arm-none-eabi-nm nuttx | grep -v '(compiled)|($)|( [aUw] )|(..ng$)|(LASH[RL]DI)' | sort > System.map"

## Impact

RELEASE

## Testing

CI