### PR TITLE
Use small lock to protect resources related to irq in arch ARM.

### DIFF
--- a/arch/arm/src/am335x/am335x_irq.c
+++ b/arch/arm/src/am335x/am335x_irq.c
@@ -41,7 +41,9 @@
  * Private Data
  ****************************************************************************/
 #ifdef CONFIG_ARCH_IRQPRIO
+#if defined(CONFIG_DEBUG_IRQ_INFO)
 static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/at32/at32_irq.c
+++ b/arch/arm/src/at32/at32_irq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -63,6 +63,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -79,7 +87,7 @@ static void at32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -123,7 +131,7 @@ static void at32_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define at32_dumpnvic(msg, irq)

--- a/arch/arm/src/efm32/efm32_gpioirq.c
+++ b/arch/arm/src/efm32/efm32_gpioirq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "hardware/efm32_gpio.h"
@@ -43,6 +43,12 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -198,7 +204,7 @@ void efm32_gpioirq(gpio_pinset_t pinset)
 
   /* Make sure that the pin interrupt is disabled */
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(&g_gpioirq_lock);
   regval  = getreg32(EFM32_GPIO_IEN);
   regval &= ~bit;
   putreg32(regval, EFM32_GPIO_IEN);
@@ -248,7 +254,7 @@ void efm32_gpioirq(gpio_pinset_t pinset)
     }
 
   putreg32(regval, EFM32_GPIO_EXTIFALL);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
 }
 
 /****************************************************************************
@@ -270,11 +276,11 @@ void efm32_gpioirqenable(int irq)
       uint32_t regval;
       uint32_t bit;
       bit     = ((uint32_t)1 << (irq - EFM32_IRQ_EXTI0));
-      flags   = enter_critical_section();
+      flags   = spin_lock_irqsave(&g_gpioirq_lock);
       regval  = getreg32(EFM32_GPIO_IEN);
       regval |= bit;
       putreg32(regval, EFM32_GPIO_IEN);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
 #else
       bitband_set_peripheral(EFM32_GPIO_IEN, (irq - EFM32_IRQ_EXTI0), 1);
 #endif
@@ -301,11 +307,11 @@ void efm32_gpioirqdisable(int irq)
       uint32_t bit;
 
       bit     = ((uint32_t)1 << (irq - EFM32_IRQ_EXTI0));
-      flags   = enter_critical_section();
+      flags   = spin_lock_irqsave(&g_gpioirq_lock);
       regval  = getreg32(EFM32_GPIO_IEN);
       regval &= ~bit;
       putreg32(regval, EFM32_GPIO_IEN);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
 #else
       bitband_set_peripheral(EFM32_GPIO_IEN, (irq - EFM32_IRQ_EXTI0), 0);
 #endif
@@ -332,11 +338,11 @@ void efm32_gpioirqclear(int irq)
       uint32_t bit;
 
       bit     = ((uint32_t)1 << (irq - EFM32_IRQ_EXTI0));
-      flags   = enter_critical_section();
+      flags   = spin_lock_irqsave(&g_gpioirq_lock);
       regval  = getreg32(EFM32_GPIO_IFC);
       regval |= bit;
       putreg32(regval, EFM32_GPIO_IFC);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
 #else
       bitband_set_peripheral(EFM32_GPIO_IFC, (irq - EFM32_IRQ_EXTI0), 1);
 #endif

--- a/arch/arm/src/efm32/efm32_irq.c
+++ b/arch/arm/src/efm32/efm32_irq.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/armv7-m/nvicpri.h>
 
@@ -62,6 +62,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Function
  ****************************************************************************/
 
@@ -78,7 +86,7 @@ static void efm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -126,7 +134,7 @@ static void efm32_dumpnvic(const char *msg, int irq)
 #endif
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define efm32_dumpnvic(msg, irq)

--- a/arch/arm/src/eoss3/eoss3_irq.c
+++ b/arch/arm/src/eoss3/eoss3_irq.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/armv7-m/nvicpri.h>
 
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void eoss3_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -107,7 +115,7 @@ static void eoss3_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define eoss3_dumpnvic(msg, irq)

--- a/arch/arm/src/gd32f4/gd32f4xx_irq.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_irq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -63,6 +63,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -79,7 +87,7 @@ static void gd32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -133,7 +141,7 @@ static void gd32_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ92_95_PRIORITY));
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define gd32_dumpnvic(msg, irq)

