### PR TITLE
stm32_i2c: fix sending large data over i2c

### DIFF
--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -1984,9 +1984,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               i2cinfo("TCR: DISABLE RELOAD: NBYTES = dcnt = %i msgc = %i\n",
                       priv->dcnt, priv->msgc);
 
-              stm32_i2c_disable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, priv->dcnt);
+
+              stm32_i2c_disable_reload(priv);
             }
 
           i2cinfo("TCR: EXIT dcnt = %i msgc = %i status 0x%08" PRIx32 "\n",

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -1984,9 +1984,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               i2cinfo("TCR: DISABLE RELOAD: NBYTES = dcnt = %i msgc = %i\n",
                       priv->dcnt, priv->msgc);
 
-              stm32_i2c_disable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, priv->dcnt);
+
+              stm32_i2c_disable_reload(priv);
             }
 
           i2cinfo("TCR: EXIT dcnt = %i msgc = %i status 0x%08" PRIx32 "\n",

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -2018,9 +2018,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               i2cinfo("TCR: DISABLE RELOAD: NBYTES = dcnt = %i msgc = %i\n",
                       priv->dcnt, priv->msgc);
 
-              stm32_i2c_disable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, priv->dcnt);
+
+              stm32_i2c_disable_reload(priv);
             }
 
           i2cinfo("TCR: EXIT dcnt = %i msgc = %i status 0x%08" PRIx32 "\n",

--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -2176,9 +2176,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
                * the transfer.
                */
 
-              stm32_i2c_enable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, 255);
+
+              stm32_i2c_enable_reload(priv);
             }
           else
             {

--- a/arch/arm/src/stm32u5/stm32_i2c.c
+++ b/arch/arm/src/stm32u5/stm32_i2c.c
@@ -2223,9 +2223,9 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               i2cinfo("TCR: DISABLE RELOAD: NBYTES = dcnt = %i msgc = %i\n",
                       priv->dcnt, priv->msgc);
 
-              stm32_i2c_disable_reload(priv);
-
               stm32_i2c_set_bytes_to_transfer(priv, priv->dcnt);
+
+              stm32_i2c_disable_reload(priv);
             }
 
           i2cinfo("TCR: EXIT dcnt = %i msgc = %i status 0x%08" PRIx32 "\n",


### PR DESCRIPTION
This PR expend the fix done under 'stm32h7/stm32_i2c: fix sending large data over i2c #12093' to all stm32 chips

To trigger TC interrupt NBYTES needs to be set before RELOAD is disabled similar to previous commit done on stm32h7 

## Testing
I could test it on stm32f7 board that required to send large data. But don't have other boards to test it too.

