### PR TITLE
use small lock in following files

### DIFF
--- a/arch/risc-v/src/litex/litex_emac.c
+++ b/arch/risc-v/src/litex/litex_emac.c
@@ -169,6 +169,7 @@ struct litex_emac_s
   uint8_t               phyaddr;     /* PHY address (pre-defined by pins on reset) */
 
   uint8_t               txslot;
+  spinlock_t            lock;
 };
 
 /****************************************************************************
@@ -511,7 +512,7 @@ static int litex_transmit(struct litex_emac_s *priv)
 
   /* Make the following operations atomic */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   /* Now start transmission */
 
@@ -528,7 +529,7 @@ static int litex_transmit(struct litex_emac_s *priv)
   wd_start(&priv->txtimeout, LITEX_TXTIMEOUT,
            litex_txtimeout_expiry, (wdparm_t)priv);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   return OK;
 }
@@ -1523,6 +1524,8 @@ static void litex_ethinitialize(void)
     {
       return;
     }
+
+  spin_lock_init(&priv->lock);
 
   nerr("ERROR: netdev_register() failed: %d\n", ret);
 }

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -214,6 +214,8 @@ static void mpfs_callback(void *arg);
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_mpfs_modifyreg_lock = SP_UNLOCKED;
+
 struct mpfs_dev_s g_coremmc_dev =
 {
   .dev =
@@ -282,12 +284,12 @@ static void mpfs_modifyreg8(uintptr_t addr, uint8_t clearbits,
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_mpfs_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_mpfs_modifyreg_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -224,6 +224,8 @@ static void   mpfs_epset_reset(struct mpfs_usbdev_s *priv, uint16_t epset);
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_mpfs_modifyreg_lock = SP_UNLOCKED;
+
 static struct mpfs_usbdev_s g_usbd;
 static uint8_t g_clkrefs;
 
@@ -297,12 +299,12 @@ static void mpfs_modifyreg16(uintptr_t addr, uint16_t clearbits,
   DEBUGASSERT((addr >= MPFS_USB_BASE) && addr < (MPFS_USB_BASE +
                MPFS_USB_REG_MAX));
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_mpfs_modifyreg_lock);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_mpfs_modifyreg_lock, flags);
 }
 
 /****************************************************************************
@@ -331,12 +333,12 @@ static void mpfs_modifyreg8(uintptr_t addr, uint8_t clearbits,
   DEBUGASSERT((addr >= MPFS_USB_BASE) && addr < (MPFS_USB_BASE +
                MPFS_USB_REG_MAX));
 
-  flags   = spin_lock_irqsave(NULL);
+  flags   = spin_lock_irqsave(&g_mpfs_modifyreg_lock);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_mpfs_modifyreg_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -90,6 +90,13 @@
 #define EARLY_WAKEUP_US       (200)
 
 #endif
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static spinlock_t g_esp32_idle_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -109,7 +116,7 @@ static void esp32_idlepm(void)
   irqstate_t flags;
 
 #ifdef CONFIG_ESP32_AUTO_SLEEP
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp32_idle_lock);
   if (esp32_pm_lockstatus() == 0)
     {
       uint64_t os_start_us;
@@ -155,7 +162,7 @@ static void esp32_idlepm(void)
         }
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp32_idle_lock, flags);
 #else /* CONFIG_ESP32_AUTO_SLEEP */
   static enum pm_state_e oldstate = PM_NORMAL;
   enum pm_state_e newstate;
@@ -169,7 +176,7 @@ static void esp32_idlepm(void)
 
   if (newstate != oldstate)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_esp32_idle_lock);
 
       /* Perform board-specific, state-dependent logic here */
 
@@ -191,7 +198,7 @@ static void esp32_idlepm(void)
           oldstate = newstate;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_esp32_idle_lock, flags);
 
       /* MCU-specific power management logic */
 

--- a/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
@@ -61,6 +61,7 @@ struct esp32_lowerhalf_s
    */
 
   const struct rtc_ops_s *ops;
