### PR TITLE
arch_atomic: change atomic_fetch_x interface to inline function

### DIFF
--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -73,13 +73,9 @@ extern "C++"
 #  define __ATOMIC_ACQ_REL 4
 #  define __ATOMIC_SEQ_CST 5
 
-#  define ATOMIC_FUNC(f, n) nx_atomic_##f##_##n
+#  define USE_ARCH_ATOMIC  1
 
-#  define atomic_fetch_add(obj, val)  ATOMIC_FUNC(fetch_add, 4)(obj, val, __ATOMIC_ACQ_REL)
-#  define atomic_fetch_sub(obj, val)  ATOMIC_FUNC(fetch_sub, 4)(obj, val, __ATOMIC_ACQ_REL)
-#  define atomic_fetch_and(obj, val)  ATOMIC_FUNC(fetch_and, 4)(obj, val, __ATOMIC_ACQ_REL)
-#  define atomic_fetch_or(obj, val)   ATOMIC_FUNC(fetch_or, 4)(obj, val, __ATOMIC_ACQ_REL)
-#  define atomic_fetch_xor(obj, val)  ATOMIC_FUNC(fetch_xor, 4)(obj, val, __ATOMIC_ACQ_REL)
+#  define ATOMIC_FUNC(f, n) nx_atomic_##f##_##n
 
 #  define nx_atomic_compare_exchange_weak_4(obj, expect, desired, success, failure) \
      nx_atomic_compare_exchange_4(obj, expect, desired, true, success, failure)
@@ -237,6 +233,33 @@ int32_t nx_atomic_fetch_xor_4(FAR volatile void *ptr, int32_t value,
                               int memorder);
 int64_t nx_atomic_fetch_xor_8(FAR volatile void *ptr, int64_t value,
                               int memorder);
+
+#ifdef USE_ARCH_ATOMIC
+static inline int32_t atomic_fetch_add(FAR volatile void *obj, int32_t val)
+{
+  return nx_atomic_fetch_add_4(obj, val, __ATOMIC_ACQ_REL);
+}
+
+static inline int32_t atomic_fetch_sub(FAR volatile void *obj, int32_t val)
+{
+  return nx_atomic_fetch_sub_4(obj, val, __ATOMIC_ACQ_REL);
+}
+
+static inline int32_t atomic_fetch_and(FAR volatile void *obj, int32_t val)
+{
+  return nx_atomic_fetch_and_4(obj, val, __ATOMIC_ACQ_REL);
+}
+
+static inline int32_t atomic_fetch_or(FAR volatile void *obj, int32_t val)
+{
+  return nx_atomic_fetch_or_4(obj, val, __ATOMIC_ACQ_REL);
+}
+
+static inline int32_t atomic_fetch_xor(FAR volatile void *obj, int32_t val)
+{
+  return nx_atomic_fetch_xor_4(obj, val, __ATOMIC_ACQ_REL);
+}
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary

When CONFIG_LIBC_ARCH_ATOMIC is defined, the atomic_fetch_x interface conflicts with the atomic_fetch_x interface in libcxx. Therefore, it has been changed to a inline function.

## Impact

CONFIG_LIBC_ARCH_ATOMIC 

## Testing

eps32c3 board
