### PR TITLE
gdb-kasan: Add gdb kasan script

### DIFF
--- a/tools/gdb/nuttxgdb/kasan.py
+++ b/tools/gdb/nuttxgdb/kasan.py
@@ -1,0 +1,145 @@
+############################################################################
+# tools/gdb/nuttxgdb/kasan.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import itertools
+
+import gdb
+
+from . import utils
+
+
+class KASanGeneric:
+    def __init__(self, begin, end, shadow, bitwidth, scale, shift=0):
+        self.begin = begin
+        self.end = end
+        self.shadow = shadow
+        self.bitwidth = bitwidth
+        self.scale = scale
+        self.shift = shift
+
+    def check_addr(self, addr):
+        distance = (addr - self.begin) / self.scale
+        index = distance / self.bitwidth
+        bit = distance % self.bitwidth
+        return True if self.shadow[index] >> bit & 0x01 else False
+
+    def is_member(self, addr):
+        if self.begin <= self.untag_addr(addr) <= self.end:
+            return True
+        return False
+
+    def get_tag(self, addr):
+        return addr >> self.shift
+
+    def untag_addr(self, addr):
+        return addr
+
+
+class KASanSwtags(KASanGeneric):
+    def check_addr(self, addr):
+        tag = self.get_tag(addr)
+        untag_addr = self.untag_addr(addr)
+        distance = untag_addr - self.begin
+        index = distance / self.scale
+        return False if self.shadow[index] == tag else True
+
+    def untag_addr(self, addr):
+        mask = ~(0xFF << self.shift)
+        return addr & mask
+
+
+class KASan(gdb.Command):
+
+    def __init__(self):
+        super().__init__("kasandebug", gdb.COMMAND_USER)
+
+        """ Common bit width and kasan alignment length in multiple modes """
+        bitwidth = utils.get_symbol_value("sizeof(long)") * 8
+        scale = utils.get_symbol_value("KASAN_SHADOW_SCALE")
+
+        """ Get the array of KASan regions """
+        g_region_count = utils.get_symbol_value("g_region_count")
+        g_region = utils.get_symbol_value("g_region")
+
+        self.regions: list[KASanGeneric] = []
+        if utils.get_symbol_value("CONFIG_MM_KASAN_GENERIC") is not None:
+            print("KASan Mode: Generic")
+            for index in range(g_region_count):
+                region = g_region[index]
+                self.regions.append(
+                    KASanGeneric(
+                        region["begin"],
+                        region["end"],
+                        region["shadow"],
+                        bitwidth,
+                        scale,
+                    )
+                )
+
+        if utils.get_symbol_value("CONFIG_MM_KASAN_SW_TAGS") is not None:
+            print("KASan Mode: Softtags")
+            shift = utils.get_symbol_value("KASAN_TAG_SHIFT")
+            for index in range(g_region_count):
+                region = g_region[index]
+                self.regions.append(
+                    KASanSwtags(
+                        region["begin"],
+                        region["end"],
+                        region["shadow"],
+                        bitwidth,
+                        scale,
+                        shift,
+                    )
+                )
+
+        if utils.get_symbol_value("CONFIG_MM_KASAN_GLOBAL") is not None:
+            print("KASan Support Checking Global Variables")
+            scale = utils.get_symbol_value("CONFIG_MM_KASAN_GLOBAL_ALIGN")
+            for index in itertools.count(0):
+                addr = utils.get_symbol_value(f"g_global_region[{index}]")
+                if addr == 0:
+                    break
+                region = utils.get_symbol_value(f"*g_global_region[{index}]")
+                self.regions.append(
+                    KASanGeneric(
+                        region["begin"],
+                        region["end"],
+                        region["shadow"],
+                        bitwidth,
+                        scale,
+                    )
+                )
+
+    def invoke(self, args, from_tty):
+        addrs = [
+            int(arg, 16) if arg.startswith("0x") else int(arg)
+            for arg in args.split()
+            if arg.startswith("0x") or arg.isdigit()
+        ]
+        for addr in addrs:
+            for region in self.regions:
+                if region.is_member(addr):
+                    if region.check_addr(addr):
+                        print("Addr 0x%x Error" % (addr))
+                    else:
+                        print("Addr 0x%x OK" % (addr))
+                    break


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

GDB source kasan.py script, use kasandebug command to determine the legitimacy of the Heap address, currently supports two types of KASan debugging, and it also supports checking the legitimacy of Data and Bss segment addresses
```
1. General KASan
2. Software tag KASan
3. KASan Globals
```

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing


