### PR TITLE
Use small lock to protect resources related to ethernet.

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -40,7 +40,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/wdog.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/signal.h>
@@ -298,6 +298,7 @@ struct lpc17_40_driver_s
   struct work_s lp_rxwork;      /* RX work continuation */
   struct work_s lp_pollwork;    /* Poll work continuation */
   uint32_t status;
+  spinlock_t lp_lock;           /* Spinlock */
 
   /* This holds the information visible to the NuttX networking layer */
 
@@ -424,6 +425,7 @@ static inline void lpc17_40_txdescinit(struct lpc17_40_driver_s *priv);
 static inline void lpc17_40_rxdescinit(struct lpc17_40_driver_s *priv);
 static inline void lpc17_40_macmode(uint8_t mode);
 static void lpc17_40_ethreset(struct lpc17_40_driver_s *priv);
+static void lpc17_40_ethreset_nolock(struct lpc17_40_driver_s *priv);
 
 /****************************************************************************
  * Private Functions
@@ -1003,14 +1005,14 @@ static void lpc17_40_rxdone_work(void *arg)
    * lp-txpending TX underrun state is in effect.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lp_lock);
   if (!priv->lp_txpending)
     {
       priv->lp_inten |= ETH_RXINTS;
       lpc17_40_putreg(priv->lp_inten, LPC17_40_ETH_INTEN);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lp_lock, flags);
 }
 
 /****************************************************************************
@@ -1534,7 +1536,7 @@ static int lpc17_40_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lp_lock);
   up_disable_irq(LPC17_40_IRQ_ETH);
 
   /* Cancel the TX timeout timers */
@@ -1543,9 +1545,9 @@ static int lpc17_40_ifdown(struct net_driver_s *dev)
 
   /* Reset the device and mark it as down. */
 
-  lpc17_40_ethreset(priv);
+  lpc17_40_ethreset_nolock(priv);
   priv->lp_ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lp_lock, flags);
   return OK;
 }
 
@@ -2909,14 +2911,8 @@ static inline void lpc17_40_macmode(uint8_t mode)
  *
  ****************************************************************************/
 
-static void lpc17_40_ethreset(struct lpc17_40_driver_s *priv)
+static void lpc17_40_ethreset_nolock(struct lpc17_40_driver_s *priv)
 {
-  irqstate_t flags;
-
-  /* Reset the MAC */
-
-  flags = enter_critical_section();
-
   /* Put the MAC into the reset state */
 
   lpc17_40_putreg((ETH_MAC1_TXRST    | ETH_MAC1_MCSTXRST | ETH_MAC1_RXRST |
@@ -2965,7 +2961,15 @@ static void lpc17_40_ethreset(struct lpc17_40_driver_s *priv)
   /* Clear any pending interrupts (shouldn't be any) */
 
   lpc17_40_putreg(0xffffffff, LPC17_40_ETH_INTCLR);
-  leave_critical_section(flags);
+}
+
+static void lpc17_40_ethreset(struct lpc17_40_driver_s *priv)
+{
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave(&priv->lp_lock);
+  lpc17_40_ethreset_nolock(priv);
+  spin_unlock_irqrestore(&priv->lp_lock, flags);
 }
 
 /****************************************************************************
@@ -3032,6 +3036,8 @@ static inline int lpc17_40_ethinitialize(int intf)
   priv->lp_dev.d_ioctl   = lpc17_40_eth_ioctl; /* Handle network IOCTL commands */
 #endif
   priv->lp_dev.d_private = priv;               /* Used to recover private state from dev */
+
+  spin_lock_init(&priv->lp_lock);              /* Initialize spinlock */
 
 #if CONFIG_LPC17_40_NINTERFACES > 1
 # error "A mechanism to associate base address an IRQ with an interface is needed"

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -39,7 +39,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/queue.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
@@ -512,6 +512,7 @@ struct lpc43_ethmac_s
   struct wdog_s        txtimeout;   /* TX timeout timer */
   struct work_s        irqwork;     /* For deferring work to the work queue */
   struct work_s        pollwork;    /* For deferring work to the work queue */
+  spinlock_t           lock;        /* Spinlock */
 
   /* This holds the information visible to the NuttX network */
 
@@ -2126,7 +2127,7 @@ static int lpc43_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   up_disable_irq(LPC43M4_IRQ_ETHERNET);
 
   /* Cancel the TX timeout timers */
@@ -2143,7 +2144,7 @@ static int lpc43_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return OK;
 }
 
@@ -3606,6 +3607,8 @@ static inline int lpc43_ethinitialize(void)
   priv->dev.d_ioctl   = lpc43_ioctl;    /* Support PHY ioctl() calls */
 #endif
   priv->dev.d_private = &g_lpc43ethmac; /* Used to recover private state from dev */
+
+  spin_lock_init(&priv->lock);          /* Initialize spinlock */
 
   /* Configure GPIO pins to support Ethernet */
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -40,7 +40,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/queue.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
@@ -614,6 +614,7 @@ struct stm32_ethmac_s
   struct wdog_s        txtimeout;   /* TX timeout timer */
   struct work_s        irqwork;     /* For deferring interrupt work to the work queue */
   struct work_s        pollwork;    /* For deferring poll work to the work queue */
+  spinlock_t           lock;        /* Spinlock */
 
   /* This holds the information visible to the NuttX network */
 
@@ -2359,7 +2360,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   up_disable_irq(STM32_IRQ_ETH);
 
   /* Cancel the TX timeout timers */
@@ -2376,7 +2377,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return OK;
 }
 
