### PR TITLE
use small lock in following file

### DIFF
--- a/arch/or1k/src/mor1kx/mor1kx_serial.c
+++ b/arch/or1k/src/mor1kx/mor1kx_serial.c
@@ -53,6 +53,14 @@
 #define OR1K_DIVISOR (OR1K_SYS_CLK / (16*OR1K_BAUD))
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef HAVE_SERIAL_CONSOLE
+static spinlock_t g_serial_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -117,10 +125,10 @@ void up_putc(int ch)
    * interrupts from firing in the serial driver code.
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_serial_lock);
 
   /* or1k_lowputc(ch); */
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_serial_lock, flags);
 #endif
 }

--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -152,6 +152,8 @@ static bool bl602_txempty(struct uart_dev_s *dev);
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_bl602_serial_lock = SP_UNLOCKED;
+
 static const struct uart_ops_s g_uart_ops =
 {
   .setup       = bl602_setup,
@@ -891,10 +893,10 @@ void riscv_serialinit(void)
 void up_putc(int ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&g_bl602_serial_lock);
 
   riscv_lowputc(ch);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_bl602_serial_lock, flags);
 #endif
 }
 

--- a/arch/risc-v/src/common/espressif/esp_lowputc.c
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.c
@@ -102,7 +102,8 @@ struct esp_uart_s g_uart0_config =
   .oflow  = false,   /* output flow control (CTS) disabled */
 #endif
 #endif
-  .hal = &g_uart0_hal
+  .hal = &g_uart0_hal,
+  .lock = SP_UNLOCKED
 };
 
 #endif /* CONFIG_ESPRESSIF_UART0 */
@@ -147,7 +148,8 @@ struct esp_uart_s g_uart1_config =
   .oflow  = false,   /* output flow control (CTS) disabled */
 #endif
 #endif
-  .hal = &g_uart1_hal
+  .hal = &g_uart1_hal,
+  .lock = SP_UNLOCKED
 };
 
 #endif /* CONFIG_ESPRESSIF_UART1 */
@@ -210,7 +212,7 @@ void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   if (current_status != NULL)
     {
@@ -227,7 +229,7 @@ void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
 
   uart_hal_clr_intsts_mask(priv->hal, UINT32_MAX);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/espressif/esp_lowputc.h
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.h
@@ -39,6 +39,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "chip.h"
 #include "esp_irq.h"
@@ -76,6 +77,7 @@ struct esp_uart_s
   bool                oflow;     /* Output flow control (CTS) enabled */
 #endif
   uart_hal_context_t *hal;       /* HAL context */
+  spinlock_t          lock;      /* Spinlock */
 };
 
 extern struct esp_uart_s g_uart0_config;

--- a/arch/risc-v/src/common/espressif/esp_tickless.c
+++ b/arch/risc-v/src/common/espressif/esp_tickless.c
@@ -59,6 +59,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_esp_tickless_lock = SP_UNLOCKED;
+
 /* Systimer HAL layer object */
 
 static systimer_hal_context_t systimer_hal;
@@ -126,10 +128,10 @@ uint32_t up_get_idletime(void)
   uint64_t counter;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp_tickless_lock);
   if (!g_timer_started)
     {
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 
       return 0;
     }
@@ -147,7 +149,7 @@ uint32_t up_get_idletime(void)
       us = 0;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 
   return us;
 }
@@ -172,12 +174,12 @@ void up_step_idletime(uint32_t idletime_us)
 
   DEBUGASSERT(g_timer_started);
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp_tickless_lock);
 
   systimer_hal_counter_value_advance(&systimer_hal, SYSTIMER_COUNTER_OS_TICK,
                                      idletime_us);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 }
 
 /****************************************************************************
@@ -216,13 +218,13 @@ void up_step_idletime(uint32_t idletime_us)
 int IRAM_ATTR up_timer_gettime(struct timespec *ts)
 {
   uint64_t time_us;
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&g_esp_tickless_lock);
 
   time_us = systimer_hal_get_time(&systimer_hal, SYSTIMER_COUNTER_OS_TICK);
   ts->tv_sec  = time_us / USEC_PER_SEC;
   ts->tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 
   return OK;
 }
@@ -267,7 +269,7 @@ int IRAM_ATTR up_timer_cancel(struct timespec *ts)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp_tickless_lock);
 
   if (ts != NULL)
     {
@@ -314,7 +316,7 @@ int IRAM_ATTR up_timer_cancel(struct timespec *ts)
   systimer_ll_clear_alarm_int(systimer_hal.dev,
                               SYSTIMER_ALARM_OS_TICK_CORE0);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 
   return OK;
 }
@@ -350,7 +352,7 @@ int IRAM_ATTR up_timer_start(const struct timespec *ts)
   uint64_t alarm_ticks;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp_tickless_lock);
 
   if (g_timer_started)
     {
@@ -375,7 +377,7 @@ int IRAM_ATTR up_timer_start(const struct timespec *ts)
 
   g_timer_started = true;
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp_tickless_lock, flags);
 
   return OK;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_idle.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_idle.c
@@ -77,6 +77,14 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static spinlock_t g_esp32c3_idle_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -94,7 +102,7 @@ static void up_idlepm(void)
   irqstate_t flags;
 
 #ifdef CONFIG_ESP32C3_AUTO_SLEEP
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_esp32c3_idle_lock);
   if (esp32c3_pm_lockstatus() == 0 &&
      (esp32c3_should_skip_light_sleep() == false))
     {
@@ -138,7 +146,7 @@ static void up_idlepm(void)
         }
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_esp32c3_idle_lock, flags);
 #else /* CONFIG_ESP32C3_AUTO_SLEEP */
   static enum pm_state_e oldstate = PM_NORMAL;
   enum pm_state_e newstate;
