### PR TITLE
arm/irq.h: fix ARCH_ARM7TDMI missing up_getusrsp after move to irq.h

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -256,6 +256,25 @@ static inline_function void up_set_interrupt_context(bool flag)
 #endif
 }
 
+static inline_function uint32_t up_getsp(void)
+{
+  register uint32_t sp;
+
+  __asm__ __volatile__
+  (
+    "mov %0, sp\n"
+    : "=r" (sp)
+  );
+
+  return sp;
+}
+
+static inline_function uintptr_t up_getusrsp(void *regs)
+{
+  uint32_t *ptr = (uint32_t *)regs;
+  return ptr[REG_SP];
+}
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Causing c5471evm/httpd ci break.

the default irq.h path is not involved when previous patch CI.
https://github.com/apache/nuttx/blob/55da7d89b55f190b04b7b7f5bf211d6319ce6833/arch/arm/include/irq.h#L73

## Impact
fix #15425 break the c5471evm/httpd.
fix the arm32 default path no up_getusrsp in irq.h

## Testing
CI-test, local build of c5471evm/httpd.

