### PR TITLE
arm/imxrt: Remove extra lock from imxrt_edma

### DIFF
--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -145,7 +145,6 @@ struct imxrt_edma_s
   /* This array describes each DMA channel */
 
   struct imxrt_dmach_s dmach[IMXRT_EDMA_NCHANNELS];
-  spinlock_t lock;                /* Spinlock */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

An extra `lock` appears in imxrt_edma due to 2 conflicting PRs:
- https://github.com/apache/nuttx/pull/15352
- https://github.com/apache/nuttx/pull/15353

This PR removes the extra `lock` in imxrt_edma.

## Impact

This PR will fix the imxrt_edma errors reported by nuttx-dashboard.org

![Screenshot 2024-12-30 at 9 25 30 PM](https://github.com/user-attachments/assets/53875d24-28a8-41e7-8092-7a0a19c167db)

## Testing

### Before this PR

`teensy-4.x:lcd-4.1` fails to build due to duplicate `lock`:
https://github.com/NuttX/nuttx/actions/runs/12545164788/job/34978997451#step:7:749
```text
Configuration/Tool: teensy-4.x/lcd-4.1,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Error: chip/imxrt_edma.c:148:14: error: duplicate member 'lock'
  148 |   spinlock_t lock;                /* Spinlock */
      |              ^~~~
```

`imxrt1064-evk:lvgl` also fails to build due to duplicate `lock`:
https://github.com/NuttX/nuttx/actions/runs/12545164788/job/34978997451#step:7:814
```text
Configuration/Tool: imxrt1064-evk/lvgl,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Error: chip/imxrt_edma.c:148:14: error: duplicate member 'lock'
  148 |   spinlock_t lock;                /* Spinlock */
      |              ^~~~
```

### After this PR

`teensy-4.x:lcd-4.1` builds successfully in Docker:
https://gist.github.com/lupyuen/649f3fae1649f33570e0ce6a96bb497b
```bash
sudo docker run \
  -it \
  ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest \
  /bin/bash
cd
git clone https://github.com/lupyuen2/wip-nuttx nuttx --branch imxrt_edma
git clone https://github.com/apache/nuttx-apps apps
pushd nuttx ; echo NuttX Source: https://github.com/apache/nuttx/tree/$(git rev-parse HEAD) ; popd
pushd apps  ; echo NuttX Apps: https://github.com/apache/nuttx-apps/tree/$(git rev-parse HEAD) ; popd
cd nuttx
tools/configure.sh teensy-4.x:lcd-4.1
make -j

Memory region         Used Size  Region Size  %age Used
           flash:      111572 B      1984 KB      5.49%
            sram:       12676 B       512 KB      2.42%
            itcm:          0 GB       512 KB      0.00%
            dtcm:          0 GB       512 KB      0.00%
CP: nuttx.hex
```

`imxrt1064-evk:lvgl` also builds successfully in Docker:
https://gist.github.com/lupyuen/4aa7830fa50d12d771567db16d64af8e
```bash
sudo docker run \
  -it \
  ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest \
  /bin/bash
cd
git clone https://github.com/lupyuen2/wip-nuttx nuttx --branch imxrt_edma
git clone https://github.com/apache/nuttx-apps apps
pushd nuttx ; echo NuttX Source: https://github.com/apache/nuttx/tree/$(git rev-parse HEAD) ; popd
pushd apps  ; echo NuttX Apps: https://github.com/apache/nuttx-apps/tree/$(git rev-parse HEAD) ; popd
cd nuttx
tools/configure.sh imxrt1064-evk/lvgl
make -j

Memory region         Used Size  Region Size  %age Used
           flash:      464796 B         4 MB     11.08%
            sram:        9180 B       512 MB      0.00%
            itcm:          0 GB       128 KB      0.00%
            dtcm:          0 GB       128 KB      0.00%
CP: nuttx.hex
CP: nuttx.srec
```
