### PR TITLE
boards/xtensa: unify linker script for MCUBoot and Simple Boot

### DIFF
--- a/boards/xtensa/esp32/common/scripts/esp32_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/esp32_sections.ld
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/xtensa/esp32s2/common/scripts/simple_boot_sections.ld
+ * boards/xtensa/esp32/common/scripts/simple_boot_sections.ld
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,13 +28,44 @@ ENTRY(__start);
 
 SECTIONS
 {
+#ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
+  .metadata :
+  {
+    /* Magic for load header */
+
+    LONG(0xace637d3)
+
+    /* Application entry point address */
+
+    KEEP(*(.entry_addr))
+
+    /* IRAM metadata:
+     * - Destination address (VMA) for IRAM region
+     * - Flash offset (LMA) for start of IRAM region
+     * - Size of IRAM region
+     */
+
+    LONG(ADDR(.iram0.vectors))
+    LONG(LOADADDR(.iram0.vectors))
+    LONG(LOADADDR(.iram0.text) + SIZEOF(.iram0.text) - LOADADDR(.iram0.vectors))
+
+    /* DRAM metadata:
+     * - Destination address (VMA) for DRAM region
+     * - Flash offset (LMA) for start of DRAM region
+     * - Size of DRAM region
+     */
+
+    LONG(ADDR(.dram0.data))
+    LONG(LOADADDR(.dram0.data))
+    LONG(SIZEOF(.dram0.data))
+  } >metadata
+#endif
+
   /* Send .iram0 code to iram */
 
-  .iram0.vectors : ALIGN(4)
+  .iram0.vectors :
   {
-    _iram_start = ABSOLUTE(.);
-
-    /* Vectors go to IRAM. */
+    /* Vectors go to IRAM */
 
     _init_start = ABSOLUTE(.);
 
@@ -74,27 +105,26 @@ SECTIONS
   {
     /* Code marked as running out of IRAM */
 
+    _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
-    . = ALIGN (4);
-    esp32s2_start.*(.literal .text .literal.* .text.*)
-    esp32s2_region.*(.text .text.* .literal .literal.*)
-
+    esp32_start.*(.literal .text .literal.* .text.*)
+    *libphy.a:(.literal .text .literal.* .text.*)
+    *librtc.a:(.literal .text .literal.* .text.*)
+    *libpp.a:(.literal .text .literal.* .text.*)
+    *libhal.a:(.literal .text .literal.* .text.*)
     *libarch.a:*esp_loader.*(.literal .text .literal.* .text.*)
     *libarch.a:*brownout_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu.*(.text .text.* .literal .literal.*)
     *libarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*periph_ctrl.*(.text .text.* .literal .literal.*)
     *libarch.a:*clk.*(.text .text.* .literal .literal.*)
-    *libarch.a:*efuse_hal.*(.literal.is_eco0 .text.is_eco0)
     *libarch.a:*efuse_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk_tree.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk_tree_common.*(.text .text.* .literal .literal.*)
     *libarch.a:*clk_tree_hal.*(.text .text.* .literal .literal.*)
-    *libarch.a:*rtc_init.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_clk.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_clk_init.*(.text .text.* .literal .literal.*)
-    *libarch.a:*rtc_sleep.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_time.*(.text .text.* .literal .literal.*)
     *libarch.a:*regi2c_ctrl.*(.text .text.* .literal .literal.*)
     *libarch.a:*uart_hal_iram.*(.text .text.* .literal .literal.*)
@@ -105,9 +135,9 @@ SECTIONS
     *libarch.a:*bootloader_common_loader.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_console.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_console_loader.*(.text .text.* .literal .literal.*)
-    *libarch.a:*bootloader_esp32s2.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_esp32.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_flash.*(.text .text.* .literal .literal.*)
-    *libarch.a:*bootloader_flash_config_esp32s2.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_flash_config_esp32.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_clock_init.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_clock_loader.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_efuse.*(.text .text.* .literal .literal.*)
@@ -116,12 +146,10 @@ SECTIONS
     *libarch.a:*bootloader_random.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
     *libarch.a:*bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libarch.a:*bootloader_random_esp32s2.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_random_esp32.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_image_format.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_soc.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_sha.*(.text .text.* .literal .literal.*)
-    *libarch.a:*flash_encrypt.*(.text .text.* .literal .literal.*)
-    *libarch.a:*cache_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*uart_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*mpu_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*mmu_hal.*(.text .text.* .literal .literal.*)
@@ -129,7 +157,6 @@ SECTIONS
     *libarch.a:*esp_rom_uart.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_sys.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_spiflash.*(.text .text.* .literal .literal.*)
-    *libarch.a:*esp_rom_cache_esp32s2_esp32s3.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_wdt.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_efuse_fields.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_efuse_api_key.*(.text .text.* .literal .literal.*)
@@ -137,39 +164,71 @@ SECTIONS
     *libarch.a:*log_noos.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu_region_protect.*(.text .text.* .literal .literal.*)
 
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.literal .text .literal.* .text.*)
+#endif
+    *libarch.a:esp32_cpuindex.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32_irq.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32_spicache.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32_user.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_assert.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_cpuint.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_irqdispatch.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_modifyreg32.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_saveusercontext.*(.literal .text .literal.* .text.*)
+    *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
+
+    *libc.a:lib_assert.*(.literal .text .literal.* .text.*)
+    *libc.a:lib_utsname.*(.literal .text .literal.* .text.*)
     *libc.a:sq_remlast.*(.literal .text .literal.* .text.*)
+
+    *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
+
+    *libsched.a:assert.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_csection.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_dispatch.*(.literal .text .literal.* .text.*)
+    *libsched.a:irq_spinlock.*(.literal .text .literal.* .text.*)
+    *libsched.a:panic_notifier.*(.literal.panic_notifier_call_chain .text.panic_notifier_call_chain)
+    *libsched.a:sched_gettcb.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_lock.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_note.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
+    *libsched.a:sched_unlock.*(.literal .text .literal.* .text.*)
+    *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
+
     *(.wifirxiram .wifirxiram.*)
-    *(.wifi0iram  .wifi0iram.*)
+    *(.wifi0iram .wifi0iram.*)
     *(.wifiorslpiram .wifiorslpiram.*)
     *(.wifislpiram .wifislpiram.*)
     *(.wifislprxiram .wifislprxiram.*)
     *(.phyiram .phyiram.*)
-    *(.wifiextrairam .wifiextrairam.*)
-
-    /* align + add 16B for CPU dummy speculative instr. fetch */
 
     . = ALIGN(4) + 16;
-    _iram_text = ABSOLUTE(.);
+
+    _iram_text_end = ABSOLUTE(.);
+
+    /* IRAM heap starts at the end of iram0_0_seg */
+
+    . = ALIGN (4);
+    _siramheap = ABSOLUTE(.);
   } >iram0_0_seg AT>ROM
 
-  /* Marks the end of IRAM code segment */
+  /* Shared RAM */
 
-  .iram0.text_end (NOLOAD) :
+  .noinit (NOLOAD):
   {
-    . = ALIGN (4);
-    _iram_end = ABSOLUTE(.);
-  } >iram0_0_seg
-
-  .dram0.dummy (NOLOAD):
-  {
-    /* This section is required to skip .iram0.text area because iram0_0_seg
-     * and dram0_0_seg reflect the same address space on different buses.
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
      */
 
-    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
+    . = ALIGN(8);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(8);
   } >dram0_0_seg
-
-  /* Shared RAM */
 
   .dram0.bss (NOLOAD) :
   {
@@ -178,6 +237,40 @@ SECTIONS
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
     _sbss = ABSOLUTE(.);
+    *(EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) .bss EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) .bss.*)
+    *(.ext_ram.bss*)
+    *(EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) COMMON)
+    . = ALIGN(4);
+    _bt_controller_bss_start = ABSOLUTE(.);
+    *libble_app.a:(.bss .bss.*)
+    . = ALIGN(4);
+    _bt_controller_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_controller_common_start = ABSOLUTE(.);
+    *libble_app.a:(COMMON)
+    . = ALIGN(4);
+    _bt_controller_common_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_bss_start = ABSOLUTE(.);
+    *libbt.a:(.bss .bss.*)
+    . = ALIGN(4);
+    _bt_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_common_start = ABSOLUTE(.);
+    *libbt.a:(COMMON)
+    . = ALIGN(4);
+    _bt_common_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _btdm_bss_start = ABSOLUTE(.);
+    *libbtdm_app.a:(.bss .bss.*)
+    . = ALIGN(4);
+    _btdm_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _btdm_common_start = ABSOLUTE(.);
+    *libbtdm_app.a:(COMMON)
+    . = ALIGN(4);
+    _btdm_common_end = ABSOLUTE(.);
+    . = ALIGN (8);
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -192,29 +285,42 @@ SECTIONS
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.bss  .bss.*  COMMON)
+#endif
+    *libarch.a:esp32_spicache.*(.bss  .bss.*  COMMON)
+    *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
+    *libarch.a:xtensa_cpupause.*(.bss  .bss.*  COMMON)
+    *libarch.a:xtensa_copystate.*(.bss  .bss.*  COMMON)
+    *libarch.a:xtensa_interruptcontext.*(.bss  .bss.*  COMMON)
+    *libarch.a:xtensa_testset.*(.bss  .bss.*  COMMON)
+
+    *libsched.a:sched_suspendscheduler.*(.bss  .bss.*  COMMON)
+    *libsched.a:sched_thistask.*(.bss  .bss.*  COMMON)
+    *libsched.a:sched_note.*(.bss  .bss.*  COMMON)
+    *libsched.a:spinlock.*(.bss  .bss.*  COMMON)
+    *libsched.a:irq_csection.*(.bss  .bss.*  COMMON)
+    *libsched.a:irq_dispatch.*(.bss  .bss.*  COMMON)
+
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
   } >dram0_0_seg
 
