### PR TITLE
arch/esp32s3_partition: Read data from SPI Flash with decryption

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_partition.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_partition.c
@@ -935,6 +935,54 @@ int esp32s3_partition_read(const char *label, size_t offset, void *buf,
 }
 
 /****************************************************************************
+ * Name: esp32s3_partition_read_decrypt
+ *
+ * Description:
+ *   Read data from SPI Flash at designated address (with decryption)
+ *
+ * Input Parameters:
+ *   label  - Partition label
+ *   offset - Offset in SPI Flash
+ *   buf    - Data buffer pointer
+ *   size   - Data number
+ *
+ * Returned Value:
+ *   0 if success or a negative value if fail.
+ *
+ ****************************************************************************/
+
+int esp32s3_partition_read_decrypt(const char *label, size_t offset,
+                                   void *buf, size_t size)
+{
+  int ret;
+  int partion_offset;
+  DEBUGASSERT(label != NULL && buf != NULL);
+  struct mtd_dev_s *mtd = esp32s3_spiflash_encrypt_mtd();
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to get SPI flash MTD\n");
+      return -ENOSYS;
+    }
+
+  partion_offset = partition_get_offset(label, strlen(label));
+  if (partion_offset < 0)
+    {
+      ferr("ERROR: Failed to get partition: %s offset\n", label);
+      return partion_offset;
+    }
+
+  ret = MTD_READ(mtd, partion_offset + offset,
+                 size, (uint8_t *)buf);
+  if (ret != size)
+    {
+      ferr("ERROR: Failed to get read data from MTD\n");
+      return -EIO;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: esp32s3_partition_write
  *
  * Description:


### PR DESCRIPTION
## Summary
arch/esp32s3_partition: Read data from SPI Flash at designated address (with decryption)

## Impact
esp32s3 add  read partition interface with decryption
## Testing
nsh> tc_ota_test --read_partion_decrypt
INFO: [label]:   otadataxx
OK:  get read decryption data from MTD
[CPU0] otadata (0x3ca02a00):
[CPU0] 0000  35 9b f2 07 b4 6d 40 89 28 b4 1e 22 98 7b 4a 36  5....m@.(..".{J6
[CPU0] 0010  ba 89 81 67 77 a3 60 5e 0a e7 51 01 b3 58 c2 f6  ...gw.`^..Q..X..



