### PR TITLE
drivers/note: fix typo falgs and align local name to irq_mask

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -2034,10 +2034,10 @@ void sched_note_filter_irq(FAR struct note_filter_named_irq_s *oldf,
 void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
                            FAR struct note_filter_named_tag_s *newf)
 {
-  irqstate_t falgs;
   FAR struct note_driver_s **driver;
+  irqstate_t irq_mask;
 
-  falgs = spin_lock_irqsave_wo_note(&g_note_lock);
+  irq_mask = spin_lock_irqsave_wo_note(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -2073,7 +2073,7 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
         }
     }
 
-  spin_unlock_irqrestore_wo_note(&g_note_lock, falgs);
+  spin_unlock_irqrestore_wo_note(&g_note_lock, irq_mask);
 }
 #endif
 


### PR DESCRIPTION
## Summary

drivers/note: fix typo falgs and align local name to irq_mask

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check