### PR TITLE
goldfish_memorymap:Resize VIRT_FLASH_PSECTION

### DIFF
--- a/arch/arm/src/goldfish/goldfish_memorymap.h
+++ b/arch/arm/src/goldfish/goldfish_memorymap.h
@@ -40,7 +40,7 @@
 
 /* Goldfish virt Physical Memory Map ****************************************/
 
-#define VIRT_FLASH_PSECTION      0x00000000  /* 0x00000000-0x08000000 */
+#define VIRT_FLASH_PSECTION      0x00600000  /* 0x00600000-0x08000000 */
 #define VIRT_IO_PSECTION         0x08000000  /* 0x08000000-0x0f000000 */
 #define VIRT_PCIE_PSECTION       0x10000000  /* 0x10000000-0x40000000 */
 #define VIRT_DDR_PSECTION        0x40000000  /* 0x40000000-0x50000000 */
@@ -54,7 +54,7 @@
 
 /* Sizes of memory regions in bytes. */
 
-#define VIRT_FLASH_SECSIZE       (128*1024*1024)
+#define VIRT_FLASH_SECSIZE       (122*1024*1024)
 #define VIRT_IO_SECSIZE          (112*1024*1024)
 #define VIRT_PCIE_SECSIZE        (3*256*1024*1024)
 #define VIRT_DDR_SECSIZE         (256*1024*1024)


### PR DESCRIPTION
## Summary
  Adjust VIRT_FLASH_PSECTION from 0x00000000-0x08000000 -> 0x00600000-0x08000000.
  The above changes avoid the problem of directly restarting in goldfish when the process accesses/executes at address 0x0 without causing assert.

## Impact
  Adjusted the MPU range so we can better expose potential issues

## Testing
  Build Host(s): Linux x86
  Target(s): Goldfish-armv7a
  Trigger assert when accessing an illegal address (0x0)
  ```
goldfish-armv7a-ap> xd 0x0 1024
Hex dump:
[   18.260700] [ 7] [ ALERT] [ap] arm_dataabort: Data abort. PC: 006332a0 DFAR: 00000000 DFSR: 00000005
[   18.261200] [ 7] [ ALERT] [ap] dump_assert_info: Current Version: NuttX  12.3.0 6d136cef66e Jan 14 2025 01:53:56 arm
[   18.261600] [ 7] [ ALERT] [ap] dump_assert_info: Assertion failed panic: at file: armv7-a/arm_dataabort.c:161 task: nsh_main process: nsh_main 0x62fb91
[   18.261900] [ 7] [ ALERT] [ap] up_dump_register: R0: 00000006 R1: 4085cdc0 R2: 00000010  R3: 4085cdc4
[   18.262100] [ 7] [ ALERT] [ap] up_dump_register: R4: 00000006 R5: 00000000 R6: 00000000  FP: 4085cda8
[   18.262400] [ 7] [ ALERT] [ap] up_dump_register: R8: 4085cdca SB: 00000010 SL: 00000400 R11: 00000000
[   18.262600] [ 7] [ ALERT] [ap] up_dump_register: IP: ffffffff SP: 4085cda8 LR: 0063329d  PC: 006332a0
[   18.262800] [ 7] [ ALERT] [ap] up_dump_register: CPSR: 8000007f
[   18.263100] [ 7] [ ALERT] [ap] dump_stackinfo: User Stack:
[   18.263200] [ 7] [ ALERT] [ap] dump_stackinfo:   base: 0x4085b160
[   18.263400] [ 7] [ ALERT] [ap] dump_stackinfo:   size: 00008088
[   18.263500] [ 7] [ ALERT] [ap] dump_stackinfo:     sp: 0x4085cda8
```
