### PR TITLE
{bp-15340} drivers/e1000: malloc size error

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -1482,7 +1482,7 @@ static int e1000_probe(FAR struct pci_device_s *dev)
 #ifdef CONFIG_NET_MCASTGROUP
   /* Allocate MTA shadow */
 
-  priv->mta = kmm_zalloc(type->mta_regs);
+  priv->mta = kmm_zalloc(type->mta_regs * sizeof(*priv->mta));
   if (priv->mta == NULL)
     {
       nerr("alloc mta failed\n");


### PR DESCRIPTION
## Summary

drivers/e1000: malloc size error， priv->mta is uint32_t

## Impact

RELEASE

## Testing

CI

