### PR TITLE
Minor net error handling improvements

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -3357,6 +3357,10 @@ static int mpfs_phyinit(struct mpfs_ethmac_s *priv)
     {
       ret = ksz9477_i2c_init(bus, KSZ9477_PORT_SGMII);
     }
+  else
+    {
+      ret = -EINVAL;
+    }
 
 #endif
 

--- a/drivers/net/ksz9477.c
+++ b/drivers/net/ksz9477.c
@@ -387,6 +387,12 @@ int ksz9477_init(ksz9477_port_t master_port)
       ret = ksz9477_sgmii_write_indirect(KSZ9477_SGMII_AUTONEG_CONTROL,
                                          &regval16, 1);
 
+      if (ret != OK)
+        {
+          nerr("Failed to set SGMII port into PHY mode, ret %d\n", ret);
+          return ret ? ret : -EINVAL;
+        }
+
       /* Write to autonegotiation advertisement register activates the new
        * setting. Advertise only full duplex.
        */
@@ -394,6 +400,12 @@ int ksz9477_init(ksz9477_port_t master_port)
       regval16 = SGMII_AUTONEG_ADVERTISE_FD;
       ret = ksz9477_sgmii_write_indirect(KSZ9477_SGMII_AUTONEG_ADVERTISE,
                                          &regval16, 1);
+
+      if (ret != OK)
+        {
+          nerr("Failed to set autoneg, ret %d\n", ret);
+          return ret ? ret : -EINVAL;
+        }
     }
 
   /* Configure the static port-based VLANs */
@@ -413,6 +425,12 @@ int ksz9477_init(ksz9477_port_t master_port)
               g_port_vlan_config[i]);
     }
 
+  if (ret != OK)
+    {
+      nerr("Failed to configure VLANs, ret %d\n", ret);
+      return ret ? ret : -EINVAL;
+    }
+
 #endif
 
 #ifdef CONFIG_NET_KSZ9477_PORT_SNIFF
@@ -424,6 +442,12 @@ int ksz9477_init(ksz9477_port_t master_port)
       ret = ksz9477_reg_write8(
               KSZ9477_PORT_MIRROR_CONTROL(KSZ9477_PORT_PHY1 + i),
               g_port_mirror_config[i]);
+    }
+
+  if (ret != OK)
+    {
+      nerr("Failed to configure sniffer port, ret %d\n", ret);
+      return ret ? ret : -EINVAL;
     }
 
 #endif


### PR DESCRIPTION
## Summary

This PR includes two minor networking related error handling improvements.

drivers/net/ksz9477.c:
Return values of register writes are not checked in ksz9477_init() 
which may lead to misbehaving ksz9477 ethernet switch in case of configuration failure.
Check return values of register writes and abort init in case of error.

arch/risc-v/src/mpfs/mpfs_ethernet.c:
Error is not returned in mpfs_phyinit() in case of mpfs_i2cbus_initialize() failure.
Return error in case of failure.

## Impact

Gives possibility to react to initialization failures in ksz9477 / mpfs_ethernet.
Check return values of register writes in drivers/net/ksz9477.c
Return error value in case of i2c bus initialization failure in arch/risc-v/src/mpfs/mpfs_ethernet.c

## Testing

Tested with custom mpfs board with ksz9477 ethernet switch.