+  spinlock_t lock;
 #ifdef CONFIG_RTC_ALARM
   /* Alarm callback information */
 
@@ -116,6 +117,7 @@ static const struct rtc_ops_s g_rtc_ops =
 static struct esp32_lowerhalf_s g_rtc_lowerhalf =
 {
   .ops = &g_rtc_ops,
+  .lock = SP_UNLOCKED
 };
 
 /****************************************************************************
@@ -376,6 +378,7 @@ static int rtc_lh_setalarm(struct rtc_lowerhalf_s *lower,
 static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
                             const struct lower_setrelative_s *alarminfo)
 {
+  struct esp32_lowerhalf_s *priv = (struct esp32_lowerhalf_s *)lower;
   struct lower_setalarm_s setalarm;
   time_t seconds;
   int ret = -EINVAL;
@@ -387,7 +390,7 @@ static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
 
   if (alarminfo->reltime > 0)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&priv->lock);
 
       seconds = alarminfo->reltime;
       gmtime_r(&seconds, (struct tm *)&setalarm.time);
@@ -399,7 +402,7 @@ static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
       setalarm.priv = alarminfo->priv;
       ret = rtc_lh_setalarm(lower, &setalarm);
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&priv->lock, flags);
     }
 
   return ret;
@@ -466,6 +469,7 @@ static int rtc_lh_cancelalarm(struct rtc_lowerhalf_s *lower, int alarmid)
 static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
                           struct lower_rdalarm_s *alarminfo)
 {
+  struct esp32_lowerhalf_s *priv = (struct esp32_lowerhalf_s *)lower;
   struct timespec ts;
   int ret;
   irqstate_t flags;
@@ -474,13 +478,13 @@ static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
   DEBUGASSERT((RTC_ALARM0 <= alarminfo->id) &&
               (alarminfo->id < RTC_ALARM_LAST));
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   ret = up_rtc_rdalarm(&ts, alarminfo->id);
   localtime_r((const time_t *)&ts.tv_sec,
               (struct tm *)alarminfo->time);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   return ret;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_idle.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_idle.c
@@ -59,6 +59,14 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static spinlock_t g_esp32s2_idle_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -86,7 +94,7 @@ static void up_idlepm(void)
 
   if (newstate != oldstate)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_esp32s2_idle_lock);
 
       /* Perform board-specific, state-dependent logic here */
 
@@ -108,7 +116,7 @@ static void up_idlepm(void)
           oldstate = newstate;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_esp32s2_idle_lock, flags);
 
       /* MCU-specific power management logic */
 

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -99,6 +99,7 @@ struct esp32s2_uart_s g_uart0_config =
   .rs485_dir_polarity = true,
 #endif
 #endif
+  .lock = SP_UNLOCKED;
 };
 
 #endif /* CONFIG_ESP32S2_UART0 */
@@ -146,6 +147,7 @@ struct esp32s2_uart_s g_uart1_config =
   .rs485_dir_polarity = true,
 #endif
 #endif
+  .lock = SP_UNLOCKED;
 };
 
 #endif /* CONFIG_ESP32S2_UART1 */
@@ -654,7 +656,7 @@ void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   if (current_status != NULL)
     {
@@ -671,7 +673,7 @@ void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
 
   putreg32(UINT32_MAX, UART_INT_CLR_REG(priv->id));
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
@@ -106,6 +106,7 @@ struct esp32s2_uart_s
   uint8_t  rs485_dir_gpio;     /* UART RS-485 DIR GPIO pin cfg */
   bool     rs485_dir_polarity; /* UART RS-485 DIR TXEN polarity */
 #endif
+  spinlock_t lock;             /* Spinlock */
 };
 
 extern struct esp32s2_uart_s g_uart0_config;

--- a/arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.c
@@ -61,6 +61,7 @@ struct esp32s2_lowerhalf_s
    */
 
   const struct rtc_ops_s *ops;
