### PR TITLE
Mpfs ddr training refinement

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_wdog.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_wdog.h
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/hardware/mpfs_wdog.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_WDOG_H
+#define __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_WDOG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Magic value for REFRESH register to reload watchdog countdown counter */
+
+#define WDOG_REFRESH_RELOAD          (0xdeadc0de)
+
+/* Magic value for FORCE register to perform immediate system reset */
+
+#define WDOG_FORCE_IMMEDIATE_RESET   (0x0c)
+
+/****************************************************************************
+ * Register Offsets
+ ****************************************************************************/
+
+#define MPFS_WDOG_REFRESH_OFFSET            0x000 /* Write value 0xdeadc0de to reset wdog. Read to get current count value */
+#define MPFS_WDOG_CONTROL_OFFSET            0x004 /* WDOG counter register */
+#define MPFS_WDOG_STATUS_OFFSET             0x008 /* WDOG status register */
+#define MPFS_WDOG_TIME_OFFSET               0x00C /* Set WDOG time value */
+#define MPFS_WDOG_MSVP_OFFSET               0x010 /* Set MSVP int level */
+#define MPFS_WDOG_TRIGGER_OFFSET            0x014 /* Set NMI int level */
+#define MPFS_WDOG_FORCE_OFFSET              0x018 /* Force trigger WDOG NMI seq. Writing 0xc triggers immediate reset */
+
+/****************************************************************************
+ * Control register masks
+ ****************************************************************************/
+
+#define WDOG_CONTROL_INTEN_MSVP_MASK        (1 << 0) /* Bit 0:  Enable MVRP interrupt when MVRP level is passed */
+#define WDOG_CONTROL_INTEN_TRIG_MASK        (1 << 1) /* Bit 1:  Enable NMI interrupt. This bit is permanenty set */
+#define WDOG_CONTROL_INTEN_SLEEP_MASK       (1 << 2) /* Bit 2:  Enable MVRP interrupt when MVRP level is passed and M3 is sleeping */
+#define WDOG_CONTROL_ACTIVE_SLEEP_MASK      (1 << 3) /* Bit 3:  Set WDOG operational during CPU sleep */
+#define WDOG_CONTROL_ENABLE_FORBITTEN_MASK  (1 << 4) /* Bit 4:  Enable trigger wdog from write during forbitten window */
+
+/****************************************************************************
+ * Status register masks
+ ****************************************************************************/
+
+#define WDOG_STATUS_MVRP_TRIPPED_MASK       (1 << 0) /* Bit 0:  MVRP level has passed. Write to clear interrupt */
+#define WDOG_STATUS_WDOG_TRIPPED_MASK       (1 << 1) /* Bit 1:  TRIGGER level has passed and NMI is asserted. Write to clear interrupt */
+#define WDOG_STATUS_FORBITTEN_MASK          (1 << 2) /* Bit 2:  Watchdog in forbitten window */
+#define WDOG_STATUS_TRIGGERED_MASK          (1 << 3) /* Bit 3:  Watchdog has triggered */
+#define WDOG_STATUS_LOCKED_MASK             (1 << 4) /* Bit 4:  Following registers are locked and cannot be changed */
+#define WDOG_STATUS_DEVRST_MASK             (1 << 5) /* Bit 5:  DEVRST caused NMI */
+
+#endif /* __ARCH_RISCV_SRC_MPFS_HARDWARE_MPFS_WDOG_H */

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -37,6 +37,7 @@
 #include "mpfs_cache.h"
 #include "mpfs_mm_init.h"
 #include "mpfs_userspace.h"
+#include "hardware/mpfs_wdog.h"
 
 #include "riscv_internal.h"
 #include "riscv_percpu.h"
@@ -149,7 +150,15 @@ void __mpfs_start(uint64_t mhartid)
       /* Reset, but let the progress come out of the uart first */
 
       up_udelay(1000);
-      up_systemreset();
+
+      /* Reset by triggering WDOG */
+
+      putreg32(WDOG_FORCE_IMMEDIATE_RESET,
+               MPFS_WDOG0_LO_BASE + MPFS_WDOG_FORCE_OFFSET);
+
+      /* Wait for the reset */
+
+      for (; ; );
     }
 #endif
 


### PR DESCRIPTION
## Summary

Refining MPFS DDR training error handling

- Reset with WDT after completely failed training to avoid leaving "soft reset" status in the boot reason register
- Avoid unnecessary resets after failed DDR training. In most cases it is enough to reset the controller and try again. The expected failures return -EAGAIN. But also the unexpected ones typically can be re-covered by just re-training. So always re-try the ddr training after a failure, but add a re-try counter counting only the unexpected errors, just as a backup.

## Impact

Impacts only mpfs platform with (LP)DDR memory, with stand-alone booting images (i.e. without HSS & u-boot, using CONFIG_MPFS_BOOTLOADER and CONFIG_MPFS_DDR_INIT). Improves boot time by avoiding unnecessary reboots, if the DDR training results in multiple failures in row.

## Testing

Tested on several custom mpfs hardware designs.
