### PR TITLE
sched: remove all spin_lock_irqsave(NULL)

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -571,6 +571,8 @@ struct task_group_s
   /* Virtual memory mapping info ********************************************/
 
   struct mm_map_s tg_mm_map;        /* Task group virtual memory mappings   */
+
+  spinlock_t tg_lock;               /* lock */
 };
 
 /* struct tcb_s *************************************************************/

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -33,6 +33,7 @@
 
 #include <nuttx/clock.h>
 #include <nuttx/compiler.h>
+#include <nuttx/spinlock_type.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -66,6 +67,7 @@ extern volatile clock_t g_system_ticks;
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
 extern struct timespec  g_basetime;
+extern spinlock_t g_basetime_lock;
 #endif
 
 /****************************************************************************

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -58,7 +58,7 @@ static clock_t clock_process_runtime(FAR struct tcb_s *tcb)
 
   group = tcb->group;
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&group->tg_lock);
   sq_for_every(&group->tg_members, curr)
     {
       tcb = container_of(curr, struct tcb_s, member);
@@ -66,7 +66,7 @@ static clock_t clock_process_runtime(FAR struct tcb_s *tcb)
       runtime += tcb->run_time;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&group->tg_lock, flags);
   return runtime;
 # else  /* HAVE_GROUP_MEMBERS */
   return tcb->run_time;
@@ -109,9 +109,9 @@ void nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
        * was last set, this gives us the current time.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_basetime_lock);
       clock_timespec_add(&g_basetime, &ts, tp);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_basetime_lock, flags);
 #else
       clock_timekeeping_get_wall_time(tp);
 #endif

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -56,6 +56,7 @@ volatile clock_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
 struct timespec   g_basetime;
+spinlock_t g_basetime_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -160,7 +161,9 @@ static void clock_inittime(FAR const struct timespec *tp)
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
   struct timespec ts;
+  irqstate_t flags;
 
+  flags = spin_lock_irqsave(&g_basetime_lock);
   if (tp)
     {
       memcpy(&g_basetime, tp, sizeof(struct timespec));
@@ -170,7 +173,11 @@ static void clock_inittime(FAR const struct timespec *tp)
       clock_basetime(&g_basetime);
     }
 
+  spin_unlock_irqrestore(&g_basetime_lock, flags);
+
   clock_systime_timespec(&ts);
+
+  flags = spin_lock_irqsave(&g_basetime_lock);
 
   /* Adjust base time to hide initial timer ticks. */
 
@@ -181,6 +188,8 @@ static void clock_inittime(FAR const struct timespec *tp)
       g_basetime.tv_nsec += NSEC_PER_SEC;
       g_basetime.tv_sec--;
     }
+
+  spin_unlock_irqrestore(&g_basetime_lock, flags);
 #else
   clock_inittimekeeping(tp);
 #endif
@@ -266,13 +275,9 @@ void clock_initialize(void)
 #ifdef CONFIG_RTC
 void clock_synchronize(FAR const struct timespec *tp)
 {
-  irqstate_t flags;
-
   /* Re-initialize the time value to match the RTC */
 
-  flags = enter_critical_section();
   clock_inittime(tp);
-  leave_critical_section(flags);
 }
 #endif
 
@@ -319,10 +324,6 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
       rtc_diff = &rtc_diff_tmp;
     }
 
-  /* Set the time value to match the RTC */
-
-  flags = enter_critical_section();
-
   /* Get RTC time */
 
   ret = clock_basetime(&rtc_time);
@@ -334,8 +335,10 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
 
       rtc_diff->tv_sec = 0;
       rtc_diff->tv_nsec = 0;
-      goto skip;
+      return;
     }
+
+  /* Set the time value to match the RTC */
 
   /* Get the elapsed time since power up (in milliseconds).  This is a
    * bias value that we need to use to correct the base time.
@@ -348,7 +351,9 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
    * was last set, this gives us the current time.
    */
 
