### PR TITLE
modifyreg[8|32]: use small lock in modifyreg[8|32]

### DIFF
--- a/arch/arm/src/common/arm_modifyreg32.c
+++ b/arch/arm/src/common/arm_modifyreg32.c
@@ -34,6 +34,12 @@
 #include "arm_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/arm/src/common/arm_modifyreg8.c
+++ b/arch/arm/src/common/arm_modifyreg8.c
@@ -34,6 +34,12 @@
 #include "arm_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/arm64/src/common/arm64_modifyreg32.c
+++ b/arch/arm64/src/common/arm64_modifyreg32.c
@@ -34,6 +34,12 @@
 #include "arm64_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/arm64/src/common/arm64_modifyreg8.c
+++ b/arch/arm64/src/common/arm64_modifyreg8.c
@@ -34,6 +34,12 @@
 #include "arm64_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/avr/src/common/avr_modifyreg32.c
+++ b/arch/avr/src/common/avr_modifyreg32.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "avr_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/avr/src/common/avr_modifyreg8.c
+++ b/arch/avr/src/common/avr_modifyreg8.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "avr_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/ceva/src/common/ceva_modifyreg32.c
+++ b/arch/ceva/src/common/ceva_modifyreg32.c
@@ -30,6 +30,12 @@
 #include "ceva_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -46,10 +52,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/ceva/src/common/ceva_modifyreg8.c
+++ b/arch/ceva/src/common/ceva_modifyreg8.c
@@ -30,6 +30,12 @@
 #include "ceva_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -46,10 +52,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/hc/src/common/hc_modifyreg32.c
+++ b/arch/hc/src/common/hc_modifyreg32.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "hc_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/hc/src/common/hc_modifyreg8.c
+++ b/arch/hc/src/common/hc_modifyreg8.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "hc_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/mips/src/common/mips_modifyreg32.c
+++ b/arch/mips/src/common/mips_modifyreg32.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "mips_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/mips/src/common/mips_modifyreg8.c
+++ b/arch/mips/src/common/mips_modifyreg8.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "mips_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/misoc/src/common/misoc_modifyreg32.c
+++ b/arch/misoc/src/common/misoc_modifyreg32.c
@@ -31,8 +31,15 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "misoc.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -51,10 +58,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/misoc/src/common/misoc_modifyreg8.c
+++ b/arch/misoc/src/common/misoc_modifyreg8.c
@@ -31,8 +31,15 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "misoc.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -51,10 +58,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/or1k/src/common/or1k_modifyreg32.c
+++ b/arch/or1k/src/common/or1k_modifyreg32.c
@@ -34,6 +34,12 @@
 #include "or1k_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/or1k/src/common/or1k_modifyreg8.c
+++ b/arch/or1k/src/common/or1k_modifyreg8.c
@@ -34,6 +34,12 @@
 #include "or1k_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/risc-v/src/common/riscv_modifyreg32.c
+++ b/arch/risc-v/src/common/riscv_modifyreg32.c
@@ -34,6 +34,12 @@
 #include "riscv_internal.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -50,10 +56,10 @@ void modifyreg32(uintreg_t addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/sparc/src/common/sparc_modifyreg32.c
+++ b/arch/sparc/src/common/sparc_modifyreg32.c
@@ -42,6 +42,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -63,11 +65,11 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }
 

--- a/arch/sparc/src/common/sparc_modifyreg8.c
+++ b/arch/sparc/src/common/sparc_modifyreg8.c
@@ -42,6 +42,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -63,11 +65,11 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }
 

--- a/arch/x86/src/common/x86_modifyreg32.c
+++ b/arch/x86/src/common/x86_modifyreg32.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/x86/src/common/x86_modifyreg8.c
+++ b/arch/x86/src/common/x86_modifyreg8.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/x86_64/src/common/x86_64_modifyreg32.c
+++ b/arch/x86_64/src/common/x86_64_modifyreg32.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_64_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/x86_64/src/common/x86_64_modifyreg8.c
+++ b/arch/x86_64/src/common/x86_64_modifyreg8.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "x86_64_internal.h"
 
@@ -41,6 +42,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -63,10 +66,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8((uint16_t)addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, (uint16_t)addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/xtensa/src/common/xtensa_modifyreg32.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg32.c
@@ -36,6 +36,12 @@
 #include "xtensa.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -52,10 +58,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/xtensa/src/common/xtensa_modifyreg8.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg8.c
@@ -36,6 +36,12 @@
 #include "xtensa.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -52,10 +58,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }

--- a/arch/z80/src/z180/z180_modifiyreg8.c
+++ b/arch/z80/src/z180/z180_modifiyreg8.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/io.h>
 
 /****************************************************************************
@@ -38,6 +39,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_modifyreg_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -60,10 +63,10 @@ void modifyreg8(uint16_t addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_modifyreg_lock);
   regval  = inp(addr);
   regval &= ~clearbits;
   regval |= setbits;
   outp(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_modifyreg_lock, flags);
 }


### PR DESCRIPTION


## Summary
modifyreg[8|32]: use small lock in modifyreg[8|32]
reason:
We would like to replace the big lock with a small lock.
## Impact

modifyreg

## Testing
ci


