### PR TITLE
arm64/tbi: Unified TBI flags for MTE and software kasan

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -151,6 +151,7 @@ menu "ARMv8.5 architectural features"
 
 config ARM64_MTE
 	bool "Memory Tagging Extension support"
+	select ARM64_TBI
 	default y
 
 endmenu # "ARMv8.5 architectural features"
@@ -163,6 +164,10 @@ config ARCH_SINGLE_SECURITY_STATE
 		security state(eg. Cortex-R82). For these Processors,
 		GIC or other ARM architecture feature will with different
 		configure
+
+config ARM64_TBI
+	bool "Top Byte Ignore support"
+	default n
 
 config ARM64_SMP_BUSY_WAIT
 	bool "Busy wait when SMP boot"

--- a/arch/arm64/src/common/arm64_mmu.c
+++ b/arch/arm64/src/common/arm64_mmu.c
@@ -155,16 +155,10 @@
 #define TCR_PS_BITS             TCR_PS_BITS_4GB
 #endif
 
-#ifdef CONFIG_MM_KASAN_SW_TAGS
-#define TCR_KASAN_SW_FLAGS (TCR_TBI0 | TCR_TBI1 | TCR_ASID_8)
+#ifdef CONFIG_ARM64_TBI
+#define TCR_TBI_FLAGS (TCR_TBI0 | TCR_TBI1 | TCR_ASID_8)
 #else
-#define TCR_KASAN_SW_FLAGS 0
-#endif
-
-#ifdef CONFIG_ARM64_MTE
-#define TCR_MTE_FLAGS (TCR_TCMA1 | TCR_TBI0 | TCR_TBI1 | TCR_ASID_8)
-#else
-#define TCR_MTE_FLAGS 0
+#define TCR_TBI_FLAGS 0
 #endif
 
 /****************************************************************************
@@ -270,7 +264,7 @@ static uint64_t get_tcr(int el)
    */
 
   tcr |= TCR_TG0_4K | TCR_SHARED_INNER | TCR_ORGN_WBWA |
-         TCR_IRGN_WBWA | TCR_KASAN_SW_FLAGS | TCR_MTE_FLAGS;
+         TCR_IRGN_WBWA | TCR_TBI_FLAGS;
 
   return tcr;
 }

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -344,6 +344,7 @@ config MM_KASAN_GENERIC
 
 config MM_KASAN_SW_TAGS
 	bool "KAsan SW tags"
+	select ARM64_TBI
 	depends on ARCH_ARM64
 	---help---
 		KAsan based on software tags


### PR DESCRIPTION
## Summary

The TCMA flag is not critical, it will be set separately in "arm64_mte.c"

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


