### PR TITLE
fix compile error

### DIFF
--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -326,7 +326,7 @@ static void efm32_restoreuartint(struct efm32_leuart_s *priv, uint32_t ien)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  efm32_restoreuartint_nolock(priv, len);
+  efm32_restoreuartint_nolock(priv, ien);
   spin_unlock_irqrestore(&priv->lock, flags);
 }
 

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -131,7 +131,6 @@ struct up_dev_s
   uint8_t         stop_2bits;    /* True: Configure with 2 stop bits instead of 1 */
   uint32_t        tx_gpio;       /* USART TX GPIO pin configuration */
   uint32_t        rx_gpio;       /* USART RX GPIO pin configuration */
-  spinlock_t      lock;          /* Spinlock */
 
 #  ifdef CONFIG_SERIAL_IFLOWCONTROL
   uint32_t        rts_gpio;      /* UART RTS GPIO pin configuration */
@@ -159,6 +158,7 @@ struct up_dev_s
   const uint8_t   stop_2bits;    /* True: Configure with 2 stop bits instead of 1 */
   const uint32_t  tx_gpio;       /* USART TX GPIO pin configuration */
   const uint32_t  rx_gpio;       /* USART RX GPIO pin configuration */
+  spinlock_t      lock;          /* Spinlock */
 
 #  ifdef CONFIG_SERIAL_IFLOWCONTROL
   const uint32_t  rts_gpio;      /* UART RTS GPIO pin configuration */

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -144,6 +144,7 @@ struct imxrt_edma_s
   /* This array describes each DMA channel */
 
   struct imxrt_dmach_s dmach[IMXRT_EDMA_NCHANNELS];
+  spinlock_t lock;                /* Spinlock */
 };
 
 /****************************************************************************
@@ -1207,7 +1208,6 @@ int imxrt_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
 void imxrt_dmach_stop(DMACH_HANDLE handle)
 {
   struct imxrt_dmach_s *dmach = (struct imxrt_dmach_s *)handle;
-  irqstate_t flags;
 
   dmainfo("dmach: %p\n", dmach);
   DEBUGASSERT(dmach != NULL);

--- a/arch/arm/src/stm32u5/stm32_serial.c
+++ b/arch/arm/src/stm32u5/stm32_serial.c
@@ -501,7 +501,7 @@ static struct stm32_serial_s g_lpuart1priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 
@@ -561,7 +561,7 @@ static struct stm32_serial_s g_usart1priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 
@@ -623,7 +623,7 @@ static struct stm32_serial_s g_usart2priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 
@@ -685,7 +685,7 @@ static struct stm32_serial_s g_usart3priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 
@@ -747,7 +747,7 @@ static struct stm32_serial_s g_uart4priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 
@@ -809,7 +809,7 @@ static struct stm32_serial_s g_uart5priv =
   .rs485_dir_polarity = true,
 #    endif
 #  endif
-  .lock =             = SP_UNLOCKED,
+  .lock               = SP_UNLOCKED,
 };
 #endif
 


### PR DESCRIPTION

## Summary
fix compile error

chip/efm32_leserial.c: In function 'efm32_restoreuartint': Error: chip/efm32_leserial.c:329:37: error: 'len' undeclared (first use in this function); did you mean 'ien'?
  329 |   efm32_restoreuartint_nolock(priv, len);
      |                                     ^~~
      |                                     ien

## Impact
efm32_leserial.c
## Testing
ci

