### PR TITLE
esp32[c6]: Fix misconfigured pin functions for esp32c6-devkitm

### DIFF
--- a/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_gpio.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_gpio.c
@@ -484,7 +484,7 @@ int esp_gpio_init(void)
       /* Configure the pins that will be used as output */
 
       esp_gpio_matrix_out(g_gpiooutputs[i], SIG_GPIO_OUT_IDX, 0, 0);
-      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1);
+      esp_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_2 | INPUT_FUNCTION_2);
       esp_gpiowrite(g_gpiooutputs[i], 0);
 
       pincount++;
@@ -503,7 +503,7 @@ int esp_gpio_init(void)
 
       /* Configure the pins that will be used as interrupt input */
 
-      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+      esp_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_2 | PULLDOWN);
 
       pincount++;
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/nuttx/issues/15456

Fix misconfigured pins for esp32c6-devkitm

- esp32[c6]: Fix misconfigured pin functions for esp32c6-devkitm

## Impact

Only ESP32C6-DevkitM

## Testing

`esp32c6-devkitm:gpio` configuration used with these commands:

```
gpio -t 1 /dev/gpio2
gpio -o 1 /dev/gpio0
gpio -o 1 /dev/gpio0
```

Output followed with an logic analyzer.