@@ -3930,6 +3931,8 @@ int stm32_ethinitialize(int intf)
 #endif
   priv->dev.d_private = g_stm32ethmac;  /* Used to recover private state from dev */
   priv->intf          = intf;           /* Remember the interface number */
+
+  spin_lock_init(&priv->lock);          /* Initialize spinlock */
 
   stm32_get_uniqueid(uid);
   crc = crc64(uid, 12);

--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -38,7 +38,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/queue.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
@@ -613,6 +613,7 @@ struct stm32_ethmac_s
   struct wdog_s        txtimeout;   /* TX timeout timer */
   struct work_s        irqwork;     /* For deferring interrupt work to the work queue */
   struct work_s        pollwork;    /* For deferring poll work to the work queue */
+  spinlock_t           lock;        /* Spinlock */
 
   /* This holds the information visible to the NuttX network */
 
@@ -2472,7 +2473,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   up_disable_irq(STM32_IRQ_ETH);
 
   /* Cancel the TX timeout timers */
@@ -2489,7 +2490,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return OK;
 }
 
@@ -4191,6 +4192,8 @@ static inline int stm32_ethinitialize(int intf)
 #endif
   priv->dev.d_private = g_stm32ethmac;  /* Used to recover private state */
   priv->intf          = intf;           /* Remember the interface number */
+
+  spin_lock_init(&priv->lock);          /* Initialize spinlock */
 
   stm32_get_uniqueid(uid);
   crc = crc64(uid, 12);

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -41,7 +41,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/queue.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
@@ -614,6 +614,7 @@ struct stm32_ethmac_s
   struct wdog_s        txtimeout;   /* TX timeout timer */
   struct work_s        irqwork;     /* For deferring interrupt work to the work queue */
   struct work_s        pollwork;    /* For deferring poll work to the work queue */
+  spinlock_t           lock;        /* Spinlock */
 
   /* This holds the information visible to the NuttX network */
 
@@ -2473,7 +2474,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   up_disable_irq(STM32_IRQ_ETH);
 
   /* Cancel the TX timeout timers */
@@ -2490,7 +2491,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return OK;
 }
 
@@ -4190,6 +4191,8 @@ static inline int stm32_ethinitialize(int intf)
 #endif
   priv->dev.d_private = g_stm32ethmac;  /* Used to recover private state */
   priv->intf          = intf;           /* Remember the interface number */
