### PR TITLE
Use small lock to protect resources related to i2c.

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_i2c.c
+++ b/arch/arm/src/cxd56xx/cxd56_i2c.c
@@ -39,7 +39,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -84,6 +84,7 @@ struct cxd56_i2cdev_s
   uint32_t         base_freq;  /* branch frequency */
 
   mutex_t          lock;       /* Only one thread can access at a time */
+  spinlock_t       spinlock;   /* Spinlock */
   sem_t            wait;       /* Place to wait for transfer completion */
   struct wdog_s    timeout;    /* watchdog to timeout when bus hung */
   uint32_t         frequency;  /* Current I2C frequency */
@@ -108,6 +109,7 @@ static struct cxd56_i2cdev_s g_i2c0dev =
   .base = CXD56_SCU_I2C0_BASE,
   .irqid = CXD56_IRQ_SCU_I2C0,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -119,6 +121,7 @@ static struct cxd56_i2cdev_s g_i2c1dev =
   .base = CXD56_SCU_I2C1_BASE,
   .irqid = CXD56_IRQ_SCU_I2C1,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -130,6 +133,7 @@ static struct cxd56_i2cdev_s g_i2c2dev =
   .base = CXD56_I2CM_BASE,
   .irqid = CXD56_IRQ_I2CM,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -358,11 +362,11 @@ static void cxd56_i2c_setfrequency(struct cxd56_i2cdev_s *priv,
 static void cxd56_i2c_timeout(wdparm_t arg)
 {
   struct cxd56_i2cdev_s *priv = (struct cxd56_i2cdev_s *)arg;
-  irqstate_t flags            = enter_critical_section();
+  irqstate_t flags            = spin_lock_irqsave(&priv->spinlock);
 
   priv->error = -ENODEV;
   nxsem_post(&priv->wait);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -521,7 +525,7 @@ static int cxd56_i2c_receive(struct cxd56_i2cdev_s *priv, int last)
           i2c_reg_write(priv, CXD56_IC_DATA_CMD, CMD_READ);
         }
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&priv->spinlock);
       wd_start(&priv->timeout, I2C_TIMEOUT,
                cxd56_i2c_timeout, (wdparm_t)priv);
 
@@ -530,7 +534,7 @@ static int cxd56_i2c_receive(struct cxd56_i2cdev_s *priv, int last)
       i2c_reg_write(priv, CXD56_IC_DATA_CMD, CMD_READ | (en ? CMD_STOP : 0));
 
       i2c_reg_rmw(priv, CXD56_IC_INTR_MASK, INTR_RX_FULL, INTR_RX_FULL);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       nxsem_wait_uninterruptible(&priv->wait);
 
       if (priv->error != OK)
