### PR TITLE
net: Change the DEBUGASSERT to WARNING log for the tcp_pollsetup.

### DIFF
--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -230,7 +230,6 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   info = conn->pollinfo;
   while (info->conn != NULL)
     {
-      DEBUGASSERT((fds->events & info->fds->events) != 0);
       if (++info >= &conn->pollinfo[CONFIG_NET_TCP_NPOLLWAITERS])
         {
           DEBUGPANIC();


### PR DESCRIPTION

## Summary

Remove the DEBUGASSERT of the same event of the same fd in tcp_pollsetup.

In libuv, if the real_timeout in the uv__io_poll is less than 0, the poll logic will be entered directly by the uv__run_timers, which will trigger the ASSERT. It seems that the situation of first epoll and then poll for the same fd is used in libuv, and the case is allowed in Linux.

## Impact
We can perform the epoll and then poll operations on the same tcp fd.

## Testing
I just used the app, which accessed an http web page through the fetch interface for testing. In this process, the application established a tcp connection by calling libuv and libcurl.
After the modification, this test can pass.


