### PR TITLE
arch: set (*running_task)->xcp.regs to NULL when exit from irq/exception

### DIFF
--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -124,5 +124,12 @@ uint32_t *arm_syscall(uint32_t *regs)
    * SYS_context_switch system call.
    */
 
-  return tcb->xcp.regs;
+  regs = tcb->xcp.regs;
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -119,5 +119,10 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   board_autoled_off(LED_INIRQ);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
   return regs;
 }

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -118,5 +118,11 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 #endif
 
   board_autoled_off(LED_INIRQ);
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  tcb->xcp.regs = NULL;
   return regs;
 }

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -556,6 +556,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   up_set_interrupt_context(false);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the
    * SYS_context_switch system call.

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -119,5 +119,10 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   board_autoled_off(LED_INIRQ);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
   return regs;
 }

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -553,6 +553,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   up_set_interrupt_context(false);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the
    * SYS_context_switch system call.

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -142,5 +142,10 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
     }
 #endif
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
   return regs;
 }

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -553,6 +553,12 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   up_set_interrupt_context(false);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the
    * SYS_context_switch system call.

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -115,6 +115,11 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 
   write_sysreg((uintptr_t)tcb & ~1ul, tpidr_el1);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  tcb->xcp.regs = NULL;
   return regs;
 }
 

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -324,5 +324,12 @@ uint64_t *arm64_syscall(uint64_t *regs)
         break;
     }
 
-  return tcb->xcp.regs;
+  regs = tcb->xcp.regs;
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -119,6 +119,12 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
           memcpy((uint32_t *)regs[REG_SP], regs, XCPTCONTEXT_SIZE);
           regs = (uint32_t *)regs[REG_SP];
         }
+
+      /* (*running_task)->xcp.regs is about to become invalid
+       * and will be marked as NULL to avoid misusage.
+       */
+
+      (*running_task)->xcp.regs = NULL;
     }
 
   return regs;

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -132,5 +132,11 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
   up_set_current_regs(NULL);
 #endif
   board_autoled_off(LED_INIRQ);
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
   return regs;
 }

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -138,5 +138,13 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 
 #endif
   board_autoled_off(LED_INIRQ);
-  return tcb->xcp.regs;
+
+  regs = tcb->xcp.regs;
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -89,5 +89,12 @@ void *riscv_perform_syscall(uintreg_t *regs)
 
   up_set_interrupt_context(false);
 
-  return tcb->xcp.regs;
+  regs = tcb->xcp.regs;
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }

--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -117,6 +117,11 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   up_set_current_regs(NULL);
 
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
   board_autoled_off(LED_INIRQ);
 #endif
 }

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -126,8 +126,14 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
   /* Clear irq flag */
 
   up_set_interrupt_context(false);
+  regs = tcb->xcp.regs;
 
-  return tcb->xcp.regs;
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }
 #endif
 

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -114,5 +114,13 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 #endif
 
   board_autoled_off(LED_INIRQ);
-  return tcb->xcp.regs;
+
+  regs = tcb->xcp.regs;
+
+  /* (*running_task)->xcp.regs is about to become invalid
+   * and will be marked as NULL to avoid misusage.
+   */
+
+  (*running_task)->xcp.regs = NULL;
+  return regs;
 }


### PR DESCRIPTION

## Summary

arch: set (*running_task)->xcp.regs to NULL when exit from irq/exception
reason:
(*running_task)->xcp.regs is invalid when in threadcontext, we marke it as NULL to avoid misusage

## Impact
arch

## Testing
qemu-armv7a:smp


