### PR TITLE
net/can/: add statistics for recv, sent and drop

### DIFF
--- a/include/nuttx/net/can.h
+++ b/include/nuttx/net/can.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/can.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2009-2012, 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007, 2009-2012, 2015 Gregory Nutt. All
+ * rights reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  * SPDX-FileContributor: Adam Dunkels <adam@dunkels.com>
@@ -43,6 +44,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/can.h>
+#include <nuttx/net/netconfig.h>
 #include <stdint.h>
 
 /****************************************************************************
@@ -58,6 +60,19 @@
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
+/* The structure holding the CAN statistics that are gathered if
+ * CONFIG_NET_STATISTICS is defined.
+ */
+
+#ifdef CONFIG_NET_STATISTICS
+struct can_stats_s
+{
+  net_stats_t drop;       /* Number of dropped CAN frames */
+  net_stats_t recv;       /* Number of received CAN frames */
+  net_stats_t sent;       /* Number of sent CAN frames */
+};
+#endif
 
 /****************************************************************************
  * Public Data

--- a/include/nuttx/net/netstats.h
+++ b/include/nuttx/net/netstats.h
@@ -66,6 +66,9 @@
 #ifdef CONFIG_NET_MLD
 #  include <nuttx/net/mld.h>
 #endif
+#ifdef CONFIG_NET_CAN
+#  include <nuttx/net/can.h>
+#endif
 
 #ifdef CONFIG_NET_STATISTICS
 
@@ -113,6 +116,10 @@ struct net_stats_s
 
 #ifdef CONFIG_NET_UDP
   struct udp_stats_s  udp;      /* UDP statistics */
+#endif
+
+#ifdef CONFIG_NET_CAN
+  struct can_stats_s  can;      /* CAN statistics */
 #endif
 };
 

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -33,6 +33,7 @@
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/mm/iob.h>
+#include <nuttx/net/netstats.h>
 
 #include "devif/devif.h"
 #include "can/can.h"
@@ -83,10 +84,7 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
       ninfo("Dropped %d bytes\n", dev->d_len);
 
 #ifdef CONFIG_NET_STATISTICS
-      /* No support CAN net statistics yet */
-
-      /* g_netstats.tcp.drop++; */
-
+      g_netstats.can.drop++;
 #endif
     }
 

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -234,6 +234,7 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
   else
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
+      ret = 0;
       goto errout;
     }
 

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/can.h>
+#include <nuttx/net/netstats.h>
 
 #include "devif/devif.h"
 #include "can/can.h"
@@ -270,6 +271,10 @@ int can_input(FAR struct net_driver_s *dev)
   FAR uint8_t *buf;
   int ret;
 
+#ifdef CONFIG_NET_STATISTICS
+  g_netstats.can.recv++;
+#endif
+
   if (dev->d_iob != NULL)
     {
       buf = dev->d_buf;
@@ -284,7 +289,15 @@ int can_input(FAR struct net_driver_s *dev)
       return ret;
     }
 
-  return netdev_input(dev, can_in, false);
+  ret = netdev_input(dev, can_in, false);
+  if (ret < 0)
+    {
+#ifdef CONFIG_NET_STATISTICS
+    g_netstats.can.drop++;
+#endif
+    }
+
+  return ret;
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_CAN */

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -41,6 +41,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
+#include <nuttx/net/netstats.h>
 
 #include "netdev/netdev.h"
 #include "devif/devif.h"
@@ -199,7 +200,13 @@ static inline void can_newdata(FAR struct net_driver_s *dev,
 
   if (recvlen < dev->d_len)
     {
-      can_datahandler(dev, pstate->pr_conn);
+      if (can_datahandler(dev, pstate->pr_conn) < dev->d_len)
+        {
+          ninfo("Dropped %d bytes\n", dev->d_len);
+#ifdef CONFIG_NET_STATISTICS
+          g_netstats.can.drop++;
+#endif
+        }
     }
 
   /* Indicate no data in the buffer */

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -42,6 +42,7 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/net/netstats.h>
 
 #include "netdev/netdev.h"
 #include "devif/devif.h"
@@ -300,6 +301,10 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
     {
       return ret;
     }
+
+#ifdef CONFIG_NET_STATISTICS
+  g_netstats.can.sent++;
+#endif
 
   /* Return the number of bytes actually sent */
 

--- a/net/devif/devif_initialize.c
+++ b/net/devif/devif_initialize.c
@@ -58,7 +58,7 @@
  * Public Data
  ****************************************************************************/
 
-/* IP/TCP/UDP/ICMP statistics for all network interfaces */
+/* IP/TCP/UDP/ICMP/CAN statistics for all network interfaces */
 
 #ifdef CONFIG_NET_STATISTICS
 struct net_stats_s g_netstats;

--- a/net/procfs/net_statistics.c
+++ b/net/procfs/net_statistics.c
@@ -40,7 +40,8 @@
 
 #if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6) || \
     defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP) || \
