### PR TITLE
drivers/timers/watchdog: add watchdog timer notifier chain

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -439,6 +439,14 @@ menuconfig WATCHDOG_AUTOMONITOR
 
 if WATCHDOG_AUTOMONITOR
 
+config WATCHDOG_TIMEOUT_NOTIFIER
+	bool "Enable watchdog timeout notifier"
+	default n
+	---help---
+		The watchdog timeout notifier chain mechanism supports users registering
+		custom callback functions, which will be called when the watchdog timer
+		managed by Auto-monitor times out.
+
 choice
 	prompt "Auto-monitor keepalive by"
 	default WATCHDOG_AUTOMONITOR_BY_WDOG

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -71,6 +71,20 @@
 #  endif
 #endif
 
+#if defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_ONESHOT)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_ONESHOT
+#elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_TIMER)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_TIMER
+#elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_WDOG)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_WDOG
+#elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_WORKER)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_WORKER
+#elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_CAPTURE)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_CAPTURE
+#elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_IDLE)
+#  define WATCHDOG_NOTIFIER_ACTION WATCHDOG_KEEPALIVE_BY_IDLE
+#endif
+
 /****************************************************************************
  * Private Type Definitions
  ****************************************************************************/
@@ -134,6 +148,10 @@ static const struct file_operations g_wdogops =
   NULL,       /* seek */
   wdog_ioctl, /* ioctl */
 };
+
+#ifdef CONFIG_WATCHDOG_TIMEOUT_NOTIFIER
+static ATOMIC_NOTIFIER_HEAD(g_watchdog_notifier_list);
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -698,6 +716,55 @@ static int wdog_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+#ifdef CONFIG_WATCHDOG_TIMEOUT_NOTIFIER
+/****************************************************************************
+ * Name:  watchdog_notifier_chain_register
+ *
+ * Description:
+ *   Add notifier to the watchdog notifier chain
+ *
+ * Input Parameters:
+ *    nb - New entry in notifier chain
+ *
+ ****************************************************************************/
+
+void watchdog_notifier_chain_register(FAR struct notifier_block *nb)
+{
+  atomic_notifier_chain_register(&g_watchdog_notifier_list, nb);
+}
+
+/****************************************************************************
+ * Name:  watchdog_notifier_chain_unregister
+ *
+ * Description:
+ *   Remove notifier from the watchdog notifier chain
+ *
+ * Input Parameters:
+ *    nb - Entry to remove from notifier chain
+ *
+ ****************************************************************************/
+
+void watchdog_notifier_chain_unregister(FAR struct notifier_block *nb)
+{
+  atomic_notifier_chain_unregister(&g_watchdog_notifier_list, nb);
+}
+
+/****************************************************************************
+ * Name: watchdog_automonitor_timeout
+ *
+ * Description:
+ *   This function can be called in the watchdog timeout interrupt handler.
+ *   If so, callbacks on the watchdog timer notify chain are called when the
+ *   watchdog timer times out.
+ *
+ ****************************************************************************/
+
+void watchdog_automonitor_timeout(void)
+{
+  atomic_notifier_call_chain(&g_watchdog_notifier_list, action, data);
+}
+#endif /* CONFIG_WATCHDOG_TIMEOUT_NOTIFIER */
 
 /****************************************************************************
  * Name: watchdog_register

--- a/include/nuttx/timers/watchdog.h
+++ b/include/nuttx/timers/watchdog.h
@@ -31,6 +31,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/irq.h>
 #include <nuttx/fs/ioctl.h>
+#include <nuttx/notifier.h>
 
 #ifdef CONFIG_WATCHDOG
 
@@ -87,6 +88,35 @@
 #define WDFLAGS_RESET    (1 << 1) /* 1=Reset when the watchdog timer expires */
 #define WDFLAGS_CAPTURE  (1 << 2) /* 1=Call the user function when the
                                    *   watchdog timer expires */
