### PR TITLE
v9fs:Add socket support

### DIFF
--- a/Documentation/components/filesystem/index.rst
+++ b/Documentation/components/filesystem/index.rst
@@ -557,6 +557,7 @@ NuttX provides support for a variety of file systems out of the box.
   nxflat.rst
   pseudofs.rst
   special_files_dev_num.rst
+  v9fs.rst
 
 FS Categories
 -------------

--- a/Documentation/components/filesystem/v9fs.rst
+++ b/Documentation/components/filesystem/v9fs.rst
@@ -1,0 +1,94 @@
+V9FS
+====
+
+V9FS is a remote file system based on the 9P2000.L protocol.
+
+Adding V9FS to the NuttX Configuration
+======================================
+
+The V9FS client is easy to add to your configuration. Just add
+``CONFIG_FS_V9FS`` to ``nuttx/.config``.
+
+In order to fully run V9FS, you also need to select a transport layer
+driver. The two currently available are:
+
+  - **VIRTIO** -> ``CONFIG_V9FS_VIRTIO_9P=y``
+  - **SOCKET** -> ``CONFIG_V9FS_SOCKET_9P=y``
+
+NFS Mount Command
+=================
+
+In V9FS, we have some special parameters
+
+  - ``uname``. Used to indicate the user identity of the client
+  - ``aname``. Optional, it specifies the file tree that the client requests to access
+  - ``trans``. Selects the transport layer (virtio/socket)
+  - ``msize``. The maximum size of the message
+  - ``tag``. The tag of the mount point
+
+Different transport layers have different requirements for parameter
+passing. Here are some examples:
+
+Qemu + VIRTIO
+--------------
+
+.. code-block:: console
+
+  mount -t v9fs -o trans=virtio,tag=<mount_tag> /dir
+
+Similarly, we need to bring the corresponding parameters in qemu
+
+.. code-block:: console
+
+  -fsdev local,security_model=none,id=fsdev1,path=<share-path> \
+  -device virtio-9p-device,id=fs1,fsdev=fsdev1,mount_tag=<mount_tag>
+
+For how to start virtio-9p in QEMU, please refer to the document:
+
+  - https://wiki.qemu.org/Documentation/9psetup
+
+
+
+Socket
+-------
+
+.. code-block:: console
+
+  mount -t v9fs -o trans=socket,tag=<IP Address>:[Port Default 563],aname=[path] /dir
+
+There are many types of 9P socket servers. Here we use R9-fileserver
+(a cross-platform 9p server based on Rust
+https://github.com/crafcat7/R9-fileserver)
+
+.. code-block:: console
+
+  sudo ./ya-vm-file-server --network-address <IP Address>:<Server Port> --mount-point <share-path>
+
+
+Result
+------
+
+.. code-block:: fish
+
+  NuttShell (NSH)
+  nsh> mkdir mnt
+  nsh> 
+  nsh> ls mnt
+  /mnt:
+  nsh> mount -t v9fs -o trans=virtio,tag=hostshare /mnt/v9fs
+  nsh> 
+  nsh> ls /mnt/v9fs
+  /mnt/v9fs:
+  sdcard/
+  mnt/
+  nsh> 
+  nsh> echo "This is a test" >/mnt/v9fs/testfile.txt
+  nsh> ls -l /mnt/v9fs
+  /mnt/v9fs:
+  drwxrwxrwx    1000    1000        4096 sdcard/
+  -rw-rw-rw-    1000    1000          15 testfile.txt
+  drwxrwxrwx    1000    1000        4096 mnt/
+  nsh> 
+  nsh> cat /mnt/v9fs/testfile.txt
+  This is a test
+  nsh> 

--- a/fs/v9fs/CMakeLists.txt
+++ b/fs/v9fs/CMakeLists.txt
@@ -27,5 +27,9 @@ if(CONFIG_FS_V9FS)
     list(APPEND V9FS virtio_9p.c)
   endif()
 
+  if(CONFIG_V9FS_SOCKET_9P)
+    list(APPEND V9FS socket_9p.c)
+  endif()
+
   target_sources(fs PRIVATE ${V9FS})
 endif()

--- a/fs/v9fs/Kconfig
+++ b/fs/v9fs/Kconfig
@@ -21,4 +21,9 @@ config V9FS_VIRTIO_9P
 	depends on DRIVERS_VIRTIO
 	default n
 
+config V9FS_SOCKET_9P
+	bool "Socket 9P support"
+	depends on NET_TCP
+	default n
+
 endif

--- a/fs/v9fs/Make.defs
+++ b/fs/v9fs/Make.defs
@@ -25,6 +25,10 @@ ifeq ($(CONFIG_FS_V9FS),y)
 
 CSRCS += client.c transport.c v9fs.c
 
+ifeq ($(CONFIG_V9FS_SOCKET_9P),y)
+  CSRCS += socket_9p.c
+endif
+
 ifeq ($(CONFIG_V9FS_VIRTIO_9P),y)
   CSRCS += virtio_9p.c
 endif

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1811,3 +1811,13 @@ int v9fs_fid_get(FAR struct v9fs_client_s *client, uint32_t fid)
   nxmutex_unlock(&client->lock);
   return 0;
 }