@@ -567,7 +571,7 @@ static int cxd56_i2c_send(struct cxd56_i2cdev_s *priv, int last)
 
   while (!(i2c_reg_read(priv, CXD56_IC_STATUS) & STATUS_TFNF));
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
   wd_start(&priv->timeout, I2C_TIMEOUT,
            cxd56_i2c_timeout, (wdparm_t)priv);
   i2c_reg_write(priv, CXD56_IC_DATA_CMD,
@@ -576,7 +580,7 @@ static int cxd56_i2c_send(struct cxd56_i2cdev_s *priv, int last)
   /* Enable TX_EMPTY interrupt for determine transfer done. */
 
   i2c_reg_rmw(priv, CXD56_IC_INTR_MASK, INTR_TX_EMPTY, INTR_TX_EMPTY);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   nxsem_wait_uninterruptible(&priv->wait);
   return 0;

--- a/arch/arm/src/lc823450/lc823450_i2c.c
+++ b/arch/arm/src/lc823450/lc823450_i2c.c
@@ -37,7 +37,7 @@
 #include <stddef.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/clock.h>
 #include <nuttx/signal.h>
@@ -121,6 +121,7 @@ struct lc823450_i2c_priv_s
 
   int   refs;                /* Reference count */
   mutex_t lock;              /* Mutual exclusion mutex */
+  spinlock_t spinlock;       /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;             /* Interrupt wait semaphore */
 #endif
@@ -209,6 +210,7 @@ static struct lc823450_i2c_priv_s lc823450_i2c0_priv =
   .config   = &lc823450_i2c0_config,
   .refs     = 0,
   .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr  = SEM_INITIALIZER(0),
 #endif
@@ -239,6 +241,7 @@ static struct lc823450_i2c_priv_s lc823450_i2c1_priv =
   .config   = &lc823450_i2c1_config,
   .refs     = 0,
   .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr  = SEM_INITIALIZER(0),
 #endif
@@ -1005,7 +1008,7 @@ static int lc823450_i2c_transfer(struct i2c_master_s *dev,
 
   if (lc823450_i2c_sem_waitdone(priv) < 0)
     {
-      irqs = enter_critical_section();
+      irqs = spin_lock_irqsave(&priv->spinlock);
 
       ret = -ETIMEDOUT;
 
@@ -1017,7 +1020,7 @@ static int lc823450_i2c_transfer(struct i2c_master_s *dev,
 
           priv->timedout = true;
 
-          leave_critical_section(irqs);
+          spin_unlock_irqrestore(&priv->spinlock, irqs);
 
           /* Wait for irq handler completion. 10msec wait is probably enough
            * to terminate i2c transaction, NACK and STOP contition for read
@@ -1028,10 +1031,9 @@ static int lc823450_i2c_transfer(struct i2c_master_s *dev,
         }
       else
         {
+          spin_unlock_irqrestore(&priv->spinlock, irqs);
           i2cerr("No need of timeout handling. "
                  "It may be done in irq handler\n");
-
-          leave_critical_section(irqs);
         }
 
 #ifndef CONFIG_LC823450_IPL2

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -60,7 +60,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -105,6 +105,7 @@ struct lpc17_40_i2cdev_s
   uint16_t         irqid;      /* IRQ for this device */
 
   mutex_t          lock;       /* Only one thread can access at a time */
+  spinlock_t       spinlock;   /* Spinlock */
   sem_t            wait;       /* Place to wait for state machine completion */
   volatile uint8_t state;      /* State of state machine */
   struct wdog_s    timeout;    /* Watchdog to timeout when bus hung */
@@ -144,22 +145,25 @@ static int  lpc17_40_i2c_reset(struct i2c_master_s *dev);
 #ifdef CONFIG_LPC17_40_I2C0
 static struct lpc17_40_i2cdev_s g_i2c0dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 #ifdef CONFIG_LPC17_40_I2C1
 static struct lpc17_40_i2cdev_s g_i2c1dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 #ifdef CONFIG_LPC17_40_I2C2
 static struct lpc17_40_i2cdev_s g_i2c2dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 
@@ -288,10 +292,10 @@ static void lpc17_40_i2c_timeout(wdparm_t arg)
 {
   struct lpc17_40_i2cdev_s *priv = (struct lpc17_40_i2cdev_s *)arg;
 
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(&priv->spinlock);
   priv->state = 0xff;
   nxsem_post(&priv->wait);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -527,7 +531,7 @@ struct i2c_master_s *lpc17_40_i2cbus_initialize(int port)
   irqstate_t flags;
   uint32_t regval;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
 #ifdef CONFIG_LPC17_40_I2C0
   if (port == 0)
@@ -617,12 +621,12 @@ struct i2c_master_s *lpc17_40_i2cbus_initialize(int port)
   else
 #endif
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       i2cerr("ERROR: LPC I2C Only supports ports 0, 1 and 2\n");
-      leave_critical_section(flags);
       return NULL;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   putreg32(I2C_CONSET_I2EN, priv->base + LPC17_40_I2C_CONSET_OFFSET);
 

--- a/arch/arm/src/lpc2378/lpc23xx_i2c.c
+++ b/arch/arm/src/lpc2378/lpc23xx_i2c.c
@@ -62,7 +62,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -109,6 +109,7 @@ struct lpc2378_i2cdev_s
   uint16_t         irqid;      /* IRQ for this device */
 
   mutex_t          lock;       /* Only one thread can access at a time */
+  spinlock_t       spinlock;   /* Spinlock */
   sem_t            wait;       /* Place to wait for state machine completion */
   volatile uint8_t state;      /* State of state machine */
   struct wdog_s    timeout;    /* Watchdog to timeout when bus hung */
@@ -148,22 +149,25 @@ static int  lpc2378_i2c_reset(struct i2c_master_s *dev);
 #ifdef CONFIG_LPC2378_I2C0
 static struct lpc2378_i2cdev_s g_i2c0dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 #ifdef CONFIG_LPC2378_I2C1
 static struct lpc2378_i2cdev_s g_i2c1dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 #ifdef CONFIG_LPC2378_I2C2
 static struct lpc2378_i2cdev_s g_i2c2dev =
 {
-  .lock = NXMUTEX_INITIALIZER,
-  .wait = SEM_INITIALIZER(0),
+  .lock     = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
+  .wait     = SEM_INITIALIZER(0),
 };
 #endif
 
@@ -265,10 +269,10 @@ static void lpc2378_i2c_timeout(wdparm_t arg)
 {
   struct lpc2378_i2cdev_s *priv = (struct lpc2378_i2cdev_s *)arg;
 
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(&priv->spinlock);
   priv->state = 0xff;
   nxsem_post(&priv->wait);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -481,7 +485,7 @@ struct i2c_master_s *lpc2378_i2cbus_initialize(int port)
   irqstate_t flags;
   uint32_t regval;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
 #ifdef CONFIG_LPC2378_I2C0
   if (port == 0)
@@ -577,11 +581,11 @@ struct i2c_master_s *lpc2378_i2cbus_initialize(int port)
   else
 #endif
     {
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       return NULL;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   putreg32(I2C_CONSET_I2EN, priv->base + I2C_CONSET_OFFSET);
 

--- a/arch/arm/src/lpc31xx/lpc31_i2c.c
+++ b/arch/arm/src/lpc31xx/lpc31_i2c.c
@@ -41,7 +41,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -74,6 +74,7 @@ struct lpc31_i2cdev_s
     uint16_t          irqid;      /* IRQ for this device */
 
     mutex_t           lock;       /* Only one thread can access at a time */
+    spinlock_t        spinlock;   /* Spinlock */
     sem_t             wait;       /* Place to wait for state machine completion */
     volatile uint8_t  state;      /* State of state machine */
     struct wdog_s     timeout;    /* Watchdog to timeout when bus hung */
@@ -96,12 +97,14 @@ struct lpc31_i2cdev_s
 static struct lpc31_i2cdev_s i2cdevices[2] =
 {
   {
-    .lock = NXMUTEX_INITIALIZER,
-    .wait = SEM_INITIALIZER(0),
+    .lock     = NXMUTEX_INITIALIZER,
+    .spinlock = SP_UNLOCKED,
+    .wait     = SEM_INITIALIZER(0),
   },
   {
-    .lock = NXMUTEX_INITIALIZER,
-    .wait = SEM_INITIALIZER(0),
+    .lock     = NXMUTEX_INITIALIZER,
+    .spinlock = SP_UNLOCKED,
+    .wait     = SEM_INITIALIZER(0),
   },
 };
 
@@ -423,7 +426,7 @@ static void i2c_timeout(wdparm_t arg)
 {
   struct lpc31_i2cdev_s *priv = (struct lpc31_i2cdev_s *)arg;
 
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave(&priv->spinlock);
 
   if (priv->state != I2C_STATE_DONE)
     {
@@ -449,7 +452,7 @@ static void i2c_timeout(wdparm_t arg)
       nxsem_post(&priv->wait);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -488,7 +491,7 @@ static int i2c_transfer(struct i2c_master_s *dev,
   /* Get exclusive access to the I2C bus */
 
   nxmutex_lock(&priv->lock);
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Set up for the transfer */
 
@@ -516,13 +519,17 @@ static int i2c_transfer(struct i2c_master_s *dev,
 
   while (priv->state != I2C_STATE_DONE)
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       nxsem_wait(&priv->wait);
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   wd_cancel(&priv->timeout);
   ret = count - priv->nmsg;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   nxmutex_unlock(&priv->lock);
   return ret;
 }

--- a/arch/arm/src/rp2040/rp2040_i2c.c
+++ b/arch/arm/src/rp2040/rp2040_i2c.c
@@ -39,7 +39,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -79,6 +79,7 @@ struct rp2040_i2cdev_s
   uint32_t         base_freq;  /* branch frequency */
 
   mutex_t          lock;       /* Only one thread can access at a time */
+  spinlock_t       spinlock;   /* Spinlock */
   sem_t            wait;       /* Place to wait for transfer completion */
   struct wdog_s    timeout;    /* watchdog to timeout when bus hung */
   uint32_t         frequency;  /* Current I2C frequency */
@@ -98,6 +99,7 @@ static struct rp2040_i2cdev_s g_i2c0dev =
   .base = RP2040_I2C0_BASE,
   .irqid = RP2040_I2C0_IRQ,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -109,6 +111,7 @@ static struct rp2040_i2cdev_s g_i2c1dev =
   .base = RP2040_I2C1_BASE,
   .irqid = RP2040_I2C1_IRQ,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -267,11 +270,11 @@ static void rp2040_i2c_setfrequency(struct rp2040_i2cdev_s *priv,
 static void rp2040_i2c_timeout(wdparm_t arg)
 {
   struct rp2040_i2cdev_s *priv = (struct rp2040_i2cdev_s *)arg;
-  irqstate_t flags             = enter_critical_section();
+  irqstate_t flags             = spin_lock_irqsave(&priv->spinlock);
 
   priv->error = -ENODEV;
   nxsem_post(&priv->wait);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -434,7 +437,7 @@ static int rp2040_i2c_receive(struct rp2040_i2cdev_s *priv, int last)
                               RP2040_I2C_IC_DATA_CMD_CMD);
         }
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&priv->spinlock);
       wd_start(&priv->timeout, I2C_TIMEOUT,
                rp2040_i2c_timeout, (wdparm_t)priv);
 
@@ -447,7 +450,7 @@ static int rp2040_i2c_receive(struct rp2040_i2cdev_s *priv, int last)
       i2c_reg_rmw(priv, RP2040_I2C_IC_INTR_MASK_OFFSET,
                   RP2040_I2C_IC_INTR_STAT_R_RX_FULL,
                   RP2040_I2C_IC_INTR_STAT_R_RX_FULL);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       nxsem_wait_uninterruptible(&priv->wait);
 
       if (priv->error != OK)
@@ -489,7 +492,7 @@ static int rp2040_i2c_send(struct rp2040_i2cdev_s *priv, int last)
            & RP2040_I2C_IC_STATUS_TFNF))
     ;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
   wd_start(&priv->timeout, I2C_TIMEOUT,
            rp2040_i2c_timeout, (wdparm_t)priv);
   i2c_reg_write(priv, RP2040_I2C_IC_DATA_CMD_OFFSET,
@@ -501,7 +504,7 @@ static int rp2040_i2c_send(struct rp2040_i2cdev_s *priv, int last)
   i2c_reg_rmw(priv, RP2040_I2C_IC_INTR_MASK_OFFSET,
               RP2040_I2C_IC_INTR_STAT_R_TX_EMPTY,
               RP2040_I2C_IC_INTR_STAT_R_TX_EMPTY);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   nxsem_wait_uninterruptible(&priv->wait);
   return 0;

--- a/arch/arm/src/rp23xx/rp23xx_i2c.c
+++ b/arch/arm/src/rp23xx/rp23xx_i2c.c
@@ -39,7 +39,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/i2c/i2c_master.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -79,6 +79,7 @@ struct rp23xx_i2cdev_s
   uint32_t         base_freq;  /* branch frequency */
 
   mutex_t          lock;       /* Only one thread can access at a time */
+  spinlock_t       spinlock;   /* Spinlock */
   sem_t            wait;       /* Place to wait for transfer completion */
   struct wdog_s    timeout;    /* watchdog to timeout when bus hung */
   uint32_t         frequency;  /* Current I2C frequency */
@@ -98,6 +99,7 @@ static struct rp23xx_i2cdev_s g_i2c0dev =
   .base = RP23XX_I2C0_BASE,
   .irqid = RP23XX_I2C0_IRQ,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -109,6 +111,7 @@ static struct rp23xx_i2cdev_s g_i2c1dev =
   .base = RP23XX_I2C1_BASE,
   .irqid = RP23XX_I2C1_IRQ,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .wait = SEM_INITIALIZER(0),
   .refs = 0,
 };
@@ -267,11 +270,11 @@ static void rp23xx_i2c_setfrequency(struct rp23xx_i2cdev_s *priv,
 static void rp23xx_i2c_timeout(wdparm_t arg)
 {
   struct rp23xx_i2cdev_s *priv = (struct rp23xx_i2cdev_s *)arg;
-  irqstate_t flags             = enter_critical_section();
+  irqstate_t flags             = spin_lock_irqsave(&priv->spinlock);
 
   priv->error = -ENODEV;
   nxsem_post(&priv->wait);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -434,7 +437,7 @@ static int rp23xx_i2c_receive(struct rp23xx_i2cdev_s *priv, int last)
                               RP23XX_I2C_IC_DATA_CMD_CMD);
         }
 
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&priv->spinlock);
       wd_start(&priv->timeout, I2C_TIMEOUT,
                rp23xx_i2c_timeout, (wdparm_t)priv);
 
@@ -447,7 +450,7 @@ static int rp23xx_i2c_receive(struct rp23xx_i2cdev_s *priv, int last)
       i2c_reg_rmw(priv, RP23XX_I2C_IC_INTR_MASK_OFFSET,
                   RP23XX_I2C_IC_INTR_STAT_R_RX_FULL,
                   RP23XX_I2C_IC_INTR_STAT_R_RX_FULL);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       nxsem_wait_uninterruptible(&priv->wait);
 
       if (priv->error != OK)
@@ -489,7 +492,7 @@ static int rp23xx_i2c_send(struct rp23xx_i2cdev_s *priv, int last)
            & RP23XX_I2C_IC_STATUS_TFNF))
     ;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
   wd_start(&priv->timeout, I2C_TIMEOUT,
            rp23xx_i2c_timeout, (wdparm_t)priv);
   i2c_reg_write(priv, RP23XX_I2C_IC_DATA_CMD_OFFSET,
@@ -501,7 +504,7 @@ static int rp23xx_i2c_send(struct rp23xx_i2cdev_s *priv, int last)
   i2c_reg_rmw(priv, RP23XX_I2C_IC_INTR_MASK_OFFSET,
               RP23XX_I2C_IC_INTR_STAT_R_TX_EMPTY,
               RP23XX_I2C_IC_INTR_STAT_R_TX_EMPTY);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   nxsem_wait_uninterruptible(&priv->wait);
   return 0;

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -65,7 +65,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -274,6 +274,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -411,6 +412,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config     = &stm32_i2c1_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -453,6 +455,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config     = &stm32_i2c2_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #  ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #  endif
@@ -493,6 +496,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config     = &stm32_i2c3_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #  ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #  endif
@@ -605,7 +609,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -621,6 +625,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
@@ -639,6 +645,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -655,7 +663,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   regval &= ~I2C_CR2_ALLINTS;
   stm32_i2c_putreg(priv, STM32_I2C_CR2_OFFSET, regval);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else

--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -209,7 +209,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kmalloc.h>
@@ -391,6 +391,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -506,6 +507,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config        = &stm32_i2c1_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -544,6 +546,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config        = &stm32_i2c2_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -582,6 +585,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config        = &stm32_i2c3_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -620,6 +624,7 @@ static struct stm32_i2c_priv_s stm32_i2c4_priv =
   .config        = &stm32_i2c4_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -785,7 +790,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   irqstate_t flags;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -802,6 +807,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32H5_I2C_DYNTIMEO
@@ -820,6 +827,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -834,7 +843,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, I2C_CR1_ALLINTS, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else
@@ -1945,7 +1954,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            */
 
 #ifdef CONFIG_I2C_POLLED
-          irqstate_t state = enter_critical_section();
+          irqstate_t state = spin_lock_irqsave(&priv->spinlock);
 #endif
           /* Receive a byte */
 
@@ -1962,7 +1971,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->dcnt--;
 
 #ifdef CONFIG_I2C_POLLED
-          leave_critical_section(state);
+          spin_unlock_irqrestore(&priv->spinlock, state);
 #endif
         }
       else

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -207,7 +207,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kmalloc.h>
@@ -394,6 +394,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -507,6 +508,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config        = &stm32_i2c1_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -543,6 +545,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config        = &stm32_i2c2_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -579,6 +582,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config        = &stm32_i2c3_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -615,6 +619,7 @@ static struct stm32_i2c_priv_s stm32_i2c4_priv =
   .config        = &stm32_i2c4_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -780,7 +785,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   irqstate_t flags;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -797,6 +802,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32H7_I2C_DYNTIMEO
@@ -815,6 +822,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -829,7 +838,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, I2C_CR1_ALLINTS, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else
@@ -1732,7 +1741,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            */
 
 #ifdef CONFIG_I2C_POLLED
-          irqstate_t state = enter_critical_section();
+          irqstate_t state = spin_lock_irqsave(&priv->spinlock);
 #endif
           /* Receive a byte */
 
@@ -1749,7 +1758,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->dcnt--;
 
 #ifdef CONFIG_I2C_POLLED
-          leave_critical_section(state);
+          spin_unlock_irqrestore(&priv->spinlock, state);
 #endif
         }
       else

--- a/arch/arm/src/stm32u5/stm32_i2c.c
+++ b/arch/arm/src/stm32u5/stm32_i2c.c
@@ -255,7 +255,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -416,6 +416,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -537,6 +538,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config     = &stm32_i2c1_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -573,6 +575,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config     = &stm32_i2c2_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -609,6 +612,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config     = &stm32_i2c3_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -645,6 +649,7 @@ static struct stm32_i2c_priv_s stm32_i2c4_priv =
   .config     = &stm32_i2c4_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -815,7 +820,7 @@ int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   irqstate_t flags;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -832,6 +837,8 @@ int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32U5_I2C_DYNTIMEO
@@ -850,6 +857,8 @@ int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -864,7 +873,7 @@ int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, I2C_CR1_ALLINTS, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else
@@ -1972,7 +1981,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            */
 
 #ifdef CONFIG_I2C_POLLED
-          irqstate_t state = enter_critical_section();
+          irqstate_t state = spin_lock_irqsave(&priv->spinlock);
 #endif
           /* Receive a byte */
 
@@ -1989,7 +1998,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->dcnt--;
 
 #ifdef CONFIG_I2C_POLLED
-          leave_critical_section(state);
+          spin_unlock_irqrestore(&priv->spinlock, state);
 #endif
         }
       else

--- a/arch/arm/src/xmc4/xmc4_i2c.c
+++ b/arch/arm/src/xmc4/xmc4_i2c.c
@@ -35,7 +35,7 @@
 
 #include <arch/board/board.h>
 #include <nuttx/mutex.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "chip.h"
@@ -122,8 +122,9 @@ struct xmc4_i2cdev_s
   uint32_t sda_gpio;            /* GPIO config of SDA */
   uint32_t scl_gpio;            /* GPIO config of SCL */
 
-  mutex_t lock; /* Only one thread can access at a time */
-  int refs;     /* Reference count */
+  mutex_t lock;                 /* Only one thread can access at a time */
+  spinlock_t spinlock;          /* Spinlock */
+  int refs;                     /* Reference count */
 };
 
 /*****************************************************************************
@@ -198,6 +199,7 @@ static struct xmc4_i2cdev_s g_i2c0 =
   .scl_gpio = GPIO_I2C0_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -214,6 +216,7 @@ static struct xmc4_i2cdev_s g_i2c1 =
   .scl_gpio = GPIO_I2C1_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -230,6 +233,7 @@ static struct xmc4_i2cdev_s g_i2c2 =
   .scl_gpio = GPIO_I2C2_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -246,6 +250,7 @@ static struct xmc4_i2cdev_s g_i2c3 =
   .scl_gpio = GPIO_I2C3_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -262,6 +267,7 @@ static struct xmc4_i2cdev_s g_i2c4 =
   .scl_gpio = GPIO_I2C4_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -278,6 +284,7 @@ static struct xmc4_i2cdev_s g_i2c5 =
   .scl_gpio = GPIO_I2C5_SCL,    /* See i2c_set_input_source */
   .frequency = (uint32_t)I2C_DEFAULT_FREQUENCY,
   .lock = NXMUTEX_INITIALIZER,
+  .spinlock = SP_UNLOCKED,
   .refs = 0,
 };
 #endif
