### PR TITLE
arch/arm/rp23xx: Set priority for svcall exception

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_irq.c
+++ b/arch/arm/src/rp23xx/rp23xx_irq.c
@@ -182,6 +182,27 @@ static int rp23xx_reserved(int irq, void *context, void *arg)
 #endif
 
 /****************************************************************************
+ * Name: rp23xx_prioritize_syscall
+ *
+ * Description:
+ *   Set the priority of an exception.  This function may be needed
+ *   internally even if support for prioritized interrupts is not enabled.
+ *
+ ****************************************************************************/
+
+static inline void rp23xx_prioritize_syscall(int priority)
+{
+  uint32_t regval;
+
+  /* SVCALL is system handler 11 */
+
+  regval  = getreg32(NVIC_SYSH8_11_PRIORITY);
+  regval &= ~NVIC_SYSH_PRIORITY_PR11_MASK;
+  regval |= (priority << NVIC_SYSH_PRIORITY_PR11_SHIFT);
+  putreg32(regval, NVIC_SYSH8_11_PRIORITY);
+}
+
+/****************************************************************************
  * Name: rp23xx_clrpend
  *
  * Description:
@@ -275,6 +296,8 @@ void up_irqinitialize(void)
 
   irq_attach(RP23XX_IRQ_SVCALL, arm_svcall, NULL);
   irq_attach(RP23XX_IRQ_HARDFAULT, arm_hardfault, NULL);
+
+  rp23xx_prioritize_syscall(NVIC_SYSH_SVCALL_PRIORITY);
 
   /* Attach all other processor exceptions (except reset and sys tick) */
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/nuttx/issues/15503.

## Impact

rp23xx

## Testing

Running `raspberrypi-pico-2:nsh` on feather rp2350


