### PR TITLE
add LINE_MAX and modify lib_pathbuffer

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -130,7 +130,7 @@
 #define _POSIX_PIPE_BUF       512
 #define _POSIX_STREAM_MAX     16
 #define _POSIX_TZNAME_MAX     3
-#define _POSIX2_LINE_MAX      80
+#define _POSIX2_LINE_MAX      CONFIG_LINE_MAX
 
 #ifdef CONFIG_SMALL_MEMORY
 

--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -35,6 +35,12 @@
  * Pre-processor definitions
  ****************************************************************************/
 
+#if CONFIG_PATH_MAX > CONFIG_LINE_MAX
+#  define PATH_MAX_SIZE CONFIG_PATH_MAX
+#else
+#  define PATH_MAX_SIZE CONFIG_LINE_MAX
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -42,7 +48,7 @@
 struct pathbuffer_s
 {
   atomic_t free_bitmap; /* Bitmap of free buffer */
-  char buffer[CONFIG_LIBC_PATHBUFFER_MAX][PATH_MAX];
+  char buffer[CONFIG_LIBC_PATHBUFFER_MAX][PATH_MAX_SIZE];
 };
 
 /****************************************************************************
@@ -69,7 +75,7 @@ static struct pathbuffer_s g_pathbuffer =
  *   The lib_get_pathbuffer() function returns a pointer to a temporary
  *   buffer.  The buffer is allocated from a pool of pre-allocated buffers
  *   and if the pool is exhausted, a new buffer is allocated through
- *   kmm_malloc(). The size of the buffer is PATH_MAX, and must freed by
+ *   kmm_malloc(). The size of the buffer is PATH_MAX_SIZE, and must freed by
  *   calling lib_put_pathbuffer().
  *
  * Returned Value:
@@ -103,7 +109,7 @@ FAR char *lib_get_pathbuffer(void)
    */
 
 #ifdef CONFIG_LIBC_PATHBUFFER_MALLOC
-  return lib_malloc(PATH_MAX);
+  return lib_malloc(PATH_MAX_SIZE);
 #else
   return NULL;
 #endif
@@ -125,7 +131,7 @@ FAR char *lib_get_pathbuffer(void)
 
 void lib_put_pathbuffer(FAR char *buffer)
 {
-  int index = (buffer - &g_pathbuffer.buffer[0][0]) / PATH_MAX;
+  int index = (buffer - &g_pathbuffer.buffer[0][0]) / PATH_MAX_SIZE;
   if (index >= 0 && index < CONFIG_LIBC_PATHBUFFER_MAX)
     {
       DEBUGASSERT((atomic_read(&g_pathbuffer.free_bitmap) &

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1412,6 +1412,16 @@ config PATH_MAX
 	---help---
 		The maximum size of path name.
 
+config LINE_MAX
+	int "Maximum size of line"
+	default 64 if DEFAULT_SMALL
+	default 80 if !DEFAULT_SMALL
+	---help---
+		The maximum size of line. Unless otherwise noted, the maximum length, in bytes,
+		of a utility's input line (either standard input or another file), when the
+		utility is described as processing text files. The length includes room for
+		the trailing newline.
+
 endmenu # Files and I/O
 
 menuconfig PRIORITY_INHERITANCE


### PR DESCRIPTION
## Summary
add LINE_MAX and modify lib_pathbuffer

1. Due to the continuous expansion of functions under the app, the 2k stack of many programs can no longer meet the requirements. If malloc is used frequently, memory fragmentation may occur, and we need an interface to optimize the use of stack and avoid memory fragmentation.

2. There are many similar configurations in the code：
config SYSTEM_CLE_CMD_HISTORY_LEN
config SYSTEM_CLE_CMD_HISTORY_LINELEN
CONFIG_NSH_LINELEN
HELP_LINELEN
PROCFS_LINELEN
The future plan is to remove these configurations and use LINE_MAX

## Impact
Optimize the use of stacks
## Testing
local test


