### PR TITLE
{bp-15197} libs/libc/stdlib: remove BSD-4 clause code

### DIFF
--- a/libs/libc/stdlib/lib_bsearch.c
+++ b/libs/libc/stdlib/lib_bsearch.c
@@ -12,11 +12,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *      This product includes software developed by the University of
- *      California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *

--- a/libs/libc/stdlib/lib_bsearch.c
+++ b/libs/libc/stdlib/lib_bsearch.c
@@ -1,8 +1,10 @@
 /****************************************************************************
  * libs/libc/stdlib/lib_bsearch.c
  *
- *   Copyright (c) 1990, 1993
- *   The Regents of the University of California.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 1990 The Regents of the University of California.
+ * SPDX-FileCopyrightText: 1993 The Regents of the University of California.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/libs/libc/stdlib/lib_qsort.c
+++ b/libs/libc/stdlib/lib_qsort.c
@@ -18,11 +18,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *    This product includes software developed by the University of
- *    California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *

--- a/libs/libc/stdlib/lib_qsort.c
+++ b/libs/libc/stdlib/lib_qsort.c
@@ -1,13 +1,12 @@
 /****************************************************************************
  * libs/libc/stdlib/lib_qsort.c
  *
- *   Copyright (C) 2007, 2009, 2011 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Leveraged from:
- *
- *  Copyright (c) 1992, 1993
- *  The Regents of the University of California.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2007, 2009, 2011 Gregory Nutt.
+ * SPDX-FileCopyrightText: 1993 The Regents of the University of California.
+ * SPDX-FileCopyrightText: 1990 The Regents of the University of California.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
## Summary

remove the advertising clause
3. All advertising materials mentioning features or use of this software must
display the following acknowledgement: This product includes software
developed by the University of California, Berkeley and its contributors.

permitted by Berkley amendment
https://ipira.berkeley.edu/sites/default/files/amendment_of_4-clause_bsd_software_license.pdf

following example from NETBSD and OPENBSD
https://github.com/NetBSD/src/commit/eb7c1594f145c931049e1fd9eb056a5987e87e59
https://github.com/openbsd/src/commit/6580fee3295c971a919cc04bfc3598c5f8bcd2b1

## Impact

RELEASE

## Testing

CI