### PR TITLE
arm64: fix tpidr maybe null

### DIFF
--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -217,12 +217,6 @@ int up_cpu_start(int cpu)
 
 void arm64_boot_secondary_c_routine(void)
 {
-  struct tcb_s *tcb = current_task(this_cpu());
-
-  /* Init idle task to percpu reg */
-
-  up_update_task(tcb);
-
 #ifdef CONFIG_ARCH_HAVE_MPU
   arm64_mpu_init(false);
 #endif
@@ -230,6 +224,14 @@ void arm64_boot_secondary_c_routine(void)
 #ifdef CONFIG_ARCH_HAVE_MMU
   arm64_mmu_init(false);
 #endif
+
+  /* We need to confirm that current_task has been initialized. */
+
+  while (!current_task(this_cpu()));
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(current_task(this_cpu()));
 
   arm64_gic_secondary_init();
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
arm64: fix tpidr maybe null

Before the MPU initialization, the up_update_task(this_cpu()) function is called at a time when hardware cache coherency is not yet enabled. In certain critical scenarios, Core 1 reads a zero value for tcb from the global variable g_assignedtask and stores this zero value into the tpidr register. This results in subsequent interrupt handlers reading a zero tcb, causing an exception.


## Impact
arm64

## Testing
qemu-armv8a:nsh_smp

