### PR TITLE
Use small lock to protect resources related to lpi2c.

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -35,9 +35,10 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -190,6 +191,7 @@ struct s32k1xx_lpi2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -343,6 +345,7 @@ static struct s32k1xx_lpi2c_priv_s s32k1xx_lpi2c0_priv =
   .config     = &s32k1xx_lpi2c0_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -381,6 +384,7 @@ static struct s32k1xx_lpi2c_priv_s s32k1xx_lpi2c1_priv =
   .config     = &s32k1xx_lpi2c1_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -497,7 +501,8 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
+  sched_lock();
 
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -580,7 +585,8 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
     }
 #endif
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
+  sched_unlock();
   return ret;
 }
 #else
@@ -1322,7 +1328,7 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
                */
 
     #ifdef CONFIG_I2C_POLLED
-              irqstate_t flags = enter_critical_section();
+              irqstate_t flags = spin_lock_irqsave(&priv->spinlock);
     #endif
 
               /* Receive a byte */
@@ -1333,7 +1339,7 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
               priv->dcnt--;
 
     #ifdef CONFIG_I2C_POLLED
-              leave_critical_section(flags);
+              spin_unlock_irqrestore(&priv->spinlock, flags);
     #endif
               /* Last byte of last message? */
 
@@ -2186,7 +2192,7 @@ struct i2c_master_s *s32k1xx_i2cbus_initialize(int port)
    * power-up hardware and configure pins.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   if ((volatile int)priv->refs++ == 0)
     {
@@ -2195,21 +2201,25 @@ struct i2c_master_s *s32k1xx_i2cbus_initialize(int port)
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
       if (priv->config->dma_txreqsrc != 0)
         {
+          spin_unlock_irqrestore(&priv->spinlock, flags);
           priv->txdma = s32k1xx_dmach_alloc(priv->config->dma_txreqsrc |
                                         DMAMUX_CHCFG_ENBL, 0);
+          flags = spin_lock_irqsave(&priv->spinlock);
           DEBUGASSERT(priv->txdma != NULL);
         }
 
       if (priv->config->dma_rxreqsrc != 0)
         {
+          spin_unlock_irqrestore(&priv->spinlock, flags);
           priv->rxdma = s32k1xx_dmach_alloc(priv->config->dma_rxreqsrc |
                                         DMAMUX_CHCFG_ENBL, 0);
+          flags = spin_lock_irqsave(&priv->spinlock);
           DEBUGASSERT(priv->rxdma != NULL);
         }
 #endif
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return (struct i2c_master_s *)priv;
 }
@@ -2236,15 +2246,15 @@ int s32k1xx_i2cbus_uninitialize(struct i2c_master_s *dev)
       return ERROR;
     }
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   if (--priv->refs > 0)
     {
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       return OK;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   /* Disable power and other HW resource (GPIO's) */
 

--- a/arch/arm64/src/imx9/imx9_lpi2c.c
+++ b/arch/arm64/src/imx9/imx9_lpi2c.c
@@ -2395,13 +2395,17 @@ struct i2c_master_s *imx9_i2cbus_initialize(int port)
 #ifdef CONFIG_IMX9_LPI2C_DMA
       if (priv->config->dma_txreqsrc != 0)
         {
+          spin_unlock_irqrestore(&priv->spinlock, flags);
           priv->txdma = imx9_dmach_alloc(priv->config->dma_txreqsrc, 0);
+          flags = spin_lock_irqsave(&priv->spinlock);
           DEBUGASSERT(priv->txdma != NULL);
         }
 
       if (priv->config->dma_rxreqsrc != 0)
         {
+          spin_unlock_irqrestore(&priv->spinlock, flags);
           priv->rxdma = imx9_dmach_alloc(priv->config->dma_rxreqsrc, 0);
+          flags = spin_lock_irqsave(&priv->spinlock);
           DEBUGASSERT(priv->rxdma != NULL);
         }
 #endif


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to lpi2c.

## Impact

The underlying lpI2C logic of arch ARM.

## Testing

CI


