### PR TITLE
tools/mkexport: kernel mode module/elf flags

### DIFF
--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -231,6 +231,10 @@ if [ "X${USRONLY}" != "Xy" ]; then
   done
 fi
 
+# Drop kernel folder modlib/gnu-elf.ld as the exported script shall suffice
+
+LDELFFLAGS=$(echo "$LDELFFLAGS" | sed -e 's:-T.*ld::')
+
 # Set LDMODULEFLAGS so that kernel modules can build in kernel mode
 
 LDMODULEFLAGS="-r"

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -231,6 +231,10 @@ if [ "X${USRONLY}" != "Xy" ]; then
   done
 fi
 
+# Set LDMODULEFLAGS so that kernel modules can build in kernel mode
+
+LDMODULEFLAGS="-r"
+
 # Save the compilation options
 
 echo "ARCHCFLAGS       = ${ARCHCFLAGS}" >"${EXPORTDIR}/scripts/Make.defs"
@@ -268,6 +272,7 @@ echo "HOSTLDFLAGS      = ${HOSTLDFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTEXEEXT       = ${HOSTEXEEXT}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "LDNAME           = ${LDNAME}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "LDELFFLAGS       = ${LDELFFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LDMODULEFLAGS    = ${LDMODULEFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_ARCH       = ${NUTTX_ARCH}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_ARCH_CHIP  = ${NUTTX_ARCH_CHIP}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_BOARD      = ${NUTTX_BOARD}" >>"${EXPORTDIR}/scripts/Make.defs"
@@ -299,6 +304,7 @@ echo "set(HOSTLDFLAGS         \"${HOSTLDFLAGS}\")"      >>"${EXPORTDIR}/scripts/
 echo "set(HOSTEXEEXT          \"${HOSTEXEEXT}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(LDNAME              \"${LDNAME}\")"           >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(LDELFFLAGS          \"${LDELFFLAGS}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(LDMODULEFLAGS       \"${LDMODULEFLAGS}\")"    >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_ARCH          \"${NUTTX_ARCH}\")"       >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_ARCH_CHIP     \"${NUTTX_ARCH_CHIP}\")"  >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_BOARD         \"${NUTTX_BOARD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"


### PR DESCRIPTION
# Summary

This adds exported LDMODULEFLAGS so that kernel modules can build with Kernel mode NuttX. Without it, we have link errors like:

```sh
make[3]: Entering directory '/tmp/apps/examples/module/chardev'
LD:  /tmp/apps/bin/chardev arm-none-eabi-ld: warning: cannot find entry symbol _start; defaulting to 0000000000008000
arm-none-eabi-ld: chardev.c.tmp.apps.examples.module.chardev.o: in function `module_uninitialize':
/tmp/apps/examples/module/chardev/chardev.c:111: undefined reference to `unregister_driver'
arm-none-eabi-ld: chardev.c.tmp.apps.examples.module.chardev.o: in function `module_initialize':
/tmp/apps/examples/module/chardev/chardev.c:129: undefined reference to `register_driver'
arm-none-eabi-ld: /tmp/apps/import/startup/crt0.o: in function `__start':
/tmp/nuttx/arch/arm/src/armv7-a/crt0.c:133: undefined reference to `main'
make[3]: *** [/tmp/apps/Application.mk:308: /tmp/apps/bin/chardev] Error 1
```

It also stops including NuttX side paths in exported `LDELFFLAGS`. Currently we have:

```sh
$ fgrep LDELFFLAGS apps/import/scripts/Make.defs
LDELFFLAGS = -e main -T /tmp/nuttx/libs/libc/modlib/gnu-elf.ld
```
But by design, exported SDK shall not refer to NuttX folder any more because apps side may not have access to kernel sources in the SDK scenario.

# Impacts

Projects using exported SDK

# Testing

- local checks with EXAMPLES_MODULE enabled `qemu-armv7a:nsh` and `qemu-armv7a:knsh`
- CI checks
