### PR TITLE
Revert "sched: misc: Remove sched_lock in _assert()"

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -840,6 +840,7 @@ void _assert(FAR const char *filename, int linenum,
   if (os_ready)
     {
       flags = spin_lock_irqsave(&g_assert_lock);
+      sched_lock();
     }
 
 #if CONFIG_BOARD_RESET_ON_ASSERT < 2
@@ -913,5 +914,6 @@ void _assert(FAR const char *filename, int linenum,
   if (os_ready)
     {
       spin_unlock_irqrestore(&g_assert_lock, flags);
+      sched_unlock();
     }
 }


### PR DESCRIPTION

## Summary

Revert "sched: misc: Remove sched_lock in _assert()"
reason:
This reverts commit d0820acbbba213dbb7e4d1b7f38b6564d265660e assert will call syslog
## Impact
assert

## Testing
ci


