### PR TITLE
cmake: Use EXTRAFLAGS to define customized compilation options

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -53,6 +53,13 @@ function(nuttx_add_library_internal target)
     ${target}
     PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx,NUTTX_INCLUDE_DIRECTORIES>>)
 
+  # add extra flags into command line
+
+  if(DEFINED EXTRAFLAGS)
+    string(REPLACE " " ";" eflags "${EXTRAFLAGS}")
+    target_compile_options(${target} PRIVATE ${eflags})
+  endif()
+
   # Set install config for all library
   install(TARGETS ${target})
 endfunction()

--- a/cmake/nuttx_mkconfig.cmake
+++ b/cmake/nuttx_mkconfig.cmake
@@ -135,22 +135,6 @@ foreach(NameAndValue ${ConfigContents})
   endif()
 endforeach()
 
-# cmake-format: off
-# add support of set custom command options to config.h
-# Use the -D parameter to pass the config to header file.
-# NOTE which must start with the CONFIG_ prefix.
-# eg:
-#    cmake -DCONFIG_AAA=1 -DCONFIG_BBB=1 -B build -DBOARD_CONFIG=sim/nsh -GNinja
-# cmake-format: on
-
-get_cmake_property(cache_vars CACHE_VARIABLES)
-foreach(var ${cache_vars})
-  string(REGEX MATCH "^CONFIG_[^=]+" name ${var})
-  if(name)
-    file(APPEND ${CONFIG_H} "#define ${var} ${${var}}\n")
-  endif()
-endforeach()
-
 file(APPEND ${CONFIG_H}
      "\n/* Sanity Checks *****************************************/\n\n")
 file(APPEND ${CONFIG_H}


### PR DESCRIPTION
## Summary

cmake: Use EXTRAFLAGS to define customized compilation options

align them with the usage habits of makefile

cmake:
```
cmake -B build -DBOARD_CONFIG=sim/nsh -GNinja -DEXTRAFLAGS="-DCONFIG_AAA=1 -DCONFIG_BBB=1 -Werror"
```
makefile:
```
make -j12 EXTRAFLAGS="-DCONFIG_AAA=1 -DCONFIG_BBB=1 -Werror"
```
Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check