### PR TITLE
fix compile error

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_pcnt.c
+++ b/arch/risc-v/src/common/espressif/esp_pcnt.c
@@ -393,7 +393,7 @@ static int IRAM_ATTR esp_pcnt_isr_default(int irq, void *context,
           int event_id = __builtin_ffs(event_status) - 1;
           event_status &= (event_status - 1);
 
-          flags = spin_lock_irqsave(unit->lock);
+          flags = spin_lock_irqsave(&unit->lock);
           if (unit->config.accum_count)
             {
               if (event_id == PCNT_LL_WATCH_EVENT_LOW_LIMIT)
@@ -406,7 +406,7 @@ static int IRAM_ATTR esp_pcnt_isr_default(int irq, void *context,
                 }
             }
 
-          spin_unlock_irqrestore(&pcnt_units[unit_id].lock, flags);
+          spin_unlock_irqrestore(&unit->lock, flags);
           if (unit->cb)
             {
               data.unit_id = unit_id;

--- a/arch/xtensa/src/common/espressif/esp_pcnt.c
+++ b/arch/xtensa/src/common/espressif/esp_pcnt.c
@@ -421,7 +421,7 @@ static int IRAM_ATTR esp_pcnt_isr_default(int irq, void *context,
           int event_id = __builtin_ffs(event_status) - 1;
           event_status &= (event_status - 1);
 
-          flags = spin_lock_irqsave(unit->lock);
+          flags = spin_lock_irqsave(&unit->lock);
           if (unit->config.accum_count)
             {
               if (event_id == PCNT_LL_WATCH_EVENT_LOW_LIMIT)
@@ -434,7 +434,7 @@ static int IRAM_ATTR esp_pcnt_isr_default(int irq, void *context,
                 }
             }
 
-          spin_unlock_irqrestore(&pcnt_units[unit_id].lock, flags);
+          spin_unlock_irqrestore(&unit->lock, flags);
           if (unit->cb)
             {
               data.unit_id = unit_id;

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -651,7 +651,7 @@ void esp32s2_lowputc_rst_rxfifo(const struct esp32s2_uart_s *priv)
  *
  ****************************************************************************/
 
-void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
+void esp32s2_lowputc_disable_all_uart_int(struct esp32s2_uart_s *priv,
                                           uint32_t *current_status)
 {
   irqstate_t flags;

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
@@ -401,7 +401,7 @@ void esp32s2_lowputc_rst_rxfifo(const struct esp32s2_uart_s *priv);
  *
  ****************************************************************************/
 
-void esp32s2_lowputc_disable_all_uart_int(const struct esp32s2_uart_s *priv,
+void esp32s2_lowputc_disable_all_uart_int(struct esp32s2_uart_s *priv,
                                           uint32_t *current_status);
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
fix compile error

common/espressif/esp_pcnt.c: In function 'esp_pcnt_isr_default': common/espressif/esp_pcnt.c:396:41: warning: passing argument 1 of 'spin_lock_irqsave' makes pointer from integer without a cast [-Wint-conversion]
  396 |           flags = spin_lock_irqsave(unit->lock);
      |                                     ~~~~^~~~~~
      |                                         |
      |                                         spinlock_t {aka unsigned char}
In file included from common/espressif/esp_pcnt.c:44:
/home/hujun5/下载/vela_sim/nuttx/include/nuttx/spinlock.h:507:55: note: expected 'volatile spinlock_t *' {aka 'volatile unsigned char *'} but argument is of type 'spinlock_t' {aka 'unsigned char'}
  507 | irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
      |                                  ~~~~~~~~~~~~~~~~~~~~~^~~~


## Impact

ci 

## Testing
ci 

