### PR TITLE
mm: make the alignment length in mm consistent with Kasan

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -143,7 +143,7 @@
  * previous freenode
  */
 
-#define MM_ALLOCNODE_OVERHEAD (MM_SIZEOF_ALLOCNODE - sizeof(mmsize_t))
+#define MM_ALLOCNODE_OVERHEAD (MM_SIZEOF_ALLOCNODE - MM_ALIGN)
 
 /* Get the node size */
 
@@ -173,7 +173,12 @@ typedef size_t mmsize_t;
 
 struct mm_allocnode_s
 {
-  mmsize_t preceding;                       /* Physical preceding chunk size */
+  union
+  {
+    mmsize_t preceding;                     /* Physical preceding chunk size */
+    uint8_t  align[MM_ALIGN];
+  };
+
   mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
@@ -182,13 +187,19 @@ struct mm_allocnode_s
   FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
 #  endif
 #endif
-};
+}
+aligned_data(MM_ALIGN);
 
 /* This describes a free chunk */
 
 struct mm_freenode_s
 {
-  mmsize_t preceding;                       /* Physical preceding chunk size */
+  union
+  {
+    mmsize_t preceding;                     /* Physical preceding chunk size */
+    uint8_t  align[MM_ALIGN];
+  };
+
   mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
@@ -199,7 +210,8 @@ struct mm_freenode_s
 #endif
   FAR struct mm_freenode_s *flink;          /* Supports a doubly linked list */
   FAR struct mm_freenode_s *blink;
-};
+}
+aligned_data(MM_ALIGN);
 
 static_assert(MM_SIZEOF_ALLOCNODE <= MM_MIN_CHUNK,
               "Error size for struct mm_allocnode_s\n");

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -150,7 +150,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   heapbase = MM_ALIGN_UP((uintptr_t)heapstart + 2 * MM_SIZEOF_ALLOCNODE) -
              2 * MM_SIZEOF_ALLOCNODE;
-  heapsize = heapsize - (heapbase - (uintptr_t)heapstart);
+  heapsize = MM_ALIGN_DOWN(heapsize - (heapbase - (uintptr_t)heapstart));
 
   /* Register KASan for access rights check. We need to register after
    * address alignment.


### PR DESCRIPTION
## Summary

    mm: The alignment length in mm is consistent with Kasan
    
    preceding will cause the mm alignment to be inconsistent with the kasan alignment

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


