### PR TITLE
libxx: Make LIBCXXABI default for sim/macOS

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -71,6 +71,7 @@ if !LIBCXXMINI
 
 choice
 	prompt "C++ low level library select"
+	default LIBCXXABI if ARCH_SIM && HOST_MACOS
 	default LIBSUPCXX_TOOLCHAIN
 
 config LIBCXXABI


### PR DESCRIPTION
## Summary

libxx: Make LIBCXXABI default for sim/macOS

Fix build errors like:
https://github.com/apache/nuttx/issues/14774

## Impact

## Testing

build tested (with https://github.com/apache/nuttx/pull/15209 and a few local changes)
macOS 15.2
x86-64
Xcode 16.1