### PR TITLE
xtensa/esp32s3: porting of spi_flash_chip_generic_write_encrypted

### DIFF
--- a/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
+++ b/arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h
@@ -33,6 +33,8 @@
 #include <nuttx/bits.h>
 
 #include "soc/soc.h"
+#include "soc/hwcrypto_reg.h"
+#include "soc/system_reg.h"
 #include "esp_attr.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

porting of spi_flash_chip_generic_write_encrypted from ESP-IDF

## Impact

Use spi_flash_write_encrypted_manu(...) instead of ROM Func spi_flash_write_encrypted(...)

## Testing

tested by case of CONFIG_ESP32S3_SPIFLASH_ENCRYPTION_TEST, for <16MB and >16MB cases.


