### PR TITLE
drivers/iovec: revert vector io implement from loop/null/zero driver

### DIFF
--- a/drivers/loop/loop.c
+++ b/drivers/loop/loop.c
@@ -40,8 +40,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t loop_readv(FAR struct file *filep, FAR struct uio *uio);
-static ssize_t loop_writev(FAR struct file *filep, FAR struct uio *uio);
+static ssize_t loop_read(FAR struct file *filep, FAR char *buffer,
+                 size_t buflen);
+static ssize_t loop_write(FAR struct file *filep, FAR const char *buffer,
+                 size_t buflen);
 static int     loop_ioctl(FAR struct file *filep, int cmd,
                  unsigned long arg);
 
@@ -53,15 +55,15 @@ static const struct file_operations g_loop_fops =
 {
   NULL,          /* open */
   NULL,          /* close */
-  NULL,          /* read */
-  NULL,          /* write */
+  loop_read,     /* read */
+  loop_write,    /* write */
   NULL,          /* seek */
   loop_ioctl,    /* ioctl */
   NULL,          /* mmap */
   NULL,          /* truncate */
   NULL,          /* poll */
-  loop_readv,    /* readv */
-  loop_writev    /* writev */
+  NULL,          /* readv */
+  NULL           /* writev */
 };
 
 /****************************************************************************
@@ -69,26 +71,23 @@ static const struct file_operations g_loop_fops =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: loop_readv
+ * Name: loop_read
  ****************************************************************************/
 
