### PR TITLE
Because sched_lock is now called in spin_lock_irqsave, there is no ne…

### DIFF
--- a/arch/arm/src/am335x/am335x_can.c
+++ b/arch/arm/src/am335x/am335x_can.c
@@ -27,7 +27,6 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
-#include <sched.h>
 
 #include <arch/board/board.h>
 #include <nuttx/irq.h>
@@ -1084,7 +1083,6 @@ struct can_dev_s *am335x_can_initialize(int port)
   syslog(LOG_DEBUG, "CAN%d\n", port);
 
   flags = spin_lock_irqsave(&g_can_lock);
-  sched_lock();
 
 #ifdef CONFIG_AM335X_CAN0
   if (port == 0)
@@ -1115,12 +1113,10 @@ struct can_dev_s *am335x_can_initialize(int port)
       canerr("Unsupported port: %d\n", port);
 
       spin_unlock_irqrestore(&g_can_lock, flags);
-      sched_unlock();
       return NULL;
     }
 
   spin_unlock_irqrestore(&g_can_lock, flags);
-  sched_unlock();
 
   return candev;
 }
@@ -1132,7 +1128,6 @@ void am335x_can_uninitialize(struct can_dev_s *dev)
   DEBUGASSERT(dev);
 
   flags = spin_lock_irqsave(&g_can_lock);
-  sched_lock();
 
 #ifdef CONFIG_AM335X_CAN0
   if (dev == &g_can0dev)
@@ -1160,7 +1155,6 @@ void am335x_can_uninitialize(struct can_dev_s *dev)
     }
 
   spin_unlock_irqrestore(&g_can_lock, flags);
-  sched_unlock();
 }
 
 #endif

