### PR TITLE
{bp-15341} sim_alsa: set paused to false when executing close

### DIFF
--- a/arch/sim/src/sim/posix/sim_alsa.c
+++ b/arch/sim/src/sim/posix/sim_alsa.c
@@ -303,6 +303,7 @@ static int sim_audio_close(struct sim_audio_s *priv)
   host_uninterruptible(snd_pcm_close, priv->pcm);
 
   priv->pcm = NULL;
+  priv->paused = false;
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Set paused = false when closing to prevent the app from executing the pause command and then executing close, which will cause paused = true when starting the second time and no frame will be displayed

## Impact

RELEASE

## Testing

CI

