### PR TITLE
Documentation: Update supported platforms for Rust guide

### DIFF
--- a/Documentation/guides/rust.rst
+++ b/Documentation/guides/rust.rst
@@ -25,8 +25,8 @@ Prerequisites
 
 Supported Platforms
 ===================
-- AArch64 (WIP)
-- ARMv7-A (WIP)
+- AArch64
+- ARMv7-A
 - ARMv6-M
 - ARMv7-M
 - ARMv8-M
@@ -47,6 +47,7 @@ Please refer to the official Rust installation guide for more details: https://w
 2. Prepare NuttX build environment
 
 Please ensure that you have a working NuttX build environment, and with the following PR merged or cherry-picked:
+
 - https://github.com/apache/nuttx-apps/pull/2487
 - https://github.com/apache/nuttx/pull/15469
 


### PR DESCRIPTION
## Summary
Please refer to https://github.com/rust-lang/rust/pull/135757

- Updated the supported platforms list in the Rust guide to reflect that ARMv7-A and AArch64 are ready
- Removed the "WIP" (Work In Progress) label from ARMv7-A and AArch64 in the supported platforms section

## Impact
- Provides accurate information to developers about the current state of Rust support for ARMv7-A and AArch64 platforms
- Aligns the documentation with the latest developments in the Rust ecosystem
- No functional changes to the codebase, only documentation updates

## Testing

Doc build

