### PR TITLE
Arm64 fix kmm map

### DIFF
--- a/arch/arm64/src/common/arm64_addrenv_pgmap.c
+++ b/arch/arm64/src/common/arm64_addrenv_pgmap.c
@@ -281,6 +281,10 @@ int up_addrenv_kmap_pages(void **pages, unsigned int npages, uintptr_t vaddr,
 
   mask |= PTE_BLOCK_DESC_UXN;
 
+  /* Flags for normal memory region */
+
+  mask |= MMU_MT_NORMAL_FLAGS;
+
   /* Let arm64_map_pages do the work */
 
   return arm64_map_pages(addrenv, (uintptr_t *)pages, npages, vaddr, mask);

--- a/mm/kmap/kmm_map.c
+++ b/mm/kmap/kmm_map.c
@@ -159,7 +159,7 @@ static FAR void *map_pages(FAR void **pages, size_t npages, int prot)
 errout_with_pgmap:
   up_addrenv_kunmap_pages((uintptr_t)vaddr, npages);
 errout_with_vaddr:
-  gran_free(&g_kmm_map_vpages, vaddr, size);
+  gran_free(g_kmm_map_vpages, vaddr, size);
   return NULL;
 }
 
@@ -385,7 +385,7 @@ void kmm_unmap(FAR void *kaddr)
 
           /* Release the virtual memory area for use */
 
-          gran_free(&g_kmm_map_vpages, entry->vaddr, entry->length);
+          gran_free(g_kmm_map_vpages, entry->vaddr, entry->length);
 
           /* Remove the mapping from the kernel mapping list */
 


### PR DESCRIPTION

## Summary

This PR fixes making page mappings into kernel:

1. In mm/kmap/kmm_map.c, a wrong pointer is given to gran_free when a mapping is released, corrupting memory
2. In arm64, MMU mapping flags were incomplete for kernel memory mappings

## Impact

This fixes memory corruption and deadlock issues when calling kmm_unmap on any platform supporting address environments.

Also fix random memory issues in arm64 platform when accessing memory mapped with kmm_map, via correcting the MMU flags.

## Testing

Tested on i.MX93 platform in CONFIG_BUILD_KERNEL 
