### PR TITLE
include/netinet/arp.h: change the type of arp_dev from uint8_t to char

### DIFF
--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -71,7 +71,7 @@ struct aligned_data(sizeof(uint32_t)) arpreq
   struct sockaddr arp_ha;                /* Hardware address */
   struct sockaddr arp_netmask;           /* Netmask of protocol address */
   uint8_t         arp_flags;             /* Flags */
-  uint8_t         arp_dev[IFNAMSIZ + 1]; /* Device name (zero terminated) */
+  char            arp_dev[IFNAMSIZ + 1]; /* Device name (zero terminated) */
 };
 
 /****************************************************************************

--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -243,8 +243,7 @@ static void arp_get_arpreq(FAR struct arpreq *output,
   outaddr->sin_addr.s_addr = input->at_ipaddr;
   memcpy(output->arp_ha.sa_data, input->at_ethaddr.ether_addr_octet,
          sizeof(struct ether_addr));
-  strlcpy((FAR char *)output->arp_dev, input->at_dev->d_ifname,
-          sizeof(output->arp_dev));
+  strlcpy(output->arp_dev, input->at_dev->d_ifname, sizeof(output->arp_dev));
 }
 #endif
 

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1361,7 +1361,7 @@ static bool ioctl_arpreq_parse(FAR struct arpreq *req,
     {
       *addr = (FAR struct sockaddr_in *)&req->arp_pa;
       *dev  = req->arp_dev[0] != '\0' ?
-              netdev_findbyname((FAR const char *)req->arp_dev) :
+              netdev_findbyname(req->arp_dev) :
               netdev_findby_ripv4addr(INADDR_ANY, (*addr)->sin_addr.s_addr);
       return true;
     }


### PR DESCRIPTION
## Summary
the same variable type in linux is char, in order to avoid modifying the third-party library code when porting the third-party library code.

## Impact

## Testing
sim:local and cortex-m33


