### PR TITLE
.github/ISSUE_TEMPLATE: Add host_info command section into bug report…

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/001_bug_report.yml
@@ -129,6 +129,13 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    attributes:
+      label: "Host information"
+      description: "What is the output of `make host_info` command while your buggy configuration selected and if possible device connected to your system?"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
## Summary

Add text area to ask host_info target output to get better system information.

- .github/ISSUE_TEMPLATE: Add host_info command section into bug report template

## Impact

- ISSUE_TEMPLATE/001_bug_report.yml

## Testing
