### PR TITLE
Revert "kconfiglib/mark: It should use pip instead of apt install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,16 @@ endif()
 
 find_program(KCONFIGLIB olddefconfig)
 if(NOT KCONFIGLIB)
+  # cmake-format: off
   message(
     FATAL_ERROR "Kconfig environment depends on kconfiglib, Please install:
-  $ sudo pip3 install kconfiglib")
+  (APT source)
+    $ sudo apt install python3-kconfiglib
+  or (pip source)
+    $ pip install kconfiglib
+  or (After Ubuntu 24.04)
+    $ pip install kconfiglib --break-system-packages")
+  # cmake-format: on
 endif()
 
 # BOARD CONFIG can be set to directory path, or <board-name>[/:]<config-name>


### PR DESCRIPTION
## Summary

Revert "kconfiglib/mark: It should use pip instead of apt install"

pip source is deprecated from ubuntu 24.04

This reverts commit 7c7a64c84c3fe1db492ff84c727e15dd4f82f147.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check
