### PR TITLE
drivers/sensors/gnss: Macro `UINT8_MAX` for maximum value of `uint8_t crefs`

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -168,7 +168,8 @@ static int gnss_activate(FAR struct sensor_lowerhalf_s *lower,
   int ret = OK;
 
   nxmutex_lock(&upper->lock);
-  if ((upper->crefs == 255 && enable) || (upper->crefs == 0 && !enable))
+  if ((upper->crefs == UINT8_MAX && enable) ||
+      (upper->crefs == 0 && !enable))
     {
       ret = -EINVAL;
     }
@@ -233,7 +234,7 @@ static int gnss_open(FAR struct file *filep)
     }
 
   nxmutex_lock(&upper->lock);
-  if (upper->crefs >= 255)
+  if (upper->crefs >= UINT8_MAX)
     {
       ret = -EMFILE;
       kmm_free(user);


### PR DESCRIPTION
## Summary
drivers/sensors/gnss: Macro `UINT8_MAX` for maximum value of `uint8_t crefs`
libs/libc/gnssutils/minmea/minmea.h:17:#include <stdint.h>

## Impact
drivers/sensors/gnss

## Testing
CI

