### PR TITLE
use small lock in following files:

### DIFF
--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -308,6 +308,7 @@ struct up_dev_s
   uint32_t          rxdmanext; /* Next byte in the DMA buffer to be read */
   char      *const  rxfifo;    /* Receive DMA buffer */
 #endif
+  spinlock_t lock;             /* Spinlock */
 };
 
 /****************************************************************************
@@ -486,6 +487,7 @@ static struct up_dev_s g_uart0priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART0_RX,
   .rxfifo         = g_uart0rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart0port =
@@ -536,6 +538,7 @@ static struct up_dev_s g_uart1priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART1_RX,
   .rxfifo         = g_uart1rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart1port =
@@ -586,6 +589,7 @@ static struct up_dev_s g_uart2priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART2_RX,
   .rxfifo         = g_uart2rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart2port =
@@ -636,6 +640,7 @@ static struct up_dev_s g_uart3priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART3_RX,
   .rxfifo         = g_uart3rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart3port =
@@ -686,6 +691,7 @@ static struct up_dev_s g_uart4priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART4_RXTX,
   .rxfifo         = g_uart4rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart4port =
@@ -736,6 +742,7 @@ static struct up_dev_s g_uart5priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART5_RX,
   .rxfifo         = g_uart5rxfifo,
 #  endif
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart5port =
@@ -786,21 +793,27 @@ static inline void up_serialout(struct up_dev_s *priv, int offset,
  * Name: up_setuartint
  ****************************************************************************/
 
-static void up_setuartint(struct up_dev_s *priv)
+static void up_setuartint_nolock(struct up_dev_s *priv)
 {
-  irqstate_t flags;
   uint8_t regval;
 
   /* Re-enable/re-disable interrupts corresponding to the state of bits in
    * ie
    */
 
-  flags    = spin_lock_irqsave(NULL);
   regval   = up_serialin(priv, KINETIS_UART_C2_OFFSET);
   regval  &= ~UART_C2_ALLINTS;
   regval  |= priv->ie;
   up_serialout(priv, KINETIS_UART_C2_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
+}
+
+static void up_setuartint(struct up_dev_s *priv)
+{
+  irqstate_t flags;
+
+  flags    = spin_lock_irqsave(&priv->lock);
+  up_setuartint_nolock(priv);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -815,10 +828,10 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
    * ie
    */
 
-  flags    = spin_lock_irqsave(NULL);
+  flags    = spin_lock_irqsave(&priv->lock);
   priv->ie = ie & UART_C2_ALLINTS;
-  up_setuartint(priv);
-  spin_unlock_irqrestore(NULL, flags);
+  up_setuartint_nolock(priv);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -830,14 +843,15 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *ie)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (ie)
     {
       *ie = priv->ie;
     }
 
-  up_restoreuartint(priv, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  priv->ie = 0;
+  up_setuartint_nolock(priv);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif
 

--- a/arch/arm/src/kl/kl_serial.c
+++ b/arch/arm/src/kl/kl_serial.c
@@ -148,6 +148,7 @@ struct up_dev_s
   uint8_t   ie;        /* Interrupts enabled */
   uint8_t   parity;    /* 0=none, 1=odd, 2=even */
   uint8_t   bits;      /* Number of bits (8 or 9) */
+  spinlock_t lock;     /* Spinlock */
 };
 
 /****************************************************************************
@@ -216,6 +217,7 @@ static struct up_dev_s g_uart0priv =
   .irq            = KL_IRQ_UART0,
   .parity         = CONFIG_UART0_PARITY,
   .bits           = CONFIG_UART0_BITS,
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart0port =
@@ -246,6 +248,7 @@ static struct up_dev_s g_uart1priv =
   .irq            = KL_IRQ_UART1,
   .parity         = CONFIG_UART1_PARITY,
   .bits           = CONFIG_UART1_BITS,
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart1port =
@@ -276,6 +279,7 @@ static struct up_dev_s g_uart2priv =
   .irq            = KL_IRQ_UART2,
   .parity         = CONFIG_UART2_PARITY,
   .bits           = CONFIG_UART2_BITS,
+  .lock           = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart2port =
@@ -322,26 +326,38 @@ static inline void up_serialout(struct up_dev_s *priv, int offset,
  * Name: up_setuartint
  ****************************************************************************/
 
-static void up_setuartint(struct up_dev_s *priv)
+static void up_setuartint_nolock(struct up_dev_s *priv)
 {
-  irqstate_t flags;
   uint8_t regval;
 
   /* Re-enable/re-disable interrupts corresponding to the state of bits
    * in ie.
    */
 
-  flags    = spin_lock_irqsave(NULL);
   regval   = up_serialin(priv, KL_UART_C2_OFFSET);
   regval  &= ~UART_C2_ALLINTS;
   regval  |= priv->ie;
   up_serialout(priv, KL_UART_C2_OFFSET, regval);
-  spin_unlock_irqrestore(NULL, flags);
+}
+
+static void up_setuartint(struct up_dev_s *priv)
+{
+  irqstate_t flags;
+
+  flags    = spin_lock_irqsave(&priv->lock);
+  up_setuartint_nolock(priv);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
  * Name: up_restoreuartint
  ****************************************************************************/
+
+static void up_restoreuartint_nolock(struct up_dev_s *priv, uint8_t ie)
+{
+  priv->ie = ie & UART_C2_ALLINTS;
+  up_setuartint_nolock(priv);
+}
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
 {
@@ -351,10 +367,9 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
    * in ie.
    */
 
-  flags    = spin_lock_irqsave(NULL);
-  priv->ie = ie & UART_C2_ALLINTS;
-  up_setuartint(priv);
-  spin_unlock_irqrestore(NULL, flags);
+  flags    = spin_lock_irqsave(&priv->lock);
+  up_restoreuartint_nolock(priv, ie);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -365,14 +380,14 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *ie)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (ie)
     {
       *ie = priv->ie;
     }
 
-  up_restoreuartint(priv, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  up_restoreuartint_nolock(priv, 0);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -97,6 +97,8 @@ const uint32_t g_cpu_intstack_top[CONFIG_SMP_NCPUS] =
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_lc823450_irq_lock = SP_UNLOCKED;
+
 #ifdef CONFIG_LC823450_VIRQ
 static struct lc823450_irq_ops *virq_ops[LC823450_IRQ_NVIRTUALIRQS];
 #endif /* CONFIG_LC823450_VIRQ */
@@ -625,7 +627,7 @@ void up_enable_irq(int irq)
        * set the bit in the System Handler Control and State Register.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_lc823450_irq_lock);
 
       if (irq >= LC823450_IRQ_NIRQS)
         {
@@ -648,7 +650,7 @@ void up_enable_irq(int irq)
           putreg32(regval, regaddr);
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_lc823450_irq_lock, flags);
     }
 
   /* lc823450_dumpnvic("enable", irq); */
@@ -773,7 +775,7 @@ int lc823450_irq_srctype(int irq, enum lc823450_srctype_e srctype)
   port = (irq & 0x70) >> 4;
   gpio = irq & 0xf;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_lc823450_irq_lock);
 
   regaddr = INTC_REG(EXTINTCND_BASE, port);
   regval = getreg32(regaddr);
