### PR TITLE
[CI] testbuild.sh: Msys2 fix toolchain change

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -324,7 +324,7 @@ function configure_default {
   fi
 
   if [ "X$toolchain" != "X" ]; then
-    setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`
+    setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_TOOLCHAIN_WINDOWS | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`
     original_toolchain=`echo $setting | cut -d'=' -f1`
     if [ ! -z "$original_toolchain" ]; then
       echo "  Disabling $original_toolchain"
@@ -347,7 +347,7 @@ function configure_cmake {
   fi
 
   if [ "X$toolchain" != "X" ]; then
-    setting=`grep _TOOLCHAIN_ $nuttx/build/.config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`
+    setting=`grep _TOOLCHAIN_ $nuttx/build/.config | grep -v CONFIG_TOOLCHAIN_WINDOWS | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`
     original_toolchain=`echo $setting | cut -d'=' -f1`
     if [ ! -z "$original_toolchain" ]; then
       echo "  Disabling $original_toolchain"


### PR DESCRIPTION
## Summary

In the Msys2 (Windows) environment, this search filter is not sufficient.

https://github.com/apache/nuttx/blob/8f435a2941778a45e348cdea6453bd6b68680cbe/tools/testbuild.sh#L327
https://github.com/apache/nuttx/blob/8f435a2941778a45e348cdea6453bd6b68680cbe/tools/testbuild.sh#L350

$ grep _TOOLCHAIN_ .config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y 
CONFIG_TOOLCHAIN_WINDOWS=y
CONFIG_ARM_TOOLCHAIN_GNU_EABI=y

It is necessary to add
$ grep _TOOLCHAIN_ .config |  grep -v CONFIG_TOOLCHAIN_WINDOWS | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y CONFIG_ARM_TOOLCHAIN_GNU_EABI=y

fixed

```
====================================================================================
Cmake in present: nucleo-l152re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Configuration/Tool: nucleo-l152re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-01-17 09:44:53
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_WINDOWS=y
  Select WINDOWS_MSYS=y
  Disabling CONFIG_TOOLCHAIN_WINDOWS
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
====================================================================================
Configuration/Tool: nucleo-f411re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-01-17 09:46:05
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_TOOLCHAIN_WINDOWS
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
chip/stm32_gpio.c:44:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
  [1/1] Normalize nucleo-f411re/nsh
====================================================================================
```

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

local and GitHub
https://github.com/simbit18/nuttx_test_pr/actions/runs/12826395325/job/35766301770#logs
```
====================================================================================
Cmake in present: nucleo-l152re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Configuration/Tool: nucleo-l152re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-01-17 09:39:54
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_WINDOWS=y
  Select WINDOWS_MSYS=y
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
====================================================================================
Configuration/Tool: nucleo-f411re/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-01-17 09:41:07
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
chip/stm32_gpio.c:44:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
  [1/1] Normalize nucleo-f411re/nsh
```

