### PR TITLE
fix coredump failed when loop counts exceeds the limit

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -328,7 +328,7 @@ static void elf_emit_tcb_note(FAR struct elf_dumpinfo_s *cinfo,
 
   if (regs != NULL)
     {
-      for (i = 0; i < nitems(status.pr_regs); i++)
+      for (i = 0; i < MIN(nitems(status.pr_regs), g_tcbinfo.regs_num); i++)
         {
           if (g_tcbinfo.reg_off.p[i] != UINT16_MAX)
             {


### PR DESCRIPTION
## Summary

elf_emit_tcb_note: nitems(status.pr_regs) is 18, g_tcbinfo.regs_num is 17, then g_tcbinfo.reg_off.p[17] has been out of bounds, this will cause random failures of the coredump function

## Impact

coredump

## Testing

arm v7m


