### PR TITLE
{bp-15201} tools/macar-qcs.sh: migrate to SPDX identifier

### DIFF
--- a/arch/arm/src/xmc4/hardware/xmc4_ccu4.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_ccu4.h
@@ -1,39 +1,29 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_ccu4.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed

--- a/arch/arm/src/xmc4/hardware/xmc4_eru.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_eru.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_eru.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -16,19 +18,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/hardware/xmc4_ethernet.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_ethernet.h
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_ethernet.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/hardware/xmc4_flash.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_flash.h
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_flash.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/hardware/xmc4_memorymap.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_memorymap.h
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_memorymap.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/hardware/xmc4_ports.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_ports.h
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_ports.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/hardware/xmc4_posif.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_posif.h
@@ -18,19 +18,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/hardware/xmc4_scu.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_scu.h
@@ -1,39 +1,29 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_scu.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed

--- a/arch/arm/src/xmc4/hardware/xmc4_usic.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_usic.h
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/hardware/xmc4_usic.h
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/hardware/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/hardware/xmc4_vadc.h
@@ -18,6 +18,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  *
+ ******************************************************************************************************************/
+
+/******************************************************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.

--- a/arch/arm/src/xmc4/xmc4_clockconfig.c
+++ b/arch/arm/src/xmc4/xmc4_clockconfig.c
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_clockconfig.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
@@ -42,8 +32,8 @@
  * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
  * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE.  INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_clockutils.c
+++ b/arch/arm/src/xmc4/xmc4_clockutils.c
@@ -1,36 +1,26 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_clockutils.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Authors: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
  *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
@@ -39,11 +29,11 @@
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_usic.c
+++ b/arch/arm/src/xmc4/xmc4_usic.c
@@ -1,49 +1,39 @@
 /****************************************************************************
  * arch/arm/src/xmc4/xmc4_usic.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
+ ****************************************************************************/
+
+/****************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_vadc.c
+++ b/arch/arm/src/xmc4/xmc4_vadc.c
@@ -1,6 +1,8 @@
 /**********************************************************************************************
  * arch/arm/src/xmc4/xmc4_vadc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -16,19 +18,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  *
+ **********************************************************************************************/
+
+/**********************************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  **********************************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_vadc.h
+++ b/arch/arm/src/xmc4/xmc4_vadc.h
@@ -1,6 +1,8 @@
 /********************************************************************************************************
  * arch/arm/src/xmc4/xmc4_vadc.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -16,19 +18,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  *
+ ********************************************************************************************************/
+
+/********************************************************************************************************
  * May include some logic from sample code provided by Infineon:
  *
- * Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
+ *   Copyright (C) 2011-2015 Infineon Technologies AG. All rights reserved.
  *
  * Infineon Technologies AG (Infineon) is supplying this software for use
  * with Infineon's microcontrollers.  This file can be freely distributed
  * within development tools that are supporting such microcontrollers.
  *
- * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS,
- * IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
- * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR
- * SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ * THIS SOFTWARE IS PROVIDED AS IS. NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS
+ * SOFTWARE. INFINEON SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
  *
  ********************************************************************************************************/
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
@@ -2,6 +2,8 @@
  * arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h
  *
  * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Jakub Janousek <janouja9@fel.cvut.cz>
+ * SPDX-FileContributor: Jakub Janousek <janouja9@fel.cvut.cz>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_cache_memory.h
+++ b/arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_cache_memory.h
@@ -3,17 +3,20 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_soc.h
+++ b/arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_soc.h
@@ -3,17 +3,20 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_clockconfig.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/ucans32k146/src/s32k1xx_clockconfig.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_periphclocks.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * boards/arm/s32k1xx/ucans32k146/src/s32k1xx_periphclocks.c
  *
- *   Copyright (c) 2013 - 2015, Freescale Semiconductor, Inc.
- *   Copyright 2016-2018 NXP
- *   All rights reserved.
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 2013 - 2015, Freescale Semiconductor, Inc.
+ * SPDX-FileCopyrightText: 2016-2018 NXP. All rights reserved.
  *
  * THIS SOFTWARE IS PROVIDED BY NXP "AS IS" AND ANY EXPRESSED OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES

