### PR TITLE
Reduce the size of tcb.

### DIFF
--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "arm.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -90,8 +91,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     {
       /* In this case just deliver the signal now. */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm/src/arm/arm_sigdeliver.c
+++ b/arch/arm/src/arm/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -59,9 +60,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always
@@ -73,7 +74,7 @@ void arm_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -93,7 +94,7 @@ void arm_sigdeliver(void)
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -34,6 +34,7 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 #include <sched/sched.h>
+#include <signal/signal.h>
 
 #include "arm_internal.h"
 #include "exc_return.h"
@@ -86,7 +87,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       irq_dispatch(irq, regs);
 #endif
-      if (tcb->sigdeliver)
+      if ((tcb->flags & TCB_FLAG_SIGDELIVER) != 0)
         {
           /* Pendsv able to access running tcb with no critical section */
 

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -37,6 +37,7 @@
 #include "psr.h"
 #include "exc_return.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 #include "irq/irq.h"
 #include "nvic.h"
@@ -96,8 +97,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handle will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {

--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +151,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -36,6 +36,7 @@
 
 #include "arm.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 #include "irq/irq.h"
 
@@ -94,8 +95,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +151,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER; /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -410,7 +410,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->sigdeliver)
+              if ((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -34,6 +34,7 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 #include <sched/sched.h>
+#include <signal/signal.h>
 
 #include "arm_internal.h"
 #include "exc_return.h"
@@ -86,7 +87,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       irq_dispatch(irq, regs);
 #endif
-      if (tcb->sigdeliver)
+      if ((tcb->flags & TCB_FLAG_SIGDELIVER) != 0)
         {
           /* Pendsv able to access running tcb with no critical section */
 

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -38,6 +38,7 @@
 #include "psr.h"
 #include "exc_return.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 #include "irq/irq.h"
 #include "nvic.h"
@@ -97,8 +98,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handle will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +151,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "arm.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -92,8 +93,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -147,7 +148,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -407,7 +407,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->sigdeliver)
+              if ((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -97,7 +97,7 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       irq_dispatch(irq, regs);
 #endif
-      if (tcb->sigdeliver)
+      if ((tcb->flags & TCB_FLAG_SIGDELIVER) != 0)
         {
           /* Pendsv able to access running tcb with no critical section */
 

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -38,6 +38,7 @@
 #include "psr.h"
 #include "exc_return.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 #include "irq/irq.h"
 #include "nvic.h"
@@ -97,8 +98,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handle will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +151,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER; /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "arm.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -92,8 +93,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/arm/src/armv8-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-r/arm_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void arm_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -147,7 +148,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -407,7 +407,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
               /* Copy "info" into user stack */
 
-              if (rtcb->sigdeliver)
+              if ((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0)
                 {
                   usp = rtcb->xcp.saved_regs[REG_SP];
                 }

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "tc32.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -90,8 +91,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
     {
       /* In this case just deliver the signal now. */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -35,6 +35,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm64_internal.h"
 #include "arm64_arch.h"
 #include "irq/irq.h"
@@ -130,8 +131,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -35,6 +35,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "arm64_internal.h"
 #include "arm64_arch.h"
 #include "irq/irq.h"
@@ -69,9 +70,9 @@ void arm64_sigdeliver(void)
   flags = (rtcb->xcp.saved_regs[REG_SPSR] & SPSR_DAIF_MASK);
 #endif
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -103,7 +104,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -150,7 +151,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
   rtcb->xcp.regs = rtcb->xcp.saved_regs;
 
   /* Then restore the correct state for this thread of execution. */

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -35,6 +35,7 @@
 #include <avr/io.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "avr_internal.h"
 
 /****************************************************************************
@@ -98,8 +99,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/avr/src/avr/avr_sigdeliver.c
+++ b/arch/avr/src/avr/avr_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "avr_internal.h"
 
 /****************************************************************************
@@ -60,9 +61,9 @@ void avr_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -78,7 +79,7 @@ void avr_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -104,7 +105,7 @@ void avr_sigdeliver(void)
   regs[REG_PC2]    = rtcb->xcp.saved_pc2;
 #endif
   regs[REG_SREG]   = rtcb->xcp.saved_sreg;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. This is an
    * unusual case that must be handled by up_fullcontextresore. This case is

--- a/arch/avr/src/avr32/avr_initialstate.c
+++ b/arch/avr/src/avr32/avr_initialstate.c
@@ -89,7 +89,7 @@ void up_initial_state(struct tcb_s *tcb)
 #else
   /* No pending signal delivery */
 
-  tcb->sigdeliver   = NULL;
+  tcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Clear the frame pointer and link register since this is the outermost
    * frame.

--- a/arch/avr/src/avr32/avr_schedulesigaction.c
+++ b/arch/avr/src/avr32/avr_schedulesigaction.c
@@ -35,6 +35,7 @@
 #include <arch/avr32/avr32.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "avr_internal.h"
 
 /****************************************************************************
@@ -96,8 +97,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/avr/src/avr32/avr_sigdeliver.c
+++ b/arch/avr/src/avr32/avr_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "avr_internal.h"
 
 /****************************************************************************
@@ -64,9 +65,9 @@ void avr_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -82,7 +83,7 @@ void avr_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -104,7 +105,7 @@ void avr_sigdeliver(void)
 
   regs[REG_PC]     = rtcb->xcp.saved_pc;
   regs[REG_SR]     = rtcb->xcp.saved_sr;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. This is an
    * unusual case that must be handled by up_fullcontextresore. This case is

--- a/arch/ceva/src/common/ceva_schedulesigaction.c
+++ b/arch/ceva/src/common/ceva_schedulesigaction.c
@@ -33,6 +33,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "ceva_internal.h"
 
 #ifndef CONFIG_DISABLE_SIGNALS
@@ -100,8 +101,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  The task that needs to receive the signal is running.

--- a/arch/ceva/src/common/ceva_sigdeliver.c
+++ b/arch/ceva/src/common/ceva_sigdeliver.c
@@ -63,17 +63,17 @@ void ceva_sigdeliver(void)
 
   int saved_errno = rtcb->pterrno;
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Get a local copy of the sigdeliver function pointer. We do this so that
    * we can nullify the sigdeliver function pointer in the TCB and accept
    * more signal deliveries while processing the current pending signals.
    */
 
-  sigdeliver       = rtcb->sigdeliver;
-  rtcb->sigdeliver = NULL;
+  sigdeliver       = nxsig_deliver;
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Deliver the signal */
 

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -36,6 +36,7 @@
 #include <arch/mips32/cp0.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "mips_internal.h"
 
 /****************************************************************************
@@ -99,8 +100,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/mips/src/mips32/mips_sigdeliver.c
+++ b/arch/mips/src/mips32/mips_sigdeliver.c
@@ -39,6 +39,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "mips_internal.h"
 
 /****************************************************************************
@@ -62,9 +63,9 @@ void mips_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -80,7 +81,7 @@ void mips_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -104,7 +105,7 @@ void mips_sigdeliver(void)
 
   regs[REG_EPC]    = rtcb->xcp.saved_epc;
   regs[REG_STATUS] = rtcb->xcp.saved_status;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -35,6 +35,7 @@
 #include <arch/lm32/irq.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "lm32.h"
 
 /****************************************************************************
@@ -96,8 +97,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -36,6 +36,7 @@
 #include <arch/minerva/csrdefs.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "minerva.h"
 
 /****************************************************************************
@@ -97,8 +98,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2: We are in an interrupt handler AND the interrupted task

--- a/arch/misoc/src/minerva/minerva_sigdeliver.c
+++ b/arch/misoc/src/minerva/minerva_sigdeliver.c
@@ -63,9 +63,9 @@ void minerva_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the real return state on the stack. */
 
@@ -78,8 +78,8 @@ void minerva_sigdeliver(void)
    * more signal deliveries while processing the current pending signals.
    */
 
-  sigdeliver       = rtcb->sigdeliver;
-  rtcb->sigdeliver = NULL;
+  sigdeliver       = nxsig_deliver;
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
 #  ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "or1k_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "renesas_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/m16c/m16c_sigdeliver.c
+++ b/arch/renesas/src/m16c/m16c_sigdeliver.c
@@ -36,6 +36,7 @@
 #include <nuttx/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "renesas_internal.h"
 
 /****************************************************************************
@@ -59,9 +60,9 @@ void renesas_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +78,7 @@ void renesas_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (sig_rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -100,7 +101,10 @@ void renesas_sigdeliver(void)
   regs[REG_PC]     = rtcb->xcp.saved_pc[0];
   regs[REG_PC + 1] = rtcb->xcp.saved_pc[1];
   regs[REG_FLG]    = rtcb->xcp.saved_flg;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+  /* Allows next handler to be scheduled */
+
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "renesas_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "renesas_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/renesas/src/sh1/sh1_sigdeliver.c
+++ b/arch/renesas/src/sh1/sh1_sigdeliver.c
@@ -36,6 +36,7 @@
 #include <nuttx/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "renesas_internal.h"
 
 /****************************************************************************
@@ -59,9 +60,9 @@ void renesas_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +78,7 @@ void renesas_sigdeliver(void)
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -99,7 +100,10 @@ void renesas_sigdeliver(void)
 
   regs[REG_PC]     = rtcb->xcp.saved_pc;
   regs[REG_SR]     = rtcb->xcp.saved_sr;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+
+  /* Allows next handler to be scheduled */
+
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -36,6 +36,7 @@
 #include <nuttx/spinlock.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "riscv_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/sim/src/sim/sim_schedulesigaction.c
+++ b/arch/sim/src/sim/sim_schedulesigaction.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 
 /****************************************************************************
  * Public Functions
@@ -81,7 +82,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
 }

--- a/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "sparc_internal.h"
 
 /****************************************************************************
@@ -93,8 +94,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the
@@ -192,8 +193,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
            * REVISIT:  Signal handler will run in a critical section!
            */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  The task that needs to receive the signal is running.

--- a/arch/tricore/src/common/tricore_schedulesigaction.c
+++ b/arch/tricore/src/common/tricore_schedulesigaction.c
@@ -36,6 +36,7 @@
 #include <nuttx/spinlock.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "tricore_internal.h"
 
 /****************************************************************************
@@ -94,8 +95,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the

--- a/arch/tricore/src/common/tricore_sigdeliver.c
+++ b/arch/tricore/src/common/tricore_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "tricore_internal.h"
 
 /****************************************************************************
@@ -60,9 +61,9 @@ void tricore_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 
@@ -76,7 +77,7 @@ retry:
 
   /* Deliver the signal */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -108,7 +109,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/x86/src/i486/i486_schedulesigaction.c
+++ b/arch/x86/src/i486/i486_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "x86_internal.h"
 
 /****************************************************************************
@@ -91,8 +92,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/x86/src/i486/i486_sigdeliver.c
+++ b/arch/x86/src/i486/i486_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "x86_internal.h"
 
 /****************************************************************************
@@ -60,9 +61,9 @@ void x86_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -78,7 +79,7 @@ void x86_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -100,7 +101,7 @@ void x86_sigdeliver(void)
 
   regs[REG_EIP]    = rtcb->xcp.saved_eip;
   regs[REG_EFLAGS] = rtcb->xcp.saved_eflags;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/x86_64/src/intel64/intel64_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/intel64_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "x86_64_internal.h"
 
 /****************************************************************************
@@ -83,8 +84,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task() && !up_interrupt_context())
     {
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
 
   /* Otherwise, we are (1) signaling a task is not running from an

--- a/arch/x86_64/src/intel64/intel64_sigdeliver.c
+++ b/arch/x86_64/src/intel64/intel64_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "x86_64_internal.h"
 
 /****************************************************************************
@@ -70,9 +71,9 @@ void x86_64_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Align regs to 64 byte boundary for XSAVE */
 
@@ -115,7 +116,7 @@ void x86_64_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -143,7 +144,7 @@ void x86_64_sigdeliver(void)
   regs[REG_RIP]    = rtcb->xcp.saved_rip;
   regs[REG_RSP]    = rtcb->xcp.saved_rsp;
   regs[REG_RFLAGS] = rtcb->xcp.saved_rflags;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
 #ifdef CONFIG_SMP
   /* Restore the saved 'irqcount' and recover the critical section

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -36,6 +36,7 @@
 
 #include "irq/irq.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 
 #include "chip.h"
 #include "xtensa.h"
@@ -95,8 +96,8 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        * REVISIT:  Signal handler will run in a critical section!
        */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
+      nxsig_deliver(tcb);
+      tcb->flags &= ~TCB_FLAG_SIGDELIVER;
     }
   else
     {

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "xtensa.h"
 
 /****************************************************************************
@@ -69,9 +70,9 @@ void xtensa_sig_deliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
 retry:
 #ifdef CONFIG_SMP
@@ -104,7 +105,7 @@ retry:
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -148,7 +149,7 @@ retry:
    * could be modified by a hostile program.
    */
 
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution.
    */

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -34,6 +34,7 @@
 #include <nuttx/irq.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z16_internal.h"
 
 /****************************************************************************
@@ -95,8 +96,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted

--- a/arch/z16/src/common/z16_sigdeliver.c
+++ b/arch/z16/src/common/z16_sigdeliver.c
@@ -37,6 +37,7 @@
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z16_internal.h"
 
 /****************************************************************************
@@ -61,9 +62,9 @@ void z16_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -79,7 +80,7 @@ void z16_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -101,7 +102,7 @@ void z16_sigdeliver(void)
 
   regs32[REG_PC / 2] = rtcb->xcp.saved_pc;
   regs[REG_FLAGS]    = rtcb->xcp.saved_i;
-  rtcb->sigdeliver   = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -119,8 +120,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/ez80/ez80_sigdeliver.c
+++ b/arch/z80/src/ez80/ez80_sigdeliver.c
@@ -39,6 +39,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -62,9 +63,9 @@ void z80_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-         rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+         rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -80,7 +81,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -102,7 +103,7 @@ void z80_sigdeliver(void)
 
   regs[XCPT_PC]    = rtcb->xcp.saved_pc;
   regs[XCPT_I]     = rtcb->xcp.saved_i;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -38,6 +38,7 @@
 
 #include "switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -122,8 +123,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z180/z180_sigdeliver.c
+++ b/arch/z80/src/z180/z180_sigdeliver.c
@@ -36,6 +36,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -59,9 +60,9 @@ void z80_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +78,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -99,7 +100,7 @@ void z80_sigdeliver(void)
 
   regs[XCPT_PC]    = rtcb->xcp.saved_pc;
   regs[XCPT_I]     = rtcb->xcp.saved_i;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -35,6 +35,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -119,8 +120,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z8/z8_sigdeliver.c
+++ b/arch/z80/src/z8/z8_sigdeliver.c
@@ -36,6 +36,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -78,9 +79,9 @@ void z80_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -96,7 +97,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -118,7 +119,10 @@ void z80_sigdeliver(void)
 
   regs[XCPT_PC]     = rtcb->xcp.saved_pc;
   regs[XCPT_IRQCTL] = rtcb->xcp.saved_irqctl;
-  rtcb->sigdeliver  = NULL;  /* Allows next handler to be scheduled */
+
+  /* Allows next handler to be scheduled */
+
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -36,6 +36,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -120,8 +121,8 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
         {
           /* In this case just deliver the signal now. */
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
+          nxsig_deliver(tcb);
+          tcb->flags &= ~TCB_FLAG_SIGDELIVER;
         }
 
       /* CASE 2:  We are in an interrupt handler AND the interrupted task

--- a/arch/z80/src/z80/z80_sigdeliver.c
+++ b/arch/z80/src/z80/z80_sigdeliver.c
@@ -36,6 +36,7 @@
 
 #include "chip/switch.h"
 #include "sched/sched.h"
+#include "signal/signal.h"
 #include "z80_internal.h"
 
 /****************************************************************************
@@ -59,9 +60,9 @@ void z80_sigdeliver(void)
 
   board_autoled_on(LED_SIGNAL);
 
-  sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
-        rtcb, rtcb->sigdeliver, rtcb->sigpendactionq.head);
-  DEBUGASSERT(rtcb->sigdeliver != NULL);
+  sinfo("rtcb=%p sigpendactionq.head=%p\n",
+        rtcb, rtcb->sigpendactionq.head);
+  DEBUGASSERT((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0);
 
   /* Save the return state on the stack. */
 
@@ -77,7 +78,7 @@ void z80_sigdeliver(void)
 
   /* Deliver the signals */
 
-  (rtcb->sigdeliver)(rtcb);
+  nxsig_deliver(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may
    * alter errno), then disable interrupts again and restore the original
@@ -99,7 +100,7 @@ void z80_sigdeliver(void)
 
   regs[XCPT_PC]    = rtcb->xcp.saved_pc;
   regs[XCPT_I]     = rtcb->xcp.saved_i;
-  rtcb->sigdeliver = NULL;  /* Allows next handler to be scheduled */
+  rtcb->flags &= ~TCB_FLAG_SIGDELIVER;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -68,7 +68,7 @@ static bool syslog_safe_to_block(void)
   /* It's not safe to block if a signal is being delivered */
 
   rtcb = nxsched_self();
-  if (rtcb->sigdeliver != NULL)
+  if ((rtcb->flags & TCB_FLAG_SIGDELIVER) != 0)
     {
       return false;
     }

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -134,6 +134,7 @@
 #define TCB_FLAG_FORCED_CANCEL     (1 << 13)                     /* Bit 13: Pthread cancel is forced */
 #define TCB_FLAG_JOIN_COMPLETED    (1 << 14)                     /* Bit 14: Pthread join completed */
 #define TCB_FLAG_FREE_TCB          (1 << 15)                     /* Bit 15: Free tcb after exit */
+#define TCB_FLAG_SIGDELIVER        (1 << 16)                     /* Bit 16: Deliver pending signals */
 
 /* Values for struct task_group tg_flags */
 
@@ -303,7 +304,6 @@ typedef enum tstate_e tstate_t;
 /* The following is the form of a thread start-up function */
 
 typedef CODE void (*start_t)(void);
-typedef CODE void (*sig_deliver_t)(FAR struct tcb_s *tcb);
 
 /* This is the entry point into the main thread of the task or into a created
  * pthread within the task.
@@ -721,11 +721,6 @@ struct tcb_s
 
   struct xcptcontext xcp;                /* Interrupt register save area    */
 
-  /* The following function pointer is non-zero if there are pending signals
-   * to be processed.
-   */
-
-  sig_deliver_t sigdeliver;
 #if CONFIG_TASK_NAME_SIZE > 0
   char name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NUL terminator) */
 #endif

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -86,7 +86,7 @@ static int sig_handler(FAR void *cookie)
       tcb->flags &= ~TCB_FLAG_CPU_LOCKED;
     }
 
-  if (tcb->sigdeliver)
+  if ((tcb->flags & TCB_FLAG_SIGDELIVER) != 0)
     {
       up_schedule_sigaction(tcb);
     }
@@ -160,13 +160,13 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
            * up_schedule_sigaction()
            */
 
-          if (!stcb->sigdeliver)
+          if ((stcb->flags & TCB_FLAG_SIGDELIVER) == 0)
             {
 #ifdef CONFIG_SMP
               int cpu = stcb->cpu;
               int me  = this_cpu();
 
-              stcb->sigdeliver = nxsig_deliver;
+              stcb->flags |= TCB_FLAG_SIGDELIVER;
               if (cpu != me && stcb->task_state == TSTATE_TASK_RUNNING)
                 {
                   struct sig_arg_s arg;
@@ -190,7 +190,7 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
               else
 #endif
                 {
-                  stcb->sigdeliver = nxsig_deliver;
+                  stcb->flags |= TCB_FLAG_SIGDELIVER;
                   up_schedule_sigaction(stcb);
                 }
             }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

### Why the old code is not needed anymore?
There is a variable tcb->sigdeliver in the current tcb structure, which is used to determine whether there is a new signal to be processed. When there is a signal to be processed, the address of the nxsig_deliver function will be assigned to tcb->sigdeliver. At the same time, if there are other signals to be processed, it will first determine whether the value of tcb->sigdeliver is empty. All signal processing is in the nxsig_deliver function, so we can call this function directly; and when judging whether there is a new signal to be delivered, we can add a flag bit TCB_FLAG_SIGDELIVER in tcb->flags. Only one bit is needed to achieve the previous effect, which optimizes both execution time and space.

### Is there some drawback after removing these lines of code?
There are no drawback so far.

## Impact

None.

## Testing

Testcase ostest is executed without failure in the smp environment of armv7a and armv8a.


