### PR TITLE
arch/arm: fix regression by spinlock change

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_qencoder.c
+++ b/arch/arm/src/stm32l4/stm32l4_qencoder.c
@@ -1086,10 +1086,10 @@ static int stm32l4_reset(struct qe_lowerhalf_s *lower)
    * Interrupts are disabled to make this atomic (if possible)
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   stm32l4_putreg32(priv, STM32L4_GTIM_CNT_OFFSET, 0);
   priv->position = 0;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 #else
   sninfo("Resetting position to zero\n");
   DEBUGASSERT(lower && priv->inuse);

--- a/arch/arm/src/stm32l4/stm32l4_qencoder.c
+++ b/arch/arm/src/stm32l4/stm32l4_qencoder.c
@@ -1043,7 +1043,7 @@ static int stm32l4_position(struct qe_lowerhalf_s *lower,
 
   /* Loop until we are certain that no interrupt occurred between samples */
 
-  spin_lock_irqsave(&priv->lock);
+  flags = spin_lock_irqsave(&priv->lock);
   do
     {
       position = priv->position;


### PR DESCRIPTION

## Summary

arch/arm: fix regression by spinlock change

| commit c96b8cdfdd6ee007ad60818565d5fd1e802dc2e5
| Author: hujun5 <hujun5@xiaomi.com>
| Date:   Mon Dec 23 16:59:20 2024 +0800
|
|     use small lock in following files:

Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

N/A

## Testing

ci-check