### PR TITLE
v4l2m2m: modify return value of g_bufsize to uint32_t

### DIFF
--- a/arch/sim/src/sim/sim_decoder.c
+++ b/arch/sim/src/sim/sim_decoder.c
@@ -89,8 +89,8 @@ static int sim_decoder_output_try_fmt(void *priv,
                                       struct v4l2_format *fmt);
 static int sim_decoder_subscribe_event(void *priv,
                                        struct v4l2_event_subscription *sub);
-static size_t sim_decoder_capture_g_bufsize(void *priv);
-static size_t sim_decoder_output_g_bufsize(void *priv);
+static uint32_t sim_decoder_capture_g_bufsize(void *priv);
+static uint32_t sim_decoder_output_g_bufsize(void *priv);
 static int sim_decoder_process(sim_decoder_t *sim_decoder,
                                struct v4l2_buffer *dst_buf,
                                struct v4l2_buffer *src_buf);
@@ -367,7 +367,7 @@ static int sim_decoder_subscribe_event(void *priv,
     }
 }
 
-static size_t sim_decoder_capture_g_bufsize(void *priv)
+static uint32_t sim_decoder_capture_g_bufsize(void *priv)
 {
   sim_decoder_t *sim_decoder = priv;
 
@@ -379,7 +379,7 @@ static size_t sim_decoder_capture_g_bufsize(void *priv)
   return 0;
 }
 
-static size_t sim_decoder_output_g_bufsize(void *priv)
+static uint32_t sim_decoder_output_g_bufsize(void *priv)
 {
   sim_decoder_t *sim_decoder = priv;
 

--- a/drivers/video/v4l2_m2m.c
+++ b/drivers/video/v4l2_m2m.c
@@ -271,7 +271,7 @@ static int codec_reqbufs(FAR struct file *filep,
   FAR codec_file_t *cfile = filep->f_priv;
   FAR codec_type_inf_t *type_inf;
   irqstate_t flags;
-  size_t buf_size;
+  uint32_t buf_size;
   int ret = OK;
 
   if (reqbufs == NULL)


### PR DESCRIPTION
## Summary

The actual return value of get_bufsize is struct v4l2_format.fmt.pix.sizeimage, and the sizeimage type is uint32_t, so change it to uint32_t

## Impact

CI has overflow of int type：【CID 1578530: (#1 of 1): INTEGER_OVERFLOW】

## Testing

CI and Execute nxcodec without error


