### PR TITLE
modlib: fix armv7a w/ unified gnu-elf.ld.in

### DIFF
--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -113,7 +113,9 @@
  */
 
 #ifdef CONFIG_BUILD_KERNEL
-#  define ARCH_DATA_RESERVE_SIZE 512
+/* use MM_PGSIZE to unify among all archs for now */
+
+#  define ARCH_DATA_RESERVE_SIZE CONFIG_MM_PGSIZE
 #else
 #  define ARCH_DATA_RESERVE_SIZE 0
 #endif

--- a/libs/libc/modlib/gnu-elf.ld.in
+++ b/libs/libc/modlib/gnu-elf.ld.in
@@ -26,7 +26,8 @@
 #  include <nuttx/addrenv.h>
 
 #  define TEXT CONFIG_ARCH_TEXT_VBASE
-#  define DATA CONFIG_ARCH_DATA_VBASE + CONFIG_MM_PGSIZE
+#  define DATA CONFIG_ARCH_DATA_VBASE + ARCH_DATA_RESERVE_SIZE
+
 #else
 #  define TEXT 0x0
 #  define DATA


### PR DESCRIPTION
## Summary

This fixes booting issue of qemu-armv7a:knsh + ELF_EXECUTABLE by aligning formula of armv7-a with its current addrenv layout.

This is a follow up of pull/15527.

## Impacts

Kernel mode with ELF_EXECUTABLE config selected.

## Testing

- local checks with qemu-armv7a:knsh + ELF_EXECTUABLE, rv-virt:knsh
- CI checks
