### PR TITLE
sim: Fixes the linker 'noexecstack' warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,6 +727,7 @@ else()
       OUTPUT nuttx.rel
       COMMAND
         ${CMAKE_C_COMPILER} ARGS -r $<$<BOOL:${CONFIG_SIM_M32}>:-m32>
+        $<$<BOOL:${CONFIG_HOST_LINUX}>:-Wl,-z,noexecstack>
         $<TARGET_OBJECTS:sim_head> $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--start-group>
         ${nuttx_libs_paths} $<$<NOT:$<BOOL:${APPLE}>>:-Wl,--end-group> -o
         nuttx.rel

--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -200,3 +200,7 @@ else()
   add_link_options(-Wl,--gc-sections)
   add_link_options(-Wl,-Ttext-segment=0x40000000)
 endif()
+
+if(CONFIG_HOST_LINUX)
+  add_link_options(-Wl,-z,noexecstack)
+endif()


### PR DESCRIPTION
Hi,

The sim arch will generate warning when compiled with cmake in linux host. I'm use ubuntu, and the gcc version is 14.2.0, ld version is 2.43.1:

> [ 99%] Generating nuttx.rel
> **/usr/bin/ld: warning: arch_setjmp_x86_64.S.o: missing .note.GNU-stack section implies executable stack**
> **/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker**
> [ 99%] Built target nuttx-rel
> [ 99%] Building C object CMakeFiles/nuttx.dir/empty.c.o
> [ 99%] Linking C executable nuttx
> **/usr/bin/ld: warning: nuttx.rel: requires executable stack (because the .note.GNU-stack section is executable)**
> [100%] Built target nuttx

The build command is as follows:

> cmake -B build -DBOARD_CONFIG=sim:nsh
>cmake --build build

One is a linking warning for nuttx, and the other is a linking warning for nuttx.rel.

So add -Wl,-z,noexecstack to fix it.

Refer to this PR #14505 