-  .noinit (NOLOAD):
-  {
-    /* This section contains data that is not initialized during load,
-     * or during the application's initialization sequence.
-     */
-
-    . = ALIGN(4);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN(4);
-  } >dram0_0_seg
-
-  .dram0.data : ALIGN(4)
+  .dram0.data :
   {
     /* .data initialized on power-up in ROMed configurations. */
 
-    _data_start = ABSOLUTE(.);
     _sdata = ABSOLUTE(.);
+    _data_start = ABSOLUTE(.);
+    _bt_data_start = ABSOLUTE(.);
+    *libbt.a:(.data .data.*)
+    . = ALIGN (4);
+    _bt_data_end = ABSOLUTE(.);
+    _btdm_data_start = ABSOLUTE(.);
+    *libbtdm_app.a:(.data .data.*)
+    . = ALIGN (4);
+    _btdm_data_end = ABSOLUTE(.);
     KEEP (*(.data))
     KEEP (*(.data.*))
     KEEP (*(.gnu.linkonce.d.*))
@@ -227,9 +333,27 @@ SECTIONS
     KEEP (*(.gnu.linkonce.s2.*))
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
-    esp32s2_start.*(.rodata .rodata.*)
-    esp32s2_region.*(.rodata .rodata.*)
+    esp32_start.*(.rodata  .rodata.*)
+    *libphy.a:(.rodata  .rodata.*)
+#ifdef CONFIG_STACK_CANARIES
+    *libc.a:lib_stackchk.*(.rodata  .rodata.*)
+#endif
+    *libarch.a:xtensa_context.*(.rodata  .rodata.*)
+    *libarch.a:xtensa_copystate.*(.rodata  .rodata.*)
+    *libarch.a:xtensa_cpupause.*(.rodata  .rodata.*)
+    *libarch.a:xtensa_testset.*(.rodata  .rodata.*)
 
+    *libdrivers.a:syslog_channel.*(.rodata  .rodata.*)
+
+    *libsched.a:sched_suspendscheduler.*(.rodata  .rodata.*)
+    *libsched.a:sched_thistask.*(.rodata  .rodata.*)
+    *libsched.a:sched_note.*(.rodata  .rodata.*)
+    *libsched.a:spinlock.*(.rodata  .rodata.*)
+    *libsched.a:irq_csection.*(.rodata  .rodata.*)
+    *libsched.a:irq_dispatch.*(.rodata  .rodata.*)
+
+    *libarch.a:esp32_spicache.*(.rodata  .rodata.*)
+    *libarch.a:esp32_spiflash.*(.rodata  .rodata.*)
     *libarch.a:*esp_loader.*(.rodata .rodata.*)
     *libarch.a:*brownout.*(.rodata .rodata.*)
     *libarch.a:*cpu.*(.rodata .rodata.*)
@@ -243,7 +367,6 @@ SECTIONS
     *libarch.a:*rtc_init.*(.rodata .rodata.*)
     *libarch.a:*rtc_clk.*(.rodata .rodata.*)
     *libarch.a:*rtc_clk_init.*(.rodata .rodata.*)
-    *libarch.a:*rtc_sleep.*(.rodata .rodata.*)
     *libarch.a:*rtc_time.*(.rodata .rodata.*)
     *libarch.a:*regi2c_ctrl.*(.rodata .rodata.*)
     *libarch.a:*uart_hal_iram.*(.rodata .rodata.*)
@@ -254,39 +377,37 @@ SECTIONS
     *libarch.a:*bootloader_common_loader.*(.rodata .rodata.*)
     *libarch.a:*bootloader_console.*(.rodata .rodata.*)
     *libarch.a:*bootloader_console_loader.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_esp32s2.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_esp32.*(.rodata .rodata.*)
     *libarch.a:*bootloader_flash.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_flash_config_esp32s2.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_flash_config_esp32.*(.rodata .rodata.*)
     *libarch.a:*bootloader_clock_init.*(.rodata .rodata.*)
     *libarch.a:*bootloader_clock_loader.*(.rodata .rodata.*)
     *libarch.a:*bootloader_efuse.*(.rodata .rodata.*)
     *libarch.a:*bootloader_panic.*(.rodata .rodata.*)
     *libarch.a:*bootloader_mem.*(.rodata .rodata.*)
     *libarch.a:*bootloader_random.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_random_esp32s2.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_random_esp32.*(.rodata .rodata.*)
     *libarch.a:*esp_image_format.*(.rodata .rodata.*)
     *libarch.a:*bootloader_soc.*(.rodata .rodata.*)
     *libarch.a:*bootloader_sha.*(.rodata .rodata.*)
-    *libarch.a:*flash_encrypt.*(.rodata .rodata.*)
-    *libarch.a:*cache_hal.*(.rodata .rodata.*)
     *libarch.a:*uart_hal.*(.rodata .rodata.*)
     *libarch.a:*mpu_hal.*(.rodata .rodata.*)
     *libarch.a:*mmu_hal.*(.rodata .rodata.*)
+    *libarch.a:*efuse_hal.*(.rodata .rodata.*)
     *libarch.a:*uart_periph.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_uart.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_sys.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_spiflash.*(.rodata .rodata.*)
-    *libarch.a:*esp_rom_cache_esp32s2_esp32s3.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_wdt.*(.rodata .rodata.*)
     *libarch.a:*esp_efuse_fields.*(.rodata .rodata.*)
     *libarch.a:*esp_efuse_api_key.*(.rodata .rodata.*)
     *libarch.a:*log.*(.rodata .rodata.*)
     *libarch.a:*log_noos.*(.rodata .rodata.*)
     *libarch.a:*cpu_region_protect.*(.rodata .rodata.*)
-
-    . = ALIGN(4);
     _edata = ABSOLUTE(.);
     _data_end = ABSOLUTE(.);
+
+    . = ALIGN(4);
 
     /* Heap starts at the end of .data */
 
@@ -308,40 +429,49 @@ SECTIONS
    * be equal.
    */
 
+#ifndef CONFIG_ESP32_APP_FORMAT_MCUBOOT
   .flash.rodata_dummy (NOLOAD) :
   {
     . = ALIGN(0x10000);
   } > ROM
+#endif
 
-  .flash.rodata :
+  .flash.rodata : ALIGN(0x10000)
   {
     _rodata_reserved_start = ABSOLUTE(.);
-
+    . = ALIGN(4);
     _srodata = ABSOLUTE(.);
-    *(EXCLUDE_FILE (esp32s2_start.*) .rodata)
-    *(EXCLUDE_FILE (esp32s2_start.*) .rodata.*)
-
+    *(EXCLUDE_FILE (*libarch.a:esp32_spiflash.* esp32_start.*
+                    *libarch.a:*esp_loader.*
+                    *libarch.a:*uart_hal.*
+                    *libarch.a:*mmu_hal.*
+                    ) .rodata)
+    *(EXCLUDE_FILE (*libarch.a:esp32_spiflash.* esp32_start.*
+                    *libarch.a:*esp_loader.*
+                    *libarch.a:*uart_hal.*
+                    *libarch.a:*mmu_hal.*
+                    ) .rodata.*)
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
-
-#ifdef CONFIG_ESPRESSIF_WIRELESS
+#ifdef CONFIG_ESP32_WIRELESS
     *(.rodata_wlog_verbose.*)
     *(.rodata_wlog_debug.*)
     *(.rodata_wlog_info.*)
     *(.rodata_wlog_warning.*)
     *(.rodata_wlog_error.*)
 #endif
-
     *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.gnu.linkonce.r.*)
     *(.rodata1)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
-    *(.gcc_except_table .gcc_except_table.*)
+    *(.gcc_except_table)
+    *(.gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
-    KEEP(*(.eh_frame))
+    *(.eh_frame)
+
     . = (. + 3) & ~ 3;
 
     /* C++ constructor and destructor tables, properly ordered: */
@@ -366,16 +496,22 @@ SECTIONS
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
+
+    /* Addresses of memory regions reserved via SOC_RESERVE_MEMORY_REGION() */
+
+    soc_reserved_memory_region_start = ABSOLUTE(.);
+    KEEP (*(.reserved_memory_address))
+    soc_reserved_memory_region_end = ABSOLUTE(.);
+
     . = ALIGN(4);               /* This table MUST be 4-byte aligned */
     _erodata = ABSOLUTE(.);
-
     /* Literals are also RO data. */
-
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)
     *(.lit4.*)
     *(.gnu.linkonce.lit4.*)
     _lit4_end = ABSOLUTE(.);
+
     /* TLS data. */
 
     . = ALIGN(4);
@@ -409,27 +545,48 @@ SECTIONS
    * be equal.
    */
 
+#ifndef CONFIG_ESP32_APP_FORMAT_MCUBOOT
   .flash.text_dummy (NOLOAD) :
   {
     . += SIZEOF(.flash.rodata);
     . = ALIGN(0x10000);
   } >default_code_seg AT> ROM
+#endif
 
-  .flash.text :
+  .flash.text : ALIGN(0x00010000)
   {
     _stext = .;
-
+    _text_start = ABSOLUTE(.);
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)
+
+    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifi0iram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifi0iram.*)
+    *(.wifiextrairam .wifiextrairam.*)
+    *(EXCLUDE_FILE(*libpp.a) .wifiorslpiram EXCLUDE_FILE(*libpp.a) .wifiorslpiram.*)
+    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifirxiram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifirxiram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifislprxiram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifislprxiram.*)
+
     . = ALIGN(4);
 
     . += 16;
 
