### PR TITLE
{bp-15219} gpio: use small lock to protect configgpio

### DIFF
--- a/arch/arm/src/at32/at32_gpio.c
+++ b/arch/arm/src/at32/at32_gpio.c
@@ -32,11 +32,18 @@
 #include <errno.h>
 #include <debug.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
 #include "at32_syscfg.h"
 #include "at32_gpio.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -199,7 +206,7 @@ int at32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Determine the alternate function (Only alternate function pins) */
 
@@ -355,7 +362,7 @@ int at32_configgpio(uint32_t cfgset)
       putreg32(regval, regaddr);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 #endif

--- a/arch/arm/src/nuc1xx/nuc_gpio.c
+++ b/arch/arm/src/nuc1xx/nuc_gpio.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/nuc1xx/chip.h>
 
 #include "arm_internal.h"
@@ -42,6 +43,12 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -240,7 +247,7 @@ void nuc_gpiowrite(gpio_cfgset_t pinset, bool value)
 
   /* Disable interrupts -- the following operations must be atomic */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Allow writing only to the selected pin in the DOUT register */
 
@@ -249,7 +256,7 @@ void nuc_gpiowrite(gpio_cfgset_t pinset, bool value)
   /* Set the pin to the selected value and re-enable interrupts */
 
   putreg32(((uint32_t)value << pin), base + NUC_GPIO_DOUT_OFFSET);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
 #endif
 }
 

--- a/arch/arm/src/sam34/sam4l_gpio.c
+++ b/arch/arm/src/sam34/sam4l_gpio.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
@@ -45,6 +46,8 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_GPIO_INFO
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
+
 static const char g_portchar[4]   =
 {
   'A', 'B', 'C', 'D'
@@ -529,7 +532,7 @@ int sam_dumpgpio(uint32_t pinset, const char *msg)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   gpioinfo("GPIO%c pinset: %08x base: %08x -- %s\n",
            g_portchar[port], pinset, base, msg);
@@ -559,7 +562,7 @@ int sam_dumpgpio(uint32_t pinset, const char *msg)
            getreg32(base + SAM_GPIO_PARAMETER_OFFSET),
            getreg32(base + SAM_GPIO_VERSION_OFFSET));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 #endif

--- a/arch/arm/src/samv7/sam_gpio.c
+++ b/arch/arm/src/samv7/sam_gpio.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
@@ -74,6 +75,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 #ifdef CONFIG_DEBUG_GPIO_INFO
 static const char g_portchar[SAMV7_NPIO] =
@@ -497,7 +500,7 @@ int sam_configgpio(gpio_pinset_t cfgset)
 
   /* Disable interrupts to prohibit re-entrance. */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Enable writing to GPIO registers */
 
@@ -606,7 +609,7 @@ int sam_dumpgpio(uint32_t pinset, const char *msg)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   gpioinfo("PIO%c pinset: %08x base: %08x -- %s\n",
            g_portchar[port], pinset, base, msg);

--- a/arch/arm/src/stm32f0l0g0/stm32_gpio.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_gpio.c
@@ -34,6 +34,7 @@
 
 #include <arch/irq.h>
 #include <arch/stm32f0l0g0/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
@@ -48,6 +49,12 @@
 #if defined(CONFIG_STM32F0G0L0_USE_LEGACY_PINMAP)
 #  pragma message "CONFIG_STM32F0G0L0_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -178,7 +185,7 @@ int stm32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -339,7 +346,7 @@ int stm32_configgpio(uint32_t cfgset)
 #endif
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32f7/stm32_gpio.c
+++ b/arch/arm/src/stm32f7/stm32_gpio.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/irq.h>
 #include <arch/stm32f7/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "hardware/stm32_syscfg.h"
@@ -50,6 +51,12 @@
 #if defined(CONFIG_STM32F7_USE_LEGACY_PINMAP)
 #  pragma message "CONFIG_STM32F7_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -176,7 +183,7 @@ int stm32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Determine the alternate function (Only alternate function pins) */
 
@@ -353,7 +360,7 @@ int stm32_configgpio(uint32_t cfgset)
       putreg32(regval, regaddr);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32h5/stm32_gpio.c