@@ -817,7 +824,7 @@ static int i2c_transfer(struct i2c_master_s *dev,
 
   /* Enter critical section to avoid interrupts during i2c transfert */
 
-  irqstate_t state = enter_critical_section();
+  irqstate_t state = spin_lock_irqsave(&priv->spinlock);
 
   for (int i = 0; i < count; i++)
     {
@@ -837,8 +844,8 @@ static int i2c_transfer(struct i2c_master_s *dev,
             }
           else
             {
+              spin_unlock_irqrestore(&priv->spinlock, state);
               i2cerr("Can't update frequency between Start & Stop symbols\n");
-              leave_critical_section(state);
               nxmutex_unlock(&priv->lock);
               return -EINVAL;
             }
@@ -926,7 +933,7 @@ static int i2c_transfer(struct i2c_master_s *dev,
         }
     }
 
-  leave_critical_section(state);
+  spin_unlock_irqrestore(&priv->spinlock, state);
   nxmutex_unlock(&priv->lock);
   return ret;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.c
@@ -40,7 +40,7 @@
 #include <sys/time.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -223,6 +223,7 @@ struct esp32c3_i2c_priv_s
   const struct esp32c3_i2c_config_s *config;
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
@@ -333,6 +334,7 @@ static struct esp32c3_i2c_priv_s esp32c3_i2c0_priv =
   .config     = &esp32c3_i2c0_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -1098,7 +1100,7 @@ static int esp32c3_i2c_reset(struct i2c_master_s *dev)
 
   DEBUGASSERT(priv->refs > 0);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   esp32c3_i2c_reset_fsmc(priv);
 
@@ -1111,7 +1113,7 @@ static int esp32c3_i2c_reset(struct i2c_master_s *dev)
   priv->bytes      = 0;
   priv->ready_read = false;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_i2c.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2c.c
@@ -39,7 +39,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/i2c/i2c_master.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -212,6 +212,7 @@ struct esp32s2_i2c_priv_s
   const struct esp32s2_i2c_config_s *config;
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
@@ -320,6 +321,7 @@ static struct esp32s2_i2c_priv_s g_esp32s2_i2c0_priv =
   .config     = &g_esp32s2_i2c0_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -356,6 +358,7 @@ static struct esp32s2_i2c_priv_s g_esp32s2_i2c1_priv =
   .config     = &g_esp32s2_i2c1_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -1120,7 +1123,7 @@ static int i2c_reset(struct i2c_master_s *dev)
   DEBUGASSERT(dev != NULL);
   DEBUGASSERT(priv->refs > 0);
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   i2c_reset_fsmc(priv);
 
@@ -1133,7 +1136,7 @@ static int i2c_reset(struct i2c_master_s *dev)
   priv->bytes      = 0;
   priv->ready_read = false;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to i2c.

## Impact

logic of i2c in all arch.

## Testing

CI


