### PR TITLE
tools: Export ZIG/ZIGFLAGS in Export.mk instead

### DIFF
--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -80,6 +80,8 @@ endif
 	@echo "NXFLATLDFLAGS2=\"$(NXFLATLDFLAGS2)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "OBJCOPY=\"$(OBJCOPY)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "OBJDUMP=\"$(OBJDUMP)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "ZIG=\"$(ZIG)\"" >> $(EXPORTDIR)/makeinfo.sh
+	@echo "ZIGFLAGS=\"$(ZIGFLAGS)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "OBJEXT=\"$(OBJEXT)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "STRIP=\"$(STRIP)\"" >> $(EXPORTDIR)/makeinfo.sh
 	@echo "NUTTX_ARCH=\"$(CONFIG_ARCH)\"" >> $(EXPORTDIR)/makeinfo.sh

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -777,8 +777,7 @@ savedefconfig: apps_preconfig
 # that the archiver is 'ar'
 
 export: $(NUTTXLIBS)
-	$(Q) ZIG="${ZIG}" ZIGFLAGS="${ZIGFLAGS}" MAKE="${MAKE}" \
-		$(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
+	$(Q) MAKE="${MAKE}" $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
 
 # General housekeeping targets:  dependencies, cleaning, etc.
 #


### PR DESCRIPTION
## Summary
- Moved the export of `ZIG` and `ZIGFLAGS` from `tools/Unix.mk` to `tools/Export.mk`
- Simplified the `export` target in `tools/Unix.mk` by removing redundant `ZIG` and `ZIGFLAGS` variables

## Impact
- No functional changes - the `ZIG` and `ZIGFLAGS` variables are still exported correctly
- Improves code maintainability by centralizing environment variable exports in `Export.mk`

## Testing

GitHub CI and local build

