### PR TITLE
drivers/rpmsg: fix compiler warning

### DIFF
--- a/drivers/rpmsg/rpmsg_port_uart.c
+++ b/drivers/rpmsg/rpmsg_port_uart.c
@@ -216,7 +216,7 @@ rpmsg_port_uart_send_connect_req(FAR struct rpmsg_port_uart_s *rpuart)
   ssize_t ret = file_write(&rpuart->file, &ch, 1);
   if (ret != 1)
     {
-      rpmsgerr("Send connect request failed, ret=%d\n", ret);
+      rpmsgerr("Send connect request failed, ret=%zu\n", ret);
       PANIC();
     }
 }
@@ -232,7 +232,7 @@ rpmsg_port_uart_send_connect_ack(FAR struct rpmsg_port_uart_s *rpuart)
   ssize_t ret = file_write(&rpuart->file, &ch, 1);
   if (ret != 1)
     {
-      rpmsgerr("Send connect ack failed, ret=%d\n", ret);
+      rpmsgerr("Send connect ack failed, ret=%zu\n", ret);
       PANIC();
     }
 }


### PR DESCRIPTION

## Summary

drivers/rpmsg: fix compiler warning

```
In file included from nuttx/drivers/rpmsg/rpmsg_port_uart.c:27:
nuttx/drivers/rpmsg/rpmsg_port_uart.c: In function ‘rpmsg_port_uart_send_connect_req’:
nuttx/drivers/rpmsg/rpmsg_port_uart.c:219:16: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ {aka ‘long int’} [-Wformat=]
  219 |       rpmsgerr("Send connect request failed, ret=%d\n", ret);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~
      |                                                         |
      |                                                         ssize_t {aka long int}
nuttx/drivers/rpmsg/rpmsg_port_uart.c:219:51: note: format string is defined here
  219 |       rpmsgerr("Send connect request failed, ret=%d\n", ret);
      |                                                  ~^
      |                                                   |
      |                                                   int
      |                                                  %ld
nuttx/drivers/rpmsg/rpmsg_port_uart.c: In function ‘rpmsg_port_uart_send_connect_ack’:
nuttx/drivers/rpmsg/rpmsg_port_uart.c:235:16: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ {aka ‘long int’} [-Wformat=]
  235 |       rpmsgerr("Send connect ack failed, ret=%d\n", ret);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~
      |                                                     |
      |                                                     ssize_t {aka long int}
nuttx/drivers/rpmsg/rpmsg_port_uart.c:235:47: note: format string is defined here
  235 |       rpmsgerr("Send connect ack failed, ret=%d\n", ret);
      |                                              ~^
      |                                               |
      |                                               int
      |                                              %ld
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh and enable CONFIG_RPMSG_PORT_UART=y