### PR TITLE
Fixed IEEE802.11 build on Arch Linux

### DIFF
--- a/include/nuttx/wireless/ieee80211/ieee80211.h
+++ b/include/nuttx/wireless/ieee80211/ieee80211.h
@@ -38,12 +38,18 @@
 
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
+#include <nuttx/bits.h>
+#include <sys/endian.h>
 
 #include <netinet/if_ether.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#ifndef hweight8
+#define hweight8 __builtin_popcount
+#endif
 
 /* DS bit usage
  *
@@ -397,7 +403,7 @@ struct ieee80211_qos_hdr
 
 static inline bool ieee80211_has_tods(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_TODS)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_TODS)) != 0;
 }
 
 /* ieee80211_has_fromds - check if IEEE80211_FCTL_FROMDS is set
@@ -406,7 +412,7 @@ static inline bool ieee80211_has_tods(uint16_t fc)
 
 static inline bool ieee80211_has_fromds(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FROMDS)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_FROMDS)) != 0;
 }
 
 /* ieee80211_has_a4 - check if IEEE80211_FCTL_TODS and
@@ -416,7 +422,7 @@ static inline bool ieee80211_has_fromds(uint16_t fc)
 
 static inline bool ieee80211_has_a4(uint16_t fc)
 {
-  uint16_t tmp = cpu_to_le16(IEEE80211_FCTL_TODS | IEEE80211_FCTL_FROMDS);
+  uint16_t tmp = htole16(IEEE80211_FCTL_TODS | IEEE80211_FCTL_FROMDS);
   return (fc & tmp) == tmp;
 }
 
@@ -426,7 +432,7 @@ static inline bool ieee80211_has_a4(uint16_t fc)
 
 static inline bool ieee80211_has_morefrags(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_MOREFRAGS)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_MOREFRAGS)) != 0;
 }
 
 /* ieee80211_has_retry - check if IEEE80211_FCTL_RETRY is set
@@ -435,7 +441,7 @@ static inline bool ieee80211_has_morefrags(uint16_t fc)
 
 static inline bool ieee80211_has_retry(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_RETRY)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_RETRY)) != 0;
 }
 
 /* ieee80211_has_pm - check if IEEE80211_FCTL_PM is set
@@ -444,7 +450,7 @@ static inline bool ieee80211_has_retry(uint16_t fc)
 
 static inline bool ieee80211_has_pm(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_PM)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_PM)) != 0;
 }
 
 /* ieee80211_has_moredata - check if IEEE80211_FCTL_MOREDATA is set
@@ -453,7 +459,7 @@ static inline bool ieee80211_has_pm(uint16_t fc)
 
 static inline bool ieee80211_has_moredata(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_MOREDATA)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_MOREDATA)) != 0;
 }
 
 /* ieee80211_has_protected - check if IEEE80211_FCTL_PROTECTED is set
@@ -462,7 +468,7 @@ static inline bool ieee80211_has_moredata(uint16_t fc)
 
 static inline bool ieee80211_has_protected(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_PROTECTED)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_PROTECTED)) != 0;
 }
 
 /* ieee80211_has_order - check if IEEE80211_FCTL_ORDER is set
@@ -471,7 +477,7 @@ static inline bool ieee80211_has_protected(uint16_t fc)
 
 static inline bool ieee80211_has_order(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_ORDER)) != 0;
+  return (fc & htole16(IEEE80211_FCTL_ORDER)) != 0;
 }
 
 /* ieee80211_is_mgmt - check if type is IEEE80211_FTYPE_MGMT
@@ -480,8 +486,8 @@ static inline bool ieee80211_has_order(uint16_t fc)
 
 static inline bool ieee80211_is_mgmt(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT);
 }
 
 /* ieee80211_is_ctl - check if type is IEEE80211_FTYPE_CTL
@@ -490,8 +496,8 @@ static inline bool ieee80211_is_mgmt(uint16_t fc)
 
 static inline bool ieee80211_is_ctl(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL);
 }
 
 /* ieee80211_is_data - check if type is IEEE80211_FTYPE_DATA
@@ -500,8 +506,8 @@ static inline bool ieee80211_is_ctl(uint16_t fc)
 
 static inline bool ieee80211_is_data(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_DATA);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE)) ==
+    htole16(IEEE80211_FTYPE_DATA);
 }
 
 /* ieee80211_is_ext - check if type is IEEE80211_FTYPE_EXT
@@ -510,8 +516,8 @@ static inline bool ieee80211_is_data(uint16_t fc)
 
 static inline bool ieee80211_is_ext(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_EXT);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE)) ==
+    htole16(IEEE80211_FTYPE_EXT);
 }
 
 /* ieee80211_is_data_qos - check if type is IEEE80211_FTYPE_DATA
@@ -525,9 +531,9 @@ static inline bool ieee80211_is_data_qos(uint16_t fc)
    * to check the one bit
    */
 
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE |
+  return (fc & htole16(IEEE80211_FCTL_FTYPE |
                            IEEE80211_STYPE_QOS_DATA)) ==