+  flags = spin_lock_irqsave(&g_basetime_lock);
   clock_timespec_add(&bias, &g_basetime, &curr_ts);
+  spin_unlock_irqrestore(&g_basetime_lock, flags);
 
   /* Check if RTC has advanced past system time. */
 
@@ -382,9 +387,6 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
       atomic_fetch_add((FAR atomic_t *)&g_system_ticks, diff_ticks);
 #endif
     }
-
-skip:
-  leave_critical_section(flags);
 }
 #endif
 

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -68,9 +68,9 @@ int clock_systime_timespec(FAR struct timespec *ts)
 
       up_rtc_gettime(ts);
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_basetime_lock);
       clock_timespec_subtract(ts, &g_basetime, ts);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_basetime_lock, flags);
     }
   else
     {

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -222,6 +222,7 @@ void group_postinitialize(FAR struct task_tcb_s *tcb)
 
   DEBUGASSERT(tcb && tcb->cmn.group);
   group = tcb->cmn.group;
+  spin_lock_init(&group->tg_lock);
 
   /* Allocate mm_map list if required */
 

--- a/sched/group/group_exitinfo.c
+++ b/sched/group/group_exitinfo.c
@@ -70,14 +70,14 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
   irqstate_t flags;
 
   DEBUGASSERT(bininfo != NULL);
-  flags = spin_lock_irqsave(NULL);
+  flags = enter_critical_section();
 
   /* Get the TCB associated with the PID */
 
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      spin_unlock_irqrestore(NULL, flags);
+      leave_critical_section(flags);
       return -ESRCH;
     }
 
@@ -90,7 +90,7 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
 
   group->tg_bininfo = bininfo;
 
-  spin_unlock_irqrestore(NULL, flags);
+  leave_critical_section(flags);
   return OK;
 }
 

--- a/sched/group/group_join.c
+++ b/sched/group/group_join.c
@@ -102,9 +102,9 @@ void group_join(FAR struct pthread_tcb_s *tcb)
 
   /* Add the member to the group */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&group->tg_lock);
   sq_addfirst(&tcb->cmn.member, &group->tg_members);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&group->tg_lock, flags);
 }
 
 #endif /* !CONFIG_DISABLE_PTHREAD */

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -185,9 +185,9 @@ void group_leave(FAR struct tcb_s *tcb)
       /* Remove the member from group. */
 
 #ifdef HAVE_GROUP_MEMBERS
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&group->tg_lock);
       sq_rem(&tcb->member, &group->tg_members);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&group->tg_lock, flags);
 
       /* Have all of the members left the group? */
 

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -36,6 +36,7 @@
  * Private Data
  ****************************************************************************/
 
+static spinlock_t g_irqlock = SP_UNLOCKED;
 #ifdef CONFIG_ARCH_MINIMAL_VECTORTABLE_DYNAMIC
 static int g_irqmap_count = 1;
 #endif
@@ -67,13 +68,13 @@ int irq_to_ndx(int irq)
 {
   DEBUGASSERT(g_irqmap_count < CONFIG_ARCH_NUSER_INTERRUPTS);
 
-  irqstate_t flags = spin_lock_irqsave(NULL);
+  irqstate_t flags = spin_lock_irqsave(&g_irqlock);
   if (g_irqmap[irq] == 0)
     {
       g_irqmap[irq] = g_irqmap_count++;
     }
 
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_irqlock, flags);
   return g_irqmap[irq];
 }
 #endif
@@ -107,7 +108,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
        * to the unexpected interrupt handler.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_irqlock);
       if (isr == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might
@@ -141,7 +142,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
       if (is_irqchain(ndx, isr))
         {
           ret = irqchain_attach(ndx, isr, arg);
-          spin_unlock_irqrestore(NULL, flags);
+          spin_unlock_irqrestore(&g_irqlock, flags);
           return ret;
         }
 #endif
@@ -156,7 +157,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
       g_irqvector[ndx].count   = 0;
 #endif
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_irqlock, flags);
       ret = OK;
     }
 

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -78,6 +78,8 @@ struct list_node g_msgfree;
 
 struct list_node g_msgfreeirq;
 
