### PR TITLE
sched/spin_lock: rename raw_spin_* to spin_*_notrace

### DIFF
--- a/arch/arm/src/am335x/am335x_can.c
+++ b/arch/arm/src/am335x/am335x_can.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
+#include <sched.h>
 
 #include <arch/board/board.h>
 #include <nuttx/irq.h>
@@ -1083,6 +1084,7 @@ struct can_dev_s *am335x_can_initialize(int port)
   syslog(LOG_DEBUG, "CAN%d\n", port);
 
   flags = spin_lock_irqsave(&g_can_lock);
+  sched_lock();
 
 #ifdef CONFIG_AM335X_CAN0
   if (port == 0)
@@ -1113,10 +1115,12 @@ struct can_dev_s *am335x_can_initialize(int port)
       canerr("Unsupported port: %d\n", port);
 
       spin_unlock_irqrestore(&g_can_lock, flags);
+      sched_unlock();
       return NULL;
     }
 
   spin_unlock_irqrestore(&g_can_lock, flags);
+  sched_unlock();
 
   return candev;
 }
@@ -1128,6 +1132,7 @@ void am335x_can_uninitialize(struct can_dev_s *dev)
   DEBUGASSERT(dev);
 
   flags = spin_lock_irqsave(&g_can_lock);
+  sched_lock();
 
 #ifdef CONFIG_AM335X_CAN0
   if (dev == &g_can0dev)
@@ -1155,6 +1160,7 @@ void am335x_can_uninitialize(struct can_dev_s *dev)
     }
 
   spin_unlock_irqrestore(&g_can_lock, flags);
+  sched_unlock();
 }
 
 #endif

--- a/arch/arm/src/cxd56xx/cxd56_timer.c
+++ b/arch/arm/src/cxd56xx/cxd56_timer.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -433,8 +432,7 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   struct cxd56_lowerhalf_s *priv = (struct cxd56_lowerhalf_s *)lower;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -444,8 +442,7 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   priv->callback = callback;
   priv->arg      = arg;
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_timer.c
+++ b/arch/arm/src/cxd56xx/cxd56_timer.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -433,6 +434,7 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -443,6 +445,7 @@ static void cxd56_setcallback(struct timer_lowerhalf_s *lower,
   priv->arg      = arg;
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/dm320/dm320_usbdev.c
+++ b/arch/arm/src/dm320/dm320_usbdev.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -1045,10 +1046,12 @@ static int dm320_wrrequest(struct dm320_ep_s *privep)
 {
   int ret;
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   ret = dm320_wrrequest_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 
   return ret;
 }
@@ -2025,10 +2028,12 @@ static int dm320_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity and reset the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   dm320_cancelrequests(privep);
   dm320_epreset(privep->epphy);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -2168,6 +2173,7 @@ static int dm320_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Check for NULL packet */
 
@@ -2228,6 +2234,7 @@ static int dm320_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -2258,8 +2265,10 @@ static int dm320_epcancel(struct usbdev_ep_s *ep,
   priv = privep->dev;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   dm320_cancelrequests(privep);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return OK;
 }
 

--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -243,8 +243,10 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
   imx9_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 #endif
 
@@ -473,6 +475,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
 
   /* Disable channel IRQ requests */
 
@@ -525,6 +528,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -242,11 +242,9 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
   imx9_tcd_free_nolock(tcd);
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 #endif
 
@@ -474,8 +472,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
 
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
 
   /* Disable channel IRQ requests */
 
@@ -527,8 +524,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
       callback((DMACH_HANDLE)dmach, arg, true, result);
     }
 
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -814,6 +814,7 @@ static int imx9_txpoll(struct net_driver_s *dev)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (priv->dev.d_len > 0)
     {
@@ -834,6 +835,7 @@ static int imx9_txpoll(struct net_driver_s *dev)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -813,8 +813,7 @@ static int imx9_txpoll(struct net_driver_s *dev)
    * the field d_len is set to a value > 0.
    */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   if (priv->dev.d_len > 0)
     {
@@ -834,8 +833,7 @@ static int imx9_txpoll(struct net_driver_s *dev)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   /* If zero is returned, the polling will continue until all connections
    * have been examined.

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -695,8 +694,7 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->spinlock);
 
 #ifdef CONFIG_IMXRT_LPI2C_DMA
   if (priv->dma == NULL)
@@ -777,8 +775,7 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
       imxrt_lpi2c_putreg(priv, IMXRT_LPI2C_SIER_OFFSET, 0);
     }
 
-  spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->spinlock, flags);
   return ret;
 }
 #else

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -695,6 +696,7 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
+  sched_lock();
 
 #ifdef CONFIG_IMXRT_LPI2C_DMA
   if (priv->dma == NULL)
@@ -776,6 +778,7 @@ imxrt_lpi2c_sem_waitdone(struct imxrt_lpi2c_priv_s *priv)
     }
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
+  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/kinetis/kinetis_edma.c
+++ b/arch/arm/src/kinetis/kinetis_edma.c
@@ -244,8 +244,10 @@ static void kinetis_tcd_free(struct kinetis_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
   kinetis_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 #endif
 
@@ -454,6 +456,7 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   uint8_t chan;
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
 
   /* Disable channel ERROR interrupts */
 
@@ -505,6 +508,7 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   dmach->state    = KINETIS_DMA_IDLE;
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/kinetis/kinetis_edma.c
+++ b/arch/arm/src/kinetis/kinetis_edma.c
@@ -243,11 +243,9 @@ static void kinetis_tcd_free(struct kinetis_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
   kinetis_tcd_free_nolock(tcd);
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 #endif
 
@@ -455,8 +453,7 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   uint8_t regval8;
   uint8_t chan;
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
 
   /* Disable channel ERROR interrupts */
 
@@ -507,8 +504,7 @@ static void kinetis_dmaterminate(struct kinetis_dmach_s *dmach, int result)
   dmach->arg      = NULL;
   dmach->state    = KINETIS_DMA_IDLE;
 
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -809,11 +808,9 @@ static uint32_t lpc17_40_usbcmd(uint16_t cmd, uint8_t data)
 
   /* Disable interrupt and clear CDFULL and CCEMPTY interrupt status */
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   tmp = lpc17_40_usbcmd_nolock(cmd, data);
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
 
   return tmp;
 }
@@ -1213,11 +1210,9 @@ static int lpc17_40_wrrequest(struct lpc17_40_ep_s *privep)
 {
   int ret;
 
-  irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  irqstate_t flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   ret = lpc17_40_wrrequest_nolock(privep);
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
 
   return ret;
 }
@@ -2762,8 +2757,7 @@ static int lpc17_40_epdisable(struct usbdev_ep_s *ep)
 
   /* Cancel any ongoing activity */
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   lpc17_40_cancelrequests(privep);
 
   /* Disable endpoint and interrupt */
@@ -2778,8 +2772,7 @@ static int lpc17_40_epdisable(struct usbdev_ep_s *ep)
   regval &= ~mask;
   lpc17_40_putreg(regval, LPC17_40_USBDEV_EPINTEN);
 
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -2968,8 +2961,7 @@ static int lpc17_40_epsubmit(struct usbdev_ep_s *ep,
 
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
-  flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags       = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3015,8 +3007,7 @@ static int lpc17_40_epsubmit(struct usbdev_ep_s *ep,
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return ret;
 }
 
@@ -3044,11 +3035,9 @@ static int lpc17_40_epcancel(struct usbdev_ep_s *ep,
 
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   lpc17_40_cancelrequests(privep);
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3067,8 +3056,7 @@ static int lpc17_40_epstall(struct usbdev_ep_s *ep, bool resume)
 
   /* STALL or RESUME the endpoint */
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, privep->epphy);
   lpc17_40_usbcmd_nolock(CMD_USBDEV_EPSETSTATUS | privep->epphy,
                          (resume ? 0 : CMD_SETSTAUS_ST));
@@ -3080,8 +3068,7 @@ static int lpc17_40_epstall(struct usbdev_ep_s *ep, bool resume)
       lpc17_40_wrrequest_nolock(privep);
     }
 
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3292,16 +3279,14 @@ static int lpc17_40_wakeup(struct usbdev_s *dev)
 
   usbtrace(TRACE_DEVWAKEUP, (uint16_t)g_usbdev.devstatus);
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   if (DEVSTATUS_CONNECT(g_usbdev.devstatus))
     {
       arg |= CMD_STATUS_CONNECT;
     }
 
   lpc17_40_usbcmd_nolock(CMD_USBDEV_SETSTATUS, arg);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return OK;
 }
 
@@ -3397,8 +3382,7 @@ void arm_usbinitialize(void)
 
   /* Step 1: Enable power by setting PCUSB in the PCONP register */
 
-  flags   = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags   = spin_lock_irqsave_nopreempt(&priv->lock);
   regval  = lpc17_40_getreg(LPC17_40_SYSCON_PCONP);
   regval |= SYSCON_PCONP_PCUSB;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_PCONP);
@@ -3439,8 +3423,7 @@ void arm_usbinitialize(void)
   regval = lpc17_40_getreg(LPC17_40_SYSCON_USBINTST);
   regval &= ~SYSCON_USBINTST_ENINTS;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_USBINTST);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   /* Initialize the device state structure */
 
@@ -3574,8 +3557,7 @@ void arm_usbuninitialize(void)
 
   /* Disconnect device */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   lpc17_40_pullup_nolock(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
   lpc17_40_usbcmd_nolock(CMD_USBDEV_CONFIG, 0);
@@ -3590,8 +3572,7 @@ void arm_usbuninitialize(void)
   regval = lpc17_40_getreg(LPC17_40_SYSCON_PCONP);
   regval &= ~SYSCON_PCONP_PCUSB;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_PCONP);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_usbdev.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -809,8 +810,10 @@ static uint32_t lpc17_40_usbcmd(uint16_t cmd, uint8_t data)
   /* Disable interrupt and clear CDFULL and CCEMPTY interrupt status */
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
+  sched_lock();
   tmp = lpc17_40_usbcmd_nolock(cmd, data);
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
+  sched_unlock();
 
   return tmp;
 }
@@ -1211,8 +1214,10 @@ static int lpc17_40_wrrequest(struct lpc17_40_ep_s *privep)
   int ret;
 
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   ret = lpc17_40_wrrequest_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 
   return ret;
 }
@@ -2758,6 +2763,7 @@ static int lpc17_40_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   lpc17_40_cancelrequests(privep);
 
   /* Disable endpoint and interrupt */
