### PR TITLE
Revert "[POSIX][Bug] syslog: Add support for `%m` modifier"

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -163,10 +163,6 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
   uint16_t flags;
   int width;
   int prec;
-
-  /* For the %m format we may need the current `errno' value */
-
-  int saved_errno = errno;
   union
   {
 #if defined (CONFIG_LIBC_LONG_LONG) || (ULONG_MAX > 4294967295UL)
@@ -913,11 +909,6 @@ flt_oper:
 #endif
           pnt = buf;
           size = 1;
-          goto str_lpad;
-
-        case 'm': /* Print error message (%m) */
-          pnt = strerror(saved_errno);
-          size = strlen(pnt); /* Adjusting the size is not supported by %m */
           goto str_lpad;
 
         case 's':


### PR DESCRIPTION
Reverts apache/nuttx#15320

It seems the `syslog` and `vsprintf` calls are being used from both user and kernel space, causing some builds to fail and introducing some uncertainty and potential new failures when running in non-flat builds.

CC/ @yamt @patacongo @fdcavalcanti @acassis @xiaoxiang781216 