### PR TITLE
Fixed errors in CI build tests for pull request #15351

### DIFF
--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -326,7 +326,7 @@ static void efm32_restoreuartint(struct efm32_leuart_s *priv, uint32_t ien)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  efm32_restoreuartint_nolock(priv, len);
+  efm32_restoreuartint_nolock(priv, ien);
   spin_unlock_irqrestore(&priv->lock, flags);
 }
 

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -131,7 +131,6 @@ struct up_dev_s
   uint8_t         stop_2bits;    /* True: Configure with 2 stop bits instead of 1 */
   uint32_t        tx_gpio;       /* USART TX GPIO pin configuration */
   uint32_t        rx_gpio;       /* USART RX GPIO pin configuration */
-  spinlock_t      lock;          /* Spinlock */
 
 #  ifdef CONFIG_SERIAL_IFLOWCONTROL
   uint32_t        rts_gpio;      /* UART RTS GPIO pin configuration */
@@ -171,6 +170,7 @@ struct up_dev_s
 
   uint32_t        ie;            /* USART enabled interrupts */
   uint16_t        sr;            /* Save USART status */
+  spinlock_t      lock;          /* Spinlock */
 
   /* TX DMA state */
 

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -137,6 +137,7 @@ struct imxrt_edma_s
   /* These mutex protect the DMA channel and descriptor tables */
 
   mutex_t chlock;                 /* Protects channel table */
+  spinlock_t lock;
 #if CONFIG_IMXRT_EDMA_NTCD > 0
   sem_t dsem;                     /* Supports wait for free descriptors */
 #endif
@@ -1207,7 +1208,6 @@ int imxrt_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
 void imxrt_dmach_stop(DMACH_HANDLE handle)
 {
   struct imxrt_dmach_s *dmach = (struct imxrt_dmach_s *)handle;
-  irqstate_t flags;
 
   dmainfo("dmach: %p\n", dmach);
   DEBUGASSERT(dmach != NULL);

--- a/arch/arm/src/stm32u5/stm32_serial.c
+++ b/arch/arm/src/stm32u5/stm32_serial.c
@@ -561,7 +561,7 @@ static struct stm32_serial_s g_usart1priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

There were two simple errors when running ci tests on pull #15351. These errors were unrelated to that pull. After investigating I found two simple errors. 
1. The len variable was likely a typo that should have been the function argument, ien. 
2. The spinlock_t lock was defined in a section dependent on CONFIG_SERIAL_TERMIOS. However, the spinlock_t lock was used in code that did not require the SERIAL_TERMIOS config. Therefore errors resulted. I moved this definition to a general section of the up_dev_s type. 

## Testing

Re-built Nuttx with fixes. No build errors after changes. 

