### PR TITLE
[PATCH] stm32 timers: add set/get prescaler operations and get period operation  to ll_ops.

### DIFF
--- a/arch/arm/src/stm32/stm32_tim.c
+++ b/arch/arm/src/stm32/stm32_tim.c
@@ -333,6 +333,10 @@ static int  stm32_tim_setmode(struct stm32_tim_dev_s *dev,
                               stm32_tim_mode_t mode);
 static int  stm32_tim_setclock(struct stm32_tim_dev_s *dev,
                                uint32_t freq);
+static uint32_t stm32_tim_getprescaler(struct stm32_tim_dev_s *dev);
+static void stm32_tim_setprescaler(struct stm32_tim_dev_s *dev,
+                                 uint32_t prescaler);
+static uint32_t stm32_tim_getperiod(struct stm32_tim_dev_s *dev);
 static void stm32_tim_setperiod(struct stm32_tim_dev_s *dev,
                                 uint32_t period);
 static uint32_t stm32_tim_getcounter(struct stm32_tim_dev_s *dev);
@@ -360,22 +364,25 @@ static int  stm32_tim_checkint(struct stm32_tim_dev_s *dev, int source);
 
 static const struct stm32_tim_ops_s stm32_tim_ops =
 {
-  .enable     = stm32_tim_enable,
-  .disable    = stm32_tim_disable,
-  .setmode    = stm32_tim_setmode,
-  .setclock   = stm32_tim_setclock,
-  .setperiod  = stm32_tim_setperiod,
-  .getcounter = stm32_tim_getcounter,
-  .setcounter = stm32_tim_setcounter,
-  .getwidth   = stm32_tim_getwidth,
-  .setchannel = stm32_tim_setchannel,
-  .setcompare = stm32_tim_setcompare,
-  .getcapture = stm32_tim_getcapture,
-  .setisr     = stm32_tim_setisr,
-  .enableint  = stm32_tim_enableint,
-  .disableint = stm32_tim_disableint,
-  .ackint     = stm32_tim_ackint,
-  .checkint   = stm32_tim_checkint,
+  .enable         = stm32_tim_enable,
+  .disable        = stm32_tim_disable,
+  .setmode        = stm32_tim_setmode,
+  .setclock       = stm32_tim_setclock,
+  .setprescaler   = stm32_tim_setprescaler,
+  .getprescaler   = stm32_tim_getprescaler,
+  .getperiod      = stm32_tim_getperiod,
+  .setperiod      = stm32_tim_setperiod,
+  .getcounter     = stm32_tim_getcounter,
+  .setcounter     = stm32_tim_setcounter,
+  .getwidth       = stm32_tim_getwidth,
+  .setchannel     = stm32_tim_setchannel,
+  .setcompare     = stm32_tim_setcompare,
+  .getcapture     = stm32_tim_getcapture,
+  .setisr         = stm32_tim_setisr,
+  .enableint      = stm32_tim_enableint,
+  .disableint     = stm32_tim_disableint,
+  .ackint         = stm32_tim_ackint,
+  .checkint       = stm32_tim_checkint,
 };
 
 #ifdef CONFIG_STM32_TIM1
@@ -897,6 +904,41 @@ static int stm32_tim_setclock(struct stm32_tim_dev_s *dev, uint32_t freq)
   stm32_tim_enable(dev);
 
   return prescaler;
