### PR TITLE
drivers/e1000: malloc size error

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -1482,7 +1482,7 @@ static int e1000_probe(FAR struct pci_device_s *dev)
 #ifdef CONFIG_NET_MCASTGROUP
   /* Allocate MTA shadow */
 
-  priv->mta = kmm_zalloc(type->mta_regs);
+  priv->mta = kmm_zalloc(type->mta_regs * sizeof(*priv->mta));
   if (priv->mta == NULL)
     {
       nerr("alloc mta failed\n");


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

  drivers/e1000: malloc size error， priv->mta is uint32_t

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


