### PR TITLE
arm/armv7: update percpu task only for co-processor

### DIFF
--- a/arch/arm/src/armv7-a/arm_scu.c
+++ b/arch/arm/src/armv7-a/arm_scu.c
@@ -58,14 +58,6 @@ void arm_enable_smp(int cpu)
 {
   uint32_t regval;
 
-  /* We need to confirm that current_task has been initialized. */
-
-  while (!current_task(this_cpu()));
-
-  /* Init idle task to percpu reg */
-
-  up_update_task(current_task(cpu));
-
   /* Handle actions unique to CPU0 which comes up first */
 
   if (cpu == 0)
@@ -112,6 +104,14 @@ void arm_enable_smp(int cpu)
       /* Wait for the SCU to be enabled by the primary processor -- should
        * not be necessary.
        */
+
+      /* We need to confirm that current_task has been initialized. */
+
+      while (!current_task(this_cpu()));
+
+      /* Init idle task to percpu reg */
+
+      up_update_task(current_task(cpu));
     }
 
   /* Enable the data cache, set the SMP mode with ACTLR.SMP=1.

--- a/arch/arm/src/armv7-r/arm_scu.c
+++ b/arch/arm/src/armv7-r/arm_scu.c
@@ -58,14 +58,6 @@ void arm_enable_smp(int cpu)
 {
   uint32_t regval;
 
-  /* We need to confirm that current_task has been initialized. */
-
-  while (!current_task(this_cpu()));
-
-  /* Init idle task to percpu reg */
-
-  up_update_task(current_task(cpu));
-
   /* Handle actions unique to CPU0 which comes up first */
 
   if (cpu == 0)
@@ -114,6 +106,14 @@ void arm_enable_smp(int cpu)
       /* Wait for the SCU to be enabled by the primary processor -- should
        * not be necessary.
        */
+
+      /* We need to confirm that current_task has been initialized. */
+
+      while (!current_task(this_cpu()));
+
+      /* Init idle task to percpu reg */
+
+      up_update_task(current_task(cpu));
     }
 
   /* Enable the data cache, set the SMP mode with ACTLR.SMP=1.


### PR DESCRIPTION
## Summary

arm/armv7: update percpu task only for co-processor

fix smp crash on sabre-6quad/smp, regression from:

```
|commit 1e49cb4828f3cdb26252eab3e68f7ca9962bc8ba
|Author: hujun5 <hujun5@xiaomi.com>
|Date:   Thu Dec 5 16:58:17 2024 +0800
|
|    armv7-a/armv7-r/armv8-r: percpu reg store this_task
|
|    This is continue work of https://github.com/apache/nuttx/pull/13726
|
|    We can utilize percpu storage to hold information about the
|    current running task. If we intend to implement this feature, we would
|    need to define two macros that help us manage this percpu information
|    effectively.
|
|    up_this_task: This macro is designed to read the contents of the percpu
|    register to retrieve information about the current
|    running task.This allows us to quickly access
|    task-specific data without having to disable interrupts,
|    access global variables and obtain the current cpu index.
|
|    up_update_task: This macro is responsible for updating the contents of
|    the percpu register.It is typically called during
|    initialization or when a context switch occurs to ensure
|    that the percpu register reflects the information of the
|    newly running task.
|
|    Signed-off-by: hujun5 <hujun5@xiaomi.com>
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

sabre-6quad/smp

## Testing

sabre-6quad/smp:

cmake -B build -DBOARD_CONFIG=sabre-6quad/smp -GNinja
cmake --build build
qemu-system-arm -semihosting -M sabrelite -m 1024 -smp 4 -nographic -kernel build/nuttx
