### PR TITLE
x86-64 coredump support

### DIFF
--- a/arch/x86_64/include/elf.h
+++ b/arch/x86_64/include/elf.h
@@ -45,4 +45,42 @@
 
 #define EF_FLAG      0
 
+/* Segment register layout in coredumps. */
+
+struct user_regs_struct
+{
+  uint64_t  r15;
+  uint64_t  r14;
+  uint64_t  r13;
+  uint64_t  r12;
+  uint64_t  bp;
+  uint64_t  bx;
+  uint64_t  r11;
+  uint64_t  r10;
+  uint64_t  r9;
+  uint64_t  r8;
+  uint64_t  ax;
+  uint64_t  cx;
+  uint64_t  dx;
+  uint64_t  si;
+  uint64_t  di;
+  uint64_t  orig_ax;
+  uint64_t  ip;
+  uint64_t  cs;
+  uint64_t  flags;
+  uint64_t  sp;
+  uint64_t  ss;
+  uint64_t  fs_base;
+  uint64_t  gs_base;
+  uint64_t  ds;
+  uint64_t  es;
+  uint64_t  fs;
+  uint64_t  gs;
+};
+
+typedef uint64_t elf_greg_t;
+
+#define ELF_NGREG (sizeof(struct user_regs_struct) / sizeof(elf_greg_t))
+typedef elf_greg_t elf_gregset_t[ELF_NGREG];
+
 #endif /* __ARCH_X86_64_INCLUDE_ELF_H */

--- a/arch/x86_64/src/common/x86_64_tcbinfo.c
+++ b/arch/x86_64/src/common/x86_64_tcbinfo.c
@@ -36,29 +36,33 @@
 
 static const uint16_t g_reg_offs[] =
 {
-  TCB_REG_OFF(REG_RAX),    /* RAX */
+  TCB_REG_OFF(REG_R15),    /* R15 */
+  TCB_REG_OFF(REG_R14),    /* R14 */
+  TCB_REG_OFF(REG_R13),    /* R13 */
+  TCB_REG_OFF(REG_R12),    /* R12 */
+  TCB_REG_OFF(REG_RBP),    /* RBP */
   TCB_REG_OFF(REG_RBX),    /* RBX */
+  TCB_REG_OFF(REG_R11),    /* R11 */
+  TCB_REG_OFF(REG_R10),    /* R10 */
+  TCB_REG_OFF(REG_R9),     /* R9 */
+  TCB_REG_OFF(REG_R8),     /* R8 */
+  TCB_REG_OFF(REG_RAX),    /* RAX */
   TCB_REG_OFF(REG_RCX),    /* RCX */
   TCB_REG_OFF(REG_RDX),    /* RDX */
   TCB_REG_OFF(REG_RSI),    /* RSI */
   TCB_REG_OFF(REG_RDI),    /* RDI */
-  TCB_REG_OFF(REG_RBP),    /* RBP */
-  TCB_REG_OFF(REG_RSP),    /* RSP */
-  TCB_REG_OFF(REG_R8),     /* R8 */
-  TCB_REG_OFF(REG_R9),     /* R9 */
-  TCB_REG_OFF(REG_R10),    /* R10 */
-  TCB_REG_OFF(REG_R11),    /* R11 */
-  TCB_REG_OFF(REG_R12),    /* R12 */
-  TCB_REG_OFF(REG_R13),    /* R13 */
-  TCB_REG_OFF(REG_R14),    /* R14 */
-  TCB_REG_OFF(REG_R15),    /* R15 */
+  TCB_REG_OFF(REG_RAX),    /* RAX */
   TCB_REG_OFF(REG_RIP),    /* RIP */
-  TCB_REG_OFF(REG_RFLAGS), /* EFLAGS */
   TCB_REG_OFF(REG_CS),     /* CS */
+  TCB_REG_OFF(REG_RFLAGS), /* RFLAGS */
+  TCB_REG_OFF(REG_RSP),    /* RSP */
   TCB_REG_OFF(REG_SS),     /* SS */
+  TCB_REG_OFF(REG_FS),     /* FS_BASE */
+  TCB_REG_OFF(REG_GS),     /* GS_BASE */
   TCB_REG_OFF(REG_DS),     /* DS */
   TCB_REG_OFF(REG_ES),     /* ES */
   TCB_REG_OFF(REG_FS),     /* FS */
+  TCB_REG_OFF(REG_GS),     /* GS */
 };
 
 /****************************************************************************

--- a/libs/libc/machine/x86_64/CMakeLists.txt
+++ b/libs/libc/machine/x86_64/CMakeLists.txt
@@ -25,7 +25,7 @@ add_subdirectory(gnu)
 set(SRCS)
 
 if(CONFIG_LIBC_ARCH_ELF)
-  list(APPEND SRCS arch_elf.c)
+  list(APPEND SRCS arch_elf64.c)
 endif()
 
 if(CONFIG_ARCH_SETJMP_H)

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -55,6 +55,12 @@
 
 #define PROGRAM_ALIGNMENT 64
 
+/* Architecture can overwrite the default XCPTCONTEXT alignment */
+
+#ifndef XCPTCONTEXT_ALIGN
+#  define XCPTCONTEXT_ALIGN 16
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -74,7 +80,8 @@ struct elf_dumpinfo_s
  * Private Data
  ****************************************************************************/
 