@@ -2773,6 +2779,7 @@ static int lpc17_40_epdisable(struct usbdev_ep_s *ep)
   lpc17_40_putreg(regval, LPC17_40_USBDEV_EPINTEN);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -2962,6 +2969,7 @@ static int lpc17_40_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3008,6 +3016,7 @@ static int lpc17_40_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -3036,8 +3045,10 @@ static int lpc17_40_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   lpc17_40_cancelrequests(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3057,6 +3068,7 @@ static int lpc17_40_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, privep->epphy);
   lpc17_40_usbcmd_nolock(CMD_USBDEV_EPSETSTATUS | privep->epphy,
                          (resume ? 0 : CMD_SETSTAUS_ST));
@@ -3069,6 +3081,7 @@ static int lpc17_40_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3280,6 +3293,7 @@ static int lpc17_40_wakeup(struct usbdev_s *dev)
   usbtrace(TRACE_DEVWAKEUP, (uint16_t)g_usbdev.devstatus);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   if (DEVSTATUS_CONNECT(g_usbdev.devstatus))
     {
       arg |= CMD_STATUS_CONNECT;
@@ -3287,6 +3301,7 @@ static int lpc17_40_wakeup(struct usbdev_s *dev)
 
   lpc17_40_usbcmd_nolock(CMD_USBDEV_SETSTATUS, arg);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3383,6 +3398,7 @@ void arm_usbinitialize(void)
   /* Step 1: Enable power by setting PCUSB in the PCONP register */
 
   flags   = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   regval  = lpc17_40_getreg(LPC17_40_SYSCON_PCONP);
   regval |= SYSCON_PCONP_PCUSB;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_PCONP);
@@ -3424,6 +3440,7 @@ void arm_usbinitialize(void)
   regval &= ~SYSCON_USBINTST_ENINTS;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_USBINTST);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   /* Initialize the device state structure */
 
@@ -3558,6 +3575,7 @@ void arm_usbuninitialize(void)
   /* Disconnect device */
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   lpc17_40_pullup_nolock(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
   lpc17_40_usbcmd_nolock(CMD_USBDEV_CONFIG, 0);
@@ -3573,6 +3591,7 @@ void arm_usbuninitialize(void)
   regval &= ~SYSCON_PCONP_PCUSB;
   lpc17_40_putreg(regval, LPC17_40_SYSCON_PCONP);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc214x/lpc214x_usbdev.c
+++ b/arch/arm/src/lpc214x/lpc214x_usbdev.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -746,12 +747,14 @@ static uint32_t lpc214x_usbcmd(uint16_t cmd, uint8_t data)
   /* Disable interrupt and clear CDFULL and CCEMPTY interrupt status */
 
   flags = spin_lock_irqsave(&g_usbdev.lock);
+  sched_lock();
 
   tmp = lpc214x_usbcmd_nolock(cmd, data);
 
   /* Restore the interrupt flags */
 
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
+  sched_unlock();
 
   return tmp;
 }
@@ -1152,8 +1155,10 @@ static int lpc214x_wrrequest(struct lpc214x_ep_s *privep)
   int ret;
 
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   ret = lpc214x_wrrequest_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 
   return ret;
 }
@@ -1241,8 +1246,10 @@ static void lpc214x_cancelrequests_nolock(struct lpc214x_ep_s *privep)
 static void lpc214x_cancelrequests(struct lpc214x_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   lpc214x_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -2729,6 +2736,7 @@ static int lpc214x_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   lpc214x_cancelrequests_nolock(privep);
 
   /* Disable endpoint and interrupt */
@@ -2744,6 +2752,7 @@ static int lpc214x_epdisable(struct usbdev_ep_s *ep)
   lpc214x_putreg(reg, LPC214X_USBDEV_EPINTEN);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -2932,6 +2941,7 @@ static int lpc214x_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -2978,6 +2988,7 @@ static int lpc214x_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -3006,8 +3017,10 @@ static int lpc214x_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   lpc214x_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3027,6 +3040,7 @@ static int lpc214x_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, privep->epphy);
   lpc214x_usbcmd_nolock(CMD_USB_EP_SETSTATUS | privep->epphy,
                 (resume ? 0 : USBDEV_EPSTALL));
@@ -3039,6 +3053,7 @@ static int lpc214x_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3249,6 +3264,7 @@ static int lpc214x_wakeup(struct usbdev_s *dev)
   usbtrace(TRACE_DEVWAKEUP, (uint16_t)g_usbdev.devstatus);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   if (DEVSTATUS_CONNECT(g_usbdev.devstatus))
     {
       arg |= USBDEV_DEVSTATUS_CONNECT;
@@ -3256,6 +3272,7 @@ static int lpc214x_wakeup(struct usbdev_s *dev)
 
   lpc214x_usbcmd_nolock(CMD_USB_DEV_SETSTATUS, arg);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3477,6 +3494,7 @@ void arm_usbuninitialize(void)
   /* Disconnect device */
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   lpc214x_pullup_nolock(&priv->usbdev, false);
   priv->usbdev.speed = USB_SPEED_UNKNOWN;
   lpc214x_usbcmd_nolock(CMD_USB_DEV_CONFIG, 0);
@@ -3492,6 +3510,7 @@ void arm_usbuninitialize(void)
   reg &= ~LPC214X_PCONP_PCUSB;
   lpc214x_putreg(reg, LPC214X_PCON_PCONP);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc43xx/lpc43_timer.c
+++ b/arch/arm/src/lpc43xx/lpc43_timer.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -635,6 +636,7 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -645,6 +647,7 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   priv->arg      = arg;
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc43xx/lpc43_timer.c
+++ b/arch/arm/src/lpc43xx/lpc43_timer.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -635,8 +634,7 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   struct lpc43_lowerhalf_s *priv = (struct lpc43_lowerhalf_s *)lower;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   DEBUGASSERT(priv);
   tmrinfo("Entry: callback=%p\n", callback);
@@ -646,8 +644,7 @@ static void lpc43_setcallback(struct timer_lowerhalf_s *lower,
   priv->callback = callback;
   priv->arg      = arg;
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -876,8 +877,10 @@ static void rp2040_cancelrequests_nolock(struct rp2040_ep_s *privep)
 static void rp2040_cancelrequests(struct rp2040_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   rp2040_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -1533,6 +1536,7 @@ static int rp2040_epdisable(struct usbdev_ep_s *ep)
   uinfo("EP%d\n", privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   privep->ep.maxpacket = 64;
   privep->stalled = false;
@@ -1544,6 +1548,7 @@ static int rp2040_epdisable(struct usbdev_ep_s *ep)
   rp2040_cancelrequests_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 
   return OK;
 }
@@ -1637,6 +1642,7 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
   req->xfrd = 0;
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   if (privep->stalled && privep->in)
     {
@@ -1682,6 +1688,7 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -1712,8 +1719,10 @@ static int rp2040_epcancel(struct usbdev_ep_s *ep,
   /* Remove request from req_queue */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   rp2040_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -1756,8 +1765,10 @@ static int rp2040_epstall_exec(struct usbdev_ep_s *ep)
   int ret;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   ret = rp2040_epstall_exec_nolock(ep);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -1776,6 +1787,7 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (resume)
     {
@@ -1817,6 +1829,7 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }
@@ -2167,6 +2180,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   usbtrace(TRACE_DEVUNREGISTER, 0);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Unbind the class driver */
 
@@ -2185,6 +2199,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   priv->driver = NULL;
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -872,8 +873,10 @@ static void rp23xx_cancelrequests_nolock(struct rp23xx_ep_s *privep)
 static void rp23xx_cancelrequests(struct rp23xx_ep_s *privep)
 {
   irqstate_t flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   rp23xx_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -1343,8 +1346,10 @@ static bool rp23xx_usbintr_buffstat(struct rp23xx_usbdev_s *priv)
                   else if (privep->pending_stall)
                     {
                       flags = spin_lock_irqsave(&priv->lock);
+                      sched_lock();
                       rp23xx_epstall_exec(&privep->ep);
                       spin_unlock_irqrestore(&priv->lock, flags);
+                      sched_unlock();
                     }
                 }
               else
@@ -1532,6 +1537,7 @@ static int rp23xx_epdisable(struct usbdev_ep_s *ep)
   uinfo("EP%d\n", privep->epphy);
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   privep->ep.maxpacket = 64;
   privep->stalled = false;
@@ -1543,6 +1549,7 @@ static int rp23xx_epdisable(struct usbdev_ep_s *ep)
   rp23xx_cancelrequests_nolock(privep);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
 
   return OK;
 }
@@ -1636,6 +1643,7 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
   req->xfrd = 0;
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   if (privep->stalled && privep->in)
     {
@@ -1681,6 +1689,7 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -1711,8 +1720,10 @@ static int rp23xx_epcancel(struct usbdev_ep_s *ep,
   /* Remove request from req_queue */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   rp23xx_cancelrequests_nolock(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -1762,6 +1773,7 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (resume)
     {
@@ -1803,6 +1815,7 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }
@@ -2153,6 +2166,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   usbtrace(TRACE_DEVUNREGISTER, 0);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Unbind the class driver */
 
@@ -2171,6 +2185,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   priv->driver = NULL;
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -449,6 +449,7 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   uint8_t chan;
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
 
   /* Disable channel ERROR interrupts */
 
@@ -498,6 +499,7 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   dmach->arg      = NULL;
   dmach->state    = S32K1XX_DMA_IDLE;
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -448,8 +448,7 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   uint8_t regval8;
   uint8_t chan;
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
 
   /* Disable channel ERROR interrupts */
 
@@ -498,8 +497,7 @@ static void s32k1xx_dmaterminate(struct s32k1xx_dmach_s *dmach, int result)
   dmach->callback = NULL;
   dmach->arg      = NULL;
   dmach->state    = S32K1XX_DMA_IDLE;
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -501,6 +502,7 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
+  sched_lock();
 
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -584,6 +586,7 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
 #endif
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
+  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -501,8 +500,7 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->spinlock);
 
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -585,8 +583,7 @@ s32k1xx_lpi2c_sem_waitdone(struct s32k1xx_lpi2c_priv_s *priv)
     }
 #endif
 
-  spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->spinlock, flags);
   return ret;
 }
 #else

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -494,8 +494,10 @@ static void s32k3xx_tcd_free(struct s32k3xx_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
   s32k3xx_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 #endif
 
@@ -724,6 +726,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
   void *arg;
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
 
   chan            = dmach->chan;
 
@@ -778,6 +781,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -493,11 +493,9 @@ static void s32k3xx_tcd_free(struct s32k3xx_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
   s32k3xx_tcd_free_nolock(tcd);
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 #endif
 
@@ -725,8 +723,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
   irqstate_t flags;
   void *arg;
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
 
   chan            = dmach->chan;
 
@@ -780,8 +777,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
       callback((DMACH_HANDLE)dmach, arg, true, result);
     }
 
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -35,7 +35,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -508,8 +507,7 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
   uint32_t regval;
   int ret;
 
-  flags = spin_lock_irqsave(&priv->spinlock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->spinlock);
 
 #ifdef CONFIG_S32K3XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -589,8 +587,7 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
       s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_SIER_OFFSET, 0);
     }
 
-  spin_unlock_irqrestore(&priv->spinlock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->spinlock, flags);
   return ret;
 }
 #else

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -508,6 +509,7 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
   int ret;
 
   flags = spin_lock_irqsave(&priv->spinlock);
+  sched_lock();
 
 #ifdef CONFIG_S32K3XX_LPI2C_DMA
   if (priv->rxdma == NULL && priv->txdma == NULL)
@@ -588,6 +590,7 @@ s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
     }
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
+  sched_unlock();
   return ret;
 }
 #else

