### PR TITLE
misc/coredump: move coredump info to note

### DIFF
--- a/include/nuttx/coredump.h
+++ b/include/nuttx/coredump.h
@@ -27,21 +27,20 @@
  * Included Files
  ****************************************************************************/
 
-#include <sys/utsname.h>
+#include <elf.h>
 #include <unistd.h>
+#include <sys/utsname.h>
 
+#include <nuttx/nuttx.h>
 #include <nuttx/streams.h>
 #include <nuttx/memoryregion.h>
-
-#ifdef CONFIG_ARM_COREDUMP_REGION
-#  include <nuttx/elf.h>
-#endif
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define COREDUMP_MAGIC    0x434f5245
+#define COREDUMP_MAGIC          0x434f5245
+#define COREDUMP_INFONAME_SIZE  ALIGN_UP(CONFIG_TASK_NAME_SIZE, 8)
 
 /****************************************************************************
  * Public Types
@@ -51,7 +50,6 @@
 
 struct coredump_info_s
 {
-  uint32_t        magic;
   struct utsname  name;
   struct timespec time;
   size_t          size;


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add a custom note for NuttX information including magic and coredump file data size, so when system reboots, we can check if the block device contains valid coredump file, and save it to file system.

## Impact

Need apps repo to update correspondingly.

## Testing

Tested when coredump is saved to block device and restored to filesystem after reboot.