-    defined(CONFIG_NET_ICMP) || defined(CONFIG_NET_ICMPv6)
+    defined(CONFIG_NET_ICMP) || defined(CONFIG_NET_ICMPv6) || \
+    defined(CONFIG_NET_CAN)
 
 /****************************************************************************
  * Private Function Prototypes
@@ -135,7 +136,10 @@ static int netprocfs_header(FAR struct netprocfs_file_s *netfile)
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ICMP");
 #endif
 #ifdef CONFIG_NET_ICMPv6
-  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ICMPv6");
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, " ICMPv6");
+#endif
+#ifdef CONFIG_NET_CAN
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, " CAN");
 #endif
 
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "\n");
@@ -178,6 +182,11 @@ static int netprocfs_received(FAR struct netprocfs_file_s *netfile)
                   g_netstats.icmpv6.recv);
 #endif
 
+#ifdef CONFIG_NET_CAN
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
+                  g_netstats.can.recv);
+#endif
+
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "\n");
   return len;
 }
@@ -216,6 +225,10 @@ static int netprocfs_dropped(FAR struct netprocfs_file_s *netfile)
 #ifdef CONFIG_NET_ICMPv6
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
                   g_netstats.icmpv6.drop);
+#endif
+#ifdef CONFIG_NET_CAN
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
+                  g_netstats.can.drop);
 #endif
 
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "\n");
@@ -278,6 +291,9 @@ static int netprocfs_checksum(FAR struct netprocfs_file_s *netfile)
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
 #endif
 #ifdef CONFIG_NET_ICMPv6
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
+#endif
+#ifdef CONFIG_NET_CAN
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
 #endif
 
@@ -344,6 +360,9 @@ static int netprocfs_prototype(FAR struct netprocfs_file_s *netfile)
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
                   g_netstats.icmpv6.typeerr);
 #endif
+#ifdef CONFIG_NET_CAN
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
+#endif
 
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "\n");
   return len;
@@ -384,6 +403,10 @@ static int netprocfs_sent(FAR struct netprocfs_file_s *netfile)
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
                   g_netstats.icmpv6.sent);
 #endif
+#ifdef CONFIG_NET_CAN
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  %04x",
+                  g_netstats.can.sent);
+#endif
 
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "\n");
   return len;
@@ -415,6 +438,9 @@ static int netprocfs_retransmissions(FAR struct netprocfs_file_s *netfile)
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
 #endif
 #ifdef CONFIG_NET_ICMPv6
+  len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
+#endif
+#ifdef CONFIG_NET_CAN
   len += snprintf(&netfile->line[len], NET_LINELEN - len, "  ----");
 #endif
 


### PR DESCRIPTION
## Summary

Add support for network statistics for CAN. It includes counters for received, sent and dropped frames.
This change was necessary for our application to monitor the dropped can frames reported in the field.
The implementation has mimicked the existing ones for tcp and udp statistics, adding a can_stats_s struct to store the recv, sent and drop counters with the already existing net_stats_t type.

## Impact

With this change, users can access the CAN statistics through procfs, the same way they access to all the other network statistics. The CAN recv, sent, and drop counters have been added to the /proc/net/stat output following the same design already existing for other network devices. This change doesn't change any driver behavior beyond just adding the new statistics. It does not introduce any new dependencies beyond the needed header files needed to access the new can_stats_s struct and g_netstats variable. These includes are nuttx/net/netconfig.h and nuttx/net/can.h.
The CAN statistics implemented are only enabled if CONFIG_NET_STATISTICS and CONFIG_NET_CAN configurations are set.

## Testing

Tested using a Ubuntu 22.04 and a stm32h7 custom board with CONFIG_NET_STATISTICS and CONFIG_NET_CAN configurations enabled. The test application opens a CAN interface using socketCAN and echoes all the frames read. Every two seconds we print out the CAN statistics and see the recv and sent counters increase accordingly. To test the drop counter, we stop reading the CAN interface from the application so the frames start accumulating in the network buffer. Eventually, that buffer gets full and we start seeing the drop counter increasing as expected.
This traces are printed after reading the counters from /proc/net/stat
CAN stats:
   Received: 00000022
   Sent:     00000022
   Dropped:  00000010