--- a/arch/arm/src/sam34/sam_rtc.c
+++ b/arch/arm/src/sam34/sam_rtc.c
@@ -658,6 +658,7 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
   /* Is there already something waiting on the ALARM? */
 
   flags = spin_lock_irqsave(&g_rtc_lock);
+  sched_lock();
   if (g_alarmcb == NULL)
     {
       /* No.. Save the callback function pointer */
@@ -736,6 +737,7 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
     }
 
   spin_unlock_irqrestore(&g_rtc_lock, flags);
+  sched_unlock();
   return ret;
 }
 #endif

--- a/arch/arm/src/sam34/sam_rtc.c
+++ b/arch/arm/src/sam34/sam_rtc.c
@@ -657,8 +657,7 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
 
   /* Is there already something waiting on the ALARM? */
 
-  flags = spin_lock_irqsave(&g_rtc_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_rtc_lock);
   if (g_alarmcb == NULL)
     {
       /* No.. Save the callback function pointer */
@@ -736,8 +735,7 @@ int sam_rtc_setalarm(const struct timespec *tp, alarmcb_t callback)
       ret = OK;
     }
 
-  spin_unlock_irqrestore(&g_rtc_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_rtc_lock, flags);
   return ret;
 }
 #endif

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -2405,10 +2405,12 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
   ssize_t nbytes;
 
   flags = spin_lock_irqsave(&config->lock);
+  sched_lock();
 
   if (config.state->rxdmastream == NULL)
     {
       spin_unlock_irqrestore(&config->lock, flags);
+      sched_unlock();
       return;
     }
 
@@ -2435,6 +2437,7 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
     }
 
   spin_unlock_irqrestore(&config->lock, flags);
+  sched_unlock();
 }
 #endif
 

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -2404,13 +2404,11 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
   irqstate_t flags;
   ssize_t nbytes;
 
-  flags = spin_lock_irqsave(&config->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&config->lock);
 
   if (config.state->rxdmastream == NULL)
     {
-      spin_unlock_irqrestore(&config->lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&config->lock, flags);
       return;
     }
 
@@ -2436,8 +2434,7 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
       handled = true;
     }
 
-  spin_unlock_irqrestore(&config->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&config->lock, flags);
 }
 #endif
 

--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -40,7 +40,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2983,8 +2982,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
 
   /* Cancel any ongoing activity */
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   stm32_cancelrequests(privep);
 
   /* Disable TX; disable RX */
@@ -2993,8 +2991,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   stm32_seteprxstatus(epno, USB_EPR_STATRX_DIS);
   stm32_seteptxstatus(epno, USB_EPR_STATTX_DIS);
 
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3087,8 +3084,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   epno        = USB_EPNO(ep->eplog);
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
-  flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags       = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3161,8 +3157,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return ret;
 }
 
@@ -3184,11 +3179,9 @@ static int stm32_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
 #endif
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   stm32_cancelrequests(privep);
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3218,8 +3211,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
 
   /* STALL or RESUME the endpoint */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, USB_EPNO(ep->eplog));
 
   /* Get status of the endpoint; stall the request if the endpoint is
@@ -3244,8 +3236,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
           priv->ep0state = EP0STATE_STALLED;
         }
 
-      spin_unlock_irqrestore(&priv->lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
       return -ENODEV;
     }
 
@@ -3331,8 +3322,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return OK;
 }
 
@@ -3496,8 +3486,7 @@ static int stm32_wakeup(struct usbdev_s *dev)
    * by the ESOF interrupt.
    */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   stm32_initresume(priv);
   priv->rsmstate = RSMSTATE_STARTED;
 
@@ -3509,8 +3498,7 @@ static int stm32_wakeup(struct usbdev_s *dev)
 
   stm32_setimask(priv, USB_CNTR_ESOFM, USB_CNTR_WKUPM | USB_CNTR_SUSPM);
   stm32_putreg(~USB_ISTR_ESOF, STM32_USB_ISTR);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return OK;
 }
 
@@ -3851,8 +3839,7 @@ void arm_usbuninitialize(void)
   struct stm32_usbdev_s *priv = &g_usbdev;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -3871,8 +3858,7 @@ void arm_usbuninitialize(void)
   /* Put the hardware in an inactive state */
 
   stm32_hwshutdown(priv);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -3981,8 +3967,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    * canceled while the class driver is still bound.
    */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   stm32_reset(priv);
 
   /* Unbind the class driver */
@@ -4005,8 +3990,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   /* Unhook the driver */
 
   priv->driver = NULL;
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
@@ -40,6 +40,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2907,6 +2908,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   stm32_cancelrequests(privep);
 
   /* Disable TX; disable RX */
@@ -2916,6 +2918,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   stm32_seteptxstatus(epno, USB_EPR_STATTX_DIS);
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3010,6 +3013,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep,
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
   flags       = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3085,6 +3089,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep,
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -3108,8 +3113,10 @@ static int stm32_epcancel(struct usbdev_ep_s *ep,
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   stm32_cancelrequests(privep);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3140,6 +3147,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, USB_EPNO(ep->eplog));
 
   /* Get status of the endpoint; stall the request if the endpoint is
@@ -3165,6 +3173,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
         }
 
       spin_unlock_irqrestore(&priv->lock, flags);
+      sched_unlock();
       return -ENODEV;
     }
 
@@ -3251,6 +3260,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3805,6 +3815,7 @@ void arm_usbuninitialize(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -3822,6 +3833,7 @@ void arm_usbuninitialize(void)
 
   stm32_hwshutdown(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -3911,8 +3923,10 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
   int ret;
 
   irqstate_t flags = spin_lock_irqsave(&g_usbdev.lock);
+  sched_lock();
   ret = usbdev_unregister_nolock(driver);
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
+  sched_unlock();
 
   return ret;
 }

--- a/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
@@ -40,7 +40,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -2907,8 +2906,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
 
   /* Cancel any ongoing activity */
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   stm32_cancelrequests(privep);
 
   /* Disable TX; disable RX */
@@ -2917,8 +2915,7 @@ static int stm32_epdisable(struct usbdev_ep_s *ep)
   stm32_seteprxstatus(epno, USB_EPR_STATRX_DIS);
   stm32_seteptxstatus(epno, USB_EPR_STATTX_DIS);
 
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3012,8 +3009,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep,
   epno        = USB_EPNO(ep->eplog);
   req->result = -EINPROGRESS;
   req->xfrd   = 0;
-  flags       = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags       = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -3088,8 +3084,7 @@ static int stm32_epsubmit(struct usbdev_ep_s *ep,
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return ret;
 }
 
@@ -3112,11 +3107,9 @@ static int stm32_epcancel(struct usbdev_ep_s *ep,
 #endif
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
-  flags = spin_lock_irqsave(&privep->dev->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&privep->dev->lock);
   stm32_cancelrequests(privep);
-  spin_unlock_irqrestore(&privep->dev->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&privep->dev->lock, flags);
   return OK;
 }
 
@@ -3146,8 +3139,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
 
   /* STALL or RESUME the endpoint */
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, USB_EPNO(ep->eplog));
 
   /* Get status of the endpoint; stall the request if the endpoint is
@@ -3172,8 +3164,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
           priv->ep0state = EP0STATE_STALLED;
         }
 
-      spin_unlock_irqrestore(&priv->lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
       return -ENODEV;
     }
 
@@ -3259,8 +3250,7 @@ static int stm32_epstall(struct usbdev_ep_s *ep, bool resume)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
   return OK;
 }
 
@@ -3814,8 +3804,7 @@ void arm_usbuninitialize(void)
   struct stm32_usbdev_s *priv = &g_usbdev;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -3832,8 +3821,7 @@ void arm_usbuninitialize(void)
   /* Put the hardware in an inactive state */
 
   stm32_hwshutdown(priv);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -3922,11 +3910,9 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 {
   int ret;
 
-  irqstate_t flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  irqstate_t flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   ret = usbdev_unregister_nolock(driver);
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
 
   return ret;
 }

--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -239,8 +239,10 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    */
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
   imx9_tcd_free_nolock(tcd);
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 #endif
 
@@ -453,6 +455,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&g_edma.lock);
+  sched_lock();
 
   /* Disable channel IRQ requests */
 
@@ -505,6 +508,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
     }
 
   spin_unlock_irqrestore(&g_edma.lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/arch/arm64/src/imx9/imx9_edma.c
+++ b/arch/arm64/src/imx9/imx9_edma.c
@@ -238,11 +238,9 @@ static void imx9_tcd_free(struct imx9_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
   imx9_tcd_free_nolock(tcd);
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 #endif
 
@@ -454,8 +452,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
 
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&g_edma.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_edma.lock);
 
   /* Disable channel IRQ requests */
 
@@ -507,8 +504,7 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
       callback((DMACH_HANDLE)dmach, arg, true, result);
     }
 
-  spin_unlock_irqrestore(&g_edma.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_edma.lock, flags);
 }
 
 /****************************************************************************

--- a/arch/avr/src/at90usb/at90usb_usbdev.c
+++ b/arch/avr/src/at90usb/at90usb_usbdev.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/spinlock.h>
@@ -2300,16 +2299,14 @@ static int avr_epdisable(FAR struct usbdev_ep_s *ep)
 
   usbtrace(TRACE_EPDISABLE, privep->ep.eplog);
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
 
   /* Disable the endpoint */
 
   avr_epreset(privep, -ESHUTDOWN);
   g_usbdev.stalled = true;
 
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
   return OK;
 }
 
@@ -2455,8 +2452,7 @@ static int avr_epsubmit(FAR struct usbdev_ep_s *ep,
 
   /* Disable Interrupts */
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
 
   /* If we are stalled, then drop all requests on the floor */
 
@@ -2517,8 +2513,7 @@ static int avr_epsubmit(FAR struct usbdev_ep_s *ep,
         }
     }
 
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
   return ret;
 }
 
