### PR TITLE
tools/nxstyle.c: Add missing zlib function names to white list

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -617,6 +617,17 @@ static const char *g_white_content_list[] =
   "unzGetCurrentFileInfo64",
   "unzGoToNextFile",
   "unzGoToFirstFile",
+
+  /* Ref:
+   * apps/netutils/telnetc/telnetc.c
+   */
+
+  "deflateInit",
+  "deflateEnd",
+  "inflateInit",
+  "inflateEnd",
+  "zError",
+
   NULL
 };
 


### PR DESCRIPTION



## Summary

The zlib compression functions are used in network utilities for compression/decompression. These functions need to be added to the nxstyle white list to prevent style checking errors since they follow the zlib naming convention rather than NuttX's style guide.

Specifically, these functions are used in:
- apps/netutils/telnetc/telnetc.c for compressed data handling

## Impact

nxstyle

## Testing

Tested with apps/netutils/telnetc/telnetc.c , see https://github.com/apache/nuttx-apps/actions/runs/12707554430/job/35422711015?pr=2939
