### PR TITLE
arch/risc-v/src/common/riscv_backtrace.c: Fix "error: pointer of type 'void *' used in arithmetic"

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -157,13 +157,15 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
                           (void *)getfp(), NULL, buffer, size, &skip);
 #else
           ret = backtrace(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (uintptr_t *)((uintptr_t)rtcb->stack_base_ptr +
+                                        rtcb->adj_stack_size),
                           (void *)getfp(), NULL, buffer, size, &skip);
 #endif
           if (ret < size)
             {
-              ret += backtrace(rtcb->stack_base_ptr,
-                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
+              ret += backtrace(rtcb->stack_base_ptr, (uintptr_t *)
+                               ((uintptr_t)rtcb->stack_base_ptr +
+                                rtcb->adj_stack_size),
                                running_regs()[REG_FP],
                                running_regs()[REG_EPC],
                                &buffer[ret], size - ret, &skip);
@@ -174,16 +176,18 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #ifdef CONFIG_ARCH_KERNEL_STACK
           if (rtcb->xcp.ustkptr != NULL)
             {
-              ret = backtrace(rtcb->stack_base_ptr,
-                              rtcb->stack_base_ptr + rtcb->adj_stack_size,
+              ret = backtrace(rtcb->stack_base_ptr, (uintptr_t *)
+                              ((uintptr_t)rtcb->stack_base_ptr +
+                               rtcb->adj_stack_size),
                               (void *)*(rtcb->xcp.ustkptr + 1), NULL,
                               buffer, size, &skip);
             }
           else
 #endif
             {
-              ret = backtrace(rtcb->stack_base_ptr,
-                              rtcb->stack_base_ptr + rtcb->adj_stack_size,
+              ret = backtrace(rtcb->stack_base_ptr, (uintptr_t *)
+                              ((uintptr_t)rtcb->stack_base_ptr +
+                               rtcb->adj_stack_size),
                               (void *)getfp(), NULL, buffer, size, &skip);
             }
         }
@@ -194,7 +198,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
       if (tcb->xcp.ustkptr != NULL)
         {
           ret = backtrace(tcb->stack_base_ptr,
-                          tcb->stack_base_ptr + tcb->adj_stack_size,
+                          (uintptr_t *)((uintptr_t)tcb->stack_base_ptr +
+                                        tcb->adj_stack_size),
                           (void *)*(tcb->xcp.ustkptr + 1), NULL,
                           buffer, size, &skip);
         }
@@ -202,7 +207,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #endif
         {
           ret = backtrace(tcb->stack_base_ptr,
-                          tcb->stack_base_ptr + tcb->adj_stack_size,
+                          (uintptr_t *)((uintptr_t)tcb->stack_base_ptr +
+                                        tcb->adj_stack_size),
                           (void *)tcb->xcp.regs[REG_FP],
                           (void *)tcb->xcp.regs[REG_EPC],
                           buffer, size, &skip);


### PR DESCRIPTION
## Summary

Fix a compilation error when using -Wpointer-arith and CONFIG_SCHED_BACKTRACE

## Impact

Makes code to compile when using -Werror.

## Testing

Tested on MPFS target, with the following flags added:

Tested compilation of "icicle/nsh" target, after adding the "CONFIG_SCHED_BACKTRACE=y" to boards/risc-v/mpfs/icicle/configs/nsh/defconfig. 

The compilation command is:
"make EXTRAFLAGS=-Wpointer-arith -Werror"

With this patch, the compilation passes without warnings/errors. Without this patch the following warnings are produced:

common/riscv_backtrace.c:166:53: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  166 |                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
      |                                                     ^
common/riscv_backtrace.c:186:52: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  186 |                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
      |                                                    ^
common/riscv_backtrace.c:205:47: error: pointer of type 'void *' used in arithmetic [-Werror=pointer-arith]
  205 |                           tcb->stack_base_ptr + tcb->adj_stack_size,
      |                                               ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:144: riscv_backtrace.o] Error 1
make: *** [tools/LibTargets.mk:170: arch/risc-v/src/libarch.a] Error 2


