### PR TITLE
use small lock to protect g_ram_vectors

### DIFF
--- a/arch/arm/src/armv6-m/arm_ramvec_attach.c
+++ b/arch/arm/src/armv6-m/arm_ramvec_attach.c
@@ -31,10 +31,17 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "ram_vectors.h"
 
 #ifdef CONFIG_ARCH_RAMVECTORS
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_ramvec_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -68,7 +75,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
        * common exception handler.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_ramvec_lock);
       if (vector == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might
@@ -87,7 +94,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
       /* Save the new vector in the vector table */
 
       g_ram_vectors[irq] = vector;
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_ramvec_lock, flags);
       ret = OK;
     }
 

--- a/arch/arm/src/armv7-m/arm_ramvec_attach.c
+++ b/arch/arm/src/armv7-m/arm_ramvec_attach.c
@@ -31,10 +31,17 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "ram_vectors.h"
 
 #ifdef CONFIG_ARCH_RAMVECTORS
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_ramvec_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -68,7 +75,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
        * common exception handler.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_ramvec_lock);
       if (vector == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might
@@ -87,7 +94,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
       /* Save the new vector in the vector table */
 
       g_ram_vectors[irq] = vector;
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_ramvec_lock, flags);
       ret = OK;
     }
 

--- a/arch/arm/src/armv8-m/arm_ramvec_attach.c
+++ b/arch/arm/src/armv8-m/arm_ramvec_attach.c
@@ -31,10 +31,17 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "ram_vectors.h"
 
 #ifdef CONFIG_ARCH_RAMVECTORS
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_ramvec_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -68,7 +75,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
        * common exception handler.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_ramvec_lock);
       if (vector == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might
@@ -87,7 +94,7 @@ int arm_ramvec_attach(int irq, up_vector_t vector)
       /* Save the new vector in the vector table */
 
       g_ram_vectors[irq] = vector;
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_ramvec_lock, flags);
       ret = OK;
     }
 


### PR DESCRIPTION
## Summary
use small lock to protect g_ram_vectors,  involving armv6-m, armv7-m, armv8-m.


## Impact
arch/arm/src/armv6-m/arm_ramvec_attach.c
arch/arm/src/armv7-m/arm_ramvec_attach.c
arch/arm/src/armv8-m/arm_ramvec_attach.c


## Testing

CI


