### PR TITLE
arch/arm64: fix typo spin_lock_irqsave -> spin_unlock_irqrestore

### DIFF
--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -204,7 +204,7 @@ static struct imx9_edmatcd_s *imx9_tcd_alloc(void)
   tcd = (struct imx9_edmatcd_s *)sq_remfirst(&g_tcd_free);
   DEBUGASSERT(tcd != NULL);
 
-  spin_lock_irqsave(&g_edma.lock, flags);
+  spin_unlock_irqrestore(&g_edma.lock, flags);
   return tcd;
 }
 #endif


### PR DESCRIPTION
## Summary

arch/arm64: fix typo spin_lock_irqsave -> spin_unlock_irqrestore

should be spin_unlock_irqrestore

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check