### PR TITLE
{bp-15254} drivers/mtd/mtd_config_fs:migrate to SPDX identifier

### DIFF
--- a/arch/arm/src/armv7-m/arm_itm.c
+++ b/arch/arm/src/armv7-m/arm_itm.c
@@ -1,9 +1,13 @@
 /****************************************************************************
  * arch/arm/src/armv7-m/arm_itm.c
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are
  *  met:
@@ -28,11 +32,6 @@
  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv7-m/dwt.h
+++ b/arch/arm/src/armv7-m/dwt.h
@@ -1,9 +1,10 @@
 /****************************************************************************
  * arch/arm/src/armv7-m/dwt.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
- *
- *  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -29,9 +30,6 @@
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv7-m/etm.h
+++ b/arch/arm/src/armv7-m/etm.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/armv7-m/etm.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 2014 Silicon Laboratories, Inc.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv7-m/itm.h
+++ b/arch/arm/src/armv7-m/itm.h
@@ -1,9 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv7-m/itm.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -28,9 +30,6 @@
  *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv7-m/tpi.h
+++ b/arch/arm/src/armv7-m/tpi.h
@@ -1,9 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv7-m/tpi.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -28,9 +30,6 @@
  *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv8-m/arm_cache.c
+++ b/arch/arm/src/armv8-m/arm_cache.c
@@ -1,14 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv8-m/arm_cache.c
  *
- *   Copyright (C) 2015, 2018-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *           Bob Feretich <bob.feretich@rafresearch.com>
- *
- * Some logic in this header file derives from the ARM CMSIS core_cm7.h
- * header file which has a compatible 3-clause BSD license:
- *
- *   Copyright (c) 2009 - 2014 ARM LIMITED.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2015, 2018-2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2014 ARM LIMITED.  All rights reserved.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
+ * SPDX-FileContributor: Bob Feretich <bob.feretich@rafresearch.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv8-m/dwt.h
+++ b/arch/arm/src/armv8-m/dwt.h
@@ -1,9 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv8-m/dwt.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -28,9 +30,6 @@
  *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv8-m/etm.h
+++ b/arch/arm/src/armv8-m/etm.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/armv8-m/etm.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv8-m/itm.h
+++ b/arch/arm/src/armv8-m/itm.h
@@ -1,9 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv8-m/itm.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -28,9 +30,6 @@
  *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/armv8-m/tpi.h
+++ b/arch/arm/src/armv8-m/tpi.h
@@ -1,9 +1,11 @@
 /****************************************************************************
  * arch/arm/src/armv8-m/tpi.h
  *
- *   Copyright (c) 2009 - 2013 ARM LIMITED
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville. All rights reserved.
+ * SPDX-FileCopyrightText: 2009 - 2013 ARM LIMITED
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
- *  All rights reserved.
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
  *  are met:
@@ -28,9 +30,6 @@
  *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/efm32_flash.c
+++ b/arch/arm/src/efm32/efm32_flash.c
@@ -1,7 +1,10 @@
 /****************************************************************************
  * arch/arm/src/efm32/efm32_flash.c
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2015 Pierre-Noel Bouteville.
+ * SPDX-FileContributor: Pierre-Noel Bouteville <pnb990@gmail.com>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,9 +26,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2015 Pierre-Noel Bouteville. All rights reserved.
- *   Author: Pierre-Noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_acmp.h
+++ b/arch/arm/src/efm32/hardware/efm32_acmp.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_acmp.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_adc.h
+++ b/arch/arm/src/efm32/hardware/efm32_adc.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_adc.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_aes.h
+++ b/arch/arm/src/efm32/hardware/efm32_aes.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_aes.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_burtc.h
+++ b/arch/arm/src/efm32/hardware/efm32_burtc.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_burtc.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_calibrate.h
+++ b/arch/arm/src/efm32/hardware/efm32_calibrate.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_calibrate.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_cmu.h
+++ b/arch/arm/src/efm32/hardware/efm32_cmu.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_cmu.h
  *
- *    (C) Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_dac.h
+++ b/arch/arm/src/efm32/hardware/efm32_dac.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_dac.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_devinfo.h
+++ b/arch/arm/src/efm32/hardware/efm32_devinfo.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_devinfo.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_dma.h
+++ b/arch/arm/src/efm32/hardware/efm32_dma.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_dma.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_emu.h
+++ b/arch/arm/src/efm32/hardware/efm32_emu.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_emu.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_flash.h
+++ b/arch/arm/src/efm32/hardware/efm32_flash.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_flash.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/efm32/hardware/efm32_gpio.h
+++ b/arch/arm/src/efm32/hardware/efm32_gpio.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_gpio.h
  *
- *    (C) Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_i2c.h
+++ b/arch/arm/src/efm32/hardware/efm32_i2c.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_i2c.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_lcd.h
+++ b/arch/arm/src/efm32/hardware/efm32_lcd.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_lcd.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_lesense.h
+++ b/arch/arm/src/efm32/hardware/efm32_lesense.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_lesense.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_letimer.h
+++ b/arch/arm/src/efm32/hardware/efm32_letimer.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_letimer.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_leuart.h
+++ b/arch/arm/src/efm32/hardware/efm32_leuart.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_leuart.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_memorymap.h
+++ b/arch/arm/src/efm32/hardware/efm32_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/efm32/hardware/efm32_msc.h
+++ b/arch/arm/src/efm32/hardware/efm32_msc.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_msc.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_pcnt.h
+++ b/arch/arm/src/efm32/hardware/efm32_pcnt.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_pcnt.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_prs.h
+++ b/arch/arm/src/efm32/hardware/efm32_prs.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_prs.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_rmu.h
+++ b/arch/arm/src/efm32/hardware/efm32_rmu.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_rmu.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_romtable.h
+++ b/arch/arm/src/efm32/hardware/efm32_romtable.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_romtable.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_rtc.h
+++ b/arch/arm/src/efm32/hardware/efm32_rtc.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_rtc.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_timer.h
+++ b/arch/arm/src/efm32/hardware/efm32_timer.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_timer.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_usart.h
+++ b/arch/arm/src/efm32/hardware/efm32_usart.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_usart.h
  *
- *    (C) Copyright 2014 Silicon Labs, http://www.silabs.com
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Labs will not be liable for any consequential, incidental, or
  * special damages, or any other relief, or for any claim by any third party,
  * arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_usb.h
+++ b/arch/arm/src/efm32/hardware/efm32_usb.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_usb.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_vcmp.h
+++ b/arch/arm/src/efm32/hardware/efm32_vcmp.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_vcmp.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32_wdog.h
+++ b/arch/arm/src/efm32/hardware/efm32_wdog.h
@@ -1,7 +1,12 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32_wdog.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileCopyrightText: 2014 Gregory Nutt. All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,11 +28,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Authors: Pierre-noel Bouteville <pnb990@gmail.com>
- *            Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32g_memorymap.h
+++ b/arch/arm/src/efm32/hardware/efm32g_memorymap.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32g_memorymap.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/efm32/hardware/efm32gg_memorymap.h
+++ b/arch/arm/src/efm32/hardware/efm32gg_memorymap.h
@@ -1,7 +1,10 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32gg_memorymap.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,9 +26,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/efm32/hardware/efm32tg_memorymap.h
+++ b/arch/arm/src/efm32/hardware/efm32tg_memorymap.h
@@ -1,7 +1,10 @@
 /****************************************************************************
  * arch/arm/src/efm32/hardware/efm32tg_memorymap.h
  *
- *  Copyright 2014 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014 Silicon Laboratories, Inc.
+ * SPDX-FileCopyrightText: 2014 Pierre-noel Bouteville . All rights reserved.
+ * SPDX-FileContributor: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
@@ -23,9 +26,6 @@
  * Silicon Laboratories, Inc. will not be liable for any consequential,
  * incidental, or special damages, or any other relief, or for any claim by
  * any third party, arising from your use of this Software.
- *
- *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
- *   Author: Pierre-noel Bouteville <pnb990@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/kinetis/kinetis_cfmconfig.c
+++ b/arch/arm/src/kinetis/kinetis_cfmconfig.c
@@ -1,11 +1,8 @@
 /****************************************************************************
  * arch/arm/src/kinetis/kinetis_cfmconfig.c
  *
- *   https://github.com/jodersky/nuttx/tree/teensy31-7.6
- *
- * Barely based on "bare metal" sample from Freedom board:
- * Copyright (c) 2012-2013 Andrew Payne
- *
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2012-2013 Andrew Payne
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/arch/arm/src/kl/kl_cfmconfig.c
+++ b/arch/arm/src/kl/kl_cfmconfig.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/kl/kl_cfmconfig.c
- * Copyright (c) 2012-2013 Andrew Payne
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2012-2013 Andrew Payne
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/arch/arm/src/lc823450/lc823450_symbols.ld
+++ b/arch/arm/src/lc823450/lc823450_symbols.ld
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/arm/src/lc823450/lc823450_symbols.ld
  *
- *   Copyright (C) 2014-2015 ON Semiconductor. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2014-2015 ON Semiconductor. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/lpc43xx/hardware/lpc43_spifi.h
+++ b/arch/arm/src/lpc43xx/hardware/lpc43_spifi.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * arch/arm/src/lpc43xx/hardware/lpc43_spifi.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -15,31 +17,6 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations
  * under the License.
- *
- ****************************************************************************/
-
-/* NOTE:  The SPIFI ROM interface is not defined in the LPC43xx user manual.
- * Some information in this file drivers from the NXP header file
- * spifi_rom_api.h.  I do not believe that any copyright restrictions apply.
- * But just to be certain:
- *
- *   Copyright(C) 2011, NXP Semiconductor
- *   All rights reserved.
- *
- * Software that is described herein is for illustrative purposes only which
- * provides customers with programming information regarding the products.
- * This software is supplied "AS IS" without any warranties. NXP
- * Semiconductors assumes no responsibility or liability for the use of the
- * software, conveys no license or title under any patent, copyright, or
- * mask work right to the product. NXP Semiconductors reserves the right to
- * make changes in the software without notification. NXP Semiconductors
- * also make no representation or warranty that such application will be
- * suitable for the specified use without further testing or modification.
- * Permission to use, copy, modify, and distribute this software and its
- * documentation is hereby granted, under NXP Semiconductors' relevant
- * copyright in the software, without fee, provided that it is used in
- * conjunction with NXP Semiconductors microcontrollers.  This copyright,
- * permission, and disclaimer notice must appear in all copies of this code.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/nrf52/nrf52_flash.c
+++ b/arch/arm/src/nrf52/nrf52_flash.c
@@ -1,15 +1,11 @@
 /****************************************************************************
  * arch/arm/src/nrf52/nrf52_flash.c
- * Standard Flash access functions needed by the flash mtd driver.
  *
- *   Copyright (C) 2018 Zglue Inc. All rights reserved.
- *   Author: Levin Li <zhiqiang@zglue.com>
- *   Author: Alan Carvalho de Assis <acassis@gmail.com>
- *
- * Ported from the Nordic SDK, this is the original license:
- *
- * Copyright (c) 2012 - 2018, Nordic Semiconductor ASA
- * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Zglue Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 - 2018, Nordic Semiconductor ASA
+ * SPDX-FileContributor: Levin Li <zhiqiang@zglue.com>
+ * SPDX-FileContributor: Alan Carvalho de Assis <acassis@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/nrf52/nrf52_nvmc.c
+++ b/arch/arm/src/nrf52/nrf52_nvmc.c
@@ -1,14 +1,11 @@
 /****************************************************************************
  * arch/arm/src/nrf52/nrf52_nvmc.c
  *
- *   Copyright (C) 2018 Zglue Inc. All rights reserved.
- *   Author: Levin Li <zhiqiang@zglue.com>
- *   Author: Alan Carvalho de Assis <acassis@gmail.com>
- *
- * Ported from the Nordic SDK, this is the original license:
- *
- * Copyright (c) 2012 - 2018, Nordic Semiconductor ASA
- * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Zglue Inc. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 - 2018, Nordic Semiconductor ASA
+ * SPDX-FileContributor: Levin Li <zhiqiang@zglue.com>
+ * SPDX-FileContributor: Alan Carvalho de Assis <acassis@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/arm/src/nrf52/nrf52_nvmc.h
+++ b/arch/arm/src/nrf52/nrf52_nvmc.h
@@ -1,13 +1,10 @@
 /****************************************************************************
  * arch/arm/src/nrf52/nrf52_nvmc.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Ported from the Nordic SDK, this is the original license:
- *
- * Copyright (c) 2012 - 2018, Nordic Semiconductor ASA
- * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2012 - 2018, Nordic Semiconductor ASA
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/arch/x86_64/include/multiboot2.h
+++ b/arch/x86_64/include/multiboot2.h
@@ -1,7 +1,9 @@
 /****************************************************************************
  * arch/x86_64/include/multiboot2.h
  *
- * Copyright (C) 1999,2003,2007,2008,2009,2010 Free Software Foundation, Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2008,2009,2010 Free Software Foundation, Inc.
+ * SPDX-FileCopyrightText: 1999,2003,2007 Free Software Foundation, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/arch/xtensa/include/esp32/core-isa.h
+++ b/arch/xtensa/include/esp32/core-isa.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32/core-isa.h
- * Xtensa processor CORE configuration
  *
- * Customer ID=11657; Build=0x5fe96; Copyright (c) 1999-2016 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2016 Tensilica Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32/tie-asm.h
+++ b/arch/xtensa/include/esp32/tie-asm.h
@@ -1,13 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32/tie-asm.h
- * Compile-time assembler definitions dependent on CORE & TIE
  *
- * This header file contains assembly-language definitions (assembly
- * macros, etc.) for this specific Xtensa processor's TIE extensions
- * and options.  It is customized to this Xtensa processor configuration.
- *
- * Customer ID=11657; Build=0x5fe96;
- * Copyright (c) 1999-2016 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2016 Cadence Design Systems Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32/tie.h
+++ b/arch/xtensa/include/esp32/tie.h
@@ -1,15 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32/tie.h
- * Compile-time HAL definitions dependent on CORE & TIE configuration
  *
- *  NOTE:  This header file is not meant to be included directly.
- *
- * This header file describes this specific Xtensa processor's TIE extensions
- *  that extend basic Xtensa core functionality.  It is customized to this
- *  Xtensa processor configuration.
- *
- *  Customer ID=11657; Build=0x5fe96;
- *  Copyright (c) 1999-2016 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2016 Cadence Design Systems Inc.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s2/core-isa.h
+++ b/arch/xtensa/include/esp32s2/core-isa.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s2/core-isa.h
- * Xtensa processor CORE configuration
  *
- * Customer ID=11657; Build=0x5fe96; Copyright (c) 1999-2016 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2016 Tensilica Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s2/tie-asm.h
+++ b/arch/xtensa/include/esp32s2/tie-asm.h
@@ -1,13 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s2/tie-asm.h
- * Compile-time assembler definitions dependent on CORE & TIE
  *
- * This header file contains assembly-language definitions (assembly
- * macros, etc.) for this specific Xtensa processor's TIE extensions
- * and options.  It is customized to this Xtensa processor configuration.
- *
- * Customer ID=11657; Build=0x5fe96;
- * Copyright (c) 1999-2016 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2016 Cadence Design Systems Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s2/tie.h
+++ b/arch/xtensa/include/esp32s2/tie.h
@@ -1,14 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s2/tie.h
- * Compile-time HAL definitions dependent on CORE & TIE configuration
  *
- *  NOTE:  This header file is not meant to be included directly.
- *
- * This header file describes this specific Xtensa processor's TIE extensions
- * that extend basic Xtensa core functionality.  It is customized to this
- * Xtensa processor configuration.
- *
- * Copyright (c) 1999-2018 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2018 Cadence Design Systems Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s3/core-isa.h
+++ b/arch/xtensa/include/esp32s3/core-isa.h
@@ -1,8 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s3/core-isa.h
- * Xtensa processor core configuration information.
  *
- * Customer ID=15128; Build=0x90f1f; Copyright (c) 1999-2021 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2021 Tensilica Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s3/tie-asm.h
+++ b/arch/xtensa/include/esp32s3/tie-asm.h
@@ -1,16 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s3/tie-asm.h
- * Compile-time HAL assembler definitions dependent on CORE & TIE
- * configuration
  *
- *  NOTE:  This header file is not meant to be included directly.
- *
- * This header file contains assembly-language definitions (assembly
- * macros, etc.) for this specific Xtensa processor's TIE extensions
- * and options.  It is customized to this Xtensa processor configuration.
- *
- * Customer ID=15128; Build=0x90f1f;
- * Copyright (c) 1999-2021 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2021 Cadence Design Systems Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/esp32s3/tie.h
+++ b/arch/xtensa/include/esp32s3/tie.h
@@ -1,15 +1,8 @@
 /****************************************************************************
  * arch/xtensa/include/esp32s3/tie.h
- * Compile-time HAL definitions dependent on CORE & TIE configuration
  *
- *  NOTE:  This header file is not meant to be included directly.
- *
- * This header file describes this specific Xtensa processor's TIE extensions
- * that extend basic Xtensa core functionality.  It is customized to this
- * Xtensa processor configuration.
- *
- * Customer ID=15128; Build=0x90f1f;
- * Copyright (c) 1999-2021 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 1999-2021 Cadence Design Systems Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/xtensa/core.h
+++ b/arch/xtensa/include/xtensa/core.h
@@ -1,13 +1,9 @@
 /****************************************************************************
  * arch/xtensa/include/xtensa/core.h
  *
- * Leveraged to NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *
- * This file derives from code provided  Cadence Design Systems, Inc.:
- *
- *   Copyright (c) 2005-2014 Cadence Design Systems, Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2014 Cadence Design Systems, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -29,16 +25,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  ****************************************************************************/
-
-/* This header file is sometimes referred to as the "compile-time HAL" or
- * CHAL. It pulls definitions tailored for a specific Xtensa processor
- * configuration.
- *
- * Sources for binaries meant to be configuration-independent generally
- * avoid including this file (they may use the configuration-specific HAL
- * library). It is normal for the HAL library source itself to include this
- * file.
- */
 
 #ifndef __ARCH_XTENSA_INCUDE_XTENSA_CORE_H
 #define __ARCH_XTENSA_INCUDE_XTENSA_CORE_H