--- a/arch/arm/src/imx9/imx9_gpioirq.c
+++ b/arch/arm/src/imx9/imx9_gpioirq.c
@@ -33,7 +33,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "imx9_gpio.h"
@@ -63,6 +63,8 @@ struct imx9_portisr_s
  ****************************************************************************/
 
 static struct imx9_portisr_s g_isrtab[IMX9_GPIO_NPORTS];
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -204,12 +206,12 @@ int imx9_gpioirq_attach(gpio_pinset_t pinset, xcpt_t isr, void *arg)
 
   /* Atomically change the handler */
 
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(&g_gpioirq_lock);
 
   g_isrtab[port].pins[pin].isr = isr;
   g_isrtab[port].pins[pin].arg = arg;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/imx9/imx9_irq.c
+++ b/arch/arm/src/imx9/imx9_irq.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include <arch/irq.h>
@@ -66,6 +66,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -82,7 +90,7 @@ static void imx9_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -210,7 +218,7 @@ static void imx9_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define imx9_dumpnvic(msg, irq)

--- a/arch/arm/src/imxrt/imxrt_irq.c
+++ b/arch/arm/src/imxrt/imxrt_irq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include <arch/irq.h>
@@ -65,6 +65,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -81,7 +89,7 @@ static void imxrt_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -209,7 +217,7 @@ static void imxrt_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define imxrt_dumpnvic(msg, irq)

--- a/arch/arm/src/kinetis/kinetis_irq.c
+++ b/arch/arm/src/kinetis/kinetis_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void kinetis_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -139,7 +147,7 @@ static void kinetis_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ116_119_PRIORITY));
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define kinetis_dumpnvic(msg, irq)

--- a/arch/arm/src/kl/kl_irq.c
+++ b/arch/arm/src/kl/kl_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -49,6 +49,14 @@
    NVIC_SYSH_PRIORITY_DEFAULT << 8  | NVIC_SYSH_PRIORITY_DEFAULT)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -65,7 +73,7 @@ static void kl_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -89,7 +97,7 @@ static void kl_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
          getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -30,7 +30,6 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/board.h>
@@ -124,7 +123,7 @@ static void lc823450_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_lc823450_irq_lock);
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
@@ -166,7 +165,7 @@ static void lc823450_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ60_63_PRIORITY));
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_lc823450_irq_lock, flags);
 }
 #else
 #  define lc823450_dumpnvic(msg, irq)
