### PR TITLE
V9FS:Adjust some code implementations to fix bugs

### DIFF
--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1098,13 +1098,13 @@ ssize_t v9fs_client_write(FAR struct v9fs_client_s *client, uint32_t fid,
 
   while (buflen > 0)
     {
+      request.count = buflen > fidp->iounit ? fidp->iounit : buflen;
       request.header.size = V9FS_HDRSZ + V9FS_BIT32SZ + V9FS_BIT64SZ +
                             V9FS_BIT32SZ + request.count;
       request.header.type = V9FS_TWRITE;
       request.header.tag = v9fs_get_tagid(client);
       request.fid = fid;
       request.offset = offset;
-      request.count = buflen > fidp->iounit ? fidp->iounit : buflen;
 
       wiov[0].iov_base = &request;
       wiov[0].iov_len = V9FS_HDRSZ + V9FS_BIT32SZ + V9FS_BIT64SZ +

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -173,7 +173,7 @@ begin_packed_struct struct v9fs_attach_s
 {
   struct v9fs_header_s header;
   uint32_t fid;
-  uint16_t afid;
+  uint32_t afid;
   uint8_t buffer[2 * (V9FS_BIT16SZ + NAME_MAX) + V9FS_BIT32SZ];
 } end_packed_struct;
 

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1589,6 +1589,16 @@ int v9fs_client_walk(FAR struct v9fs_client_s *client, FAR const char *path,
       newfid = ret;
     }
 
+  /* There are differences in different server implementations, so it is
+   * necessary to check whether the returned nwqid satisfies the requested
+   * number.
+   */
+
+  if (response.nwqid != nwname)
+    {
+      newfid = -ENOENT;
+    }
+
 err:
   lib_put_pathbuffer(request_payload);
   lib_put_pathbuffer(response_payload);


### PR DESCRIPTION
## Summary
The V9FS brought by the last PR https://github.com/apache/nuttx/pull/13001 enhances the distributed application capabilities of NuttX. It is currently applicable to the scenario of QEMU and host as transparent file systems (similar to hostfs), and its performance is excellent.
I encountered some minor implementation problems during use, so I reorganized the following code logic:
- Protocol encapsulation process
- Type size
- Function interface return value
- Compatibility of different interfaces

This prepares V9FS to be compatible with more different scenarios in the future, for example, we can use sockets to make distributed file systems.

Next, I will also prepare a document guide to submit

## Impact
It has no impact, mainly fixes the error process of v9fs

## Testing
Build Host(s): Linux x86
Target(s): qemu-armv7a
It can pass the existing file system test.

