### PR TITLE
esp32c3_rtc: use small lock in arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c

### DIFF
--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c
@@ -455,6 +455,7 @@ static RTC_DATA_ATTR struct esp32c3_rtc_backup_s rtc_saved_data;
 
 static struct esp32c3_rtc_backup_s *g_rtc_save;
 static bool g_rt_timer_enabled = false;
+static spinlock_t g_rtc_lock = SP_UNLOCKED;
 
 #endif
 
@@ -3076,7 +3077,7 @@ time_t up_rtc_time(void)
   uint64_t time_us;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   /* NOTE: RT-Timer starts to work after the board is initialized, and the
    * RTC controller starts works after up_rtc_initialize is initialized.
@@ -3105,7 +3106,7 @@ time_t up_rtc_time(void)
                   esp32c3_rtc_get_boot_time();
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return (time_t)(time_us / USEC_PER_SEC);
 }
@@ -3133,7 +3134,7 @@ int up_rtc_settime(const struct timespec *ts)
   uint64_t rtc_offset_us;
 
   DEBUGASSERT(ts != NULL && ts->tv_nsec < NSEC_PER_SEC);
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   now_us = ((uint64_t) ts->tv_sec) * USEC_PER_SEC +
           ts->tv_nsec / NSEC_PER_USEC;
@@ -3153,7 +3154,7 @@ int up_rtc_settime(const struct timespec *ts)
   g_rtc_save->offset = 0;
   esp32c3_rtc_set_boot_time(rtc_offset_us);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }
@@ -3219,7 +3220,7 @@ int up_rtc_gettime(struct timespec *tp)
   irqstate_t flags;
   uint64_t time_us;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   if (g_rt_timer_enabled == true)
     {
@@ -3234,7 +3235,7 @@ int up_rtc_gettime(struct timespec *tp)
   tp->tv_sec  = time_us / USEC_PER_SEC;
   tp->tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }
@@ -3277,7 +3278,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
     {
       /* Create the RT-Timer alarm */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       if (cbinfo->alarm_hdl == NULL)
         {
@@ -3288,7 +3289,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
           if (ret < 0)
             {
               rtcerr("ERROR: Failed to create rt_timer error=%d\n", ret);
-              spin_unlock_irqrestore(NULL, flags);
+              spin_unlock_irqrestore(&g_rtc_lock, flags);
               return ret;
             }
         }
@@ -3309,7 +3310,7 @@ int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
           ret = OK;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
     }
 
   return ret;
@@ -3344,7 +3345,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
 
@@ -3355,7 +3356,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->deadline_us = 0;
       cbinfo->alarm_hdl = NULL;
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_rtc_lock, flags);
 
       ret = OK;
     }
@@ -3386,7 +3387,7 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
   DEBUGASSERT((RTC_ALARM0 <= alarmid) &&
               (alarmid < RTC_ALARM_LAST));
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_rtc_lock);
 
   /* Get the alarm according to the alarmid */
 
@@ -3397,7 +3398,7 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
   tp->tv_nsec = ((rt_timer_time_us() + g_rtc_save->offset +
               cbinfo->deadline_us) % USEC_PER_SEC) * NSEC_PER_USEC;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rtc_lock, flags);
 
   return OK;
 }


### PR DESCRIPTION


## Summary

esp32c3_rtc: use small lock in arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c

reason:
We would like to replace the big lock with a small lock.

## Impact
esp32c3_rtc

## Testing
ci 


