### PR TITLE
sched/wdog: remove wd_cancel_irq() implement

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -298,25 +298,6 @@ static inline int wd_start_realtime(FAR struct wdog_s *wdog,
 int wd_cancel(FAR struct wdog_s *wdog);
 
 /****************************************************************************
- * Name: wd_cancel_irq
- *
- * Description:
- *   This function cancels a currently running watchdog timer. Watchdog
- *   timers may be cancelled from the interrupt level.  This function is
- *   intended to be called from critical sections.
- *
- * Input Parameters:
- *   wdog - ID of the watchdog to cancel.
- *
- * Returned Value:
- *   Zero (OK) is returned on success;  A negated errno value is returned to
- *   indicate the nature of any failure.
- *
- ****************************************************************************/
-
-int wd_cancel_irq(FAR struct wdog_s *wdog);
-
-/****************************************************************************
  * Name: wd_gettime
  *
  * Description:

--- a/sched/wdog/wd_cancel.c
+++ b/sched/wdog/wd_cancel.c
@@ -60,32 +60,6 @@
 
 int wd_cancel(FAR struct wdog_s *wdog)
 {
-  int ret;
-
-  ret = wd_cancel_irq(wdog);
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: wd_cancel_irq
- *
- * Description:
- *   This function cancels a currently running watchdog timer. Watchdog
- *   timers may be cancelled from the interrupt level.  This function is
- *   intended to be called from critical sections.
- *
- * Input Parameters:
- *   wdog - ID of the watchdog to cancel.
- *
- * Returned Value:
- *   Zero (OK) is returned on success;  A negated errno value is returned to
- *   indicate the nature of any failure.
- *
- ****************************************************************************/
-
-int wd_cancel_irq(FAR struct wdog_s *wdog)
-{
   irqstate_t flags;
   bool head;
 
@@ -127,5 +101,5 @@ int wd_cancel_irq(FAR struct wdog_s *wdog)
       nxsched_reassess_timer();
     }
 
-  return OK;
+  return 0;
 }


### PR DESCRIPTION
## Summary

sched/wdog: remove wd_cancel_irq() implement

we do not need this implement after change the lock from csec to spin_lock

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check