+
+/* Keepalive Actions ********************************************************/
+
+/* According to the keepalive action specified by the Auto-monitor, callback
+ * functions registered on the watchdog notifier chain may take corresponding
+ * actions.
+ *
+ * These are detected and handled by the "upper half" watchdog timer driver.
+ *
+ * WATCHDOG_KEEPALIVE_BY_ONESHOT      - The watchdog timer is keepalive by
+ *                                      oneshot timer.
+ * WATCHDOG_KEEPALIVE_BY_TIMER        - The watchdog timer is keepalive by
+ *                                      timer.
+ * WATCHDOG_KEEPALIVE_BY_WDOG         - The watchdog timer is keepalive by
+ *                                      wdog.
+ * WATCHDOG_KEEPALIVE_BY_WORKER       - The watchdog timer is keepalive by
+ *                                      worker queue.
+ * WATCHDOG_KEEPALIVE_BY_CAPTURE      - The watchdog timer is keepalive by
+ *                                      capture.
+ * WATCHDOG_KEEPALIVE_BY_IDLE         - The watchdog timer is keepalive by
+ *                                      idle task.
+ */
+
+#define WATCHDOG_KEEPALIVE_BY_ONESHOT 0
+#define WATCHDOG_KEEPALIVE_BY_TIMER   1
+#define WATCHDOG_KEEPALIVE_BY_WDOG    2
+#define WATCHDOG_KEEPALIVE_BY_WORKER  3
+#define WATCHDOG_KEEPALIVE_BY_CAPTURE 4
+#define WATCHDOG_KEEPALIVE_BY_IDLE    5
 
 /****************************************************************************
  * Public Types
@@ -196,6 +226,47 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
+
+#ifdef CONFIG_WATCHDOG_TIMEOUT_NOTIFIER
+/****************************************************************************
+ * Name:  watchdog_notifier_chain_register
+ *
+ * Description:
+ *   Add notifier to the watchdog notifier chain
+ *
+ * Input Parameters:
+ *    nb - New entry in notifier chain
+ *
+ ****************************************************************************/
+
+void watchdog_notifier_chain_register(FAR struct notifier_block *nb);
+
+/****************************************************************************
+ * Name:  watchdog_notifier_chain_unregister
+ *
+ * Description:
+ *   Remove notifier from the watchdog notifier chain
+ *
+ * Input Parameters:
+ *    nb - Entry to remove from notifier chain
+ *
+ ****************************************************************************/
+
+void watchdog_notifier_chain_unregister(FAR struct notifier_block *nb);
+
+/****************************************************************************
+ * Name: watchdog_automonitor_timeout
+ *
+ * Description:
+ *   This function can be called in the watchdog timeout interrupt handler.
+ *   If so, callbacks on the watchdog timer notify chain are called when the
+ *   watchdog timer times out.
+ *
+ ****************************************************************************/
+
+void watchdog_automonitor_timeout(void);
+
+#endif /* CONFIG_WATCHDOG_TIMEOUT_NOTIFIER */
 
 /****************************************************************************
  * Name: watchdog_register


### PR DESCRIPTION
Add support for watchdog timer notifer chain so that users 
can customize the callback function when the watchdog timer 
times out which enabled by Auto-monitor.

## Summary

Some watchdog timers support an interrupt on timeout and allow 
the user to perform some custom processing actions instead of 
immediately sending a reset signal. However, when watchdog 
timer is managed by auto-monitor, users can no longer register 
the timeout callback function implemented by users for watchdog 
timer through ioctl.

## Impact

We provide CONFIG_WATCHDOG_TIMEOUT_NOTIFIER to enable 
or disable watchdog timer notifier chain, This option depends 
on CONFIG_WATCHDOG_AUTOMONITOR.

After the watchdog timer notifier chain is enabled, user can put the 
watchdog_automonitor_timeout function in the timeout interrupt handler 
of the watchdog timer, for example
```C
//wdt_handler is the watchdog interrupt handler function
int wdt_handler(void)
{
  watchdog_automonitor_timeout();
  return OK;
}
```

This function will call the function registered on the wdt notifier chain 
when the watchdog timer times out.

To register the user-defined timeout callback function on the wdt 
notifier chain, users should perform the following steps：

### step 1：
Include necessary header files
```C
#include <nuttx/wdt_notifier.h>
```

### step 2：
Define the necessary notifier_block
```C
struct notifier_block g_wdt_nb;
```

### step 3：
Define the function to be registered. In The following example, 
"The callback function registered by the user is triggered!" is 
printed when the watchdog timer times out.
```C
int user_wdt_timeout_callback(FAR struct notifier_block *nb, unsigned long action,
                         FAR void *data)
{
  UNUSED(data);
  UNUSED(nb);
  UNUSED(action);
  printf("The callback function registered by the user is triggered!\n");
  return 0;
}
```

### step 4：
Register user-defined callback functions with wdt_notifier_chain_register
```C
g_wdt_nb.notifier_call = user_wdt_timeout_callback;
wdt_notifier_chain_register(&g_wdt_nb);
```

### \*step 5(not necessary)：
If users need to unregister the callback function that has been registered
on the watchdog timer notifier chain.
```C
wdt_notifier_chain_unregister(&g_wdt_nb);
```
## Testing

I verified this feature on a private platform where the WDT could support 
an interrupt signal instead of a reset signal when times out.

In the test we need to register the custom timeout callback function as 
described in **Impact**. We can add these changes in 
`nuttx-apps/examples/watchdog/watchdog_main.C`, 
this example can make watchdog timeout. 

I registered The callback function shown in Impact and it just prints 
"The callback function registered by the user is triggered!"
After we execute the modified watchdog_example, when the watchdog
times out, the log will show as follows：
```
wdog_main: timeout=1000_timeleft=497
NO ping elapsed=2012
The callback function registered by the user is triggered!
```




