### PR TITLE
gcc/gcov: fix problems with fork

### DIFF
--- a/libs/libbuiltin/libgcc/CMakeLists.txt
+++ b/libs/libbuiltin/libgcc/CMakeLists.txt
@@ -25,5 +25,7 @@ endif()
 
 if(CONFIG_COVERAGE_MINI AND CONFIG_ARCH_TOOLCHAIN_GCC)
   nuttx_add_system_library(libcoverage)
+  target_compile_options(libcoverage PRIVATE -fno-profile-arcs
+                                             -fno-test-coverage)
   target_sources(libcoverage PRIVATE gcov.c)
 endif()

--- a/libs/libbuiltin/libgcc/CMakeLists.txt
+++ b/libs/libbuiltin/libgcc/CMakeLists.txt
@@ -25,7 +25,8 @@ endif()
 
 if(CONFIG_COVERAGE_MINI AND CONFIG_ARCH_TOOLCHAIN_GCC)
   nuttx_add_system_library(libcoverage)
-  target_compile_options(libcoverage PRIVATE -fno-profile-arcs
-                                             -fno-test-coverage)
+  target_compile_options(
+    libcoverage PRIVATE -fno-profile-arcs -fno-test-coverage
+                        -fno-stack-protector)
   target_sources(libcoverage PRIVATE gcov.c)
 endif()

--- a/libs/libbuiltin/libgcc/Make.defs
+++ b/libs/libbuiltin/libgcc/Make.defs
@@ -24,6 +24,13 @@ endif
 
 ifeq ($(CONFIG_COVERAGE_MINI)$(CONFIG_ARCH_TOOLCHAIN_GCC),yy)
 CSRCS += gcov.c
+
+GCOV_CFLAGS += -fno-profile-arcs -fno-test-coverage
+GCOV_CFLAGS += -fno-stack-protector
+
+bin/gcov.o: CFLAGS += $(GCOV_CFLAGS)
+kbin/gcov.o: CFLAGS += $(GCOV_CFLAGS)
+
 endif
 
 DEPPATH += --dep-path libgcc

--- a/libs/libbuiltin/libgcc/gcov.c
+++ b/libs/libbuiltin/libgcc/gcov.c
@@ -327,8 +327,9 @@ void __gcov_execv(void)
 {
 }
 
-void __gcov_fork(void)
+pid_t __gcov_fork(void)
 {
+  return fork();
 }
 
 void __gcov_dump(void)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

gcov: Fix gcov fork() issue:
    1.  After code coverage is enabled, fork will be replaced by __gcov_fork
gcov: Prevent pile insertion recursion
gcov: Disable stack checking
```
        When enable CONFIG_STACK_CANARIES, in general, the stack check in the __gcov_fork function is:
    " return fork();
    18: e59f3020 ldr r3, [pc, #32] @ 40 <__gcov_fork+0x40>
    1c: e5932000 ldr r2, [r3]
    20: e59d3004 ldr r3, [sp, #4]
    24: e0332002 eors r2, r3, r2
    28: e3a03000 mov r3, #0
    2c: 1a000002 bne 3c <__gcov_fork+0x3c>"
    r3 is obtained by taking the value of sp offset. But after opening thumb, the second comparison value in
    "8c6: 4a06 ldr r2, [pc, #24] @ (8e0 <__gcov_fork+0x30>)
    8c8: 6811 ldr r1, [r2, #0]
    8ca: 687a ldr r2, [r7, #4]
    8cc: 4051 eors r1, r2"
    is obtained through r7. Since r7 stores the stack address at this time, which stores the address of the parent process, the stack out of bounds will occur in the child process
```
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


