### PR TITLE
sim: Disable chained fixups for sim_macho_init.c

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -133,6 +133,13 @@ ifeq ($(CONFIG_HAVE_CXXINITIALIZE),y)
   # the place in the object list for linking. Namely, its constructor
   # should be the first one in the executable.
   HEADSRC = sim_macho_init.c
+
+  # sim_macho_init.c is not compatible with chained fixups.
+  # cf. https://github.com/apache/nuttx/issues/15208
+  ifeq ($(shell $(LD) -ld_classic -no_fixup_chains 2>&1 | grep "unknown option"),)
+    LDLINKFLAGS += -ld_classic -no_fixup_chains
+    LDFLAGS += -Wl,-ld_classic,-no_fixup_chains
+  endif
 endif
 else
   STDLIBS += -lrt


### PR DESCRIPTION
## Summary
sim: Disable chained fixups for sim_macho_init.c

This is a workaround for https://github.com/apache/nuttx/issues/15208

Tested with:
    macOS 15.2
    x86-64
    Xcode 16.2

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


