### PR TITLE
armv8m: Default open hardware stack check

### DIFF
--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -57,6 +57,7 @@ config ARMV8M_TARGET2_PREL
 
 choice
 	prompt "Select the stack protection Schema"
+	default ARMV8M_STACKCHECK_HARDWARE if DEBUG_FEATURES
 	default ARMV8M_STACKCHECK_NONE
 
 config ARMV8M_STACKCHECK_NONE


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

armv8m: Default open hardware stack check

## Impact

Hardware detection will not have any performance impact

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


