### PR TITLE
tools:add script to show cibuild diff

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -427,6 +427,7 @@ function refresh_default {
     if [ -d $nuttx/.git ] || [ -d $APPSDIR/.git ]; then
       if [[ -n $(git -C $nuttx status -s) ]]; then
         git -C $nuttx status
+        git --no-pager -C $nuttx diff
         fail=1
       fi
       if [[ -n $(git -C $APPSDIR status -s) ]]; then


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
CI does not give enough information to show problems in the build.

## Impact
CIbuild.

## Testing
CI test.


