### PR TITLE
sem: Replace addrenv_select with kmm_map for sem_waitirq/sem_holder

### DIFF
--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -416,6 +416,9 @@ int addrenv_leave(FAR struct tcb_s *tcb);
  *   0 (OK) is returned on success and a negated errno is returned on
  *   failure.
  *
+ * Note:
+ *   This API is not safe to use from interrupt.
+ *
  ****************************************************************************/
 
 int addrenv_select(FAR struct addrenv_s *addrenv,

--- a/include/nuttx/mm/kmap.h
+++ b/include/nuttx/mm/kmap.h
@@ -24,6 +24,16 @@
 #define __INCLUDE_NUTTX_MM_KMAP_H
 
 /****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct tcb_s;                  /* Forward reference to TCB */
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: kmm_map_initialize
  *
  * Description:
@@ -81,6 +91,8 @@ void kmm_unmap(FAR void *kaddr);
  *   a continuous virtual memory area.
  *
  * Input Parameters:
+ *   tcb   - The tcb of the task whose address environment the mapping
+ *           belongs to.
  *   uaddr - The user virtual address where mapping begins.
  *   size  - Size of the region.
  *
@@ -89,7 +101,7 @@ void kmm_unmap(FAR void *kaddr);
  *
  ****************************************************************************/
 
-FAR void *kmm_map_user(FAR void *uaddr, size_t size);
+FAR void *kmm_map_user(FAR struct tcb_s *tcb, FAR void *uaddr, size_t size);
 
 /****************************************************************************
  * Name: kmm_map_user_page
@@ -99,6 +111,8 @@ FAR void *kmm_map_user(FAR void *uaddr, size_t size);
  *   returns the kernel addressable page pool virtual address.
  *
  * Input Parameters:
+ *   tcb   - The tcb of the task whose address environment the mapping
+ *           belongs to.
  *   uaddr - The virtual address of the user page.
  *
  * Returned Value:
@@ -106,6 +120,6 @@ FAR void *kmm_map_user(FAR void *uaddr, size_t size);
  *
  ****************************************************************************/
 
-FAR void *kmm_map_user_page(FAR void *uaddr);
+FAR void *kmm_map_user_page(FAR struct tcb_s *tcb, FAR void *uaddr);
 
 #endif /* __INCLUDE_NUTTX_MM_KMAP_H */

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -76,11 +76,11 @@ static struct mm_map_s g_kmm_map;
  *
  ****************************************************************************/
 
-static int get_user_pages(FAR void **pages, size_t npages, uintptr_t vaddr)
+static int get_user_pages(FAR struct tcb_s *tcb, FAR void **pages,
+                          size_t npages, uintptr_t vaddr)
 {
-  FAR struct tcb_s *tcb = this_task();
-  uintptr_t         page;
-  int               i;
+  uintptr_t page;
+  int       i;
 
   /* Find the pages associated with the user virtual address space */
 
@@ -170,19 +170,18 @@ errout_with_vaddr:
  *   Map a single user page into kernel memory.
  *
  * Input Parameters:
- *   pages  - Pointer to buffer that contains the physical page addresses.
- *   npages - Amount of pages.
- *   prot   - Access right flags.
+ *   tcb   - The tcb of the task whose address environment the mapping
+ *           belongs to.
+ *   vaddr - The virtual address of the page to map.
  *
  * Returned Value:
  *   Pointer to the mapped virtual memory on success; NULL on failure
  *
  ****************************************************************************/
 
-static FAR void *map_single_user_page(uintptr_t vaddr)
+static FAR void *map_single_user_page(FAR struct tcb_s *tcb, uintptr_t vaddr)
 {
-  FAR struct tcb_s *tcb = this_task();
-  uintptr_t         page;
+  uintptr_t page;
 
   /* Find the page associated with this virtual address */
 
@@ -405,6 +404,8 @@ void kmm_unmap(FAR void *kaddr)
  *   a continuous virtual memory area.
  *
  * Input Parameters:
+ *   tcb   - The tcb of the task whose address environment the mapping
+ *           belongs to.
  *   uaddr - The user virtual address where mapping begins.
  *   size  - Size of the region.
  *
@@ -413,7 +414,7 @@ void kmm_unmap(FAR void *kaddr)
  *
  ****************************************************************************/
 
-FAR void *kmm_map_user(FAR void *uaddr, size_t size)
+FAR void *kmm_map_user(FAR struct tcb_s *tcb, FAR void *uaddr, size_t size)
 {
   FAR void **pages;
   uintptr_t vaddr;
@@ -446,7 +447,7 @@ FAR void *kmm_map_user(FAR void *uaddr, size_t size)
     {
       /* Yes, can simply return the kernel addressable virtual address */
 
-      vaddr = (uintptr_t)map_single_user_page(vaddr);
+      vaddr = (uintptr_t)map_single_user_page(tcb, vaddr);
       return (FAR void *)(vaddr + offset);
     }
 
@@ -460,7 +461,7 @@ FAR void *kmm_map_user(FAR void *uaddr, size_t size)
 
   /* Fetch the physical pages for the user virtual address range */
 
-  ret = get_user_pages(pages, npages, vaddr);
+  ret = get_user_pages(tcb, pages, npages, vaddr);
   if (ret < 0)
     {
       goto errout_with_pages;
@@ -492,6 +493,8 @@ errout_with_pages:
  *   returns the kernel addressable page pool virtual address.
  *
  * Input Parameters:
+ *   tcb   - The tcb of the task whose address environment the mapping
+ *           belongs to.
  *   uaddr - The virtual address of the user page.
  *
  * Returned Value:
@@ -499,7 +502,7 @@ errout_with_pages:
  *
  ****************************************************************************/
 
-FAR void *kmm_map_user_page(FAR void *uaddr)
+FAR void *kmm_map_user_page(FAR struct tcb_s *tcb, FAR void *uaddr)
 {
   uintptr_t vaddr;
   uintptr_t offset;
@@ -522,7 +525,7 @@ FAR void *kmm_map_user_page(FAR void *uaddr)
   offset = vaddr & MM_PGMASK;
   vaddr = MM_PGALIGNDOWN(vaddr);
 
-  vaddr = (uintptr_t)map_single_user_page(vaddr);
+  vaddr = (uintptr_t)map_single_user_page(tcb, vaddr);
   if (!vaddr)
     {
       return NULL;

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -339,6 +339,9 @@ int addrenv_leave(FAR struct tcb_s *tcb)
  *   0 (OK) is returned on success and a negated errno is returned on
  *   failure.
  *
+ * Note:
+ *   This API is not safe to use from interrupt.
+ *
  ****************************************************************************/
 
 int addrenv_select(FAR struct addrenv_s *addrenv,

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -30,8 +30,8 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
+#include <nuttx/mm/kmap.h>
 
 #include "sched/sched.h"
 #include "semaphore/semaphore.h"
@@ -97,6 +97,10 @@ nxsem_allocholder(FAR sem_t *sem, FAR struct tcb_s *htcb)
       serr("ERROR: Insufficient pre-allocated holders\n");
       PANIC();
     }
+
+#ifdef CONFIG_MM_KMAP
+  sem = kmm_map_user(this_task(), sem, sizeof(*sem));
+#endif
 
   pholder->sem    = sem;
   pholder->htcb   = htcb;
@@ -193,6 +197,10 @@ static inline void nxsem_freeholder(FAR sem_t *sem,
           break;
         }
     }
+
+#ifdef CONFIG_MM_KMAP
+  kmm_unmap(pholder->sem);
+#endif
 
   /* Release the holder and counts */
 
@@ -398,15 +406,6 @@ static void nxsem_restore_priority(FAR struct tcb_s *htcb)
     {
       FAR struct semholder_s *pholder;
 
-#ifdef CONFIG_ARCH_ADDRENV
-      FAR struct addrenv_s *oldenv;
-
-      if (htcb->addrenv_own)
-        {
-          addrenv_select(htcb->addrenv_own, &oldenv);
-        }
-#endif
-
       /* Try to find the highest priority across all the threads that are
        * waiting for any semaphore held by htcb.
        */
@@ -423,13 +422,6 @@ static void nxsem_restore_priority(FAR struct tcb_s *htcb)
               hpriority = stcb->sched_priority;
             }
         }
-
-#ifdef CONFIG_ARCH_ADDRENV
-      if (htcb->addrenv_own)
-        {
-          addrenv_restore(oldenv);
-        }
-#endif
 
       /* Apply the selected priority to the thread (hopefully back to the
        * threads base_priority).


### PR DESCRIPTION
## Summary

As semaphores reside in user virtual memory, there are some cases where accessing said semaphore needs a trick where
the mappings are changed to the semaphore's owner process. Using addrenv_select was a quick kludge fix for the issue
and it seemed to work. However, this is not the case in one exception; an interrupt level context switch.

Using addrenv_select() from interrupt context causes random crashes due to usage of this_task(). If an interrupt level
context switch occurs, this_task() will point to the NEXT task that will be executed once the interrupt returns. Temporarily
mapping this task's address environment to access e.g. the semaphore in question will obviously fail. Just get rid of this
kludge fix and properly address the issue once and for all.

Both sem_waitirq and nxsem_restore_priority can be invoked from interrupt handlers, thus using addrenv_select() is not
safe. Replace all references with kmm_map() which will temporarily map the (user) semaphore into kernel virtual memory,
making it safe to access from other contexts than the task itself.

There are other obvious impacts when addrenv_select() is used, the most obvious one being a full nuking of the local TLB when this is done! It is a huge performance impact and usage of addrenv_select() should be phased out gradually.

## Impact

This fixes random crashes in sem_waitirq and nxsem_restore_priority. Impact is for targets that have CONFIG_ARCH_ADDRENV=y only. Other modes are not affected.

## Testing

rv-virt:knsh64
rv-virt:ksmp64
MPFS target with >100 processes and threads, SMP, priority inheritance enabled

