### PR TITLE
drivers/usbdev/cdcacm.c: Fix a crash in cdcacm if usbdev gets unregistered while client calls close for the tty

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -2618,6 +2618,13 @@ static bool cdcuart_txempty(FAR struct uart_dev_s *dev)
 #endif
 
   flags = enter_critical_section();
+
+  if (dev->disconnected)
+    {
+      leave_critical_section(flags);
+      return true;
+    }
+
   priv->ispolling = true;
   EP_POLL(ep);
   priv->ispolling = false;
@@ -3011,6 +3018,10 @@ void cdcacm_uninitialize(FAR struct usbdevclass_driver_s *classdev)
   FAR struct cdcacm_dev_s    *priv = drvr->dev;
   char devname[CDCACM_DEVNAME_SIZE];
   int ret;
+
+  /* Disconnect in case we are connected */
+
+  cdcacm_disconnect(classdev, priv->usbdev);
 
 #ifndef CONFIG_CDCACM_COMPOSITE
   usbdev_unregister(&drvr->drvr);


### PR DESCRIPTION
## Summary

Make sure that the cdcacm is disconnected before the usbdev gets unregistered.

Also, check if the device is connected or not in cdcuart_txempty (uart_txempty). Otherwise there may be a crash during uart_tcdrain, called in tty close path, if the usbdev unregistration happens during the loop.

This issue can be triggered by monitoring the cable connection status in one thread, sending BOARDIOC_USBDEV_DISCONNECT if the usb cable is detached. In another thread close the ttyACM.

## Impact

This fixes a race condition in ttyACM/serial stack, leading to a kernel crash

## Testing

Tested with imx9 platform in PX4 stack, where one thread manages the ttyACM state and another reads/writes to the ttyACM serial.
