### PR TITLE
{bp-15209} sim: Fix build errors on macOS

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -149,8 +149,13 @@ ifeq ($(CONFIG_SIM_M32),y)
   ARCHCFLAGS += -m32
   ARCHCXXFLAGS += -m32
 else
-  ARCHCFLAGS += -fno-pic -mcmodel=medium
-  ARCHCXXFLAGS += -fno-pic -mcmodel=medium
+  ifeq ($(CONFIG_HOST_MACOS),y)
+    ARCHCFLAGS += -fno-pic
+    ARCHCXXFLAGS += -fno-pic
+  else
+    ARCHCFLAGS += -fno-pic -mcmodel=medium
+    ARCHCXXFLAGS += -fno-pic -mcmodel=medium
+  endif
 endif
 
 # LLVM style architecture flags


### PR DESCRIPTION
## Summary

macOS 15.2
x86-64
Xcode 16.1
```
ld: warning: disabling chained fixups because of unaligned pointers
ld: illegal text-relocation in '_main'+0x1F (/Users/yamamoto/git/nuttx/nuttx/arc
h/sim/src/nuttx.rel) to '_g_argc'
```
## Impact

RELEASE

## Testing

CI