### PR TITLE
nuttx/uorb.h: Add carrier frequency for GNSS Satellite

### DIFF
--- a/include/nuttx/uorb.h
+++ b/include/nuttx/uorb.h
@@ -914,6 +914,8 @@ struct sensor_gnss_satellite
 
   uint32_t constellation;
 
+  float cf;                 /* Carrier Frequency(Hz), GSV.signal_id */
+
   struct satellite
   {
     uint32_t svid;          /* Space vehicle ID */


### PR DESCRIPTION
## Summary
The `struct sensor_gnss_satellite.cf`(carrier frequency) can be parsed from `GSV.signal_id`(e.g. NMEA 0183 v4.11) and `struct sensor_gnss_satellite.constellation`(sv_type)

## Impact
uorb:gnss_satellite

## Testing
NuttX CI


