### PR TITLE
syslog/intbuffer: fix spinlock deadlock

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -165,7 +165,7 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
     }
   else
     {
-      syslog_flush_intbuffer(true);
+      syslog_flush_internal(true, sizeof(g_syslog_intbuffer.buffer));
       space = buflen - sizeof(g_syslog_intbuffer.buffer);
       syslog_write_foreach(buffer, space, true);
       circbuf_write(&g_syslog_intbuffer.circ,


### PR DESCRIPTION
## Summary

syslog/intbuffer: fix spinlock deadlock

just read the code, still have the deadlock after below change:

```
| commit 3b6f463ce2b54d1934e4357b4ea1d81635161c95
| Author: chenrun1 <chenrun1@xiaomi.com>
| Date:   Tue Dec 31 14:31:46 2024 +0800
|
|     syslog_inbuffer:Fixed the lock reentry issue in single core + spinlock scenario
|
|     Summary:
|       When spinlock.h is enabled in a single-core scenario, spinlock reentry and exceptions may occur when spin_lock_irqsave_wo_note is used in syslog_add_intbuffer
|
|     Signed-off-by: chenrun1 <chenrun1@xiaomi.com>

```
Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check