### PR TITLE
arch/armv7-r: fix gic.h build error

### DIFF
--- a/arch/arm/src/armv7-r/gic.h
+++ b/arch/arm/src/armv7-r/gic.h
@@ -696,7 +696,7 @@ static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
        * SMP scenario.
        */
 
-      regval |= GIC_ICDSGIR_NSATT_GRP1;
+      regval |= GIC_ICDSGIR_NSATT;
     }
 
   putreg32(regval, GIC_ICDSGIR);


### PR DESCRIPTION
## Summary

This fixes compilation error:

```
/tmp/nuttx/arch/arm/src/armv7-r/gic.h:699:17: error: 'GIC_ICDSGIR_NSATT_GRP1' undeclared (first use in this function); did you mean 'GIC_ICDSGIR_NSATT'?
```

## Impacts

Allow armv7-r code to build

## Testing

- local check when adding armv7-r support.
- CI checks
