### PR TITLE
syslog/intbuffer: some improve for intbuffer

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -94,10 +94,10 @@ static struct syslog_intbuffer_s g_syslog_intbuffer =
  *
  ****************************************************************************/
 
-void syslog_flush_internal(bool force, size_t buflen)
+static void syslog_flush_internal(bool force, size_t buflen)
 {
   irqstate_t flags;
-  char *buffer;
+  FAR char *buffer;
   size_t size;
 
   /* This logic is performed with the scheduler disabled to protect from


### PR DESCRIPTION
## Summary

syslog/intbuffer: some improve for intbuffer

1. add static for internal function
2. add FAR for pointer prototype

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check