### PR TITLE
Use small lock to protect resources related to irq in arch avr, hc, m…

### DIFF
--- a/arch/avr/src/at32uc3/at32uc3_gpioirq.c
+++ b/arch/avr/src/at32uc3/at32uc3_gpioirq.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "avr_internal.h"
 #include "irq/irq.h"
@@ -59,6 +59,10 @@ struct g_gpiohandler_s
 /* A table of handlers for each GPIO interrupt */
 
 static struct g_gpiohandler_s g_gpiohandler[NR_GPIO_IRQS];
+
+/* Spinlock */
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -328,7 +332,7 @@ int gpio_irqattach(int irq, xcpt_t handler, void *arg)
        * to the unexpected interrupt handler.
        */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_gpioirq_lock);
       if (handler == NULL)
         {
            gpio_irqdisable(irq);
@@ -342,7 +346,7 @@ int gpio_irqattach(int irq, xcpt_t handler, void *arg)
       g_gpiohandler[irq].handler = handler;
       g_gpiohandler[irq].arg     = arg;
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
       ret = OK;
     }
 

--- a/arch/hc/src/m9s12/m9s12_gpioirq.c
+++ b/arch/hc/src/m9s12/m9s12_gpioirq.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "hc_internal.h"
 #include "m9s12.h"
@@ -48,6 +48,12 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* Spinlock */
+
+#ifdef CONFIG_HCS12_GPIOIRQ
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -250,11 +256,11 @@ void hcs12_gpioirqenable(int irq)
 
   if (hcs12_mapirq(irq, &regaddr, &pin) == OK)
     {
-       irqstate_t flags  = enter_critical_section();
+       irqstate_t flags  = spin_lock_irqsave(&g_gpioirq_lock);
        uint8_t    regval = getreg8(regaddr);
        regval           |= (1 << pin);
        putreg8(regval, regaddr);
-       leave_critical_section(flags);
+       spin_unlock_irqrestore(&g_gpioirq_lock, flags);
     }
 }
 #endif /* CONFIG_HCS12_GPIOIRQ */
@@ -275,11 +281,11 @@ void hcs12_gpioirqdisable(int irq)
 
   if (hcs12_mapirq(irq, &regaddr, &pin) == OK)
     {
-       irqstate_t flags  = enter_critical_section();
+       irqstate_t flags  = spin_lock_irqsave(&g_gpioirq_lock);
        uint8_t    regval = getreg8(regaddr);
        regval           &= ~(1 << pin);
        putreg8(regval, regaddr);
-       leave_critical_section(flags);
+       spin_unlock_irqrestore(&g_gpioirq_lock, flags);
     }
 }
 #endif /* CONFIG_HCS12_GPIOIRQ */

--- a/arch/mips/src/pic32mx/pic32mx_gpioirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_gpioirq.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <assert.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/board/board.h>
 
@@ -54,6 +54,10 @@ struct g_cnisrs_s
  ****************************************************************************/
 
 static struct g_cnisrs_s g_cnisrs[IOPORT_NUMCN];
+
+/* Spinlock */
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -203,7 +207,7 @@ int pic32mx_gpioattach(uint32_t pinset, unsigned int cn, xcpt_t handler,
     {
       /* Get the previously attached handler as the return value */
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&g_gpioirq_lock);
 
       /* Are we attaching or detaching? */
 
@@ -240,7 +244,7 @@ int pic32mx_gpioattach(uint32_t pinset, unsigned int cn, xcpt_t handler,
 
       g_cnisrs[cn].handler = handler;
       g_cnisrs[cn].arg     = arg;
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&g_gpioirq_lock, flags);
     }
 
   return OK;

--- a/arch/mips/src/pic32mz/pic32mz_gpioirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_gpioirq.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <assert.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/board/board.h>
 #include <arch/pic32mz/irq.h>
@@ -151,6 +151,10 @@ static struct ioport_level2_s * const g_level2_handlers[CHIP_NPORTS] =
   [PIC32MZ_IOPORTK] = &g_ioportk_cnisrs,
 #endif
 };
+
+/* Spinlock */
+
+static spinlock_t g_gpioirq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -480,7 +484,7 @@ int pic32mz_gpioattach(pinset_t pinset, xcpt_t handler, void *arg)
         {
           /* Get the previously attached handler as the return value */
 
-          flags = enter_critical_section();
+          flags = spin_lock_irqsave(&g_gpioirq_lock);
 
           /* Are we attaching or detaching? */
 
@@ -535,7 +539,7 @@ int pic32mz_gpioattach(pinset_t pinset, xcpt_t handler, void *arg)
 
           handlers->handler[pin].entry = handler;
           handlers->handler[pin].arg   = arg;
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(&g_gpioirq_lock, flags);
         }
     }
 

--- a/arch/or1k/src/mor1kx/or1k_irq.c
+++ b/arch/or1k/src/mor1kx/or1k_irq.c
@@ -30,12 +30,22 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/spr.h>
 
 #include "or1k_internal.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Spinlock */
+
+#ifdef CONFIG_DEBUG_IRQ_INFO
+static spinlock_t g_irq_lock = SP_UNLOCKED;
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -134,11 +144,6 @@ void or1k_ack_irq(int irq)
 #ifdef CONFIG_DEBUG_IRQ_INFO
 void or1k_dump_pic(const char *msg, int irq)
 {
-  irqstate_t flags;
-
-  flags = enter_critical_section();
-
-  leave_critical_section(flags);
 }
 
 #else

--- a/arch/sparc/src/s698pm/s698pm-irq.c
+++ b/arch/sparc/src/s698pm/s698pm-irq.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 
 #include <arch/irq.h>
@@ -66,7 +66,7 @@
 #define IRQ_MKMAP(c, i)   (((c) << 0x05) | (i))
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
 static volatile uint8_t g_irqmap[NR_IRQS];
@@ -98,6 +98,10 @@ uintptr_t g_cpu_intstack_top[CONFIG_SMP_NCPUS] =
 #endif /* defined(CONFIG_SMP) */
 };
 #endif /* if CONFIG_ARCH_INTERRUPTSTACK > 7 */
+
+/* Spinlock */
+
+static spinlock_t g_irq_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Private Functions
@@ -219,10 +223,10 @@ int s698pm_cpuint_initialize(void)
 
 int s698pm_setup_irq(int cpu, int irq, int priority)
 {
-  irqstate_t irqstate;
+  irqstate_t flags;
   int cpuint;
 
-  irqstate = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   if (irq >= S698PM_IRQ_FIRST_INT && irq <= S698PM_IRQ_LAST_INT)
     {
@@ -251,7 +255,7 @@ int s698pm_setup_irq(int cpu, int irq, int priority)
   g_irqmap[irq] = IRQ_MKMAP(cpu, cpuint);
   (void)up_prioritize_irq(irq, priority);
 
-  leave_critical_section(irqstate);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 
   return cpuint;
 }
@@ -273,13 +277,13 @@ int s698pm_setup_irq(int cpu, int irq, int priority)
 
 void s698pm_teardown_irq(int irq)
 {
-  irqstate_t irqstate;
+  irqstate_t flags;
 
-  irqstate = enter_critical_section();
+  flags = spin_lock_irqsave(&g_irq_lock);
 
   g_irqmap[irq] = IRQ_UNMAPPED;
 
-  leave_critical_section(irqstate);
+  spin_unlock_irqrestore(&g_irq_lock, flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
…ips and or1k.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to irq in arch avr, hc, mips and or1k.

## Impact

The underlying IRQ logic of arch  avr, hc, mips and or1k.

## Testing

CI


