### PR TITLE
drivers: mcp23x08 add missing header and fix some defines

### DIFF
--- a/drivers/ioexpander/mcp23x08.c
+++ b/drivers/ioexpander/mcp23x08.c
@@ -749,7 +749,7 @@ static FAR void *mcp23x08_attach(FAR struct ioexpander_dev_s *dev,
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)dev;
   FAR void *handle = NULL;
-  uint8_t addr = MCP23X08_GPINTENA;
+  uint8_t addr = MCP23X08_GPINTEN;
   uint8_t buf[2];
   int i;
   int ret;
@@ -849,7 +849,7 @@ static int mcp23x08_detach(FAR struct ioexpander_dev_s *dev,
 static void mcp23x08_irqworker(void *arg)
 {
   FAR struct mcp23x08_dev_s *priv = (FAR struct mcp23x08_dev_s *)arg;
-  uint8_t addr = MCP23X08_INTFA;
+  uint8_t addr = MCP23X08_INTF;
   uint8_t buf[2];
   ioe_pinset_t pinset;
   int ret;
@@ -959,7 +959,7 @@ static int mcp23x08_interrupt(int irq, FAR void *context, FAR void *arg)
 
 FAR struct ioexpander_dev_s *mcp23x08_initialize(
                               FAR struct i2c_master_s *i2cdev,
-                              FAR struct mcp23x08_config_s *config)
+                              FAR const struct mcp23x08_config_s *config)
 {
   FAR struct mcp23x08_dev_s *priv;
 #ifdef CONFIG_MCP23X08_INT_MIRROR

--- a/include/nuttx/ioexpander/mcp23x08.h
+++ b/include/nuttx/ioexpander/mcp23x08.h
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * include/nuttx/ioexpander/mcp23x08.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_IOEXPANDER_MCP23X08_H
+#define __INCLUDE_NUTTX_IOEXPANDER_MCP23X08_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include <stdbool.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* A reference to a structure of this type must be passed to the mcp23x08
+ * driver when the driver is instantiated. This structure provides
+ * information about the configuration of the mcp23x08 and provides some
+ * board-specific hooks.
+ *
+ * Memory for this structure is provided by the caller.  It is not copied by
+ * the driver and is presumed to persist while the driver is active. The
+ * memory must be writeable because, under certain circumstances, the driver
+ * may modify the frequency.
+ */
+
+struct mcp23x08_config_s
+{
+  /* Device characterization */
+
+  uint8_t address;     /* 7-bit I2C address (only bits 0-6 used) */
+  uint32_t frequency;  /* I2C or SPI frequency */
+
+  /* Sets the state of the MCP23X08's nReset pin */
+
+  CODE void (*set_nreset_pin)(bool state);
+
+#ifdef CONFIG_IOEXPANDER_INT_ENABLE
+  /* If multiple mcp23x08 devices are supported, then an IRQ number must
+   * be provided for each so that their interrupts can be distinguished.
+   */
+
+  /* IRQ/GPIO access callbacks.  These operations all hidden behind
+   * callbacks to isolate the mcp23x08 driver from differences in GPIO
+   * interrupt handling by varying boards and MCUs.
+   *
+   * attach  - Attach the mcp23x08 interrupt handler to the GPIO interrupt
+   * enable  - Enable or disable the GPIO interrupt
+   */
+
+  CODE int  (*attach)(FAR struct mcp23x08_config_s *state, xcpt_t isr,
+                      FAR void *arg);
+  CODE void (*enable)(FAR struct mcp23x08_config_s *state, bool enable);
+#endif
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: mcp23x08_initialize
+ *
+ * Description:
+ *   Initialize a MCP23X08 I2C device.
+ *
+ * TODO: Add support for more than one device.
+ *
+ ****************************************************************************/
+
+FAR struct ioexpander_dev_s *mcp23x08_initialize(
+                              FAR struct i2c_master_s *i2cdev,
+                              FAR const struct mcp23x08_config_s *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_IOEXPANDER_MCP23X08_H */


### PR DESCRIPTION
This patch fix mcp23x08 support. Issue #15592


