### PR TITLE
gcov.py: add copy skip paths, prevent recursion

### DIFF
--- a/tools/gcov.py
+++ b/tools/gcov.py
@@ -87,13 +87,16 @@ def correct_content_path(file, newpath):
             f.write(new_content)
 
 
-def copy_file_endswith(endswith, source_dir, target_dir):
+def copy_file_endswith(endswith, source_dir, target_dir, skip_dir):
     print(f"Collect {endswith} files {source_dir} -> {target_dir}")
 
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
 
     for root, _, files in os.walk(source_dir):
+        if skip_dir in root:
+            continue
+
         for file in files:
             if file.endswith(endswith):
                 source_file = os.path.join(root, file)
@@ -176,8 +179,8 @@ def main():
         gcov_data_dir.append(dir)
         os.makedirs(dir)
 
-        copy_file_endswith(".gcno", gcno_dir, dir)
-        copy_file_endswith(".gcda", i, dir)
+        copy_file_endswith(".gcno", gcno_dir, dir, gcov_dir)
+        copy_file_endswith(".gcda", i, dir, gcov_dir)
 
     # Only copy files
     if args.only_copy:


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

When the copy path is a subdirectory of the source path, the copy will occur recursively

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


