### PR TITLE
sched/clock: remove unlock logic to avoid relock

### DIFF
--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -163,6 +163,8 @@ static void clock_inittime(FAR const struct timespec *tp)
   struct timespec ts;
   irqstate_t flags;
 
+  clock_systime_timespec(&ts);
+
   flags = spin_lock_irqsave(&g_basetime_lock);
   if (tp)
     {
@@ -172,12 +174,6 @@ static void clock_inittime(FAR const struct timespec *tp)
     {
       clock_basetime(&g_basetime);
     }
-
-  spin_unlock_irqrestore(&g_basetime_lock, flags);
-
-  clock_systime_timespec(&ts);
-
-  flags = spin_lock_irqsave(&g_basetime_lock);
 
   /* Adjust base time to hide initial timer ticks. */
 


### PR DESCRIPTION
## Summary

sched/clock: remove unlock logic to avoid relock

get time spec before protect g_basetime

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check