### PR TITLE
arch/x86_64: this_task is stored in the CPU private data

### DIFF
--- a/arch/x86_64/src/intel64/intel64_backtrace_fp.c
+++ b/arch/x86_64/src/intel64/intel64_backtrace_fp.c
@@ -145,8 +145,8 @@ int up_backtrace(struct tcb_s *tcb,
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                               (void *)up_current_regs()[REG_RBP],
-                               (void *)up_current_regs()[REG_RIP],
+                               (void *)running_regs()[REG_RBP],
+                               (void *)running_regs()[REG_RIP],
                                &buffer[ret], size - ret, &skip);
             }
         }

--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -148,7 +148,7 @@ void x86_64_ap_boot(void)
 
   x86_64_cpu_priv_set(cpu);
 
-  tcb = this_task();
+  tcb = current_task(cpu);
   UNUSED(tcb);
 
   /* Configure interrupts */
@@ -191,6 +191,8 @@ void x86_64_ap_boot(void)
     {
       __revoke_low_memory();
     }
+
+  up_update_task(tcb);
 
   /* Then transfer control to the IDLE task */
 

--- a/arch/x86_64/src/intel64/intel64_regdump.c
+++ b/arch/x86_64/src/intel64/intel64_regdump.c
@@ -30,6 +30,7 @@
 #include <debug.h>
 #include <nuttx/irq.h>
 
+#include "sched/sched.h"
 #include "x86_64_internal.h"
 
 /****************************************************************************
@@ -113,7 +114,7 @@ void backtrace(uint64_t rbp)
 
 void up_dump_register(void *dumpregs)
 {
-  volatile uint64_t *regs = dumpregs ? dumpregs : up_current_regs();
+  volatile uint64_t *regs = dumpregs ? dumpregs : running_regs();
   uint64_t mxcsr;
   uint64_t cr2;
 


### PR DESCRIPTION
By default in SMP, obtaining this_task requires disabling interrupts, obtaining the current CPU index, accessing a global variable, and re-enabling interrupts. Storing this_task in percpu makes retrieval faster.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
arch/x86_64: this_task is stored in the CPU private data
*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
no impact
*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
ostest
*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


