### PR TITLE
cmake/mkconfig: add support of set custom command options to config.h

### DIFF
--- a/cmake/nuttx_mkconfig.cmake
+++ b/cmake/nuttx_mkconfig.cmake
@@ -135,6 +135,22 @@ foreach(NameAndValue ${ConfigContents})
   endif()
 endforeach()
 
+# cmake-format: off
+# add support of set custom command options to config.h
+# Use the -D parameter to pass the config to header file.
+# NOTE which must start with the CONFIG_ prefix.
+# eg:
+#    cmake -DCONFIG_AAA=1 -DCONFIG_BBB=1 -B build -DBOARD_CONFIG=sim/nsh -GNinja
+# cmake-format: on
+
+get_cmake_property(cache_vars CACHE_VARIABLES)
+foreach(var ${cache_vars})
+  string(REGEX MATCH "^CONFIG_[^=]+" name ${var})
+  if(name)
+    file(APPEND ${CONFIG_H} "#define ${var} ${${var}}\n")
+  endif()
+endforeach()
+
 file(APPEND ${CONFIG_H}
      "\n/* Sanity Checks *****************************************/\n\n")
 file(APPEND ${CONFIG_H}


### PR DESCRIPTION
## Summary

cmake/mkconfig: add support of set custom command options to config.h

add support of set custom command options to config.h
Use the -D parameter to pass the config to header file.
NOTE which must begin with the CONFIG_ prefix.
eg:
```
  cmake -DCONFIG_AAA=1 -DCONFIG_BBB=1 -B build -DBOARD_CONFIG=sim/nsh -GNinja
```


source file:
```
#include <nuttx/config.h>

int main(int argc, FAR char *argv[])
{
#ifdef CONFIG_AAA
  printf("Hello, World!! AAA: %d\n", CONFIG_AAA);
#endif
#ifdef CONFIG_BBB
  printf("Hello, World!! BBB: %d\n", CONFIG_BBB);
#endif
  return 0;
}
```

output:
```
$ ./build/nuttx 

NuttShell (NSH) NuttX-10.4.0
nsh> hello
Hello, World!! AAA: 1
Hello, World!! BBB: 1
nsh> 
```

Signed-off-by: chao an <anchao.archer@bytedance.com>



## Impact

N/A

## Testing

ci-check