+++ b/arch/arm/src/stm32h5/stm32_gpio.c
@@ -34,10 +34,17 @@
 
 #include <arch/irq.h>
 #include <arch/stm32h5/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
 #include "stm32_gpio.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -177,7 +184,7 @@ int stm32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -290,7 +297,7 @@ int stm32_configgpio(uint32_t cfgset)
 
   putreg32(regval, base + STM32_GPIO_OTYPER_OFFSET);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32h7/stm32_gpio.c
+++ b/arch/arm/src/stm32h7/stm32_gpio.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/irq.h>
 #include <arch/stm32h7/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "hardware/stm32_syscfg.h"
@@ -51,6 +52,12 @@
 #if defined(CONFIG_STM32H7_USE_LEGACY_PINMAP)
 #  pragma message "CONFIG_STM32H7_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -208,7 +215,7 @@ int stm32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Determine the alternate function (Only alternate function pins) */
 
@@ -386,7 +393,7 @@ int stm32_configgpio(uint32_t cfgset)
       putreg32(regval, regaddr);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32l4/stm32l4_gpio.c
+++ b/arch/arm/src/stm32l4/stm32l4_gpio.c
@@ -33,6 +33,7 @@
 #include <debug.h>
 
 #include <arch/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/stm32l4/chip.h>
 
 #include "arm_internal.h"
@@ -44,6 +45,11 @@
 #if defined(CONFIG_STM32L4_USE_LEGACY_PINMAP)
 #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
 #endif
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -195,7 +201,7 @@ int stm32l4_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -356,7 +362,7 @@ int stm32l4_configgpio(uint32_t cfgset)
     }
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32l5/stm32l5_gpio.c
+++ b/arch/arm/src/stm32l5/stm32l5_gpio.c
@@ -34,12 +34,19 @@
 
 #include <arch/irq.h>
 #include <arch/stm32l5/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
 #include "stm32l5_gpio.h"
 
 #include "hardware/stm32l5_syscfg.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -183,7 +190,7 @@ int stm32l5_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -296,7 +303,7 @@ int stm32l5_configgpio(uint32_t cfgset)
 
   putreg32(regval, base + STM32L5_GPIO_OTYPER_OFFSET);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32u5/stm32_gpio.c
+++ b/arch/arm/src/stm32u5/stm32_gpio.c
@@ -34,12 +34,19 @@
 
 #include <arch/irq.h>
 #include <arch/stm32u5/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
 #include "stm32_gpio.h"
 
 #include "hardware/stm32_syscfg.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -182,7 +189,7 @@ int stm32_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -295,7 +302,7 @@ int stm32_configgpio(uint32_t cfgset)
 
   putreg32(regval, base + STM32_GPIO_OTYPER_OFFSET);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32wb/stm32wb_gpio.c
+++ b/arch/arm/src/stm32wb/stm32wb_gpio.c
@@ -32,6 +32,8 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/spinlock.h>
+
 #include "arm_internal.h"
 #include "chip.h"
 #include "stm32wb_gpio.h"
@@ -41,6 +43,12 @@
 #if defined(CONFIG_STM32WB_USE_LEGACY_PINMAP)
 #  pragma message "CONFIG_STM32WB_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
 #endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -160,7 +168,7 @@ int stm32wb_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -296,7 +304,7 @@ int stm32wb_configgpio(uint32_t cfgset)
       putreg32(regval, regaddr);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32wl5/stm32wl5_gpio.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_gpio.c
@@ -34,6 +34,7 @@
 
 #include <arch/irq.h>
 #include <arch/stm32wl5/chip.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 
@@ -41,6 +42,12 @@
 #include "stm32wl5_gpio.h"
 
 #include "hardware/stm32wl5_syscfg.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Data
@@ -168,7 +175,7 @@ int stm32wl5_configgpio(uint32_t cfgset)
    * exclusive access to all of the GPIO configuration registers.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Now apply the configuration to the mode register */
 
@@ -305,7 +312,7 @@ int stm32wl5_configgpio(uint32_t cfgset)
       putreg32(regval, regaddr);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
@@ -41,6 +41,8 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -64,7 +66,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
 #ifdef CONFIG_TIVA_GPIO_IRQS
   /* Mask and clear any pending GPIO interrupt */
