### PR TITLE
sensors/sht4x: Converted SHT4X driver to UORB framework.

### DIFF
--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -533,9 +533,9 @@ int rp2040_common_bringup(void)
 
 #ifdef CONFIG_SENSORS_SHT4X
 
-  /* Try to register SHT4X device as /dev/sht4x0 at I2C0. */
+  /* Try to register SHT4X device on I2C0 */
 
-  ret = sht4x_register("/dev/sht4x0", rp2040_i2cbus_initialize(0),
+  ret = sht4x_register(rp2040_i2cbus_initialize(0), 0,
                        CONFIG_SHT4X_I2C_ADDR);
   if (ret < 0)
     {

--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -285,7 +285,7 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_SHT4X)
-      list(APPEND SRCS sht4x.c)
+      list(APPEND SRCS sht4x_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_SPS30)

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -1627,18 +1627,18 @@ config SHT4X_I2C_FREQUENCY
 	default 400000
 	range 1 400000
 
+config SHT4X_THREAD_STACKSIZE
+    int "SHT4X worker thread stack size"
+	default 1024
+	---help---
+		The stack size for the worker thread that performs measurements
+
 config SHT4X_I2C_ADDR
 	hex "SHT4X I2C address"
 	default 0x44
 	range 0x44 0x46
 	---help---
 		Enables debug features for the SHT4X
-
-config SHT4X_FAHRENHEIT
-	bool "SHT4X use Fahrenheit"
-	default n
-	---help---
-		Configures read outputs of the SHT4X to be in Fahrenheit. Default uses Celsius.
 
 config SHT4X_LIMIT_HUMIDITY
 	bool "SHT4X limit humidity between 0-100%"
@@ -1652,11 +1652,12 @@ config SHT4X_CRC_LOOKUP
 	---help---
 		Configures the SHT4X to do CRC checks with a lookup table. Default uses a bitwise CRC calculation.
 
-config SHT4X_DEBUG
-	bool "SHT4X debug support"
-	default n
+config SENSORS_SHT4X_POLL
+	bool "Use polling"
+	default y
 	---help---
-		Enables debug features for the SHT4X
+        Configures the SHT4X to be polled at an interval instead of allowing user code to choose when measurements are
+        taken.
 
 endif # SENSORS_SHT4X
 

--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -289,7 +289,7 @@ ifeq ($(CONFIG_SENSORS_SHT3X),y)
 endif
 
 ifeq ($(CONFIG_SENSORS_SHT4X),y)
-  CSRCS += sht4x.c
+  CSRCS += sht4x_uorb.c
 endif
 
 ifeq ($(CONFIG_SENSORS_SPS30),y)

--- a/include/nuttx/sensors/sht4x.h
+++ b/include/nuttx/sensors/sht4x.h
@@ -35,18 +35,6 @@
 
 struct i2c_master_s; /* Forward reference */
 
-struct sht4x_conv_data_s
-{
-  int32_t temp; /* Millidegrees Celsius or Fahrenheit (depending on config) */
-  int16_t hum;  /* Percentage relative humidity in units of 0.01 %RH */
-};
-
-struct sht4x_raw_data_s
-{
-  uint16_t raw_temp;
-  uint16_t raw_hum;
-};
-
 /* Precision for reading. */
 
 enum sht4x_precision_e
@@ -79,9 +67,9 @@ enum sht4x_heater_e
  *   Register the SHT4X character device as 'devpath'
  *
  * Input Parameters:
- *   devpath - The full path to the driver to register. E.g., "/dev/temp0"
  *   i2c     - An instance of the I2C interface to use to communicate with
  *             the SHT4X
+ *   devno   - The device number that this device should have.
  *   addr    - The I2C address of the SHT4X. The I2C address is one of 0x44,
  *             0x45 and 0x46.
  *
@@ -90,7 +78,6 @@ enum sht4x_heater_e
  *
  ****************************************************************************/
 
-int sht4x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
-                   uint8_t addr);
+int sht4x_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr);
 
 #endif /* __INCLUDE_NUTTX_SENSORS_SHT4X_H */


### PR DESCRIPTION
## Summary

This PR converts the SHT4X driver to the UORB framework.

## Impact

The impact is that one more sensor is part of the UORB framework, which unifies the way that sensors are interacted with under NuttX and provides lots of beneficial features such as configurable sampling rates and buffering for free from the UORB upper half.

## Testing

To test, I compiled and built the driver for the Raspberry Pi Pico W and included the `uorb_listener` application. The driver correctly registers the two topics (relative humidity and ambient temperature) which produce measurements at the configured interval. I tested using multiple different intervals from 1Hz to 100Hz.

```console
nsh> uorb_listener

Mointor objects num:2
object_name:sensor_temp, object_instance:0
object_name:sensor_humi, object_instance:0
sensor_temp(now:6690000):timestamp:6690000,temperature:23.424999
sensor_humi(now:6690000):timestamp:6690000,humi:32.750000
sensor_temp(now:7720000):timestamp:7720000,temperature:23.424999
sensor_humi(now:7720000):timestamp:7720000,humi:32.750000
sensor_temp(now:8750000):timestamp:8750000,temperature:23.424999
sensor_humi(now:8750000):timestamp:8750000,humi:32.750000
sensor_temp(now:9780000):timestamp:9780000,temperature:23.424999
sensor_humi(now:9780000):timestamp:9780000,humi:32.750000
```

I also verified that the Documentation compiles locally and looks correct in the browser.