+    _text_end = ABSOLUTE(.);
     _etext = .;
   } >default_code_seg AT>ROM
+
+  /* External memory bss, from any global variable with EXT_RAM_ATTR attribute */
+
+  .extmem.bss (NOLOAD) :
+  {
+    _sbss_extmem = ABSOLUTE(.);
+    *(.extmem.bss .extmem.bss.*)
+    . = ALIGN(4);
+    _ebss_extmem = ABSOLUTE(.);
+  } >extmem_seg
 
   .rtc.text :
   {
@@ -437,25 +594,8 @@ SECTIONS
     *(.rtc.literal .rtc.text)
   } >rtc_iram_seg AT>ROM
 
-  .rtc.dummy (NOLOAD) :
-  {
-    /* This section is required to skip .rtc.text area because the text and
-     * data segments reflect the same address space on different buses.
-     */
-
-    . = SIZEOF(.rtc.text);
-  } >rtc_data_seg
-
-  /* RTC BSS section. */
-
-  .rtc.bss (NOLOAD) :
-  {
-    *(.rtc.bss)
-  } >rtc_slow_seg
-
   .rtc.data :
   {
-    . = ALIGN(4);
     *(.rtc.data)
     *(.rtc.data.*)
     *(.rtc.rodata)

--- a/boards/xtensa/esp32/esp32-2432S028/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-2432S028/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-audio-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-audio-kit/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-lyrat/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-lyrat/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-pico-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-pico-kit/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-sparrow-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-sparrow-kit/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/lilygo_tbeam_lora_gps/scripts/Make.defs
+++ b/boards/xtensa/esp32/lilygo_tbeam_lora_gps/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/ttgo_eink5_v2/scripts/Make.defs
+++ b/boards/xtensa/esp32/ttgo_eink5_v2/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32/ttgo_t_display_esp32/scripts/Make.defs
+++ b/boards/xtensa/esp32/ttgo_t_display_esp32/scripts/Make.defs
@@ -34,12 +34,10 @@ ifeq ($(CONFIG_BUILD_PROTECTED),y)
 else
   ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
 
-  ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-  else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-    ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-  else
+  ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
     ARCHSCRIPT += $(call FINDSCRIPT,legacy_sections.ld)
+  else
+    ARCHSCRIPT += $(call FINDSCRIPT,esp32_sections.ld)
   endif
 endif
 

--- a/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/xtensa/esp32/common/scripts/simple_boot_sections.ld
+ * boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -28,11 +28,46 @@ ENTRY(__start);
 
 SECTIONS
 {
+#ifdef CONFIG_ESP32S2_APP_FORMAT_MCUBOOT
+  .metadata :
+  {
+    /* Magic for load header */
+
+    LONG(0xace637d3)
+
+    /* Application entry point address */
+
+    KEEP(*(.entry_addr))
+
+    /* IRAM metadata:
+     * - Destination address (VMA) for IRAM region
+     * - Flash offset (LMA) for start of IRAM region
+     * - Size of IRAM region
+     */
+
+    LONG(ADDR(.iram0.vectors))
+    LONG(LOADADDR(.iram0.vectors))
+    LONG(LOADADDR(.iram0.text) + SIZEOF(.iram0.text) - LOADADDR(.iram0.vectors))
+
+    /* DRAM metadata:
+     * - Destination address (VMA) for DRAM region
+     * - Flash offset (LMA) for start of DRAM region
+     * - Size of DRAM region
+     */
+
+    LONG(ADDR(.dram0.data))
+    LONG(LOADADDR(.dram0.data))
+    LONG(SIZEOF(.dram0.data))
+  } >metadata
+#endif
+
   /* Send .iram0 code to iram */
 
-  .iram0.vectors :
+  .iram0.vectors : ALIGN(4)
   {
-    /* Vectors go to IRAM */
+    _iram_start = ABSOLUTE(.);
+
+    /* Vectors go to IRAM. */
 
     _init_start = ABSOLUTE(.);
 
@@ -72,26 +107,28 @@ SECTIONS
   {
     /* Code marked as running out of IRAM */
 
-    _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
-    esp32_start.*(.literal .text .literal.* .text.*)
-    *libphy.a:(.literal .text .literal.* .text.*)
-    *librtc.a:(.literal .text .literal.* .text.*)
-    *libpp.a:(.literal .text .literal.* .text.*)
-    *libhal.a:(.literal .text .literal.* .text.*)
+    . = ALIGN (4);
+    esp32s2_start.*(.literal .text .literal.* .text.*)
+    esp32s2_region.*(.text .text.* .literal .literal.*)
+
     *libarch.a:*esp_loader.*(.literal .text .literal.* .text.*)
+    *libarch.a:esp32s2_spiflash.*(.literal .text .literal.* .text.*)
     *libarch.a:*brownout_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu.*(.text .text.* .literal .literal.*)
     *libarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*periph_ctrl.*(.text .text.* .literal .literal.*)
     *libarch.a:*clk.*(.text .text.* .literal .literal.*)
+    *libarch.a:*efuse_hal.*(.literal.is_eco0 .text.is_eco0)
     *libarch.a:*efuse_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk_tree.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_clk_tree_common.*(.text .text.* .literal .literal.*)
     *libarch.a:*clk_tree_hal.*(.text .text.* .literal .literal.*)
+    *libarch.a:*rtc_init.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_clk.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_clk_init.*(.text .text.* .literal .literal.*)
+    *libarch.a:*rtc_sleep.*(.text .text.* .literal .literal.*)
     *libarch.a:*rtc_time.*(.text .text.* .literal .literal.*)
     *libarch.a:*regi2c_ctrl.*(.text .text.* .literal .literal.*)
     *libarch.a:*uart_hal_iram.*(.text .text.* .literal .literal.*)
@@ -102,9 +139,9 @@ SECTIONS
     *libarch.a:*bootloader_common_loader.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_console.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_console_loader.*(.text .text.* .literal .literal.*)
-    *libarch.a:*bootloader_esp32.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_esp32s2.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_flash.*(.text .text.* .literal .literal.*)
-    *libarch.a:*bootloader_flash_config_esp32.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_flash_config_esp32s2.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_clock_init.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_clock_loader.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_efuse.*(.text .text.* .literal .literal.*)
@@ -113,10 +150,12 @@ SECTIONS
     *libarch.a:*bootloader_random.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
     *libarch.a:*bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
-    *libarch.a:*bootloader_random_esp32.*(.text .text.* .literal .literal.*)
+    *libarch.a:*bootloader_random_esp32s2.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_image_format.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_soc.*(.text .text.* .literal .literal.*)
     *libarch.a:*bootloader_sha.*(.text .text.* .literal .literal.*)
+    *libarch.a:*flash_encrypt.*(.text .text.* .literal .literal.*)
+    *libarch.a:*cache_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*uart_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*mpu_hal.*(.text .text.* .literal .literal.*)
     *libarch.a:*mmu_hal.*(.text .text.* .literal .literal.*)
@@ -124,6 +163,7 @@ SECTIONS
     *libarch.a:*esp_rom_uart.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_sys.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_spiflash.*(.text .text.* .literal .literal.*)
+    *libarch.a:*esp_rom_cache_esp32s2_esp32s3.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_rom_wdt.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_efuse_fields.*(.text .text.* .literal .literal.*)
     *libarch.a:*esp_efuse_api_key.*(.text .text.* .literal .literal.*)
@@ -131,71 +171,39 @@ SECTIONS
     *libarch.a:*log_noos.*(.text .text.* .literal .literal.*)
     *libarch.a:*cpu_region_protect.*(.text .text.* .literal .literal.*)
 
-#ifdef CONFIG_STACK_CANARIES
-    *libc.a:lib_stackchk.*(.literal .text .literal.* .text.*)
-#endif
-    *libarch.a:esp32_cpuindex.*(.literal .text .literal.* .text.*)
-    *libarch.a:esp32_irq.*(.literal .text .literal.* .text.*)
-    *libarch.a:esp32_spicache.*(.literal .text .literal.* .text.*)
-    *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
-    *libarch.a:esp32_user.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_assert.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_cpuint.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_cpupause.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_irqdispatch.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_modifyreg32.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_saveusercontext.*(.literal .text .literal.* .text.*)
-    *libarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
-
-    *libc.a:lib_assert.*(.literal .text .literal.* .text.*)
-    *libc.a:lib_utsname.*(.literal .text .literal.* .text.*)
     *libc.a:sq_remlast.*(.literal .text .literal.* .text.*)
-
-    *libdrivers.a:syslog_flush.*(.literal .text .literal.* .text.*)
-
-    *libsched.a:assert.*(.literal .text .literal.* .text.*)
-    *libsched.a:irq_csection.*(.literal .text .literal.* .text.*)
-    *libsched.a:irq_dispatch.*(.literal .text .literal.* .text.*)
-    *libsched.a:irq_spinlock.*(.literal .text .literal.* .text.*)
-    *libsched.a:panic_notifier.*(.literal.panic_notifier_call_chain .text.panic_notifier_call_chain)
-    *libsched.a:sched_gettcb.*(.literal .text .literal.* .text.*)
-    *libsched.a:sched_lock.*(.literal .text .literal.* .text.*)
-    *libsched.a:sched_note.*(.literal .text .literal.* .text.*)
-    *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
-    *libsched.a:sched_thistask.*(.literal .text .literal.* .text.*)
-    *libsched.a:sched_unlock.*(.literal .text .literal.* .text.*)
-    *libsched.a:spinlock.*(.literal .text .literal.* .text.*)
-
     *(.wifirxiram .wifirxiram.*)
-    *(.wifi0iram .wifi0iram.*)
+    *(.wifi0iram  .wifi0iram.*)
     *(.wifiorslpiram .wifiorslpiram.*)
     *(.wifislpiram .wifislpiram.*)
     *(.wifislprxiram .wifislprxiram.*)
     *(.phyiram .phyiram.*)
+    *(.wifiextrairam .wifiextrairam.*)
+
+    /* align + add 16B for CPU dummy speculative instr. fetch */
 
     . = ALIGN(4) + 16;
-
-    _iram_text_end = ABSOLUTE(.);
-
-    /* IRAM heap starts at the end of iram0_0_seg */
-
-    . = ALIGN (4);
-    _siramheap = ABSOLUTE(.);
+    _iram_text = ABSOLUTE(.);
   } >iram0_0_seg AT>ROM
 
-  /* Shared RAM */
+  /* Marks the end of IRAM code segment */
 
-  .noinit (NOLOAD):
+  .iram0.text_end (NOLOAD) :
   {
-    /* This section contains data that is not initialized during load,
-     * or during the application's initialization sequence.
+    . = ALIGN (4);
+    _iram_end = ABSOLUTE(.);
+  } >iram0_0_seg
+
+  .dram0.dummy (NOLOAD):
+  {
+    /* This section is required to skip .iram0.text area because iram0_0_seg
+     * and dram0_0_seg reflect the same address space on different buses.
      */
 
-    . = ALIGN(8);
-    *(.noinit)
-    *(.noinit.*)
-    . = ALIGN(8);
+    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
   } >dram0_0_seg
+
+  /* Shared RAM */
 
   .dram0.bss (NOLOAD) :
   {
@@ -204,40 +212,6 @@ SECTIONS
     . = ALIGN (8);
     _bss_start = ABSOLUTE(.);
     _sbss = ABSOLUTE(.);
-    *(EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) .bss EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) .bss.*)
-    *(.ext_ram.bss*)
-    *(EXCLUDE_FILE(*libble_app.a *libbt.a *libbtdm_app.a *libnimble.a) COMMON)
-    . = ALIGN(4);
-    _bt_controller_bss_start = ABSOLUTE(.);
-    *libble_app.a:(.bss .bss.*)
-    . = ALIGN(4);
-    _bt_controller_bss_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _bt_controller_common_start = ABSOLUTE(.);
-    *libble_app.a:(COMMON)
-    . = ALIGN(4);
-    _bt_controller_common_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _bt_bss_start = ABSOLUTE(.);
-    *libbt.a:(.bss .bss.*)
-    . = ALIGN(4);
-    _bt_bss_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _bt_common_start = ABSOLUTE(.);
-    *libbt.a:(COMMON)
-    . = ALIGN(4);
-    _bt_common_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _btdm_bss_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.bss .bss.*)
-    . = ALIGN(4);
-    _btdm_bss_end = ABSOLUTE(.);
-    . = ALIGN(4);
-    _btdm_common_start = ABSOLUTE(.);
-    *libbtdm_app.a:(COMMON)
-    . = ALIGN(4);
-    _btdm_common_end = ABSOLUTE(.);
-    . = ALIGN (8);
     *(.dynsbss)
     *(.sbss)
     *(.sbss.*)
@@ -252,42 +226,29 @@ SECTIONS
     *(.share.mem)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-#ifdef CONFIG_STACK_CANARIES
-    *libc.a:lib_stackchk.*(.bss  .bss.*  COMMON)
-#endif
-    *libarch.a:esp32_spicache.*(.bss  .bss.*  COMMON)
-    *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
-    *libarch.a:xtensa_cpupause.*(.bss  .bss.*  COMMON)
-    *libarch.a:xtensa_copystate.*(.bss  .bss.*  COMMON)
-    *libarch.a:xtensa_interruptcontext.*(.bss  .bss.*  COMMON)
-    *libarch.a:xtensa_testset.*(.bss  .bss.*  COMMON)
-
-    *libsched.a:sched_suspendscheduler.*(.bss  .bss.*  COMMON)
-    *libsched.a:sched_thistask.*(.bss  .bss.*  COMMON)
-    *libsched.a:sched_note.*(.bss  .bss.*  COMMON)
-    *libsched.a:spinlock.*(.bss  .bss.*  COMMON)
-    *libsched.a:irq_csection.*(.bss  .bss.*  COMMON)
-    *libsched.a:irq_dispatch.*(.bss  .bss.*  COMMON)
-
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
     _bss_end = ABSOLUTE(.);
   } >dram0_0_seg
 
