### PR TITLE
mempool: addbacktrace should be before kasan_unpoison

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -397,14 +397,15 @@ retry:
 
   pool->nalloc++;
   spin_unlock_irqrestore(&pool->lock, flags);
-  blk = kasan_unpoison(blk, pool->blocksize);
-#ifdef CONFIG_MM_FILL_ALLOCATIONS
-  memset(blk, MM_ALLOC_MAGIC, pool->blocksize);
-#endif
 
 #if CONFIG_MM_BACKTRACE >= 0
   mempool_add_backtrace(pool, (FAR struct mempool_backtrace_s *)
                               ((FAR char *)blk + pool->blocksize));
+#endif
+
+  blk = kasan_unpoison(blk, pool->blocksize);
+#ifdef CONFIG_MM_FILL_ALLOCATIONS
+  memset(blk, MM_ALLOC_MAGIC, pool->blocksize);
 #endif
 
   return blk;


### PR DESCRIPTION
## Summary

If thread 1 is executing kasan_unpoison but a scheduling occurs and the block is trampled upon, the displayed backtracking may still be from the previously allocated backtracking

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


