### PR TITLE
arm-m armv7a riscv32 :use cfi in irq asm function, make a debug frame

### DIFF
--- a/arch/arm/src/armv6-m/arm_exception.S
+++ b/arch/arm/src/armv6-m/arm_exception.S
@@ -85,7 +85,8 @@
 	.syntax	unified
 	.type	exception_common, function
 exception_common:
-
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 	/* Complete the context save */
 
 	/* Get the current stack pointer.  The EXC_RETURN value tells us whether
@@ -162,7 +163,11 @@ exception_common:
 	isb		sy
 3:
 #endif
-
+	mov		fp,	r1
+	.cfi_def_cfa	fp,	0				/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_doirq				/* R0=IRQ, R1=register save area on stack */
 
 	/* On return from arm_doirq, R0 will hold a pointer to register context
@@ -215,7 +220,7 @@ exception_common:
 	 */
 
 	bx		r14					/* And return */
-
+	.cfi_endproc
 	.size	exception_common, .-exception_common
 
 /****************************************************************************

--- a/arch/arm/src/armv7-a/arm_vectors.S
+++ b/arch/arm/src/armv7-a/arm_vectors.S
@@ -173,6 +173,8 @@
 	.type	arm_vectorirq, %function
 
 arm_vectorirq:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 
 	/* Save the LR and SPSR onto the SYS mode stack before switch. */
 
@@ -234,6 +236,11 @@ arm_vectorirq:
 #endif
 
 	bic		sp, sp, #7			/* Force 8-byte alignment */
+	mov		fp,	r0
+	.cfi_def_cfa	fp,	0			/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_decodeirq			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
 
@@ -267,6 +274,7 @@ arm_vectorirq:
 .Lirqstacktop:
 	.word	g_intstacktop
 #endif
+	.cfi_endproc
 	.size	arm_vectorirq, . - arm_vectorirq
 
 	.align	5
@@ -394,6 +402,8 @@ arm_vectorsvc:
 	.type	arm_vectordata, %function
 
 arm_vectordata:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 
 	/* Save the LR and SPSR onto the SYS mode stack before switch. */
 
@@ -437,6 +447,11 @@ arm_vectordata:
 	mrc		CP15_DFSR(r2)			/* Get r2=DFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
+	mov		fp,	r0
+	.cfi_def_cfa	fp,	0			/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_dataabort			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
 
@@ -465,6 +480,7 @@ arm_vectordata:
 	/* Restore the CPSR, SYS mode registers and return. */
 
 	rfeia		r14
+	.cfi_endproc
 	.size	arm_vectordata, . - arm_vectordata
 
 	.align	5
@@ -485,6 +501,8 @@ arm_vectordata:
 	.type	arm_vectorprefetch, %function
 
 arm_vectorprefetch:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 
 	/* Save the LR and SPSR onto the SYS mode stack before switch. */
 
@@ -522,6 +540,11 @@ arm_vectorprefetch:
 	mrc		CP15_IFSR(r2)			/* Get r2=IFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
+	mov		fp,	r0
+	.cfi_def_cfa	fp,	0			/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_prefetchabort		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
 
@@ -550,6 +573,7 @@ arm_vectorprefetch:
 	/* Restore the CPSR, SYS mode registers and return. */
 
 	rfeia		r14
+	.cfi_endproc
 	.size	arm_vectorprefetch, . - arm_vectorprefetch
 
 	.align	5
@@ -568,7 +592,8 @@ arm_vectorprefetch:
 	.type	arm_vectorundefinsn, %function
 
 arm_vectorundefinsn:
-
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 	/* Save the LR and SPSR onto the SYS mode stack before switch. */
 
 	srsdb		sp!, #PSR_MODE_SYS
@@ -602,6 +627,11 @@ arm_vectorundefinsn:
 	mov		r0, sp				/* Get r0=xcp */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
+	mov		fp,	r0
+	.cfi_def_cfa	fp,	0			/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_undefinedinsn		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
 
@@ -630,6 +660,7 @@ arm_vectorundefinsn:
 	/* Restore the CPSR, SYS mode registers and return. */
 
 	rfeia		r14
+	.cfi_endproc
 	.size	arm_vectorundefinsn, . - arm_vectorundefinsn
 
 	.align	5
@@ -650,6 +681,8 @@ arm_vectorundefinsn:
 	.type	arm_vectorfiq, %function
 
 arm_vectorfiq:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 #if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_HIPRI_INTERRUPT)
 
 	/* Save the LR and SPSR onto the SYS mode stack before switch. */
