### PR TITLE
fix compile error

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -99,7 +99,7 @@ struct esp32s2_uart_s g_uart0_config =
   .rs485_dir_polarity = true,
 #endif
 #endif
-  .lock = SP_UNLOCKED;
+  .lock = SP_UNLOCKED
 };
 
 #endif /* CONFIG_ESP32S2_UART0 */
@@ -147,7 +147,7 @@ struct esp32s2_uart_s g_uart1_config =
   .rs485_dir_polarity = true,
 #endif
 #endif
-  .lock = SP_UNLOCKED;
+  .lock = SP_UNLOCKED
 };
 
 #endif /* CONFIG_ESP32S2_UART1 */


### PR DESCRIPTION

## Summary

Configuration/Tool: esp32s2-kaluga-1/audio
Error: chip/esp32s2_lowputc.c:102:22: error: expected '}' before ';' token
  102 |   .lock = SP_UNLOCKED;
      |                      ^
chip/esp32s2_lowputc.c:62:1: note: to match this '{'
   62 | {

## Impact
none

## Testing
ci


