### PR TITLE
sim/posix/uart: add host_printf() to debug some critical issue

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostuart.c
+++ b/arch/sim/src/sim/posix/sim_hostuart.c
@@ -32,6 +32,8 @@
 #include <termios.h>
 #include <poll.h>
 #include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 #include "sim_internal.h"
 
@@ -241,4 +243,17 @@ bool host_uart_checkout(int fd)
   pfd.fd     = fd;
   pfd.events = POLLOUT;
   return poll(&pfd, 1, 0) == 1;
+}
+
+/****************************************************************************
+ * Name: host_printf
+ ****************************************************************************/
+
+void host_printf(const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start(ap, fmt);
+  vprintf(fmt, ap);
+  va_end(ap);
 }

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -287,6 +287,7 @@ bool host_uart_checkin(int fd);
 bool host_uart_checkout(int fd);
 int  host_uart_setcflag(int fd, unsigned int cflag);
 int  host_uart_getcflag(int fd, unsigned int *cflag);
+void host_printf(const char *fmt, ...);
 
 /* sim_deviceimage.c ********************************************************/
 


### PR DESCRIPTION
## Summary

sim/posix/uart: add host_printf() to debug some critical issue

Sometimes we need to bypass the system to debug some issue in critical sections

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh