### PR TITLE
nuttx/typo: fix some typo

### DIFF
--- a/Documentation/ReleaseNotes/NuttX-12.3.0
+++ b/Documentation/ReleaseNotes/NuttX-12.3.0
@@ -566,7 +566,7 @@ Drivers With Improvements
 * [#10778](https://github.com/apache/nuttx/pull/10778) mmcsd: add get emmc cid register interface.
 * [#10168](https://github.com/apache/nuttx/pull/10168) mmcsd: fix byte_block_count error in byte mode
 * [#10440](https://github.com/apache/nuttx/pull/10440) mmcsd: fix regression causing emmcsd not working
-* [#9937](https://github.com/apache/nuttx/pull/9937) mmcsd: mmcsd_sdio: config timout to write one data block
+* [#9937](https://github.com/apache/nuttx/pull/9937) mmcsd: mmcsd_sdio: config timeout to write one data block
 * [#10560](https://github.com/apache/nuttx/pull/10560) mmcsd: Rename mmc_rpmb_frame_s to rpmb_frame
 * [#10732](https://github.com/apache/nuttx/pull/10732) mmcsd: support dump cid and csd with mmc-utils
 * [#10672](https://github.com/apache/nuttx/pull/10672) mmcsd: update cid reg layout

--- a/Documentation/ReleaseNotes/NuttX-12.3.0
+++ b/Documentation/ReleaseNotes/NuttX-12.3.0
@@ -774,7 +774,7 @@ Boards With Improvements
 * [#9884](https://github.com/apache/nuttx/pull/9884) xtensa: esp32: esp32-devkitc: Refresh wifi_smp_rmt config
 * [#9709](https://github.com/apache/nuttx/pull/9709) xtensa: esp32: esp32-devkitc: wamr_wasi_debug: enable wasi-threads
 * [#9752](https://github.com/apache/nuttx/pull/9752) xtensa: esp32s2: Add basic support to SPIFLASH
-* [#9868](https://github.com/apache/nuttx/pull/9868) xtensa: esp32s3: Do not include specfic board in commom
+* [#9868](https://github.com/apache/nuttx/pull/9868) xtensa: esp32s3: Do not include specific board in commom
 * [#9870](https://github.com/apache/nuttx/pull/9870) xtensa: esp32s3: Some follow-up changes for ESP32s3 32M flash support
 * [#10748](https://github.com/apache/nuttx/pull/10748) xtensa: esp32s3: esp32s3-devkit:disable esp32s3-devkit:ksta_softap spinlock config
 * [#10588](https://github.com/apache/nuttx/pull/10588) xtensa: esp32s3: esp32s3-devkit:Add board GPIO support

--- a/Documentation/ReleaseNotes/NuttX-12.4.0
+++ b/Documentation/ReleaseNotes/NuttX-12.4.0
@@ -448,7 +448,7 @@ Improvements
 * [#11197](https://github.com/apache/nuttx/pull/11197) igmp: call IFF_SET_IPv4 when igmp_send
 * [#11384](https://github.com/apache/nuttx/pull/11384) ipv6: Fix source address with many addresses in same network
 * [#11378](https://github.com/apache/nuttx/pull/11378) ipv6: Move xxx_ipv6multicast from arch to common code
-* [#10894](https://github.com/apache/nuttx/pull/10894) netdb: When set a dns nameserver which already exists, retrun OK
+* [#10894](https://github.com/apache/nuttx/pull/10894) netdb: When set a dns nameserver which already exists, return OK
 * [#11076](https://github.com/apache/nuttx/pull/11076) netconfig: Enable SOCK_CLOEXEC for ioctl sockets
 * [#11396](https://github.com/apache/nuttx/pull/11396) netdev: Modify the logic for setting the IFF_RUNNING status of interfaces.
 * [#11110](https://github.com/apache/nuttx/pull/11110) Simplify getting value for different domain

--- a/arch/arm/src/imxrt/hardware/imxrt_adc_etc.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_adc_etc.h
@@ -142,7 +142,7 @@
                                                         /* Bits 1-3:   Reserved */
 #define ADC_ETC_TRIG_CTRL_TRIG_MODE         (1 << 4)    /* Bit  4:     Sotware trigger select */
                                                         /* Bits 5-7:   Reserved */
-#define ADC_ETC_TRIG_CTRL_TRIG_CHAIN_SHIFT  (8)         /* Bits 8-11:  TRIG chain lenght to the ADC */
+#define ADC_ETC_TRIG_CTRL_TRIG_CHAIN_SHIFT  (8)         /* Bits 8-11:  TRIG chain length to the ADC */
 #define ADC_ETC_TRIG_CTRL_TRIG_CHAIN_MASK   (0x7 << ADC_ETC_TRIG_CTRL_TRIG_CHAIN_SHIFT)
 #define ADC_ETC_TRIG_CTRL_TRIG_CHAIN(n)     (((uint32_t)(n) << ADC_ETC_TRIG_CTRL_TRIG_CHAIN_SHIFT) & ADC_ETC_TRIG_CTRL_TRIG_CHAIN_MASK)
                                                         /* Bit  11:    Reserved */

--- a/arch/arm/src/nrf91/nrf91_modem.h
+++ b/arch/arm/src/nrf91/nrf91_modem.h
@@ -55,19 +55,19 @@
 #define NRF91_SHMEM_TRACE_SIZE (CONFIG_NRF91_MODEM_SHMEM_TRACE_SIZE)
 
 #if !(NRF91_SHMEM_CTRL_BASE % 4 == 0)
-#  error SHMEM base addres must be word-aligned (4 bytes)
+#  error SHMEM base address must be word-aligned (4 bytes)
 #endif
 
 #if !(NRF91_SHMEM_TX_BASE % 4 == 0)
-#  error SHMEM base addres must be word-aligned (4 bytes)
+#  error SHMEM base address must be word-aligned (4 bytes)
 #endif
 
 #if !(NRF91_SHMEM_RX_BASE % 4 == 0)
-#  error SHMEM base addres must be word-aligned (4 bytes)
+#  error SHMEM base address must be word-aligned (4 bytes)
 #endif
 
 #if !(NRF91_SHMEM_TRACE_BASE % 4 == 0)
-#  error SHMEM base addres must be word-aligned (4 bytes)
+#  error SHMEM base address must be word-aligned (4 bytes)
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -1371,7 +1371,7 @@ static int sam_dma_setup(struct uart_dev_s *dev)
 
       sam_dmastart_circular(priv->rxdma, sam_dma_rxcallback, (void *)dev);
 
-      /* Use defined timout to check if RX bus is in idle state */
+      /* Use defined timeout to check if RX bus is in idle state */
 
       sam_serialout(priv, SAM_UART_RTOR_OFFSET,
                     CONFIG_SAMV7_SERIAL_DMA_TIMEOUT);

--- a/arch/arm/src/samv7/sam_xdmac.c
+++ b/arch/arm/src/samv7/sam_xdmac.c
@@ -1915,7 +1915,7 @@ int sam_dmarxsetup(DMA_HANDLE handle, uint32_t paddr, uint32_t maddr,
  *   maddr - array of memory addresses (i.e. destination addresses)
  *   paddr - peripheral address (i.e. source address)
  *   nbytes - number of bytes to transfer
- *   ndescrs - number of descriptors (i.e. the lenght of descr array)
+ *   ndescrs - number of descriptors (i.e. the length of descr array)
  *
  ****************************************************************************/
 

--- a/arch/arm/src/samv7/sam_xdmac.h
+++ b/arch/arm/src/samv7/sam_xdmac.h
@@ -350,7 +350,7 @@ int sam_dmarxsetup(DMA_HANDLE handle, uint32_t paddr,
  *   maddr - array of memory addresses (i.e. destination addresses)
  *   paddr - peripheral address (i.e. source address)
  *   nbytes - number of bytes to transfer
- *   ndescrs - number of descriptors (i.e. the lenght of descr array)
+ *   ndescrs - number of descriptors (i.e. the length of descr array)
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/common/espressif/esp_nxdiag.c
+++ b/arch/risc-v/src/common/espressif/esp_nxdiag.c
@@ -172,7 +172,7 @@ int esp_nxdiag_read_flash_status(uint32_t *status)
  *   Read MAC adress.
  *
  * Input Parameters:
- *   mac - Mac adress to return.
+ *   mac - Mac address to return.
  *
  * Returned Value:
  *   OK on success; ERROR on failure.

--- a/arch/risc-v/src/common/espressif/esp_ws2812.c
+++ b/arch/risc-v/src/common/espressif/esp_ws2812.c
@@ -464,7 +464,7 @@ static ssize_t esp_write(struct file *filep, const char *data, size_t len)
 
   if (len > 0)
     {
-      /* Check if the lenght to be updated, considering the current position,
+      /* Check if the length to be updated, considering the current position,
        * is valid. The number of LEDs to be updated should, starting from the
        * current offset should be less than the LED strip total length.
        */

--- a/arch/x86_64/src/common/x86_64_mmu.h
+++ b/arch/x86_64/src/common/x86_64_mmu.h
@@ -105,7 +105,7 @@ static inline uintptr_t mmu_pte_to_paddr(uintptr_t pte)
     {
       paddr = pte;
 
-      /* Get page addres - remove flags */
+      /* Get page address - remove flags */
 
       paddr &= 0x0dfffffffffff000;
     }

--- a/arch/xtensa/src/common/espressif/esp_nxdiag.c
+++ b/arch/xtensa/src/common/espressif/esp_nxdiag.c
@@ -179,7 +179,7 @@ int esp_nxdiag_read_flash_status(uint32_t *status)
  *   Read MAC adress.
  *
  * Input Parameters:
- *   mac - Mac adress to return.
+ *   mac - Mac address to return.
  *
  * Returned Value:
  *   OK on success; ERROR on failure.

--- a/arch/xtensa/src/common/espressif/esp_ws2812.c
+++ b/arch/xtensa/src/common/espressif/esp_ws2812.c
@@ -464,7 +464,7 @@ static ssize_t esp_write(struct file *filep, const char *data, size_t len)
 
   if (len > 0)
     {
-      /* Check if the lenght to be updated, considering the current position,
+      /* Check if the length to be updated, considering the current position,
        * is valid. The number of LEDs to be updated should, starting from the
        * current offset should be less than the LED strip total length.
        */

--- a/boards/arm/cxd56xx/common/src/cxd56_alt1250.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_alt1250.c
@@ -242,7 +242,7 @@ static struct spi_dev_s *alt1250_poweron(bool keep_on)
 
   up_mdelay(TIME_TO_STABLE_VDDIO);
 
-  /* Initialize spi deivce */
+  /* Initialize spi device */
 
   spi = cxd56_spibus_initialize(SPI_CH);
   if (!spi)

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -884,7 +884,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* Set specfic can transceiver state */
+      /* Set specific can transceiver state */
 
       case CANIOC_SET_TRANSVSTATE:
         {
@@ -907,7 +907,7 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* Get specfic can transceiver state */
+      /* Get specific can transceiver state */
 
       case CANIOC_GET_TRANSVSTATE:
         {

--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -780,7 +780,7 @@ static int rpmsgblk_unlink(FAR struct inode *inode)
  *
  * Parameters:
  *   priv  - The rpmsg-blk handle
- *   len   - The got memroy size
+ *   len   - The got memory size
  *
  * Returned Values:
  *   NULL     - failure

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -745,7 +745,7 @@ static int rpmsgdev_poll(FAR struct file *filep, FAR struct pollfd *fds,
  *
  * Parameters:
  *   priv  - The rpmsg-device handle
- *   len   - The got memroy size
+ *   len   - The got memory size
  *
  * Returned Values:
  *   NULL     - failure

--- a/drivers/mtd/rpmsgmtd.c
+++ b/drivers/mtd/rpmsgmtd.c
@@ -667,7 +667,7 @@ static int rpmsgmtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
  *
  * Parameters:
  *   priv  - The rpmsg-mtd handle
- *   len   - The got memroy size
+ *   len   - The got memory size
  *
  * Returned Values:
  *   NULL     - failure

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -638,7 +638,7 @@ static void pci_register_bus_devices(FAR struct pci_bus_s *bus)
  * Input Parameters:
  *   base    - PCI address base address
  *   maxbase - PCI max base address
- *   mask    - PCI addres mask
+ *   mask    - PCI address mask
  *
  * Returned Value:
  *   Return the size result

--- a/drivers/reset/core.c
+++ b/drivers/reset/core.c
@@ -431,7 +431,7 @@ reset_controller_get_by_name(FAR const char *name)
  *
  *   Firstly, get a reset controller device from list, and then call
  *   reset_control_get_internal function by index, shared or acquired
- *   parameters retrun a reset control.
+ *   parameters return a reset control.
  *
  * Input Parameters:
  *   name     - The reset controller name

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -291,7 +291,7 @@ static int rpmsg_virtio_ivshmem_probe(FAR struct ivshmem_device_s *ivdev)
   ret = rpmsg_virtio_initialize(&priv->dev);
   if (ret < 0)
     {
-      rpmsgerr("Rpmsg virtio intialize failed, ret=%d\n", ret);
+      rpmsgerr("Rpmsg virtio initialize failed, ret=%d\n", ret);
       goto err;
     }
 

--- a/drivers/rptun/rptun_ivshmem.c
+++ b/drivers/rptun/rptun_ivshmem.c
@@ -396,7 +396,7 @@ static int rptun_ivshmem_probe(FAR struct ivshmem_device_s *ivdev)
   ret = rptun_initialize(&priv->rptun);
   if (ret < 0)
     {
-      pcierr("rptun intialize failed, ret=%d\n", ret);
+      pcierr("rptun initialize failed, ret=%d\n", ret);
       goto err;
     }
 

--- a/drivers/thermal/thermal_dummy.c
+++ b/drivers/thermal/thermal_dummy.c
@@ -348,7 +348,7 @@ int thermal_dummy_init(void)
                                       &g_dummy_zone_ops, &g_dummy_params);
   if (zdev == NULL)
     {
-      therr("Register zone deivce failed!\n");
+      therr("Register zone device failed!\n");
       return -ENOTSUP;
     }
 

--- a/drivers/virtio/virtio-blk.c
+++ b/drivers/virtio/virtio-blk.c
@@ -116,7 +116,7 @@ begin_packed_struct struct virtio_blk_config_s
 
 struct virtio_blk_priv_s
 {
-  FAR struct virtio_device     *vdev;           /* Virtio deivce */
+  FAR struct virtio_device     *vdev;           /* Virtio device */
   spinlock_t                    lock;           /* Lock */
   uint64_t                      nsectors;       /* Sectore numbers */
   uint32_t                      block_size;     /* Block size */

--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -178,7 +178,7 @@
 
 struct virtio_mmio_device_s
 {
-  struct virtio_device   vdev;       /* Virtio deivce */
+  struct virtio_device   vdev;       /* Virtio device */
   struct metal_io_region shm_io;     /* Share memory io region, virtqueue
                                       * use this io.
                                       */

--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -688,7 +688,7 @@ static int virtio_net_probe(FAR struct virtio_device *vdev)
 
 #endif
 
-  /* Register the net deivce */
+  /* Register the net device */
 
   ret = netdev_lower_register(netdev,
 #ifdef CONFIG_DRIVERS_WIFI_SIM

--- a/drivers/virtio/virtio-pci.h
+++ b/drivers/virtio/virtio-pci.h
@@ -78,7 +78,7 @@ struct virtio_pci_ops_s
 
 struct virtio_pci_device_s
 {
-  struct virtio_device               vdev;    /* Virtio deivce */
+  struct virtio_device               vdev;    /* Virtio device */
   FAR struct pci_device_s           *dev;     /* PCI device */
   FAR const struct virtio_pci_ops_s *ops;
   metal_phys_addr_t                  shm_phy;

--- a/drivers/virtio/virtio-rng.c
+++ b/drivers/virtio/virtio-rng.c
@@ -211,7 +211,7 @@ static int virtio_rng_probe(FAR struct virtio_device *vdev)
   priv->vdev = vdev;
   vdev->priv = priv;
 
-  /* Call openamp api to intialize the virtio deivce */
+  /* Call openamp api to initialize the virtio deivce */
 
   virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_DRIVER);
   virtio_set_features(vdev, 0);

--- a/drivers/virtio/virtio-rng.c
+++ b/drivers/virtio/virtio-rng.c
@@ -211,7 +211,7 @@ static int virtio_rng_probe(FAR struct virtio_device *vdev)
   priv->vdev = vdev;
   vdev->priv = priv;
 
-  /* Call openamp api to initialize the virtio deivce */
+  /* Call openamp api to initialize the virtio device */
 
   virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_DRIVER);
   virtio_set_features(vdev, 0);

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -265,7 +265,7 @@
  *   Dependencies:   None
  *
  * CANIOC_SET_STATE
- *   Description:    Set specfic can controller state
+ *   Description:    Set specific can controller state
  *
  *   Argument:       A pointer to an int type that describes the CAN
  *                   controller state.
@@ -275,7 +275,7 @@
  *   Dependencies:   None
  *
  * CANIOC_GET_STATE
- *   Description:    Get specfic can controller state
+ *   Description:    Get specific can controller state
  *
  *   Argument:       A pointer to an int type that describes the CAN
  *                   controller state.
@@ -285,7 +285,7 @@
  *   Dependencies:   None
  *
  * CANIOC_SET_TRANSV_STATE
- *   Description:    Set specfic can transceiver state
+ *   Description:    Set specific can transceiver state
  *
  *   Argument:       A pointer to an int type that describes the CAN
  *                   transceiver state.
@@ -295,7 +295,7 @@
  *   Dependencies:   None
  *
  * CANIOC_GET_TRANSV_STATE
- *   Description:    Get specfic can transceiver state
+ *   Description:    Get specific can transceiver state
  *
  *   Argument:       A pointer to an int type that describes the CAN
  *                   transceiver state.

--- a/include/nuttx/reset/reset.h
+++ b/include/nuttx/reset/reset.h
@@ -137,7 +137,7 @@ int reset_control_status(FAR struct reset_control *rstc);
  *
  *   Firstly, get a reset controller device from list, and then call
  *   reset_control_get_internal function by index, shared or acquired
- *   parameters retrun a reset control.
+ *   parameters return a reset control.
  *
  * Input Parameters:
  *   name     - The reset controller name

--- a/libs/libc/machine/x86_64/gnu/arch_strcpy.S
+++ b/libs/libc/machine/x86_64/gnu/arch_strcpy.S
@@ -138,7 +138,7 @@ ENTRY (STRCPY)
 	movdqu	(%rsi, %rcx), %xmm1   /* copy 16 bytes */
 	movdqu	%xmm1, (%rdi)
 
-/* If source adress alignment != destination adress alignment */
+/* If source address alignment != destination address alignment */
 	.p2align 4
 L(Unalign16Both):
 	sub	%rcx, %rdi
@@ -334,7 +334,7 @@ L(Unaligned64Leave):
 	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
 #endif
 
-/* If source adress alignment == destination adress alignment */
+/* If source address alignment == destination address alignment */
 
 L(SourceStringAlignmentLess32):
 	pxor	%xmm0, %xmm0

--- a/net/icmp/Kconfig
+++ b/net/icmp/Kconfig
@@ -32,7 +32,7 @@ config NET_ICMP_PMTU_TIMEOUT
 	default 10
 	depends on NET_ICMP_PMTU_ENTRIES != 0
 	---help---
-		The timout of the ICMP pmtu entry
+		The timeout of the ICMP pmtu entry
 
 config NET_ICMP_SOCKET
 	bool "IPPROTO_ICMP socket support"

--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -34,7 +34,7 @@ config NET_ICMPv6_PMTU_TIMEOUT
 	default 10
 	depends on NET_ICMPv6_PMTU_ENTRIES != 0
 	---help---
-		The timout of the ICMPv6 pmtu entry
+		The timeout of the ICMPv6 pmtu entry
 
 config NET_ICMPv6_SOCKET
 	bool "IPPROTO_ICMP6 socket support"

--- a/tools/parsetrace.py
+++ b/tools/parsetrace.py
@@ -484,14 +484,14 @@ class TraceDecoder(SymbolTables):
         return "%s", length, fmt % value
 
     def extract_string(self, fmt, data):
-        lenght = 0
+        length = 0
         if fmt == "%.*s":
-            lenght = int.from_bytes(
+            length = int.from_bytes(
                 data[:4], byteorder=self.elfinfo["byteorder"], signed=True
             )
             data = data[4:]
         else:
-            lenght = 0
+            length = 0
 
         try:
             string = data.split(b"\x00")[0].decode("utf-8")
@@ -501,17 +501,17 @@ class TraceDecoder(SymbolTables):
                     data[:size], byteorder=self.elfinfo["byteorder"], signed=False
                 )
                 string = f"<<0x{address}>>"
-                lenght += size
+                length += size
             else:
-                lenght += len(string) + 1
+                length += len(string) + 1
         except Exception:
             size = 4 if self.typeinfo["size_t"] == "uint32" else 8
             address = int.from_bytes(
                 data[:size], byteorder=self.elfinfo["byteorder"], signed=False
             )
             string = f"<<0x{address}>>"
-            lenght += size
-        return "%s", lenght, string
+            length += size
+        return "%s", length, string
 
     def extract_point(self, fmt, data):
         length = 4 if self.typeinfo["size_t"] == "int32" else 8


### PR DESCRIPTION
## Summary

1. drivers/reset: fix typo retrun -> return
2. drivers/can: fix typo specfic -> specific
3. net/icmp: fix typo timout -> timeout
4. drivers/virtio: fix typo deivce -> device
5. drivers/rpmsg: fix typo intialize -> initialize
6. drivers/misc: fix typo memroy -> memory
7. tools/parsetrace.py: fix typo lenght -> length
8. libc/gnu: fix typo adress -> address
9. drivers/pci: fix typo addres -> address


## Impact

N/A

## Testing

ci-check

