### PR TITLE
net/udp: Let cansend return EWOULDBLOCK when send buffer is full

### DIFF
--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -941,7 +941,11 @@ int psock_udp_cansend(FAR struct udp_conn_s *conn)
    * many more.
    */
 
-  if (udp_wrbuffer_test() < 0 || iob_navail(false) <= 0)
+  if (udp_wrbuffer_test() < 0 || iob_navail(false) <= 0
+#if CONFIG_NET_SEND_BUFSIZE > 0
+      || udp_wrbuffer_inqueue_size(conn) >= conn->sndbufs
+#endif
+     )
     {
       return -EWOULDBLOCK;
     }


### PR DESCRIPTION
## Summary

Notes:
1. This commit do the same thing as TCP did: https://github.com/apache/nuttx/pull/10627
2. UDP uses `iob_navail(false)` but TCP uses `iob_navail(true)`, this is because of a problem related to TCP recv window (https://github.com/apache/nuttx/pull/4142), so we don't need to change UDP now.

## Impact

UDP

## Testing

SIM


