### PR TITLE
libs/gdbstub fixes

### DIFF
--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1609,7 +1609,7 @@ retry:
 
       case GDB_STOPREASON_CTRLC:
       default:
-        ret = sprintf(state->pkt_buf, "T05thread:%d;", state->pid + 1);
+        ret = sprintf(state->pkt_buf, "T05thread:%x;", state->pid + 1);
     }
 
   if (ret < 0)

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -1376,11 +1376,11 @@ static int gdb_query(FAR struct gdb_state_s *state)
     {
 #ifdef CONFIG_ARCH_HAVE_DEBUG
       state->pkt_len = sprintf(state->pkt_buf,
-                               "hwbreak+;PacketSize=%x",
+                               "hwbreak+;PacketSize=%zx",
                                sizeof(state->pkt_buf));
 #else
       state->pkt_len = sprintf(state->pkt_buf,
-                               "PacketSize=%x",
+                               "PacketSize=%zx",
                                sizeof(state->pkt_buf));
 #endif
       gdb_send_packet(state);


### PR DESCRIPTION
## Summary
- libs/libc/gdbstub/lib_gdbstub.c: fix warning

- libs/libc/gdbstub/lib_gdbstub.c: fix format for trap response
   fix gdb crash after a few step breakpoints because trap is not correctly reported

## Impact

gdbstub fixes

## Testing

x86_64 with gdbstub over serial port

