### PR TITLE
arch/qemu-armv7a: kernel mode cmake support

### DIFF
--- a/arch/arm/src/CMakeLists.txt
+++ b/arch/arm/src/CMakeLists.txt
@@ -29,7 +29,7 @@ add_subdirectory(common)
 target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common
                                               ${ARCH_SUBDIR})
 
-if(NOT CONFIG_BUILD_FLAT)
+if(CONFIG_BUILD_PROTECTED)
   target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
                                                           common ${ARCH_SUBDIR})
 endif()

--- a/arch/arm/src/qemu/CMakeLists.txt
+++ b/arch/arm/src/qemu/CMakeLists.txt
@@ -30,4 +30,8 @@ if(CONFIG_ARCH_IDLE_CUSTOM)
   list(APPEND SRCS qemu_idle.c)
 endif()
 
+if(CONFIG_BUILD_KERNEL)
+  list(APPEND SRCS qemu_pgalloc.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})


### PR DESCRIPTION

## Summary

This allows to build kernel mode NuttX with cmake for qemu-armv7a target.

## Impacts

None

## Testing

- local check with config: qemu-armv7a:knsh
- CI checks
