### PR TITLE
{bp-15210} libxx: Make LIBCXXABI default for sim/macOS

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -71,6 +71,7 @@ if !LIBCXXMINI
 
 choice
 	prompt "C++ low level library select"
+	default LIBCXXABI if ARCH_SIM && HOST_MACOS
 	default LIBSUPCXX_TOOLCHAIN
 
 config LIBCXXABI


### PR DESCRIPTION
## Summary
Fix build errors like:
https://github.com/apache/nuttx/issues/14774

## Impact

RELEASE

## Testing

CI
