### PR TITLE
drivers/video: add BRGA8888 support for goldfish gpu fb

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -72,6 +72,19 @@ config GOLDFISH_GPU_FB
 	depends on VIDEO_FB
 	default n
 
+choice
+	prompt "Select Goldfish GPU Framebuffer format"
+	default GOLDFISH_GPU_FB_RGB565
+	depends on GOLDFISH_GPU_FB
+
+config GOLDFISH_GPU_FB_RGB565
+	bool "RGB565"
+
+config GOLDFISH_GPU_FB_BGRA8888
+	bool "BGRA8888"
+
+endchoice
+
 config GOLDFISH_GPU_FB_PRIORITY
 	int "Goldfish GPU Framebuffer vsync task priority"
 	depends on GOLDFISH_GPU_FB


### PR DESCRIPTION
## Summary

add bgra8888 color format support

reason:

for device needs

## Impact

goldfish gpu fb

## Testing

ci & goldfish


