### PR TITLE
serial/uart_ram: update lower buffer offset if previous send completes

### DIFF
--- a/drivers/serial/uart_ram.c
+++ b/drivers/serial/uart_ram.c
@@ -452,6 +452,7 @@ static void uart_ram_wdog(wdparm_t arg)
     {
       dev->dmatx.nbytes = dev->dmatx.length + dev->dmatx.nlength;
       uart_xmitchars_done(dev);
+      uart_ram_dmatxavail(dev);
     }
 
   /* When the read and write pointers of the rx buffer are different,


### PR DESCRIPTION
## Summary

serial/uart_ram: update lower buffer offset if previous send completes

UART RAM will have probabilistic bubble time during continuous transmission.
Update the offset after sending to avoid this problem.

Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

N/A

## Testing

sim/rpproxy_uart  sim/rpserver_uart

test cu command with out any delay