### PR TITLE
fix(libc): lib_strftime %F month number off-by-one

### DIFF
--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -402,7 +402,7 @@ process_next:
             case 'F':
               {
                 len = snprintf(dest, chleft, "%04d-%02d-%02d",
-                              tm->tm_year + TM_YEAR_BASE, tm->tm_mon,
+                              tm->tm_year + TM_YEAR_BASE, tm->tm_mon + 1,
                               tm->tm_mday);
               }
               break;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Corrects the month number output for the %F format specifier in lib_strftime.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
- Disable NSH_DISABLE_DATE to enable the built-in date command.
- Enter the shell and set the date. Ex., nsh> date -s "Jan 21 00:00:00 2025"
- Specify the %F format: nsh> date +"%F", but unfortunately, we received the incorrect month number: 2025-**00**-21.


