### PR TITLE
arch/risc-v/src/mpfs: Disable external interrupts on all SMP harts

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -60,7 +60,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   /* Firstly, check if the irq is machine external interrupt */
 
-  uintptr_t claim_address = mpfs_plic_get_claimbase();
+  uintptr_t claim_address = mpfs_plic_get_claimbase(up_cpu_index());
 
   if (irq == RISCV_IRQ_EXT)
     {

--- a/arch/risc-v/src/mpfs/mpfs_plic.c
+++ b/arch/risc-v/src/mpfs/mpfs_plic.c
@@ -58,7 +58,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: get_iebase
+ * Name: mpfs_plic_get_iebase
  *
  * Description:
  *   Get base address for interrupt enable bits for a specific hart.
@@ -71,7 +71,7 @@
  *
  ****************************************************************************/
 
-static uintptr_t get_iebase(uintptr_t hartid)
+uintptr_t mpfs_plic_get_iebase(uintptr_t hartid)
 {
   uintptr_t iebase;
 
@@ -89,7 +89,7 @@ static uintptr_t get_iebase(uintptr_t hartid)
 }
 
 /****************************************************************************
- * Name: get_claimbase
+ * Name: mpfs_plic_get_claimbase
  *
  * Description:
  *   Get base address for interrupt claim for a specific hart.
@@ -102,7 +102,7 @@ static uintptr_t get_iebase(uintptr_t hartid)
  *
  ****************************************************************************/
 
-uintptr_t get_claimbase(uintptr_t hartid)
+uintptr_t mpfs_plic_get_claimbase(uintptr_t hartid)
 {
   uintptr_t claim_address;
 
@@ -173,7 +173,7 @@ void mpfs_plic_init_hart(uintptr_t hartid)
 {
   /* Disable all global interrupts for current hart */
 
-  uintptr_t iebase = get_iebase(hartid);
+  uintptr_t iebase = mpfs_plic_get_iebase(hartid);
 
   putreg32(0x0, iebase + 0);
   putreg32(0x0, iebase + 4);
@@ -187,7 +187,7 @@ void mpfs_plic_init_hart(uintptr_t hartid)
    * This has no effect on non-claimed or disabled interrupts.
    */
 
-  uintptr_t claim_address = get_claimbase(hartid);
+  uintptr_t claim_address = mpfs_plic_get_claimbase(hartid);
 
   for (int irq = MPFS_IRQ_EXT_START; irq < NR_IRQS; irq++)
     {
@@ -198,38 +198,6 @@ void mpfs_plic_init_hart(uintptr_t hartid)
 
   uintptr_t threshold_address = get_thresholdbase(hartid);
   putreg32(0, threshold_address);
-}
-
-/****************************************************************************
- * Name: mpfs_plic_get_iebase
- *
- * Description:
- *   Context aware way to query PLIC interrupt enable base address
- *
- * Returned Value:
- *   Interrupt enable base address
- *
- ****************************************************************************/
-
-uintptr_t mpfs_plic_get_iebase(void)
-{
-  return get_iebase(up_cpu_index());
-}
-
-/****************************************************************************
- * Name: mpfs_plic_get_claimbase
- *
- * Description:
- *   Context aware way to query PLIC interrupt claim base address
- *
- * Returned Value:
- *   Interrupt enable claim address
- *
- ****************************************************************************/
-
-uintptr_t mpfs_plic_get_claimbase(void)
-{
-  return get_claimbase(up_cpu_index());
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_plic.h
+++ b/arch/risc-v/src/mpfs/mpfs_plic.h
@@ -60,7 +60,7 @@ void mpfs_plic_init_hart(uintptr_t hartid);
  *
  ****************************************************************************/
 
-uintptr_t mpfs_plic_get_iebase(void);
+uintptr_t mpfs_plic_get_iebase(uintptr_t hartid);
 
 /****************************************************************************
  * Name: mpfs_plic_get_claimbase
@@ -73,7 +73,7 @@ uintptr_t mpfs_plic_get_iebase(void);
  *
  ****************************************************************************/
 
-uintptr_t mpfs_plic_get_claimbase(void);
+uintptr_t mpfs_plic_get_claimbase(uintptr_t hartid);
 
 /****************************************************************************
  * Name: mpfs_plic_get_thresholdbase


### PR DESCRIPTION

## Summary

Interrupts on MPFS platform are currently served on the hart, on which the up_enable_irq was called.

Call to up_disable_irq may execute on different hart than on which the up_enable_irq was executed. In this case the interrupt is not disabled currently.

While there is nothing fancy (irq affinity control or such), an easy way to fix this is to simply disable the irq on all harts.

This also changes the prototypes of mpfs_plic_get_iebase and mpfs_plic_get_claimbase to get the hart id as an argument, in order to accomplish this.

## Impact

This fixes spurious interrupts & crashes on MPFS, in SMP build.

## Testing

Tested on custom MPFS hardware, with SMP enabled on 4 harts (1-4).

