### PR TITLE
use small lock in following files

### DIFF
--- a/arch/arm/src/am335x/am335x_irq.c
+++ b/arch/arm/src/am335x/am335x_irq.c
@@ -29,12 +29,20 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "sctlr.h"
 
 #include "am335x_gpio.h"
 #include "am335x_irq.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+#ifdef CONFIG_ARCH_IRQPRIO
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Public Data
@@ -328,7 +336,7 @@ int up_prioritize_irq(int irq, int priority)
     {
       /* These operations must be atomic */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_irq_lock);
 
 #if 0 // TODO
       /* Set the new priority */
@@ -340,7 +348,7 @@ int up_prioritize_irq(int irq, int priority)
       putreg32(regval, regaddr);
 #endif
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_irq_lock, flags);
       return OK;
     }
 

--- a/arch/arm/src/am335x/am335x_serial.c
+++ b/arch/arm/src/am335x/am335x_serial.c
@@ -39,6 +39,7 @@
 #endif
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/serial/serial.h>
@@ -76,13 +77,14 @@
 
 struct up_dev_s
 {
-  uint32_t uartbase;  /* Base address of UART registers */
-  uint32_t baud;      /* Configured baud */
-  uint32_t ier;       /* Saved IER value */
-  uint8_t  irq;       /* IRQ associated with this UART */
-  uint8_t  parity;    /* 0=none, 1=odd, 2=even */
-  uint8_t  bits;      /* Number of bits (7 or 8) */
-  bool     stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+  uint32_t   uartbase;  /* Base address of UART registers */
+  uint32_t   baud;      /* Configured baud */
+  uint32_t   ier;       /* Saved IER value */
+  uint8_t    irq;       /* IRQ associated with this UART */
+  uint8_t    parity;    /* 0=none, 1=odd, 2=even */
+  uint8_t    bits;      /* Number of bits (7 or 8) */
+  bool       stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+  spinlock_t spinlock;  /* Spinlock */
 };
 
 /****************************************************************************
@@ -169,6 +171,7 @@ static struct up_dev_s g_uart0priv =
   .parity         = CONFIG_UART0_PARITY,
   .bits           = CONFIG_UART0_BITS,
   .stopbits2      = CONFIG_UART0_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart0port =
@@ -200,6 +203,7 @@ static struct up_dev_s g_uart1priv =
   .parity         = CONFIG_UART1_PARITY,
   .bits           = CONFIG_UART1_BITS,
   .stopbits2      = CONFIG_UART1_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart1port =
@@ -230,6 +234,7 @@ static struct up_dev_s g_uart2priv =
   .parity         = CONFIG_UART2_PARITY,
   .bits           = CONFIG_UART2_BITS,
   .stopbits2      = CONFIG_UART2_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart2port =
@@ -260,6 +265,7 @@ static struct up_dev_s g_uart3priv =
   .parity         = CONFIG_UART3_PARITY,
   .bits           = CONFIG_UART3_BITS,
   .stopbits2      = CONFIG_UART3_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart3port =
@@ -290,6 +296,7 @@ static struct up_dev_s g_uart4priv =
   .parity         = CONFIG_UART4_PARITY,
   .bits           = CONFIG_UART4_BITS,
   .stopbits2      = CONFIG_UART4_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart4port =
@@ -320,6 +327,7 @@ static struct up_dev_s g_uart5priv =
   .parity         = CONFIG_UART5_PARITY,
   .bits           = CONFIG_UART5_BITS,
   .stopbits2      = CONFIG_UART5_2STOP,
+  .spinlock       = SP_UNLOCKED,
 };
 
 static uart_dev_t g_uart5port =
@@ -484,6 +492,10 @@ static uart_dev_t g_uart5port =
 #  define UART5_ASSIGNED      1
 #endif
 
+/* Spinlock */
+
+static spinlock_t g_gpio_lock = SP_UNLOCKED;
+
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -567,7 +579,7 @@ static inline void am335x_uart0config(void)
 
   /* Step 1: Enable power to UART0 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking to UART0 */
