### PR TITLE
{bp-15252} crypto/xform.c: migrate to SPDX identifier

### DIFF
--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -1,6 +1,18 @@
 /****************************************************************************
  * crypto/xform.c
- * $OpenBSD: xform.c,v 1.61 2021/10/22 12:30:53 bluhm Exp $
+ *
+ * SPDX-License-Identifier: 0BSD
+ * SPDX-FileCopyrightText: 1995, 1996, 1997, 1998, 1999 John Ioannidis
+ * SPDX-FileCopyrightText: 1995, 1996, 1997, 1998, 1999 Angelos D. Keromytis
+ * SPDX-FileCopyrightText: 1995, 1996, 1997, 1998, 1999 Niels Provos.
+ * SPDX-FileCopyrightText: 2001 Angelos D. Keromytis.
+ * SPDX-FileCopyrightText: 2008 Damien Miller
+ * SPDX-FileCopyrightText: 2010, 2015 Mike Belopuhov
+ * SPDX-FileContributor: John Ioannidis (ji@tla.org)
+ * SPDX-FileContributor: Angelos D. Keromytis (kermit@csd.uch.gr)
+ * SPDX-FileContributor: Niels Provos (provos@physnet.uni-hamburg.de)
+ * SPDX-FileContributor: Damien Miller (djm@mindrot.org)
+ * SPDX-FileContributor: Mike Belopuhov (mikeb@openbsd.org)
  *
  * The authors of this code are John Ioannidis (ji@tla.org),
  * Angelos D. Keromytis (kermit@csd.uch.gr),


### PR DESCRIPTION
## Summary

NOTE
The code was reported as GPL by FOSS ID
and Xiaomi scanned the file xform.c with Black Duck Security and it showed that the license was BSD-3-Clause and no risk was reported.

Since there is no clause on the license it was concluded as 0BSD

Refference
https://github.com/apache/nuttx/pull/15252


## Impact

RELEASE

## Testing
CI