### PR TITLE
use small lock in following files:

### DIFF
--- a/arch/arm64/src/a64/a64_serial.c
+++ b/arch/arm64/src/a64/a64_serial.c
@@ -270,6 +270,12 @@ struct a64_uart_port_s
 };
 
 /***************************************************************************
+ * Private Data
+ ***************************************************************************/
+
+static spinlock_t g_a64_serial_lock = SP_UNLOCKED;
+
+/***************************************************************************
  * Private Function Prototypes
  ***************************************************************************/
 
@@ -967,7 +973,7 @@ static int a64_uart_init(uint32_t gating, uint32_t rst, pio_pinset_t tx,
   irqstate_t flags;
   int ret = OK;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_a64_serial_lock);
 
   /* Enable clocking to UART */
 
@@ -993,7 +999,7 @@ static int a64_uart_init(uint32_t gating, uint32_t rst, pio_pinset_t tx,
         }
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_a64_serial_lock, flags);
   return ret;
 };
 

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -141,6 +141,7 @@ struct up_dev_s
   uint8_t   parity;    /* 0=none, 1=odd, 2=even */
   uint8_t   bits;      /* Number of bits (5, 6, 7 or 8) */
   bool      stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+  spinlock_t lock;     /* Spinlock */
 };
 
 /****************************************************************************
@@ -152,7 +153,9 @@ struct up_dev_s
 static inline uint32_t up_serialin(struct up_dev_s *priv, int offset);
 static inline void up_serialout(struct up_dev_s *priv, int offset,
                                 uint32_t value);
+#ifdef HAVE_SERIAL_CONSOLE
 static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im);
+#endif
 static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im);
 
 /* Serial driver methods */
@@ -220,6 +223,7 @@ static struct up_dev_s g_uart1priv =
   .parity    = CONFIG_UART1_PARITY,
   .bits      = CONFIG_UART1_BITS,
   .stopbits2 = CONFIG_UART1_2STOP,
+  .lock      = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart1port =
@@ -254,6 +258,7 @@ static struct up_dev_s g_uart2priv =
   .parity    = CONFIG_UART2_PARITY,
   .bits      = CONFIG_UART2_BITS,
   .stopbits2 = CONFIG_UART2_2STOP,
+  .lock      = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart2port =
@@ -300,19 +305,27 @@ static inline void up_serialout(struct up_dev_s *priv, int offset,
  * Name: up_restoreuartint
  ****************************************************************************/
 
+static void up_restoreuartint_nolock(struct uart_dev_s *dev, uint8_t im)
+{
+  up_rxint(dev, RX_ENABLED(im));
+  up_txint(dev, TX_ENABLED(im));
+}
+
+#ifdef HAVE_SERIAL_CONSOLE
 static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
 {
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
   /* Re-enable/re-disable interrupts corresponding to the state
    * of bits in im.
    */
 
-  flags = spin_lock_irqsave(NULL);
-  up_rxint(dev, RX_ENABLED(im));
-  up_txint(dev, TX_ENABLED(im));
-  spin_unlock_irqrestore(NULL, flags);
+  flags = spin_lock_irqsave(&priv->lock);
+  up_restoreuartint_nolock(dev, im);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
+#endif
 
 /****************************************************************************
  * Name: up_disableuartint
@@ -323,14 +336,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (im)
     {
       *im = priv->im;
     }
 
-  up_restoreuartint(dev, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  up_restoreuartint_nolock(dev, 0);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/c906/c906_serial.c
+++ b/arch/risc-v/src/c906/c906_serial.c
@@ -101,6 +101,7 @@ struct up_dev_s
   uint32_t  baud;     /* Configured baud */
   uint8_t   irq;      /* IRQ associated with this UART */
   uint8_t   im;       /* Interrupt mask state */
+  spinlock_t lock;    /* Spinlock */
 };
 
 /****************************************************************************
@@ -167,6 +168,7 @@ static struct up_dev_s g_uart0priv =
   .uartbase  = C906_UART0_BASE,
   .baud      = CONFIG_UART0_BAUD,
   .irq       = C906_IRQ_UART0,
+  .lock      = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart0port =
@@ -217,12 +219,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -231,7 +233,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   /* Return the current interrupt mask value */
 
@@ -244,7 +246,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -101,6 +101,7 @@ struct up_dev_s
   uint32_t  baud;     /* Configured baud */
   uint8_t   irq;      /* IRQ associated with this UART */
   uint8_t   im;       /* Interrupt mask state */
+  spinlock_t lock;    /* Spinlock */
 };
 
 /****************************************************************************
@@ -167,6 +168,7 @@ static struct up_dev_s g_uart0priv =
   .uartbase  = FE310_UART0_BASE,
   .baud      = CONFIG_UART0_BAUD,
   .irq       = FE310_IRQ_UART0,
+  .lock      = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart0port =
@@ -217,12 +219,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -231,7 +233,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   /* Return the current interrupt mask value */
 
@@ -244,7 +246,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/hpm6750/hpm6750_serial.c
+++ b/arch/risc-v/src/hpm6750/hpm6750_serial.c
@@ -101,6 +101,7 @@ struct up_dev_s
   uint32_t  uartbase;          /* Base address of UART registers */
   uint32_t  irq;               /* IRQ associated with this UART */
   uint32_t  im;                /* Interrupt mask state */
+  spinlock_t     lock;         /* Spinlock */
   uart_config_t  config;       /* Uart config */
 };
 
@@ -158,6 +159,7 @@ static struct up_dev_s g_uart0priv =
   .uartbase  = HPM6750_UART0_BASE,
   .irq       = HPM6750_IRQ_UART0,
   .im        = 0,
