### PR TITLE
arm/gd32f4: Remove extra lock from gd32f4xx_serial

### DIFF
--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -171,7 +171,6 @@ struct up_dev_s
 
   uint32_t        ie;            /* USART enabled interrupts */
   uint16_t        sr;            /* Save USART status */
-  spinlock_t      lock;          /* Spinlock */
 
   /* TX DMA state */
 


### PR DESCRIPTION
## Summary

An extra `lock` appears in gd32f4xx_serial due to 2 conflicting PRs:
- https://github.com/apache/nuttx/pull/7011
- https://github.com/apache/nuttx/pull/15352

This PR removes the extra `lock` in gd32f4xx_serial.

## Impact

This PR will fix the gd32f4xx_serial errors reported by nuttx-dashboard.org

![Screenshot 2024-12-30 at 1 46 16 PM](https://github.com/user-attachments/assets/a5b5c1f2-07cf-448d-863e-e860a664774e)

## Testing

Before this PR: `gd32f470zk-eval:nsh` fails to build due to duplicate `lock`
https://github.com/NuttX/nuttx/actions/runs/12539724506/job/34966149597#step:7:998
```text
Configuration/Tool: gd32f470zk-eval/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Error: chip/gd32f4xx_serial.c:174:19: error: duplicate member 'lock'
  174 |   spinlock_t      lock;          /* Spinlock */
      |                   ^~~~
```

After this PR: `gd32f470zk-eval:nsh` builds successfully in Docker
https://gist.github.com/lupyuen/1e4095824e44561517eff9ebc028bfc8
```bash
sudo docker run \
  -it \
  ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest \
  /bin/bash
cd
git clone https://github.com/lupyuen2/wip-nuttx nuttx --branch gd32f4xx_serial
git clone https://github.com/apache/nuttx-apps apps
pushd nuttx ; echo NuttX Source: https://github.com/apache/nuttx/tree/$(git rev-parse HEAD) ; popd
pushd apps  ; echo NuttX Apps: https://github.com/apache/nuttx-apps/tree/$(git rev-parse HEAD) ; popd
cd nuttx
tools/configure.sh gd32f470zk-eval:nsh
make -j

NuttX Source: https://github.com/apache/nuttx/tree/d50cc1c518fb1e68e985df8489bffe4b4d71f22b
NuttX Apps: https://github.com/apache/nuttx-apps/tree/7a36a70e06402b9c1647dcf6833ca5a58e927132
# tools/configure.sh gd32f470zk-eval:nsh
# make -j
Memory region         Used Size  Region Size  %age Used
           flash:      143604 B         3 MB      4.57%
            sram:        6420 B       112 KB      5.60%
CP: nuttx.hex
CP: nuttx.bin
```
