### PR TITLE
arch/risc-v: inline up_cpu_index if RISCV_PERCPU_SCRATCH is not enabled

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -697,10 +697,27 @@ irqstate_t up_irq_enable(void);
  * Description:
  *   Return the real core number regardless CONFIG_SMP setting
  *
+ *   When CONFIG_RISCV_PERCPU_SCRATCH is enabled, this uses the percpu
+ *   scratch area to store the hart ID. This is needed when the CSR_MHARTID
+ *   register may not contain the actual hart ID.
+ *
+ *   When CONFIG_RISCV_PERCPU_SCRATCH is not enabled, this directly reads
+ *   the CSR_MHARTID register. Use this version when you can guarantee
+ *   CSR_MHARTID contains the actual hart ID. This is the default behavior
+ *   that can be achieved by single instruction to provide better
+ *   performance.
+ *
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_HAVE_MULTICPU
+#ifdef CONFIG_RISCV_PERCPU_SCRATCH
 int up_cpu_index(void) noinstrument_function;
+#else
+noinstrument_function static inline int up_cpu_index(void)
+{
+  return READ_CSR(CSR_MHARTID);
+}
+#endif
 #endif /* CONFIG_ARCH_HAVE_MULTICPU */
 
 /****************************************************************************

--- a/arch/risc-v/src/common/riscv_cpuindex.c
+++ b/arch/risc-v/src/common/riscv_cpuindex.c
@@ -45,10 +45,12 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_RISCV_PERCPU_SCRATCH
 int up_cpu_index(void)
 {
   return (int)riscv_mhartid();
 }
+#endif
 
 /****************************************************************************
  * Name: up_this_cpu


### PR DESCRIPTION
## Summary

Inline the short function to provide better performance.

## Impact

RISCV Only

## Testing

Local machine & CI


