### PR TITLE
fix compile error

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_lowputc.c
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.c
@@ -207,7 +207,7 @@ void esp_lowputc_enable_sysclk(const struct esp_uart_s *priv)
  *
  ****************************************************************************/
 
-void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
+void esp_lowputc_disable_all_uart_int(struct esp_uart_s *priv,
                                       uint32_t *current_status)
 {
   irqstate_t flags;

--- a/arch/risc-v/src/common/espressif/esp_lowputc.h
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.h
@@ -129,7 +129,7 @@ void esp_lowputc_enable_sysclk(const struct esp_uart_s *priv);
  *
  ****************************************************************************/
 
-void esp_lowputc_disable_all_uart_int(const struct esp_uart_s *priv,
+void esp_lowputc_disable_all_uart_int(struct esp_uart_s *priv,
                                       uint32_t *current_status);
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
fix compile error

common/espressif/esp_lowputc.c: In function 'esp_lowputc_disable_all_uart_int':
common/espressif/esp_lowputc.c:215:29: error: passing argument 1 of 'spin_lock_irqsave' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  215 |   flags = spin_lock_irqsave(&priv->lock);
      |                             ^~~~~~~~~~~
In file included from common/espressif/esp_lowputc.c:40:
/home/fdcavalcanti/nuttxspace1/nuttx/include/nuttx/spinlock.h:511:55: note: expected 'volatile spinlock_t *' {aka 'volatile unsigned int *'} but argument is of type 'const spinlock_t *' {aka 'const unsigned int *'}
  511 | irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
      |                                  ~~~~~~~~~~~~~~~~~~~~~^~~~
common/espressif/esp_lowputc.c:232:26: error: passing argument 1 of 'spin_unlock_irqrestore' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  232 |   spin_unlock_irqrestore(&priv->lock, flags);
      |                          ^~~~~~~~~~~
/home/fdcavalcanti/nuttxspace1/nuttx/include/nuttx/spinlock.h:674:54: note: expected 'volatile spinlock_t *' {aka 'volatile unsigned int *'} but argument is of type 'const spinlock_t *' {aka 'const unsigned int *'}
  674 | void spin_unlock_irqrestore(FAR volatile spinlock_t *lock,
      |                                 ~~~~~~~~~~~~~~~~~~~~~^~~~
IN: boards/libboards.a -> staging/libboards.a cc1: all warnings being treated as errors
make[1]: *** [Makefile:144: esp_lowputc.o] Error 1
make[1]: *** Waiting for unfinished jobs....
CC:  misc/reboot_notifier.c make: *** [tools/LibTargets.mk:170: arch/risc-v/src/libarch.a] Error 2
make: *** Waiting for unfinished jobs....

## Impact
none

## Testing

ci


