### PR TITLE
arch: select LIBC_ARCH_ELF when using COREDUMP

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -2011,6 +2011,7 @@ config ASSERT_PAUSE_CPU_TIMEOUT
 config COREDUMP
 	bool "Coredump support"
 	depends on ARCH_HAVE_TCBINFO
+	select LIBC_ARCH_ELF
 	default n
 	---help---
 		Generate ELF core dump to provide information about the CPU state and the


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Coredump doens't need CONFIG_ELF to be enabled, but need elf.h to include correct elf32.h or elf64.h.
Select `LIBC_ARCH_ELF` in `COREDUMP` to allow `LIBC_ARCH_ELF_64BIT` to be
defined correctly.

## Impact

64bit coredump will work correctly without enabling `CONFIG_ELF`

## Testing

Using exact method in https://github.com/apache/nuttx/pull/15638 but with `CONFIG_ELF` disabled.
Note, need to revert a095b1d6a6adf560894b27e953e02908305922c8 for unknown reason, which is currently under investigatement.