-  .dram0.data :
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
+
+    . = ALIGN(4);
+    *(.noinit)
+    *(.noinit.*)
+    . = ALIGN(4);
+  } >dram0_0_seg
+
+  .dram0.data : ALIGN(4)
   {
     /* .data initialized on power-up in ROMed configurations. */
 
-    _sdata = ABSOLUTE(.);
     _data_start = ABSOLUTE(.);
-    _bt_data_start = ABSOLUTE(.);
-    *libbt.a:(.data .data.*)
-    . = ALIGN (4);
-    _bt_data_end = ABSOLUTE(.);
-    _btdm_data_start = ABSOLUTE(.);
-    *libbtdm_app.a:(.data .data.*)
-    . = ALIGN (4);
-    _btdm_data_end = ABSOLUTE(.);
+    _sdata = ABSOLUTE(.);
     KEEP (*(.data))
     KEEP (*(.data.*))
     KEEP (*(.gnu.linkonce.d.*))
@@ -300,28 +261,11 @@ SECTIONS
     KEEP (*(.gnu.linkonce.s2.*))
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
-    esp32_start.*(.rodata  .rodata.*)
-    *libphy.a:(.rodata  .rodata.*)
-#ifdef CONFIG_STACK_CANARIES
-    *libc.a:lib_stackchk.*(.rodata  .rodata.*)
-#endif
-    *libarch.a:xtensa_context.*(.rodata  .rodata.*)
-    *libarch.a:xtensa_copystate.*(.rodata  .rodata.*)
-    *libarch.a:xtensa_cpupause.*(.rodata  .rodata.*)
-    *libarch.a:xtensa_testset.*(.rodata  .rodata.*)
+    esp32s2_start.*(.rodata .rodata.*)
+    esp32s2_region.*(.rodata .rodata.*)
 
-    *libdrivers.a:syslog_channel.*(.rodata  .rodata.*)
-
-    *libsched.a:sched_suspendscheduler.*(.rodata  .rodata.*)
-    *libsched.a:sched_thistask.*(.rodata  .rodata.*)
-    *libsched.a:sched_note.*(.rodata  .rodata.*)
-    *libsched.a:spinlock.*(.rodata  .rodata.*)
-    *libsched.a:irq_csection.*(.rodata  .rodata.*)
-    *libsched.a:irq_dispatch.*(.rodata  .rodata.*)
-
-    *libarch.a:esp32_spicache.*(.rodata  .rodata.*)
-    *libarch.a:esp32_spiflash.*(.rodata  .rodata.*)
     *libarch.a:*esp_loader.*(.rodata .rodata.*)
+    *libarch.a:esp32s2_spiflash.*(.rodata .rodata.*)
     *libarch.a:*brownout.*(.rodata .rodata.*)
     *libarch.a:*cpu.*(.rodata .rodata.*)
     *libarch.a:*gpio_hal.*(.rodata .rodata.*)
@@ -334,6 +278,7 @@ SECTIONS
     *libarch.a:*rtc_init.*(.rodata .rodata.*)
     *libarch.a:*rtc_clk.*(.rodata .rodata.*)
     *libarch.a:*rtc_clk_init.*(.rodata .rodata.*)
+    *libarch.a:*rtc_sleep.*(.rodata .rodata.*)
     *libarch.a:*rtc_time.*(.rodata .rodata.*)
     *libarch.a:*regi2c_ctrl.*(.rodata .rodata.*)
     *libarch.a:*uart_hal_iram.*(.rodata .rodata.*)
@@ -344,37 +289,39 @@ SECTIONS
     *libarch.a:*bootloader_common_loader.*(.rodata .rodata.*)
     *libarch.a:*bootloader_console.*(.rodata .rodata.*)
     *libarch.a:*bootloader_console_loader.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_esp32.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_esp32s2.*(.rodata .rodata.*)
     *libarch.a:*bootloader_flash.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_flash_config_esp32.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_flash_config_esp32s2.*(.rodata .rodata.*)
     *libarch.a:*bootloader_clock_init.*(.rodata .rodata.*)
     *libarch.a:*bootloader_clock_loader.*(.rodata .rodata.*)
     *libarch.a:*bootloader_efuse.*(.rodata .rodata.*)
     *libarch.a:*bootloader_panic.*(.rodata .rodata.*)
     *libarch.a:*bootloader_mem.*(.rodata .rodata.*)
     *libarch.a:*bootloader_random.*(.rodata .rodata.*)
-    *libarch.a:*bootloader_random_esp32.*(.rodata .rodata.*)
+    *libarch.a:*bootloader_random_esp32s2.*(.rodata .rodata.*)
     *libarch.a:*esp_image_format.*(.rodata .rodata.*)
     *libarch.a:*bootloader_soc.*(.rodata .rodata.*)
     *libarch.a:*bootloader_sha.*(.rodata .rodata.*)
+    *libarch.a:*flash_encrypt.*(.rodata .rodata.*)
+    *libarch.a:*cache_hal.*(.rodata .rodata.*)
     *libarch.a:*uart_hal.*(.rodata .rodata.*)
     *libarch.a:*mpu_hal.*(.rodata .rodata.*)
     *libarch.a:*mmu_hal.*(.rodata .rodata.*)
-    *libarch.a:*efuse_hal.*(.rodata .rodata.*)
     *libarch.a:*uart_periph.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_uart.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_sys.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_spiflash.*(.rodata .rodata.*)
+    *libarch.a:*esp_rom_cache_esp32s2_esp32s3.*(.rodata .rodata.*)
     *libarch.a:*esp_rom_wdt.*(.rodata .rodata.*)
     *libarch.a:*esp_efuse_fields.*(.rodata .rodata.*)
     *libarch.a:*esp_efuse_api_key.*(.rodata .rodata.*)
     *libarch.a:*log.*(.rodata .rodata.*)
     *libarch.a:*log_noos.*(.rodata .rodata.*)
     *libarch.a:*cpu_region_protect.*(.rodata .rodata.*)
-    _edata = ABSOLUTE(.);
-    _data_end = ABSOLUTE(.);
 
     . = ALIGN(4);
+    _edata = ABSOLUTE(.);
+    _data_end = ABSOLUTE(.);
 
     /* Heap starts at the end of .data */
 
@@ -401,36 +348,38 @@ SECTIONS
     . = ALIGN(0x10000);
   } > ROM
 