@@ -2552,11 +2547,9 @@ static int avr_epcancel(FAR struct usbdev_ep_s *ep,
    * all requests ...
    */
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   avr_cancelrequests(privep, -ESHUTDOWN);
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
   return OK;
 }
 
@@ -2766,11 +2759,9 @@ static int avr_wakeup(struct usbdev_s *dev)
 
   usbtrace(TRACE_DEVWAKEUP, 0);
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   avr_genwakeup();
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
   return OK;
 }
 
@@ -2909,8 +2900,7 @@ void avr_usbuninitialize(void)
 
   /* Disconnect device */
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   avr_pullup(&g_usbdev.usbdev, false);
   g_usbdev.usbdev.speed = USB_SPEED_UNKNOWN;
 
@@ -2922,8 +2912,7 @@ void avr_usbuninitialize(void)
   /* Shutdown the USB controller hardware */
 
   avr_usbshutdown();
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
 }
 
 /****************************************************************************
@@ -3038,10 +3027,8 @@ void avr_pollvbus(void)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&g_usbdev.lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_usbdev.lock);
   avr_genvbus();
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_usbdev.lock, flags);
 }
 #endif

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -44,6 +44,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
@@ -3334,6 +3335,7 @@ static int pic32mx_epdisable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   pic32mx_cancelrequests(privep, -ESHUTDOWN);
 
   /* Disable the endpoint */
@@ -3351,6 +3353,7 @@ static int pic32mx_epdisable(struct usbdev_ep_s *ep)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3451,6 +3454,7 @@ static int pic32mx_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   privreq->inflight[1] = 0;
 #endif
   flags                = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Add the new request to the request queue for the OUT endpoint */
 
@@ -3495,6 +3499,7 @@ static int pic32mx_epsubmit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -3518,8 +3523,10 @@ static int pic32mx_epcancel(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   usbtrace(TRACE_EPCANCEL, USB_EPNO(ep->eplog));
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   pic32mx_cancelrequests(privep, -EAGAIN);
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -3711,6 +3718,7 @@ static int pic32mx_epstall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   /* Special case EP0.  When we stall EP0 we have to stall both the IN and
    * OUT BDTs.
@@ -3740,6 +3748,7 @@ static int pic32mx_epstall(struct usbdev_ep_s *ep, bool resume)
     }
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -4393,6 +4402,7 @@ void mips_usbuninitialize(void)
   irqstate_t flags;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   usbtrace(TRACE_DEVUNINIT, 0);
 
   /* Disable and detach the USB IRQs */
@@ -4410,6 +4420,7 @@ void mips_usbuninitialize(void)
 
   pic32mx_hwshutdown(priv);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -4514,6 +4525,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
    */
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   pic32mx_swreset(priv);
   pic32mx_hwreset(priv);
 
@@ -4537,6 +4549,7 @@ int usbdev_unregister(struct usbdevclass_driver_s *driver)
 
   priv->driver = NULL;
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return OK;
 }
 

--- a/arch/renesas/src/rx65n/rx65n_rtc.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc.c
@@ -481,6 +481,7 @@ int up_rtc_gettime(struct timespec *tp)
   struct tm t;
 
   flags = spin_lock_irqsave(&g_rtc_lock);
+  sched_lock();
 
   if (RTC.RCR2.BIT.START == 0)
     {
@@ -549,6 +550,7 @@ int up_rtc_gettime(struct timespec *tp)
   UNUSED(seccnt);
 
   spin_unlock_irqrestore(&g_rtc_lock, flags);
+  sched_unlock();
   return OK;
 }
 #endif

--- a/arch/renesas/src/rx65n/rx65n_rtc.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc.c
@@ -480,8 +480,7 @@ int up_rtc_gettime(struct timespec *tp)
   uint8_t regval;
   struct tm t;
 
-  flags = spin_lock_irqsave(&g_rtc_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_rtc_lock);
 
   if (RTC.RCR2.BIT.START == 0)
     {
@@ -549,8 +548,7 @@ int up_rtc_gettime(struct timespec *tp)
   UNUSED(mincnt);
   UNUSED(seccnt);
 
-  spin_unlock_irqrestore(&g_rtc_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_rtc_lock, flags);
   return OK;
 }
 #endif

--- a/arch/risc-v/src/common/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_hr_timer.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
@@ -219,6 +220,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
   systimer_ll_clear_alarm_int(priv->hal.dev, SYSTIMER_ALARM_ESPTIMER);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -289,6 +291,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }

--- a/arch/risc-v/src/common/espressif/esp_hr_timer.c
+++ b/arch/risc-v/src/common/espressif/esp_hr_timer.c
@@ -34,7 +34,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
@@ -219,8 +218,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
 
   systimer_ll_clear_alarm_int(priv->hal.dev, SYSTIMER_ALARM_ESPTIMER);
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* Check if there is a timer running */
 
@@ -290,8 +288,7 @@ static int IRAM_ATTR esp_hr_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   return OK;
 }

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -28,6 +28,7 @@
 
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -521,6 +522,7 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
   DEBUGASSERT(source >= 0 && source < ESP_NSOURCES);
 
   flags = spin_lock_irqsave(&g_irq_lock);
+  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -551,6 +553,7 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
     }
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
+  sched_unlock();
 
   return cpuint;
 }

--- a/arch/risc-v/src/common/espressif/esp_irq.c
+++ b/arch/risc-v/src/common/espressif/esp_irq.c
@@ -28,7 +28,6 @@
 
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -521,8 +520,7 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
 
   DEBUGASSERT(source >= 0 && source < ESP_NSOURCES);
 
-  flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_irq_lock);
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -552,8 +550,7 @@ int esp_setup_irq(int source, irq_priority_t priority, int type)
       esp_irq_unset_iram_isr(irq);
     }
 
-  spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 
   return cpuint;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c
@@ -31,7 +31,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -367,11 +366,9 @@ void esp32c3_free_cpuint(uint8_t periphid)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_irq_lock);
   esp32c3_free_cpuint_nolock(periphid);
-  spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 }
 
 /****************************************************************************
@@ -487,8 +484,7 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
 
   irqinfo("periphid = %d\n", periphid);
 
-  flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_irq_lock);
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -501,8 +497,7 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
     {
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
              priority, type);
-      spin_unlock_irqrestore(&g_irq_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 
       return cpuint;
     }
@@ -518,8 +513,7 @@ int esp32c3_setup_irq(int periphid, int priority, int type)
 
   esp32c3_bind_irq(cpuint, periphid, priority, type);
 
-  spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 
   return cpuint;
 }
@@ -549,8 +543,7 @@ void esp32c3_teardown_irq(int periphid, int cpuint)
   uintptr_t regaddr;
   int irq;
 
-  flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_irq_lock);
 
   /* Tearing down an IRQ includes the following steps:
    *   1. Free the previously allocated CPU interrupt.
@@ -571,8 +564,7 @@ void esp32c3_teardown_irq(int periphid, int cpuint)
 
   putreg32(NO_CPUINT, regaddr);
 
-  spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -294,8 +293,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
 
   struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -322,8 +320,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
     }
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -446,8 +443,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
 
   ESP32C3_TIM_ACKINT(priv->timer);
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* Check if there is a timer running */
 
@@ -506,8 +502,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   return 0;
 }

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c
@@ -34,6 +34,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -294,6 +295,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -321,6 +323,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -444,6 +447,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   ESP32C3_TIM_ACKINT(priv->timer);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -503,6 +507,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return 0;
 }

--- a/arch/sim/src/sim/sim_usbdev.c
+++ b/arch/sim/src/sim/sim_usbdev.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
@@ -643,6 +644,7 @@ static int sim_ep_disable(struct usbdev_ep_s *ep)
   /* Cancel any ongoing activity */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
 
   /* Disable TX; disable RX */
 
@@ -651,6 +653,7 @@ static int sim_ep_disable(struct usbdev_ep_s *ep)
   privep->epstate = SIM_EPSTATE_DISABLED;
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return OK;
 }
 
@@ -706,6 +709,7 @@ static int sim_ep_stall(struct usbdev_ep_s *ep, bool resume)
   /* STALL or RESUME the endpoint */
 
   flags = spin_lock_irqsave(&privep->dev->lock);
+  sched_lock();
   usbtrace(resume ? TRACE_EPRESUME : TRACE_EPSTALL, epno);
 
   ret = host_usbdev_epstall(epno, resume);
@@ -713,6 +717,7 @@ static int sim_ep_stall(struct usbdev_ep_s *ep, bool resume)
   privep->epstate = SIM_EPSTATE_STALLED;
 
   spin_unlock_irqrestore(&privep->dev->lock, flags);
+  sched_unlock();
   return ret;
 }
 
@@ -741,11 +746,13 @@ static int sim_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
   req->result       = -EINPROGRESS;
   req->xfrd         = 0;
   flags             = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (privep->epstate == SIM_EPSTATE_STALLED)
     {
       sim_reqabort(privep, privreq, -EBUSY);
       spin_unlock_irqrestore(&priv->lock, flags);
+      sched_unlock();
       return -EPERM;
     }
 
@@ -781,6 +788,7 @@ static int sim_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
   return ret;
 }
 

--- a/arch/x86_64/src/intel64/intel64_oneshot.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <sched.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>

--- a/arch/x86_64/src/intel64/intel64_oneshot.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot.c
@@ -29,7 +29,6 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <sched.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -2189,6 +2189,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
+      sched_lock();
       flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
@@ -2201,6 +2202,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->alarm_hdl = NULL;
 
       spin_unlock_irqrestore(&g_rtc_lock, flags);
+      sched_unlock();
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -2189,8 +2189,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      sched_lock();
-      flags = spin_lock_irqsave(&g_rtc_lock);
+      flags = spin_lock_irqsave_nopreempt(&g_rtc_lock);
 
       /* Stop and delete the alarm */
 
@@ -2201,8 +2200,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->deadline_us = 0;
       cbinfo->alarm_hdl = NULL;
 
-      spin_unlock_irqrestore(&g_rtc_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_rtc_lock, flags);
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32s2/esp32s2_irq.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.c
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <debug.h>
+#include <sched.h>
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
@@ -500,6 +501,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
   int cpuint;
 
   flags = spin_lock_irqsave(&g_irq_lock);
+  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -513,6 +515,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
              priority, type);
       spin_unlock_irqrestore(&g_irq_lock, flags);
+      sched_unlock();
 
       return cpuint;
     }
@@ -530,6 +533,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
   putreg32(cpuint, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, flags);
