### PR TITLE
arch/esp32s3_wdt: ESP32-S3 WDT1 clock init

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_tim.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tim.c
@@ -39,6 +39,7 @@
 
 #include "soc/periph_defs.h"
 #include "esp_private/periph_ctrl.h"
+#include "hardware/esp32s3_system.h"
 
 /****************************************************************************
  * Private Types
@@ -937,6 +938,8 @@ struct esp32s3_tim_dev_s *esp32s3_tim_init(int timer)
       case ESP32S3_TIMER0:
         {
           tim = &g_esp32s3_tim0_priv;
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0, SYSTEM_TIMERGROUP_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP_RST_M, 0);
           break;
         }
 #endif
@@ -945,6 +948,9 @@ struct esp32s3_tim_dev_s *esp32s3_tim_init(int timer)
       case ESP32S3_TIMER1:
         {
           tim = &g_esp32s3_tim1_priv;
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0,
+                      SYSTEM_TIMERGROUP1_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP1_RST_M, 0);
           break;
         }
 #endif

--- a/arch/xtensa/src/esp32s3/esp32s3_wdt.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt.c
@@ -33,6 +33,7 @@
 #include "hardware/esp32s3_rtccntl.h"
 #include "hardware/esp32s3_tim.h"
 #include "hardware/esp32s3_efuse.h"
+#include "hardware/esp32s3_system.h"
 
 #include "esp32s3_irq.h"
 #include "esp32s3_rtc_gpio.h"
@@ -990,6 +991,8 @@ struct esp32s3_wdt_dev_s *esp32s3_wdt_init(enum esp32s3_wdt_inst_e wdt_id)
       case ESP32S3_WDT_MWDT0:
         {
           wdt = &g_esp32s3_mwdt0_priv;
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0, SYSTEM_TIMERGROUP_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP_RST_M, 0);
           break;
         }
 
@@ -999,6 +1002,9 @@ struct esp32s3_wdt_dev_s *esp32s3_wdt_init(enum esp32s3_wdt_inst_e wdt_id)
       case ESP32S3_WDT_MWDT1:
         {
           wdt = &g_esp32s3_mwdt1_priv;
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0,
+                      SYSTEM_TIMERGROUP1_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP1_RST_M, 0);
           break;
         }
 #endif


### PR DESCRIPTION
## Summary
arch/esp32s3_wdt: ESP32-S3 WDT & TIMER  adds clock enable and reset operations in the initial section

## Impact
Only esp32s3 TIMERGROUP0 & 1
## Testing
Enable esp32s3 wdt & timer


