### PR TITLE
drivers/sensors/gnss: Fix integer overflow error

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -168,14 +168,21 @@ static int gnss_activate(FAR struct sensor_lowerhalf_s *lower,
   int ret = OK;
 
   nxmutex_lock(&upper->lock);
-  if ((upper->crefs == 0 && enable) || (upper->crefs == 1 && !enable))
+  if ((upper->crefs == 255 && enable) || (upper->crefs == 0 && !enable))
     {
-      ret = upper->lower->ops->activate(upper->lower, filep, enable);
+      ret = -EINVAL;
     }
-
-  if (ret >= 0)
+  else
     {
-      upper->crefs += enable ? 1 : -1;
+      if ((upper->crefs == 0 && enable) || (upper->crefs == 1 && !enable))
+        {
+          ret = upper->lower->ops->activate(upper->lower, filep, enable);
+        }
+
+      if (ret >= 0)
+        {
+          upper->crefs += enable ? 1 : -1;
+        }
     }
 
   nxmutex_unlock(&upper->lock);


### PR DESCRIPTION
## Summary
Fix integer overflow error
```
CID 1309501: (#1 of 1): Overflow constant (INTEGER_OVERFLOW)
overflow_const: Expression upper->crefs, which is equal to 255, where enable ? 1 : -1 is known to be equal to -1, overflows the type that receives it, an unsigned integer 8 bits wide.
```
## Impact
drivers/sensors/gnss

## Testing
CI