+
+/****************************************************************************
+ * v9fs_parse_size
+ ****************************************************************************/
+
+ssize_t v9fs_parse_size(FAR const void *buffer)
+{
+  FAR const struct v9fs_header_s *ptr = buffer;
+  return ptr->size;
+}

--- a/fs/v9fs/client.h
+++ b/fs/v9fs/client.h
@@ -127,5 +127,6 @@ void v9fs_transport_destroy(FAR struct v9fs_transport_s *transport);
 void v9fs_transport_done(FAR struct v9fs_payload_s *cookie, int ret);
 int v9fs_fid_put(FAR struct v9fs_client_s *client, uint32_t fid);
 int v9fs_fid_get(FAR struct v9fs_client_s *client, uint32_t fid);
+ssize_t v9fs_parse_size(FAR const void *buffer);
 
 #endif /* __FS_V9FS_CLIENT_H */

--- a/fs/v9fs/socket_9p.c
+++ b/fs/v9fs/socket_9p.c
@@ -1,0 +1,229 @@
+/****************************************************************************
+ * fs/v9fs/socket_9p.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/param.h>
+#include <nuttx/kmalloc.h>
+#include <arpa/inet.h>
+#include <nuttx/net/net.h>
+#include <nuttx/fs/fs.h>
+
+#include "client.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define V9FS_HEADER_OFFSET 7
+#define V9FS_DEAFULT_PORT ":563"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct socket_9p_priv_s
+{
+  struct v9fs_transport_s transport;
+  struct socket psock;
+  mutex_t lock;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int socket_9p_create(FAR struct v9fs_transport_s **transport,
+                            FAR const char *args);
+static int socket_9p_request(FAR struct v9fs_transport_s *transport,
+                             FAR struct v9fs_payload_s *payload);
+static void socket_9p_destroy(FAR struct v9fs_transport_s *transport);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct v9fs_transport_ops_s g_socket_9p_transport_ops =
+{
+  socket_9p_create,  /* create */
+  socket_9p_request, /* request */
+  socket_9p_destroy, /* close */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: socket_9p_create
+ ****************************************************************************/
+
+static int socket_9p_create(FAR struct v9fs_transport_s **transport,
+                            FAR const char *args)
+{
+  FAR struct socket_9p_priv_s *priv;
+  struct sockaddr_in sin;
+  FAR const char *port;
+  FAR const char *addr;
+  int ret;
+
+  /* Parse IP and port */
+
+  addr = strstr(args, "tag=");
+  if (addr == NULL)
+    {
+      return -EINVAL;
+    }
+
+  addr += 4;
+  port = strchr(addr, ':');
+  if (port == NULL)
+    {
+      /* set default port */
+
+      port = V9FS_DEAFULT_PORT;
+    }
+
+  priv = kmm_zalloc(sizeof(struct socket_9p_priv_s));
+  if (priv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  ret = psock_socket(PF_INET, SOCK_STREAM, IPPROTO_TCP, &priv->psock);
+  if (ret < 0)
+    {
+      kmm_free(priv);
+      return ret;
+    }
+
+  sin.sin_family = PF_INET;
+  sin.sin_port = htons(atoi(port + 1));
+  sin.sin_addr.s_addr = inet_addr(addr);
+  ret = psock_connect(&priv->psock, (FAR const struct sockaddr *)&sin,
+                      sizeof(sin));
+  if (ret < 0)
+    {
+      goto out;
+    }
+
+  nxmutex_init(&priv->lock);
+  priv->transport.ops = &g_socket_9p_transport_ops;
+  *transport = &priv->transport;
+  return 0;
+
+out:
+  psock_close(&priv->psock);
+  kmm_free(priv);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: socket_9p_request
+ ****************************************************************************/
+
+static int socket_9p_request(FAR struct v9fs_transport_s *transport,
+                             FAR struct v9fs_payload_s *payload)
+{
+  FAR struct socket_9p_priv_s *priv =
+                              (FAR struct socket_9p_priv_s *)transport;
+  struct msghdr msg;
+  FAR char *ptr;
+  size_t len;
+  int ret;
+
+  memset(&msg, 0, sizeof(struct msghdr));
+  msg.msg_iov = payload->wiov;
+  msg.msg_iovlen = payload->wcount;
+
+  nxmutex_lock(&priv->lock);
+  ret = psock_sendmsg(&priv->psock, &msg, 0);
+  if (ret < 0)
+    {
+      goto out;
+    }
+
+  ptr = payload->riov[0].iov_base;
+  ret = psock_recvfrom(&priv->psock, ptr, V9FS_HEADER_OFFSET,
+                       MSG_WAITALL, NULL, NULL);
+  if (ret < 0)
+    {
+      goto out;
+    }
+
+  len = v9fs_parse_size(ptr);
+  len -= ret;
+
+  if (len > 0)
+    {
+      /* There is still data left to process */
+
+      int index;
+
+      /* Skip the header */
+
+      payload->riov[0].iov_base += V9FS_HEADER_OFFSET;
+      payload->riov[0].iov_len -= V9FS_HEADER_OFFSET;
+
+      for (index = 0; index < payload->rcount; index++)
+        {
+          payload->riov[index].iov_len =
+            MIN(len, payload->riov[index].iov_len);
+          len -= payload->riov[index].iov_len;
+        }
+
+      msg.msg_iov = payload->riov;
+      msg.msg_iovlen = payload->rcount;
+
+      ret = psock_recvmsg(&priv->psock, &msg, MSG_WAITALL);
+      if (ret < 0)
+        {
+          goto out;
+        }
+
+      /* Restore the header */
+
+      payload->riov[0].iov_base -= V9FS_HEADER_OFFSET;
+      payload->riov[0].iov_len += V9FS_HEADER_OFFSET;
+    }
+
+  ret = 0;
+
+out:
+  nxmutex_unlock(&priv->lock);
+  v9fs_transport_done(payload, ret);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: socket_9p_destroy
+ ****************************************************************************/
+
+static void socket_9p_destroy(FAR struct v9fs_transport_s *transport)
+{
+  FAR struct socket_9p_priv_s *priv =
+                              (FAR struct socket_9p_priv_s *)transport;
+
+  psock_close(&priv->psock);
+  nxmutex_destroy(&priv->lock);
+  kmm_free(priv);
+}

--- a/fs/v9fs/transport.c
+++ b/fs/v9fs/transport.c
@@ -45,11 +45,17 @@ struct v9fs_transport_ops_map_s
 #ifdef CONFIG_V9FS_VIRTIO_9P
 extern const struct v9fs_transport_ops_s g_virtio_9p_transport_ops;
 #endif
+#ifdef CONFIG_V9FS_SOCKET_9P
+extern const struct v9fs_transport_ops_s g_socket_9p_transport_ops;
+#endif
 
 static const struct v9fs_transport_ops_map_s g_transport_ops_map[] =
 {
 #ifdef CONFIG_V9FS_VIRTIO_9P
   { "virtio", &g_virtio_9p_transport_ops },
+#endif
+#ifdef CONFIG_V9FS_SOCKET_9P
+  { "socket", &g_socket_9p_transport_ops },
 #endif
   { NULL, NULL},
 };

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -330,6 +330,11 @@ ssize_t bluetooth_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -EPROTONOSUPPORT;
     }
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   /* Perform the packet recvmsg() operation */
 
   /* Initialize the state structure.  This is done with the network

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -526,6 +526,11 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -ENOSYS;
     }
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   net_lock();
 
   /* Initialize the state structure. */

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -296,6 +296,11 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   DEBUGASSERT(buf != NULL);
 
   if (len < ICMP_HDRLEN)

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -307,6 +307,11 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Some sanity checks */
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   DEBUGASSERT(buf != NULL);
 
   if (len < ICMPv6_HDRLEN)

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -330,6 +330,11 @@ ssize_t ieee802154_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -EPROTONOSUPPORT;
     }
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   /* Perform the packet recvfrom() operation */
 
   /* Initialize the state structure.  This is done with the network

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -2273,6 +2273,11 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
 {
   ssize_t ret;
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   /* If a 'from' address has been provided, verify that it is large
    * enough to hold this address family.
    */

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -2273,11 +2273,6 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
 {
   ssize_t ret;
 
-  if (msg->msg_iovlen != 1)
-    {
-      return -ENOTSUP;
-    }
-
   /* If a 'from' address has been provided, verify that it is large
    * enough to hold this address family.
    */

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -552,6 +552,11 @@ ssize_t local_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return 0;
     }
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   DEBUGASSERT(buf);
 
   /* Check for a stream socket */

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -680,6 +680,11 @@ static ssize_t netlink_recvmsg(FAR struct socket *psock,
   DEBUGASSERT(from == NULL ||
               (fromlen != NULL && *fromlen >= sizeof(struct sockaddr_nl)));
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   /* Find the response to this message.  The return value */
 
   entry = netlink_tryget_response(psock->s_conn);

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -410,6 +410,11 @@ ssize_t pkt_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -EINVAL;
     }
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   if (psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1240,6 +1240,11 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
   size_t len = msg->msg_iov->iov_len;
   ssize_t ret;
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   if (psock->s_type != SOCK_STREAM &&
       _SS_ISBOUND(conn->sconn.s_flags) &&
       !_SS_ISCONNECTED(conn->sconn.s_flags))

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -88,11 +88,6 @@ ssize_t psock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return -EINVAL;
     }
 
-  if (msg->msg_iovlen != 1)
-    {
-      return -ENOTSUP;
-    }
-
   /* Verify that the sockfd corresponds to valid, allocated socket */
 
   if (psock == NULL || psock->s_conn == NULL)

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -647,8 +647,6 @@ static void udp_notify_recvcpu(FAR struct udp_conn_s *conn)
 
       conn->rcvcpu = cpu;
     }
