### PR TITLE
arch/arm/stm32: fix stm32g4 enable pll code.

### DIFF
--- a/arch/arm/src/stm32/stm32g4xxxx_rcc.c
+++ b/arch/arm/src/stm32/stm32g4xxxx_rcc.c
@@ -702,7 +702,7 @@ static inline bool stm32_rcc_enablepll(void)
   /* Preserve reserved bits when altering the PLLCFGR register */
 
   regval = getreg32(STM32_RCC_PLLCFGR);
-  regval &= ~(RCC_PLLCFGR_RESERVED_MASK);
+  regval &= RCC_PLLCFGR_RESERVED_MASK;
 
   /* Configure PLL source and enables */
 


### PR DESCRIPTION
In the file stm32g474xxxx_rcc.c, the enable PLL
code, according to the intent of the comment,
wants to keep the reserved bit, but the code
clears the reserved bit.

## Summary

### Why change is necessary (fix, update, new feature)?
Avoid problems with clearing reservations.

### What functional part of the code is being changed?
arch/arm/src/stm32/stm2xxxx_rcc.c

static inline bool stm32_rcc_enablepll(void)
{
  uint32_t regval;
  uint32_t timeout;

  /* Preserve reserved bits when altering the PLLCFGR register */

  regval = getreg32(STM32_RCC_PLLCFGR);
  regval &= RCC_PLLCFGR_RESERVED_MASK;
  ......
}

### How does the change exactly work (what will change and how)?
This part of the code changes will retain the reserved bits

## Impact

### Is new feature added? Is existing feature changed?
No

### Impact on user (will user need to adapt to change)? 
No.

### Impact on build (will build process change)? 
No.

### Impact on hardware (will arch(s) / board(s) / driver(s) change)? 
No.

### Impact on documentation (is update required / provided)?
No.

### Impact on security (any sort of implications)? 
No.

### Impact on compatibility (backward/forward/interoperability)? 
No.

## Testing

### host:       
ubuntu20.04

### complier: 
```
arm-none-eabi-gcc --version
arm-none-eabi-gcc (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
```



