### PR TITLE
tools: Export LLVM flags for kernel build

### DIFF
--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -107,6 +107,9 @@ ifdef CONFIG_LIBCXX
 else
 	@echo "NUTTX_CXX=\"cxx\"" >> $(EXPORTDIR)/makeinfo.sh
 endif
+	@echo "LLVM_ARCHTYPE=\"$(LLVM_ARCHTYPE)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "LLVM_CPUTYPE=\"$(LLVM_CPUTYPE)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "LLVM_ABITYPE=\"$(LLVM_ABITYPE)\"" >> $(EXPORTDIR)/makeinfo.sh
 	$(Q) chmod 755 $(EXPORTDIR)/makeinfo.sh
 
 clean:

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -273,6 +273,9 @@ echo "NUTTX_ARCH_CHIP  = ${NUTTX_ARCH_CHIP}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_BOARD      = ${NUTTX_BOARD}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_BUILD      = ${NUTTX_BUILD}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "NUTTX_CXX        = ${NUTTX_CXX}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LLVM_ARCHTYPE    = ${LLVM_ARCHTYPE}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LLVM_CPUTYPE     = ${LLVM_CPUTYPE}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LLVM_ABITYPE     = ${LLVM_ABITYPE}" >>"${EXPORTDIR}/scripts/Make.defs"
 
 echo "set(ARCHCFLAGS          \"${ARCHCFLAGS}\")"       > "${EXPORTDIR}/scripts/target.cmake"
 echo "set(ARCHCPUFLAGS        \"${ARCHCPUFLAGS}\")"     >>"${EXPORTDIR}/scripts/target.cmake"
@@ -304,6 +307,9 @@ echo "set(NUTTX_ARCH_CHIP     \"${NUTTX_ARCH_CHIP}\")"  >>"${EXPORTDIR}/scripts/
 echo "set(NUTTX_BOARD         \"${NUTTX_BOARD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_BUILD         \"${NUTTX_BUILD}\")"      >>"${EXPORTDIR}/scripts/target.cmake"
 echo "set(NUTTX_CXX           \"${NUTTX_CXX}\")"        >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(LLVM_ARCHTYPE       \"${LLVM_ARCHTYPE}\")"    >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(LLVM_CPUTYPE        \"${LLVM_CPUTYPE}\")"     >>"${EXPORTDIR}/scripts/target.cmake"
+echo "set(LLVM_ABITYPE        \"${LLVM_ABITYPE}\")"     >>"${EXPORTDIR}/scripts/target.cmake"
 
 
 # Additional compilation options when the kernel is built


### PR DESCRIPTION
##Summary
- Added LLVM_ARCHTYPE, LLVM_CPUTYPE, and LLVM_ABITYPE to the exported build configuration in both `Export.mk` and `mkexport.sh`
- These flags are now included in the generated `makeinfo.sh`, `Make.defs`, and `target.cmake` files during the export process

##Impact
- Enables LLVM-specific build configurations to be properly exported and used in kernel builds
- Improves compatibility with LLVM-based toolchains by ensuring necessary architecture, CPU, and ABI information is available during the build process
- No functional changes for non-LLVM builds, as these flags are only used when LLVM toolchains are specified

## Testing

GitHub CI and local board