+  spinlock_t lock;
 #ifdef CONFIG_RTC_ALARM
   /* Alarm callback information */
 
@@ -115,6 +116,7 @@ static const struct rtc_ops_s g_rtc_ops =
 static struct esp32s2_lowerhalf_s g_rtc_lowerhalf =
 {
   .ops = &g_rtc_ops,
+  .lock = SP_UNLOCKED,
 };
 
 /****************************************************************************
@@ -375,6 +377,7 @@ static int rtc_lh_setalarm(struct rtc_lowerhalf_s *lower,
 static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
                             const struct lower_setrelative_s *alarminfo)
 {
+  struct esp32s2_lowerhalf_s *priv = (struct esp32s2_lowerhalf_s *)lower;
   struct lower_setalarm_s setalarm;
   time_t seconds;
   int ret = -EINVAL;
@@ -386,7 +389,7 @@ static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
 
   if (alarminfo->reltime > 0)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&priv->lock);
 
       seconds = alarminfo->reltime;
       gmtime_r(&seconds, (struct tm *)&setalarm.time);
@@ -398,7 +401,7 @@ static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
       setalarm.priv = alarminfo->priv;
       ret = rtc_lh_setalarm(lower, &setalarm);
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&priv->lock, flags);
     }
 
   return ret;
@@ -465,6 +468,7 @@ static int rtc_lh_cancelalarm(struct rtc_lowerhalf_s *lower, int alarmid)
 static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
                           struct lower_rdalarm_s *alarminfo)
 {
+  struct esp32s2_lowerhalf_s *priv = (struct esp32s2_lowerhalf_s *)lower;
   struct timespec ts;
   int ret;
   irqstate_t flags;
@@ -473,13 +477,13 @@ static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
   DEBUGASSERT((RTC_ALARM0 <= alarminfo->id) &&
               (alarminfo->id < RTC_ALARM_LAST));
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   ret = up_rtc_rdalarm(&ts, alarminfo->id);
   localtime_r((const time_t *)&ts.tv_sec,
               (struct tm *)alarminfo->time);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   return ret;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_idle.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_idle.c
@@ -64,6 +64,14 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static spinlock_t g_esp32s3_idle_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -91,7 +99,7 @@ static void up_idlepm(void)
 
   if (newstate != oldstate)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_esp32s3_idle_lock);
 
       /* Perform board-specific, state-dependent logic here */
 
@@ -113,7 +121,7 @@ static void up_idlepm(void)
           oldstate = newstate;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_esp32s3_idle_lock, flags);
 
       /* MCU-specific power management logic */
 


### PR DESCRIPTION

## Summary
use small lock in following files

arch/risc-v/src/litex/litex_emac.c
arch/risc-v/src/mpfs/mpfs_coremmc.c
arch/risc-v/src/mpfs/mpfs_usb.c
arch/xtensa/src/esp32/esp32_idle.c
arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
arch/xtensa/src/esp32s2/esp32s2_idle.c
arch/xtensa/src/esp32s2/esp32s2_lowputc.c
arch/xtensa/src/esp32s2/esp32s2_lowputc.h
arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.c
arch/xtensa/src/esp32s3/esp32s3_idle.c
arch/xtensa/src/esp32s3/esp32s3_rtc_lowerhalf.c

## Impact
arch/risc-v/src/litex/litex_emac.c
arch/risc-v/src/mpfs/mpfs_coremmc.c
arch/risc-v/src/mpfs/mpfs_usb.c
arch/xtensa/src/esp32/esp32_idle.c
arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
arch/xtensa/src/esp32s2/esp32s2_idle.c
arch/xtensa/src/esp32s2/esp32s2_lowputc.c
arch/xtensa/src/esp32s2/esp32s2_lowputc.h
arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.c
arch/xtensa/src/esp32s3/esp32s3_idle.c
arch/xtensa/src/esp32s3/esp32s3_rtc_lowerhalf.c

## Testing
ci

