### PR TITLE
riscv/Toolchain.defs: guard -r use

### DIFF
--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -433,7 +433,12 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden
 
-LDELFFLAGS = -r -e main
+LDELFFLAGS = -e main
+
+ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
+  LDELFFLAGS += -r
+endif
+
 ifeq ($(CONFIG_ARCH_RV32),y)
   LDELFFLAGS += --oformat elf32-littleriscv
 else


### PR DESCRIPTION
# Summary

This fix the issue that `-r` is blindly used when linking kernel build apps. The option should only be used when `BINFMT_ELF_RELOCATABLE` is selected.

# Impact

RiscV kernel build with EXECUTABLE apps format.

# Testing

- locally with `rv-virt:knsh64`
- CI checks



