### PR TITLE
CI: Increase CI Jobs to 100% for Complex PRs

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -173,21 +173,14 @@ jobs:
 
           # If Not a Simple PR: Build all targets
           if [[ "$quit" == "1" ]]; then
-            # If PR was Created or Modified: Exclude some boards
+            # If PR was Created or Modified: Include all boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-0[1249], arm-1[124-9], risc-v-04..06, sim-03, xtensa-02"
+              echo "Include all boards"
               boards=$(
                 echo '${{ inputs.boards }}' |
                 jq --compact-output \
-                'map(
-                  select(
-                    test("arm-0[1249]") == false and test("arm-1[124-9]") == false and
-                    test("risc-v-0[4-9]") == false and
-                    test("sim-0[3-9]") == false and
-                    test("xtensa-0[2-9]") == false
-                  )
-                )'
+                '.'
               )
             fi
             echo "selected_builds=$boards" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

This PR increases the CI Jobs for Complex PRs from 50% to 100%, as explained here:
- https://github.com/apache/nuttx/issues/15451#issuecomment-2576576664

## Impact

By increasing the CI Checks, we will have better quality PRs that won't fail the Daily Builds.

Complex PRs will now complete CI Checks in 2 hours 10 mins. (Instead of 1.5 hours previously)

No impact on Simple PRs that affect only One Single Architecture (arm32, risc-v, etc).

## Testing

Complex PRs will now execute 100% of CI Jobs:
- https://github.com/lupyuen5/label-nuttx/actions/runs/12663293294

Simple PRs (Arm32) are not affected:
- https://github.com/lupyuen5/label-nuttx/actions/runs/12663305618
