### PR TITLE
arch/arm64/src/imx9/imx9_lpuart.c: Call uart_xmitchars when txint is enabled

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2358,6 +2358,14 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
+
+#ifndef CONFIG_SUPPRESS_SERIAL_INTS
+  if (enable)
+    {
+      uart_xmitchars(dev);
+    }
+#endif
+
   spin_unlock_irqrestore(&priv->lock, flags);
 }
 #endif


### PR DESCRIPTION

## Summary

Call uart_xmitchars once already when tx interrupts are enabled, to push a character already existing in the uart buffers into uart fifo.

Specifically this fixes a serial console getting stuck issue on some custom builds, where console is disabled during runtime.

## Impact

Only impacts imx9 lpuart

## Testing

Tested on imx93-evk and on a custom imx93 based HW, using multiple uarts.