+spinlock_t g_msgfreelock = SP_UNLOCKED;
+
 #endif
 
 /****************************************************************************

--- a/sched/mqueue/mq_msgfree.c
+++ b/sched/mqueue/mq_msgfree.c
@@ -69,9 +69,9 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_msgfreelock);
       list_add_tail(&g_msgfree, &mqmsg->node);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_msgfreelock, flags);
     }
 
   /* If this is a message pre-allocated for interrupts,
@@ -84,9 +84,9 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_msgfreelock);
       list_add_tail(&g_msgfreeirq, &mqmsg->node);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_msgfreelock, flags);
     }
 
   /* Otherwise, deallocate it.  Note:  interrupt handlers

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -139,9 +139,9 @@ static FAR struct mqueue_msg_s *nxmq_alloc_msg(uint16_t msgsize)
 
   /* Try to get the message from the generally available free list. */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_msgfreelock);
   mqmsg = (FAR struct mqueue_msg_s *)list_remove_head(&g_msgfree);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_msgfreelock, flags);
   if (mqmsg == NULL)
     {
       /* If we were called from an interrupt handler, then try to get the
@@ -153,9 +153,9 @@ static FAR struct mqueue_msg_s *nxmq_alloc_msg(uint16_t msgsize)
         {
           /* Try the free list reserved for interrupt handlers */
 
-          flags = spin_lock_irqsave(NULL);
+          flags = spin_lock_irqsave(&g_msgfreelock);
           mqmsg = (FAR struct mqueue_msg_s *)list_remove_head(&g_msgfreeirq);
-          spin_unlock_irqrestore(NULL, flags);
+          spin_unlock_irqrestore(&g_msgfreelock, flags);
         }
 
       /* We were not called from an interrupt handler. */

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -37,6 +37,7 @@
 #include <mqueue.h>
 #include <sched.h>
 
+#include <nuttx/spinlock.h>
 #include <nuttx/mqueue.h>
 
 #if defined(CONFIG_MQ_MAXMSGSIZE) && CONFIG_MQ_MAXMSGSIZE > 0
@@ -100,6 +101,8 @@ EXTERN struct list_node g_msgfree;
  */
 
 EXTERN struct list_node g_msgfreeirq;
+
+EXTERN spinlock_t g_msgfreelock;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -534,9 +534,9 @@ _sa_handler_t nxsig_default(FAR struct tcb_s *tcb, int signo, bool defaction)
         {
           /* nxsig_addset() is not atomic (but neither is sigaction()) */
 
-          flags = spin_lock_irqsave(NULL);
+          flags = spin_lock_irqsave(&group->tg_lock);
           nxsig_addset(&group->tg_sigdefault, signo);
-          spin_unlock_irqrestore(NULL, flags);
+          spin_unlock_irqrestore(&group->tg_lock, flags);
         }
     }
 
@@ -546,9 +546,9 @@ _sa_handler_t nxsig_default(FAR struct tcb_s *tcb, int signo, bool defaction)
        * atomic (but neither is sigaction()).
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&group->tg_lock);
       nxsig_delset(&group->tg_sigdefault, signo);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&group->tg_lock, flags);
     }
 
   return handler;

--- a/sched/signal/sig_findaction.c
+++ b/sched/signal/sig_findaction.c
@@ -57,7 +57,7 @@ FAR sigactq_t *nxsig_find_action(FAR struct task_group_s *group, int signo)
        * protection.
        */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&group->tg_lock);
 
       /* Search the list for a sigaction on this signal */
 
