### PR TITLE
arm/imx9: sched_unlock should called after spin_unlock()

### DIFF
--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -807,6 +807,7 @@ static int imx9_txpoll(struct net_driver_s *dev)
   struct imx9_driver_s *priv =
     (struct imx9_driver_s *)dev->d_private;
   irqstate_t flags;
+  int ret = 0;
 
   /* If the polling resulted in data that should be sent out on the network,
    * the field d_len is set to a value > 0.
@@ -829,20 +830,18 @@ static int imx9_txpoll(struct net_driver_s *dev)
 
       if (imx9_txringfull(priv))
         {
-          sched_unlock();
-          spin_unlock_irqrestore(&priv->lock, flags);
-          return -EBUSY;
+          ret = -EBUSY;
         }
     }
 
-  sched_unlock();
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.
    */
 
-  return 0;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

arm/imx9: sched_unlock should called after spin_unlock()

fix deadlock if sched_unlock switch out to other task

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check