--- a/crypto/cast.c
+++ b/crypto/cast.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/cast.c
  *
- * $OpenBSD: cast.c,v 1.4 2012/04/25 04:12:27 matthew Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * CAST-128 in C
  * Written by Steve Reid <sreid@sea-to-sky.net>

--- a/crypto/castsb.h
+++ b/crypto/castsb.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/castsb.h
  *
- * $OpenBSD: castsb.h,v 1.1 2000/02/28 23:13:04 deraadt Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * CAST-128 in C
  * Written by Steve Reid <sreid@sea-to-sky.net>

--- a/crypto/chacha_private.h
+++ b/crypto/chacha_private.h
@@ -1,9 +1,8 @@
 /****************************************************************************
  * crypto/chacha_private.h
  *
- * $OpenBSD: chacha_private.h,v 1.4 2020/07/22 13:54:30 tobhe Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
- * chacha-merged.c version 20080118
  * D. J. Bernstein
  * Public domain.
  ****************************************************************************/

--- a/crypto/md5.c
+++ b/crypto/md5.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/md5.c
  *
- * $OpenBSD: md5.c,v 1.4 2014/12/28 10:04:35 tedu Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest. This code was

--- a/crypto/poly1305.c
+++ b/crypto/poly1305.c
@@ -1,11 +1,10 @@
 /****************************************************************************
  * crypto/poly1305.c
  *
- * $OpenBSD: poly1305.c,v 1.2 2020/07/22 13:54:30 tobhe Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * Public Domain poly1305 from Andrew Moon
- * Based on poly1305-donna.c, poly1305-donna-32.h and poly1305-donna.h from:
- *   https://github.com/floodyberry/poly1305-donna
+ *
  ****************************************************************************/
 
 /****************************************************************************

--- a/crypto/rijndael.c
+++ b/crypto/rijndael.c
@@ -1,19 +1,10 @@
 /****************************************************************************
  * crypto/rijndael.c
  *
- * $OpenBSD: rijndael.c,v 1.20 2014/11/17 12:27:47 mikeb Exp $
- *
- * rijndael-alg-fst.c
- *
- * @version 3.0 (December 2000)
- *
- * Optimised ANSI C code for the Rijndael cipher (now AES)
- *
- * @author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
- * @author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
- * @author Paulo Barreto <paulo.barreto@terra.com.br>
- *
- * This code is hereby placed in the public domain.
+ * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-FileContributor: Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+ * SPDX-FileContributor: Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+ * SPDX-FileContributor: Paulo Barreto <paulo.barreto@terra.com.br>
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/crypto/sha1.c
+++ b/crypto/sha1.c
@@ -1,20 +1,11 @@
 /****************************************************************************
  * crypto/sha1.c
  *
- * $OpenBSD: sha1.c,v 1.11 2014/12/28 10:04:35 tedu Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
- * SHA-1 in C
  * By Steve Reid <steve@edmweb.com>
  * 100% Public Domain
  *
- * Test Vectors (from FIPS PUB 180-1)
- * "abc"
- *   A9993E36 4706816A BA3E2571 7850C26C 9CD0D89D
- * "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
- *   84983E44 1C3BD26E BAAE4AA1 F95129E5 E54670F1
- * A million repetitions of "a"
- *   34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
-
  ****************************************************************************/
 
 /****************************************************************************

--- a/drivers/spi/ice40.c
+++ b/drivers/spi/ice40.c
@@ -1,6 +1,10 @@
 /****************************************************************************
  * drivers/spi/ice40.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Jakub Janousek <janouja9@fel.cvut.cz>
+ * SPDX-FileContributor: Jakub Janousek <janouja9@fel.cvut.cz>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/include/crypto/cast.h
+++ b/include/crypto/cast.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * include/crypto/cast.h
- * $OpenBSD: cast.h,v 1.2 2002/03/14 01:26:51 millert Exp $
  *
- * CAST-128 in C
+ * SPDX-License-Identifier: NuttX-PublicDomain
+ *
  * Written by Steve Reid <sreid@sea-to-sky.net>
  * 100% Public Domain - no warranty
  * Released 1997.10.11

--- a/include/crypto/md5.h
+++ b/include/crypto/md5.h
@@ -1,17 +1,12 @@
 /****************************************************************************
  * include/crypto/md5.h
- * $OpenBSD: md5.h,v 1.3 2014/11/16 17:39:09 tedu Exp $
  *
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.  This code was
  * written by Colin Plumb in 1993, no copyright is claimed.
  * This code is in the public domain; do with it what you wish.
- *
- * Equivalent code is available from RSA Data Security, Inc.
- * This code has been tested against that, and is equivalent,
- * except that you don't need to include two pages of legalese
- * with every copy.
  *
  ****************************************************************************/
 

--- a/include/crypto/poly1305.h
+++ b/include/crypto/poly1305.h
@@ -1,11 +1,10 @@
 /****************************************************************************
  * include/crypto/poly1305.h
- * $OpenBSD: poly1305.h,v 1.2 2020/07/22 13:54:30 tobhe Exp $
+ *
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * Public Domain poly1305 from Andrew Moon
  *
- * poly1305 implementation using 32 bit * 32 bit = 64 bit multiplication
- * and 64 bit addition from https://github.com/floodyberry/poly1305-donna
  ****************************************************************************/
 
 #ifndef __INCLUDE_CRYPTO_POLY1305_H

--- a/include/crypto/rijndael.h
+++ b/include/crypto/rijndael.h
@@ -1,16 +1,11 @@
 /****************************************************************************
  * include/crypto/rijndael.h
- * $OpenBSD: rijndael.h,v 1.13 2008/06/09 07:49:45 djm Exp $
  *
- * rijndael-alg-fst.h
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
- * @version 3.0 (December 2000)
- *
- * Optimised ANSI C code for the Rijndael cipher (now AES)
- *
- * @author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
- * @author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
- * @author Paulo Barreto <paulo.barreto@terra.com.br>
+ * SPDX-FileContributor: Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+ * SPDX-FileContributor: Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+ * SPDX-FileContributor: Paulo Barreto <paulo.barreto@terra.com.br>
  *
  * This code is hereby placed in the public domain.
  *

--- a/include/crypto/sha1.h
+++ b/include/crypto/sha1.h
@@ -1,7 +1,8 @@
 /****************************************************************************
  * include/crypto/sha1.h
- * $OpenBSD: sha1.h,v 1.6 2014/11/16 17:39:09 tedu Exp $
- * SHA-1 in C
+ *
+ * SPDX-License-Identifier: NuttX-PublicDomain
+ *
  * By Steve Reid <steve@edmweb.com>
  * 100% Public Domain
  ****************************************************************************/

--- a/include/search.h
+++ b/include/search.h
@@ -1,8 +1,7 @@
 /****************************************************************************
  * include/search.h
  *
- * $NetBSD: search.h,v 1.12 1999/02/22 10:34:28 christos Exp $
- * $FreeBSD: src/include/search.h,v 1.4 2002/03/23 17:24:53 imp Exp $
+ * SPDX-License-Identifier: NuttX-PublicDomain
  *
  * Written by J.T. Conklin <jtc@netbsd.org>
  * Public domain.

--- a/tools/macar-qcs.sh
+++ b/tools/macar-qcs.sh
@@ -1,18 +1,25 @@
 #! /usr/bin/env bash
-
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+ ############################################################################
+ # tools/macar-qcs.sh
+ #
+ # SPDX-License-Identifier: Apache-2.0
+ #
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements.  See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.  The
+ # ASF licenses this file to you under the Apache License, Version 2.0 (the
+ # "License"); you may not use this file except in compliance with the
+ # License.  You may obtain a copy of the License at
+ #
+ #   http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ # License for the specific language governing permissions and limitations
+ # under the License.
+ #
+ ############################################################################
 
 # This is an "ar rcs" equivalent without "no symbols" warnings.
 


### PR DESCRIPTION
## Summary

Most tools used for compliance and SBOM generation use SPDX identifiers
This change brings us a step closer to an easy SBOM generation.
included

https://github.com/apache/nuttx/pull/15201
https://github.com/apache/nuttx/pull/15202
https://github.com/apache/nuttx/pull/15196

## Impact

RELEASE

## Testing

CI