### PR TITLE
sim_hostfs:add host_errno_convert API for convert result

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostfs.c
+++ b/arch/sim/src/sim/posix/sim_hostfs.c
@@ -43,6 +43,19 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: host_errno_convert
+ ****************************************************************************/
+
+static int host_errno_convert(int errcode)
+{
+  /* Provide a common interface, which should have different conversions
+   * on different platforms.
+   */
+
+  return errcode;
+}
+
+/****************************************************************************
  * Name: host_stat_convert
  ****************************************************************************/
 
@@ -196,7 +209,7 @@ int host_open(const char *pathname, int flags, int mode)
   int ret = open(pathname, mapflags, mode);
   if (ret == -1)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -213,7 +226,7 @@ int host_close(int fd)
   int ret = close(fd);
   if (ret == -1)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -230,7 +243,7 @@ nuttx_ssize_t host_read(int fd, void *buf, nuttx_size_t count)
   nuttx_ssize_t ret = read(fd, buf, count);
   if (ret == -1)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -247,7 +260,7 @@ nuttx_ssize_t host_write(int fd, const void *buf, nuttx_size_t count)
   nuttx_ssize_t ret = write(fd, buf, count);
   if (ret == -1)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -265,7 +278,7 @@ nuttx_off_t host_lseek(int fd, nuttx_off_t pos, nuttx_off_t offset,
   nuttx_off_t ret = lseek(fd, offset, whence);
   if (ret == (nuttx_off_t)-1)
     {
-      ret = -errno;
+      ret =  host_errno_convert(-errno);
     }
 
   return ret;
@@ -279,7 +292,13 @@ int host_ioctl(int fd, int request, unsigned long arg)
 {
   /* Just call the ioctl routine */
 
-  return ioctl(fd, request, arg);
+  int ret = ioctl(fd, request, arg);
+  if (ret < 0)
+    {
+      ret = host_errno_convert(-errno);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -299,7 +318,13 @@ void host_sync(int fd)
 
 int host_dup(int fd)
 {
-  return dup(fd);
+  int ret = dup(fd);
+  if (ret < 0)
+    {
+      ret = host_errno_convert(-errno);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -316,7 +341,7 @@ int host_fstat(int fd, struct nuttx_stat_s *buf)
   ret = fstat(fd, &hostbuf);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   /* Map the return values */
@@ -339,7 +364,7 @@ int host_fchstat(int fd, const struct nuttx_stat_s *buf, int flags)
       ret = fchmod(fd, buf->st_mode);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 
@@ -348,7 +373,7 @@ int host_fchstat(int fd, const struct nuttx_stat_s *buf, int flags)
       ret = fchown(fd, buf->st_uid, buf->st_gid);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 
@@ -379,7 +404,7 @@ int host_fchstat(int fd, const struct nuttx_stat_s *buf, int flags)
       ret = futimens(fd, times);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 
@@ -395,7 +420,7 @@ int host_ftruncate(int fd, nuttx_off_t length)
   int ret = ftruncate(fd, length);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -491,7 +516,7 @@ int host_closedir(void *dirp)
   int ret = closedir(dirp);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -511,7 +536,7 @@ int host_statfs(const char *path, struct nuttx_statfs_s *buf)
   ret = statvfs(path, &hostbuf);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   /* Map the struct statfs value */
@@ -537,7 +562,7 @@ int host_unlink(const char *pathname)
   int ret = unlink(pathname);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -554,7 +579,7 @@ int host_mkdir(const char *pathname, int mode)
   int ret = mkdir(pathname, mode);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -569,7 +594,7 @@ int host_rmdir(const char *pathname)
   int ret = rmdir(pathname);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -584,7 +609,7 @@ int host_rename(const char *oldpath, const char *newpath)
   int ret = rename(oldpath, newpath);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   return ret;
@@ -604,7 +629,7 @@ int host_stat(const char *path, struct nuttx_stat_s *buf)
   ret = stat(path, &hostbuf);
   if (ret < 0)
     {
-      ret = -errno;
+      ret = host_errno_convert(-errno);
     }
 
   /* Map the return values */
@@ -627,7 +652,7 @@ int host_chstat(const char *path, const struct nuttx_stat_s *buf, int flags)
       ret = chmod(path, buf->st_mode);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 
@@ -636,7 +661,7 @@ int host_chstat(const char *path, const struct nuttx_stat_s *buf, int flags)
       ret = chown(path, buf->st_uid, buf->st_gid);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 
@@ -667,7 +692,7 @@ int host_chstat(const char *path, const struct nuttx_stat_s *buf, int flags)
       ret = utimensat(AT_FDCWD, path, times, 0);
       if (ret < 0)
         {
-          return -errno;
+          return host_errno_convert(-errno);
         }
     }
 


### PR DESCRIPTION
## Summary
  This PR comes from the discussion of https://github.com/apache/nuttx/pull/15535#event-15924592365.
  A common conversion interface `host_errno_convert` is provided in `arch/sim/posix`. Subsequent contributors with needs can add host to nuttx errno conversion here

## Impact
  Modified all places where errno is returned in `arch/sim/posix` to be converted via `host_errno_convert` before returning (current implementation is to return directly)

## Testing
Build Host(s): Linux x86
Target(s): sim/nsh
```
nsh> cmocka_fs_test
[==========] nuttx_fs_test_suites: Running 41 test(s).
[ RUN      ] test_nuttx_fs_creat01
[       OK ] test_nuttx_fs_creat01
[ RUN      ] test_nuttx_fs_dup01
[       OK ] test_nuttx_fs_dup01
[ RUN      ] test_nuttx_fs_fcntl01
[       OK ] test_nuttx_fs_fcntl01
[ RUN      ] test_nuttx_fs_fstat01
[       OK ] test_nuttx_fs_fstat01
[ RUN      ] test_nuttx_fs_fstatfs01
[       OK ] test_nuttx_fs_fstatfs01
[ RUN      ] test_nuttx_fs_fsync01
[       OK ] test_nuttx_fs_fsync01
[ RUN      ] test_nuttx_fs_fsync02
the fbsize = 4096,buffer size=4096
[       OK ] test_nuttx_fs_fsync02
[ RUN      ] test_nuttx_fs_getfilep01
[       OK ] test_nuttx_fs_getfilep01
[ RUN      ] test_nuttx_fs_mkdir01
[       OK ] test_nuttx_fs_mkdir01
[ RUN      ] test_nuttx_fs_open01
[       OK ] test_nuttx_fs_open01
[ RUN      ] test_nuttx_fs_open02
[       OK ] test_nuttx_fs_open02
[ RUN      ] test_nuttx_fs_opendir01
[       OK ] test_nuttx_fs_opendir01
[ RUN      ] test_nuttx_fs_opendir02
[       OK ] test_nuttx_fs_opendir02
[ RUN      ] test_nuttx_fs_pread01
[       OK ] test_nuttx_fs_pread01
[ RUN      ] test_nuttx_fs_pwrite01
[       OK ] test_nuttx_fs_pwrite01
[ RUN      ] test_nuttx_fs_readdir01
[       OK ] test_nuttx_fs_readdir01
[ RUN      ] test_nuttx_fs_readlink01
[       OK ] test_nuttx_fs_readlink01
[ RUN      ] test_nuttx_fs_rename01
[       OK ] test_nuttx_fs_rename01
[ RUN      ] test_nuttx_fs_rename02
[       OK ] test_nuttx_fs_rename02
[ RUN      ] test_nuttx_fs_rewinddir01
[       OK ] test_nuttx_fs_rewinddir01
[ RUN      ] test_nuttx_fs_rmdir01
[       OK ] test_nuttx_fs_rmdir01
[ RUN      ] test_nuttx_fs_rmdir02
[       OK ] test_nuttx_fs_rmdir02
[ RUN      ] test_nuttx_fs_rmdir03
[       OK ] test_nuttx_fs_rmdir03
[ RUN      ] test_nuttx_fs_seek01
[       OK ] test_nuttx_fs_seek01
[ RUN      ] test_nuttx_fs_seek02
[       OK ] test_nuttx_fs_seek02
[ RUN      ] test_nuttx_fs_statfs01
[       OK ] test_nuttx_fs_statfs01
[ RUN      ] test_nuttx_fs_symlink01
[       OK ] test_nuttx_fs_symlink01
[ RUN      ] test_nuttx_fs_truncate01
[       OK ] test_nuttx_fs_truncate01
[ RUN      ] test_nuttx_fs_unlink01
[       OK ] test_nuttx_fs_unlink01
[ RUN      ] test_nuttx_fs_write01
[       OK ] test_nuttx_fs_write01
[ RUN      ] test_nuttx_fs_write02
[       OK ] test_nuttx_fs_write02
[ RUN      ] test_nuttx_fs_write03
[       OK ] test_nuttx_fs_write03
[ RUN      ] test_nuttx_fs_append01
[       OK ] test_nuttx_fs_append01
[ RUN      ] test_nuttx_fs_sendfile01
[       OK ] test_nuttx_fs_sendfile01
[ RUN      ] test_nuttx_fs_sendfile02
[       OK ] test_nuttx_fs_sendfile02
[ RUN      ] test_nuttx_fs_stream01
[       OK ] test_nuttx_fs_stream01
[ RUN      ] test_nuttx_fs_stream02
[       OK ] test_nuttx_fs_stream02
[ RUN      ] test_nuttx_fs_stream03
[       OK ] test_nuttx_fs_stream03
[ RUN      ] test_nuttx_fs_stream04
[       OK ] test_nuttx_fs_stream04
[ RUN      ] test_nuttx_fs_eventfd
[       OK ] test_nuttx_fs_eventfd
[ RUN      ] test_nuttx_fs_poll01
[       OK ] test_nuttx_fs_poll01
[==========] nuttx_fs_test_suites: 41 test(s) run.
[  PASSED  ] 41 test(s).
```
