### PR TITLE
sched/wqueue: fix potential deadlock

### DIFF
--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -404,8 +404,8 @@ void work_notifier_signal(enum work_evtype_e evtype,
         }
     }
 
-  sched_unlock();
   spin_unlock_irqrestore(&g_notifier_lock, flags);
+  sched_unlock();
 }
 
 #endif /* CONFIG_WQUEUE_NOTIFIER */


### PR DESCRIPTION
## Summary

sched/wqueue: fix potential deadlock

sched_unlock() should called after spin_unlock

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check