### PR TITLE
Added comma to fix undefined bits struct member

### DIFF
--- a/arch/arm/src/imx6/imx_serial.c
+++ b/arch/arm/src/imx6/imx_serial.c
@@ -296,7 +296,7 @@ static struct imx_uart_s g_uart1priv =
   .baud           = CONFIG_UART1_BAUD,
   .irq            = IMX_IRQ_UART1,
   .parity         = CONFIG_UART1_PARITY,
-  .lock           = SP_UNLOCKED
+  .lock           = SP_UNLOCKED,
   .bits           = CONFIG_UART1_BITS,
   .stopbits2      = CONFIG_UART1_2STOP,
 };


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Initialization of g_uart1priv was missing a comma after SP_UNLOCKED. This failure was causing a CI build failure for another pull request by me. I fixed this so that I can move on with the other pull request. 

The other pull request is this: https://github.com/apache/nuttx/pull/15271


