### PR TITLE
boards/qemu-armv7r: fix typo

### DIFF
--- a/boards/arm/qemu/qemu-armv7r/src/qemu_bringup.c
+++ b/boards/arm/qemu/qemu-armv7r/src/qemu_bringup.c
@@ -94,7 +94,7 @@ static void register_devices_from_fdt(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: imx_bringup
+ * Name: qemu_bringup
  *
  * Description:
  *   Bring up board features


### PR DESCRIPTION
## Summary

Fixes typo in comment: rename imx_bringup as qemu_bringup, as pointed out in #15593

## Impacts

None

## Testing

CI checks
