### PR TITLE
{bp-15241} Fix for WiFi AP password wrongly stored on some Espressif devices

### DIFF
--- a/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
@@ -5172,7 +5172,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
       if (ext->alg != IW_ENCODE_ALG_NONE)
         {
-          memcpy(wifi_cfg.sta.password, pdata, len);
+          memcpy(wifi_cfg.ap.password, pdata, len);
         }
 
       if (g_softap_started)

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -6169,7 +6169,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
       if (ext->alg != IW_ENCODE_ALG_NONE)
         {
-          memcpy(wifi_cfg.sta.password, pdata, len);
+          memcpy(wifi_cfg.ap.password, pdata, len);
         }
 
       if (g_softap_started)

--- a/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
@@ -5965,7 +5965,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
       if (ext->alg != IW_ENCODE_ALG_NONE)
         {
-          memcpy(wifi_cfg.sta.password, pdata, len);
+          memcpy(wifi_cfg.ap.password, pdata, len);
         }
 
       if (g_softap_started)

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -6217,7 +6217,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
       if (ext->alg != IW_ENCODE_ALG_NONE)
         {
-          memcpy(wifi_cfg.sta.password, pdata, len);
+          memcpy(wifi_cfg.ap.password, pdata, len);
         }
 
       if (g_softap_started)


### PR DESCRIPTION
## Summary

Fix a situation where WiFi Access Point password was wrongly copied to WiFi Station configuration instead, when crypto algorithm IW_ENCODE_ALG_NONE was not used.

## Impact

RELEASE

## Testing

CI