-    cpu_to_le16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_QOS_DATA);
+    htole16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_QOS_DATA);
 }
 
 /* ieee80211_is_data_present - check if type is IEEE80211_FTYPE_DATA
@@ -541,8 +547,8 @@ static inline bool ieee80211_is_data_present(uint16_t fc)
    * for the data-containing substypes.
    */
 
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | 0x40)) ==
-    cpu_to_le16(IEEE80211_FTYPE_DATA);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | 0x40)) ==
+    htole16(IEEE80211_FTYPE_DATA);
 }
 
 /* ieee80211_is_assoc_req - check if IEEE80211_FTYPE_MGMT &&
@@ -552,8 +558,8 @@ static inline bool ieee80211_is_data_present(uint16_t fc)
 
 static inline bool ieee80211_is_assoc_req(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ASSOC_REQ);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ASSOC_REQ);
 }
 
 /* ieee80211_is_assoc_resp - check if IEEE80211_FTYPE_MGMT &&
@@ -563,8 +569,8 @@ static inline bool ieee80211_is_assoc_req(uint16_t fc)
 
 static inline bool ieee80211_is_assoc_resp(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ASSOC_RESP);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ASSOC_RESP);
 }
 
 /* ieee80211_is_reassoc_req - check if IEEE80211_FTYPE_MGMT &&
@@ -574,8 +580,8 @@ static inline bool ieee80211_is_assoc_resp(uint16_t fc)
 
 static inline bool ieee80211_is_reassoc_req(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_REASSOC_REQ);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_REASSOC_REQ);
 }
 
 /* ieee80211_is_reassoc_resp - check if IEEE80211_FTYPE_MGMT &&
@@ -585,8 +591,8 @@ static inline bool ieee80211_is_reassoc_req(uint16_t fc)
 
 static inline bool ieee80211_is_reassoc_resp(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_REASSOC_RESP);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_REASSOC_RESP);
 }
 
 /* ieee80211_is_probe_req - check if IEEE80211_FTYPE_MGMT &&
@@ -596,8 +602,8 @@ static inline bool ieee80211_is_reassoc_resp(uint16_t fc)
 
 static inline bool ieee80211_is_probe_req(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_PROBE_REQ);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_PROBE_REQ);
 }
 
 /* ieee80211_is_probe_resp - check if IEEE80211_FTYPE_MGMT &&
@@ -607,8 +613,8 @@ static inline bool ieee80211_is_probe_req(uint16_t fc)
 
 static inline bool ieee80211_is_probe_resp(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_PROBE_RESP);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_PROBE_RESP);
 }
 
 /* ieee80211_is_beacon - check if IEEE80211_FTYPE_MGMT &&
@@ -618,8 +624,8 @@ static inline bool ieee80211_is_probe_resp(uint16_t fc)
 
 static inline bool ieee80211_is_beacon(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_BEACON);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_BEACON);
 }
 
 /* ieee80211_is_s1g_beacon - check if IEEE80211_FTYPE_EXT &&
@@ -629,9 +635,9 @@ static inline bool ieee80211_is_beacon(uint16_t fc)
 
 static inline bool ieee80211_is_s1g_beacon(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE |
+  return (fc & htole16(IEEE80211_FCTL_FTYPE |
         IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_EXT | IEEE80211_STYPE_S1G_BEACON);
+    htole16(IEEE80211_FTYPE_EXT | IEEE80211_STYPE_S1G_BEACON);
 }
 
 /* ieee80211_next_tbtt_present - check if IEEE80211_FTYPE_EXT &&
@@ -641,9 +647,9 @@ static inline bool ieee80211_is_s1g_beacon(uint16_t fc)
 
 static inline bool ieee80211_next_tbtt_present(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_EXT | IEEE80211_STYPE_S1G_BEACON) &&
-    fc & cpu_to_le16(IEEE80211_S1G_BCN_NEXT_TBTT);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_EXT | IEEE80211_STYPE_S1G_BEACON) &&
+    fc & htole16(IEEE80211_S1G_BCN_NEXT_TBTT);
 }
 
 /* ieee80211_is_s1g_short_beacon - check if next tbtt present bit is set.
@@ -662,8 +668,8 @@ static inline bool ieee80211_is_s1g_short_beacon(uint16_t fc)
 
 static inline bool ieee80211_is_atim(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ATIM);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ATIM);
 }
 
 /* ieee80211_is_disassoc - check if IEEE80211_FTYPE_MGMT &&
@@ -673,8 +679,8 @@ static inline bool ieee80211_is_atim(uint16_t fc)
 
 static inline bool ieee80211_is_disassoc(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_DISASSOC);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_DISASSOC);
 }
 
 /* ieee80211_is_auth - check if IEEE80211_FTYPE_MGMT && IEEE80211_STYPE_AUTH
@@ -683,8 +689,8 @@ static inline bool ieee80211_is_disassoc(uint16_t fc)
 
 static inline bool ieee80211_is_auth(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_AUTH);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_AUTH);
 }
 
 /* ieee80211_is_deauth - check if IEEE80211_FTYPE_MGMT &&
@@ -694,8 +700,8 @@ static inline bool ieee80211_is_auth(uint16_t fc)
 
 static inline bool ieee80211_is_deauth(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_DEAUTH);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_DEAUTH);
 }
 
 /* ieee80211_is_action - check if IEEE80211_FTYPE_MGMT &&
@@ -705,8 +711,8 @@ static inline bool ieee80211_is_deauth(uint16_t fc)
 
 static inline bool ieee80211_is_action(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ACTION);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_MGMT | IEEE80211_STYPE_ACTION);
 }
 
 /* ieee80211_is_back_req - check if IEEE80211_FTYPE_CTL &&
@@ -716,8 +722,8 @@ static inline bool ieee80211_is_action(uint16_t fc)
 
 static inline bool ieee80211_is_back_req(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_BACK_REQ);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_BACK_REQ);
 }
 
 /* ieee80211_is_back - check if IEEE80211_FTYPE_CTL &&
@@ -727,8 +733,8 @@ static inline bool ieee80211_is_back_req(uint16_t fc)
 
 static inline bool ieee80211_is_back(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_BACK);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_BACK);
 }
 
 /* ieee80211_is_pspoll - check if IEEE80211_FTYPE_CTL &&
@@ -738,8 +744,8 @@ static inline bool ieee80211_is_back(uint16_t fc)
 
 static inline bool ieee80211_is_pspoll(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_PSPOLL);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_PSPOLL);
 }
 
 /* ieee80211_is_rts - check if IEEE80211_FTYPE_CTL && IEEE80211_STYPE_RTS
@@ -748,8 +754,8 @@ static inline bool ieee80211_is_pspoll(uint16_t fc)
 
 static inline bool ieee80211_is_rts(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_RTS);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_RTS);
 }
 
 /* ieee80211_is_cts - check if IEEE80211_FTYPE_CTL && IEEE80211_STYPE_CTS
@@ -758,8 +764,8 @@ static inline bool ieee80211_is_rts(uint16_t fc)
 
 static inline bool ieee80211_is_cts(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CTS);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CTS);
 }
 
 /* ieee80211_is_ack - check if IEEE80211_FTYPE_CTL && IEEE80211_STYPE_ACK
@@ -768,8 +774,8 @@ static inline bool ieee80211_is_cts(uint16_t fc)
 
 static inline bool ieee80211_is_ack(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_ACK);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_ACK);
 }
 
 /* ieee80211_is_cfend - check if IEEE80211_FTYPE_CTL && IEEE80211_STYPE_CFEND
@@ -778,8 +784,8 @@ static inline bool ieee80211_is_ack(uint16_t fc)
 
 static inline bool ieee80211_is_cfend(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CFEND);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CFEND);
 }
 
 /* ieee80211_is_cfendack - check if IEEE80211_FTYPE_CTL &&
@@ -789,8 +795,8 @@ static inline bool ieee80211_is_cfend(uint16_t fc)
 
 static inline bool ieee80211_is_cfendack(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CFENDACK);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_CTL | IEEE80211_STYPE_CFENDACK);
 }
 
 /* ieee80211_is_nullfunc - check if frame is a regular
@@ -800,8 +806,8 @@ static inline bool ieee80211_is_cfendack(uint16_t fc)
 
 static inline bool ieee80211_is_nullfunc(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_NULLFUNC);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_NULLFUNC);
 }
 
 /* ieee80211_is_qos_nullfunc - check if frame is a QoS nullfunc frame
@@ -810,8 +816,8 @@ static inline bool ieee80211_is_nullfunc(uint16_t fc)
 
 static inline bool ieee80211_is_qos_nullfunc(uint16_t fc)
 {
-  return (fc & cpu_to_le16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
-    cpu_to_le16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_QOS_NULLFUNC);
+  return (fc & htole16(IEEE80211_FCTL_FTYPE | IEEE80211_FCTL_STYPE)) ==
+    htole16(IEEE80211_FTYPE_DATA | IEEE80211_STYPE_QOS_NULLFUNC);
 }
 
 /* ieee80211_is_any_nullfunc - check if frame is regular or QoS
@@ -846,7 +852,7 @@ static inline bool ieee80211_is_bufferable_mmpdu(uint16_t fc)
 
 static inline bool ieee80211_is_first_frag(uint16_t seq_ctrl)
 {
-  return (seq_ctrl & cpu_to_le16(IEEE80211_SCTL_FRAG)) == 0;
+  return (seq_ctrl & htole16(IEEE80211_SCTL_FRAG)) == 0;
 }
 
 /* ieee80211_is_frag - check if a frame is a fragment
@@ -856,7 +862,7 @@ static inline bool ieee80211_is_first_frag(uint16_t seq_ctrl)
 static inline bool ieee80211_is_frag(FAR struct ieee80211_hdr *hdr)
 {
   return ieee80211_has_morefrags(hdr->frame_control) ||
-    hdr->seq_ctrl & cpu_to_le16(IEEE80211_SCTL_FRAG);
+    hdr->seq_ctrl & htole16(IEEE80211_SCTL_FRAG);
 }
 
 struct ieee80211s_hdr
@@ -2593,7 +2599,7 @@ ieee80211_he_oper_size(FAR const uint8_t *he_oper_ie)
 
   /* Calc required length */
 
