### PR TITLE
nxsem_destroyholder: Use critical section when destroying holder(s)

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -566,6 +566,8 @@ void nxsem_initialize_holders(void)
 
 void nxsem_destroyholder(FAR sem_t *sem)
 {
+  irqstate_t flags = enter_critical_section();
+
   /* It might be an error if a semaphore is destroyed while there are any
    * holders of the semaphore (except perhaps the thread that release the
    * semaphore itself).  We actually have to assume that the caller knows
@@ -600,6 +602,8 @@ void nxsem_destroyholder(FAR sem_t *sem)
 #endif
 
   nxsem_foreachholder(sem, nxsem_recoverholders, NULL);
+
+  leave_critical_section(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Must use critical section here, otherwise the free holder list will leak, causing either a crash due to holder->htcb = NULL, or the free holder list becomes (erroneously) empty even though most of the holder entries are free.

## Impact

Fix g_freeholders list integrity.

## Testing

rv-virt:knsh64
rv-virt:ksmp64
MPFS target with > 100 threads and processeds, PI=yes, SMP=yes