+
+  spin_lock_init(&priv->lock);          /* Initialize spinlock */
 
   stm32_get_uniqueid(uid);
   crc = crc64(uid, 12);

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -39,7 +39,7 @@
 
 #include <arpa/inet.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
@@ -304,6 +304,7 @@ struct pic32mx_driver_s
   struct wdog_s pd_txtimeout;   /* TX timeout timer */
   struct work_s pd_irqwork;     /* For deferring interrupt work to the work queue */
   struct work_s pd_pollwork;    /* For deferring poll work to the work queue */
+  spinlock_t pd_lock;           /* Spinlock */
 
   sq_queue_t pd_freebuffers;    /* The free buffer list */
 
@@ -2217,7 +2218,7 @@ static int pic32mx_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->pd_lock);
 #if CONFIG_PIC32MX_NINTERFACES > 1
   up_disable_irq(priv->pd_irqsrc);
 #else
@@ -2232,7 +2233,7 @@ static int pic32mx_ifdown(struct net_driver_s *dev)
 
   pic32mx_ethreset(priv);
   priv->pd_ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->pd_lock, flags);
   return OK;
 }
 
@@ -3082,7 +3083,7 @@ static void pic32mx_ethreset(struct pic32mx_driver_s *priv)
 
   /* Reset the MAC */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->pd_lock);
 
   /* Ethernet Controller Initialization *************************************/
 
@@ -3146,7 +3147,7 @@ static void pic32mx_ethreset(struct pic32mx_driver_s *priv)
 
   up_udelay(50);
   pic32mx_putreg(0, PIC32MX_EMAC1_CFG1);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->pd_lock, flags);
 }
 
 /****************************************************************************
@@ -3199,6 +3200,8 @@ static inline int pic32mx_ethinitialize(int intf)
   priv->pd_irq           = ??;             /* Ethernet controller IRQ vector number */
   priv->pd_irqsrc        = ??;             /* Ethernet controller IRQ source number */
 #endif
+
+  spin_lock_init(&priv->pd_lock);          /* Initialize spinlock */
 
   /* Reset the Ethernet controller and leave in the ifdown state.  The
    * Ethernet controller will be properly re-initialized each time

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -38,7 +38,7 @@
 #include <arpa/inet.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/kmalloc.h>
@@ -272,6 +272,7 @@ struct mpfs_ethmac_s
   struct wdog_s txtimeout;                       /* TX timeout timer */
   struct work_s irqwork;                         /* For deferring interrupt work to the work queue */
   struct work_s pollwork;                        /* For deferring poll work to the work queue */
+  spinlock_t    lock;                            /* Spinlock */
 
   /* This holds the information visible to the NuttX network */
 
@@ -1588,7 +1589,7 @@ static int mpfs_ifdown(struct net_driver_s *dev)
 
   /* Disable the Ethernet interrupt */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&priv->lock);
   up_disable_irq(priv->mac_q_int[0]);
   up_disable_irq(priv->mac_q_int[1]);
   up_disable_irq(priv->mac_q_int[2]);
@@ -1613,7 +1614,7 @@ static int mpfs_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&priv->lock, flags);
   return OK;
 }
 
@@ -3607,6 +3608,8 @@ int mpfs_ethinitialize(int intf)
   priv->queue[1].dma_rxbuf_size = (uint32_t *)(base + DMA_RXBUF_SIZE_Q1);
   priv->queue[2].dma_rxbuf_size = (uint32_t *)(base + DMA_RXBUF_SIZE_Q2);
   priv->queue[3].dma_rxbuf_size = (uint32_t *)(base + DMA_RXBUF_SIZE_Q3);
+
+  spin_lock_init(&priv->lock);          /* Initialize spinlock */
 
   /* Generate a locally administrated MAC address for this ethernet if */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to ethernet.

## Impact

The underlying implementation of Ethernet.

## Testing

CI


