### PR TITLE
sim: Align LLVM target info across CMake and Makefile

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -29,6 +29,32 @@ if(WIN32)
   return()
 endif()
 
+# LLVM style architecture flags
+if(CONFIG_HOST_X86_64)
+  if(CONFIG_SIM_M32)
+    set(LLVM_ARCHTYPE "x86")
+    set(LLVM_CPUTYPE "i686")
+  else()
+    set(LLVM_ARCHTYPE "x86_64")
+    set(LLVM_CPUTYPE "skylake")
+  endif()
+elseif(CONFIG_HOST_X86_32)
+  set(LLVM_ARCHTYPE "x86")
+  set(LLVM_CPUTYPE "i686")
+elseif(CONFIG_HOST_ARM64)
+  set(LLVM_ARCHTYPE "aarch64")
+  set(LLVM_CPUTYPE "cortex-a53")
+elseif(CONFIG_HOST_ARM)
+  set(LLVM_ARCHTYPE "arm")
+  set(LLVM_CPUTYPE "cortex-a9")
+endif()
+
+if(CONFIG_HOST_LINUX OR CONFIG_HOST_MACOS)
+  set(LLVM_ABITYPE "sysv")
+elseif(WIN32)
+  set(LLVM_ABITYPE "msvc")
+endif()
+
 # NuttX is sometimes built as a native target. In that case, the __NuttX__ macro
 # is predefined by the compiler. https://github.com/NuttX/buildroot
 #

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -179,9 +179,9 @@ else ifeq ($(CONFIG_HOST_ARM),y)
 endif
 
 ifeq ($(CONFIG_HOST_LINUX),y)
-  LLVM_ABITYPE := gnu
+  LLVM_ABITYPE := sysv
 else ifeq ($(CONFIG_HOST_MACOS),y)
-  LLVM_ABITYPE := darwin
+  LLVM_ABITYPE := sysv
 endif
 
 ARCHPICFLAGS = -fpic

--- a/tools/Rust.defs
+++ b/tools/Rust.defs
@@ -38,13 +38,13 @@ ifeq ($(CONFIG_ARCH_SIM),y)
   ifeq ($(CONFIG_HOST_LINUX),y)
     ifeq ($(LLVM_ARCHTYPE),x86)
       # Only for x86 based host or x64 but m32 build
-      RUSTFLAGS += --target i686-unknown-linux-$(LLVM_ABITYPE)
+      RUSTFLAGS += --target i686-unknown-linux-gnu
     else
       # For other archs, such as aarch64, arm etc
-      RUSTFLAGS += --target $(LLVM_ARCHTYPE)-unknown-linux-$(LLVM_ABITYPE)
+        RUSTFLAGS += --target $(LLVM_ARCHTYPE)-unknown-linux-gnu
     endif
   else ifeq ($(CONFIG_HOST_MACOS),y)
-    RUSTFLAGS += --target $(LLVM_ARCHTYPE)-apple-$(LLVM_ABITYPE)
+    RUSTFLAGS += --target $(LLVM_ARCHTYPE)-apple-darwin
   endif
 else ifeq ($(CONFIG_ARCH_RISCV),y)
   # Target triple is riscv[32|64][isa]-unknown-none-elf


### PR DESCRIPTION
## Summary
- Unified the specification of LLVM architecture and ABI types across the CMake and Makefile configurations.
- Introduced `LLVM_ARCHTYPE` and `LLVM_CPUTYPE` variables in the CMake configuration to match the Makefile's approach.
- Standardized the ABI type (`LLVM_ABITYPE`) to `sysv` for both Linux and macOS host configurations.

## Impact
- Ensures consistent LLVM target definitions across build systems (CMake and Makefile).
- Simplifies future maintenance by avoiding divergence in LLVM-related configurations.
- No functional changes to the build output; only the internal representation of LLVM target information is aligned.

## Testing

GitHub CI and local build