--- a/arch/xtensa/include/xtensa/xtensa_abi.h
+++ b/arch/xtensa/include/xtensa/xtensa_abi.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/include/xtensa/xtensa_abi.h
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2015 Cadence Design Systems, Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/xtensa/xtensa_coproc.h
+++ b/arch/xtensa/include/xtensa/xtensa_coproc.h
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/include/xtensa/xtensa_coproc.h
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2015 Cadence Design Systems, Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/xtensa/xtensa_corebits.h
+++ b/arch/xtensa/include/xtensa/xtensa_corebits.h
@@ -1,16 +1,10 @@
 /****************************************************************************
  * arch/xtensa/include/xtensa/xtensa_corebits.h
- * Xtensa Special Register field positions, masks, values.
- * NOTE: This file may be processor configuration dependent.
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Tensilica Inc.
- *
- *   Copyright (c) 2005-2011 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2011 Tensilica Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/include/xtensa/xtensa_specregs.h
+++ b/arch/xtensa/include/xtensa/xtensa_specregs.h
@@ -1,15 +1,10 @@
 /****************************************************************************
  * arch/xtensa/include/xtensa/xtensa_specregs.h
- * Xtensa Special Register symbolic names
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Tensilica Inc.
- *
- *   Copyright (c) 2005-2011 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2005-2011 Tensilica Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_context.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_coproc.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_cpuint.S
+++ b/arch/xtensa/src/common/xtensa_cpuint.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_cpuint.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_int_handlers.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_panic.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_timer.h
+++ b/arch/xtensa/src/common/xtensa_timer.h
@@ -1,13 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_timer.h
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- * Copyright (c) 2003-2015 Cadence Design Systems, Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2003-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_user_handler.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_vectors.S
+++ b/arch/xtensa/src/common/xtensa_vectors.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_vectors.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_window_vector.S
+++ b/arch/xtensa/src/common/xtensa_window_vector.S
@@ -1,14 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_window_vector.S
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Cadence Design Systems Inc.
- *
- *   Copyright (c) 2006-2015 Cadence Design Systems Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2006-2015 Cadence Design Systems Inc.
+ * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/arch/xtensa/src/common/xtensa_windowspill.S
+++ b/arch/xtensa/src/common/xtensa_windowspill.S
@@ -1,16 +1,10 @@
 /****************************************************************************
  * arch/xtensa/src/common/xtensa_windowspill.S
- * Register window spill routine
  *
- * Adapted from use in NuttX by:
- *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Derives from logic originally provided by Tensilica Inc.
- *
- *   $Id: //depot/rel/Eaglenest/Xtensa/OS/hal/windowspill_asm.S#1 $
- *   Copyright (c) 1999-2010 Tensilica Inc.
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: 2016 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 1999-2010 Tensilica Inc.
+ * SPDX-FileContributor:Gregory Nutt <gnutt@nuttx.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -1,17 +1,23 @@
 /****************************************************************************
  * drivers/input/uinput.c
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * SPDX-License-Identifier: Apache-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  ****************************************************************************/
 
 /****************************************************************************

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -1,6 +1,9 @@
 /****************************************************************************
  * drivers/mtd/mtd_config_fs.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2018 Laczen
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -15,12 +18,6 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
  * License for the specific language governing permissions and limitations
  * under the License.
- *
- * NVS: non volatile storage in flash
- *
- * Copyright (c) 2018 Laczen
- *
- * SPDX-License-Identifier: Apache-2.0
  *
  ****************************************************************************/
 

