### PR TITLE
{bp-15198} lib_pathbuffer.c:Use atomic instead of locks

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -31,6 +31,9 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 
+#include <limits.h>
+#include <alloca.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -119,8 +122,13 @@ unsigned long nrand(unsigned long limit);
 
 /* Functions defined in lib_pathbuffer.c ************************************/
 
+#ifdef CONFIG_LIBC_PATHBUFFER
 FAR char *lib_get_pathbuffer(void);
 void lib_put_pathbuffer(FAR char *buffer);
+#else
+#  define lib_get_pathbuffer() alloca(PATH_MAX)
+#  define lib_put_pathbuffer(b)
+#endif
 
 /* Functions defined in lib_realpath.c **************************************/
 

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -47,8 +47,11 @@ list(
   lib_mkdirat.c
   lib_utimensat.c
   lib_mallopt.c
-  lib_getnprocs.c
-  lib_pathbuffer.c)
+  lib_getnprocs.c)
+
+if(CONFIG_LIBC_PATHBUFFER)
+  list(APPEND SRCS lib_pathbuffer.c)
+endif()
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -119,6 +119,16 @@ config LIBC_MEM_FD_VFS_PATH
 	---help---
 		The relative path to where memfd will exist in the tmpfs namespace.
 
+config LIBC_PATHBUFFER
+	bool "Enable global path buffer"
+	default !DEFAULT_SMALL
+	---help---
+		Enable this option to enable the global path buffer, otherwise use stack variables via alloca().
+		If the current platform does not require a large PATH_MAX size support and toolchain supports alloca(),
+		we could turn off this option to improve performance.
+
+if LIBC_PATHBUFFER
+
 config LIBC_MAX_PATHBUFFER
 	int "Maximum size of a temporary file path buffer array"
 	range 0 32
@@ -132,6 +142,8 @@ config LIBC_PATHBUFFER_MALLOC
 	default y
 	---help---
 		Enable malloc path buffer from the heap when pathbuffer is insufficient.
+
+endif # LIBC_PATHBUFFER
 
 config LIBC_BACKTRACE_BUFFSIZE
 	int "The size of backtrace record buffer"

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -129,7 +129,7 @@ config LIBC_PATHBUFFER
 
 if LIBC_PATHBUFFER
 
-config LIBC_MAX_PATHBUFFER
+config LIBC_PATHBUFFER_MAX
 	int "Maximum size of a temporary file path buffer array"
 	range 0 32
 	default 2

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -27,7 +27,11 @@ CSRCS += lib_getrandom.c lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
 CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
 CSRCS += lib_fchmodat.c lib_fstatat.c lib_getfullpath.c lib_openat.c
 CSRCS += lib_mkdirat.c lib_utimensat.c lib_mallopt.c
-CSRCS += lib_idr.c lib_getnprocs.c lib_pathbuffer.c
+CSRCS += lib_idr.c lib_getnprocs.c
+
+ifeq ($(CONFIG_LIBC_PATHBUFFER),y)
+CSRCS += lib_pathbuffer.c
+endif
 
 # Support for platforms that do not have long long types
 

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -43,7 +43,7 @@ struct pathbuffer_s
 {
   spinlock_t lock;           /* Lock for the buffer */
   unsigned long free_bitmap; /* Bitmap of free buffer */
-  char buffer[CONFIG_LIBC_MAX_PATHBUFFER][PATH_MAX];
+  char buffer[CONFIG_LIBC_PATHBUFFER_MAX][PATH_MAX];
 };
 
 /****************************************************************************
@@ -53,7 +53,7 @@ struct pathbuffer_s
 static struct pathbuffer_s g_pathbuffer =
 {
   SP_UNLOCKED,
-  (1u << CONFIG_LIBC_MAX_PATHBUFFER) - 1,
+  (1u << CONFIG_LIBC_PATHBUFFER_MAX) - 1,
 };
 
 /****************************************************************************
@@ -89,7 +89,7 @@ FAR char *lib_get_pathbuffer(void)
 
   flags = spin_lock_irqsave(&g_pathbuffer.lock);
   index = ffsl(g_pathbuffer.free_bitmap) - 1;
-  if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
+  if (index >= 0 && index < CONFIG_LIBC_PATHBUFFER_MAX)
     {
       g_pathbuffer.free_bitmap &= ~(1u << index);
       spin_unlock_irqrestore(&g_pathbuffer.lock, flags);
@@ -129,7 +129,7 @@ void lib_put_pathbuffer(FAR char *buffer)
   int index;
 
   index = (buffer - &g_pathbuffer.buffer[0][0]) / PATH_MAX;
-  if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
+  if (index >= 0 && index < CONFIG_LIBC_PATHBUFFER_MAX)
     {
       /* Mark the corresponding bit as free */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Avoid spinlock/mutex by using atomic

Use atomic_cmpxchg to ensure that in multithreaded situations, if someone releases the buffer, it can be applied for in time. And use atomic_ulong to save free_bitmap

includes 
https://github.com/apache/nuttx/pull/15104

## Impact

RELEASE

## Testing

CI
