### PR TITLE
esp32s3_rtc: use small lock in arch/xtensa/src/esp32s3/esp32s3_rtc.c

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_rtc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtc.c
@@ -366,6 +366,8 @@ static uint32_t g_rtc_dbias_pvt_240m = 28;
 static uint32_t g_dig_dbias_pvt_non_240m = 27;
 static uint32_t g_rtc_dbias_pvt_non_240m = 27;
 
+static spinlock_t g_rtc_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -2740,7 +2742,7 @@ time_t up_rtc_time(void)
   uint64_t time_us;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   /* NOTE: RT-Timer starts to work after the board is initialized, and the
    * RTC controller starts works after up_rtc_initialize is initialized.
@@ -2769,7 +2771,7 @@ time_t up_rtc_time(void)
                   esp32s3_rtc_get_boot_time();
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return (time_t)(time_us / USEC_PER_SEC);
 }
@@ -2797,7 +2799,7 @@ int up_rtc_settime(const struct timespec *ts)
   uint64_t rtc_offset_us;
 
   DEBUGASSERT(ts != NULL && ts->tv_nsec < NSEC_PER_SEC);
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   now_us = ((uint64_t) ts->tv_sec) * USEC_PER_SEC +
           ts->tv_nsec / NSEC_PER_USEC;
@@ -2817,7 +2819,7 @@ int up_rtc_settime(const struct timespec *ts)
   g_rtc_save->offset = 0;
   esp32s3_rtc_set_boot_time(rtc_offset_us);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }
@@ -2883,7 +2885,7 @@ int up_rtc_gettime(struct timespec *tp)
   irqstate_t flags;
   uint64_t time_us;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   if (g_rt_timer_enabled == true)
     {
@@ -2898,7 +2900,7 @@ int up_rtc_gettime(struct timespec *tp)
   tp->tv_sec  = time_us / USEC_PER_SEC;
   tp->tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }
@@ -2941,7 +2943,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
     {
       /* Create the RT-Timer alarm */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       if (cbinfo->alarm_hdl == NULL)
         {
@@ -2952,7 +2954,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
           if (ret < 0)
             {
               rtcerr("ERROR: Failed to create rt_timer error=%d\n", ret);
-              spin_unlock_irqrestore(NULL, flags);
+              spin_unlock_irqrestore(&g_rtc_lock, flags);
               return ret;
             }
         }
@@ -2974,7 +2976,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
           ret = OK;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
     }
 
   return ret;
@@ -3009,7 +3011,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
 
@@ -3020,7 +3022,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->deadline_us = 0;
       cbinfo->alarm_hdl = NULL;
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
 
       ret = OK;
     }
@@ -3051,7 +3053,7 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
   DEBUGASSERT((RTC_ALARM0 <= alarmid) &&
               (alarmid < RTC_ALARM_LAST));
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   /* Get the alarm according to the alarmid */
 
@@ -3062,7 +3064,7 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
   tp->tv_nsec = ((esp32s3_rt_timer_time_us() + g_rtc_save->offset +
               cbinfo->deadline_us) % USEC_PER_SEC) * NSEC_PER_USEC;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
esp32s3_rtc: use small lock in arch/xtensa/src/esp32s3/esp32s3_rtc.c
reason:
We would like to replace the big lock with a small lock.

## Impact
esp32s3_rtc

## Testing
ci


