### PR TITLE
risc-v/qemu-rv: Initialize the userleds without late initialization

### DIFF
--- a/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
+++ b/boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_appinit.c
@@ -146,6 +146,16 @@ int board_app_initialize(uintptr_t arg)
   qemu_rptun_init();
 #endif
 
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  int ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+    }
+#endif
+
   return OK;
 #endif
 }


### PR DESCRIPTION
## Summary

* risc-v/qemu-rv: Initialize the userleds without late initialization

If `CONFIG_BOARD_LATE_INITIALIZE` is not selected, the userleds will not be initialized. The userled initialization is not required to be done within `board_late_initialize()`, thus this commit enables initializing it in `board_app_initialize()` too.

## Impact

Initialize the userleds even if `CONFIG_BOARD_LATE_INITIALIZE` is selected for `rv-virt` board. On the other hand, if `CONFIG_BOARD_LATE_INITIALIZE` is set, nothing changes.

## Testing

Internal CI testing + `rv-virt:netnsh`:

Build it with:
```
$ make -j distclean && ./tools/configure.sh rv-virt:netnsh && kconfig-tweak -e EXAMPLES_LEDS && kconfig-tweak -e USERLED && kconfig-tweak -e USERLED_LOWER && make olddefconfig && make -j$(nproc)
```

The userleds are not being initialized:

```
$ qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 8 \
  -global virtio-mmio.force-legacy=false \
  -device virtio-serial-device,bus=virtio-mmio-bus.0 \
  -chardev socket,telnet=on,host=127.0.0.1,port=3450,server=on,wait=off,id=foo \
  -device virtconsole,chardev=foo \
  -device virtio-rng-device,bus=virtio-mmio-bus.1 \
  -netdev user,id=u1,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23,hostfwd=tcp:127.0.0.1:15001-10.0.2.15:5001 \
  -device virtio-net-device,netdev=u1,bus=virtio-mmio-bus.2 \
  -drive file=./mydisk-1gb.img,if=none,format=raw,id=hd \
  -device virtio-blk-device,bus=virtio-mmio-bus.3,drive=hd \
  -bios none -kernel ./nuttx -nographic
telnetd [4:100]

NuttShell (NSH) NuttX-10.4.0
nsh> leds
leds_main: Starting the led_daemon
leds_main: led_daemon started

led_daemon (pid# 6): Running
led_daemon: Opening /dev/userleds
led_daemon: ERROR: Failed to open /dev/userleds: 2
led_daemon: Terminating
nsh>
```

After applying the proposed changes, the userleds are properly intitialized:
```
qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 8 \
  -global virtio-mmio.force-legacy=false \
  -device virtio-serial-device,bus=virtio-mmio-bus.0 \
  -chardev socket,telnet=on,host=127.0.0.1,port=3450,server=on,wait=off,id=foo \
  -device virtconsole,chardev=foo \
  -device virtio-rng-device,bus=virtio-mmio-bus.1 \
  -netdev user,id=u1,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23,hostfwd=tcp:127.0.0.1:15001-10.0.2.15:5001 \
  -device virtio-net-device,netdev=u1,bus=virtio-mmio-bus.2 \
  -drive file=./mydisk-1gb.img,if=none,format=raw,id=hd \
  -device virtio-blk-device,bus=virtio-mmio-bus.3,drive=hd \
  -bios none -kernel ./nuttx -nographic
telnetd [4:100]

NuttShell (NSH) NuttX-10.4.0
nsh> leds
leds_main: Starting the led_daemon
leds_main: led_daemon started

led_daemon (pid# 6): Running
led_daemon: Opening /dev/userleds
led_daemon: Supported LEDs 0x07
led_daemon: LED set 0x01
nsh> led_daemon: LED set 0x02
led_daemon: LED set 0x03
led_daemon: LED set 0x04
led_daemon: LED set 0x05
led_daemon: LED set 0x06
led_daemon: LED set 0x07
```