+  sched_unlock();
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_irq.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.c
@@ -26,7 +26,6 @@
 
 #include <assert.h>
 #include <debug.h>
-#include <sched.h>
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
@@ -500,8 +499,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
   int irq;
   int cpuint;
 
-  flags = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_irq_lock);
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -514,8 +512,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
     {
       irqerr("Unable to allocate CPU interrupt for priority=%d and type=%d",
              priority, type);
-      spin_unlock_irqrestore(&g_irq_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 
       return cpuint;
     }
@@ -532,8 +529,7 @@ int esp32s2_setup_irq(int periphid, int priority, int type)
 
   putreg32(cpuint, regaddr);
 
-  spin_unlock_irqrestore(&g_irq_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, flags);
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -196,8 +197,10 @@ static void start_rt_timer(struct rt_timer_s *timer,
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
   start_rt_timer_nolock(timer, timeout, repeat);
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -303,6 +306,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -330,6 +334,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************
@@ -453,6 +458,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   ESP32S2_TIM_ACKINT(priv->timer);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -512,6 +518,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return 0;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -32,7 +32,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -196,11 +195,9 @@ static void start_rt_timer(struct rt_timer_s *timer,
   irqstate_t flags;
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
   start_rt_timer_nolock(timer, timeout, repeat);
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -305,8 +302,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
   irqstate_t flags;
   struct esp32s2_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -333,8 +329,7 @@ static void delete_rt_timer(struct rt_timer_s *timer)
     }
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************
@@ -457,8 +452,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
 
   ESP32S2_TIM_ACKINT(priv->timer);
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* Check if there is a timer running */
 
@@ -517,8 +511,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   return 0;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_rtc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rtc.c
@@ -2688,6 +2688,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
+      sched_lock();
       flags = spin_lock_irqsave(&g_rtc_lock);
 
       /* Stop and delete the alarm */
@@ -2700,6 +2701,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->alarm_hdl = NULL;
 
       spin_unlock_irqrestore(&g_rtc_lock, flags);
+      sched_unlock();
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32s2/esp32s2_rtc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rtc.c
@@ -2688,8 +2688,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
 
   if (cbinfo->ac_cb != NULL)
     {
-      sched_lock();
-      flags = spin_lock_irqsave(&g_rtc_lock);
+      flags = spin_lock_irqsave_nopreempt(&g_rtc_lock);
 
       /* Stop and delete the alarm */
 
@@ -2700,8 +2699,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
       cbinfo->deadline_us = 0;
       cbinfo->alarm_hdl = NULL;
 
-      spin_unlock_irqrestore(&g_rtc_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_rtc_lock, flags);
 
       ret = OK;
     }

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -815,6 +816,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
     }
 
   irqstate = spin_lock_irqsave(&g_irq_lock);
+  sched_lock();
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -829,6 +831,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
       irqerr("Unable to allocate CPU interrupt for priority=%d and flags=%d",
              priority, flags);
       spin_unlock_irqrestore(&g_irq_lock, irqstate);
+      sched_unlock();
 
       return cpuint;
     }
@@ -857,6 +860,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
   putreg32(cpuint, regaddr);
 
   spin_unlock_irqrestore(&g_irq_lock, irqstate);
+  sched_unlock();
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -29,7 +29,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
-#include <sched.h>
 
 #include <nuttx/spinlock.h>
 #include <nuttx/arch.h>
@@ -815,8 +814,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
       return -EINVAL;
     }
 
-  irqstate = spin_lock_irqsave(&g_irq_lock);
-  sched_lock();
+  irqstate = spin_lock_irqsave_nopreempt(&g_irq_lock);
 
   /* Setting up an IRQ includes the following steps:
    *    1. Allocate a CPU interrupt.
@@ -830,8 +828,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
     {
       irqerr("Unable to allocate CPU interrupt for priority=%d and flags=%d",
              priority, flags);
-      spin_unlock_irqrestore(&g_irq_lock, irqstate);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_irq_lock, irqstate);
 
       return cpuint;
     }
@@ -859,8 +856,7 @@ int esp32s3_setup_irq(int cpu, int periphid, int priority, int flags)
 
   putreg32(cpuint, regaddr);
 
-  spin_unlock_irqrestore(&g_irq_lock, irqstate);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_irq_lock, irqstate);
 
   return cpuint;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -612,8 +611,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
 
   modifyreg32(SYSTIMER_INT_CLR_REG, 0, SYSTIMER_TARGET2_INT_CLR);
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   /* Check if there is a timer running */
 
@@ -674,8 +672,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
         }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 
   return OK;
 }
@@ -808,8 +805,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
   irqstate_t flags;
   struct esp32s3_rt_priv_s *priv = &g_rt_priv;
 
-  flags = spin_lock_irqsave(&priv->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&priv->lock);
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -836,8 +832,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
     }
 
 exit:
-  spin_unlock_irqrestore(&priv->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&priv->lock, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rt_timer.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sched.h>
 
 #include <nuttx/nuttx.h>
 #include <nuttx/spinlock.h>
@@ -612,6 +613,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   modifyreg32(SYSTIMER_INT_CLR_REG, 0, SYSTIMER_TARGET2_INT_CLR);
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   /* Check if there is a timer running */
 
@@ -673,6 +675,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
     }
 
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 
   return OK;
 }
@@ -806,6 +809,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
   struct esp32s3_rt_priv_s *priv = &g_rt_priv;
 
   flags = spin_lock_irqsave(&priv->lock);
+  sched_lock();
 
   if (timer->state == RT_TIMER_READY)
     {
@@ -833,6 +837,7 @@ void esp32s3_rt_timer_delete(struct rt_timer_s *timer)
 
 exit:
   spin_unlock_irqrestore(&priv->lock, flags);
+  sched_unlock();
 }
 
 /****************************************************************************

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1841,7 +1841,7 @@ void sched_note_filter_mode(FAR struct note_filter_named_mode_s *oldm,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = raw_spin_lock_irqsave(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldm != NULL)
     {
@@ -1877,7 +1877,7 @@ void sched_note_filter_mode(FAR struct note_filter_named_mode_s *oldm,
         }
     }
 
-  raw_spin_unlock_irqrestore(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 
 /****************************************************************************
@@ -1907,7 +1907,7 @@ void sched_note_filter_syscall(FAR struct note_filter_named_syscall_s *oldf,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = raw_spin_lock_irqsave(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -1943,7 +1943,7 @@ void sched_note_filter_syscall(FAR struct note_filter_named_syscall_s *oldf,
         }
     }
 
-  raw_spin_unlock_irqrestore(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 #endif
 
@@ -1974,7 +1974,7 @@ void sched_note_filter_irq(FAR struct note_filter_named_irq_s *oldf,
   irqstate_t irq_mask;
   FAR struct note_driver_s **driver;
 
-  irq_mask = raw_spin_lock_irqsave(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -2010,7 +2010,7 @@ void sched_note_filter_irq(FAR struct note_filter_named_irq_s *oldf,
         }
     }
 
-  raw_spin_unlock_irqrestore(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 #endif
 
@@ -2041,7 +2041,7 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
   FAR struct note_driver_s **driver;
   irqstate_t irq_mask;
 
-  irq_mask = raw_spin_lock_irqsave(&g_note_lock);
+  irq_mask = spin_lock_irqsave_notrace(&g_note_lock);
 
   if (oldf != NULL)
     {
@@ -2077,7 +2077,7 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
         }
     }
 
-  raw_spin_unlock_irqrestore(&g_note_lock, irq_mask);
+  spin_unlock_irqrestore_notrace(&g_note_lock, irq_mask);
 }
 #endif
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -467,9 +467,9 @@ static ssize_t noteram_read(FAR struct file *filep, FAR char *buffer,
 
   if (ctx->mode == NOTERAM_MODE_READ_BINARY)
     {
-      flags = raw_spin_lock_irqsave(&drv->lock);
+      flags = spin_lock_irqsave_notrace(&drv->lock);
       ret = noteram_get(drv, (FAR uint8_t *)buffer, buflen);
-      raw_spin_unlock_irqrestore(&drv->lock, flags);
+      spin_unlock_irqrestore_notrace(&drv->lock, flags);
     }
   else
     {
@@ -481,9 +481,9 @@ static ssize_t noteram_read(FAR struct file *filep, FAR char *buffer,
 
           /* Get the next note (removing it from the buffer) */
 
-          flags = raw_spin_lock_irqsave(&drv->lock);
+          flags = spin_lock_irqsave_notrace(&drv->lock);
           ret = noteram_get(drv, note, sizeof(note));
