### PR TITLE
arch/armv7a: fix vfork for KERNEL build

### DIFF
--- a/arch/arm/src/common/arm_fork.c
+++ b/arch/arm/src/common/arm_fork.c
@@ -98,6 +98,11 @@ pid_t arm_fork(const struct fork_s *context)
   uint32_t newtop;
   uint32_t stacktop;
   uint32_t stackutil;
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  uint32_t oldsp = (uint32_t)parent->xcp.ustkptr;
+#else
+  uint32_t oldsp = context->sp;
+#endif
 
   sinfo("fork context [%p]:\n", context);
   sinfo("  r4:%08" PRIx32 " r5:%08" PRIx32
@@ -106,7 +111,7 @@ pid_t arm_fork(const struct fork_s *context)
   sinfo("  r8:%08" PRIx32 " r9:%08" PRIx32 " r10:%08" PRIx32 "\n",
         context->r8, context->r9, context->r10);
   sinfo("  r11:%08" PRIx32 " sp:%08" PRIx32 " lr:%08" PRIx32 "\n",
-        context->r11, context->sp, context->lr);
+        context->r11, oldsp, context->lr);
 
   /* Allocate and initialize a TCB for the child task. */
 
@@ -127,8 +132,8 @@ pid_t arm_fork(const struct fork_s *context)
 
   stacktop = (uint32_t)parent->stack_base_ptr +
                        parent->adj_stack_size;
-  DEBUGASSERT(stacktop > context->sp);
-  stackutil = stacktop - context->sp;
+  DEBUGASSERT(stacktop > oldsp && oldsp >= (uint32_t)parent->stack_base_ptr);
+  stackutil = stacktop - oldsp;
 
   sinfo("Parent: stackutil:%" PRIu32 "\n", stackutil);
 
@@ -151,11 +156,11 @@ pid_t arm_fork(const struct fork_s *context)
 
   child->cmn.xcp.regs = (void *)(newsp - XCPTCONTEXT_SIZE);
 
-  memcpy((void *)newsp, (const void *)context->sp, stackutil);
+  memcpy((void *)newsp, (const void *)oldsp, stackutil);
 
   /* Was there a frame pointer in place before? */
 
-  if (context->fp >= context->sp && context->fp < stacktop)
+  if (context->fp >= oldsp && context->fp < stacktop)
     {
       uint32_t frameutil = stacktop - context->fp;
       newfp = newtop - frameutil;
@@ -166,7 +171,7 @@ pid_t arm_fork(const struct fork_s *context)
     }
 
   sinfo("Old stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
-        stacktop, context->sp, context->fp);
+        stacktop, oldsp, context->fp);
   sinfo("New stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
         newtop, newsp, newfp);
 


### PR DESCRIPTION
## Summary

This tries to fix armv7-a kernel build `vfork()`. In kernel mode, forked child needs copying parents userspace stack instead.

## Impacts

Devices using armv7-a kernel mode, such as qemu-armv7a:knsh.

## Testing

- local checks with `qemu-armv7a:knsh`
- CI checks
