### PR TITLE
arch/intel64: allow to attach handlers to ISR

### DIFF
--- a/arch/x86_64/src/intel64/intel64_vectors.S
+++ b/arch/x86_64/src/intel64/intel64_vectors.S
@@ -41,7 +41,6 @@
  ****************************************************************************/
 
 	.globl    irq_handler
-	.globl    isr_handler
 	.globl    irq_xcp_regs
 	.globl    g_interrupt_stack
 	.globl    g_interrupt_stack_end
@@ -69,7 +68,7 @@ vector_isr\intno:
 	pushq   %rdi
 	pushq   %rsi
 	movq    $\intno,   %rsi     /* INT Number is saved to 2nd parameter of function call */
-	jmp     isr_common           /* Go to the common ISR handler code. */
+	jmp     irq_common           /* Go to the common IRQ handler code. */
 	.endm
 
 	/* This macro creates a stub for an ISR which passes it's own
@@ -87,7 +86,7 @@ vector_isr\intno:
 	pushq   %rdi
 	pushq   %rsi
 	movq    $\intno,   %rsi     /* INT Number is saved to 2nd parameter of function call */
-	jmp     isr_common          /* Go to the common ISR handler code. */
+	jmp     irq_common          /* Go to the common IRQ handler code. */
 	.endm
 
 	/* This macro creates a stub for an IRQ - the first parameter is
@@ -693,69 +692,6 @@ vector_isr\intno:
 	.balign 16
 
 /****************************************************************************
- * Name: isr_common
- *
- * Description:
- *   This is the common ISR logic. It saves the processor state, sets up for
- *   kernel mode segments, calls the C-level fault handler, and finally
- *   restores the stack frame.
- *
- ****************************************************************************/
-
-isr_common:
-	/* Already swap to the interrupt stack */
-	/* stack is automatically recovered by iretq using task state */
-
-	/* x86_64 don't have pusha, we have to do things manually */
-	/* RDI and RSI are pushed above for handling IRQ no */
-	pushq   %rdx
-	pushq   %rcx
-	pushq   %r8
-	pushq   %r9
-
-	pushq   %r15
-	pushq   %r14
-	pushq   %r13
-	pushq   %r12
-	pushq   %r11
-	pushq   %r10
-	pushq   %rbp
-	pushq   %rbx
-	pushq   %rax
-
-	xor     %rax, %rax    /* Reset rax */
-	mov     %ds, %ax      /* Lower 16-bits of rax. */
-	pushq   %rax          /* Save the data segment descriptor */
-	mov     %es, %ax      /* Lower 16-bits of rax. */
-	pushq   %rax          /* Save the data segment descriptor */
-	mov     %gs, %ax      /* Lower 16-bits of rax. */
-	pushq   %rax          /* Save the data segment descriptor */
-	mov     %fs, %ax      /* Lower 16-bits of rax. */
-	pushq   %rax          /* Save the data segment descriptor */
-
-	/* Align to 64-bytes boundary */
-	leaq    -(XMMAREA_REG_ALIGN * 8)(%rsp), %rsp
-
-	/* Save xmm registers */
-	leaq    -XCPTCONTEXT_XMM_AREA_SIZE(%rsp), %rsp
-#ifndef CONFIG_ARCH_X86_64_HAVE_XSAVE
-	fxsaveq (%rsp)
-#else
-	movl $XSAVE_STATE_COMPONENTS, %eax
-	xor     %edx, %edx
-	xsave   (%rsp)
-#endif
-
-	/* The current value of the SP points to the beginning of the state save
-	 * structure.  Save that in RDI as the input parameter to isr_handler.
-	 */
-
-	mov     %rsp, %rdi
-	call    isr_handler
-	jmp     .Lreturn
-	.size   isr_common, . - isr_common
-
-/****************************************************************************
  * Name: irq_common
  *
  * Description:
@@ -850,7 +786,7 @@ irq_common:
 	add     $8, %rsp
 	popq    %rdi
 
-	/* The common return point for both isr_handler and irq_handler */
+	/* The common return point for irq_handler */
 
 .Lreturn:
 


### PR DESCRIPTION
## Summary

arch/intel64: allow to attach handlers to ISR

## Impact

we can attach interrupt handlers to ISR, this is required to support hardware breakpoints

## Testing

intel hw and qemu


