### PR TITLE
Fix CRC and test on Raspberry Pi Pico

### DIFF
--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -80,6 +80,11 @@
 #include "rp2040_i2c.h"
 #endif
 
+#ifdef CONFIG_SENSORS_MS56XX
+#include <nuttx/sensors/ms56xx.h>
+#include "rp2040_i2c.h"
+#endif
+
 #ifdef CONFIG_SENSORS_MAX6675
 #include <nuttx/sensors/max6675.h>
 #include "rp2040_max6675.h"
@@ -550,6 +555,17 @@ int rp2040_common_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: couldn't initialize MCP9600: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_MS56XX
+  /* Try to register MS56xx device at I2C0 */
+
+  ret = ms56xx_register(rp2040_i2cbus_initialize(0), 0, MS56XX_ADDR0,
+                        MS56XX_MODEL_MS5611);
+  if (ret < 0)
+    {
+        syslog(LOG_ERR, "ERROR: couldn't register MS5611: %d\n", ret);
     }
 #endif
 

--- a/include/nuttx/sensors/msxxxx_crc4.h
+++ b/include/nuttx/sensors/msxxxx_crc4.h
@@ -44,41 +44,40 @@ static uint8_t msxxxx_crc4(FAR uint16_t *src,
                            uint16_t crcmask)
 {
   uint16_t cnt;
-  uint16_t n_rem;
-  uint16_t crc_read;
+  uint16_t n_rem;     /* CRC remainder */
+  uint16_t crc_read;  /* Original value of the CRC */
   uint8_t n_bit;
 
   n_rem = 0x00;
-  crc_read = src[crcndx];
-  src[crcndx] &= ~crcmask;
+  crc_read = src[crcndx];   /* Save read CRC */
+  src[crcndx] &= ~crcmask;  /* CRC byte is replaced by 0 */
 
-  for (cnt = 0; cnt < 16; cnt++)
+  for (cnt = 0; cnt < 16; cnt++)  /* Operation is performed on bytes */
     {
       if (cnt % 2 == 1)
         {
-          n_rem ^= src[cnt >> 1] & 0x00ff;
+          n_rem ^= (uint16_t)((src[cnt >> 1]) & 0x00ff);
         }
       else
         {
-          n_rem ^= src[cnt >> 1] >> 8;
+          n_rem ^= (uint16_t)(src[cnt >> 1] >> 8);
         }
 
       for (n_bit = 8; n_bit > 0; n_bit--)
         {
-          if (n_rem & (0x8000) != 0)
+          if (n_rem & (0x8000))
             {
               n_rem = (n_rem << 1) ^ 0x3000;
             }
           else
             {
-              n_rem <<= 1;
+              n_rem = (n_rem << 1);
             }
         }
     }
-
-  n_rem = (n_rem >> 12) & 0x000f;
-  src[crcndx] = crc_read;
-  return n_rem ^ 0x00;
+  n_rem = (0x000f & (n_rem >> 12));  /* Final 4-bit reminder is CRC code */
+  src[crcndx] = crc_read;            /* Restore the crc_read to its original place */
+  return (n_rem ^ 0x00);
 }
 
 #endif /* __INCLUDE_NUTTX_SENSORS_MSXXXX_CRC4_H */


### PR DESCRIPTION
## Summary

This PR comes from InSpace.

For some reason, the CRC check in its current state fails for the MS5611 sensors that InSpace has. We've tested on four different sensors to confirm that this is not due to the sensors being faulty. The official CRC4 code from the manufacturer is slightly different than the NuttX implementation and it passes when used on the MS5611s.

## Impact

MS56xx driver no longer fails to register due to faulty CRC.

## Testing

Tested the previous version of the driver on 4 different MS5611s and viewed failing CRC in the debug logs. Then tested with this version from the manufacturer and had successful device registration.