### PR TITLE
arch/arm/stm32/i2c: raise compilation error when configuration is invalid

### DIFF
--- a/arch/arm/src/stm32/stm32_i2c.c
+++ b/arch/arm/src/stm32/stm32_i2c.c
@@ -95,6 +95,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if STM32_PCLK1_FREQUENCY < 4000000
+#  warning STM32_I2C: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
+#endif
+
+#if STM32_PCLK1_FREQUENCY < 2000000
+#  error STM32_I2C: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
+#endif
+
 /* Configuration ************************************************************/
 
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
@@ -1858,15 +1866,6 @@ out:
 struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;
-
-#if STM32_PCLK1_FREQUENCY < 4000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
-#endif
-
-#if STM32_PCLK1_FREQUENCY < 2000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32/stm32_i2c_alt.c
+++ b/arch/arm/src/stm32/stm32_i2c_alt.c
@@ -118,6 +118,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if STM32_PCLK1_FREQUENCY < 4000000
+#  warning STM32_I2C: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
+#endif
+
+#if STM32_PCLK1_FREQUENCY < 2000000
+#  error STM32_I2C: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
+#endif
+
 /* Configuration ************************************************************/
 
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
@@ -2365,15 +2373,6 @@ out:
 struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;
-
-#if STM32_PCLK1_FREQUENCY < 4000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
-#endif
-
-#if STM32_PCLK1_FREQUENCY < 2000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -249,6 +249,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#warning TODO: check I2C clock source. It must be HSI!
 #undef INVALID_CLOCK_SOURCE
 
 #if defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
@@ -263,8 +264,6 @@
 #else
 #  error STM32_I2C: Device not Supported.
 #endif
-
-#warning TODO: check I2C clock source. It must be HSI!
 
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
  * Instead, CPU-intensive polling will be used.

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -95,6 +95,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if STM32_PCLK1_FREQUENCY < 4000000
+#  warning STM32_I2C: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
+#endif
+
+#if STM32_PCLK1_FREQUENCY < 2000000
+#  error STM32_I2C: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
+#endif
+
 /* Configuration ************************************************************/
 
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
@@ -2586,15 +2594,6 @@ out:
 struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;
-
-#if STM32_PCLK1_FREQUENCY < 4000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
-#endif
-
-#if STM32_PCLK1_FREQUENCY < 2000000
-#   warning STM32_I2C_INIT: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -252,7 +252,7 @@
 
 #undef INVALID_CLOCK_SOURCE
 
-#warning TODO: check I2C clock source. It must be HSI!
+#warning TODO: check I2C clock source and clock frequency. It must be HSI!
 
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
  * Instead, CPU-intensive polling will be used.
@@ -2701,13 +2701,6 @@ struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;  /* private data of device with multiple instances */
   struct stm32_i2c_inst_s *inst = NULL;  /* device, single instance */
-
-#if 0                           /* REVISIT: this is not true for all STM32 M0 */
-#if STM32_HSI_FREQUENCY != 8000000 || defined(INVALID_CLOCK_SOURCE)
-#  warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-  return NULL;
-#endif
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -290,6 +290,10 @@
 #  endif
 #endif
 
+#if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
+#  error STM32_I2C: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
+#endif
+
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
  * Instead, CPU-intensive polling will be used.
  */
@@ -2730,11 +2734,6 @@ static int stm32_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;  /* private data of device with multiple instances */
-
-#if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
-# warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -236,6 +236,10 @@
 
 #undef INVALID_CLOCK_SOURCE
 
+#if defined(INVALID_CLOCK_SOURCE)
+#   error STM32_I2C: Peripheral input clock must be HSI or the speed/timing calculations need to be redone.
+#endif
+
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
  * Instead, CPU-intensive polling will be used.
  */
@@ -3004,11 +3008,6 @@ struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;  /* private data of device with multiple instances */
   struct stm32_i2c_inst_s *inst = NULL;  /* device, single instance */
-
-#if defined(INVALID_CLOCK_SOURCE)
-#   warning STM32_I2C_INIT: Peripheral input clock must be HSI or the speed/timing calculations need to be redone.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -248,6 +248,10 @@
 #  endif
 #endif
 
+#if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
+#   error STM32_I2C: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
+#endif
+
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.
  * Instead, CPU-intensive polling will be used.
  */
@@ -2705,11 +2709,6 @@ struct i2c_master_s *stm32_i2cbus_initialize(int port)
 {
   struct stm32_i2c_priv_s *priv = NULL;  /* private data of device with multiple instances */
   struct stm32_i2c_inst_s *inst = NULL;  /* device, single instance */
-
-#if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
-#   warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-  return NULL;
-#endif
 
   /* Get I2C private structure */
 


### PR DESCRIPTION
## Summary

Raise compilation error when I2C configuration is invalid. It's better to catch invalid clock configuration during compilation instead of producing binary that doesn't work as expected anyway.

## Impact

instead of returning null pointer which must be caught during program execution, we now return an error during compilation

## Testing
CI

