### PR TITLE
remove big lock in arch_phy_irq

### DIFF
--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -47,6 +47,7 @@
 #include <nuttx/net/mii.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/net/netdev.h>
+#include <nuttx/spinlock.h>
 
 #if defined(CONFIG_ARCH_PHY_INTERRUPT)
 #  include <nuttx/net/phy.h>
@@ -410,6 +411,7 @@ struct rx65n_ethmac_s
 
   uint32_t             prevlinkstatus; /* Previous link status to ignore multiple link change interrupt (specific to GR-Rose) */
   uint8_t              mc_filter_flag; /* Multicast filter */
+  spinlock_t           lock;           /* SpinLock */
 };
 
 /****************************************************************************
@@ -2097,7 +2099,7 @@ static int rx65n_ifdown(struct net_driver_s *dev)
   irqstate_t flags;
   int ret = OK;
   ninfo("Taking the network down\n");
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
 
   /* Disable the Ethernet interrupt */
 
@@ -2125,7 +2127,7 @@ static int rx65n_ifdown(struct net_driver_s *dev)
 
   priv->prevlinkstatus = ETHER_LINKDOWN;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return ret;
 }
 
@@ -2648,7 +2650,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
       return -ENODEV;
     }
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_rx65nethmac[0].lock);
   rx65n_phyintenable(false);
 
   /* Configure the interrupt */
@@ -2677,7 +2679,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_rx65nethmac[0].lock, flags);
   return OK;
 }
 #endif
@@ -3890,6 +3892,8 @@ int rx65n_ethinitialize(int intf)
 
   rx65n_cmtw0_create(RX65N_CMTW0_COUNT_VALUE_FOR_TXPOLL ,
                      RX65N_CMTW0_COUNT_VALUE_FOR_TXTIMEOUT);
+
+  spin_lock_init(&priv->lock);
 
   /* Attach the IRQ to the driver */
 

--- a/boards/arm/at32/at32f437-mini/src/at32_ethernet.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_ethernet.c
@@ -44,6 +44,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/spinlock.h>
 
 #include "at32_gpio.h"
 #include "at32_eth.h"
@@ -79,6 +80,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_ethmac_lock = SP_UNLOCKED;
 
 #ifdef HAVE_NETMONITOR
 static xcpt_t g_ethmac_handler;
@@ -214,7 +217,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   DEBUGASSERT(intf);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_ethmac_lock);
 
   if (strcmp(intf, AT32_ETHMAC_DEVNAME) == 0)
     {
@@ -234,7 +237,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
       *enable = enabler;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_ethmac_lock, flags);
   return OK;
 }
 #endif

--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
@@ -73,6 +73,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -235,7 +241,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -270,7 +276,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* GPIO_ENET_IRQ */

--- a/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
@@ -76,6 +76,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -243,7 +249,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -278,7 +284,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
@@ -74,6 +74,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -235,7 +241,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -270,7 +276,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
@@ -74,6 +74,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -235,7 +241,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -270,7 +276,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/imxrt1170-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1170-evk/src/imxrt_ethernet.c
@@ -75,6 +75,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -254,7 +260,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -289,7 +295,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
@@ -74,6 +74,12 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -235,7 +241,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -270,7 +276,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/sam34/sam4e-ek/src/sam_ethernet.c
+++ b/boards/arm/sam34/sam4e-ek/src/sam_ethernet.c
@@ -41,6 +41,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_gpio.h"
 #include "sam_emac.h"
@@ -69,6 +70,14 @@
 #  define phyerr(x...)
 #  define phywarn(x...)
 #  define phyinfo(x...)
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SAM34_GPIOD_IRQ
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -205,7 +214,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -237,7 +246,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAM34_GPIOD_IRQ */

--- a/boards/arm/sama5/jupiter-nano/src/sam_ethernet.c
+++ b/boards/arm/sama5/jupiter-nano/src/sam_ethernet.c
@@ -41,6 +41,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_pio.h"
 #include "sam_ethernet.h"
@@ -79,6 +80,14 @@
 #  define phyerr(x...)
 #  define phywarn(x...)
 #  define phyinfo(x...)
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SAMA5_PIOE_IRQ
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -290,7 +299,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -322,7 +331,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMA5_PIOE_IRQ */

--- a/boards/arm/sama5/sama5d2-xult/src/sam_ethernet.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_ethernet.c
@@ -41,6 +41,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_pio.h"
 #include "sam_ethernet.h"
@@ -80,6 +81,12 @@
 #  define phywarn(x...)
 #  define phyinfo(x...)
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -290,7 +297,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -322,7 +329,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMA5_PIOE_IRQ */

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_ethernet.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_ethernet.c
@@ -41,6 +41,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_pio.h"
 #include "sam_ethernet.h"
@@ -79,6 +80,14 @@
 #  define phyerr(x...)
 #  define phywarn(x...)
 #  define phyinfo(x...)
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SAMA5_PIOE_IRQ
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -290,7 +299,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -322,7 +331,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMA5_PIOE_IRQ */

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_ethernet.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_ethernet.c
@@ -41,6 +41,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_pio.h"
 #include "sam_ethernet.h"
@@ -80,6 +81,12 @@
 #  define phywarn(x...)
 #  define phyinfo(x...)
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -290,7 +297,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -322,7 +329,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMA5_PIOE_IRQ */

--- a/boards/arm/samv7/same70-xplained/src/sam_ethernet.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_ethernet.c
@@ -44,6 +44,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_gpio.h"
 #include "sam_twihs.h"
@@ -76,6 +77,12 @@
 #  define phywarn(x...)
 #  define phyinfo(x...)
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -310,7 +317,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -342,7 +349,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMV7_GPIOA_IRQ */

--- a/boards/arm/samv7/samv71-xult/src/sam_ethernet.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ethernet.c
@@ -44,6 +44,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/spinlock.h>
 
 #include "sam_gpio.h"
 #include "sam_twihs.h"
@@ -76,6 +77,12 @@
 #  define phywarn(x...)
 #  define phyinfo(x...)
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -315,7 +322,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   /* Configure the interrupt */
 
@@ -347,7 +354,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif /* CONFIG_SAMV7_GPIOA_IRQ */

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ethernet.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ethernet.c
@@ -44,6 +44,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/spinlock.h>
 
 #include "stm32_gpio.h"
 #include "stm32_eth.h"
@@ -79,6 +80,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 
 #ifdef HAVE_NETMONITOR
 static xcpt_t g_ethmac_handler;
@@ -214,7 +217,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
 
   DEBUGASSERT(intf);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_phy_lock);
 
   if (strcmp(intf, STM32_ETHMAC_DEVNAME) == 0)
     {
@@ -234,7 +237,7 @@ int arch_phy_irq(const char *intf, xcpt_t handler, void *arg,
       *enable = enabler;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_phy_lock, flags);
   return OK;
 }
 #endif


### PR DESCRIPTION
## Summary

remove big lock in arch_phy_irq
reason:
We would like to replace the big lock with a small lock.

## Impact
arch_phy_irq


## Testing
ci