+}
+
+/****************************************************************************
+ * Name: stm32_tim_getprescaler
+ ****************************************************************************/
+
+static uint32_t stm32_tim_getprescaler(struct stm32_tim_dev_s *dev)
+{
+  DEBUGASSERT(dev != NULL);
+  return stm32_tim_getwidth(dev) > 16 ?
+    stm32_getreg32(dev, STM32_GTIM_PSC_OFFSET) :
+    (uint32_t)stm32_getreg16(dev, STM32_GTIM_PSC_OFFSET);
+}
+
+/****************************************************************************
+ * Name: stm32_tim_setprescaler
+ ****************************************************************************/
+
+static void stm32_tim_setprescaler(struct stm32_tim_dev_s *dev,
+                                 uint32_t prescaler)
+{
+  DEBUGASSERT(dev != NULL);
+  stm32_putreg32(dev, STM32_GTIM_PSC_OFFSET, prescaler);
+}
+
+/****************************************************************************
+ * Name: stm32_tim_getperiod
+ ****************************************************************************/
+
+static uint32_t stm32_tim_getperiod(struct stm32_tim_dev_s *dev)
+{
+  DEBUGASSERT(dev != NULL);
+  return stm32_tim_getwidth(dev) > 16 ?
+    stm32_getreg32(dev, STM32_GTIM_ARR_OFFSET) :
+    (uint32_t)stm32_getreg16(dev, STM32_GTIM_ARR_OFFSET);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32/stm32_tim.h
+++ b/arch/arm/src/stm32/stm32_tim.h
@@ -40,22 +40,25 @@
 
 /* Helpers ******************************************************************/
 
-#define STM32_TIM_SETMODE(d,mode)       ((d)->ops->setmode(d,mode))
-#define STM32_TIM_SETCLOCK(d,freq)      ((d)->ops->setclock(d,freq))
-#define STM32_TIM_SETPERIOD(d,period)   ((d)->ops->setperiod(d,period))
-#define STM32_TIM_GETCOUNTER(d)         ((d)->ops->getcounter(d))
-#define STM32_TIM_SETCOUNTER(d,c)       ((d)->ops->setcounter(d,c))
-#define STM32_TIM_GETWIDTH(d)           ((d)->ops->getwidth(d))
-#define STM32_TIM_SETCHANNEL(d,ch,mode) ((d)->ops->setchannel(d,ch,mode))
-#define STM32_TIM_SETCOMPARE(d,ch,comp) ((d)->ops->setcompare(d,ch,comp))
-#define STM32_TIM_GETCAPTURE(d,ch)      ((d)->ops->getcapture(d,ch))
-#define STM32_TIM_SETISR(d,hnd,arg,s)   ((d)->ops->setisr(d,hnd,arg,s))
-#define STM32_TIM_ENABLEINT(d,s)        ((d)->ops->enableint(d,s))
-#define STM32_TIM_DISABLEINT(d,s)       ((d)->ops->disableint(d,s))
-#define STM32_TIM_ACKINT(d,s)           ((d)->ops->ackint(d,s))
-#define STM32_TIM_CHECKINT(d,s)         ((d)->ops->checkint(d,s))
-#define STM32_TIM_ENABLE(d)             ((d)->ops->enable(d))
-#define STM32_TIM_DISABLE(d)            ((d)->ops->disable(d))
+#define STM32_TIM_SETMODE(d,mode)          ((d)->ops->setmode(d,mode))
+#define STM32_TIM_SETCLOCK(d,freq)         ((d)->ops->setclock(d,freq))
+#define STM32_TIM_GETPRESCALER(d)          ((d)->ops->getprescaler(d))
+#define STM32_TIM_SETPRESCALER(d,p)        ((d)->ops->setprescaler(d,p))
+#define STM32_TIM_GETPERIOD(d)             ((d)->ops->getperiod(d))
+#define STM32_TIM_SETPERIOD(d,p)           ((d)->ops->setperiod(d,p))
+#define STM32_TIM_GETCOUNTER(d)            ((d)->ops->getcounter(d))
+#define STM32_TIM_SETCOUNTER(d,c)          ((d)->ops->setcounter(d,c))
+#define STM32_TIM_GETWIDTH(d)              ((d)->ops->getwidth(d))
+#define STM32_TIM_SETCHANNEL(d,ch,mode)    ((d)->ops->setchannel(d,ch,mode))
+#define STM32_TIM_SETCOMPARE(d,ch,comp)    ((d)->ops->setcompare(d,ch,comp))
+#define STM32_TIM_GETCAPTURE(d,ch)         ((d)->ops->getcapture(d,ch))
+#define STM32_TIM_SETISR(d,hnd,arg,s)      ((d)->ops->setisr(d,hnd,arg,s))
+#define STM32_TIM_ENABLEINT(d,s)           ((d)->ops->enableint(d,s))
+#define STM32_TIM_DISABLEINT(d,s)          ((d)->ops->disableint(d,s))
+#define STM32_TIM_ACKINT(d,s)              ((d)->ops->ackint(d,s))
+#define STM32_TIM_CHECKINT(d,s)            ((d)->ops->checkint(d,s))
+#define STM32_TIM_ENABLE(d)                ((d)->ops->enable(d))
+#define STM32_TIM_DISABLE(d)               ((d)->ops->disable(d))
 
 /****************************************************************************
  * Public Types
@@ -159,6 +162,9 @@ struct stm32_tim_ops_s
   void (*disable)(struct stm32_tim_dev_s *dev);
   int  (*setmode)(struct stm32_tim_dev_s *dev, stm32_tim_mode_t mode);
   int  (*setclock)(struct stm32_tim_dev_s *dev, uint32_t freq);
+  uint32_t (*getprescaler)(struct stm32_tim_dev_s *dev);
+  void (*setprescaler)(struct stm32_tim_dev_s *dev, uint32_t prescaler);
+  uint32_t (*getperiod)(struct stm32_tim_dev_s *dev);
   void (*setperiod)(struct stm32_tim_dev_s *dev, uint32_t period);
   uint32_t (*getcounter)(struct stm32_tim_dev_s *dev);
   void (*setcounter)(struct stm32_tim_dev_s *dev, uint32_t count);


### PR DESCRIPTION
		      add get period operation to ll_ops.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