+  .lock      = SP_UNLOCKED,
   .config =
     {
       .src_freq_in_hz = 24000000,
@@ -236,12 +238,12 @@ static void up_serialmodfiy(struct up_dev_s *priv, int offset,
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   priv->im = im;
   up_serialout(priv, UART_IER_OFFSET, im);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -250,7 +252,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   /* Return the current interrupt mask value */
 
@@ -263,7 +265,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IER_OFFSET, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -101,6 +101,7 @@ struct up_dev_s
   uint32_t  baud;     /* Configured baud */
   uint8_t   irq;      /* IRQ associated with this UART */
   uint8_t   im;       /* Interrupt mask state */
+  spinlock_t lock;    /* Spinllock */
 };
 
 /****************************************************************************
@@ -167,6 +168,7 @@ static struct up_dev_s g_uart0priv =
   .uartbase  = K210_UART0_BASE,
   .baud      = CONFIG_UART0_BAUD,
   .irq       = K210_IRQ_UART0,
+  .lock      = SP_UNLOCKED
 };
 
 static uart_dev_t g_uart0port =
@@ -217,12 +219,12 @@ static void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 
 static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   priv->im = im;
   up_serialout(priv, UART_IE_OFFSET, im);
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -231,7 +233,7 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t im)
 
 static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 {
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&priv->lock);
 
   /* Return the current interrupt mask value */
 
@@ -244,7 +246,7 @@ static void up_disableuartint(struct up_dev_s *priv, uint8_t *im)
 
   priv->im = 0;
   up_serialout(priv, UART_IE_OFFSET, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/sparc/src/bm3803/bm3803-serial.c
+++ b/arch/sparc/src/bm3803/bm3803-serial.c
@@ -156,6 +156,7 @@ struct up_dev_s
   uint8_t   parity;    /* 0=none, 1=odd, 2=even */
   uint8_t   bits;      /* Number of bits (5, 6, 7 or 8) */
   bool      stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+  spinlock_t lock;     /* Spinlock */
 };
 
 /****************************************************************************
@@ -235,6 +236,7 @@ static struct up_dev_s g_uart1priv =
   .parity    = CONFIG_UART1_PARITY,
   .bits      = CONFIG_UART1_BITS,
   .stopbits2 = CONFIG_UART1_2STOP,
+  .lock      = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart1port =
@@ -265,6 +267,7 @@ static struct up_dev_s g_uart2priv =
   .parity    = CONFIG_UART2_PARITY,
   .bits      = CONFIG_UART2_BITS,
   .stopbits2 = CONFIG_UART2_2STOP,
+  .lock      = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart2port =
@@ -295,6 +298,7 @@ static struct up_dev_s g_uart3priv =
   .parity    = CONFIG_UART3_PARITY,
   .bits      = CONFIG_UART3_BITS,
   .stopbits2 = CONFIG_UART3_2STOP,
+  .lock      = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart3port =
@@ -354,18 +358,24 @@ static inline void up_setuartint(struct up_dev_s *priv)
  * Name: up_restoreuartint
  ****************************************************************************/
 
+static void up_restoreuartint_nolock(struct uart_dev_s *dev, uint8_t im)
+{
+  up_rxint(dev, RX_ENABLED(im));
+  up_txint(dev, TX_ENABLED(im));
+}
+
 static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
 {
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
   /* Re-enable/re-disable interrupts corresponding to the state of bits
    * in im
    */
 
-  flags = spin_lock_irqsave(NULL);
-  up_rxint(dev, RX_ENABLED(im));
-  up_txint(dev, TX_ENABLED(im));
-  spin_unlock_irqrestore(NULL, flags);
+  flags = spin_lock_irqsave(&priv->lock);
+  up_restoreuartint_nolock(dev, im);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -377,14 +387,14 @@ static void up_disableuartint(struct uart_dev_s *dev, uint8_t *im)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&priv->lock);
   if (im)
     {
       *im = priv->im;
     }
 
-  up_restoreuartint(dev, 0);
-  spin_unlock_irqrestore(NULL, flags);
+  up_restoreuartint_nolock(dev, 0);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
use small lock in following files:

arch/arm/src/tiva/common/tiva_hciuart.c
arch/arm/src/tms570/tms570_lowputc.c
arch/arm/src/xmc4/xmc4_serial.c
arch/arm64/src/a64/a64_serial.c
arch/mips/src/pic32mx/pic32mx_serial.c
arch/mips/src/pic32mz/pic32mz_serial.c
arch/risc-v/src/c906/c906_serial.c
arch/risc-v/src/fe310/fe310_serial.c
arch/risc-v/src/hpm6750/hpm6750_serial.c
arch/risc-v/src/k210/k210_serial.c
arch/sparc/src/bm3803/bm3803-serial.c
arch/sparc/src/bm3823/bm3823-serial.c

## Impact

arch/arm/src/tiva/common/tiva_hciuart.c
arch/arm/src/tms570/tms570_lowputc.c
arch/arm/src/xmc4/xmc4_serial.c
arch/arm64/src/a64/a64_serial.c
arch/mips/src/pic32mx/pic32mx_serial.c
arch/mips/src/pic32mz/pic32mz_serial.c
arch/risc-v/src/c906/c906_serial.c
arch/risc-v/src/fe310/fe310_serial.c
arch/risc-v/src/hpm6750/hpm6750_serial.c
arch/risc-v/src/k210/k210_serial.c
arch/sparc/src/bm3803/bm3803-serial.c
arch/sparc/src/bm3823/bm3823-serial.c

## Testing

ci 


