### PR TITLE
Fix Overlap Handling in sim_copyfullstate to Prevent Undefined Behavior

### DIFF
--- a/arch/sim/src/sim/sim_copyfullstate.c
+++ b/arch/sim/src/sim/sim_copyfullstate.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <string.h>
 #include <arch/irq.h>
 
 #include "sim_internal.h"
@@ -45,8 +46,6 @@
 
 void sim_copyfullstate(xcpt_reg_t *dest, xcpt_reg_t *src)
 {
-  int i;
-
   /* In the sim model, the state is copied from the stack to the TCB,
    * but only a reference is passed to get the state from the TCB.  So the
    * following check avoids copying the TCB save area onto itself:
@@ -54,9 +53,6 @@ void sim_copyfullstate(xcpt_reg_t *dest, xcpt_reg_t *src)
 
   if (src != dest)
     {
-      for (i = 0; i < XCPTCONTEXT_REGS; i++)
-        {
-          *dest++ = *src++;
-        }
+      memmove(dest, src, XCPTCONTEXT_REGS * sizeof(xcpt_reg_t));
     }
 }


### PR DESCRIPTION
## Summary

The current implementation of `sim_copyfullstate` uses a manual loop to copy memory from `src` to `dest`. This implementation does not account for cases where the `src` and `dest` memory regions overlap partially. In such cases, copying with the current method (*dest++ = *src++) can lead to undefined behavior as data in the source region may be overwritten before it is fully read.

## Impact

If `sim_savestate` is invoked with overlapping memory regions for `CURRENT_REGS` and `rtcb->xcp.regs`, the loop in `sim_copyfullstate` can corrupt the copied data. This might happen if `CURRENT_REGS` and `rtcb->xcp.regs` are adjacent or partially overlapping due to memory layout.

## Potential Fix

The PR proposes replacing the manual loop in `sim_copyfullstate` with a call to `memmove` which internally determines whether to copy forward or backward to prevent premature overwriting of source data.


