### PR TITLE
imx9_flexcan: use small lock in arch/arm/src/imx9/imx9_flexcan.c

### DIFF
--- a/boards/arm/at32/at32f437-mini/src/at32_ethernet.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_ethernet.c
@@ -81,9 +81,8 @@
  * Private Data
  ****************************************************************************/
 
-static spinlock_t g_ethmac_lock = SP_UNLOCKED;
-
 #ifdef HAVE_NETMONITOR
+static spinlock_t g_ethmac_lock = SP_UNLOCKED;
 static xcpt_t g_ethmac_handler;
 static void  *g_ethmac_arg;
 #endif

--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
@@ -76,7 +76,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef GPIO_ENET_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
@@ -79,7 +79,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_GPIO1_0_15_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
@@ -77,7 +77,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_GPIO1_0_15_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
@@ -77,7 +77,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_GPIO1_0_15_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
@@ -77,7 +77,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_GPIO1_0_15_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/sama5/sama5d2-xult/src/sam_ethernet.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_ethernet.c
@@ -86,7 +86,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_SAMA5_PIOE_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_ethernet.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_ethernet.c
@@ -86,7 +86,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_SAMA5_PIOE_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/samv7/same70-xplained/src/sam_ethernet.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_ethernet.c
@@ -82,7 +82,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_SAMV7_GPIOA_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/samv7/samv71-xult/src/sam_ethernet.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ethernet.c
@@ -82,7 +82,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_SAMV7_GPIOA_IRQ
 static spinlock_t g_phy_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ethernet.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ethernet.c
@@ -81,9 +81,8 @@
  * Private Data
  ****************************************************************************/
 
-static spinlock_t g_phy_lock = SP_UNLOCKED;
-
 #ifdef HAVE_NETMONITOR
+static spinlock_t g_phy_lock = SP_UNLOCKED;
 static xcpt_t g_ethmac_handler;
 static void  *g_ethmac_arg;
 #endif


### PR DESCRIPTION
## Summary
imx9_flexcan: use small lock in arch/arm/src/imx9/imx9_flexcan.c
reason:
We would like to replace the big lock with a small lock.

## Impact
imx9_flexcan

## Testing
ci


