### PR TITLE
modlib: preprocess gnu-elf.ld for executable ELF

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -546,7 +546,9 @@ ifeq ($(CONFIG_PIC),y)
   # Generate an executable elf, need to ignore undefined symbols
   LDELFFLAGS += --unresolved-symbols=ignore-in-object-files --emit-relocs
 else
-  LDELFFLAGS += -r
+  ifneq ($(CONFIG_BINFMT_ELF_EXECUTABLE),y)
+    LDELFFLAGS += -r
+  endif
 endif
 
 LDELFFLAGS +=  -e main -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)modlib$(DELIM)gnu-elf.ld)

--- a/arch/arm/src/qemu/Kconfig
+++ b/arch/arm/src/qemu/Kconfig
@@ -15,6 +15,7 @@ config ARCH_CHIP_QEMU_CORTEXA7
 	bool "Qemu virtual Processor (cortex-a7)"
 	select ARCH_CORTEXA7
 	select ARCH_HAVE_ADDRENV
+	select ARCH_HAVE_ELF_EXECUTABLE
 	select ARCH_HAVE_LOWVECTORS
 	select ARCH_HAVE_MULTICPU
 	select ARCH_NEED_ADDRENV_MAPPING

--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -29,6 +29,8 @@
 
 #include <nuttx/config.h>
 
+#ifndef __ASSEMBLY__
+
 #ifdef CONFIG_BUILD_KERNEL
 #  include <signal.h>
 #endif
@@ -39,6 +41,8 @@
 #include <nuttx/wqueue.h>
 
 #include <arch/arch.h>
+
+#endif /* __ASSEMBLY__ */
 
 #ifdef CONFIG_ARCH_ADDRENV
 
@@ -241,6 +245,9 @@
      (CONFIG_ARCH_PGPOOL_VBASE + CONFIG_ARCH_PGPOOL_SIZE)
 
 #endif
+
+#ifndef __ASSEMBLY__
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -250,8 +257,6 @@ struct tcb_s;                  /* Forward reference to TCB */
 /****************************************************************************
  * Public Types
  ****************************************************************************/
-
-#ifndef __ASSEMBLY__
 
 struct addrenv_s
 {

--- a/libs/libc/.gitignore
+++ b/libs/libc/.gitignore
@@ -1,2 +1,3 @@
 /exec_symtab.c
 /modlib_symtab.c
+modlib/gnu-elf.ld

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -183,6 +183,10 @@ context:: bin kbin
 ifeq ($(CONFIG_LIBC_ZONEINFO_ROMFS),y)
 	$(Q) $(MAKE) -C zoneinfo context BIN=$(BIN)
 endif
+ifeq ($(CONFIG_LIBC_MODLIB),y)
+	$(Q) $(MAKE) -C modlib context
+endif
+
 
 # Dependencies
 
@@ -210,6 +214,7 @@ depend:: .depend
 
 clean::
 	$(Q) $(MAKE) -C zoneinfo clean BIN=$(BIN)
+	$(Q) $(MAKE) -C modlib clean
 	$(call DELFILE, $(BIN))
 	$(call DELFILE, $(KBIN))
 	$(call CLEAN)
@@ -218,6 +223,7 @@ clean::
 
 distclean:: clean
 	$(Q) $(MAKE) -C zoneinfo distclean BIN=$(BIN)
+	$(Q) $(MAKE) -C modlib distclean
 	$(call DELFILE, exec_symtab.c)
 	$(call DELFILE, .depend)
 	$(call DELDIR, bin)

--- a/libs/libc/modlib/Makefile
+++ b/libs/libc/modlib/Makefile
@@ -1,0 +1,40 @@
+############################################################################
+# libs/libc/modlib/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(TOPDIR)/Make.defs
+
+# Generate gnu-elf.ld from gnu-elf.ld.in
+
+gnu-elf.ld: gnu-elf.ld.in
+	$(call PREPROCESS, $<, $@)
+
+# Create initial context
+
+context: gnu-elf.ld
+
+.PHONY: context clean distclean
+
+clean:
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, gnu-elf.ld)

--- a/libs/libc/modlib/gnu-elf.ld.in
+++ b/libs/libc/modlib/gnu-elf.ld.in
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/modlib/gnu-elf.ld
+ * libs/libc/modlib/gnu-elf.ld.in
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,9 +18,23 @@
  *
  ****************************************************************************/
 
+
+#include <nuttx/config.h>
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_BINFMT_ELF_EXECUTABLE)
+#  define __ASSEMBLY__
+#  include <nuttx/addrenv.h>
+
+#  define TEXT CONFIG_ARCH_TEXT_VBASE
+#  define DATA CONFIG_ARCH_DATA_VBASE + ARCH_DATA_RESERVE_SIZE
+#else
+#  define TEXT 0x0
+#  define DATA
+#endif
+
 SECTIONS
 {
-  .text 0x00000000 :
+  .text TEXT :
     {
       _stext = . ;
       *(.text)
@@ -58,7 +72,7 @@ SECTIONS
       _erodata = . ;
     }
 
-  .data :
+  .data DATA :
     {
       _sdata = . ;
       *(.data)


### PR DESCRIPTION
# Summary

This allows apps for kernel mode NuttX (e.g. on arm/qemu-armv7a) can be built as executable type ELF files. Benefits of executable programs are smaller in size and easier GDB debugging.

Initial scope was only for qemu-armv7a but it used an almost duplicated `gnu-elf.ld` which differs only at `.text` and `.data` addresses from the `gnu-elf.ld` in modlib.  

To avoid such duplications, a preprocessed `gnu-elf.ld` in modlib is added  so that to adapt to target config. This requires minor tweaks for `addrenv.h` so that some macros can be included in `gnu-elf.ld.in`.

# Impacts

Hardware: qemu-armv7a or using kernel build.

# Testing

- local checks with QEMU v6.2 on Ubuntu 22.04: `qemu-armv7a:knsh`, `bl602evb:elf`.
- CI checks

