### PR TITLE
Use small lock to protect resources related to i2c master and slave.

### DIFF
--- a/arch/arm/src/rp2040/rp2040_i2c_slave.c
+++ b/arch/arm/src/rp2040/rp2040_i2c_slave.c
@@ -37,7 +37,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/i2c/i2c_slave.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 
 #include <arch/chip/i2c_slave.h>
@@ -77,6 +77,8 @@ typedef struct rp2040_i2c_slave_s
 
   i2c_slave_callback_t  *callback;     /* Callback function */
   void                  *callback_arg; /* Argument for callback */
+
+  spinlock_t             spinlock;     /* Spinlock */
 } rp2040_i2c_slave_t;
 
 /****************************************************************************
@@ -123,6 +125,7 @@ rp2040_i2c_slave_t i2c0_slave_dev =
 {
   .dev.ops      = &i2c_slaveops, /* Slave operations */
   .controller   =             0, /* I2C controller number */
+  .spinlock     = SP_UNLOCKED,   /* Spinlock */
 };
 
 #endif
@@ -133,6 +136,7 @@ rp2040_i2c_slave_t i2c1_slave_dev =
 {
   .dev.ops      = &i2c_slaveops, /* Slave operations */
   .controller   =             1, /* I2C controller number */
+  .spinlock     = SP_UNLOCKED,   /* Spinlock */
 };
 
 #endif
@@ -312,12 +316,9 @@ static int i2c_interrupt(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static void enable_i2c_slave(struct i2c_slave_s *dev)
+static void enable_i2c_slave_nolock(struct i2c_slave_s *dev)
 {
   rp2040_i2c_slave_t *priv = (rp2040_i2c_slave_t *) dev;
-  irqstate_t flags;
-
-  flags = enter_critical_section();
 
   uint32_t intr_mask =   RP2040_I2C_IC_INTR_STAT_R_RD_REQ
                        | RP2040_I2C_IC_INTR_STAT_R_RX_FULL
@@ -344,8 +345,15 @@ static void enable_i2c_slave(struct i2c_slave_s *dev)
 
   putreg32(RP2040_I2C_IC_ENABLE_ENABLE,
            RP2040_I2C_IC_ENABLE(priv->controller));
+}
 
-  leave_critical_section(flags);
+static void enable_i2c_slave(struct i2c_slave_s *dev)
+{
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&priv->spinlock);
+  enable_i2c_slave_nolock(dev);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -366,7 +374,7 @@ static int my_set_own_address(struct i2c_slave_s  *dev,
                  | RP2040_I2C_IC_CON_SPEED_FAST;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   putreg32(address, RP2040_I2C_IC_SAR(priv->controller));
 
@@ -377,9 +385,9 @@ static int my_set_own_address(struct i2c_slave_s  *dev,
 
   putreg32(con, RP2040_I2C_IC_CON(priv->controller));
 
-  enable_i2c_slave(dev);
+  enable_i2c_slave_nolock(dev);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }
@@ -399,13 +407,13 @@ static int my_write(struct i2c_slave_s  *dev,
   rp2040_i2c_slave_t *priv = (rp2040_i2c_slave_t *) dev;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   priv->tx_buffer  = buffer;
   priv->tx_buf_ptr = buffer;
   priv->tx_buf_end = priv->tx_buffer + length;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }
@@ -426,13 +434,13 @@ static int my_read(struct i2c_slave_s  *dev,
   rp2040_i2c_slave_t *priv = (rp2040_i2c_slave_t *) dev;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   priv->rx_buffer  = buffer;
   priv->rx_buf_ptr = buffer;
   priv->rx_buf_end = priv->rx_buffer + length;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }
@@ -453,12 +461,12 @@ static int my_register_callback(struct i2c_slave_s   *dev,
   rp2040_i2c_slave_t *priv = (rp2040_i2c_slave_t *) dev;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   priv->callback     = callback;
   priv->callback_arg = arg;
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 
   return OK;
 }

--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -58,7 +58,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wdog.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
@@ -171,6 +171,7 @@ struct sam_i2c_dev_s
   uint16_t nextflags;            /* Next message flags */
 
   mutex_t lock;               /* Only one thread can access at a time */
+  spinlock_t spinlock;        /* Spinlock */
   sem_t waitsem;              /* Wait for I2C transfer completion */
   volatile int result;        /* The result of the transfer */
   volatile int xfrd;          /* Number of bytes transfers */
@@ -284,6 +285,7 @@ static struct sam_i2c_dev_s g_i2c0 =
   },
   .attr      = &g_i2c0attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -310,6 +312,7 @@ static struct sam_i2c_dev_s g_i2c1 =
   },
   .attr      = &g_i2c1attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -337,6 +340,7 @@ static struct sam_i2c_dev_s g_i2c2 =
   },
   .attr      = &g_i2c2attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -364,6 +368,7 @@ static struct sam_i2c_dev_s g_i2c3 =
   },
   .attr      = &g_i2c3attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -391,6 +396,7 @@ static struct sam_i2c_dev_s g_i2c4 =
   },
   .attr      = &g_i2c4attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -418,6 +424,7 @@ static struct sam_i2c_dev_s g_i2c5 =
   },
   .attr      = &g_i2c5attr,
   .lock      = NXMUTEX_INITIALIZER,