-          raw_spin_unlock_irqrestore(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           if (ret <= 0)
             {
               return ret;
@@ -508,7 +508,7 @@ static int noteram_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
   int ret = -ENOSYS;
   FAR struct noteram_driver_s *drv = filep->f_inode->i_private;
-  irqstate_t flags = raw_spin_lock_irqsave(&drv->lock);
+  irqstate_t flags = spin_lock_irqsave_notrace(&drv->lock);
 
   /* Handle the ioctl commands */
 
@@ -600,7 +600,7 @@ static int noteram_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           break;
     }
 
-  raw_spin_unlock_irqrestore(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   return ret;
 }
 
@@ -622,7 +622,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
   DEBUGASSERT(inode != NULL && inode->i_private != NULL);
   drv = inode->i_private;
 
-  flags = raw_spin_lock_irqsave(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   /* Ignore waits that do not include POLLIN */
 
@@ -655,7 +655,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (noteram_unread_length(drv) > 0)
         {
-          raw_spin_unlock_irqrestore(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           poll_notify(&drv->pfd, 1, POLLIN);
           return ret;
         }
@@ -666,7 +666,7 @@ static int noteram_poll(FAR struct file *filep, FAR struct pollfd *fds,
     }
 
 errout:
-  raw_spin_unlock_irqrestore(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   return ret;
 }
 
@@ -698,11 +698,11 @@ static void noteram_add(FAR struct note_driver_s *driver,
   unsigned int space;
   irqstate_t flags;
 
-  flags = raw_spin_lock_irqsave(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   if (drv->ni_overwrite == NOTERAM_MODE_OVERWRITE_OVERFLOW)
     {
-      raw_spin_unlock_irqrestore(&drv->lock, flags);
+      spin_unlock_irqrestore_notrace(&drv->lock, flags);
       return;
     }
 
@@ -716,7 +716,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
           /* Stop recording if not in overwrite mode */
 
           drv->ni_overwrite = NOTERAM_MODE_OVERWRITE_OVERFLOW;
-          raw_spin_unlock_irqrestore(&drv->lock, flags);
+          spin_unlock_irqrestore_notrace(&drv->lock, flags);
           return;
         }
 
@@ -737,7 +737,7 @@ static void noteram_add(FAR struct note_driver_s *driver,
   memcpy(drv->ni_buffer + head, note, space);
   memcpy(drv->ni_buffer, buf + space, notelen - space);
   drv->ni_head = noteram_next(drv, head, NOTE_ALIGN(notelen));
-  raw_spin_unlock_irqrestore(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
   poll_notify(&drv->pfd, 1, POLLIN);
 }
 

--- a/drivers/note/noterpmsg_driver.c
+++ b/drivers/note/noterpmsg_driver.c
@@ -180,7 +180,7 @@ static bool noterpmsg_transfer(FAR struct noterpmsg_driver_s *drv,
 static void noterpmsg_work(FAR void *priv)
 {
   FAR struct noterpmsg_driver_s *drv = priv;
-  irqstate_t flags = raw_spin_lock_irqsave(&drv->lock);
+  irqstate_t flags = spin_lock_irqsave_notrace(&drv->lock);
 
   if (!noterpmsg_transfer(drv, false))
     {
@@ -188,7 +188,7 @@ static void noterpmsg_work(FAR void *priv)
                  NOTE_RPMSG_WORK_DELAY);
     }
 
-  raw_spin_unlock_irqrestore(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
 }
 
 static void noterpmsg_add(FAR struct note_driver_s *driver,
@@ -199,7 +199,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
   irqstate_t flags;
   size_t space;
 
-  flags = raw_spin_lock_irqsave(&drv->lock);
+  flags = spin_lock_irqsave_notrace(&drv->lock);
 
   space = CONFIG_DRIVERS_NOTERPMSG_BUFSIZE - noterpmsg_length(drv);
   if (space < notelen)
@@ -236,7 +236,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
                  NOTE_RPMSG_WORK_DELAY);
     }
 
-  raw_spin_unlock_irqrestore(&drv->lock, flags);
+  spin_unlock_irqrestore_notrace(&drv->lock, flags);
 }
 
 static int noterpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -89,11 +89,11 @@ extern spinlock_t g_segger_lock;
 
 /* Lock RTT (nestable)   (i.e. disable interrupts) */
 
-#define SEGGER_RTT_LOCK()               irqstate_t __flags = raw_spin_lock_irqsave(&g_segger_lock)
+#define SEGGER_RTT_LOCK()               irqstate_t __flags = spin_lock_irqsave_notrace(&g_segger_lock)
 
 /* Unlock RTT (nestable) (i.e. enable previous interrupt lock state) */
 
-#define SEGGER_RTT_UNLOCK()             raw_spin_unlock_irqrestore(&g_segger_lock, __flags)
+#define SEGGER_RTT_UNLOCK()             spin_unlock_irqrestore_notrace(&g_segger_lock, __flags)
 
 /* Disable RTT SEGGER_RTT_WriteSkipNoLock */
 

--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -150,7 +150,7 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
 
   /* Disable concurrent modification from interrupt handling logic */
 
-  flags = raw_spin_lock_irqsave(&g_syslog_intbuffer.splock);
+  flags = spin_lock_irqsave_notrace(&g_syslog_intbuffer.splock);
 
   space = circbuf_space(&g_syslog_intbuffer.circ);
 
@@ -172,7 +172,7 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
                     buffer + space, buflen - space);
     }
 
-  raw_spin_unlock_irqrestore(&g_syslog_intbuffer.splock, flags);
+  spin_unlock_irqrestore_notrace(&g_syslog_intbuffer.splock, flags);
 }
 
 /****************************************************************************
@@ -198,9 +198,9 @@ void syslog_flush_intbuffer(bool force)
 {
   irqstate_t flags;
 
-  flags = raw_spin_lock_irqsave(&g_syslog_intbuffer.splock);
+  flags = spin_lock_irqsave_notrace(&g_syslog_intbuffer.splock);
   syslog_flush_internal(force, sizeof(g_syslog_intbuffer.buffer));
-  raw_spin_unlock_irqrestore(&g_syslog_intbuffer.splock, flags);
+  spin_unlock_irqrestore_notrace(&g_syslog_intbuffer.splock, flags);
 }
 
 #endif /* CONFIG_SYSLOG_INTBUFFER */

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -72,9 +72,9 @@ static FAR struct file *files_fget_by_index(FAR struct filelist *list,
   FAR struct file *filep;
   irqstate_t flags;
 
-  flags = raw_spin_lock_irqsave(&list->fl_lock);
+  flags = spin_lock_irqsave(&list->fl_lock);
   filep = &list->fl_files[l1][l2];
-  raw_spin_unlock_irqrestore(&list->fl_lock, flags);
+  spin_unlock_irqrestore(&list->fl_lock, flags);
 
 #ifdef CONFIG_FS_REFCOUNT
   if (filep->f_inode != NULL)
@@ -164,7 +164,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
     }
   while (++i < row);
 
-  flags = raw_spin_lock_irqsave(&list->fl_lock);
+  flags = spin_lock_irqsave(&list->fl_lock);
 
   /* To avoid race condition, if the file list is updated by other threads
    * and list rows is greater or equal than temp list,
@@ -173,7 +173,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   if (orig_rows != list->fl_rows && list->fl_rows >= row)
     {
-      raw_spin_unlock_irqrestore(&list->fl_lock, flags);
+      spin_unlock_irqrestore(&list->fl_lock, flags);
 
       for (j = orig_rows; j < i; j++)
         {
@@ -195,7 +195,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
   list->fl_files = files;
   list->fl_rows = row;
 
-  raw_spin_unlock_irqrestore(&list->fl_lock, flags);
+  spin_unlock_irqrestore(&list->fl_lock, flags);
 
   if (tmp != NULL && tmp != &list->fl_prefile)
     {
@@ -565,13 +565,13 @@ int file_allocate_from_tcb(FAR struct tcb_s *tcb, FAR struct inode *inode,
 
   /* Find free file */
 
-  flags = raw_spin_lock_irqsave(&list->fl_lock);
+  flags = spin_lock_irqsave(&list->fl_lock);
 
   for (; ; i++, j = 0)
     {
       if (i >= list->fl_rows)
         {
-          raw_spin_unlock_irqrestore(&list->fl_lock, flags);
+          spin_unlock_irqrestore(&list->fl_lock, flags);
 
           ret = files_extend(list, i + 1);
           if (ret < 0)
@@ -579,7 +579,7 @@ int file_allocate_from_tcb(FAR struct tcb_s *tcb, FAR struct inode *inode,
               return ret;
             }
 
-          flags = raw_spin_lock_irqsave(&list->fl_lock);
+          flags = spin_lock_irqsave(&list->fl_lock);
         }
 
       do
@@ -608,7 +608,7 @@ int file_allocate_from_tcb(FAR struct tcb_s *tcb, FAR struct inode *inode,
     }
 
 found:
-  raw_spin_unlock_irqrestore(&list->fl_lock, flags);
+  spin_unlock_irqrestore(&list->fl_lock, flags);
 
   if (addref)
     {

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -80,7 +80,7 @@
   do \
     { \
       g_cpu_irqset = 0; \
-      raw_spin_unlock(&g_cpu_irqlock); \
+      spin_unlock_notrace(&g_cpu_irqlock); \
     } \
   while (0)
 #endif

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -208,6 +208,51 @@ static inline_function void spin_lock_notrace(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
+ * Name: spin_lock_nopreempt
+ *
+ * Description:
+ *   If this CPU does not already hold the spinlock, then loop until the
+ *   spinlock is successfully locked.
+ *
+ *   This implementation is non-reentrant and is prone to deadlocks in
+ *   the case that any logic on the same CPU attempts to take the lock
+ *   more than once.
+ *
+ * Input Parameters:
+ *   lock - A reference to the spinlock object to lock.
+ *
+ * Returned Value:
+ *   None.  When the function returns, the spinlock was successfully locked
+ *   by this CPU.
+ *
+ * Assumptions:
+ *   Not running at the interrupt level.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+static inline_function void
+spin_lock_nopreempt(FAR volatile spinlock_t *lock)
+{
+  sched_lock();
+
+  /* Notify that we are waiting for a spinlock */
+
+  sched_note_spinlock_lock(lock);
+
+  /* Lock without trace note */
+
+  spin_lock_notrace(lock);
+
+  /* Notify that we have the spinlock */
+
+  sched_note_spinlock_locked(lock);
+}
+#else
+#  define spin_lock_nopreempt(l) sched_lock()
+#endif /* CONFIG_SPINLOCK */
+
+/****************************************************************************
  * Name: spin_lock
  *
  * Description:
@@ -291,6 +336,60 @@ spin_trylock_notrace(FAR volatile spinlock_t *lock)
   UP_DMB();
   return true;
 }
+#endif /* CONFIG_SPINLOCK */
+
+/****************************************************************************
+ * Name: spin_trylock_nopreempt
+ *
+ * Description:
+ *   Try once to lock the spinlock.  Do not wait if the spinlock is already
+ *   locked.
+ *
+ * Input Parameters:
+ *   lock - A reference to the spinlock object to lock.
+ *
+ * Returned Value:
+ *   SP_LOCKED   - Failure, the spinlock was already locked
+ *   SP_UNLOCKED - Success, the spinlock was successfully locked
+ *
+ * Assumptions:
+ *   Not running at the interrupt level.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+static inline_function bool
+spin_trylock_nopreempt(FAR volatile spinlock_t *lock)
+{
+  bool locked;
+
+  sched_lock();
+
+  /* Notify that we are waiting for a spinlock */
+
+  sched_note_spinlock_lock(lock);
+
+  /* Try lock without trace note */
+
+  locked = spin_trylock_notrace(lock);
+  if (locked)
+    {
+      /* Notify that we have the spinlock */
+
+      sched_note_spinlock_locked(lock);
+    }
+  else
+    {
+      /* Notify that we abort for a spinlock */
+
+      sched_note_spinlock_abort(lock);
+      sched_unlock();
+    }
+
+  return locked;
+}
+#else
+#  define spin_trylock_nopreempt(l) (sched_lock(), true)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
@@ -382,6 +481,46 @@ spin_unlock_notrace(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
+ * Name: spin_unlock_nopreempt
+ *
+ * Description:
+ *   Release one count on a non-reentrant spinlock.
+ *
+ * Input Parameters:
+ *   lock - A reference to the spinlock object to unlock.
+ *
+ * Returned Value:
+ *   None.
+ *
+ * Assumptions:
+ *   Not running at the interrupt level.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+#  ifdef __SP_UNLOCK_FUNCTION
+static inline_function void
+spin_unlock_nopreempt(FAR volatile spinlock_t *lock)
+{
+  /* Unlock without trace note */
+
+  spin_unlock_notrace(lock);
+
+  /* Notify that we are unlocking the spinlock */
+
+  sched_note_spinlock_unlock(lock);
+
+  sched_unlock();
+}
+#  else
+#    define spin_unlock_nopreempt(l)  \
+  do { *(l) = SP_UNLOCKED; sched_unlock();} while (0)
+#  endif
+#else
+#  define spin_unlock_nopreempt(l)  sched_unlock()
+#endif /* CONFIG_SPINLOCK */
+
+/****************************************************************************
  * Name: spin_unlock
  *
  * Description:
@@ -462,6 +601,59 @@ irqstate_t spin_lock_irqsave_notrace(FAR volatile spinlock_t *lock)
 }
 #else
 #  define spin_lock_irqsave_notrace(l) ((void)(l), up_irq_save())
+#endif
+
+/****************************************************************************
+ * Name: spin_lock_irqsave_nopreempt
+ *
+ * Description:
+ *   If SMP is enabled:
+ *     Disable local interrupts, sched_lock and take the lock spinlock and
+ *     return the interrupt state.
+ *
+ *     NOTE: This API is very simple to protect data (e.g. H/W register
+ *     or internal data structure) in SMP mode. But do not use this API
+ *     with kernel APIs which suspend a caller thread. (e.g. nxsem_wait)
+ *
+ *   If SMP is not enabled:
+ *     This function is equivalent to up_irq_save() + sched_lock().
+ *
+ * Input Parameters:
+ *   lock - Caller specific spinlock. not NULL.
+ *
+ * Returned Value:
+ *   An opaque, architecture-specific value that represents the state of
+ *   the interrupts prior to the call to spin_lock_irqsave(lock);
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+static inline_function
+irqstate_t spin_lock_irqsave_nopreempt(FAR volatile spinlock_t *lock)
+{
+  irqstate_t flags;
+
+  /* Notify that we are waiting for a spinlock */
+
+  sched_note_spinlock_lock(lock);
+
+  flags = spin_lock_irqsave_notrace(lock);
+  sched_lock();
+
+  /* Notify that we have the spinlock */
+
+  sched_note_spinlock_locked(lock);
+
+  return flags;
+}
+#else
+static inline_function
+irqstate_t spin_lock_irqsave_nopreempt(FAR volatile spinlock_t *lock)
+{
+  irqstate_t flags = up_irq_save();
+  sched_lock();
+  return flags;
+}
 #endif
 
 /****************************************************************************
@@ -557,6 +749,43 @@ irqstate_t spin_lock_irqsave(FAR volatile spinlock_t *lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
+ * Name: spin_trylock_irqsave_nopreempt
+ *
+ * Description:
+ *   Try once to lock the spinlock.  Do not wait if the spinlock is already
+ *   locked.
+ *
+ * Input Parameters:
+ *   lock  - A reference to the spinlock object to lock.
+ *   flags - flag of interrupts status
+ *
+ * Returned Value:
+ *   SP_LOCKED   - Failure, the spinlock was already locked
+ *   SP_UNLOCKED - Success, the spinlock was successfully locked
+ *
+ * Assumptions:
+ *   Not running at the interrupt level.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+#  define spin_trylock_irqsave_nopreempt(l, f) \
+({ \
+  f = up_irq_save(); \
+  spin_trylock_nopreempt(l) ? \
+  true : ({ up_irq_restore(f); false; }); \
+})
+#else
+#  define spin_trylock_irqsave_nopreempt(l, f) \
+({ \
+  (void)(l); \
+  f = up_irq_save(); \
+  sched_lock(); \
+  true; \
+})
+#endif /* CONFIG_SPINLOCK */
+
+/****************************************************************************
  * Name: spin_trylock_irqsave
  *
  * Description:
@@ -612,6 +841,48 @@ void spin_unlock_irqrestore_notrace(FAR volatile spinlock_t *lock,
 }
 #else
 #  define spin_unlock_irqrestore_notrace(l, f) ((void)(l), up_irq_restore(f))
+#endif
+
+/****************************************************************************
+ * Name: spin_unlock_irqrestore_nopreempt
+ *
+ * Description:
+ *   If SMP is enabled:
+ *     Release the lock and restore the interrupt state, sched_unlock
+ *     as it was prior to the previous call to spin_lock_irqsave(lock).
+ *
+ *   If SMP is not enabled:
+ *     This function is equivalent to up_irq_restore() + sched_unlock().
+ *
+ * Input Parameters:
+ *   lock - Caller specific spinlock. not NULL
+ *
+ *   flags - The architecture-specific value that represents the state of
+ *           the interrupts prior to the call to spin_lock_irqsave(lock);
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPINLOCK
+static inline_function
+void spin_unlock_irqrestore_nopreempt(FAR volatile spinlock_t *lock,
+                                      irqstate_t flags)
+{
+  /* Unlock without trace note */
+
+  spin_unlock_irqrestore_notrace(lock, flags);
+
+  sched_unlock();
+
+  /* Notify that we are unlocking the spinlock */
+
+  sched_note_spinlock_unlock(lock);
+}
+#else
+#  define spin_unlock_irqrestore_nopreempt(l, f) \
+  ((void)(l), up_irq_restore(f), sched_unlock())
 #endif
 
 /****************************************************************************

--- a/libs/libc/machine/arch_atomic.c
+++ b/libs/libc/machine/arch_atomic.c
@@ -46,11 +46,11 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   void weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
                                                                      \
     *(FAR type *)ptr = value;                                        \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
   }
 
 #define LOAD(fn, n, type)                                             \
@@ -58,11 +58,11 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR const volatile void *ptr, \
                                         int memorder)                 \
   {                                                                   \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);      \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock);  \
                                                                       \
     type ret = *(FAR type *)ptr;                                      \
                                                                       \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);             \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);         \
     return ret;                                                       \
   }
 
@@ -71,13 +71,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     type ret = *tmp;                                                 \
     *tmp = value;                                                    \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -89,7 +89,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         int success, int failure)    \
   {                                                                  \
     bool ret = false;                                                \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmpmem = (FAR type *)mem;                              \
     FAR type *tmpexp = (FAR type *)expect;                           \
                                                                      \
@@ -103,7 +103,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmpexp = *tmpmem;                                           \
       }                                                              \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -112,13 +112,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         int memorder)                \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *(FAR type *)ptr = 1;                                            \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -127,13 +127,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp + value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -142,13 +142,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp - value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -157,13 +157,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp & value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -172,13 +172,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp | value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -187,13 +187,13 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value, int memorder)    \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
     *tmp = *tmp ^ value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -202,12 +202,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp + value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -216,12 +216,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp - value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -230,12 +230,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp | value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -244,12 +244,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp & value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -258,12 +258,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = *tmp ^ value;                                             \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -272,12 +272,12 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
   type weak_function CONCATENATE(fn, n)(FAR volatile void *ptr,      \
                                         type value)                  \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     *tmp = ~(*tmp & value);                                          \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return *tmp;                                                     \
   }
 
@@ -288,7 +288,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         type newvalue)               \
   {                                                                  \
     bool ret = false;                                                \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
                                                                      \
     if (*tmp == oldvalue)                                            \
@@ -297,7 +297,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmp = newvalue;                                             \
       }                                                              \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 
@@ -307,7 +307,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
                                         type oldvalue,               \
                                         type newvalue)               \
   {                                                                  \
-    irqstate_t irqstate = raw_spin_lock_irqsave(&g_atomic_lock);     \
+    irqstate_t irqstate = spin_lock_irqsave_notrace(&g_atomic_lock); \
     FAR type *tmp = (FAR type *)ptr;                                 \
     type ret = *tmp;                                                 \
                                                                      \
@@ -316,7 +316,7 @@ static spinlock_t g_atomic_lock = SP_UNLOCKED;
         *tmp = newvalue;                                             \
       }                                                              \
                                                                      \
-    raw_spin_unlock_irqrestore(&g_atomic_lock, irqstate);            \
+    spin_unlock_irqrestore_notrace(&g_atomic_lock, irqstate);        \
     return ret;                                                      \
   }
 

--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -114,8 +114,7 @@ static int adjtime_start(long long adjust_usec)
       ppb = -ppb_limit;
     }
 
-  flags = spin_lock_irqsave(&g_adjtime_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_adjtime_lock);
 
   /* Set new adjustment */
 
@@ -141,8 +140,7 @@ static int adjtime_start(long long adjust_usec)
       wd_cancel(&g_adjtime_wdog);
     }
 
-  spin_unlock_irqrestore(&g_adjtime_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_adjtime_lock, flags);
 
   return ret;
 }