--- a/arch/arm/src/cxd56xx/cxd56_timer.c
+++ b/arch/arm/src/cxd56xx/cxd56_timer.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -434,7 +433,6 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -445,7 +443,6 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   priv->arg      = arg;
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -40,7 +40,6 @@
 #include <debug.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -1137,12 +1136,10 @@ static void cxd56_cancelrequests_nolock(struct cxd56_ep_s *privep)
 static void cxd56_cancelrequests(struct cxd56_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   cxd56_cancelrequests_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -2296,11 +2293,9 @@ static int cxd56_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity and reset the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   cxd56_epstall(&privep->ep, false);
   cxd56_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2440,7 +2435,6 @@ static int cxd56_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor, except OUT */
 
@@ -2545,7 +2539,6 @@ static int cxd56_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -2574,10 +2567,8 @@ static int cxd56_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   cxd56_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3174,7 +3165,6 @@ void arm_usbuninitialize(void)
     }
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   cxd56_pullup(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
 
@@ -3192,7 +3182,6 @@ void arm_usbuninitialize(void)
 
   cxd56_usb_clock_disable();
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   /* Clear signal */
 
@@ -3287,7 +3276,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   CLASS_UNBIND(driver, &g_usbdev.usbdev);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Disable IRQs */
 
@@ -3308,7 +3296,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   cxd56_usbhwuninit();
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   up_pm_release_freqlock(&g_hv_lock);
   up_pm_release_wakelock(&g_wake_lock);

--- a/arch/arm/src/dm320/dm320_usbdev.c
+++ b/arch/arm/src/dm320/dm320_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -1046,12 +1045,10 @@ static int dm320_wrrequest(struct dm320_ep_s *privep)
 {
   int ret;
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   ret = dm320_wrrequest_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 
   return ret;
 }
@@ -2028,12 +2025,10 @@ static int dm320_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity and reset the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   dm320_cancelrequests(privep);
   dm320_epreset(privep->epphy);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2173,7 +2168,6 @@ static int dm320_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Check for NULL packet */
 
@@ -2234,7 +2228,6 @@ static int dm320_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -2265,10 +2258,8 @@ static int dm320_epcancel(struct usbdev_ep_s *ep,
   priv = privep->dev;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   dm320_cancelrequests(privep);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 

--- a/arch/arm/src/efm32/efm32_usbdev.c
+++ b/arch/arm/src/efm32/efm32_usbdev.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -4130,7 +4129,6 @@ static void efm32_epout_disable(struct efm32_ep_s *privep)
    */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   efm32_enablegonak(privep);
 
   /* Disable the required OUT endpoint by setting the EPDIS and SNAK bits
@@ -4178,7 +4176,6 @@ static void efm32_epout_disable(struct efm32_ep_s *privep)
   efm32_req_cancel(privep, -ESHUTDOWN);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -4244,7 +4241,6 @@ static void efm32_epin_disable(struct efm32_ep_s *privep)
    */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   regaddr = EFM32_USB_DIEPCTL(privep->epphy);
   regval  = efm32_getreg(regaddr);
   regval &= ~USB_DIEPCTL_USBACTEP;
@@ -4276,7 +4272,6 @@ static void efm32_epin_disable(struct efm32_ep_s *privep)
 
   efm32_req_cancel(privep, -ESHUTDOWN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -4468,7 +4463,6 @@ static int efm32_ep_submit(struct usbdev_ep_s *ep,
   /* Disable Interrupts */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -4514,7 +4508,6 @@ static int efm32_ep_submit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -4543,7 +4536,6 @@ static int efm32_ep_cancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* FIXME: if the request is the first, then we need to flush the EP
    *         otherwise just remove it from the list
@@ -4553,7 +4545,6 @@ static int efm32_ep_cancel(struct usbdev_ep_s *ep,
 
   efm32_req_cancel(privep, -ESHUTDOWN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -4764,7 +4755,6 @@ static int efm32_ep_stall(struct usbdev_ep_s *ep, bool resume)
   /* Set or clear the stall condition as requested */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   if (resume)
     {
       ret = efm32_ep_clrstall(privep);
@@ -4775,7 +4765,6 @@ static int efm32_ep_stall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 
   return ret;
 }
@@ -4836,7 +4825,6 @@ static struct usbdev_ep_s *efm32_ep_alloc(struct usbdev_s *dev,
   /* Get the set of available endpoints depending on the direction */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   epavail = priv->epavail[in];
 
   /* A physical address of 0 means that any endpoint will do */
@@ -4884,7 +4872,6 @@ static struct usbdev_ep_s *efm32_ep_alloc(struct usbdev_s *dev,
               /* And return the pointer to the standard endpoint structure */
 
               spin_unlock_irqrestore(&priv->lock, flags);
-              sched_unlock();
               return in ? &priv->epin[epno].ep : &priv->epout[epno].ep;
             }
         }
@@ -4894,7 +4881,6 @@ static struct usbdev_ep_s *efm32_ep_alloc(struct usbdev_s *dev,
 
   usbtrace(TRACE_DEVERROR(EFM32_TRACEERR_NOEP), (uint16_t)eplog);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return NULL;
 }
 
@@ -4964,7 +4950,6 @@ static int efm32_wakeup(struct usbdev_s *dev)
   /* Is wakeup enabled? */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   if (priv->wakeup)
     {
       /* Yes... is the core suspended? */
@@ -4991,7 +4976,6 @@ static int efm32_wakeup(struct usbdev_s *dev)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -5064,10 +5048,8 @@ static int efm32_pullup(struct usbdev_s *dev, bool enable)
   struct efm32_usbdev_s *priv = (struct efm32_usbdev_s *)dev;
 
   irqstate_t flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   ret = efm32_pullup_nolock(dev, enable);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return ret;
 }
@@ -5696,7 +5678,6 @@ void arm_usbuninitialize(void)
   /* Disconnect device */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   efm32_pullup_nolock(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
 
@@ -5733,7 +5714,6 @@ void arm_usbuninitialize(void)
 
   priv->devstate = DEVSTATE_DEFAULT;
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -5845,10 +5825,8 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   efm32_usbreset(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   /* Unbind the class driver */
 
@@ -5857,7 +5835,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   /* Disable USB controller interrupts */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   up_disable_irq(EFM32_IRQ_USB);
 
   /* Disconnect device */
@@ -5868,7 +5845,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 
   priv->driver = NULL;
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }

--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -243,10 +243,8 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
   imx9_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 #endif
 
@@ -475,7 +473,6 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
 
   /* Disable channel IRQ requests */
 
@@ -528,7 +525,6 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -814,7 +814,6 @@ static int imx9_txpoll(struct net_driver_s *dev)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (priv->dev.d_len > 0)
     {
@@ -835,7 +834,6 @@ static int imx9_txpoll(struct net_driver_s *dev)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -696,7 +695,6 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
 
 #ifdef CONFIG_IMXRT_LPI2C_DMA
   if (priv->dma == NULL)
@@ -778,7 +776,6 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
     }
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/imxrt/imxrt_usbdev.c
+++ b/arch/arm/src/imxrt/imxrt_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2245,7 +2244,6 @@ static int imxrt_epdisable(struct usbdev_ep_s *ep)
   usbtrace(TRACE_EPDISABLE, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* Disable Endpoint */
 
@@ -2267,7 +2265,6 @@ static int imxrt_epdisable(struct usbdev_ep_s *ep)
   imxrt_cancelrequests(privep, -ESHUTDOWN);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2425,7 +2422,6 @@ static int imxrt_epsubmit(struct usbdev_ep_s *ep,
   /* Disable Interrupts */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -2453,7 +2449,6 @@ static int imxrt_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -2482,7 +2477,6 @@ static int imxrt_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* FIXME: if the request is the first, then we need to flush the EP
    *         otherwise just remove it from the list
@@ -2492,7 +2486,6 @@ static int imxrt_epcancel(struct usbdev_ep_s *ep,
 
   imxrt_cancelrequests(privep, -ESHUTDOWN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2512,7 +2505,6 @@ static int imxrt_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, privep->epphy);
 
   uint32_t addr    = IMXRT_USBDEV_ENDPTCTRL(privep->epphy >> 1);
@@ -2537,7 +2529,6 @@ static int imxrt_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2818,10 +2809,8 @@ static int imxrt_pullup(struct usbdev_s *dev, bool enable)
   int ret;
 
   irqstate_t flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   ret = imxrt_pullup_nolock(dev, enable);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return ret;
 }
@@ -2996,7 +2985,6 @@ void arm_usbuninitialize(void)
     }
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Disconnect device */
 
@@ -3028,7 +3016,6 @@ void arm_usbuninitialize(void)
   imxrt_clockoff_usboh3();
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/kinetis/kinetis_edma.c
+++ b/arch/arm/src/kinetis/kinetis_edma.c
@@ -244,10 +244,8 @@ static void kinetis_tcd_free(struct kinetis_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
   kinetis_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 #endif
 
@@ -456,7 +454,6 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   uint8_t chan;
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
 
   /* Disable channel ERROR interrupts */
 
@@ -508,7 +505,6 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   dmach->state    = KINETIS_DMA_IDLE;
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -48,7 +48,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/wdog.h>
@@ -3209,7 +3208,6 @@ static void khci_resume(struct khci_usbdev_s *priv)
   uint32_t regval;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* This function is called when the USB resume interrupt occurs.
    * If using clock switching, this is the place to call out to
@@ -3251,7 +3249,6 @@ static void khci_resume(struct khci_usbdev_s *priv)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -3537,7 +3534,6 @@ static int khci_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   khci_cancelrequests(privep, -ESHUTDOWN);
 
   /* Disable the endpoint */
@@ -3555,7 +3551,6 @@ static int khci_epdisable(struct usbdev_ep_s *ep)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3655,7 +3650,6 @@ static int khci_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   privreq->inflight[1] = 0;
 #endif
   flags                = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Add the new request to the request queue for the OUT endpoint */
 
@@ -3700,7 +3694,6 @@ static int khci_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -3724,10 +3717,8 @@ static int khci_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   khci_cancelrequests(privep, -EAGAIN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3935,7 +3926,6 @@ static int khci_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* Special case EP0.  When we stall EP0 we have to stall both the IN and
    * OUT BDTs.
@@ -3965,7 +3955,6 @@ static int khci_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -4615,7 +4604,6 @@ void arm_usbuninitialize(void)
   /* Disconnect the device */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   khci_swreset(priv);
 
@@ -4640,7 +4628,6 @@ void arm_usbuninitialize(void)
   putreg32(regval, KINETIS_SIM_SCGC4);
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -4742,7 +4729,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   khci_swreset(priv);
   kinetis_usbpullup(&priv->usbdev, false);
   khci_hwreset(priv);
@@ -4764,7 +4750,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   khci_swinitialize(priv);
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 #endif /* CONFIG_USBDEV */

--- a/arch/arm/src/lpc31xx/lpc31_usbdev.c
+++ b/arch/arm/src/lpc31xx/lpc31_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2103,7 +2102,6 @@ static int lpc31_epdisable(struct usbdev_ep_s *ep)
   usbtrace(TRACE_EPDISABLE, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* Disable Endpoint */
 
@@ -2121,7 +2119,6 @@ static int lpc31_epdisable(struct usbdev_ep_s *ep)
   lpc31_cancelrequests(privep, -ESHUTDOWN);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2271,7 +2268,6 @@ static int lpc31_epsubmit(struct usbdev_ep_s *ep,
   /* Disable Interrupts */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -2295,7 +2291,6 @@ static int lpc31_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -2324,7 +2319,6 @@ static int lpc31_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* FIXME: if the request is the first, then we need to flush the EP
    *         otherwise just remove it from the list
@@ -2334,7 +2328,6 @@ static int lpc31_epcancel(struct usbdev_ep_s *ep,
 
   lpc31_cancelrequests(privep, -ESHUTDOWN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2354,7 +2347,6 @@ static int lpc31_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, privep->epphy);
 
   uint32_t addr    = LPC31_USBDEV_ENDPTCTRL(privep->epphy);
@@ -2379,7 +2371,6 @@ static int lpc31_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2649,10 +2640,8 @@ static int lpc31_pullup(struct usbdev_s *dev, bool enable)
   int ret;
 
   irqstate_t flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   ret = lpc31_pullup_nolock(dev, enable);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return ret;
 }
@@ -2825,7 +2814,6 @@ void arm_usbuninitialize(void)
   /* Disconnect device */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   lpc31_pullup_nolock(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
 
@@ -2846,7 +2834,6 @@ void arm_usbuninitialize(void)
   lpc31_disableclock (CLKID_EVENTROUTERPCLK);
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc43xx/lpc43_timer.c
+++ b/arch/arm/src/lpc43xx/lpc43_timer.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -636,7 +635,6 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -647,7 +645,6 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   priv->arg      = arg;
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -34,7 +34,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -877,10 +876,8 @@ static void rp2040_cancelrequests_nolock(struct rp2040_ep_s *privep)
 static void rp2040_cancelrequests(struct rp2040_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rp2040_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -1536,7 +1533,6 @@ static int rp2040_epdisable(struct usbdev_ep_s *ep)
   uinfo("EP%d\n", privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   privep->ep.maxpacket = 64;
   privep->stalled = false;
@@ -1548,7 +1544,6 @@ static int rp2040_epdisable(struct usbdev_ep_s *ep)
   rp2040_cancelrequests_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 
   return OK;
 }
@@ -1642,7 +1637,6 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
   req->xfrd = 0;
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   if (privep->stalled && privep->in)
     {
@@ -1688,7 +1682,6 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -1719,10 +1712,8 @@ static int rp2040_epcancel(struct usbdev_ep_s *ep,
   /* Remove request from req_queue */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rp2040_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -1765,10 +1756,8 @@ static int rp2040_epstall_exec(struct usbdev_ep_s *ep)
   int ret;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   ret = rp2040_epstall_exec_nolock(ep);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -1787,7 +1776,6 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (resume)
     {
@@ -1829,7 +1817,6 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }
@@ -2180,7 +2167,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   usbtrace(TRACE_DEVUNREGISTER, 0);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Unbind the class driver */
 
@@ -2199,7 +2185,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   priv->driver = NULL;
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -34,7 +34,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -873,10 +872,8 @@ static void rp23xx_cancelrequests_nolock(struct rp23xx_ep_s *privep)
 static void rp23xx_cancelrequests(struct rp23xx_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rp23xx_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -1346,10 +1343,8 @@ static bool rp23xx_usbintr_buffstat(struct rp23xx_usbdev_s *priv)
                   else if (privep->pending_stall)
                     {
                       flags = spin_lock_irqsave(&priv->lock);
-                      sched_lock();
                       rp23xx_epstall_exec(&privep->ep);
                       spin_unlock_irqrestore(&priv->lock, flags);
-                      sched_unlock();
                     }
                 }
               else
@@ -1537,7 +1532,6 @@ static int rp23xx_epdisable(struct usbdev_ep_s *ep)
   uinfo("EP%d\n", privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   privep->ep.maxpacket = 64;
   privep->stalled = false;
@@ -1549,7 +1543,6 @@ static int rp23xx_epdisable(struct usbdev_ep_s *ep)
   rp23xx_cancelrequests_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
 
   return OK;
 }
@@ -1643,7 +1636,6 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
   req->xfrd = 0;
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   if (privep->stalled && privep->in)
     {
@@ -1689,7 +1681,6 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -1720,10 +1711,8 @@ static int rp23xx_epcancel(struct usbdev_ep_s *ep,
   /* Remove request from req_queue */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rp23xx_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -1773,7 +1762,6 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (resume)
     {
@@ -1815,7 +1803,6 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }
@@ -2166,7 +2153,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   usbtrace(TRACE_DEVUNREGISTER, 0);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Unbind the class driver */
 
@@ -2185,7 +2171,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   priv->driver = NULL;
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -449,7 +449,6 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   uint8_t chan;
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
 
   /* Disable channel ERROR interrupts */
 
@@ -499,7 +498,6 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   dmach->arg      = NULL;
   dmach->state    = S32K1XX_DMA_IDLE;
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -502,7 +501,6 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
 
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -586,7 +584,6 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
 #endif
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -494,10 +494,8 @@ static void s32k3xx_tcd_free(struct s32k3xx_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
   s32k3xx_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 #endif
 
@@ -726,7 +724,6 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
   void *arg;
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
 
   chan            = dmach->chan;
 
@@ -781,7 +778,6 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -509,7 +508,6 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
 
 #ifdef CONFIG_S32K3XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -590,7 +588,6 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
     }
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/sam34/sam_rtc.c
+++ b/arch/arm/src/sam34/sam_rtc.c
@@ -658,7 +658,6 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
   /* Is there already something waiting on the ALARM? */
 
   flags = spin_lock_irqsave(&g_rtc_lock);
-  sched_lock();
   if (g_alarmcb == NULL)
     {
       /* No.. Save the callback function pointer */
@@ -737,7 +736,6 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
     }
 
   spin_unlock_irqrestore(&g_rtc_lock, flags);
-  sched_unlock();
   return ret;
 }
 #endif

--- a/arch/arm/src/samv7/sam_usbdevhs.c
+++ b/arch/arm/src/samv7/sam_usbdevhs.c
@@ -50,7 +50,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -4030,7 +4029,6 @@ static int sam_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   req->xfrd         = 0;
   privreq->inflight = 0;
   flags             = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Handle IN (device-to-host) requests.  NOTE:  If the class device is
    * using the bi-directional EP0, then we assume that they intend the EP0
@@ -4083,7 +4081,6 @@ static int sam_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -4102,10 +4099,8 @@ static int sam_ep_cancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   sam_req_cancel(privep, -EAGAIN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -4137,7 +4132,6 @@ static int sam_ep_stall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, USB_EPNO(ep->eplog));
 
   /* Handle the resume condition */
@@ -4261,7 +4255,6 @@ static int sam_ep_stall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -5073,7 +5066,6 @@ void arm_usbuninitialize(void)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USBHS IRQ */
@@ -5092,7 +5084,6 @@ void arm_usbuninitialize(void)
   sam_hw_shutdown(priv);
   sam_sw_shutdown(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -5170,7 +5161,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Unbind the class driver */
 
@@ -5195,7 +5185,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 
   priv->driver = NULL;
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -2405,12 +2405,10 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
   ssize_t nbytes;
 
   flags = spin_lock_irqsave(&config->lock);
-  sched_lock();
 
   if (config.state->rxdmastream == NULL)
     {
       spin_unlock_irqrestore(&config->lock, flags);
-      sched_unlock();
       return;
     }
 
@@ -2437,7 +2435,6 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
     }
 
   spin_unlock_irqrestore(&config->lock, flags);
-  sched_unlock();
 }
 #endif
 

--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -40,7 +40,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2984,7 +2983,6 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   stm32_cancelrequests(privep);
 
   /* Disable TX; disable RX */
@@ -2994,7 +2992,6 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   stm32_seteptxstatus(epno, USB_EPR_STATTX_DIS);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3088,7 +3085,6 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3162,7 +3158,6 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -3185,10 +3180,8 @@ static int stm32_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   stm32_cancelrequests(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3219,7 +3212,6 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, USB_EPNO(ep->eplog));
 
   /* Get status of the endpoint; stall the request if the endpoint is
@@ -3245,7 +3237,6 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
         }
 
       spin_unlock_irqrestore(&priv->lock, flags);
-      sched_unlock();
       return -ENODEV;
     }
 
@@ -3332,7 +3323,6 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3497,7 +3487,6 @@ static int stm32_wakeup(struct usbdev_s *dev)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   stm32_initresume(priv);
   priv->rsmstate = RSMSTATE_STARTED;
 
@@ -3510,7 +3499,6 @@ static int stm32_wakeup(struct usbdev_s *dev)
   stm32_setimask(priv, USB_CNTR_ESOFM, USB_CNTR_WKUPM | USB_CNTR_SUSPM);
   stm32_putreg(~USB_ISTR_ESOF, STM32_USB_ISTR);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3852,7 +3840,6 @@ void arm_usbuninitialize(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -3872,7 +3859,6 @@ void arm_usbuninitialize(void)
 
   stm32_hwshutdown(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -3982,7 +3968,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   stm32_reset(priv);
 
   /* Unbind the class driver */
@@ -4006,7 +3991,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 
   priv->driver = NULL;
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 

--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -239,10 +239,8 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
   imx9_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 #endif
 
@@ -455,7 +453,6 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
 
   /* Disable channel IRQ requests */
 
@@ -508,7 +505,6 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/avr/src/at90usb/at90usb_usbdev.c
+++ b/arch/avr/src/at90usb/at90usb_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -2301,7 +2300,6 @@ static int avr_epdisable(FAR struct usbdev_ep_s *ep)
   usbtrace(TRACE_EPDISABLE, privep->ep.eplog);
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
 
   /* Disable the endpoint */
 
@@ -2309,7 +2307,6 @@ static int avr_epdisable(FAR struct usbdev_ep_s *ep)
   g_usbdev.stalled = true;
 
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2456,7 +2453,6 @@ static int avr_epsubmit(FAR struct usbdev_ep_s *ep,
   /* Disable Interrupts */
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -2518,7 +2514,6 @@ static int avr_epsubmit(FAR struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -2553,10 +2548,8 @@ static int avr_epcancel(FAR struct usbdev_ep_s *ep,
    */
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
   avr_cancelrequests(privep, -ESHUTDOWN);
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2767,10 +2760,8 @@ static int avr_wakeup(struct usbdev_s *dev)
   usbtrace(TRACE_DEVWAKEUP, 0);
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
   avr_genwakeup();
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -2910,7 +2901,6 @@ void avr_usbuninitialize(void)
   /* Disconnect device */
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
   avr_pullup(&g_usbdev.usbdev, false);
   g_usbdev.usbdev.speed = USB_SPEED_UNKNOWN;
 
@@ -2923,7 +2913,6 @@ void avr_usbuninitialize(void)
 
   avr_usbshutdown();
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -3039,9 +3028,7 @@ void avr_pollvbus(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
   avr_genvbus();
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
 }
 #endif

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -44,7 +44,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -3335,7 +3334,6 @@ static int pic32mx_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   pic32mx_cancelrequests(privep, -ESHUTDOWN);
 
   /* Disable the endpoint */
@@ -3353,7 +3351,6 @@ static int pic32mx_epdisable(struct usbdev_ep_s *ep)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3454,7 +3451,6 @@ static int pic32mx_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   privreq->inflight[1] = 0;
 #endif
   flags                = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Add the new request to the request queue for the OUT endpoint */
 
@@ -3499,7 +3495,6 @@ static int pic32mx_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -3523,10 +3518,8 @@ static int pic32mx_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   pic32mx_cancelrequests(privep, -EAGAIN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3718,7 +3711,6 @@ static int pic32mx_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
 
   /* Special case EP0.  When we stall EP0 we have to stall both the IN and
    * OUT BDTs.
@@ -3748,7 +3740,6 @@ static int pic32mx_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -4402,7 +4393,6 @@ void mips_usbuninitialize(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -4420,7 +4410,6 @@ void mips_usbuninitialize(void)
 
   pic32mx_hwshutdown(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -4525,7 +4514,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   pic32mx_swreset(priv);
   pic32mx_hwreset(priv);
 
@@ -4549,7 +4537,6 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 
   priv->driver = NULL;
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return OK;
 }
 

--- a/arch/renesas/src/rx65n/rx65n_rtc.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc.c
@@ -481,7 +481,6 @@ int up_rtc_gettime(struct timespec *tp)
   struct tm t;
 
   flags = spin_lock_irqsave(&g_rtc_lock);
-  sched_lock();
 
   if (RTC.RCR2.BIT.START == 0)
     {
@@ -550,7 +549,6 @@ int up_rtc_gettime(struct timespec *tp)
   UNUSED(seccnt);
 
   spin_unlock_irqrestore(&g_rtc_lock, flags);
-  sched_unlock();
   return OK;
 }
 #endif

--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -35,7 +35,6 @@
 #include <debug.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -3005,11 +3004,9 @@ static int rx65n_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rx65n_cancelrequests(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 
@@ -3115,7 +3112,6 @@ static int rx65n_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3143,7 +3139,6 @@ static int rx65n_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
           privreq->req.len = CDC_CLASS_DATA_LENGTH;
           rx65n_rdrequest(epno, priv, privep);
           spin_unlock_irqrestore(&priv->lock, flags);
-          sched_unlock();
           return OK;
         }
 
@@ -3153,7 +3148,6 @@ static int rx65n_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
         {
           ret = rx65n_wrrequest(epno, priv, privep);
           spin_unlock_irqrestore(&priv->lock, flags);
-          sched_unlock();
           return OK;
         }
     }
@@ -3168,7 +3162,6 @@ static int rx65n_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
         {
           rx65n_rdrequest(epno, priv, privep);
           spin_unlock_irqrestore(&priv->lock, flags);
-          sched_unlock();
           return OK;
         }
 
@@ -3202,7 +3195,6 @@ static int rx65n_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
   return ret;
 }
 
@@ -3244,10 +3236,8 @@ static int rx65n_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
   rx65n_cancelrequests(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
   return OK;
 }
 

--- a/arch/risc-v/src/common/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_hr_timer.c
@@ -34,7 +34,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
@@ -220,7 +219,6 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
   systimer_ll_clear_alarm_int(priv->hal.dev, SYSTIMER_ALARM_ESPTIMER);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -291,7 +289,6 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -28,7 +28,6 @@
 
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -522,7 +521,6 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
   DEBUGASSERT(source >= 0 && source < ESP_NSOURCES);
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -553,7 +551,6 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
     }
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 
   return cpuint;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
@@ -31,7 +31,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -368,10 +367,8 @@ void esp32c3_free_cpuint(uint8_t periphid)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
   esp32c3_free_cpuint_nolock(periphid);
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -488,7 +485,6 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
   irqinfo("periphid = %d\n", periphid);
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -502,7 +498,6 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
              priority, type);
       spin_unlock_irqrestore(&g_irq_lock, flags);
-      sched_unlock();
 
       return cpuint;
     }
@@ -519,7 +514,6 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
   esp32c3_bind_irq(cpuint, periphid, priority, type);
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 
   return cpuint;
 }
@@ -550,7 +544,6 @@ void esp32c3_teardown_irq(int periphid, int cpuint)
   int irq;
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Tearing down an IRQ includes the following steps:
    *   1. Free the previously allocated CPU interrupt.
@@ -572,7 +565,6 @@ void esp32c3_teardown_irq(int periphid, int cpuint)
   putreg32(NO_CPUINT, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -295,7 +294,6 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -323,7 +321,6 @@ static void delete_rt_timer(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -447,7 +444,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   ESP32C3_TIM_ACKINT(priv->timer);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -507,7 +503,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return 0;
 }

--- a/arch/x86_64/src/intel64/intel64_oneshot.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot.c
@@ -29,7 +29,6 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <sched.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -29,7 +29,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -231,10 +230,8 @@ static void esp32_irq_dump(const char *msg, int irq)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 #warning Missing logic
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 }
 #else
 #  define esp32_irq_dump(msg, irq)
@@ -882,7 +879,6 @@ int esp32_setup_irq(int cpu, int periphid, int priority, int flags)
   int cpuint;
 
   irqstate = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -897,7 +893,6 @@ int esp32_setup_irq(int cpu, int periphid, int priority, int flags)
       irqerr("Unable to allocate CPU interrupt for priority=%d and flags=%d",
              priority, flags);
       spin_unlock_irqrestore(&g_irq_lock, irqstate);
-      sched_unlock();
 
       return cpuint;
     }
@@ -935,7 +930,6 @@ int esp32_setup_irq(int cpu, int periphid, int priority, int flags)
   putreg32(cpuint, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, irqstate);
-  sched_unlock();
 
   return cpuint;
 }
@@ -968,7 +962,6 @@ void esp32_teardown_irq(int cpu, int periphid, int cpuint)
   int irq;
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Tearing down an IRQ includes the following steps:
    *   1. Free the previously allocated CPU interrupt.
@@ -991,7 +984,6 @@ void esp32_teardown_irq(int cpu, int periphid, int cpuint)
   putreg32(NO_CPUINT, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -2189,7 +2189,6 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      sched_lock();
       flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
@@ -2202,7 +2201,6 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->alarm_hdl = NULL;
 
       spin_unlock_irqrestore(&g_rtc_lock, flags);
-      sched_unlock();
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32s2/esp32s2_irq.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.c
@@ -26,7 +26,6 @@
 
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
@@ -501,7 +500,6 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
   int cpuint;
 
   flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -515,7 +513,6 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
              priority, type);
       spin_unlock_irqrestore(&g_irq_lock, flags);
-      sched_unlock();
 
       return cpuint;
     }
@@ -533,7 +530,6 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
   putreg32(cpuint, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -32,7 +32,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -197,10 +196,8 @@ static void start_rt_timer(struct rt_timer_s *timer,
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
   start_rt_timer_nolock(timer, timeout, repeat);
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -306,7 +303,6 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -334,7 +330,6 @@ static void delete_rt_timer(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************
@@ -458,7 +453,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   ESP32S2_TIM_ACKINT(priv->timer);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -518,7 +512,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return 0;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_rtc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rtc.c
@@ -2688,7 +2688,6 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      sched_lock();
       flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
@@ -2701,7 +2700,6 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->alarm_hdl = NULL;
 
       spin_unlock_irqrestore(&g_rtc_lock, flags);
-      sched_unlock();
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -29,7 +29,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -816,7 +815,6 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
     }
 
   irqstate = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -831,7 +829,6 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
       irqerr("Unable to allocate CPU interrupt for priority=%d and flags=%d",
              priority, flags);
       spin_unlock_irqrestore(&g_irq_lock, irqstate);
-      sched_unlock();
 
       return cpuint;
     }
@@ -860,7 +857,6 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
   putreg32(cpuint, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, irqstate);
-  sched_unlock();
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -613,7 +612,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   modifyreg32(SYSTIMER_INT_CLR_REG, 0, SYSTIMER_TARGET2_INT_CLR);
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -675,7 +673,6 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 
   return OK;
 }
@@ -809,7 +806,6 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
   struct esp32s3_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -837,7 +833,6 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Because sched_lock is now called in spin_lock_irqsave, there is no need to call it explicitly.
please see https://github.com/apache/nuttx/pull/14578 for more info.

## Impact

All places that call the spin_lock_irqsave interface and also call sched_lock in arch directory.

## Testing

CI


