### PR TITLE
fs_procfs:Fix closedir should handle the release dir handle on a case-by-case basis

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -787,9 +787,24 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 static int procfs_closedir(FAR struct inode *mountpt,
                            FAR struct fs_dirent_s *dir)
 {
+  FAR struct procfs_dir_priv_s *dirpriv;
+  int ret = OK;
+
   DEBUGASSERT(mountpt && dir);
-  fs_heap_free(dir);
-  return OK;
+
+  dirpriv = (FAR struct procfs_dir_priv_s *)dir;
+
+  if (dirpriv->procfsentry != NULL &&
+      dirpriv->procfsentry->ops->closedir != NULL)
+    {
+      ret = dirpriv->procfsentry->ops->closedir(dir);
+    }
+  else
+    {
+      fs_heap_free(dir);
+    }
+
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
  This issue aims to fix some problems caused by the previously introduced fs_heap (https://github.com/apache/nuttx/pull/13722) feature.
  Different modules in the kernel have their own procfs, such as net-procfs, and they may have their own private handles. When we use fs_heap, the kmm heap and fs heap are not in the same area. In this way, the corresponding destructor should be executed when procfs_closedir is executed uniformly, avoiding assertions caused by releasing in different heaps.
  If the module's procfs provides a destructor, it is executed. Otherwise, priv is released via fs_heap_free

## Impact
  Adjusted the handling of procf_closedir in fs_procfs.c.

## Testing
  Build Host(s): Linux x86
  Target(s): Goldfish-armv7a
  In a qemu configured with fs_heap, we use the command ifconfig (because it uses opendir/closedir of net_procfs) and it can be executed successfully without assert
```
goldfish-armv7a-ap> ifconfig
lo      Link encap:Local Loopback at RUNNING mtu 1518
        inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
        inet6 addr: ::1/128
        inet6 DRaddr: ::1

        RX: Received Fragment Errors   Bytes   
            00000000 00000000 00000000 0               
            IPv4     IPv6     ARP      Dropped 
            00000000 00000000 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes   
            00000000 00000000 00000000 00000000 0                
        Total Errors: 00000000

wlan0   Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at RUNNING mtu 1500
        inet addr:10.0.2.16 DRaddr:10.0.2.2 Mask:255.255.255.0
        inet6 addr: fec0::2e0:deff:fead:beef/64
        inet6 DRaddr: fe80::2

        RX: Received Fragment Errors   Bytes   
            00000003 00000000 00000000 50a             
            IPv4     IPv6     ARP      Dropped 
            00000002 00000001 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes   
            00000008 00000004 00000000 00000000 461              
        Total Errors: 00000000
```