--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -115,6 +115,7 @@ static int adjtime_start(long long adjust_usec)
     }
 
   flags = spin_lock_irqsave(&g_adjtime_lock);
+  sched_lock();
 
   /* Set new adjustment */
 
@@ -141,6 +142,7 @@ static int adjtime_start(long long adjust_usec)
     }
 
   spin_unlock_irqrestore(&g_adjtime_lock, flags);
+  sched_unlock();
 
   return ret;
 }

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -180,7 +180,7 @@ irqstate_t enter_critical_section_wo_note(void)
                * no longer blocked by the critical section).
                */
 
-              raw_spin_lock(&g_cpu_irqlock);
+              spin_lock_notrace(&g_cpu_irqlock);
               cpu_irqlock_set(cpu);
             }
 
@@ -231,7 +231,7 @@ irqstate_t enter_critical_section_wo_note(void)
 
           DEBUGASSERT((g_cpu_irqset & (1 << cpu)) == 0);
 
-          raw_spin_lock(&g_cpu_irqlock);
+          spin_lock_notrace(&g_cpu_irqlock);
 
           /* Then set the lock count to 1.
            *

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -840,6 +840,7 @@ void _assert(FAR const char *filename, int linenum,
   if (os_ready)
     {
       flags = spin_lock_irqsave(&g_assert_lock);
+      sched_lock();
     }
 
 #if CONFIG_BOARD_RESET_ON_ASSERT < 2
@@ -913,5 +914,6 @@ void _assert(FAR const char *filename, int linenum,
   if (os_ready)
     {
       spin_unlock_irqrestore(&g_assert_lock, flags);
+      sched_unlock();
     }
 }

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -839,8 +839,7 @@ void _assert(FAR const char *filename, int linenum,
   flags = 0; /* suppress GCC warning */
   if (os_ready)
     {
-      flags = spin_lock_irqsave(&g_assert_lock);
-      sched_lock();
+      flags = spin_lock_irqsave_nopreempt(&g_assert_lock);
     }
 
 #if CONFIG_BOARD_RESET_ON_ASSERT < 2
