### PR TITLE
Documentation: Fix typo and list format in Rust guide

### DIFF
--- a/Documentation/guides/rust.rst
+++ b/Documentation/guides/rust.rst
@@ -52,7 +52,8 @@ Please ensure that you have a working NuttX build environment, and with the foll
 
 3. Enable essential kernel configurations
 
-Pleae enable the following configurations in your NuttX configuration:
+Please enable the following configurations in your NuttX configuration:
+
 - CONFIG_SYSTEM_TIME64
 - CONFIG_FS_LARGEFILE
 - CONFIG_TLS_NELEM = 16


### PR DESCRIPTION
## Summary
- Fixed a typo in the Rust guide ("Pleae" -> "Please")
- Improved list formatting for better readability and consistency

## Impact
- Improves documentation quality and readability
- Ensures users have complete and accurate configuration information
- Maintains consistency with the actual requirements for Rust development in NuttX

## Testing

GitHub CI and local doc build