-  .flash.rodata :
+  .flash.rodata : ALIGN(0x10000)
   {
     _rodata_reserved_start = ABSOLUTE(.);
-    . = ALIGN(4);
     _srodata = ABSOLUTE(.);
-    *(EXCLUDE_FILE (*libarch.a:esp32_spiflash.* *libarch.a:esp32_spicache.*
-                    *libarch.a:esp_loader.* esp32_start.*) .rodata)
-    *(EXCLUDE_FILE (*libarch.a:esp32_spiflash.* *libarch.a:esp32_spicache.*
-                    *libarch.a:esp_loader.* esp32_start.*) .rodata.*)
-    *(.srodata.*)
-    *(.rodata)
-    *(.rodata.*)
-#ifdef CONFIG_ESP32_WIRELESS
+    *(EXCLUDE_FILE (esp32s2_start.* esp32s2_region.*
+                    *libarch.a:*esp_loader.*
+                    *libarch.a:esp32s2_spiflash.*
+                    *libarch.a:*cache_hal.* *libarch.a:*mmu_hal.*
+                    *libarch.a:*mpu_hal.*) .rodata)
+    *(EXCLUDE_FILE (esp32s2_start.* esp32s2_region.*
+                    *libarch.a:*esp_loader.*
+                    *libarch.a:esp32s2_spiflash.*
+                    *libarch.a:*cache_hal.* *libarch.a:*mmu_hal.*
+                    *libarch.a:*mpu_hal.*) .rodata.*)
+
+#ifdef CONFIG_ESPRESSIF_WIRELESS
     *(.rodata_wlog_verbose.*)
     *(.rodata_wlog_debug.*)
     *(.rodata_wlog_info.*)
     *(.rodata_wlog_warning.*)
     *(.rodata_wlog_error.*)
 #endif
+
     *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.gnu.linkonce.r.*)
     *(.rodata1)
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
-    *(.gcc_except_table)
-    *(.gcc_except_table.*)
+    *(.gcc_except_table .gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
-    *(.eh_frame)
-
+    KEEP(*(.eh_frame))
     . = (. + 3) & ~ 3;
 
     /* C++ constructor and destructor tables, properly ordered: */
@@ -455,16 +404,11 @@ SECTIONS
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
-
-    /* Addresses of memory regions reserved via SOC_RESERVE_MEMORY_REGION() */
-
-    soc_reserved_memory_region_start = ABSOLUTE(.);
-    KEEP (*(.reserved_memory_address))
-    soc_reserved_memory_region_end = ABSOLUTE(.);
-
     . = ALIGN(4);               /* This table MUST be 4-byte aligned */
     _erodata = ABSOLUTE(.);
+
     /* Literals are also RO data. */
+
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)
     *(.lit4.*)