+  .spinlock  = SP_UNLOCKED,
   .waitsem   = SEM_INITIALIZER(0),
 };
 #endif
@@ -1018,14 +1025,16 @@ static int sam_i2c_transfer(struct i2c_master_s *dev,
     {
       priv->msg = msgs;
       priv->nextflags = count == 0 ? 0 : msgs[1].flags;
-      flags = enter_critical_section();
+      flags = spin_lock_irqsave(&priv->spinlock);
       i2c_startmessage(priv, msgs);
 
       /* And wait for the transfers to complete.
        * Interrupts will be re-enabled while we are waiting.
        */
 
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       ret = i2c_wait_for_bus(priv, msgs->length);
+      flags = spin_lock_irqsave(&priv->spinlock);
       if (ret < 0)
         {
 #if 0
@@ -1040,12 +1049,12 @@ static int sam_i2c_transfer(struct i2c_master_s *dev,
           i2c_putreg8(priv, I2C_INT_MB | I2C_INT_SB,
                       SAM_I2C_INTENCLR_OFFSET);
 
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(&priv->spinlock, flags);
           nxmutex_unlock(&priv->lock);
           return ret;
         }
 
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
 
       /* Move to the next message */
 
@@ -1169,9 +1178,9 @@ static uint32_t sam_i2c_setfrequency(struct sam_i2c_dev_s *priv,
  *
  ****************************************************************************/
 
-static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
+static void i2c_hw_initialize_nolock(struct sam_i2c_dev_s *priv,
+                                     uint32_t frequency)
 {
-  irqstate_t flags;
   uint32_t regval;
   uint32_t ctrla = 0;
 
@@ -1179,7 +1188,6 @@ static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
 
   /* Enable clocking to the SERCOM module in PM */
 
-  flags = enter_critical_section();
   sercom_enable(priv->attr->sercom);
 
   /* Configure the GCLKs for the SERCOM module */
@@ -1194,7 +1202,6 @@ static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
     {
       i2cerr
        ("ERROR: Cannot initialize I2C because it is already initialized!\n");
-      leave_critical_section(flags);
       return;
     }
 
@@ -1204,7 +1211,6 @@ static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
   if (regval & I2C_CTRLA_SWRST)
     {
       i2cerr("ERROR: Module is in RESET process!\n");
-      leave_critical_section(flags);
       return;
     }
 
@@ -1244,7 +1250,15 @@ static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
   /* Enable SERCOM interrupts at the NVIC */
 
   up_enable_irq(priv->attr->irq);
-  leave_critical_section(flags);
+}
+
+static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
+{
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&priv->spinlock);
+  i2c_hw_initialize_nolock(priv, frequency);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
 }
 
 /****************************************************************************
@@ -1369,7 +1383,7 @@ struct i2c_master_s *sam_i2c_master_initialize(int bus)
 
   /* Perform one-time I2C initialization */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Attach Interrupt Handler */
 
@@ -1377,14 +1391,14 @@ struct i2c_master_s *sam_i2c_master_initialize(int bus)
   if (ret < 0)
     {
       i2cerr("ERROR: Failed to attach irq %d\n", priv->attr->irq);
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(&priv->spinlock, flags);
       return NULL;
     }
 
   /* Perform repeatable I2C hardware initialization */
 
-  i2c_hw_initialize(priv, frequency);
-  leave_critical_section(flags);
+  i2c_hw_initialize_nolock(priv, frequency);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return &priv->dev;
 }
 

--- a/arch/arm/src/stm32/stm32_i2c_alt.c
+++ b/arch/arm/src/stm32/stm32_i2c_alt.c
@@ -89,7 +89,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
@@ -288,6 +288,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -406,6 +407,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config     = &stm32_i2c1_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -439,6 +441,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config     = &stm32_i2c2_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -472,6 +475,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config     = &stm32_i2c3_config,
   .refs       = 0,
   .lock       = NXMUTEX_INITIALIZER,
+  .spinlock   = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr    = SEM_INITIALIZER(0),
 #endif
@@ -577,7 +581,7 @@ static int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -593,6 +597,8 @@ static int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
@@ -611,6 +617,8 @@ static int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -627,7 +635,7 @@ static int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   regval &= ~I2C_CR2_ALLINTS;
   stm32_i2c_putreg(priv, STM32_I2C_CR2_OFFSET, regval);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else

--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -225,7 +225,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kmalloc.h>
@@ -407,6 +407,7 @@ struct stm32_i2c_priv_s
 
   int refs;                    /* Reference count */
   mutex_t lock;                /* Mutual exclusion mutex */
+  spinlock_t spinlock;         /* Spinlock */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
 #endif
@@ -520,6 +521,7 @@ static struct stm32_i2c_priv_s stm32_i2c1_priv =
   .config        = &stm32_i2c1_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -556,6 +558,7 @@ static struct stm32_i2c_priv_s stm32_i2c2_priv =
   .config        = &stm32_i2c2_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -592,6 +595,7 @@ static struct stm32_i2c_priv_s stm32_i2c3_priv =
   .config        = &stm32_i2c3_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -628,6 +632,7 @@ static struct stm32_i2c_priv_s stm32_i2c4_priv =
   .config        = &stm32_i2c4_config,
   .refs          = 0,
   .lock          = NXMUTEX_INITIALIZER,
+  .spinlock      = SP_UNLOCKED,
 #ifndef CONFIG_I2C_POLLED
   .sem_isr       = SEM_INITIALIZER(0),
 #endif
@@ -793,7 +798,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   irqstate_t flags;
   int ret;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   /* Enable I2C interrupts */
 
@@ -810,6 +815,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
   priv->intstate = INTSTATE_WAITING;
   do
     {
+      spin_unlock_irqrestore(&priv->spinlock, flags);
+
       /* Wait until either the transfer is complete or the timeout expires */
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
@@ -828,6 +835,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
           break;
         }
+
+      flags = spin_lock_irqsave(&priv->spinlock);
     }
 
   /* Loop until the interrupt level transfer is complete. */
@@ -842,7 +851,7 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, I2C_CR1_ALLINTS, 0);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->spinlock, flags);
   return ret;
 }
 #else
@@ -1742,7 +1751,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            */
 
 #ifdef CONFIG_I2C_POLLED
-          irqstate_t state = enter_critical_section();
+          irqstate_t state = spin_lock_irqsave(&priv->spinlock);
 #endif
           /* Receive a byte */
 
@@ -1759,7 +1768,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->dcnt--;
 
 #ifdef CONFIG_I2C_POLLED
-          leave_critical_section(state);
+          spin_unlock_irqrestore(&priv->spinlock, state);
 #endif
         }
       else


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to i2c master and slave.

## Impact

The underlying implementation of I2C master and slave.

## Testing

CI


