### PR TITLE
xtensa/esp32: add lock for async operation work

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -348,6 +348,7 @@ static struct esp32_spiflash_s g_esp32_spiflash1_encrypt =
 static mutex_t g_lock = NXMUTEX_INITIALIZER;
 #ifdef CONFIG_ESP32_SPI_FLASH_SUPPORT_PSRAM_STACK
 static struct work_s g_work;
+static mutex_t g_work_lock = NXMUTEX_INITIALIZER;
 #endif
 
 static volatile bool g_flash_op_can_start = false;
@@ -1717,12 +1718,20 @@ static int esp32_async_op(enum spiflash_op_code_e opcode,
     .sem = NXSEM_INITIALIZER(0, 0)
   };
 
+  ret = nxmutex_lock(&g_work_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = work_queue(LPWORK, &g_work, esp32_spiflash_work, &work_arg, 0);
   if (ret == 0)
     {
       nxsem_wait(&work_arg.sem);
       ret = work_arg.ret;
     }
+
+  nxmutex_unlock(&g_work_lock);
 
   return ret;
 }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

g_work as singleton can be changed by context switching, but previous one async operation have not finished yet.

adapt based on: 10a1d17a85a325f30c08e358a27c03d133a30ee3

## Impact

one additonal mutex is used for g_work to keep the sequence correctly.

## Testing

reproduce and verified by below steps

Variable g_wrok is sent to work_queue() function and set value to this variable.
Another context changes g_work by call esp32_async_op during step 1. g_work of Step 1 is changed because g_work is singleton.
Step 1 hanges because g_work of step 1 are cleared by step 2.


