### PR TITLE
Revert "sched/wqueue: some minor improve to reduce sched_lock range"

### DIFF
--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -140,6 +140,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR void *arg, clock_t delay)
 {
   irqstate_t flags;
+  int ret = OK;
 
   if (wqueue == NULL || work == NULL || worker == NULL)
     {
@@ -151,6 +152,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
    */
 
   flags = spin_lock_irqsave(&wqueue->lock);
+  sched_lock();
 
   /* Remove the entry from the timer and work queue. */
 
@@ -170,8 +172,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
   if (work_is_canceling(wqueue->worker, wqueue->nthreads, work))
     {
-      spin_unlock_irqrestore(&wqueue->lock, flags);
-      return 0;
+      goto out;
     }
 
   /* Initialize the work structure. */
@@ -184,18 +185,17 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
   if (!delay)
     {
-      sched_lock();
       queue_work(wqueue, work);
-      spin_unlock_irqrestore(&wqueue->lock, flags);
-      sched_unlock();
     }
   else
     {
       wd_start(&work->u.timer, delay, work_timer_expiry, (wdparm_t)work);
-      spin_unlock_irqrestore(&wqueue->lock, flags);
     }
 
-  return 0;
+out:
+  spin_unlock_irqrestore(&wqueue->lock, flags);
+  sched_unlock();
+  return ret;
 }
 
 int work_queue(int qid, FAR struct work_s *work, worker_t worker,

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -149,6 +149,7 @@ static int work_thread(int argc, FAR char *argv[])
             ((uintptr_t)strtoul(argv[2], NULL, 16));
 
   flags = spin_lock_irqsave(&wqueue->lock);
+  sched_lock();
 
   /* Loop forever */
 
@@ -191,10 +192,11 @@ static int work_thread(int argc, FAR char *argv[])
            */
 
           spin_unlock_irqrestore(&wqueue->lock, flags);
+          sched_unlock();
 
           CALL_WORKER(worker, arg);
-
           flags = spin_lock_irqsave(&wqueue->lock);
+          sched_lock();
 
           /* Mark the thread un-busy */
 
@@ -205,9 +207,7 @@ static int work_thread(int argc, FAR char *argv[])
           while (kworker->wait_count > 0)
             {
               kworker->wait_count--;
-              sched_lock();
               nxsem_post(&kworker->wait);
-              sched_unlock();
             }
         }
 
@@ -217,18 +217,19 @@ static int work_thread(int argc, FAR char *argv[])
        */
 
       wqueue->wait_count++;
-
       spin_unlock_irqrestore(&wqueue->lock, flags);
+      sched_unlock();
 
       nxsem_wait_uninterruptible(&wqueue->sem);
-
       flags = spin_lock_irqsave(&wqueue->lock);
+      sched_lock();
     }
 
   spin_unlock_irqrestore(&wqueue->lock, flags);
+  sched_unlock();
 
   nxsem_post(&wqueue->exsem);
-  return 0;
+  return OK;
 }
 
 /****************************************************************************
@@ -291,7 +292,7 @@ static int work_thread_create(FAR const char *name, int priority,
     }
 
   sched_unlock();
-  return 0;
+  return OK;
 }
 
 /****************************************************************************
@@ -407,7 +408,7 @@ int work_queue_free(FAR struct kwork_wqueue_s *wqueue)
   nxsem_destroy(&wqueue->exsem);
   kmm_free(wqueue);
 
-  return 0;
+  return OK;
 }
 
 /****************************************************************************


### PR DESCRIPTION


## Summary
This reverts commit a095b1d6a6adf560894b27e953e02908305922c8.
![fc694db0-9a9f-4fc1-a32b-26ab6aca758b](https://github.com/user-attachments/assets/6d605c2b-8c44-45a9-881a-b612655951f0)
![d5b1b30d-dd74-4851-bc2f-ebbe1daefb4d](https://github.com/user-attachments/assets/e80ff47d-eada-4c4f-b235-72d9c115a3be)

reason:
may cause dead lock

## Impact

wqueue

## Testing
sim