@@ -577,7 +589,7 @@ static inline void am335x_uart0config(void)
 
   am335x_gpio_config(GPIO_UART0_TXD);
   am335x_gpio_config(GPIO_UART0_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -588,7 +600,7 @@ static inline void am335x_uart1config(void)
 
   /* Step 1: Enable power to UART1 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking to UART1 */
@@ -598,7 +610,7 @@ static inline void am335x_uart1config(void)
 
   am335x_gpio_config(GPIO_UART1_TXD);
   am335x_gpio_config(GPIO_UART1_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -609,7 +621,7 @@ static inline void am335x_uart2config(void)
 
   /* Step 1: Enable power to UART2 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking on UART2 */
@@ -619,7 +631,7 @@ static inline void am335x_uart2config(void)
 
   am335x_gpio_config(GPIO_UART2_TXD);
   am335x_gpio_config(GPIO_UART2_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -630,7 +642,7 @@ static inline void am335x_uart3config(void)
 
   /* Step 1: Enable power to UART3 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking to UART3 */
@@ -640,7 +652,7 @@ static inline void am335x_uart3config(void)
 
   am335x_gpio_config(GPIO_UART3_TXD);
   am335x_gpio_config(GPIO_UART3_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -651,7 +663,7 @@ static inline void am335x_uart4config(void)
 
   /* Step 1: Enable power to UART4 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking to UART4 */
@@ -661,7 +673,7 @@ static inline void am335x_uart4config(void)
 
   am335x_gpio_config(GPIO_UART4_TXD);
   am335x_gpio_config(GPIO_UART4_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -672,7 +684,7 @@ static inline void am335x_uart5config(void)
 
   /* Step 1: Enable power to UART5 */
 
-  flags   = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 #warning Missing logic
 
   /* Step 2: Enable clocking to UART5 */
@@ -682,7 +694,7 @@ static inline void am335x_uart5config(void)
 
   am335x_gpio_config(GPIO_UART5_TXD);
   am335x_gpio_config(GPIO_UART5_RXD);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 };
 #endif
 
@@ -1029,18 +1041,18 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
-        irqstate_t flags = enter_critical_section();
+        irqstate_t flags = spin_lock_irqsave(&priv->spinlock);
         up_enablebreaks(priv, true);
-        leave_critical_section(flags);
+        spin_unlock_irqrestore(&priv->spinlock, flags);
       }
       break;
 
     case TIOCCBRK:  /* BSD compatibility: Turn break off, unconditionally */
       {
         irqstate_t flags;
-        flags = enter_critical_section();
+        flags = spin_lock_irqsave(&priv->spinlock);
         up_enablebreaks(priv, false);
-        leave_critical_section(flags);
+        spin_unlock_irqrestore(&priv->spinlock, flags);
       }
       break;
 
@@ -1204,12 +1216,14 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
       priv->ier |= UART_IER_THR;
       up_serialout(priv, AM335X_UART_IER_OFFSET, priv->ier);
+
+      spin_unlock_irqrestore(&priv->spinlock, flags);
 
       /* Fake a TX interrupt here by just calling uart_xmitchars() with
        * interrupts disabled (note this may recurse).
@@ -1222,9 +1236,9 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~UART_IER_THR;
       up_serialout(priv, AM335X_UART_IER_OFFSET, priv->ier);
-    }
 
-  leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+    }
 }
 
 /****************************************************************************

--- a/arch/arm64/src/imx9/imx9_gpio.c
+++ b/arch/arm64/src/imx9/imx9_gpio.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <imx9_gpiobase.c>
 
@@ -44,6 +45,10 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/* Spinlock */
+
+static spinlock_t g_gpio_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Name: imx9_gpio_dirout
@@ -174,7 +179,7 @@ int imx9_config_gpio(gpio_pinset_t pinset)
 
   /* Configure the pin as an input initially to avoid any spurious outputs */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
 
   /* Configure based upon the pin mode */
 
@@ -223,7 +228,7 @@ int imx9_config_gpio(gpio_pinset_t pinset)
         break;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
   return ret;
 }
 
@@ -243,9 +248,9 @@ void imx9_gpio_write(gpio_pinset_t pinset, bool value)
 
   DEBUGASSERT((unsigned int)port < IMX9_GPIO_NPORTS);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
   imx9_gpio_setoutput(port, pin, value);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
 }
 
 /****************************************************************************
@@ -265,7 +270,7 @@ bool imx9_gpio_read(gpio_pinset_t pinset)
 
   DEBUGASSERT((unsigned int)port < IMX9_GPIO_NPORTS);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpio_lock);
   if ((pinset & (GPIO_OUTPUT)) == (GPIO_OUTPUT))
     {
       value = imx9_gpio_get_pinstatus(port, pin);
@@ -275,6 +280,6 @@ bool imx9_gpio_read(gpio_pinset_t pinset)
       value = imx9_gpio_getinput(port, pin);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpio_lock, flags);
   return value;
 }

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -2438,7 +2438,7 @@ int imx9_i2cbus_uninitialize(struct i2c_master_s *dev)
 
   if (--priv->refs > 0)
     {
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       return OK;
     }
 

--- a/arch/arm64/src/imx9/imx9_lpspi.c
+++ b/arch/arm64/src/imx9/imx9_lpspi.c
@@ -1798,8 +1798,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
 {
   struct imx9_lpspidev_s *priv = NULL;
 
-  irqstate_t flags = enter_critical_section();
-
 #ifdef CONFIG_IMX9_LPSPI1
   if (bus == 1)
     {
@@ -2017,7 +2015,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
   else
 #endif
     {
-      leave_critical_section(flags);
       spierr("ERROR: Unsupported SPI bus: %d\n", bus);
       return NULL;
     }
@@ -2061,7 +2058,6 @@ struct spi_dev_s *imx9_lpspibus_initialize(int bus)
     }
 #endif
 
-  leave_critical_section(flags);
   return (struct spi_dev_s *)priv;
 }
 

--- a/arch/arm64/src/imx9/imx9_usbdev.c
+++ b/arch/arm64/src/imx9/imx9_usbdev.c
@@ -2319,9 +2319,9 @@ static int imx9_epdisable(struct usbdev_ep_s *ep)
 
   /* Cancel any ongoing activity */
 
-  spin_unlock_irqrestore(&privep->spinlock, flags);
+  imx9_cancelrequests(privep, -ESHUTDOWN);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&privep->spinlock, flags);
   return OK;
 }
 

