### PR TITLE
Use small lock to protect resources related to timers in arch risc-v,…

### DIFF
--- a/arch/tricore/src/common/tricore_systimer.c
+++ b/arch/tricore/src/common/tricore_systimer.c
@@ -24,7 +24,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 
 #include <nuttx/timers/oneshot.h>
@@ -51,6 +51,7 @@ struct tricore_systimer_lowerhalf_s
   uint64_t                   alarm;
   oneshot_callback_t         callback;
   void                       *arg;
+  spinlock_t                 lock;
 };
 
 /****************************************************************************
@@ -94,11 +95,11 @@ tricore_systimer_get_time(struct tricore_systimer_lowerhalf_s *priv)
   irqstate_t flags;
   uint64_t ticks;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
 
   ticks = IfxStm_get(priv->tbase);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 
   return ticks;
 }
@@ -109,11 +110,11 @@ tricore_systimer_set_timecmp(struct tricore_systimer_lowerhalf_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
 
   IfxStm_updateCompare(priv->tbase, IfxStm_Comparator_0, value);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -315,6 +316,7 @@ tricore_systimer_initialize(volatile void *tbase, int irq, uint64_t freq)
 
   priv->tbase = tbase;
   priv->freq  = freq;
+  spin_lock_init(&priv->lock);
 
   IfxStm_setCompareControl(tbase,
       IfxStm_Comparator_0,


### PR DESCRIPTION
… xtensa and tricore.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to timers in arch risc-v, xtensa and tricore.

## Impact

arch/risc-v/src/common/espressif/esp_hr_timer.c
arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
arch/xtensa/src/esp32/esp32_rt_timer.c
arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
arch/tricore/src/common/tricore_systimer.c

## Testing

CI


