### PR TITLE
x86/Toolchain.defs: Add LLVM target definitions

### DIFF
--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -32,6 +32,11 @@ ARCHCPUFLAGS = -march=i486 -mtune=i486 -fno-stack-protector
 ARCHPICFLAGS = -fpic
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 
+# LLVM target definitions
+LLVM_ARCHTYPE := x86
+LLVM_CPUTYPE := i486
+LLVM_ABITYPE := sysv
+
 # Check if building a 32-bit target with a 64-bit toolchain
 
 ifeq ($(CONFIG_ARCH_X86_M32),y)

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -122,6 +122,11 @@ add_compile_options(
   -Wno-unknown-pragmas
   $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
 
+# LLVM target definitions
+set(LLVM_ARCH "x86_64")
+set(LLVM_CPU "x86-64")
+set(LLVM_ABI "sysv")
+
 if(CONFIG_CXX_STANDARD)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=${CONFIG_CXX_STANDARD}>)
 endif()

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -70,6 +70,11 @@ ARCHCPUFLAGS = -fno-pic -mcmodel=large -mno-red-zone -mrdrnd
 ARCHPICFLAGS = -fPIC
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 
+# LLVM target definitions
+LLVM_ARCHTYPE := x86_64
+LLVM_CPUTYPE := x86-64
+LLVM_ABITYPE := sysv
+
 # We have to use a cross-development toolchain under Cygwin because the native
 # Cygwin toolchains don't generate ELF binaries.
 


### PR DESCRIPTION
## Summary
- Added LLVM target definitions (`LLVM_ARCHTYPE`, `LLVM_CPUTYPE`, `LLVM_ABITYPE`) to the x86 toolchain configuration file
- These definitions are necessary for compatibility with LLVM-based toolchains

## Impact
- Enables support for LLVM toolchains when building for x86 targets
- No functional changes for existing GCC-based toolchains
- Improves cross-compilation flexibility by supporting additional toolchain options

## Testing
qemu-i486 with rust/hello example