### PR TITLE
{bp-15240} fix compile error

### DIFF
--- a/arch/arm/src/tiva/tm4c/tm4c_gpio.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_gpio.c
@@ -33,6 +33,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "tiva_enablepwr.h"


### PR DESCRIPTION
## Summary
Create version.h
CC:  chip/tm4c/tm4c_gpio.c chip/tm4c/tm4c_gpio.c: In function 'tiva_configgpio': chip/tm4c/tm4c_gpio.c:793:11: warning: implicit declaration of function 'spin_lock_irqsave' [-Wimplicit-function-declaration]
  793 |   flags = spin_lock_irqsave(&g_configgpio_lock);
      |           ^~~~~~~~~~~~~~~~~
CC:  nsh_parse.c chip/tm4c/tm4c_gpio.c:844:3: warning: implicit declaration of function 'spin_unlock_irqrestore' [-Wimplicit-function-declaration]
  844 |   spin_unlock_irqrestore(&g_configgpio_lock, flags);

## Impact

RELEASE

## Testing

CI