@@ -65,7 +65,7 @@ FAR sigactq_t *nxsig_find_action(FAR struct task_group_s *group, int signo)
            ((sigact) && (sigact->signo != signo));
            sigact = sigact->flink);
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&group->tg_lock, flags);
     }
 
   return sigact;

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -482,10 +482,10 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
 
       /* Add the task to the inactive task list */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = enter_critical_section();
       dq_addfirst((FAR dq_entry_t *)tcb, list_inactivetasks());
       tcb->task_state = TSTATE_TASK_INACTIVE;
-      spin_unlock_irqrestore(NULL, flags);
+      leave_critical_section(flags);
     }
 
   return ret;

--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -35,6 +35,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/signal.h>
 #include <nuttx/wdog.h>
+#include <nuttx/spinlock.h>
 
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
 
@@ -84,6 +85,8 @@ extern volatile sq_queue_t g_freetimers;
  */
 
 extern volatile sq_queue_t g_alloctimers;
+
+extern spinlock_t g_locktimers;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -63,10 +63,10 @@ static FAR struct posix_timer_s *timer_allocate(void)
   /* Try to get a preallocated timer from the free list */
 
 #if CONFIG_PREALLOC_TIMERS > 0
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_locktimers);
   ret   = (FAR struct posix_timer_s *)
     sq_remfirst((FAR sq_queue_t *)&g_freetimers);
-  spin_unlock_irqrestore(NULL, flags);
+  spin_unlock_irqrestore(&g_locktimers, flags);
 
   /* Did we get one? */
 
@@ -95,9 +95,9 @@ static FAR struct posix_timer_s *timer_allocate(void)
 
       /* And add it to the end of the list of allocated timers */
 
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_locktimers);
       sq_addlast((FAR sq_entry_t *)ret, (FAR sq_queue_t *)&g_alloctimers);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_locktimers, flags);
     }
 
   return ret;

--- a/sched/timer/timer_initialize.c
+++ b/sched/timer/timer_initialize.c
@@ -66,6 +66,8 @@ volatile sq_queue_t g_freetimers;
 
 volatile sq_queue_t g_alloctimers;
 
+spinlock_t g_locktimers = SP_UNLOCKED;
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -173,7 +175,7 @@ FAR struct posix_timer_s *timer_gethandle(timer_t timerid)
 
   if (timerid != NULL)
     {
-      flags = spin_lock_irqsave(NULL);
+      flags = spin_lock_irqsave(&g_locktimers);
 
       sq_for_every(&g_alloctimers, entry)
         {
@@ -184,7 +186,7 @@ FAR struct posix_timer_s *timer_gethandle(timer_t timerid)
             }
         }
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_locktimers, flags);
     }
 
   return timer;

--- a/sched/timer/timer_release.c
+++ b/sched/timer/timer_release.c
@@ -57,7 +57,7 @@ static inline void timer_free(struct posix_timer_s *timer)
 
   /* Remove the timer from the allocated list */
 
-  flags = spin_lock_irqsave(NULL);
+  flags = spin_lock_irqsave(&g_locktimers);
   sq_rem((FAR sq_entry_t *)timer, (FAR sq_queue_t *)&g_alloctimers);
 
   /* Return it to the free list if it is one of the preallocated timers */
@@ -66,14 +66,14 @@ static inline void timer_free(struct posix_timer_s *timer)
   if ((timer->pt_flags & PT_FLAGS_PREALLOCATED) != 0)
     {
       sq_addlast((FAR sq_entry_t *)timer, (FAR sq_queue_t *)&g_freetimers);
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_locktimers, flags);
     }
   else
 #endif
     {
       /* Otherwise, return it to the heap */
 
-      spin_unlock_irqrestore(NULL, flags);
+      spin_unlock_irqrestore(&g_locktimers, flags);
       kmm_free(timer);
     }
 }


### PR DESCRIPTION
## Summary
sched: remove all spin_lock_irqsave(NULL)

depends on https://github.com/apache/nuttx/pull/15413 https://github.com/apache/nuttx/pull/15414
## Impact

sched

## Testing

ci

