### PR TITLE
Revert "mm_heap: double malloced memory default alignment (4 -> 8, 8 -> 16)"

### DIFF
--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -157,7 +157,7 @@
 #endif
 
 #if CONFIG_MM_DEFAULT_ALIGNMENT == 0
-#  define MM_ALIGN       (2 * sizeof(uintptr_t))
+#  define MM_ALIGN       sizeof(uintptr_t)
 #else
 #  define MM_ALIGN       CONFIG_MM_DEFAULT_ALIGNMENT
 #endif

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -62,7 +62,7 @@ config MM_KERNEL_HEAPSIZE
 
 config MM_DEFAULT_ALIGNMENT
 	int "Memory default alignment in bytes"
-	default 0
+	default 8
 	range 0 64
 	---help---
 		The memory default alignment in bytes, if this value is 0, the real


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

mm: default mm align 32->4,64->8

## Impact

The modification at that time was because of x86-64, but the problem has been fixed elsewhere, and other architectures will not encounter any problems for the time being.

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


