### PR TITLE
arm/rp2040,rp2350: Allow configuring XOSC startup delay, and set similarly to pico-sdk

### DIFF
--- a/arch/arm/src/rp2040/rp2040_xosc.c
+++ b/arch/arm/src/rp2040/rp2040_xosc.c
@@ -80,7 +80,7 @@ void rp2040_xosc_init(void)
 
   /* Set xosc startup delay */
 
-  uint32_t startup_delay = (((12 * MHZ) / 1000) + 128) / 256;
+  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) + 128) / 256;
   putreg32(startup_delay, RP2040_XOSC_STARTUP);
 
   /* Set the enable bit now that we have set freq range and startup delay */

--- a/arch/arm/src/rp2040/rp2040_xosc.c
+++ b/arch/arm/src/rp2040/rp2040_xosc.c
@@ -80,7 +80,9 @@ void rp2040_xosc_init(void)
 
   /* Set xosc startup delay */
 
-  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) + 128) / 256;
+  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) *
+                            BOARD_XOSC_STARTUPDELAY + 255) / 256;
+  ASSERT(startup_delay < 1 << 13);
   putreg32(startup_delay, RP2040_XOSC_STARTUP);
 
   /* Set the enable bit now that we have set freq range and startup delay */

--- a/arch/arm/src/rp23xx/rp23xx_xosc.c
+++ b/arch/arm/src/rp23xx/rp23xx_xosc.c
@@ -78,7 +78,9 @@ void rp23xx_xosc_init(void)
 
   /* Set xosc startup delay */
 
-  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) + 128) / 256;
+  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) *
+                            BOARD_XOSC_STARTUPDELAY + 255) / 256;
+  ASSERT(startup_delay < 1 << 13);
   putreg32(startup_delay, RP23XX_XOSC_STARTUP);
 
   /* Set the enable bit now that we have set freq range and startup delay */

--- a/arch/arm/src/rp23xx/rp23xx_xosc.c
+++ b/arch/arm/src/rp23xx/rp23xx_xosc.c
@@ -78,7 +78,7 @@ void rp23xx_xosc_init(void)
 
   /* Set xosc startup delay */
 
-  uint32_t startup_delay = (((12 * MHZ) / 1000) + 128) / 256;
+  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) + 128) / 256;
   putreg32(startup_delay, RP23XX_XOSC_STARTUP);
 
   /* Set the enable bit now that we have set freq range and startup delay */

--- a/boards/arm/rp2040/adafruit-feather-rp2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/adafruit-feather-rp2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/include/board.h
@@ -48,7 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
-#define BOARD_XOSC_STARTUPDELAY 1
+#define BOARD_XOSC_STARTUPDELAY 64
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/adafruit-kb2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-kb2040/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/adafruit-kb2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-kb2040/include/board.h
@@ -48,7 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
-#define BOARD_XOSC_STARTUPDELAY 1
+#define BOARD_XOSC_STARTUPDELAY 64
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/include/board.h
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/include/board.h
@@ -48,7 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
-#define BOARD_XOSC_STARTUPDELAY 1
+#define BOARD_XOSC_STARTUPDELAY 64
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/pimoroni-tiny2040/include/board.h
+++ b/boards/arm/rp2040/pimoroni-tiny2040/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/raspberrypi-pico-w/include/board.h
+++ b/boards/arm/rp2040/raspberrypi-pico-w/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/raspberrypi-pico/include/board.h
+++ b/boards/arm/rp2040/raspberrypi-pico/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/seeed-xiao-rp2040/include/board.h
+++ b/boards/arm/rp2040/seeed-xiao-rp2040/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/seeed-xiao-rp2040/include/board.h
+++ b/boards/arm/rp2040/seeed-xiao-rp2040/include/board.h
@@ -48,7 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
-#define BOARD_XOSC_STARTUPDELAY 1
+#define BOARD_XOSC_STARTUPDELAY 64
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/w5500-evb-pico/include/board.h
+++ b/boards/arm/rp2040/w5500-evb-pico/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/board.h
+++ b/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/board.h
@@ -48,6 +48,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp2040/waveshare-rp2040-zero/include/board.h
+++ b/boards/arm/rp2040/waveshare-rp2040-zero/include/board.h
@@ -46,6 +46,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (125 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/include/board.h
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/include/board.h
@@ -44,6 +44,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (150 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 

--- a/boards/arm/rp23xx/raspberrypi-pico-2/include/board.h
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/include/board.h
@@ -45,6 +45,7 @@
 #define MHZ                     1000000
 
 #define BOARD_XOSC_FREQ         (12 * MHZ)
+#define BOARD_XOSC_STARTUPDELAY 1
 #define BOARD_PLL_SYS_FREQ      (150 * MHZ)
 #define BOARD_PLL_USB_FREQ      (48 * MHZ)
 


### PR DESCRIPTION
## Summary

On some boards, the 1ms startup delay for the XOSC isn't sufficient, and NuttX can fail to start. (Depending on how the board was was reset.) To fix this, the delay has to be increased of affected boards, so this adds a configuration in `board.h`.

https://github.com/raspberrypi/pico-sdk/pull/457 changed this in pico-sdk, and talks a bit about why this is needed.

## Impact

For the Adafruit RP2040 boards and the Seeed XIAO, affected boards should now boot properly. At the cost of about 64ms delay on start.

Behavior should be entirely unchanged on other boards.

## Testing

* `adafruit-feather-rp2040:usbnsh` works on my unit before and after this change; so the one I have isn't affected, or it's very intermittent
* I needed this fix for NuttX to start properly on power on reset or when plugged in on my Feather RP2350. I'll be opening another PR to add that board.
