### PR TITLE
kconfiglib/mark: It should use pip instead of apt install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ find_program(KCONFIGLIB olddefconfig)
 if(NOT KCONFIGLIB)
   message(
     FATAL_ERROR "Kconfig environment depends on kconfiglib, Please install:
-  $ sudo apt install python3-kconfiglib")
+  $ sudo pip3 install kconfiglib")
 endif()
 
 # BOARD CONFIG can be set to directory path, or <board-name>[/:]<config-name>


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

kconfiglib/mark: It should use pip instead of apt install

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