-static ssize_t loop_readv(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t loop_read(FAR struct file *filep, FAR char *buffer,
+                         size_t len)
 {
   return 0; /* Return EOF */
 }
 
 /****************************************************************************
- * Name: loop_writev
+ * Name: loop_write
  ****************************************************************************/
 
-static ssize_t loop_writev(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t loop_write(FAR struct file *filep, FAR const char *buffer,
+                          size_t len)
 {
-  /* Say that everything was written */
-
-  size_t ret = uio->uio_resid;
-
-  uio_advance(uio, ret);
-  return ret;
+  return len; /* Say that everything was written */
 }
 
 /****************************************************************************

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -40,8 +40,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t devnull_readv(FAR struct file *filep, FAR struct uio *uio);
-static ssize_t devnull_writev(FAR struct file *filep, FAR struct uio *uio);
+static ssize_t devnull_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen);
+static ssize_t devnull_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t buflen);
 static int     devnull_poll(FAR struct file *filep, FAR struct pollfd *fds,
                             bool setup);
 
@@ -51,17 +53,17 @@ static int     devnull_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_devnull_fops =
 {
-  NULL,           /* open */
-  NULL,           /* close */
-  NULL,           /* read */
-  NULL,           /* writev */
-  NULL,           /* seek */
-  NULL,           /* ioctl */
-  NULL,           /* mmap */
-  NULL,           /* truncate */
-  devnull_poll,   /* poll */
-  devnull_readv,  /* readv */
-  devnull_writev  /* writev */
+  NULL,          /* open */
+  NULL,          /* close */
+  devnull_read,  /* read */
+  devnull_write, /* write */
+  NULL,          /* seek */
+  NULL,          /* ioctl */
+  NULL,          /* mmap */
+  NULL,          /* truncate */
+  devnull_poll,  /* poll */
+  NULL,          /* readv */
+  NULL           /* writev */
 };
 
 /****************************************************************************
@@ -69,31 +71,30 @@ static const struct file_operations g_devnull_fops =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: devnull_readv
+ * Name: devnull_read
  ****************************************************************************/
 
-static ssize_t devnull_readv(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t devnull_read(FAR struct file *filep, FAR char *buffer,
+                            size_t len)
 {
   UNUSED(filep);
-  UNUSED(uio);
+  UNUSED(buffer);
+  UNUSED(len);
 
   return 0; /* Return EOF */
 }
 
 /****************************************************************************
- * Name: devnull_writev
+ * Name: devnull_write
  ****************************************************************************/
 
-static ssize_t devnull_writev(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t devnull_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t len)
 {
   UNUSED(filep);
+  UNUSED(buffer);
 
-  /* Say that everything was written */
-
-  size_t ret = uio->uio_resid;
-
-  uio_advance(uio, ret);
-  return ret;
+  return len; /* Say that everything was written */
 }
 
 /****************************************************************************

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -40,8 +40,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t devzero_readv(FAR struct file *filep, FAR struct uio *uio);
-static ssize_t devzero_writev(FAR struct file *filep, FAR struct uio *uio);
+static ssize_t devzero_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen);
+static ssize_t devzero_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t buflen);
 static int     devzero_poll(FAR struct file *filep, FAR struct pollfd *fds,
                             bool setup);
 
@@ -51,17 +53,17 @@ static int     devzero_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_devzero_fops =
 {
-  NULL,           /* open */
-  NULL,           /* close */
-  NULL,           /* read */
-  NULL,           /* write */
-  NULL,           /* seek */
-  NULL,           /* ioctl */
-  NULL,           /* mmap */
-  NULL,           /* truncate */
-  devzero_poll,   /* poll */
-  devzero_readv,  /* readv */
-  devzero_writev  /* writev */
+  NULL,          /* open */
+  NULL,          /* close */
+  devzero_read,  /* read */
+  devzero_write, /* write */
+  NULL,          /* seek */
+  NULL,          /* ioctl */
+  NULL,          /* mmap */
+  NULL,          /* truncate */
+  devzero_poll,  /* poll */
+  NULL,          /* readv */
+  NULL           /* writev */
 };
 
 /****************************************************************************
@@ -69,41 +71,29 @@ static const struct file_operations g_devzero_fops =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: devzero_readv
+ * Name: devzero_read
  ****************************************************************************/
 
-static ssize_t devzero_readv(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t devzero_read(FAR struct file *filep, FAR char *buffer,
+                            size_t len)
 {
-  size_t total = uio->uio_resid;
-  FAR const struct iovec *iov = uio->uio_iov;
-  int iovcnt = uio->uio_iovcnt;
-  int i;
-
   UNUSED(filep);
 
-  for (i = 0; i < iovcnt; i++)
-    {
-      memset(iov[i].iov_base, 0, iov[i].iov_len);
-    }
-
-  uio_advance(uio, total);
-
-  return total;
+  memset(buffer, 0, len);
+  return len;
 }
 
 /****************************************************************************
- * Name: devzero_writev
+ * Name: devzero_write
  ****************************************************************************/
 
-static ssize_t devzero_writev(FAR struct file *filep, FAR struct uio *uio)
+static ssize_t devzero_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t len)
 {
-  size_t total;
   UNUSED(filep);
+  UNUSED(buffer);
 
-  total = uio->uio_resid;
-
-  uio_advance(uio, total);
-  return total;
+  return len;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

drivers/iovec: revert vector io implement from loop/null/zero driver

basic driver does not need such complex wrapper

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

improve the performance

## Testing

test code on ubuntu 24.04 x86_64

```
static void timespec_sub(struct timespec *dest,
                         struct timespec *ts1,
                         struct timespec *ts2)
{
  dest->tv_sec = ts1->tv_sec - ts2->tv_sec;
  dest->tv_nsec = ts1->tv_nsec - ts2->tv_nsec;

  if (dest->tv_nsec < 0)
    {
      dest->tv_nsec += 1000000000;
      dest->tv_sec -= 1;
    }
}


int main(int argc, FAR char *argv[])
{
  struct timespec result;
  struct timespec start;
  struct timespec end;
  int fd = open("/dev/zero", O_RDONLY);
  int loop = 0;
  int i = 0;
  char c;

  while (loop++ < 10)
    {
      i = 0;
      clock_gettime(CLOCK_MONOTONIC, &start);
      while (i++ < 100000)
        {
          read(fd, &c, 1);
        }
      clock_gettime(CLOCK_MONOTONIC, &end);

      timespec_sub(&result, &end, &start);
      printf("%d:spending %d.%lds\n", loop, result.tv_sec, result.tv_nsec);
    }

  close(fd);
  return 0;
}
```

before:
```
nsh> hello
1:spending 0.39044654s
2:spending 0.28245015s
3:spending 0.28215794s
4:spending 0.28436127s
5:spending 0.28330915s
6:spending 0.28564837s
7:spending 0.28116804s
8:spending 0.27876377s
9:spending 0.28266779s
10:spending 0.28328176s
nsh>
```



this PR + https://github.com/apache/nuttx/pull/15603
```
nsh> hello
1:spending 0.30323709s
2:spending 0.22735038s
3:spending 0.22735801s
4:spending 0.22715055s
5:spending 0.22756127s
6:spending 0.22938592s
7:spending 0.22860041s
8:spending 0.22718114s
9:spending 0.22785607s
10:spending 0.22676567s
nsh> poweroff
```