### PR TITLE
gcov: add reboot gcov storage coverage info

### DIFF
--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -26,11 +26,12 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
 #include <sys/boardctl.h>
+#include <sys/types.h>
+#include <assert.h>
 #include <stdint.h>
 #include <errno.h>
-#include <assert.h>
+#include <gcov.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>

--- a/libs/libbuiltin/Kconfig
+++ b/libs/libbuiltin/Kconfig
@@ -66,6 +66,25 @@ config COVERAGE_NONE
 
 endchoice
 
+config COVERAGE_GCOV_DUMP_REBOOT
+	bool "Dump gcov data on reboot"
+	default n
+	---help---
+		Dump gcov data on reboot, this will cause the gcov data to be
+		dumped to the default path when the system is rebooted.
+
+config COVERAGE_DEFAULT_PREFIX_STRIP
+	string "Default gcov dump path prefix strip"
+	default "99"
+	---help---
+		The default prefix strip of the gcov data
+
+config COVERAGE_DEFAULT_PREFIX
+	string "Default gcov dump path prefix"
+	default "/data"
+	---help---
+		The default prefix to store the gcov data
+
 choice
 	prompt "Builtin profile support"
 	default PROFILE_NONE


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

gcov: add reboot gcov storage coverage info

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