-
-  return;
 }
 #else
 #  define udp_notify_recvcpu(c)
@@ -683,9 +681,14 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR struct msghdr *msg,
   FAR struct net_driver_s *dev;
   struct udp_callback_s info;
   struct udp_recvfrom_s state;
-  int ret;
+  ssize_t ret;
 
   /* Perform the UDP recvfrom() operation */
+
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
 
   /* Initialize the state structure.  This is done with the network locked
    * because we don't want anything to happen until we are ready.

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -222,6 +222,11 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   socklen_t outaddrlen = 0;
   ssize_t ret;
 
+  if (msg->msg_iovlen != 1)
+    {
+      return -ENOTSUP;
+    }
+
   if (fromlen)
     {
       if (*fromlen > 0 && from == NULL)


### PR DESCRIPTION
## Summary
  In https://github.com/apache/nuttx/pull/13001, I added a new distributed file system in NuttX, which only supports VIRTIO as a data transmission method.
  In this PR, I implemented a Socket-based transmission method, so that V9FS can access the content on the Host based on the Socket method, which is suitable for more scenarios.
  I also added the V9FS document to explain how to use it.
  In short:
    - mplemented a socket-based v9fs driver
    - Enhanced Net-related, now TCP supports multi-segment IOV sending
    - Added V9FS Document

## Impact
  1. Enhanced NET related changes, now TCP supports multi-segment IOV mode sending.
  2. V9FS supports socket as a transmission medium
  3. Added V9FS Document

## Testing
  Build Host(s): Linux x86
  Target(s): qemu
  Passed local file system related tests