-static uint8_t g_running_regs[XCPTCONTEXT_SIZE] aligned_data(16);
+static uint8_t g_running_regs[XCPTCONTEXT_SIZE]
+               aligned_data(XCPTCONTEXT_ALIGN);
 
 #ifdef CONFIG_BOARD_COREDUMP_COMPRESSION
 static struct lib_lzfoutstream_s  g_lzfstream;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add coredump support for x86-64.

## Impact

coredump now works on x86-64.

## Testing

1. config
```patch
 CONFIG_BOARD_LOOPSPERMSEC=999
 CONFIG_BOOT_RUNFROMEXTSRAM=y
 CONFIG_BUILTIN=y
 CONFIG_CONSOLE_SYSLOG=y
+CONFIG_COREDUMP=y
+CONFIG_DEBUG_FEATURES=y
 CONFIG_DEBUG_SYMBOLS=y
 CONFIG_DEFAULT_TASK_STACKSIZE=4194304
+CONFIG_ELF=y
 CONFIG_EXAMPLES_HELLO=y
 CONFIG_FS_PROCFS=y
 CONFIG_IDLETHREAD_STACKSIZE=4194304
@@ -58,4 +63,5 @@ CONFIG_SYSTEM_NSH=y
 CONFIG_SYSTEM_TIME64=y
 CONFIG_TESTING_OSTEST=y
 CONFIG_TESTING_OSTEST_STACKSIZE=4194304
+CONFIG_TTY_FORCE_PANIC=y
 CONFIG_USEC_PER_TICK=1
```
2. compile
 cmake -Bbuild -GNinja -DBOARD_CONFIG=qemu-intel64:nsh nuttx
ninjia -Cbuild

3. run
```
qemu-system-x86_64 -m 2G -cpu host -enable-kvm -kernel build/nuttx -nographic -chardev pty,id=ch1 -device pci-serial,chardev=ch1 -s
```
Press CTRL+? to force panic, collect the log output and convert to core file using `python nuttx/tools/coredump.py coredump.log`

4. debug with core file

