### PR TITLE
macro/align: Use ALIGN_UP and ALIGN_DOWN uniformly

### DIFF
--- a/arch/arm/src/imx9/imx9_lpi2c.c
+++ b/arch/arm/src/imx9/imx9_lpi2c.c
@@ -1103,7 +1103,7 @@ static void imx9_lpi2c_setclock(struct imx9_lpi2c_priv_s *priv,
                                             &src_freq);
 
           /* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
-           *   (CLKLO + 1 + CLKHI + 1 + ROUNDDOWN((2 + FILTSCL) / 2^prescale)
+           *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
            *
            * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
            */

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -1161,7 +1161,7 @@ static void imxrt_lpi2c_setclock(struct imxrt_lpi2c_priv_s *priv,
 #endif
 
           /* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
-           *   (CLKLO + 1 + CLKHI + 1 + ROUNDDOWN((2 + FILTSCL) / 2^prescale)
+           *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
            *
            * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
            */

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1010,7 +1010,7 @@ static void s32k1xx_lpi2c_setclock(struct s32k1xx_lpi2c_priv_s *priv,
           DEBUGASSERT(src_freq != 0);
 
           /* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
-           *   (CLKLO + 1 + CLKHI + 1 + ROUNDDOWN((2 + FILTSCL) / 2^prescale)
+           *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
            *
            * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
            */

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -990,7 +990,7 @@ static void s32k3xx_lpi2c_setclock(struct s32k3xx_lpi2c_priv_s *priv,
           DEBUGASSERT(src_freq != 0);
 
           /* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
-           *   (CLKLO + 1 + CLKHI + 1 + ROUNDDOWN((2 + FILTSCL) / 2^prescale)
+           *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
            *
            * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
            */

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -1122,7 +1122,7 @@ static void imx9_lpi2c_setclock(struct imx9_lpi2c_priv_s *priv,
           imx9_get_rootclock(priv->config->clk_root, &src_freq);
 
           /* LPI2C output frequency = (Source Clock (Hz)/ 2^prescale) /
-           *   (CLKLO + 1 + CLKHI + 1 + ROUNDDOWN((2 + FILTSCL) / 2^prescale)
+           *   (CLKLO + 1 + CLKHI + 1 + ALIGN_DOWN((2 + FILTSCL)/2^prescale)
            *
            * Assume  CLKLO = 2 * CLKHI, SETHOLD = CLKHI, DATAVD = CLKHI / 2
            */

--- a/binfmt/binfmt_copyactions.c
+++ b/binfmt/binfmt_copyactions.c
@@ -31,17 +31,12 @@
 #include <errno.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/binfmt/binfmt.h>
 
 #include "binfmt.h"
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL) && !defined(CONFIG_BINFMT_DISABLE)
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define ROUNDUP(x, y)     (((x) + (y) - 1) / (y) * (y))
 
 /****************************************************************************
  * Public Functions
@@ -98,8 +93,8 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
 
           case SPAWN_FILE_ACTION_OPEN:
             open = (FAR struct spawn_open_file_action_s *)entry;
-            size += ROUNDUP(SIZEOF_OPEN_FILE_ACTION_S(strlen(open->path)),
-                            sizeof(FAR void *));
+            size += ALIGN_UP(SIZEOF_OPEN_FILE_ACTION_S(strlen(open->path)),
+                             sizeof(FAR void *));
             break;
 
           default:
@@ -155,8 +150,8 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
             strcpy(open->path, tmp->path);
 
             buffer = (FAR char *)buffer +
-                     ROUNDUP(SIZEOF_OPEN_FILE_ACTION_S(strlen(tmp->path)),
-                             sizeof(FAR void *));
+                     ALIGN_UP(SIZEOF_OPEN_FILE_ACTION_S(strlen(tmp->path)),
+                              sizeof(FAR void *));
             break;
 
           default:

--- a/libs/libbuiltin/libgcc/profile.c
+++ b/libs/libbuiltin/libgcc/profile.c
@@ -35,6 +35,7 @@
 #include <nuttx/init.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
 
 /****************************************************************************
@@ -111,11 +112,6 @@
  */
 
 #define MAXARCS         (1 << 20)
-
-/* General rounding functions. */
-
-#define ROUNDDOWN(x, y) (((x) / (y)) * (y))
-#define ROUNDUP(x, y)   ((((x) + (y) - 1) / (y)) * (y))
 
 /* See profil(2) where this is described (incorrectly) */
 
@@ -288,13 +284,13 @@ void moncontrol(int mode)
 
   if (mode)
     {
-      uintptr_t lowpc = ROUNDDOWN((uintptr_t)&_stext,
+      uintptr_t lowpc = ALIGN_DOWN((uintptr_t)&_stext,
                                    HISTFRACTION * sizeof(HISTCOUNTER));
-      uintptr_t highpc = ROUNDUP((uintptr_t)&_etext,
-                                 HISTFRACTION * sizeof(HISTCOUNTER));
+      uintptr_t highpc = ALIGN_UP((uintptr_t)&_etext,
+                                  HISTFRACTION * sizeof(HISTCOUNTER));
       size_t textsize = highpc - lowpc;
-      size_t kcountsize = ROUNDUP(textsize / HISTFRACTION,
-                                  sizeof(*p->kcount));
+      size_t kcountsize = ALIGN_UP(textsize / HISTFRACTION,
+                                   sizeof(*p->kcount));
       int scale = kcountsize >= textsize ? SCALE_1_TO_1 :
                   (float)kcountsize / textsize * SCALE_1_TO_1;
       FAR unsigned short *kcount = kmm_zalloc(kcountsize);
@@ -370,10 +366,10 @@ void monstartup(unsigned long lowpc, unsigned long highpc)
    * so the rest of the scaling (here and in gprof) stays in ints.
    */
 
-  lowpc = ROUNDDOWN(lowpc, HISTFRACTION * sizeof(HISTCOUNTER));
-  highpc = ROUNDUP(highpc, HISTFRACTION * sizeof(HISTCOUNTER));
+  lowpc = ALIGN_DOWN(lowpc, HISTFRACTION * sizeof(HISTCOUNTER));
+  highpc = ALIGN_UP(highpc, HISTFRACTION * sizeof(HISTCOUNTER));
   textsize = highpc - lowpc;
-  fromssize = ROUNDUP(textsize / HASHFRACTION, sizeof(*p->froms));
+  fromssize = ALIGN_UP(textsize / HASHFRACTION, sizeof(*p->froms));
   tolimit = textsize * ARCDENSITY / 100;
 
   if (tolimit < MINARCS)

--- a/mm/iob/iob.h
+++ b/mm/iob/iob.h
@@ -41,8 +41,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ROUNDUP(x, y)            (((x) + (y) - 1) / (y) * (y))
-
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_IOB_DEBUG)
 #  define ioberr                 _err
 #  define iobwarn                _warn

--- a/mm/iob/iob_alloc.c
+++ b/mm/iob/iob_alloc.c
@@ -35,6 +35,7 @@
 #ifdef CONFIG_IOB_ALLOC
 #  include <nuttx/kmalloc.h>
 #endif
+#include <nuttx/nuttx.h>
 #include <nuttx/mm/iob.h>
 
 #include "iob.h"
@@ -333,7 +334,7 @@ FAR struct iob_s *iob_alloc_dynamic(uint16_t size)
   FAR struct iob_s *iob;
   size_t alignsize;
 
-  alignsize = ROUNDUP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT) + size;
+  alignsize = ALIGN_UP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT) + size;
 
   iob = kmm_memalign(CONFIG_IOB_ALIGNMENT, alignsize);
   if (iob)
@@ -344,8 +345,8 @@ FAR struct iob_s *iob_alloc_dynamic(uint16_t size)
       iob->io_bufsize = size;             /* Total length of the iob buffer */
       iob->io_pktlen  = 0;                /* Total length of the packet */
       iob->io_free    = iob_free_dynamic; /* Customer free callback */
-      iob->io_data    = (FAR uint8_t *)ROUNDUP((uintptr_t)(iob + 1),
-                                               CONFIG_IOB_ALIGNMENT);
+      iob->io_data    = (FAR uint8_t *)ALIGN_UP((uintptr_t)(iob + 1),
+                                                CONFIG_IOB_ALIGNMENT);
     }
 
   return iob;

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -28,6 +28,7 @@
 
 #include <stdbool.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/mm/iob.h>
 
 #include "iob.h"
@@ -39,10 +40,10 @@
 /* Fix the I/O Buffer size with specified alignment size */
 
 #ifdef CONFIG_IOB_ALLOC
-#  define IOB_ALIGN_SIZE  ROUNDUP(sizeof(struct iob_s) + CONFIG_IOB_BUFSIZE, \
-                                  CONFIG_IOB_ALIGNMENT)
+#  define IOB_ALIGN_SIZE  ALIGN_UP(sizeof(struct iob_s) + CONFIG_IOB_BUFSIZE, \
+                                   CONFIG_IOB_ALIGNMENT)
 #else
-#  define IOB_ALIGN_SIZE  ROUNDUP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT)
+#  define IOB_ALIGN_SIZE  ALIGN_UP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT)
 #endif
 
 #define IOB_BUFFER_SIZE   (IOB_ALIGN_SIZE * CONFIG_IOB_NBUFFERS + \
@@ -137,8 +138,8 @@ void iob_initialize(void)
    * aligned to the CONFIG_IOB_ALIGNMENT memory boundary
    */
 
-  buf = ROUNDUP((uintptr_t)g_iob_buffer + offsetof(struct iob_s, io_data),
-                CONFIG_IOB_ALIGNMENT) - offsetof(struct iob_s, io_data);
+  buf = ALIGN_UP((uintptr_t)g_iob_buffer + offsetof(struct iob_s, io_data),
+                 CONFIG_IOB_ALIGNMENT) - offsetof(struct iob_s, io_data);
 
   /* Get I/O buffer instance from the start address and add each I/O buffer
    * to the free list


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

macro/align: Use ALIGN_UP and ALIGN_DOWN uniformly

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