-  he_oper_params = le32_to_cpu(he_oper->he_oper_params);
+  he_oper_params = le32toh(he_oper->he_oper_params);
   if (he_oper_params & IEEE80211_HE_OPERATION_VHT_OPER_INFO)
     oper_len += 3;
   if (he_oper_params & IEEE80211_HE_OPERATION_CO_HOSTED_BSS)
@@ -2624,7 +2630,7 @@ ieee80211_he_6ghz_oper(FAR const struct ieee80211_he_operation *he_oper)
   if (!he_oper)
     return NULL;
 
-  he_oper_params = le32_to_cpu(he_oper->he_oper_params);
+  he_oper_params = le32toh(he_oper->he_oper_params);
 
   if (!(he_oper_params & IEEE80211_HE_OPERATION_6GHZ_OP_INFO))
     return NULL;


### PR DESCRIPTION
## Summary

Some macros used in the ieee80211.h header were missing definitions when attempting to build on Arch Linux. It appears this is a system difference between Arch Linux and Ubuntu. The definitions were:

- `hweight8`
- `cpu_to_le16`
- `le32_to_cpu`
- `BIT`

## Impact

This PR replaces the `cpu_to_le16` and `le32_to_cpu` references with their equivalent definitions `htole16` and `le32toh` from `sys/endian.h`. I have also included definitions of `hweight8` and `BIT` at the top of the file if they are found to be undefined.

Now, users on Arch Linux can compile the IEEE802.11 header. This resolves issue #13704.

## Testing

After implementing these changes, I built the `raspberrypi-pico-w:telnet` configuration and connected to my home network successfully. I was able to ping other devices on my network.