@@ -783,7 +785,7 @@ int lc823450_irq_srctype(int irq, enum lc823450_srctype_e srctype)
 
   putreg32(regval, regaddr);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_lc823450_irq_lock, flags);
 
   return OK;
 }

--- a/arch/arm/src/lc823450/lc823450_syscontrol.c
+++ b/arch/arm/src/lc823450/lc823450_syscontrol.c
@@ -43,6 +43,7 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_lc823450_syscontrol_lock = SP_UNLOCKED;
 static struct clk_st lc823450_clocks[] = LC823450_CLOCKS;
 
 /****************************************************************************
@@ -132,7 +133,7 @@ void mod_stby_regs(uint32_t enabits, uint32_t disbits)
 void up_enable_clk(enum clock_e clk)
 {
   irqstate_t flags;
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_lc823450_syscontrol_lock);
 
   DEBUGASSERT(clk < LC823450_CLOCK_NUM);
 
@@ -142,7 +143,7 @@ void up_enable_clk(enum clock_e clk)
                   0, lc823450_clocks[clk].regmask);
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_lc823450_syscontrol_lock, flags);
 }
 
 /****************************************************************************
@@ -152,7 +153,7 @@ void up_enable_clk(enum clock_e clk)
 void up_disable_clk(enum clock_e clk)
 {
   irqstate_t flags;
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_lc823450_syscontrol_lock);
 
   DEBUGASSERT(clk < LC823450_CLOCK_NUM);
 
@@ -169,7 +170,7 @@ void up_disable_clk(enum clock_e clk)
       lc823450_clocks[clk].count = 0;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_lc823450_syscontrol_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -378,6 +378,7 @@ struct lpc54_dev_s
 {
   uintptr_t uartbase;  /* Base address of USART registers */
   uint8_t   irq;       /* IRQ associated with this USART */
+  spinlock_t lock;     /* Spinlock */
 
   /* USART configuration */
 
