### PR TITLE
libc/gnssutils: remove C99 standard flag from Make.defs

### DIFF
--- a/libs/libc/gnssutils/Make.defs
+++ b/libs/libc/gnssutils/Make.defs
@@ -39,7 +39,6 @@ $(MINMEA_UNPACKNAME):
 # Files
 
 CSRCS  += minmea.c
-CFLAGS += -std=c99
 
 clean::
 	$(call DELFILE, $(OBJS))


### PR DESCRIPTION
## Summary
- Removed explicit -std=c99 flag from Make.defs
- The project-wide C standard is already set at a higher level
- Keeps build configuration consistent across the codebase

## Impact
- No functional changes to the code
- Maintains consistency with project-wide C standard settings

## Testing

GitHub CI

