### PR TITLE
drivers/sensors: Add Velocity sensor type to UORB

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -214,6 +214,7 @@ static const struct sensor_meta_s g_sensor_meta[] =
   {sizeof(struct sensor_gnss_measurement),    "gnss_measurement"},
   {sizeof(struct sensor_gnss_clock),          "gnss_clock"},
   {sizeof(struct sensor_gnss_geofence_event), "gnss_geofence_event"},
+  {sizeof(struct sensor_velocity),            "velocity"},
 };
 
 static const struct file_operations g_sensor_fops =

--- a/include/nuttx/uorb.h
+++ b/include/nuttx/uorb.h
@@ -467,9 +467,18 @@
 
 #define SENSOR_TYPE_GNSS_GEOFENCE                   52
 
-/* The total number of sensor */
+/* Velocity Sensor
+ * A sensor of this type measures the velocity as it is moving.
+ * The default unit velocity is meter by seconds m/s (SI).
+ */
 
-#define SENSOR_TYPE_COUNT                           53
+#define SENSOR_TYPE_VELOCITY                        53
+
+/* The total number of sensor
+ * please increase it if you added a new sensor type!
+ */
+
+#define SENSOR_TYPE_COUNT                           54
 
 /* The additional sensor open flags */
 
@@ -745,6 +754,12 @@ struct sensor_force         /* Type: Force */
   uint64_t timestamp;       /* Unit is microseconds */
   float force;              /* Force value, units is N */
   int32_t event;            /* Force event */
+};
+
+struct sensor_velocity      /* Type: Velocity */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float velocity;           /* Velocity value, units is m/s (SI) */
 };
 
 struct sensor_hall          /* Type: HALL */


### PR DESCRIPTION
## Summary

This patch adds support for velocity measurement sensors. I plan to use it as a generic speed type to be used for Renesas FS3000 (Air Velocity Flow).

Related PR: https://github.com/apache/nuttx-apps/pull/2908

## Impact

Now uORB will support Velocity sensors

## Testing

Tested with FS3000 air velocity flow sensor

