### PR TITLE
Documentation: Replace `CONFIG_NSH_LINELEN` with `CONFIG_LINE_MAX`

### DIFF
--- a/Documentation/applications/nsh/config.rst
+++ b/Documentation/applications/nsh/config.rst
@@ -202,9 +202,6 @@ Configuration                        Description
                                      setting is *y*. This setting depends upon the ``strerror()``
                                      having been enabled with ``CONFIG_LIBC_STRERROR``.
 
- ``CONFIG_NSH_LINELEN``              The maximum length of one command line and of one output line.
-                                     Default: 80
-
  ``CONFIG_NSH_DISABLE_SEMICOLON``    By default, you can enter multiple NSH commands on a line
                                      with each command separated by a semicolon. You can disable this
                                      feature to save a little memory on FLASH challenged platforms.

--- a/Documentation/guides/pysimcoder.rst
+++ b/Documentation/guides/pysimcoder.rst
@@ -47,7 +47,7 @@ with NuttX. The list is the following:
 
 ==================================== =====================================
 ``CONFIG_ARCH_RAMVECTORS=y``         ``CONFIG_NSH_FILE_APPS=y``
-``CONFIG_BOARDCTL_APP_SYMTAB=y``     ``CONFIG_NSH_LINELEN=64``
+``CONFIG_BOARDCTL_APP_SYMTAB=y``     ``CONFIG_LINE_MAX=64``
 ``CONFIG_BOARDCTL_OS_SYMTAB=y``      ``CONFIG_NSH_READLINE=y``
 ``CONFIG_BUILTIN=y``                 ``CONFIG_ETC_ROMFS=y``
 ``CONFIG_ELF=y``                     ``CONFIG_PSEUDOTERM=y``

--- a/Documentation/platforms/sim/sim/boards/sim/index.rst
+++ b/Documentation/platforms/sim/sim/boards/sim/index.rst
@@ -1049,7 +1049,7 @@ NOTES
          -
          +sleep(2); // REMOVE ME
          +#if 0 // REMOVE ME
-                ret = readline(pstate->cn_line, CONFIG_NSH_LINELEN,
+                ret = readline(pstate->cn_line, LINE_MAX,
                                INSTREAM(pstate), OUTSTREAM(pstate));
                 if (ret > 0)
          @@ -153,6 +155,7 @@


### PR DESCRIPTION
## Summary
Documentation: Replace `CONFIG_NSH_LINELEN` with `CONFIG_LINE_MAX`
https://github.com/apache/nuttx/pull/15541
https://github.com/apache/nuttx-apps/pull/2943

## Impact
Documentation

## Testing
CI

