### PR TITLE
esp32s3_wifi_adapter.c: Fix a deadlock

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -2125,6 +2125,13 @@ static void esp_evt_work_cb(void *arg)
           break;
         }
 
+      /* Some of the following logic (eg. esp32s3_wlan_sta_set_linkstatus)
+       * can take net_lock(). To maintain the consistent locking order,
+       * we take net_lock() here before taking esp_wifi_lock. Note that
+       * net_lock() is a recursive lock.
+       */
+
+      net_lock();
       esp_wifi_lock(true);
 
       switch (evt_adpt->id)
@@ -2268,6 +2275,7 @@ static void esp_evt_work_cb(void *arg)
         }
 
       esp_wifi_lock(false);
+      net_unlock();
 
       kmm_free(evt_adpt);
     }


### PR DESCRIPTION
## Summary

esp32s3_wifi_adapter.c: Fix a deadlock
    
Fixes: https://github.com/apache/nuttx/issues/15314

## Impact

## Testing

esp32s3-devkit:wifi
