### PR TITLE
syslog_intbuffer.c:Fixed recursive spinlock during assert

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -96,7 +96,6 @@ static struct syslog_intbuffer_s g_syslog_intbuffer =
 
 static void syslog_flush_internal(bool force, size_t buflen)
 {
-  irqstate_t flags;
   FAR char *buffer;
   size_t size;
 

--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -104,8 +104,6 @@ static void syslog_flush_internal(bool force, size_t buflen)
    * concurrent modification by other tasks.
    */
 
-  flags = spin_lock_irqsave_wo_note(&g_syslog_intbuffer.splock);
-
   do
     {
       buffer = circbuf_get_readptr(&g_syslog_intbuffer.circ, &size);
@@ -118,8 +116,6 @@ static void syslog_flush_internal(bool force, size_t buflen)
         }
     }
   while (size > 0 && buflen > 0);
-
-  spin_unlock_irqrestore_wo_note(&g_syslog_intbuffer.splock, flags);
 }
 
 /****************************************************************************
@@ -201,7 +197,11 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
 
 void syslog_flush_intbuffer(bool force)
 {
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave_wo_note(&g_syslog_intbuffer.splock);
   syslog_flush_internal(force, sizeof(g_syslog_intbuffer.buffer));
+  spin_unlock_irqrestore_wo_note(&g_syslog_intbuffer.splock, flags);
 }
 
 #endif /* CONFIG_SYSLOG_INTBUFFER */


### PR DESCRIPTION
## Summary
  Fixed the issue of using SPINLOCK + SYSLOG_INTBUFFER in single core causing recursive spinlock during assert.
```
dump_running_task
  -> ...
    -> syslog_write
      -> syslog_add_intbuffer (spin_lock_irqsave_wo_note first)
        -> syslog_flush_internal (spin_lock_irqsave_wo_note recursive)
```
  Removed spinlock protection in syslog_flush_internal and added spinlock where it is called.

## Impact
  **Is a new feature added?:** NO
  **Impact on build:** NO
  **Impact on hardware:** NO, this change does not specifically target any particular hardware architectures or boards.
  **Impact on documentation:** NO,This patch does not introduce any new features
  **Impact on compatibility:** This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing
  Build Host(s): Linux x86
  Target(s): qemu-armv7a:nsh
  enable
```  
CONFIG_SPINLOCK=y
CONFIG_SYSLOG_INTBUFFER=y
```

Correct result:
```
nsh> mw -1
nx_start: CPU0: Beginning Idle Loop
arm_dataabort: Data abort. PC: 0060de90 DFAR: ffffffff DFSR: 00000005
dump_assert_info: Current Version: NuttX  12.7.2-vela f680060f40 Jan 15 2025 16:33:32 arm
dump_assert_info: Assertion failed panic: at file: armv7-a/arm_dataabort.c:159 task: nsh_main process: nsh_main 0x60af6c
up_dump_register: R0: ffffffff R1: 00000000 R2: 4020764c  R3: 00000000
up_dump_register: R4: 00000000 R5: 40207860 R6: 00000000  R7: 00000001
up_dump_register: R8: ffffffff SB: 00000000 SL: 0062f079  FP: ffffffff
up_dump_register: IP: 00000000 SP: 40207670 LR: 00608e84  PC: 0060de90
up_dump_register: CPSR: 8000005f
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x402005f0      2048       172     8.3%    irq
dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x40204010      4080       616    15.0%    Idle_Task
dump_task:       1     0 192 RR       Kthread -   Waiting Semaphore  0000000000000000 0x40205438      4032       400     9.9%    hpwork 0x40200000 0x4020002c
dump_task:       2     2 100 RR       Task    -   Running            0000000000000000 0x40206850      4056      1600    39.4%    nsh_main
```

Previous results:
```
nsh> mw -1
nx_start: CPU0: Beginning Idle Loop
arm_dataabort: Data abort. PC: 0060de88 DFAR: ffffffff DFSR: 00000005
```