@@ -692,6 +725,11 @@ arm_vectorfiq:
 #endif
 
 	bic		sp, sp, #7			/* Force 8-byte alignment */
+	mov		fp,	r0
+	.cfi_def_cfa	fp,	0			/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_decodefiq			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
 
@@ -731,6 +769,7 @@ arm_vectorfiq:
 #else
 	subs	pc, lr, #4
 #endif
+	.cfi_endproc
 	.size	arm_vectorfiq, . - arm_vectorfiq
 
 /****************************************************************************

--- a/arch/arm/src/armv7-m/arm_exception.S
+++ b/arch/arm/src/armv7-m/arm_exception.S
@@ -121,7 +121,8 @@
 	.type	exception_common, function
 #endif
 exception_common:
-
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 	mrs		r0, ipsr				/* R0=exception number */
 	mrs		r12, control				/* R12=control */
 
@@ -199,7 +200,11 @@ exception_common:
 	mov		sp, r2					/* Instantiate the aligned stack */
 3:
 #endif
-
+	mov		fp,	r1
+	.cfi_def_cfa	r4,	0				/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_doirq				/* R0=IRQ, R1=register save (msp) */
 
 	/* On return from arm_doirq, R0 will hold a pointer to register context
@@ -235,6 +240,7 @@ exception_common:
 	 */
 
 	bx		r14					/* And return */
+	.cfi_endproc
 
 	.size	exception_common, .-exception_common
 

--- a/arch/arm/src/armv8-m/arm_exception.S
+++ b/arch/arm/src/armv8-m/arm_exception.S
@@ -114,7 +114,8 @@
 	.thumb_func
 	.type	exception_common, function
 exception_common:
-
+	.cfi_sections	.debug_frame
+	.cfi_startproc
 	mrs		r12, control				/* R12=control */
 
 	/* Complete the context save */
@@ -209,7 +210,11 @@ exception_common:
 	mov		sp, r2					/* Instantiate the aligned stack */
 3:
 #endif
-
+	mov		fp,	r1
+	.cfi_def_cfa	fp,	0				/* Register in fp, so we just set fp as frame */
+	.cfi_offset	pc,	REG_PC * 4
+	.cfi_offset	sp,	REG_SP * 4
+	.cfi_offset	lr,	REG_LR * 4
 	bl		arm_doirq				/* R0=IRQ, R1=register save (msp) */
 
 	/* On return from arm_doirq, R0 will hold a pointer to register context
@@ -255,7 +260,7 @@ exception_common:
 	 */
 
 	bx		r14					/* And return */
-
+	.cfi_endproc
 	.size	exception_common, .-exception_common
 
 /****************************************************************************

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -106,6 +106,8 @@
   .align  8
 
 exception_common:
+  .cfi_sections .debug_frame
+  .cfi_startproc
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
   /* Take the kernel stack into use */
@@ -200,6 +202,10 @@ handle_irq:
 
   mv         a0, s2               /* exception cause */
   mv         a1, sp               /* context = sp */
+  mv         fp, a1               /* Use fp to debug frame */
+  .cfi_def_cfa fp, 0              /* Register in fp, so we just set fp as frame */
+  .cfi_offset x2, 8               /* Toolchain not support macro, is REG_X2 * 4 */
+  .cfi_offset ra, 0               /* Toolchain not support macro, is REG_EPC * 4 */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 
@@ -274,6 +280,7 @@ return_from_exception:
   /* Return from exception */
 
   ERET