@@ -186,7 +185,6 @@ static void lc823450_dumpnvic(const char *msg, int irq)
 #ifdef CONFIG_DEBUG
 static int lc823450_nmi(int irq, void *context, void *arg)
 {
-  enter_critical_section();
   irqinfo("PANIC!!! NMI received\n");
   PANIC();
   return 0;
@@ -194,7 +192,6 @@ static int lc823450_nmi(int irq, void *context, void *arg)
 
 static int lc823450_pendsv(int irq, void *context, void *arg)
 {
-  enter_critical_section();
   irqinfo("PANIC!!! PendSV received\n");
   PANIC();
   return 0;
@@ -202,7 +199,6 @@ static int lc823450_pendsv(int irq, void *context, void *arg)
 
 static int lc823450_reserved(int irq, void *context, void *arg)
 {
-  enter_critical_section();
   irqinfo("PANIC!!! Reserved interrupt\n");
   PANIC();
   return 0;

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_irq.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void lpc17_40_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -111,7 +119,7 @@ static void lpc17_40_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define lpc17_40_dumpnvic(msg, irq)

--- a/arch/arm/src/lpc214x/lpc214x_irq.c
+++ b/arch/arm/src/lpc214x/lpc214x_irq.c
@@ -29,11 +29,18 @@
 #include <stdint.h>
 #include <debug.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm.h"
 #include "chip.h"
 #include "arm_internal.h"
 #include "lpc214x_vic.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_irq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -116,7 +123,7 @@ void up_enable_irq(int irq)
     {
       /* Disable all interrupts */
 
-      irqstate_t flags = enter_critical_section();
+      irqstate_t flags = spin_lock_irqsave(&g_irq_lock);
 
       /* Enable the irq by setting the corresponding bit in the VIC
        * Interrupt Enable register.
@@ -124,7 +131,7 @@ void up_enable_irq(int irq)
 
       uint32_t val = vic_getreg(LPC214X_VIC_INTENABLE_OFFSET);
       vic_putreg(val | (1 << irq), LPC214X_VIC_INTENABLE_OFFSET);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_irq_lock, flags);
     }
 }
 
@@ -147,7 +154,7 @@ void up_attach_vector(int irq, int vector, vic_vector_t handler)
 
       /* Disable all interrupts */
 
-      irqstate_t flags = enter_critical_section();
+      irqstate_t flags = spin_lock_irqsave(&g_irq_lock);
 
       /* Save the vector address */
 
@@ -158,7 +165,7 @@ void up_attach_vector(int irq, int vector, vic_vector_t handler)
       vic_putreg(((irq << LPC214X_VECTCNTL_IRQSHIFT) |
                   LPC214X_VECTCNTL_ENABLE),
                   LPC214X_VIC_VECTCNTL0_OFFSET + offset);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_irq_lock, flags);
     }
 }
 #endif

--- a/arch/arm/src/lpc43xx/lpc43_irq.c
+++ b/arch/arm/src/lpc43xx/lpc43_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void lpc43_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -117,7 +125,7 @@ static void lpc43_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define lpc43_dumpnvic(msg, irq)

--- a/arch/arm/src/lpc54xx/lpc54_irq.c
+++ b/arch/arm/src/lpc54xx/lpc54_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void lpc54_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -116,7 +124,7 @@ static void lpc54_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define lpc54_dumpnvic(msg, irq)

--- a/arch/arm/src/max326xx/common/max326_irq.c
+++ b/arch/arm/src/max326xx/common/max326_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void max326_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -117,7 +125,7 @@ static void max326_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define max326_dumpnvic(msg, irq)

--- a/arch/arm/src/mx8mp/mx8mp_irq.c
+++ b/arch/arm/src/mx8mp/mx8mp_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void mx8mp_dump_nvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -147,7 +155,7 @@ static void mx8mp_dump_nvic(const char *msg, int irq)
   irqinfo("              %08x %08x\n",
           getreg32(NVIC_IRQ144_147_PRIORITY),
           getreg32(NVIC_IRQ148_151_PRIORITY));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define mx8mp_dump_nvic(msg, irq)

--- a/arch/arm/src/nrf52/nrf52_irq.c
+++ b/arch/arm/src/nrf52/nrf52_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -62,6 +62,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -78,7 +86,7 @@ static void nrf52_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -118,7 +126,7 @@ static void nrf52_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define nrf52_dumpnvic(msg, irq)

--- a/arch/arm/src/nrf53/nrf53_irq.c
+++ b/arch/arm/src/nrf53/nrf53_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv8-m/nvicpri.h>
@@ -62,6 +62,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -78,7 +86,7 @@ static void nrf53_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -118,7 +126,7 @@ static void nrf53_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define nrf53_dumpnvic(msg, irq)

--- a/arch/arm/src/nrf91/nrf91_irq.c
+++ b/arch/arm/src/nrf91/nrf91_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv8-m/nvicpri.h>
@@ -62,6 +62,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -78,7 +86,7 @@ static void nrf91_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -118,7 +126,7 @@ static void nrf91_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define nrf91_dumpnvic(msg, irq)

--- a/arch/arm/src/nuc1xx/nuc_irq.c
+++ b/arch/arm/src/nuc1xx/nuc_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -49,6 +49,14 @@
    NVIC_SYSH_PRIORITY_DEFAULT << 8  | NVIC_SYSH_PRIORITY_DEFAULT)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -65,7 +73,7 @@ static void nuc_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -89,7 +97,7 @@ static void nuc_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
           getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/rp2040/rp2040_irq.c
+++ b/arch/arm/src/rp2040/rp2040_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -50,6 +50,14 @@
 
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
 #  define INTSTACK_ALLOC (CONFIG_SMP_NCPUS * INTSTACK_SIZE)
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -95,7 +103,7 @@ static void rp2040_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -119,7 +127,7 @@ static void rp2040_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
           getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/s32k1xx/s32k11x/s32k11x_irq.c
