### PR TITLE
armv7a: Amp mode support

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -724,13 +724,8 @@ void arm_cpu_sgi(int sgi, unsigned int cpuset)
 
   arm_gic_wait_done(cpuset);
 
-#ifdef CONFIG_SMP
   regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(cpuset) |
            GIC_ICDSGIR_TGTFILTER_LIST;
-#else
-  regval = GIC_ICDSGIR_INTID(sgi) | GIC_ICDSGIR_CPUTARGET(0) |
-           GIC_ICDSGIR_TGTFILTER_THIS;
-#endif
 
 #if defined(CONFIG_ARCH_TRUSTZONE_SECURE)
   if (sgi >= GIC_IRQ_SGI0 && sgi <= GIC_IRQ_SGI7)

--- a/arch/arm/src/qemu/qemu_irq.c
+++ b/arch/arm/src/qemu/qemu_irq.c
@@ -116,9 +116,15 @@ void up_irqinitialize(void)
    * access to the GIC.
    */
 
-  /* Initialize the Generic Interrupt Controller (GIC) for CPU0 */
+  /* Initialize the Generic Interrupt Controller (GIC) for CPU0.
+   * In AMP mode, we want arm_gic0_initialize to be called only once.
+   */
 
-  arm_gic0_initialize();  /* Initialization unique to CPU0 */
+  if (sched_getcpu() == 0)
+    {
+      arm_gic0_initialize();  /* Initialization unique to CPU0 */
+    }
+
   arm_gic_initialize();   /* Initialization common to all CPUs */
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS


### PR DESCRIPTION

## Summary
armv7a: Amp mode support
reason:
In AMP mode, we can also use SGI as an inter-core interrupt, and ensure that arm_gic0_initialize is called only once.


## Impact

armv7a

## Testing

ci

