### PR TITLE
arch/risc-v/espressif: add missing spinlock to wlan_recvframe

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_wlan.c
+++ b/arch/risc-v/src/common/espressif/esp_wlan.c
@@ -321,8 +321,11 @@ static inline void wlan_cache_txpkt_tail(struct wlan_priv_s *priv)
 static struct iob_s *wlan_recvframe(struct wlan_priv_s *priv)
 {
   struct iob_s *iob;
+  irqstate_t flags;
 
+  flags = spin_lock_irqsave(&priv->lock);
   iob = iob_remove_queue(&priv->rxb);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   return iob;
 }


### PR DESCRIPTION
## Summary

Long term (1 hour) IPERF test was failing for ESP32C3 and ESP32C6 when running as server.
The failure happened on debug assertion related to IOB, as shown below.

```
[dut-0]  626.25- 631.26 sec    1376256 Bytes    2.20 Mbits/sec
[dut-1] dump_assert_info: Current Version: NuttX  10.4.0 e7f3a53706 Dec 10 2024 09:53:08 risc-v
[dut-1] dump_assert_info: Assertion failed iobq->qh_tail: at file: iob/iob_add_queue.c:73 task: wifi process: Kernel 0x40001720
[dut-1] up_dump_register: EPC: 420038aa
[dut-1] up_dump_register: A0: 3fc8ed70 A1: 00000049 A2: 3c0b6c04 A3: 00000000
```
Analyzing the IOB status at this assertion, it was found that in this backtrace sequence, wlan_recvframe did not have a spinlock as expected (this is present on Xtensa devices). This caused unexpected behavior as some IOBs were deleted.

```
gdb) backtrace
+backtrace
#0  iob_add_queue_internal (iob=0x40817c74 <g_iob_buffer+12064>, iobq=0x4081d244 <g_wlan_priv+256>,
    qentry=0x40814c94 <g_iob_qpool+800>) at iob/iob_add_queue.c:75
#1  0x42044e3a in wlan_rx_done (priv=0x4081d144 <g_wlan_priv>, buffer=<optimized out>, len=590, eb=0x40837760)
    at common/espressif/esp_wlan.c:464
#2  0x4080bf7a in sta_input ()
```

## Impact

Increased stability on WiFi networking for ESP32C3 and ESP32C6.

## Testing

Internal CI testing + local test on host machine with WiFi.
Results for one hour IPERF test, with target running IPERF server and host PC running IPERF client.

- ESP32C6
	0.0000-3600.3443 sec  4.08 GBytes  9.73 Mbits/sec
- ESP32C3
	0.0000-3600.3273 sec  2.28 GBytes  5.43 Mbits/sec