@@ -123,7 +125,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
       putreg32(regval, TIVA_GPIO_DOE);
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/tiva/lm/lm3s_gpio.c
+++ b/arch/arm/src/tiva/lm/lm3s_gpio.c
@@ -33,6 +33,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "tiva_enablepwr.h"
@@ -119,6 +120,8 @@ struct gpio_func_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 static const struct gpio_func_s g_funcbits[] =
 {
@@ -717,7 +720,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Enable power and clocking for this GPIO peripheral.  Applies both power
    * and clocking to the GPIO peripheral, bringing it a fully functional
@@ -767,7 +770,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
     }
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/tiva/lm/lm4f_gpio.c
+++ b/arch/arm/src/tiva/lm/lm4f_gpio.c
@@ -33,6 +33,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "tiva_enablepwr.h"
@@ -119,6 +120,8 @@ struct gpio_func_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 static const struct gpio_func_s g_funcbits[] =
 {
@@ -741,7 +744,7 @@ int tiva_configgpio(uint32_t pinconfig)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Enable power and clocking for this GPIO peripheral.  Applies both power
    * and clocking to the GPIO peripheral, bringing it a fully functional
@@ -787,7 +790,7 @@ int tiva_configgpio(uint32_t pinconfig)
     }
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/tiva/tm4c/tm4c_gpio.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_gpio.c
@@ -121,6 +121,8 @@ struct gpio_func_s
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
+
 static const struct gpio_func_s g_funcbits[] =
 {
   {GPIO_INPUT_SETBITS,     GPIO_INPUT_CLRBITS},     /* GPIO_FUNC_INPUT */
@@ -789,7 +791,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_configgpio_lock);
 
   /* Enable power and clocking for this GPIO peripheral.
    *
@@ -840,7 +842,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
     }
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
   return OK;
 }
 

--- a/arch/hc/src/m9s12/m9s12_gpio.c
+++ b/arch/hc/src/m9s12/m9s12_gpio.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "hc_internal.h"
 #include "m9s12.h"
@@ -134,6 +135,8 @@ struct mebi_portaddr_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 static const struct mebi_portaddr_s mebi_portaddr[HCS12_MEBI_NPORTS] =
 {
@@ -443,7 +446,7 @@ void hcs12_gpiowrite(uint16_t pinset, bool value)
 {
   uint8_t    portndx = HCS12_PORTNDX(pinset);
   uint8_t    pin     = HCS12_PIN(pinset);
-  irqstate_t flags   = enter_critical_section();
+  irqstate_t flags   = spin_lock_irqsave(&g_configgpio_lock);
 
   DEBUGASSERT((pinset & GPIO_DIRECTION) == GPIO_OUTPUT);
   if (HCS12_PIMPORT(pinset))
@@ -455,7 +458,7 @@ void hcs12_gpiowrite(uint16_t pinset, bool value)
       mebi_gpiowrite(portndx, pin, value);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_configgpio_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/mips/src/pic32mx/pic32mx_gpio.c
+++ b/arch/mips/src/pic32mx/pic32mx_gpio.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "mips_internal.h"
@@ -50,6 +51,8 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
 
 static const uintptr_t g_gpiobase[CHIP_NPORTS] =
 {
@@ -150,7 +153,7 @@ int pic32mx_configgpio(uint16_t cfgset)
 
       /* Is this an input or an output? */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_configgpio_lock);
       if (pic32mx_output(cfgset))
         {
           /* Not analog */
@@ -206,7 +209,7 @@ int pic32mx_configgpio(uint16_t cfgset)
 #endif
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_configgpio_lock, flags);
       return OK;
     }
 

--- a/arch/mips/src/pic32mz/pic32mz_gpio.c
+++ b/arch/mips/src/pic32mz/pic32mz_gpio.c
@@ -46,6 +46,12 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_configgpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -173,7 +179,7 @@ int pic32mz_configgpio(pinset_t cfgset)
 
       base = g_gpiobase[port];
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_configgpio_lock);
 
       /* Is Slew Rate control enabled? */
 
@@ -243,7 +249,7 @@ int pic32mz_configgpio(pinset_t cfgset)
             }
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_configgpio_lock, flags);
       return OK;
     }
 


### PR DESCRIPTION
## Summary

reason:
We would like to replace the critical section with a small lock.

## Impact

RELEASE

## Testing

CI
