### PR TITLE
{bp-15207} nuttx/can.h: delete "begin_packed_struct" and "end_packed_struct" qualifier

### DIFF
--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -622,11 +622,11 @@ begin_packed_struct struct can_hdr_s
 } end_packed_struct;
 #endif
 
-begin_packed_struct struct can_msg_s
+struct can_msg_s
 {
   struct can_hdr_s cm_hdr;                  /* The CAN header */
   uint8_t          cm_data[CAN_MAXDATALEN]; /* CAN message data (0-8 byte) */
-} end_packed_struct;
+};
 
 /* This structure defines a CAN message FIFO. */
 


### PR DESCRIPTION
## Summary
delete "begin_packed_struct" and "end_packed_struct" qualifiers of struct can_msg_s
for resolving the problem that is data address not alignment!
the reason of the problem is forcing to use uint32 to access cm_data, then system will crash.

## Impact

RELEASE

## Testing

CI