@@ -475,7 +419,6 @@ SECTIONS
 
     . = ALIGN(4);
     _thread_local_start = ABSOLUTE(.);
-
     _stdata = ABSOLUTE(.);
     *(.tdata .tdata.* .gnu.linkonce.td.*);
     _etdata = ABSOLUTE(.);
@@ -484,9 +427,8 @@ SECTIONS
     _etbss = ABSOLUTE(.);
 
     _thread_local_end = ABSOLUTE(.);
-
     _rodata_reserved_end = ABSOLUTE(.);
-  } >default_rodata_seg AT>ROM
+  } >drom0_0_seg AT>ROM
   _rodata_reserved_align = ALIGNOF(.flash.rodata);
 
   _image_irom_vma = ADDR(.flash.text);
@@ -504,46 +446,33 @@ SECTIONS
    * be equal.
    */
 
+#ifndef CONFIG_ESP32S2_RUN_IRAM
   .flash.text_dummy (NOLOAD) :
   {
+    /* This section is required to skip .flash.rodata area because irom0_0_seg
+     * and drom0_0_seg reflect the same address space on different buses.
+     */
+
     . += SIZEOF(.flash.rodata);
     . = ALIGN(0x10000);
   } >default_code_seg AT> ROM
+#endif
 
-  .flash.text :
+  .flash.text : ALIGN(0x00010000)
   {
     _stext = .;
-    _text_start = ABSOLUTE(.);
+
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)
-
-    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifi0iram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifi0iram.*)
-    *(.wifiextrairam .wifiextrairam.*)
-    *(EXCLUDE_FILE(*libpp.a) .wifiorslpiram EXCLUDE_FILE(*libpp.a) .wifiorslpiram.*)
-    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifirxiram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifirxiram.*)
-    *(.wifislpiram .wifislpiram.*)
-    *(EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifislprxiram EXCLUDE_FILE(*libnet80211.a *libpp.a) .wifislprxiram.*)
-
     . = ALIGN(4);
 
     . += 16;
 
