### PR TITLE
arch/risc-v: Improve LLVM CPU type detection with findstring

### DIFF
--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -277,17 +277,17 @@ endif
 # These models can't cover all implementation of RISCV, but it's enough for most cases.
 
 ifeq ($(CONFIG_ARCH_RV32),y)
-  ifeq ($(ARCHCPUEXTFLAGS), imc)
+  ifeq ($(findstring imc,$(ARCHCPUEXTFLAGS)),imc)
     LLVM_CPUTYPE := sifive-e20
-  else ifeq ($(ARCHCPUEXTFLAGS), imac)
+  else ifeq ($(findstring imac,$(ARCHCPUEXTFLAGS)),imac)
     LLVM_CPUTYPE := sifive-e31
-  else ifeq ($(ARCHCPUEXTFLAGS), imafc)
+  else ifeq ($(findstring imafc,$(ARCHCPUEXTFLAGS)),imafc)
     LLVM_CPUTYPE := sifive-e76
   endif
 else
-  ifeq ($(ARCHCPUEXTFLAGS), imac)
+  ifeq ($(findstring imac,$(ARCHCPUEXTFLAGS)),imac)
     LLVM_CPUTYPE := sifive-s51
-  else ifeq ($(ARCHCPUEXTFLAGS), imafdc)
+  else ifeq ($(findstring imafdc,$(ARCHCPUEXTFLAGS)),imafdc)
     LLVM_CPUTYPE := sifive-u54
   endif
 endif


### PR DESCRIPTION

## Summary

Use findstring instead of direct equality checks for LLVM_CPUTYPE conditions to better handle ARCHCPUEXTFLAGS that may contain additional ISA extensions. This makes the CPU type detection more robust when dealing with extended instruction sets while still ensuring the required base ISA extensions are present.

For example, ARCHCPUEXTFLAGS="imc_zicsr_zifencei" will now correctly match as sifive-e20 rather than failing the exact match check.

## Impact

Makefile only

## Testing

GitHub CI and local machine

