### PR TITLE
[POSIX][Bug] syslog: Add support for `%m` modifier

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -163,6 +163,10 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
   uint16_t flags;
   int width;
   int prec;
+
+  /* For the %m format we may need the current `errno' value */
+
+  int saved_errno = errno;
   union
   {
 #if defined (CONFIG_LIBC_LONG_LONG) || (ULONG_MAX > 4294967295UL)
@@ -909,6 +913,11 @@ flt_oper:
 #endif
           pnt = buf;
           size = 1;
+          goto str_lpad;
+
+        case 'm': /* Print error message (%m) */
+          pnt = strerror(saved_errno);
+          size = strlen(pnt); /* Adjusting the size is not supported by %m */
           goto str_lpad;
 
         case 's':


### PR DESCRIPTION
## Summary

The POSIX standard states that the `syslog()` function generates the body from the message and arguments the same way as `printf()`,

> except that the additional conversion specification `%m` shall be recognized;

*https://pubs.opengroup.org/onlinepubs/009695399/functions/syslog.html*

What most of the implementations do is to leverage the processing to `vsprintf` internals, to reduce code duplicity. This means the `%m` modifier is present on almost all `printf` implementations. Take the following code snippet as an example: https://onlinegdb.com/YdR9pU6KS.

Therefore, the underlying library must also be updated for `syslog` to support such a specification.

## Impact

All the code using `vsprintf` underneath will have the ability to use the `%m` modifier, which is a wrapper for `%s` and `strerror(errno)`. This is not a problem at all as such a modifier was previously ignored, and does not increase the processing significantly because it relies on existing code.

Additionally, this change is needed for NuttX to be POSIX-compliant. Otherwise, it is not following the implementation.

## Testing

To verify this change, I:

1. Modified the `defconfig` of the `sim:nsh` target, enabling `CONFIG_LIBC_STRERROR` and `CONFIG_LIBC_STRERROR_ERRNUM` - this is only required to have meaningful messages.
2. For the NuttX Apps repo, apply the following patch: 
[0001-Test-POSIX-syslog-Add-demo-application.patch](https://github.com/user-attachments/files/18230529/0001-Test-POSIX-syslog-Add-demo-application.txt). The patch adds a demo command called `syslog` that generates a random `errno` and outputs it through `syslog` using the `%m` modifier.
3. Build and run the application:
  * `tools/configure.sh sim:nsh`
  * `make`
  * `./nuttx`

Running the `syslog` command should output something like:

![NuttX Console Output](https://github.com/user-attachments/assets/dbfa3123-990f-4250-bd63-0acea915b792)
