### PR TITLE
drivers/vhost: fix compile error while get vhost status.

### DIFF
--- a/drivers/vhost/vhost-rng.c
+++ b/drivers/vhost/vhost-rng.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/vhost/vhost.h>
 #include <nuttx/wqueue.h>
 
@@ -151,7 +152,7 @@ static int vhost_rng_probe(FAR struct vhost_device *hdev)
 
   vqnames[0]  = "virtio_rng";
   callback[0] = vhost_rng_handler;
-  ret = vhost_create_virtqueues(hdev, 0, 1, vqnames, callback);
+  ret = vhost_create_virtqueues(hdev, 0, 1, vqnames, callback, NULL);
   if (ret < 0)
     {
       vhosterr("virtio_device_create_virtqueue failed, ret=%d\n", ret);

--- a/drivers/vhost/vhost.c
+++ b/drivers/vhost/vhost.c
@@ -83,8 +83,15 @@ static struct vhost_bus_s g_vhost_bus =
 
 static bool vhost_status_driver_ok(FAR struct vhost_device *hdev)
 {
-  uint8_t status = vhost_get_status(hdev);
   bool driver_ok = false;
+  uint8_t status;
+  int ret;
+
+  ret = vhost_get_status(hdev, &status);
+  if (ret)
+    {
+      return driver_ok;
+    }
 
   /* Busy wait until the remote is ready */
 


### PR DESCRIPTION
## Summary
vhost compile error as below:

```
vhost/vhost-rng.c:154:9: error: too few arguments to function 'virtio_create_virtqueues'
      154 |   ret = vhost_create_virtqueues(hdev, 0, 1, vqnames, callback);
```
```
vhost/vhost.c: In function 'vhost_status_driver_ok': vhost/vhost.c:86:20: error: too few arguments to function 'virtio_get_status'
   86 |   uint8_t status = vhost_get_status(hdev);
```

## Impact

vhost

## Testing

CI