@@ -913,7 +912,6 @@ void _assert(FAR const char *filename, int linenum,
 
   if (os_ready)
     {
-      spin_unlock_irqrestore(&g_assert_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_assert_lock, flags);
     }
 }

--- a/sched/sched/sched_process_delivered.c
+++ b/sched/sched/sched_process_delivered.c
@@ -73,7 +73,7 @@ void nxsched_process_delivered(int cpu)
 
   if ((g_cpu_irqset & (1 << cpu)) == 0)
     {
-      raw_spin_lock(&g_cpu_irqlock);
+      spin_lock_notrace(&g_cpu_irqlock);
 
       g_cpu_irqset |= (1 << cpu);
     }

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
+#include <sched.h>
 #include <assert.h>
 
 #include <nuttx/arch.h>
@@ -360,6 +361,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
    */
 
   flags = spin_lock_irqsave(&g_notifier_lock);
+  sched_lock();
 
   /* Process the notification at the head of the pending list until the
    * pending list is empty
@@ -403,6 +405,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
     }
 
   spin_unlock_irqrestore(&g_notifier_lock, flags);
+  sched_unlock();
 }
 
 #endif /* CONFIG_WQUEUE_NOTIFIER */

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -360,8 +360,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
    * the notifications have been sent.
    */
 
-  flags = spin_lock_irqsave(&g_notifier_lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&g_notifier_lock);
 
   /* Process the notification at the head of the pending list until the
    * pending list is empty
@@ -404,8 +403,7 @@ void work_notifier_signal(enum work_evtype_e evtype,
         }
     }
 
-  spin_unlock_irqrestore(&g_notifier_lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&g_notifier_lock, flags);
 }
 
 #endif /* CONFIG_WQUEUE_NOTIFIER */

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -68,8 +68,7 @@ static void work_timer_expiry(wdparm_t arg)
 {
   FAR struct work_s *work = (FAR struct work_s *)arg;
 
-  irqstate_t flags = spin_lock_irqsave(&work->wq->lock);
-  sched_lock();
+  irqstate_t flags = spin_lock_irqsave_nopreempt(&work->wq->lock);
 
   /* We have being canceled */
 
@@ -78,8 +77,7 @@ static void work_timer_expiry(wdparm_t arg)
       queue_work(work->wq, work);
     }
 
-  spin_unlock_irqrestore(&work->wq->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&work->wq->lock, flags);
 }
 
 static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
@@ -151,8 +149,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
    * task logic or from interrupt handling logic.
    */
 
-  flags = spin_lock_irqsave(&wqueue->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
 
   /* Remove the entry from the timer and work queue. */
 
@@ -193,8 +190,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
     }
 
 out:
-  spin_unlock_irqrestore(&wqueue->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&wqueue->lock, flags);
   return ret;
 }
 

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -69,6 +69,7 @@ static void work_timer_expiry(wdparm_t arg)
   FAR struct work_s *work = (FAR struct work_s *)arg;
 
   irqstate_t flags = spin_lock_irqsave(&work->wq->lock);
+  sched_lock();
 
   /* We have being canceled */
 
@@ -78,6 +79,7 @@ static void work_timer_expiry(wdparm_t arg)
     }
 
   spin_unlock_irqrestore(&work->wq->lock, flags);
+  sched_unlock();
 }
 
 static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
@@ -182,8 +184,10 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
   if (!delay)
     {
+      sched_lock();
       queue_work(wqueue, work);
       spin_unlock_irqrestore(&wqueue->lock, flags);
+      sched_unlock();
     }
   else
     {

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -140,6 +140,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR void *arg, clock_t delay)
 {
   irqstate_t flags;
+  int ret = OK;
 
   if (wqueue == NULL || work == NULL || worker == NULL)
     {
@@ -151,6 +152,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
    */
 
   flags = spin_lock_irqsave(&wqueue->lock);
+  sched_lock();
 
   /* Remove the entry from the timer and work queue. */
 
@@ -170,8 +172,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
   if (work_is_canceling(wqueue->worker, wqueue->nthreads, work))
     {
-      spin_unlock_irqrestore(&wqueue->lock, flags);
-      return 0;
+      goto out;
     }
 
   /* Initialize the work structure. */
@@ -184,18 +185,17 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
   if (!delay)
     {
-      sched_lock();
       queue_work(wqueue, work);
-      spin_unlock_irqrestore(&wqueue->lock, flags);
-      sched_unlock();
     }
   else
     {
       wd_start(&work->u.timer, delay, work_timer_expiry, (wdparm_t)work);
-      spin_unlock_irqrestore(&wqueue->lock, flags);
     }
 
-  return 0;
+out:
+  spin_unlock_irqrestore(&wqueue->lock, flags);
+  sched_unlock();
+  return ret;
 }
 
 int work_queue(int qid, FAR struct work_s *work, worker_t worker,

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <unistd.h>
+#include <sched.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -204,7 +205,9 @@ static int work_thread(int argc, FAR char *argv[])
           while (kworker->wait_count > 0)
             {
               kworker->wait_count--;
+              sched_lock();
               nxsem_post(&kworker->wait);
+              sched_unlock();
             }
         }
 

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -149,6 +149,7 @@ static int work_thread(int argc, FAR char *argv[])
             ((uintptr_t)strtoul(argv[2], NULL, 16));
 
   flags = spin_lock_irqsave(&wqueue->lock);
+  sched_lock();
 
   /* Loop forever */
 
@@ -191,10 +192,11 @@ static int work_thread(int argc, FAR char *argv[])
            */
 
           spin_unlock_irqrestore(&wqueue->lock, flags);
+          sched_unlock();
 
           CALL_WORKER(worker, arg);
-
           flags = spin_lock_irqsave(&wqueue->lock);
+          sched_lock();
 
           /* Mark the thread un-busy */
 
@@ -205,9 +207,7 @@ static int work_thread(int argc, FAR char *argv[])
           while (kworker->wait_count > 0)
             {
               kworker->wait_count--;
-              sched_lock();
               nxsem_post(&kworker->wait);
-              sched_unlock();
             }
         }
 
@@ -217,18 +217,19 @@ static int work_thread(int argc, FAR char *argv[])
        */
 
       wqueue->wait_count++;
-
       spin_unlock_irqrestore(&wqueue->lock, flags);
+      sched_unlock();
 
       nxsem_wait_uninterruptible(&wqueue->sem);
-
       flags = spin_lock_irqsave(&wqueue->lock);
+      sched_lock();
     }
 
   spin_unlock_irqrestore(&wqueue->lock, flags);
+  sched_unlock();
 
   nxsem_post(&wqueue->exsem);
-  return 0;
+  return OK;
 }
 
 /****************************************************************************
@@ -291,7 +292,7 @@ static int work_thread_create(FAR const char *name, int priority,
     }
 
   sched_unlock();
-  return 0;
+  return OK;
 }
 
 /****************************************************************************
@@ -407,7 +408,7 @@ int work_queue_free(FAR struct kwork_wqueue_s *wqueue)
   nxsem_destroy(&wqueue->exsem);
   kmm_free(wqueue);
 
-  return 0;
+  return OK;
 }
 
 /****************************************************************************

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -148,8 +148,7 @@ static int work_thread(int argc, FAR char *argv[])
   kworker = (FAR struct kworker_s *)
             ((uintptr_t)strtoul(argv[2], NULL, 16));
 
-  flags = spin_lock_irqsave(&wqueue->lock);
-  sched_lock();
+  flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
 
   /* Loop forever */
 
@@ -191,12 +190,10 @@ static int work_thread(int argc, FAR char *argv[])
            * performed... we don't have any idea how long this will take!
            */
 
-          spin_unlock_irqrestore(&wqueue->lock, flags);
-          sched_unlock();
+          spin_unlock_irqrestore_nopreempt(&wqueue->lock, flags);
 
           CALL_WORKER(worker, arg);
-          flags = spin_lock_irqsave(&wqueue->lock);
-          sched_lock();
+          flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
 
           /* Mark the thread un-busy */
 
@@ -217,16 +214,13 @@ static int work_thread(int argc, FAR char *argv[])
        */
 
       wqueue->wait_count++;
-      spin_unlock_irqrestore(&wqueue->lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&wqueue->lock, flags);
 
       nxsem_wait_uninterruptible(&wqueue->sem);
-      flags = spin_lock_irqsave(&wqueue->lock);
-      sched_lock();
+      flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
     }
 
-  spin_unlock_irqrestore(&wqueue->lock, flags);
-  sched_unlock();
+  spin_unlock_irqrestore_nopreempt(&wqueue->lock, flags);
 
   nxsem_post(&wqueue->exsem);
   return OK;


### PR DESCRIPTION
## Summary

1. sched/spin_lock: rename raw_spin_* to spin_*_notrace

raw_spin in the Linux kernel means disable the preemption before
holding the spin lock, not disable trace. Rename raw_spin to
spin_*_notrace to make the interface more semantically consistent.


2. sched/spinlock: add a new set of interfaces to disable preemption

```
spin_lock                ->      spin_lock_nopreempt
spin_trylock             ->      spin_trylock_nopreempt
spin_unlock              ->      spin_unlock_nopreempt
spin_lock_irqsave        ->      spin_lock_irqsave_nopreempt
spin_trylock_irqsave     ->      spin_trylock_irqsave_nopreempt
spin_unlock_irqrestore   ->      spin_unlock_irqrestore_nopreempt
```

3. sched/spinlock: replace all disable preemption case with spin_*_nopreempt

```
flags = spin_lock_irqsave(&g_can_lock);       ->   flags = spin_lock_irqsave_nopreempt(&g_can_lock);
sched_lock();                                 ->

spin_unlock_irqrestore(&g_can_lock, flags);   ->
sched_unlock();                               ->   spin_unlock_irqrestore_nopreempt(&g_can_lock, flags);
```


4. sched/spinlock: removed the semantics of disable preemption from default spin_lock

In the RTOS environment, spin_lock is simplified as much as possible to improve performance.
At the same time, we provide an set of APIs that disable preemption by default:

```
spin_lock                ->      spin_lock_nopreempt
spin_trylock             ->      spin_trylock_nopreempt
spin_unlock              ->      spin_unlock_nopreempt
spin_lock_irqsave        ->      spin_lock_irqsave_nopreempt
spin_trylock_irqsave     ->      spin_trylock_irqsave_nopreempt
spin_unlock_irqrestore   ->      spin_unlock_irqrestore_nopreempt

```
This also has the same intention with RT-Linux.

Signed-off-by: chao an <anchao.archer@bytedance.com>



## Impact

N/A

## Testing

ci-check