### PR TITLE
mm: Add CONFIG_MM_NODE_PENDING configuration

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -69,6 +69,14 @@ config MM_DEFAULT_ALIGNMENT
 		memory default alignment is equal to sizoef(uintptr), if this value
 		is not 0, this value must be 2^n and at least sizeof(uintptr).
 
+config MM_NODE_PENDING
+	bool "Enable pending memory node"
+	default n
+	---help---
+		After it is enabled, the "preceding" member will be retained
+		forever regardless of whether the previous node is in the
+		alloc state or the free state.
+
 config MM_SMALL
 	bool "Small memory model"
 	default n

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -143,7 +143,11 @@
  * previous freenode
  */
 
-#define MM_ALLOCNODE_OVERHEAD (MM_SIZEOF_ALLOCNODE - sizeof(mmsize_t))
+#ifdef CONFIG_MM_NODE_PENDING
+#  define MM_ALLOCNODE_OVERHEAD (MM_SIZEOF_ALLOCNODE)
+#else
+#  define MM_ALLOCNODE_OVERHEAD (MM_SIZEOF_ALLOCNODE - sizeof(mmsize_t))
+#endif
 
 /* Get the node size */
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -152,8 +152,14 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
         {
           heap->mm_curused += newsize - oldsize;
           mm_shrinkchunk(heap, oldnode, newsize);
+
+#ifdef CONFIG_MM_NODE_PENDING
+          kasan_poison((FAR char *)oldnode + MM_SIZEOF_NODE(oldnode),
+                       oldsize - MM_SIZEOF_NODE(oldnode));
+#else
           kasan_poison((FAR char *)oldnode + MM_SIZEOF_NODE(oldnode) +
                        sizeof(mmsize_t), oldsize - MM_SIZEOF_NODE(oldnode));
+#endif
         }
 
       /* Then return the original address */


### PR DESCRIPTION
## Summary

  After it is enabled, the preceding member of the next node will no longer belong to the valid area of the previous alloc node.
  Due to the existence of the preceding member, the memory block size of the node can only be aligned with sizeof(mmsize_t).
  This configuration will be applied in the following scenarios:
          ARM64 MTE hardware tag KASan, which requires the tag's memory address to be 16-byte aligned and the memory size must also be 16-byte aligned

## Impact

The new feature arm64 MTE is added, "https://github.com/apache/nuttx/pull/15461" requires that the allocated block address must be 16-byte aligned and the size must also be 16-byte aligned. Our current memory management does not meet the requirements.

## Testing

CI