```
gdb-multiarch build/nuttx -c coredump.core
GNU gdb (GDB) 17.0.50.20250117-git
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from build/nuttx...

warning: core file may not match specified executable file.

warning: found thread with pid 0, assigned replacement Target Id: LWP 2
[New LWP 2]
[New LWP 1]
Core was generated by `'.
#0  up_idle () at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/intel64/intel64_idle.c:91
91      }
[Current thread is 1 (LWP 2)]
(gdb) bt
#0  up_idle () at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/intel64/intel64_idle.c:91
#1  0x0000000100913bed in nx_start () at /home/neo/projects/nuttx/nuttx/sched/init/nx_start.c:782
#2  0x0000000100909220 in __nxstart () at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/intel64/intel64_start.c:209
#3  0x0000000000000000 in ?? ()
(gdb) t 2
[Switching to thread 2 (LWP 1)]
#0  0x000000010092548c in up_switch_context (tcb=0x100988200 <g_idletcb>, rtcb=0x10119f5d8) at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/common/x86_64_switchcontext.c:85
85        else if (!up_saveusercontext(rtcb->xcp.regs))
(gdb) bt
#0  0x000000010092548c in up_switch_context (tcb=0x100988200 <g_idletcb>, rtcb=0x10119f5d8) at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/common/x86_64_switchcontext.c:85
#1  0x0000000100916b22 in nxsem_wait_slow (sem=0x100983098 <g_uart0port+56>) at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:170
#2  0x0000000100916bb0 in nxsem_wait (sem=0x100983098 <g_uart0port+56>) at /home/neo/projects/nuttx/nuttx/sched/semaphore/sem_wait.c:270
#3  0x000000010090c02b in uart_readv (filep=0x10119fad0, uio=0x10159f670) at /home/neo/projects/nuttx/nuttx/drivers/serial/serial.c:1252
#4  0x000000010095a97a in file_readv (filep=0x10119fad0, uio=0x10159f670) at /home/neo/projects/nuttx/nuttx/fs/vfs/fs_read.c:165
#5  0x000000010095aa3a in nx_readv (fd=0, iov=0x10159f710, iovcnt=1) at /home/neo/projects/nuttx/nuttx/fs/vfs/fs_read.c:266
#6  0x000000010095aa89 in readv (fd=0, iov=0x10159f710, iovcnt=1) at /home/neo/projects/nuttx/nuttx/fs/vfs/fs_read.c:330
#7  0x000000010095ab02 in read (fd=0, buf=0x10159f743, nbytes=1) at /home/neo/projects/nuttx/nuttx/fs/vfs/fs_read.c:364
#8  0x0000000100933217 in cle_getch (priv=0x10159f7e0) at /home/neo/projects/nuttx/apps/system/cle/cle.c:305
#9  0x0000000100933863 in cle_editloop (priv=0x10159f7e0) at /home/neo/projects/nuttx/apps/system/cle/cle.c:705
#10 0x0000000100933d9c in cle_fd (line=0x1015a057c <error: Cannot access memory at address 0x1015a057c>, prompt=0x100983540 <g_nshprompt> "nsh> ", linelen=80, infd=0, outfd=1) at /home/neo/projects/nuttx/apps/system/cle/cle.c:1098
#11 0x000000010093309f in nsh_session (pstate=0x1015a0050, login=1, argc=1, argv=0x10119fcd0) at /home/neo/projects/nuttx/apps/nshlib/nsh_session.c:212
#12 0x000000010093274b in nsh_consolemain (argc=1, argv=0x10119fcd0) at /home/neo/projects/nuttx/apps/nshlib/nsh_consolemain.c:77
#13 0x0000000100922e23 in nsh_main (argc=1, argv=0x10119fcd0) at /home/neo/projects/nuttx/apps/system/nsh/nsh_main.c:76
#14 0x000000010092d9df in nxtask_startup (entrypt=0x100922da6 <nsh_main>, argc=1, argv=0x10119fcd0) at /home/neo/projects/nuttx/nuttx/libs/libc/sched/task_startup.c:72
#15 0x000000010091eaea in nxtask_start () at /home/neo/projects/nuttx/nuttx/sched/task/task_start.c:116
#16 0x0000000000000000 in ?? ()
(gdb) info threads
  Id   Target Id         Frame
  1    LWP 2             up_idle () at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/intel64/intel64_idle.c:91
* 2    LWP 1             0x000000010092548c in up_switch_context (tcb=0x100988200 <g_idletcb>, rtcb=0x10119f5d8) at /home/neo/projects/nuttx/nuttx/arch/x86_64/src/common/x86_64_switchcontext.c:85
(gdb) quit

```


