### PR TITLE
cxd: use small lock

### DIFF
--- a/arch/arm/src/cxd32xx/cxd32_uart.c
+++ b/arch/arm/src/cxd32xx/cxd32_uart.c
@@ -112,6 +112,8 @@ struct uartdev
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_cxd32xx_lock = SP_UNLOCKED;
+
 static const struct uartdev g_uartdevs[] =
 {
   {
@@ -270,7 +272,7 @@ void cxd32_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   uint32_t fbrd;
   uint32_t lcr_h;
 
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&g_cxd32xx_lock);
 
   div  = (uint64_t)(basefreq);
   div *= (uint64_t)(256);
@@ -287,5 +289,5 @@ void cxd32_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   lcr_h = getreg32(uartbase + CXD32_UART_LCR_H);
   putreg32(lcr_h, uartbase + CXD32_UART_LCR_H);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_cxd32xx_lock, flags);
 }

--- a/arch/arm/src/cxd56xx/cxd56_gpioint.c
+++ b/arch/arm/src/cxd56xx/cxd56_gpioint.c
@@ -95,6 +95,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_cxd56_lock = SP_UNLOCKED;
+
 static xcpt_t g_isr[MAX_SLOT];
 static uint32_t g_bothedge = 0;
 
@@ -114,7 +116,7 @@ static int alloc_slot(int pin, bool isalloc)
                                      : CXD56_TOPREG_IOCAPP_INTSEL0;
   int offset = (pin < PIN_IS_CLK) ? 1 : 56;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_cxd56_lock);
 
   for (slot = 0; slot < MAX_SYS_SLOT; slot++)
     {
@@ -144,12 +146,12 @@ static int alloc_slot(int pin, bool isalloc)
         }
       else
         {
-          spin_unlock_irqrestore(NULL, flags);
+          spin_unlock_irqrestore(&g_cxd56_lock, flags);
           return -ENXIO; /* no space */
         }
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_cxd56_lock, flags);
 
   if (PIN_IS_CLK <= pin)
     {
@@ -309,13 +311,13 @@ static void invert_irq(int irq)
   irqstate_t flags;
   uint32_t val;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_cxd56_lock);
 
   val = getreg32(CXD56_INTC_INVERT);
   val ^= (1 << (irq - CXD56_IRQ_EXTINT));
   putreg32(val, CXD56_INTC_INVERT);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_cxd56_lock, flags);
 }
 
 static bool inverted_irq(int irq)
@@ -431,9 +433,9 @@ int cxd56_gpioint_config(uint32_t pin, uint32_t gpiocfg, xcpt_t isr,
       irq_attach(irq, NULL, NULL);
       g_isr[slot] = NULL;
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_cxd56_lock);
       g_bothedge &= ~(1 << slot);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_cxd56_lock, flags);
       return irq;
     }
 
@@ -447,9 +449,9 @@ int cxd56_gpioint_config(uint32_t pin, uint32_t gpiocfg, xcpt_t isr,
     {
       /* set GPIO pseudo both edge interrupt */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_cxd56_lock);
       g_bothedge |= (1 << slot);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_cxd56_lock, flags);
 
       /* detect the change from the current signal */
 


### PR DESCRIPTION
## Summary

cxd: use small lock
reason:
We would like to replace the big lock with a small lock.

## Impact
cxd32_uart

## Testing
ci

