### PR TITLE
sched/event: init deleted node to avoid null pointer reference

### DIFF
--- a/sched/event/event_post.c
+++ b/sched/event/event_post.c
@@ -127,7 +127,7 @@ int nxevent_post(FAR nxevent_t *event, nxevent_mask_t events,
           if ((!waitall && ((wait->expect & event->events) != 0)) ||
               (waitall && ((wait->expect & event->events) == wait->expect)))
             {
-              list_delete(&wait->node);
+              list_delete_init(&wait->node);
 
               ret = nxevent_sem_post(&wait->sem);
               if (ret < 0)

--- a/sched/event/event_wait.c
+++ b/sched/event/event_wait.c
@@ -127,16 +127,17 @@ nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
 
       if (delay == UINT32_MAX)
         {
-          ret = nxsem_wait(&wait.sem);
+          ret = nxsem_wait_uninterruptible(&wait.sem);
         }
       else
         {
-          ret = nxsem_tickwait(&wait.sem, delay);
+          ret = nxsem_tickwait_uninterruptible(&wait.sem, delay);
         }
 
       /* Destroy local variables */
 
       nxsem_destroy(&wait.sem);
+      list_delete(&wait.node);
 
       if (ret == 0)
         {
@@ -144,7 +145,6 @@ nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
         }
       else
         {
-          list_delete(&wait.node);
           events = 0;
         }
     }


### PR DESCRIPTION
## Summary

sched/event: init deleted node to avoid null pointer reference

nxevent_tickwait() will remove the node in failure case(EINTR). If the node
has been deleted in the nxevent_post(), NULL pointer reference will
be triggered after semaphore wait.

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ostest/ci-check