--- a/drivers/usbhost/hid_parser.c
+++ b/drivers/usbhost/hid_parser.c
@@ -1,12 +1,10 @@
 /****************************************************************************
  * drivers/usbhost/hid_parser.c
  *
- *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
- *
- * Adapted from the LUFA Library:
- *
- *   Copyright 2011  Dean Camera (dean [at] fourwalledcubicle [dot] com)
- *   dean [at] fourwalledcubicle [dot] com, www.lufa-lib.org
+ * SPDX-License-Identifier: X11
+ * SPDX-FileCopyrightText: 2011 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2011 Dean Camera (dean@fourwalledcubicle.com)
+ * SPDX-FileContributor: dean@fourwalledcubicle.com, www.lufa-lib.org
  *
  * Permission to use, copy, modify, distribute, and sell this
  * software and its documentation for any purpose is hereby granted

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -1,6 +1,11 @@
 /****************************************************************************
  * include/crypto/cryptodev.h
- * $OpenBSD: cryptodev.h,v 1.58 2013/10/31 10:32:38 mikeb Exp $
+ *
+ * SPDX-License-Identifier: OAR AND BSD-2 Clause
+ * SPDX-FileCopyrightText: 2000 Angelos D. Keromytis
+ * SPDX-FileCopyrightText: 2001 Theo de Raadt
+ * SPDX-FileContributor: Angelos D. Keromytis (angelos@cis.upenn.edu)
+ *
  * The author of this code is Angelos D. Keromytis (angelos@cis.upenn.edu)
  *
  * This code was written by Angelos D. Keromytis in Athens, Greece, in

--- a/include/crypto/cryptosoft.h
+++ b/include/crypto/cryptosoft.h
@@ -1,6 +1,9 @@
 /****************************************************************************
  * include/crypto/cryptosoft.h
- * $OpenBSD: cryptosoft.h,v 1.14 2012/12/07 17:03:22 mikeb Exp $
+ *
+ * SPDX-License-Identifier: OAR
+ * SPDX-FileCopyrightText: 2000 Angelos D. Keromytis
+ * SPDX-FileContributor: Angelos D. Keromytis (angelos@cis.upenn.edu)
  *
  * The author of this code is Angelos D. Keromytis (angelos@cis.upenn.edu)
  *

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -1,6 +1,9 @@
 /****************************************************************************
  * include/crypto/xform.h
- * $OpenBSD: xform.h,v 1.32 2021/10/22 12:30:53 bluhm Exp $
+ *
+ * SPDX-License-Identifier: OAR
+ * SPDX-FileCopyrightText: 2000 Angelos D. Keromytis
+ * SPDX-FileContributor: Angelos D. Keromytis (angelos@cis.upenn.edu)
  *
  * The author of this code is Angelos D. Keromytis (angelos@cis.upenn.edu)
  *
@@ -20,6 +23,7 @@
  * REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE
  * MERCHANTABILITY OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR
  * PURPOSE.
+ *
  ****************************************************************************/
 
 #ifndef __INCLUDE_CRYPTO_XFORM_H

--- a/include/nuttx/input/uinput.h
+++ b/include/nuttx/input/uinput.h
@@ -3,17 +3,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  ****************************************************************************/
 
 #ifndef __INCLUDE_NUTTX_INPUT_UINPUT_H


### PR DESCRIPTION
## Summary
Most tools used for compliance and SBOM generation use SPDX identifiers This change brings us a step closer to an easy SBOM generation.

Included
https://github.com/apache/nuttx/pull/15253
https://github.com/apache/nuttx/pull/15251

## Impact

RELEASE

## Testing

CI