### PR TITLE
arch/x86_64:Resolve the issue of abnormal interrupt numbers triggered when KASAN is enabled

### DIFF
--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -190,6 +190,7 @@ uint64_t *irq_handler(uint64_t *regs, uint64_t irq_no)
  *
  ****************************************************************************/
 
+nosanitize_address
 uint64_t *irq_xcp_regs(void)
 {
   /* This must be the simplest as possible, so we not use too much registers.


### PR DESCRIPTION
## Summary

When assembly code calls a C function, it needs to save the context. After enabling KASAN, the inserted __asan_load8_noabort function uses the rsi register, causing the value of rsi in the interrupt handler to be modified, which results in an incorrect interrupt number.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