+++ b/arch/arm/src/s32k1xx/s32k11x/s32k11x_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -48,6 +48,14 @@
 #define DEFPRIORITY32 \
   (NVIC_SYSH_PRIORITY_DEFAULT << 24 | NVIC_SYSH_PRIORITY_DEFAULT << 16 | \
    NVIC_SYSH_PRIORITY_DEFAULT << 8  | NVIC_SYSH_PRIORITY_DEFAULT)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -279,7 +287,7 @@ void s32k11x_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -303,7 +311,7 @@ void s32k11x_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
           getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.c
+++ b/arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void s32k14x_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -151,7 +159,7 @@ static void s32k14x_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ152_155_PRIORITY),
           getreg32(NVIC_IRQ156_159_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define s32k14x_dumpnvic(msg, irq)

--- a/arch/arm/src/s32k1xx/s32k1xx_pinirq.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pinirq.c
@@ -31,7 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include "arm_internal.h"
@@ -93,6 +93,12 @@ static struct s32k1xx_pinirq_s g_portdisrs[32];
 #endif
 #ifdef CONFIG_S32K1XX_PORTEINTS
 static struct s32k1xx_pinirq_s g_porteisrs[32];
+#endif
+
+/* Spinlock */
+
+#ifdef HAVE_PORTINTS
+static spinlock_t g_pinirq_lock = SP_UNLOCKED;
 #endif
 
 /****************************************************************************
@@ -297,7 +303,7 @@ int s32k1xx_pinirqattach(uint32_t pinset, xcpt_t pinisr, void *arg)
   /* Get the table associated with this port */
 
   DEBUGASSERT(port < S32K1XX_NPORTS);
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_pinirq_lock);
   switch (port)
     {
 #ifdef CONFIG_S32K1XX_PORTAINTS
@@ -326,7 +332,7 @@ int s32k1xx_pinirqattach(uint32_t pinset, xcpt_t pinisr, void *arg)
         break;
 #endif
       default:
-        leave_critical_section(flags);
+        spin_unlock_irqrestore(&g_pinirq_lock, flags);
         return -EINVAL;
     }
 
@@ -337,7 +343,7 @@ int s32k1xx_pinirqattach(uint32_t pinset, xcpt_t pinisr, void *arg)
 
   /* And return the old PIN isr address */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_pinirq_lock, flags);
   return OK;
 #else
   return -ENOSYS;

--- a/arch/arm/src/s32k3xx/s32k3xx_irq.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -65,6 +65,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -81,7 +89,7 @@ static void s32k3xx_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -156,7 +164,7 @@ static void s32k3xx_dumpnvic(const char *msg, int irq)
           getreg32(NVIC_IRQ152_155_PRIORITY),
           getreg32(NVIC_IRQ156_159_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define s32k3xx_dumpnvic(msg, irq)

--- a/arch/arm/src/sam34/sam_irq.c
+++ b/arch/arm/src/sam34/sam_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -63,6 +63,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -79,7 +87,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -137,7 +145,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define sam_dumpnvic(msg, irq)

--- a/arch/arm/src/samd2l2/sam_irq.c
+++ b/arch/arm/src/samd2l2/sam_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -47,6 +47,14 @@
 #define DEFPRIORITY32 \
   (NVIC_SYSH_PRIORITY_DEFAULT << 24 | NVIC_SYSH_PRIORITY_DEFAULT << 16 | \
    NVIC_SYSH_PRIORITY_DEFAULT << 8  | NVIC_SYSH_PRIORITY_DEFAULT)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -270,7 +278,7 @@ void sam_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -294,7 +302,7 @@ void sam_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
           getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/samd5e5/sam_irq.c
+++ b/arch/arm/src/samd5e5/sam_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -63,6 +63,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -79,7 +87,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -175,7 +183,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define sam_dumpnvic(msg, irq)

--- a/arch/arm/src/samv7/sam_irq.c
+++ b/arch/arm/src/samv7/sam_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -65,6 +65,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -81,7 +89,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -139,7 +147,7 @@ static void sam_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define sam_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32/stm32_irq.c
+++ b/arch/arm/src/stm32/stm32_irq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -63,6 +63,16 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -79,7 +89,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -123,7 +133,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32f0l0g0/stm32_irq.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 
@@ -50,6 +50,14 @@
    NVIC_SYSH_PRIORITY_DEFAULT << 8  | NVIC_SYSH_PRIORITY_DEFAULT)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -66,7 +74,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  ISER:       %08x ICER:   %08x\n",