+  .cfi_endproc
 
 /****************************************************************************
  * Function: riscv_jump_to_user


### PR DESCRIPTION
## Summary

use cfi in irq asm function, make a debug frame

## Impact

debug, if do backtrace in irq

## Testing
test code hello_main

```
int main(int argc, FAR char *argv[])
{
  uint32_t *p = 0xdeedbeff;
  *p = 0xffffff;

  printf("%p\n %x\n", p, *p);
  return 0;
}
```

qemu mps3-an547 hello_main :
Triggering an exception, and gdb backtrace is:

before:
```
(gdb) bt
#0  0x0001168a in systick_getstatus (lower_=0x100010c <g_systick_lower>, status=0x1000a30 <g_intstackalloc+1600>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_systick.c:142
#1  0x000122f4 in current_usec () at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:105 
#2  0x0001234c in udelay_accurate (microseconds=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:115 
#3  0x000124bc in up_udelay (microseconds=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:463 #4  0x0001249e in up_mdelay (milliseconds=250) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:446 #5  0x0000920c in reset_board () at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:830 
#6  0x0000937c in _assert (filename=0x393f8 "/arch/arm/src/armv8-m/arm_busfault.c", linenum=113, msg=0x393f0 "panic", regs=0x1008500)
    at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:940
#7  0x00000e2c in arm_busfault (irq=3, context=0x1008500, arg=0x0 <up_ndelay>) at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_busfault.c:113 
#8  0x000012d2 in arm_hardfault (irq=3, context=0x1008500, arg=0x0 <up_ndelay>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_hardfault.c:142
#9  0x00008b20 in irq_dispatch (irq=3, context=0x1008500) at /home/ajh/work/vela_system/nuttx/sched/irq/irq_dispatch.c:145 
#10 0x0000041a in arm_doirq (irq=3, regs=0x1008500) at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_doirq.c:103 
#11 0x0000034e in exception_common () at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_exception.S:224
```


after:
```
(gdb) bt
#0  systick_is_running () at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_systick.c:106 
#1  0x000125c0 in systick_getstatus (lower_=0x1000114 <g_systick_lower>, status=0x1007a20)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_systick.c:141
#2  0x0001323c in current_usec () at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:105 
#3  0x00013294 in udelay_accurate (microseconds=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:115 
#4  0x00013404 in up_udelay (microseconds=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:463 #5  0x000133e6 in up_mdelay (milliseconds=250) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_timer.c:446 #6  0x00008c5c in reset_board () at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:816 
#7  0x00008e88 in _assert (filename=0x39408 "/arch/arm/src/armv8-m/arm_busfault.c", linenum=113, msg=0x39400 "panic", regs=0x1007cf0)
    at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:915
#8  0x00000ce4 in arm_busfault (irq=3, context=0x1007cf0, arg=0x0 <up_ndelay>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_busfault.c:113
#9  0x0000118a in arm_hardfault (irq=3, context=0x1007cf0, arg=0x0 <up_ndelay>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_hardfault.c:142
#10 0x000086cc in irq_dispatch (irq=3, context=0x1007cf0) at /home/ajh/work/vela_system/nuttx/sched/irq/irq_dispatch.c:145 
#11 0x0000041e in arm_doirq (irq=3, regs=0x1007cf0) at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_doirq.c:99 
#12 0x00000360 in exception_common () at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv8-m/arm_exception.S:230 
#13 0x00027a8c in hello_main (argc=1, argv=0x1006e20) at /home/ajh/work/vela_system/apps/examples/hello/hello_main.c:39 
#14 0x00014968 in nxtask_startup (entrypt=0x27a7d <hello_main>, argc=1, argv=0x1006e20)
    at /home/ajh/work/vela_system/nuttx/libs/libc/sched/task_startup.c:72
#15 0x0000f450 in nxtask_start () at /home/ajh/work/vela_system/nuttx/sched/task/task_start.c:116 /#16 0x00000000 in ?? ()
(gdb)
```

qemu armv7a nsh, hello_main:
before:
```
(gdb) bt
#0  udelay_coarse (microseconds=156000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:67 
#1  up_ndelay (nanoseconds=nanoseconds@entry=250000000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:431 
#2  0x0060c630 in up_udelay (microseconds=microseconds@entry=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:416 
#3  0x0060c644 in up_mdelay (milliseconds=milliseconds@entry=250) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:401 
#4  0x006056bc in reset_board () at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:816 
#5  _assert (filename=filename@entry=0x63047f "/arch/arm/src/armv7-a/arm_dataabort.c", linenum=linenum@entry=157, msg=msg@entry=0x62f56d "panic",
    regs=<optimized out>, regs@entry=0x4020af10) at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:915
#6  0x0060bd74 in arm_dataabort (regs=0x4020af10, dfar=<optimized out>, dfsr=<optimized out>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv7-a/arm_dataabort.c:157
#7  0x0060bc04 in arm_vectordata () at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv7-a/arm_vectors.S:438 Backtrace stopped: previous frame identical to this frame (corrupt stack?) (gdb)
```
after:
```
(gdb) bt
#0  udelay_coarse (microseconds=192000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:67 
#1  up_ndelay (nanoseconds=nanoseconds@entry=250000000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:431 
#2  0x0060c650 in up_udelay (microseconds=microseconds@entry=250000) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:416 
#3  0x0060c664 in up_mdelay (milliseconds=milliseconds@entry=250) at /home/ajh/work/vela_system/nuttx/drivers/timers/arch_alarm.c:401 
#4  0x006056bc in reset_board () at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:816 
#5  _assert (filename=filename@entry=0x63047f "/arch/arm/src/armv7-a/arm_dataabort.c", linenum=linenum@entry=157, msg=msg@entry=0x62f56d "panic",
    regs=<optimized out>, regs@entry=0x4020af10) at /home/ajh/work/vela_system/nuttx/sched/misc/assert.c:915
#6  0x0060bd94 in arm_dataabort (regs=0x4020af10, dfar=<optimized out>, dfsr=<optimized out>)
    at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv7-a/arm_dataabort.c:157
#7  0x0060bc08 in arm_vectordata () at /home/ajh/work/vela_system/nuttx/arch/arm/src/armv7-a/arm_vectors.S:453 
#8  0x00620cd4 in hello_main (argc=4999, argv=0x0) at /home/ajh/work/vela_system/apps/examples/hello/hello_main.c:41 #9  0x0060d320 in nxtask_startup (entrypt=0x620cc4 <hello_main>, argc=1, argv=0x4020a088)
    at /home/ajh/work/vela_system/nuttx/libs/libc/sched/task_startup.c:72
#10 0x00609b50 in nxtask_start () at /home/ajh/work/vela_system/nuttx/sched/task/task_start.c:116 /#11 0x00000000 in ?? ()
```


qemu risc-v nsh
before:
```
(gdb) bt
#0  udelay_coarse (microseconds=228000, microseconds@entry=891896832) at timers/arch_alarm.c:67
#1  up_ndelay (nanoseconds=nanoseconds@entry=250000000) at timers/arch_alarm.c:431 
#2  0x8000397e in up_udelay (microseconds=microseconds@entry=250000) at timers/arch_alarm.c:416 
#3  0x80003988 in up_mdelay (milliseconds=milliseconds@entry=250) at timers/arch_alarm.c:401 
#4  0x80011f1c in reset_board () at misc/assert.c:813 
#5  0x80011f7a in _assert (filename=filename@entry=0x0, linenum=linenum@entry=0, msg=msg@entry=0x8002114c "panic", regs=<optimized out>,
    regs@entry=0x80030704) at misc/assert.c:915
#6  0x80006ad6 in riscv_exception (mcause=<optimized out>, regs=0x80030704, args=<optimized out>) at common/riscv_exception.c:129 /#7  0x80000d9e in riscv_doirq (irq=7, regs=<optimized out>) at common/riscv_doirq.c:99 #8  0x80000164 in exception_common () at common/riscv_exception_common.S:210 Backtrace stopped: frame did not save the PC
(gdb)
```

after
```
(gdb) bt
#0  0x80003922 in udelay_coarse (microseconds=90000, microseconds@entry=891896832) at timers/arch_alarm.c:67 #1  up_ndelay (nanoseconds=nanoseconds@entry=250000000) at timers/arch_alarm.c:431 
#2  0x8000397e in up_udelay (microseconds=microseconds@entry=250000) at timers/arch_alarm.c:416 
#3  0x80003988 in up_mdelay (milliseconds=milliseconds@entry=250) at timers/arch_alarm.c:401 
#4  0x80011f2a in reset_board () at misc/assert.c:816 /#5  0x80011f7a in _assert (filename=filename@entry=0x0, linenum=linenum@entry=0, msg=msg@entry=0x8002114c "panic", regs=<optimized out>,
    regs@entry=0x80030704) at misc/assert.c:915
#6  0x80006ad6 in riscv_exception (mcause=<optimized out>, regs=0x80030704, args=<optimized out>) at common/riscv_exception.c:129 
#7  0x80000d9e in riscv_doirq (irq=7, regs=<optimized out>) at common/riscv_doirq.c:99 
#8  0x80000166 in exception_common () at common/riscv_exception_common.S:215 
#9  0x8001792a in hello_main (argc=<optimized out>, argv=<optimized out>) at hello_main.c:41 
#10 0x80004b52 in nxtask_startup (entrypt=0x80030704, argc=1, argv=0x800300e8) at sched/task_startup.c:72 
#11 0x80001e72 in nxtask_start () at task/task_start.c:116 /#12 0x00000000 in ?? ()
Backtrace stopped: frame did not save the PC
(gdb)
```
