### PR TITLE
modifyreg16: use small lock in modifyreg16

### DIFF
--- a/arch/arm/src/common/arm_modifyreg16.c
+++ b/arch/arm/src/common/arm_modifyreg16.c
@@ -34,6 +34,12 @@
 #include "arm_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/arm64/src/common/arm64_modifyreg16.c
+++ b/arch/arm64/src/common/arm64_modifyreg16.c
@@ -34,6 +34,12 @@
 #include "arm64_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/avr/src/common/avr_modifyreg16.c
+++ b/arch/avr/src/common/avr_modifyreg16.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "avr_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/ceva/src/common/ceva_modifyreg16.c
+++ b/arch/ceva/src/common/ceva_modifyreg16.c
@@ -30,6 +30,12 @@
 #include "ceva_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -46,10 +52,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/hc/src/common/hc_modifyreg16.c
+++ b/arch/hc/src/common/hc_modifyreg16.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "hc_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/mips/src/common/mips_modifyreg16.c
+++ b/arch/mips/src/common/mips_modifyreg16.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "mips_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/misoc/src/common/misoc_modifyreg16.c
+++ b/arch/misoc/src/common/misoc_modifyreg16.c
@@ -31,8 +31,15 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "misoc.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -51,10 +58,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/or1k/src/common/or1k_modifyreg16.c
+++ b/arch/or1k/src/common/or1k_modifyreg16.c
@@ -34,6 +34,12 @@
 #include "or1k_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/sparc/src/common/sparc_modifyreg16.c
+++ b/arch/sparc/src/common/sparc_modifyreg16.c
@@ -42,6 +42,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -63,11 +65,11 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }
 

--- a/arch/x86/src/common/x86_modifyreg16.c
+++ b/arch/x86/src/common/x86_modifyreg16.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/x86_64/src/common/x86_64_modifyreg16.c
+++ b/arch/x86_64/src/common/x86_64_modifyreg16.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_64_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/xtensa/src/common/xtensa_modifyreg16.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg16.c
@@ -36,6 +36,12 @@
 #include "xtensa.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -52,10 +58,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }


### PR DESCRIPTION

## Summary
modifyreg16: use small lock in modifyreg16
reason:
We would like to replace the big lock with a small lock.
## Impact
modifyreg16

## Testing
ci