@@ -90,7 +98,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
   irqinfo("  SHPR2:      %08x SHPR3:  %08x\n",
           getreg32(ARMV6M_SYSCON_SHPR2), getreg32(ARMV6M_SYSCON_SHPR3));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 #else

--- a/arch/arm/src/stm32f7/stm32_irq.c
+++ b/arch/arm/src/stm32f7/stm32_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include <arch/irq.h>
@@ -64,6 +64,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -80,7 +88,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
@@ -159,7 +167,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 #  warning Missing logic
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32h5/stm32_irq.c
+++ b/arch/arm/src/stm32h5/stm32_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv8-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -105,7 +113,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32h7/stm32_irq.c
+++ b/arch/arm/src/stm32h7/stm32_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include <arch/irq.h>
@@ -64,6 +64,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -80,7 +88,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -154,7 +162,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 
   /* TODO: Make sure this covers all interrupts that are available. */
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32l4/stm32l4_irq.c
+++ b/arch/arm/src/stm32l4/stm32l4_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void stm32l4_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -120,7 +128,7 @@ static void stm32l4_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32l4_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32l5/stm32l5_irq.c
+++ b/arch/arm/src/stm32l5/stm32l5_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv8-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void stm32l5_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -105,7 +113,7 @@ static void stm32l5_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32l5_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32u5/stm32_irq.c
+++ b/arch/arm/src/stm32u5/stm32_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv8-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -105,7 +113,7 @@ static void stm32_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32wb/stm32wb_irq.c
+++ b/arch/arm/src/stm32wb/stm32wb_irq.c
@@ -30,7 +30,7 @@
 #include <debug.h>
 #include <assert.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include "arm_internal.h"
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void stm32wb_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -121,7 +129,7 @@ static void stm32wb_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32wb_dumpnvic(msg, irq)

--- a/arch/arm/src/stm32wl5/stm32wl5_irq.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -60,6 +60,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -76,7 +84,7 @@ static void stm32wl5_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
@@ -120,7 +128,7 @@ static void stm32wl5_dumpnvic(const char *msg, int irq)
   irqinfo("              %08x\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define stm32wl5_dumpnvic(msg, irq)

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
@@ -26,7 +26,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <stdint.h>
 #include <string.h>
@@ -60,6 +60,10 @@ struct gpio_handler_s
 /* A table of handlers for each GPIO port interrupt */
 
 static struct gpio_handler_s g_gpio_inthandler[TIVA_NIRQ_PINS];
+
+/* Spinlock */
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -176,7 +180,7 @@ int tiva_gpioirqattach(pinconfig_t pinconfig, xcpt_t isr, void *arg)
 
   if (dio < TIVA_NDIO)
     {
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_gpioirq_lock);
 
       /* If the new ISR is NULL, then the ISR is being detached.
        * In this case, disable the ISR and direct any interrupts
@@ -199,7 +203,7 @@ int tiva_gpioirqattach(pinconfig_t pinconfig, xcpt_t isr, void *arg)
           tiva_gpioirqenable(pinconfig);
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
     }
 
   return OK;

--- a/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
@@ -26,7 +26,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -69,6 +69,10 @@ struct gpio_handler_s
 /* A table of handlers for each GPIO port interrupt */
 
 static struct gpio_handler_s g_gpioportirqvector[TIVA_NIRQ_PINS];
+
+/* Spinlock */
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -287,11 +291,11 @@ static int tiva_gpioporthandler(uint8_t port, void *context)
 static int tiva_gpioahandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTA >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -300,11 +304,11 @@ static int tiva_gpioahandler(int irq, void *context, void *arg)
 static int tiva_gpiobhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTB >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -313,11 +317,11 @@ static int tiva_gpiobhandler(int irq, void *context, void *arg)
 static int tiva_gpiochandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTC >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -326,11 +330,11 @@ static int tiva_gpiochandler(int irq, void *context, void *arg)
 static int tiva_gpiodhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTD >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -339,11 +343,11 @@ static int tiva_gpiodhandler(int irq, void *context, void *arg)
 static int tiva_gpioehandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTE >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -352,11 +356,11 @@ static int tiva_gpioehandler(int irq, void *context, void *arg)
 static int tiva_gpiofhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTF >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -365,11 +369,11 @@ static int tiva_gpiofhandler(int irq, void *context, void *arg)
 static int tiva_gpioghandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTG >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -378,11 +382,11 @@ static int tiva_gpioghandler(int irq, void *context, void *arg)
 static int tiva_gpiohhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTH >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -391,11 +395,11 @@ static int tiva_gpiohhandler(int irq, void *context, void *arg)
 static int tiva_gpiojhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTJ >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -404,11 +408,11 @@ static int tiva_gpiojhandler(int irq, void *context, void *arg)
 static int tiva_gpiokhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTK >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -417,11 +421,11 @@ static int tiva_gpiokhandler(int irq, void *context, void *arg)
 static int tiva_gpiolhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTL >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -430,11 +434,11 @@ static int tiva_gpiolhandler(int irq, void *context, void *arg)
 static int tiva_gpiomhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTM >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -443,11 +447,11 @@ static int tiva_gpiomhandler(int irq, void *context, void *arg)
 static int tiva_gpionhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTN >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -456,11 +460,11 @@ static int tiva_gpionhandler(int irq, void *context, void *arg)
 static int tiva_gpiophandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTP >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -469,11 +473,11 @@ static int tiva_gpiophandler(int irq, void *context, void *arg)
 static int tiva_gpioqhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTQ >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -482,11 +486,11 @@ static int tiva_gpioqhandler(int irq, void *context, void *arg)
 static int tiva_gpiorhandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTR >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -495,11 +499,11 @@ static int tiva_gpiorhandler(int irq, void *context, void *arg)
 static int tiva_gpioshandler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_gpioirq_lock);
   up_disable_irq(irq);
   int ret = tiva_gpioporthandler((GPIO_PORTS >> GPIO_PORT_SHIFT), context);
   up_enable_irq(irq);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_gpioirq_lock, flags);
   return ret;
 }
 #endif
