### PR TITLE
build: CMake fix for sim:btuart

### DIFF
--- a/drivers/wireless/bluetooth/CMakeLists.txt
+++ b/drivers/wireless/bluetooth/CMakeLists.txt
@@ -54,5 +54,9 @@ if(CONFIG_DRIVERS_BLUETOOTH)
     list(APPEND SRCS bt_rpmsghci.c)
   endif()
 
+  if(CONFIG_BLUETOOTH_BRIDGE)
+    list(APPEND SRCS bt_bridge.c)
+  endif()
+
   target_sources(drivers PRIVATE ${SRCS})
 endif()


### PR DESCRIPTION
## Summary

CMake build was broken with undefined reference to bt_bridge_register function.
```
[9/11] Linking C executable nuttx
FAILED: nuttx 
: && /usr/bin/cc  -Wl,--gc-sections -Wl,-no-pie -Wl,-Ttext-segment=0x40000000 -Wl,-z,noexecstack -T nuttx.ld @CMakeFiles/nuttx.rsp -o nuttx && :
/usr/bin/ld: nuttx.rel: in function `bt_driver_register_with_id':
/home/dan/priv/nuttx/nuttx/drivers/wireless/bluetooth/bt_driver.c:100: undefined reference to `bt_bridge_register'
```

It was because bt_bridge.c file is missing in drivers/wireless/bluetooth/CMakeLists.txt. 

## Impact

Minor impact, makefile based build worked fine, CMake based build is fixed now.

## Testing

Host used:
```
Linux 6.8.0-51-generic #52~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Dec  9 15:00:52 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```
```
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
```

Target:
```
cmake .. -G Ninja -DBOARD_CONFIG=sim:btuart
```


