### PR TITLE
sim/virtio: fix typo sim_rpmsg_vritio.c -> sim_rpmsg_virtio.c

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -120,7 +120,7 @@ if(CONFIG_LIBM_TOOLCHAIN)
 endif()
 
 if(CONFIG_RPMSG_VIRTIO_LITE)
-  list(APPEND SRCS sim_rpmsg_vritio.c)
+  list(APPEND SRCS sim_rpmsg_virtio.c)
 endif()
 
 if(CONFIG_RPTUN)


### PR DESCRIPTION
## Summary

sim/virtio: fix typo sim_rpmsg_vritio.c -> sim_rpmsg_virtio.c

Build Error:
```
CMake Error at arch/sim/src/sim/CMakeLists.txt:278 (target_sources):
  Cannot find source file:

    /home/archer/code/nuttx/n3/nuttx/arch/sim/src/sim/sim_rpmsg_vritio.c

```
Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/rpserver_virtio:

```
cmake -B build -DBOARD_CONFIG=sim/rpserver_virtio -GNinja
cmake --build build
```