-    _text_end = ABSOLUTE(.);
     _etext = .;
   } >default_code_seg AT>ROM
-
-  /* External memory bss, from any global variable with EXT_RAM_ATTR attribute */
-
-  .extmem.bss (NOLOAD) :
-  {
-    _sbss_extmem = ABSOLUTE(.);
-    *(.extmem.bss .extmem.bss.*)
-    . = ALIGN(4);
-    _ebss_extmem = ABSOLUTE(.);
-  } >extmem_seg
 
   .rtc.text :
   {
@@ -551,8 +480,25 @@ SECTIONS
     *(.rtc.literal .rtc.text)
   } >rtc_iram_seg AT>ROM
 
+  .rtc.dummy (NOLOAD) :
+  {
+    /* This section is required to skip .rtc.text area because the text and
+     * data segments reflect the same address space on different buses.
+     */
+
+    . = SIZEOF(.rtc.text);
+  } >rtc_data_seg
+
+  /* RTC BSS section. */
+
+  .rtc.bss (NOLOAD) :
+  {
+    *(.rtc.bss)
+  } >rtc_slow_seg
+
   .rtc.data :
   {
+    . = ALIGN(4);
     *(.rtc.data)
     *(.rtc.data.*)
     *(.rtc.rodata)

--- a/boards/xtensa/esp32s2/esp32s2-kaluga-1/scripts/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-kaluga-1/scripts/Make.defs
@@ -32,12 +32,7 @@ ARCHSCRIPT += $(BOARD_COMMON_DIR)$(DELIM)scripts$(DELIM)esp32s2_peripherals.ld
 # pick the common linker scripts.
 
 ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
-
-ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-endif
+ARCHSCRIPT += $(call FINDSCRIPT,esp32s2_sections.ld)
 
 ARCHPICFLAGS = -fpic
 

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/scripts/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/scripts/Make.defs
@@ -32,12 +32,7 @@ ARCHSCRIPT += $(BOARD_COMMON_DIR)$(DELIM)scripts$(DELIM)esp32s2_peripherals.ld
 # pick the common linker scripts.
 
 ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
-
-ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-endif
+ARCHSCRIPT += $(call FINDSCRIPT,esp32s2_sections.ld)
 
 ARCHPICFLAGS = -fpic
 

--- a/boards/xtensa/esp32s2/franzininho-wifi/scripts/Make.defs
+++ b/boards/xtensa/esp32s2/franzininho-wifi/scripts/Make.defs
@@ -32,12 +32,8 @@ ARCHSCRIPT += $(BOARD_COMMON_DIR)$(DELIM)scripts$(DELIM)esp32s2_peripherals.ld
 # pick the common linker scripts.
 
 ARCHSCRIPT += $(call FINDSCRIPT,flat_memory.ld)
+ARCHSCRIPT += $(call FINDSCRIPT,esp32s2_sections.ld)
 
-ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,mcuboot_sections.ld)
-else ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
-  ARCHSCRIPT += $(call FINDSCRIPT,simple_boot_sections.ld)
-endif
 
 ARCHPICFLAGS = -fpic
 


### PR DESCRIPTION
## Summary

This PR merges the MCUBoot and Simple Boot linker scripts into one single file.
Affects ESP32 and ESP32S2 (S3 is already merged).

## Impact

Simplify linker maintenance by using only one file for both simple boot and MCUBoot.
Modifies all ESP32 and ESP32S2 boards to use this new .ld.

## Testing

Internal CI test on all boards.
