### PR TITLE
[cmake] savedefconfig.cmake: fix EOL changes to defconfig files on Windows native

### DIFF
--- a/cmake/savedefconfig.cmake
+++ b/cmake/savedefconfig.cmake
@@ -71,4 +71,7 @@ foreach(LINE IN LISTS LINES)
   file(APPEND ${OUTPUT_FILE} "${LINE}\n")
 endforeach()
 
+# Converts the newline style for the output file.
+configure_file(${OUTPUT_FILE} ${OUTPUT_FILE} @ONLY NEWLINE_STYLE LF)
+
 execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${TARGET_FILE})


### PR DESCRIPTION
## Summary

defconfig is created with CRLF EOL on Windows, even if LF EOL is used in the cmake file manipulation commands. 

```
On branch master
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   ../../boards/arm/stm32/nucleo-l152re/configs/nsh/defconfig

no changes added to commit (use "git add" and/or "git commit -a")
```

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

local

Without this PR
![CRLF](https://github.com/user-attachments/assets/788b2826-0f94-49b2-b67b-ff372becbd9d)

With this PR
![LF](https://github.com/user-attachments/assets/06a32e52-23e2-4c3e-8129-28bb31cba208)


