### PR TITLE
sim: fix regression from https://github.com/apache/nuttx/pull/14623

### DIFF
--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -68,9 +68,8 @@ static void work_timer_expiry(wdparm_t arg)
 {
   FAR struct work_s *work = (FAR struct work_s *)arg;
 
-  DEBUGASSERT(up_interrupt_context());
-
   irqstate_t flags = spin_lock_irqsave(&work->wq->lock);
+  sched_lock();
 
   /* We have being canceled */
 
@@ -80,6 +79,7 @@ static void work_timer_expiry(wdparm_t arg)
     }
 
   spin_unlock_irqrestore(&work->wq->lock, flags);
+  sched_unlock();
 }
 
 static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,


### PR DESCRIPTION

## Summary
sim: fix regression from https://github.com/apache/nuttx/pull/14623
reason:
work_timer_expiry may be called in thread context
## Impact

sim

## Testing
https://github.com/apache/nuttx/issues/15582
