### PR TITLE
modlib:gnu-elf.ld.in load exe elf data section mismatch

### DIFF
--- a/libs/libc/modlib/gnu-elf.ld.in
+++ b/libs/libc/modlib/gnu-elf.ld.in
@@ -26,7 +26,7 @@
 #  include <nuttx/addrenv.h>
 
 #  define TEXT CONFIG_ARCH_TEXT_VBASE
-#  define DATA CONFIG_ARCH_DATA_VBASE + ARCH_DATA_RESERVE_SIZE
+#  define DATA CONFIG_ARCH_DATA_VBASE + CONFIG_MM_PGSIZE
 #else
 #  define TEXT 0x0
 #  define DATA


### PR DESCRIPTION
```
arch/risc-v/src/common/riscv_addrenv.c:418:

{
...
  database = resvbase + MM_PGALIGNUP(resvsize) + ARCH_DATA_RESERVE_SIZE;
...
}

```
if not add MM_PGALIGNUP(resvsize), will mismatch address load .data section

## Summary

risc-v:fix modlib load exe elf data section mismatch

## Impact

risc-v elf load

## Testing

risc-v:knsh with hello apps:

```
static char test_static[] = "Testing Static Var";

int main(int argc, FAR char *argv[]) {
  printf("test_static=%s\n", test_static);
  printf("Address of test_static=%p\n", test_static);
  return 0;
}
```

and output:

```
NuttShell (NSH) NuttX-12.7.2-vela
nsh> hello
test_static=Testing Static Var
Address of test_static=0xc0101200
nsh> QEMU: Terminated

```

fix it https://github.com/apache/nuttx/issues/15526