```

static bool test_heap_underflow(FAR struct mm_heap_s *heap, size_t size)
{
  FAR uint8_t *mem = mm_malloc(heap, size);
  *(mem - 1) = 0x12;
  return false;
}

Generic KASan examples:

nsh> kasantest
spawn_execattrs: Setting policy=2 priority=101 for pid=3
nxtask_activate: kasantest pid=3,TCB=0x4021bb70
KASan test: heap underflow
nxtask_activate: kasantest pid=4,TCB=0x4021dfa0
kasan_report: kasan detected a write access error, address at 0x40213667,size is 1, return address: 0x62f82c
kasan_show_memory: Shadow bytes around the buggy address:
kasan_show_memory:   0x40213610: 18 36 21 40 f8 35 21 40 00 00 00 00 00 00 00 00
kasan_show_memory:   0x40213620: 28 36 21 40 08 36 21 40 00 00 00 00 00 00 00 00
kasan_show_memory:   0x40213630: 38 36 21 40 18 36 21 40 00 00 00 00 00 00 00 00
kasan_show_memory:   0x40213640: 00 00 00 00 28 36 21 40 00 00 00 00 20 3a 65 00
kasan_show_memory:   0x40213650: f0 34 21 40 5c 91 21 40 00 00 00 00 09 00 00 00
kasan_show_memory:   0x40213660: 00 00 00 00 11 00 00[00 b8 35 21 40 a8 35 21 40
kasan_show_memory:   0x40213670: 00 00 00 00 08 25 00 00 b8 35 21 40 a8 35 21 40
kasan_show_memory:   0x40213680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
kasan_show_memory:   0x40213690: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
kasan_show_memory:   0x402136a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
dump_assert_info: Current Version: NuttX  0.0.0 8599c6bb10-dirty Jan 14 2025 17:05:39 arm
dump_assert_info: Assertion failed panic: at file: kasan/hook.c:189 task: kasantest process: kasantest 0x630ce0
up_dump_register: R0: 402117a0 R1: 4021dfe8 R2: 47c0ce80  R3: 00000000
up_dump_register: R4: 4021dfa0 R5: 402117a0 R6: 006428d3  R7: 006428d9
up_dump_register: R8: 40210de0 SB: 00000006 SL: 000000bd  FP: 0064289e
up_dump_register: IP: 4021dfe4 SP: 40220060 LR: 00606964  PC: 00606964
up_dump_register: CPSR: 600000df

What happened is heap underflow. It can be clearly analyzed that the address 0x40213667 is inaccessible,
but the next byte 0x40213668 is accessible. For details, see kasantest:

At this time, access gdb:
(gdb) kasandebug 0x40213667
Addr 0x40213667 Error
(gdb) kasandebug 0x40213666
Addr 0x40213666 Error
(gdb) kasandebug 0x40213668
Addr 0x40213668 OK

```
```
Softtags KASan examples:

NuttShell (NSH)
nsh> kasantest
KASan test: heap underflow
kasan_report: kasan detected a write access error, address at 0x1b0000004041245f,size is 1, return address: 0x4029e190
kasan_show_memory: Shadow bytes around the buggy address:
kasan_show_memory:   0x1b00000040412400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
kasan_show_memory:   0x1b00000040412410: 00 00 00 00 00 00 00 00 e0 23 41 40 00 00 00 00
kasan_show_memory:   0x1b00000040412420: 00 00 00 00 00 00 00 00 40 94 3c 40 00 00 00 00
kasan_show_memory:   0x1b00000040412430: 98 21 41 40 00 00 00 00 90 b2 41 40 00 00 00 00
kasan_show_memory:   0x1b00000040412440: 00 00 00 00 00 00 00 00 11 00 00 00 00 00 00 00
kasan_show_memory:   0x1b00000040412450: 00 00 00 00 00 00 00 00 59 0f 00 00 00 00 00[00
kasan_show_memory:   0x1b00000040412460: 00 23 41 40 00 00 00 00 e0 22 41 40 00 00 00 00
kasan_show_memory:   0x1b00000040412470: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
kasan_show_memory:   0x1b00000040412480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
kasan_show_memory:   0x1b00000040412490: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
dump_assert_info: Current Version: NuttX  0.0.0 8599c6bb10-dirty Jan 14 2025 17:15:58 arm64
dump_assert_info: Assertion failed panic: at file: kasan/hook.c:189 task: kasantest process: kasantest 0x4029f3f4

(gdb) kasandebug 0x1b0000004041245f
Addr 0x1b0000004041245f Error
(gdb) kasandebug 0x1b00000040412460
Addr 0x1b00000040412460 OK
(gdb)

```