### PR TITLE
risc-v: replace fence.i with __ISB for instruction sync

### DIFF
--- a/libs/libc/machine/risc-v/arch_elf.c
+++ b/libs/libc/machine/risc-v/arch_elf.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 
 #include <nuttx/elf.h>
+#include <arch/barriers.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -129,7 +130,7 @@ static void _set_val(uint16_t *addr, uint32_t val)
 
   /* NOTE: Ensure relocation before execution */
 
-  asm volatile ("fence.i");
+  __ISB();
 }
 
 static void _add_val(uint16_t *addr, uint32_t val)


### PR DESCRIPTION
## Summary
- Replace direct use of `fence.i` instruction with `__ISB()` macro for instruction synchronization
- This change improves portability while maintaining the same functionality

## Impact
- No functional changes - both `fence.i` and `__ISB()` ensure instruction synchronization on RISC-V
- Makes the code more maintainable by using the architecture abstraction layer

## Testing

GitHub CI and local test


