### PR TITLE
gdbstub: add const to send buffer

### DIFF
--- a/drivers/serial/serial_gdbstub.c
+++ b/drivers/serial/serial_gdbstub.c
@@ -253,7 +253,8 @@ static ssize_t uart_gdbstub_receive(FAR void *priv, FAR void *buf,
  *
  ****************************************************************************/
 
-static ssize_t uart_gdbstub_send(FAR void *priv, FAR void *buf, size_t len)
+static ssize_t uart_gdbstub_send(FAR void *priv, FAR const char *buf,
+                                 size_t len)
 {
   FAR struct uart_gdbstub_s *uart_gdbstub = priv;
   FAR uart_dev_t *dev = uart_gdbstub->dev;
@@ -269,7 +270,7 @@ static ssize_t uart_gdbstub_send(FAR void *priv, FAR void *buf, size_t len)
             }
           else
             {
-              uart_gdbstub->org_ops->send(dev, ((FAR char *)buf)[i++]);
+              uart_gdbstub->org_ops->send(dev, buf[i++]);
             }
         }
     }

--- a/include/nuttx/gdbstub.h
+++ b/include/nuttx/gdbstub.h
@@ -47,7 +47,7 @@
  ****************************************************************************/
 
 struct gdb_state_s;
-typedef CODE ssize_t (*gdb_send_func_t)(FAR void *priv, FAR void *buf,
+typedef CODE ssize_t (*gdb_send_func_t)(FAR void *priv, FAR const char *buf,
                                         size_t len);
 typedef CODE ssize_t (*gdb_recv_func_t)(FAR void *priv, FAR void *buf,
                                         size_t len);

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -269,7 +269,7 @@ static int gdb_expect_addr_lenth(FAR struct gdb_state_s *state,
 
 static int gdb_putchar(FAR struct gdb_state_s *state, int ch)
 {
-  unsigned char tmp = ch & 0xff;
+  char tmp = ch & 0xff;
   ssize_t ret;
 
   ret = state->send(state->priv, &tmp, 1);
@@ -328,8 +328,8 @@ static int gdb_getchar(FAR struct gdb_state_s *state)
 
 static int gdb_send_packet(FAR struct gdb_state_s *state)
 {
-  unsigned char buf[3];
-  unsigned char csum;
+  char buf[3];
+  char csum;
   int ret;
 
   ret = gdb_putchar(state, '$'); /* Send packet start */
@@ -406,8 +406,8 @@ static int gdb_send_packet(FAR struct gdb_state_s *state)
 
 static int gdb_recv_packet(FAR struct gdb_state_s *state)
 {
-  unsigned char buf[2];
-  unsigned char csum;
+  char buf[2];
+  char csum;
   int ret;
 
   /* Wait for packet start */
@@ -525,7 +525,7 @@ static int gdb_recv_packet(FAR struct gdb_state_s *state)
 
 static int gdb_checksum(FAR const char *buf, size_t len)
 {
-  unsigned char csum = 0;
+  char csum = 0;
 
   while (len--)
     {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add const to send buffer.

## Impact

I have searched and corrected `gdb_state_init ` where the function signature should be changed.
Should not have impact on existing project.

## Testing

Build pass locally. CI needs https://github.com/apache/nuttx-apps/pull/2958 to pass.

