### PR TITLE
Add fs_heap_mallinfo_task and fix proc_heap bug

### DIFF
--- a/fs/fs_heap.c
+++ b/fs/fs_heap.c
@@ -137,4 +137,9 @@ int fs_heap_asprintf(FAR char **strp, FAR const char *fmt, ...)
   return len;
 }
 
+struct mallinfo_task fs_heap_mallinfo_task(FAR const struct malltask *task)
+{
+  return mm_mallinfo_task(g_fs_heap, task);
+}
+
 #endif

--- a/fs/fs_heap.h
+++ b/fs/fs_heap.h
@@ -51,17 +51,19 @@ FAR char *fs_heap_strdup(FAR const char *s) malloc_like;
 FAR char *fs_heap_strndup(FAR const char *s, size_t size) malloc_like;
 int       fs_heap_asprintf(FAR char **strp, FAR const char *fmt, ...)
           printf_like(2, 3);
+struct mallinfo_task fs_heap_mallinfo_task(FAR const struct malltask *task);
 #else
 #  define fs_heap_initialize()
-#  define fs_heap_zalloc       kmm_zalloc
-#  define fs_heap_malloc       kmm_malloc
-#  define fs_heap_malloc_size  kmm_malloc_size
-#  define fs_heap_realloc      kmm_realloc
-#  define fs_heap_memalign     kmm_memalign
-#  define fs_heap_free         kmm_free
-#  define fs_heap_strdup       strdup
-#  define fs_heap_strndup      strndup
-#  define fs_heap_asprintf     asprintf
+#  define fs_heap_zalloc        kmm_zalloc
+#  define fs_heap_malloc        kmm_malloc
+#  define fs_heap_malloc_size   kmm_malloc_size
+#  define fs_heap_realloc       kmm_realloc
+#  define fs_heap_memalign      kmm_memalign
+#  define fs_heap_free          kmm_free
+#  define fs_heap_mallinfo_task kmm_mallinfo_task
+#  define fs_heap_strdup        strdup
+#  define fs_heap_strndup       strndup
+#  define fs_heap_asprintf      asprintf
 #endif
 
 #endif

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -902,7 +902,7 @@ static ssize_t proc_heap(FAR struct proc_file_s *procfile,
 #ifdef CONFIG_MM_KERNEL_HEAP
   if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
-      info = fs_heap_mallinfo_task(&task);
+      info = kmm_mallinfo_task(&task);
     }
   else
 #endif


### PR DESCRIPTION
## Summary
  1. Added fs_heap_mallinfo_task implementation.
  2. Change fs_heap_mallinfo_task in proc_heap back to kmm_mallinfo_task.

## Impact
  **Is a new feature added?:** NO
  **Impact on build:** NO
  **Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
  **Impact on documentation:** NO,This patch does not introduce any new features
  **Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
  Build Host(s): Linux x86
  Target(s): sim/nsh
  Passed the file system related syscall test

