### PR TITLE
xtensa/esp32s3: set cpuint to initial value after deallocate

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wdt.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt.c
@@ -774,6 +774,7 @@ static int32_t wdt_setisr(struct esp32s3_wdt_dev_s *dev, xcpt_t handler,
               up_disable_irq(wdt->irq);
               esp32s3_teardown_irq(wdt->cpu, wdt->periph, wdt->cpuint);
               irq_detach(wdt->irq);
+              wdt->cpuint = -ENOMEM;
             }
         }
 


### PR DESCRIPTION
## Summary

cpuint was allocated when register wdt handler, but not deallocated when unregister, which cause debug assert when checking DEBUGASSERT((*freeints & bitmask) == 0), so set cpuint to initial value after deallocate.

## Impact

Impact watchdog handler register/unregister.

## Testing

Test with running below test case WDTExceptionTest1() and WDTExceptionTest2() .

```
static void WDTExceptionTest1(void) {
  // WDT Open
  printf("---------- open ----------\n");
  int wdt_handle = open("/dev/watchdog0", O_RDONLY);  // open
  if (wdt_handle < 0) {
    printf("open error. errno=%d\n", errno);
    return -1;
  }

  // Set timeout
  printf("---------- set timeout ----------\n");
  unsigned long msec = 40 * 1000;  // 40 sec
  int ret = ioctl(wdt_handle, WDIOC_SETTIMEOUT, msec);
  if (ret < 0) {
    printf("SetTimeout error. errno=%d\n", errno);
    return -1;
  }

  // WDT Register
  printf("---------- regiter irq ----------\n");
  struct watchdog_capture_s wdt_cap_reg = {
    .newhandler = (void *)SampleHandler,
    .oldhandler = NULL,
  };
  ret = ioctl(wdt_handle, WDIOC_CAPTURE, &wdt_cap_reg);
  if (ret < 0) {
    printf("Registered error. errno=%d\n", errno);
    return -1;
  }

  // WDT Start
  printf("---------- start ----------\n");
  ret = ioctl(wdt_handle, WDIOC_START, 0);
  if (ret < 0) {
    printf("Start error. errno=%d\n", errno);
    return -1;
  }

  // WDT Stop
  printf("---------- stop ----------\n");
  ret = ioctl(wdt_handle, WDIOC_STOP, 0);
  if (ret < 0) {
    printf("Stop error. errno=%d\n", errno);
    return -1;
  }

  // WDT Close
  printf("---------- close ----------\n");
  ret = close(wdt_handle);
  if (ret < 0) {
    printf("Close error. errno=%d", errno);
    return -1;
  }
}

static void WDTExceptionTest2(void) {
  // WDT Open
  printf("---------- open ----------\n");
  int wdt_handle = open("/dev/watchdog0", O_RDONLY);  // open
  if (wdt_handle < 0) {
    printf("open error. errno=%d\n", errno);
    return -1;
  }

  // Set timeout
  printf("---------- set timeout ----------\n");
  unsigned long msec = 40 * 1000;  // 40 sec
  int ret = ioctl(wdt_handle, WDIOC_SETTIMEOUT, msec);
  if (ret < 0) {
    printf("SetTimeout error. errno=%d\n", errno);
    return -1;
  }

  // WDT Register
  printf("---------- regiter irq ----------\n");
  struct watchdog_capture_s wdt_cap_reg = {
    .newhandler = (void *)SampleHandler,
    .oldhandler = NULL,
  };
  ret = ioctl(wdt_handle, WDIOC_CAPTURE, &wdt_cap_reg);
  if (ret < 0) {
    printf("Registered error. errno=%d\n", errno);
    return -1;
  }

  // WDT Unregister
  printf("---------- unregister irq ----------\n");
  struct watchdog_capture_s wdt_cap_unreg = {
    .newhandler = NULL,
    .oldhandler = (void *)SampleHandler,
  };
  ret = ioctl(wdt_handle, WDIOC_CAPTURE, &wdt_cap_unreg);
  if (ret < 0) {
    printf("Unregistered error. errno=%d\n", errno);
    return -1;
  }

  // WDT Close
  printf("---------- close ----------\n");
  ret = close(wdt_handle);
  if (ret < 0) {
    printf("Close error. errno=%d", errno);
    return -1;
  }
}
```

