### PR TITLE
{bp-15333} netdev/upper: Fix wrong CPU when RSS is disabled

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -754,7 +754,11 @@ static inline void netdev_upper_queue_work(FAR struct net_driver_s *dev)
   FAR struct netdev_upperhalf_s *upper = dev->d_private;
 
 #ifdef CONFIG_NETDEV_WORK_THREAD
+#  ifdef CONFIG_NETDEV_RSS
   int cpu = this_cpu();
+#  else
+  const int cpu = 0;
+#  endif
   int semcount;
 
   if (nxsem_get_value(&upper->sem[cpu], &semcount) == OK &&


### PR DESCRIPTION
## Summary

When `CONFIG_NETDEV_RSS` is disabled, `NETDEV_THREAD_COUNT` will be 1, and we should not access `upper->sem[cpu]` with `cpu > 0`.

## Impact

RELEASE

## Testing

CI

