### PR TITLE
boards/xtensa: disable DEV_CONSOLE on usbnsh defconfig

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-devkit/configs/usbnsh/defconfig
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/configs/usbnsh/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_ARCH_LEDS is not set
+# CONFIG_DEV_CONSOLE is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 CONFIG_ARCH="xtensa"

--- a/boards/xtensa/esp32s3/esp32s3-eye/configs/usbnsh/defconfig
+++ b/boards/xtensa/esp32s3/esp32s3-eye/configs/usbnsh/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_ARCH_LEDS is not set
+# CONFIG_DEV_CONSOLE is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 CONFIG_ARCH="xtensa"

--- a/boards/xtensa/esp32s3/esp32s3-lhcbit/configs/usbnsh/defconfig
+++ b/boards/xtensa/esp32s3/esp32s3-lhcbit/configs/usbnsh/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_DEV_CONSOLE is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 CONFIG_ARCH="xtensa"

--- a/boards/xtensa/esp32s3/esp32s3-meadow/configs/usbnsh/defconfig
+++ b/boards/xtensa/esp32s3/esp32s3-meadow/configs/usbnsh/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_ARCH_LEDS is not set
+# CONFIG_DEV_CONSOLE is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 CONFIG_ARCH="xtensa"


### PR DESCRIPTION
## Summary

ESP32S3 on the usbnsh defconfig fails to bring up the expected ttyACMx when DEBUG_ASSERTIONS are enabled.

After reset, the ACM0 comes up and quickly disconnects. Somehow, it worked without DEBUG_ASSERTIONS.
Issue was found to be a assignment of `/dev/console` on both CDC_ACM and DEV_CONSOLE setup, which would returned a negated ERRNO on `group_setupidlefiles`.

This PR disables `CONFIG_DEV_CONSOLE` and fixes the issue.

## Impact

Allows use of esp32s3-devkit:usbnsh when DEBUG_ASSERTIONS are enabled.

## Testing

Manually tested this defconfig in many reset scenarios.
Internal CI testing as well.
