### PR TITLE
esp32[c3|c6|h2]: Fix misconfigured gpio issue

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_gpio.c
+++ b/boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_gpio.c
@@ -484,7 +484,7 @@ int esp_gpio_init(void)
       /* Configure the pins that will be used as output */
 
       esp_gpio_matrix_out(g_gpiooutputs[i], SIG_GPIO_OUT_IDX, 0, 0);
-      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1);
+      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_2 | INPUT_FUNCTION_2);
       esp_gpiowrite(g_gpiooutputs[i], 0);
 
       pincount++;
@@ -503,7 +503,7 @@ int esp_gpio_init(void)
 
       /* Configure the pins that will be used as interrupt input */
 
-      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_2 | PULLDOWN);
 
       pincount++;
     }

--- a/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_gpio.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_gpio.c
@@ -484,7 +484,7 @@ int esp_gpio_init(void)
       /* Configure the pins that will be used as output */
 
       esp_gpio_matrix_out(g_gpiooutputs[i], SIG_GPIO_OUT_IDX, 0, 0);
-      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1);
+      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_2 | INPUT_FUNCTION_2);
       esp_gpiowrite(g_gpiooutputs[i], 0);
 
       pincount++;
@@ -503,7 +503,7 @@ int esp_gpio_init(void)
 
       /* Configure the pins that will be used as interrupt input */
 
-      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_2 | PULLDOWN);
 
       pincount++;
     }

--- a/boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_gpio.c
+++ b/boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_gpio.c
@@ -484,7 +484,7 @@ int esp_gpio_init(void)
       /* Configure the pins that will be used as output */
 
       esp_gpio_matrix_out(g_gpiooutputs[i], SIG_GPIO_OUT_IDX, 0, 0);
-      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1);
+      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_2 | INPUT_FUNCTION_2);
       esp_gpiowrite(g_gpiooutputs[i], 0);
 
       pincount++;
@@ -503,7 +503,7 @@ int esp_gpio_init(void)
 
       /* Configure the pins that will be used as interrupt input */
 
-      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_2 | PULLDOWN);
 
       pincount++;
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/nuttx/issues/15456

Fix misconfigured pins for risc-v based esp chips

- esp32[c3|c6|h2]: Fix misconfigured gpio issue

## Impact

ESP32C3, ESP32C6 and ESP32H2

## Testing

`esp32c6-devkitc:gpio` configuration used with these commands:

```
gpio -t 1 /dev/gpio2
gpio -o 1 /dev/gpio0
gpio -o 1 /dev/gpio0
```

Output followed with an logic analyzer.