### PR TITLE
drivers/rpmsg_port_uart: remove debug message of datalen

### DIFF
--- a/drivers/rpmsg/rpmsg_port_uart.c
+++ b/drivers/rpmsg/rpmsg_port_uart.c
@@ -129,8 +129,6 @@ static void rpmsg_port_uart_send_packet(FAR struct rpmsg_port_uart_s *rpuart,
       data = (FAR uint8_t *)data + ret;
       datalen -= ret;
     }
-
-  rpmsgdbg("Sent %zu Data\n", datalen);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

drivers/rpmsg_port_uart: remove debug message of datalen

datalen message after file_read is always 0

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/rpproxy_uart sim/rpserver_uart