### PR TITLE
docs: Rename hello_rust to rust/baremetal to reflect the actual codebase

### DIFF
--- a/Documentation/applications/examples/hello_rust/index.rst
+++ b/Documentation/applications/examples/hello_rust/index.rst
@@ -1,5 +1,0 @@
-==================================
-``hello_rust`` Hello World in Rust
-==================================
-
-Hello World in Rust.

--- a/Documentation/applications/examples/rust/baremetal/index.rst
+++ b/Documentation/applications/examples/rust/baremetal/index.rst
@@ -1,0 +1,16 @@
+==================================
+`baremetal` Hello World in Rust
+==================================
+
+This example demonstrates how to create a simple "Hello World" program in Rust for a bare-metal environment. The program is compiled using the `rustc` compiler directly, without relying on any operating system or standard library.
+
+The key aspects of this example include:
+
+- **No Standard Library**: The program uses the `#![no_std]` attribute, which means it does not link against the standard library. This is essential for bare-metal programming where the standard library is not available.
+- **No Main Function**: The program uses the `#![no_main]` attribute, which indicates that the program does not have a standard `main` function. Instead, it defines a custom entry point.
+- **Panic Handler**: A custom panic handler is defined using the `#[panic_handler]` attribute. This handler is called when a panic occurs, and in this case, it enters an infinite loop to halt the program.
+- **C Interoperability**: The program uses the `extern "C"` block to declare the `printf` function from the C standard library. This allows the Rust program to call C functions directly.
+- **Entry Point**: The `hello_rust_main` function is the entry point of the program. It is marked with `#[no_mangle]` to prevent the Rust compiler from mangling its name, making it callable from C.
+- **Printing**: The program uses the `printf` function to print "Hello, Rust!!" to the console. The `printf` function is called using the `unsafe` block because it involves calling a C function.
+
+This example is a great starting point for understanding how to write and compile Rust programs for bare-metal environments, where you have full control over the hardware and no operating system overhead.

--- a/Documentation/applications/examples/rust/index.rst
+++ b/Documentation/applications/examples/rust/index.rst
@@ -1,0 +1,11 @@
+Rust Examples
+=============
+
+This directory contains examples of Rust applications.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :titlesonly:
+
+   */index*


### PR DESCRIPTION
## Summary
- The `hello_rust` example has been moved to `rust/baremetal` to better reflect its purpose as a bare-metal Rust application.
- The move also helps in organizing the Rust examples more clearly, separating them into categories based on their environment (bare-metal vs. non-bare-metal).
- A new directory structure has been created under `rust/baremetal`, and the `index.rst` file has been updated to describe the `baremetal` example in detail.
- The top-level `rust/index.rst` file has been created to include the new `rust/baremetal` directory in the toctree.

## Impact
- The new file structure and documentation improvements will help new contributors and users understand the purpose and setup of the example more easily.
- This change aligns the documentation with the actual codebase, enhancing the overall maintainability and clarity of the project.


## Testing

GitHub CI and local document build