@@ -646,7 +650,7 @@ int tiva_gpioirqattach(pinconfig_t pinconfig, xcpt_t isr, void *arg)
 
   if (port < TIVA_NPORTS)
     {
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_gpioirq_lock);
 
       /* If the new ISR is NULL, then the ISR is being detached.
        * In this case, disable the ISR and direct any interrupts
@@ -670,7 +674,7 @@ int tiva_gpioirqattach(pinconfig_t pinconfig, xcpt_t isr, void *arg)
           tiva_gpioirqenable(pinconfig);
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
     }
 
   return OK;

--- a/arch/arm/src/tiva/common/tiva_irq.c
+++ b/arch/arm/src/tiva/common/tiva_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -61,6 +61,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -77,7 +85,7 @@ static void tiva_dumpnvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
@@ -188,7 +196,7 @@ static void tiva_dumpnvic(const char *msg, int irq)
 #if TIVA_IRQ_NEXTINT > 159
 #  warning Missing output
 #endif
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define tiva_dumpnvic(msg, irq)

--- a/arch/arm/src/tms570/tms570_gioirq.c
+++ b/arch/arm/src/tms570/tms570_gioirq.c
@@ -34,7 +34,7 @@
 #include <nuttx/init.h>
 #include <nuttx/arch.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
@@ -42,6 +42,12 @@
 #include "hardware/tms570_gio.h"
 
 #ifdef CONFIG_TMS570_GIO_IRQ
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t g_irq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -132,7 +138,7 @@ void tms570_gioirq(gio_pinset_t pinset)
 
   if ((pinset & GIO_MODE_MASK) == GIO_INPUT && port < TMS570_NIRQPORTS)
     {
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_irq_lock);
       switch (pinset & GIO_INT_MASK)
       {
         case GIO_INT_NONE:
@@ -182,7 +188,7 @@ void tms570_gioirq(gio_pinset_t pinset)
           break;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_irq_lock, flags);
     }
 }
 

--- a/arch/arm/src/xmc4/xmc4_irq.c
+++ b/arch/arm/src/xmc4/xmc4_irq.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/armv7-m/nvicpri.h>
@@ -59,6 +59,14 @@
 #define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_DEBUG_IRQ_INFO)
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -75,7 +83,7 @@ static void xmc4_dump_nvic(const char *msg, int irq)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
@@ -138,7 +146,7 @@ static void xmc4_dump_nvic(const char *msg, int irq)
           getreg32(NVIC_IRQ116_119_PRIORITY));
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 #else
 #  define xmc4_dump_nvic(msg, irq)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources about irq in arch ARM.

## Impact

Some logic related to irq under arm architecture.

## Testing
CI