--- a/arch/x86_64/src/intel64/intel64_tsc_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tsc_tickless.c
@@ -57,6 +57,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/spinlock.h>
 
 #ifdef CONFIG_SCHED_TICKLESS
 
@@ -90,6 +91,7 @@ static uint32_t g_timer_active;
 
 static irqstate_t g_tmr_sync_count;
 static irqstate_t g_tmr_flags;
+static spinlock_t g_tmr_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -161,7 +163,7 @@ static inline void up_tmr_sync_up(void)
 {
   if (!g_tmr_sync_count)
     {
-      g_tmr_flags = enter_critical_section();
+      g_tmr_flags = spin_lock_irqsave(&g_tmr_lock);
     }
 
   g_tmr_sync_count++;
@@ -171,7 +173,7 @@ static inline void up_tmr_sync_down(void)
 {
   if (g_tmr_sync_count == 1)
     {
-      leave_critical_section(g_tmr_flags);
+      spin_unlock_irqrestore(&g_tmr_lock, g_tmr_flags);
     }
 
   if (g_tmr_sync_count > 0)


### PR DESCRIPTION
## Summary

### use small lock in following files:

arch/arm/src/am335x/am335x_can.c
arch/arm/src/am335x/am335x_gpio.c
arch/arm/src/am335x/am335x_i2c.c
arch/arm/src/am335x/am335x_irq.c
arch/arm/src/am335x/am335x_serial.c
arch/arm64/src/imx9/imx9_gpio.c
arch/arm64/src/imx9/imx9_lpi2c.c
arch/arm64/src/imx9/imx9_lpspi.c
arch/arm64/src/imx9/imx9_usbdev.c
arch/x86_64/src/intel64/intel64_tsc_tickless.c

## Impact


arch/arm/src/am335x/am335x_can.c
arch/arm/src/am335x/am335x_gpio.c
arch/arm/src/am335x/am335x_i2c.c
arch/arm/src/am335x/am335x_irq.c
arch/arm/src/am335x/am335x_serial.c
arch/arm64/src/imx9/imx9_gpio.c
arch/arm64/src/imx9/imx9_lpi2c.c
arch/arm64/src/imx9/imx9_lpspi.c
arch/arm64/src/imx9/imx9_usbdev.c
arch/x86_64/src/intel64/intel64_tsc_tickless.c

## Testing

CI