@@ -459,6 +460,7 @@ static struct lpc54_dev_s g_uart0priv =
 {
   .uartbase       = LPC54_FLEXCOMM0_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM0,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART0_BAUD,
@@ -501,6 +503,7 @@ static struct lpc54_dev_s g_uart1priv =
 {
   .uartbase       = LPC54_FLEXCOMM1_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM1,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART1_BAUD,
@@ -543,6 +546,7 @@ static struct lpc54_dev_s g_uart2priv =
 {
   .uartbase       = LPC54_FLEXCOMM2_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM2,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART2_BAUD,
@@ -585,6 +589,7 @@ static struct lpc54_dev_s g_uart3priv =
 {
   .uartbase       = LPC54_FLEXCOMM3_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM3,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART3_BAUD,
@@ -627,6 +632,7 @@ static struct lpc54_dev_s g_uart4priv =
 {
   .uartbase       = LPC54_FLEXCOMM4_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM4,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART4_BAUD,
@@ -669,6 +675,7 @@ static struct lpc54_dev_s g_uart5priv =
 {
   .uartbase       = LPC54_FLEXCOMM5_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM5,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART5_BAUD,
@@ -711,6 +718,7 @@ static struct lpc54_dev_s g_uart6priv =
 {
   .uartbase       = LPC54_FLEXCOMM6_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM6,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART6_BAUD,
@@ -753,6 +761,7 @@ static struct lpc54_dev_s g_uart7priv =
 {
   .uartbase       = LPC54_FLEXCOMM7_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM7,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART7_BAUD,
@@ -795,6 +804,7 @@ static struct lpc54_dev_s g_uart8priv =
 {
   .uartbase       = LPC54_FLEXCOMM8_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM8,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART8_BAUD,
@@ -837,6 +847,7 @@ static struct lpc54_dev_s g_uart9priv =
 {
   .uartbase       = LPC54_FLEXCOMM9_BASE,
   .irq            = LPC54_IRQ_FLEXCOMM9,
+  .lock           = SP_UNLOCKED,
   .config         =
   {
     .baud         = CONFIG_USART9_BAUD,
@@ -925,14 +936,14 @@ static void lpc54_fifoint_disableall(struct lpc54_dev_s *priv,
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (intset)
     {
       *intset = lpc54_serialin(priv, LPC54_USART_FIFOINTENCLR_OFFSET);
     }
 
   lpc54_serialout(priv, LPC54_USART_FIFOINTENCLR_OFFSET, USART_FIFOINT_ALL);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/max326xx/max32660/max32660_dma.c
+++ b/arch/arm/src/max326xx/max32660/max32660_dma.c
@@ -67,6 +67,7 @@ struct max326_dmach_s
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_max326_dmach_lock = SP_UNLOCKED;
 struct max326_dmach_s g_max326_dmach[MAX326_DMA_NCHAN];
 
 /****************************************************************************
@@ -267,7 +268,7 @@ DMA_HANDLE max326_dma_channel(void)
    * allocation.  Just check each channel until a free one is found (on not).
    */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_max326_dmach_lock);
   for (i = 0; i < 0; i++)
     {
       struct max326_dmach_s *dmach = &g_max326_dmach[i];
@@ -279,12 +280,12 @@ DMA_HANDLE max326_dma_channel(void)
           /* No.. allocate this channel */
 
           dmach->inuse = true;
-          spin_unlock_irqrestore(NULL, flags);
+          spin_unlock_irqrestore(&g_max326_dmach_lock, flags);
           return (DMA_HANDLE)dmach;
         }
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_max326_dmach_lock, flags);
   return NULL;
 }
 

--- a/arch/arm/src/max326xx/max32660/max32660_gpio.c
+++ b/arch/arm/src/max326xx/max32660/max32660_gpio.c
@@ -64,6 +64,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_max32660_gpio_lock = SP_UNLOCKED;
+
 #ifdef CONFIG_DEBUG_GPIO_INFO
 static const char *g_afmode[4] =
 {
@@ -242,7 +244,7 @@ int max326_gpio_config(max326_pinset_t pinset)
 
   /* Modification of all registers must be atomic */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_max32660_gpio_lock);
 
   /* First, force the pin configuration to the default generic input state.
    * So that we know we are starting from a known state.
@@ -403,7 +405,7 @@ int max326_gpio_config(max326_pinset_t pinset)
       putreg32(regval, MAX326_GPIO0_WAKEEN);
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_max32660_gpio_lock, flags);
   return OK;
 }
 
@@ -426,7 +428,7 @@ void max326_gpio_write(max326_pinset_t pinset, bool value)
 
   /* Modification of registers must be atomic */
 
-  flags  = spin_lock_irqsave(NULL);
+  flags  = spin_lock_irqsave(&g_max32660_gpio_lock);
   regval = getreg32(MAX326_GPIO0_OUT);
   if (value)
     {
@@ -438,7 +440,7 @@ void max326_gpio_write(max326_pinset_t pinset, bool value)
     }
 
   putreg32(regval, MAX326_GPIO0_OUT);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_max32660_gpio_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -39,6 +39,12 @@
 #include "nrf52_gpio.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_nrf52_gpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -275,7 +281,7 @@ int nrf52_gpio_config(nrf52_pinset_t cfgset)
 
       pin = GPIO_PIN_DECODE(cfgset);
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_nrf52_gpio_lock);
 
       /* First, configure the port as a generic input so that we have a
        * known starting point and consistent behavior during the re-
@@ -310,7 +316,7 @@ int nrf52_gpio_config(nrf52_pinset_t cfgset)
           ret = -EINVAL;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_nrf52_gpio_lock, flags);
     }
   else
     {

--- a/arch/arm/src/nrf53/nrf53_gpio.c
+++ b/arch/arm/src/nrf53/nrf53_gpio.c
@@ -39,6 +39,12 @@
 #include "nrf53_gpio.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_nrf53_gpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -330,7 +336,7 @@ int nrf53_gpio_config(nrf53_pinset_t cfgset)
 
       pin = GPIO_PIN_DECODE(cfgset);
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_nrf53_gpio_lock);
 
       /* First, configure the port as a generic input so that we have a
        * known starting point and consistent behavior during the re-
@@ -373,7 +379,7 @@ int nrf53_gpio_config(nrf53_pinset_t cfgset)
           ret = -EINVAL;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_nrf53_gpio_lock, flags);
     }
   else
     {

--- a/arch/arm/src/nrf91/nrf91_gpio.c
+++ b/arch/arm/src/nrf91/nrf91_gpio.c
@@ -39,6 +39,12 @@
 #include "nrf91_gpio.h"
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_nrf91_gpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -271,7 +277,7 @@ int nrf91_gpio_config(nrf91_pinset_t cfgset)
 
       pin = GPIO_PIN_DECODE(cfgset);
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_nrf91_gpio_lock);
 
       /* First, configure the port as a generic input so that we have a
        * known starting point and consistent behavior during the re-
@@ -306,7 +312,7 @@ int nrf91_gpio_config(nrf91_pinset_t cfgset)
           ret = -EINVAL;
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_nrf91_gpio_lock, flags);
     }
   else
     {

--- a/arch/arm/src/rp2040/rp2040_uart.c
+++ b/arch/arm/src/rp2040/rp2040_uart.c
@@ -116,6 +116,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_rp2040_uart_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -189,7 +191,7 @@ void rp2040_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   uint32_t div;
   uint32_t lcr_h;
 
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&g_rp2040_uart_lock);
 
   div  = basefreq / (16 * baud / 100);
   ibrd = div / 100;
@@ -214,5 +216,5 @@ void rp2040_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   putreg32(lcr_h, uartbase + RP2040_UART_UARTLCR_H_OFFSET);
 
 finish:
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_rp2040_uart_lock, flags);
 }


### PR DESCRIPTION

## Summary

use small lock in following files:
arch/arm/src/kinetis/kinetis_serial.c
arch/arm/src/kl/kl_serial.c
arch/arm/src/lc823450/lc823450_irq.c
arch/arm/src/lc823450/lc823450_syscontrol.c
arch/arm/src/lpc54xx/lpc54_serial.c
arch/arm/src/max326xx/max32660/max32660_dma.c
arch/arm/src/max326xx/max32660/max32660_gpio.c
arch/arm/src/max326xx/max32660/max32660_lowputc.c
arch/arm/src/max326xx/max32660/max32660_serial.c
arch/arm/src/mx8mp/mx8mp_serial.c
arch/arm/src/nrf52/nrf52_gpio.c
arch/arm/src/nrf53/nrf53_gpio.c
arch/arm/src/nrf91/nrf91_gpio.c
arch/arm/src/rp2040/rp2040_uart.c


## Impact
use small lock in following files:
arch/arm/src/kinetis/kinetis_serial.c
arch/arm/src/kl/kl_serial.c
arch/arm/src/lc823450/lc823450_irq.c
arch/arm/src/lc823450/lc823450_syscontrol.c
arch/arm/src/lpc54xx/lpc54_serial.c
arch/arm/src/max326xx/max32660/max32660_dma.c
arch/arm/src/max326xx/max32660/max32660_gpio.c
arch/arm/src/max326xx/max32660/max32660_lowputc.c
arch/arm/src/max326xx/max32660/max32660_serial.c
arch/arm/src/mx8mp/mx8mp_serial.c
arch/arm/src/nrf52/nrf52_gpio.c
arch/arm/src/nrf53/nrf53_gpio.c
arch/arm/src/nrf91/nrf91_gpio.c
arch/arm/src/rp2040/rp2040_uart.c

## Testing
ci

