### PR TITLE
riscv_cpustart.c: Change CPU start related traces to sinfo

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -98,7 +98,7 @@ void riscv_cpu_boot(int cpu)
   mmu_enable(g_kernel_pgt_pbase, 0);
 #endif
 
-  _info("CPU%d Started\n", this_cpu());
+  sinfo("CPU%d Started\n", this_cpu());
 
 #ifdef CONFIG_STACK_COLORATION
   struct tcb_s *tcb = this_task();
@@ -159,7 +159,7 @@ void riscv_cpu_boot(int cpu)
 
 int up_cpu_start(int cpu)
 {
-  _info("CPU=%d\n", cpu);
+  sinfo("CPU=%d\n", cpu);
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify of the start event */


### PR DESCRIPTION
## Summary

Do the trace like all other platforms do. Motivation is to remove useless traces from boot process, unless the user explicitly asks for such (schedule related) traces.

## Impact

Tracing, RISCV with SMP only.

## Testing

CI pass, no functional testing.