@@ -152,7 +160,7 @@ static void up_idlepm(void)
 
   if (newstate != oldstate)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_esp32c3_idle_lock);
 
       /* Perform board-specific, state-dependent logic here */
 
@@ -174,7 +182,7 @@ static void up_idlepm(void)
           oldstate = newstate;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_esp32c3_idle_lock, flags);
 
       /* MCU-specific power management logic */
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
@@ -79,6 +79,7 @@ struct esp32c3_uart_s g_uart0_config =
   .txsig = U0TXD_OUT_IDX,
   .rxpin = CONFIG_ESP32C3_UART0_RXPIN,
   .rxsig = U0RXD_IN_IDX,
+  .lock = SP_UNLOCKED,
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   .rtspin = CONFIG_ESP32C3_UART0_RTSPIN,
   .rtssig = U0RTS_OUT_IDX,
@@ -118,6 +119,7 @@ struct esp32c3_uart_s g_uart1_config =
   .txsig = U1TXD_OUT_IDX,
   .rxpin = CONFIG_ESP32C3_UART1_RXPIN,
   .rxsig = U1RXD_IN_IDX,
+  .lock = SP_UNLOCKED,
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   .rtspin = CONFIG_ESP32C3_UART1_RTSPIN,
   .rtssig = U1RTS_OUT_IDX,
@@ -708,12 +710,12 @@ void esp32c3_lowputc_enable_sysclk(const struct esp32c3_uart_s *priv)
  *
  ****************************************************************************/
 
-void esp32c3_lowputc_disable_all_uart_int(const struct esp32c3_uart_s *priv,
+void esp32c3_lowputc_disable_all_uart_int(struct esp32c3_uart_s *priv,
                                           uint32_t *current_status)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
 
   if (current_status != NULL)
     {
@@ -730,7 +732,7 @@ void esp32c3_lowputc_disable_all_uart_int(const struct esp32c3_uart_s *priv,
 
   putreg32(0xffffffff, UART_INT_CLR_REG(priv->id));
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -102,6 +103,7 @@ struct esp32c3_uart_s
   uint8_t   txsig;          /* TX signal */
   uint8_t   rxpin;          /* RX pin */
   uint8_t   rxsig;          /* RX signal */
+  spinlock_t lock;          /* Spinlock */
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   uint8_t  rtspin;          /* RTS pin number */
   uint8_t  rtssig;          /* RTS signal */
@@ -433,7 +435,7 @@ void esp32c3_lowputc_enable_sysclk(const struct esp32c3_uart_s *priv);
  *
  ****************************************************************************/
 
-void esp32c3_lowputc_disable_all_uart_int(const struct esp32c3_uart_s *priv,
+void esp32c3_lowputc_disable_all_uart_int(struct esp32c3_uart_s *priv,
                                           uint32_t *current_status);
 
 /****************************************************************************

--- a/arch/risc-v/src/fe310/fe310_gpio.c
+++ b/arch/risc-v/src/fe310/fe310_gpio.c
@@ -39,6 +39,12 @@
 #include "fe310_memorymap.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_fe310_gpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -147,7 +153,7 @@ int fe310_gpio_config(uint16_t gpiocfg)
 
   uint32_t pin  = fe310_gpio_getpin(gpiocfg);
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_fe310_gpio_lock);
 
   /* Disable IOF for the pin to be used as GPIO */
 
@@ -182,7 +188,7 @@ int fe310_gpio_config(uint16_t gpiocfg)
         break;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_fe310_gpio_lock, flags);
 
   return ret;
 }


### PR DESCRIPTION

## Summary
use small lock in following file

arch/or1k/src/mor1kx/mor1kx_serial.c
arch/risc-v/src/bl602/bl602_serial.c
arch/risc-v/src/common/espressif/esp_lowputc.c
arch/risc-v/src/common/espressif/esp_lowputc.h
arch/risc-v/src/common/espressif/esp_tickless.c
arch/risc-v/src/esp32c3-legacy/esp32c3_idle.c
arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.h
arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_lowerhalf.c arch/risc-v/src/fe310/fe310_gpio.c


## Impact
arch/or1k/src/mor1kx/mor1kx_serial.c
arch/risc-v/src/bl602/bl602_serial.c
arch/risc-v/src/common/espressif/esp_lowputc.c
arch/risc-v/src/common/espressif/esp_lowputc.h
arch/risc-v/src/common/espressif/esp_tickless.c
arch/risc-v/src/esp32c3-legacy/esp32c3_idle.c
arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c
arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.h
arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_lowerhalf.c arch/risc-v/src/fe310/fe310_gpio.c



## Testing
ci


