### PR TITLE
arch: Remove the abuse of spinlock in smp boot

### DIFF
--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
 #include "nvic.h"
@@ -65,7 +64,7 @@
  * Public Data
  ****************************************************************************/
 
-static volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS];
+static volatile bool g_cpu_wait[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions
@@ -112,7 +111,7 @@ static void cpu1_boot(void)
       up_enable_irq(LC823450_IRQ_SMP_CALL_01);
     }
 
-  spin_unlock(&g_cpu_wait[0]);
+  g_cpu_wait[0] = true;
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */
@@ -177,8 +176,6 @@ int up_cpu_start(int cpu)
                      tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
   putreg32((uint32_t)cpu1_boot, CPU1_VECTOR_RESETV);
 
-  spin_lock(&g_cpu_wait[0]);
-
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify of the start event */
 
@@ -198,7 +195,7 @@ int up_cpu_start(int cpu)
   irq_attach(LC823450_IRQ_SMP_CALL_11, lc823450_smp_call_handler, NULL);
   up_enable_irq(LC823450_IRQ_SMP_CALL_11);
 
-  spin_lock(&g_cpu_wait[0]);
+  while (!g_cpu_wait[0]);
 
   /* CPU1 boot done */
 
@@ -207,8 +204,6 @@ int up_cpu_start(int cpu)
   putreg32(backup[0], CPU1_VECTOR_ISTACK);
   putreg32(backup[1], CPU1_VECTOR_RESETV);
   putreg32(0x0, REMAP); /* remap disable */
-
-  spin_unlock(&g_cpu_wait[0]);
 
   return 0;
 }

--- a/arch/arm/src/rp2040/rp2040_cpustart.c
+++ b/arch/arm/src/rp2040/rp2040_cpustart.c
@@ -34,7 +34,6 @@
 #include <errno.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
 #include "nvic.h"
@@ -67,7 +66,7 @@
  * Public Data
  ****************************************************************************/
 
-volatile static spinlock_t g_core1_boot;
+static volatile bool g_core1_boot;
 
 extern int rp2040_smp_call_handler(int irq, void *c, void *arg);
 
@@ -156,7 +155,7 @@ static void core1_boot(void)
   irq_attach(RP2040_SMP_CALL_PROC1, rp2040_smp_call_handler, NULL);
   up_enable_irq(RP2040_SMP_CALL_PROC1);
 
-  spin_unlock(&g_core1_boot);
+  g_core1_boot = true;
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */
@@ -221,8 +220,6 @@ int up_cpu_start(int cpu)
     ;
   clrbits_reg32(RP2040_PSM_PROC1, RP2040_PSM_FRCE_OFF);
 
-  spin_lock(&g_core1_boot);
-
   /* Send initial VTOR, MSP, PC for Core 1 boot */
 
   core1_boot_msg[0] = 0;
@@ -252,11 +249,9 @@ int up_cpu_start(int cpu)
   irq_attach(RP2040_SMP_CALL_PROC0, rp2040_smp_call_handler, NULL);
   up_enable_irq(RP2040_SMP_CALL_PROC0);
 
-  spin_lock(&g_core1_boot);
+  while (!g_core1_boot);
 
   /* CPU Core 1 boot done */
-
-  spin_unlock(&g_core1_boot);
 
   return 0;
 }

--- a/arch/sparc/src/s698pm/s698pm_cpustart.c
+++ b/arch/sparc/src/s698pm/s698pm_cpustart.c
@@ -34,7 +34,6 @@
 #include <errno.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
 #include "sched/sched.h"
@@ -51,7 +50,7 @@
  * Public Data
  ****************************************************************************/
 
-volatile static spinlock_t g_cpu_boot;
+static volatile bool g_cpu_boot;
 
 /****************************************************************************
  * Public Functions
@@ -79,7 +78,7 @@ void s698pm_cpu_boot(void)
 
   s698pm_cpuint_initialize();
 
-  spin_unlock(&g_cpu_boot);
+  g_cpu_boot = true;
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify that this CPU has started */
@@ -150,17 +149,13 @@ int up_cpu_start(int cpu)
   regaddr = S698PM_DSU_BASE + (0x1000000 * cpu) + S698PM_DSU_NPC_OFFSET;
   putreg32(0x40001004, regaddr);
 
-  spin_lock(&g_cpu_boot);
-
   /* set 1 to bit n of multiprocessor status register to active cpu n */
 
   putreg32(1 << cpu, S698PM_IRQREG_MPSTATUS);
 
-  spin_lock(&g_cpu_boot);
+  while (!g_cpu_boot);
 
   /* prev cpu boot done */
-
-  spin_unlock(&g_cpu_boot);
 
   return 0;
 }

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -32,7 +32,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
-#include <nuttx/spinlock.h>
 #include <nuttx/sched_note.h>
 
 #include "sched/sched.h"
@@ -51,7 +50,6 @@
  ****************************************************************************/
 
 static volatile bool g_appcpu_started;
-static volatile spinlock_t g_appcpu_interlock;
 
 /****************************************************************************
  * ROM function prototypes
@@ -128,12 +126,9 @@ void IRAM_ATTR xtensa_appcpu_start(void)
   sched_note_cpu_started(tcb);
 #endif
 
-  /* Release the spinlock to signal to the PRO CPU that the APP CPU has
-   * started.
-   */
+  /* Signal to the PRO CPU that the APP CPU has started. */
 
   g_appcpu_started = true;
-  spin_unlock(&g_appcpu_interlock);
 
   /* Reset scheduler parameters */
 
@@ -220,81 +215,67 @@ void IRAM_ATTR xtensa_appcpu_start(void)
 
 int up_cpu_start(int cpu)
 {
+  uint32_t regval;
+
   DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS && cpu != this_cpu());
 
-  if (!g_appcpu_started)
-    {
-      uint32_t regval;
+  /* Start CPU1 */
 
-      /* Start CPU1 */
-
-      sinfo("Starting CPU%d\n", cpu);
+  sinfo("Starting CPU%d\n", cpu);
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
-      /* Notify of the start event */
+  /* Notify of the start event */
 
-      sched_note_cpu_start(this_task(), cpu);
+  sched_note_cpu_start(this_task(), cpu);
 #endif
 
-      /* This spinlock will be used as a handshake between the two CPUs.
-       * It's first initialized to its locked state, later the PRO CPU will
-       * try to lock it but spins until the APP CPU starts and unlocks it.
-       */
+  /* Unstall the APP CPU */
 
-      spin_lock_init(&g_appcpu_interlock);
-      spin_lock(&g_appcpu_interlock);
+  regval  = getreg32(RTC_CNTL_SW_CPU_STALL_REG);
+  regval &= ~RTC_CNTL_SW_STALL_APPCPU_C1_M;
+  putreg32(regval, RTC_CNTL_SW_CPU_STALL_REG);
 
-      /* Unstall the APP CPU */
+  regval  = getreg32(RTC_CNTL_OPTIONS0_REG);
+  regval &= ~RTC_CNTL_SW_STALL_APPCPU_C0_M;
+  putreg32(regval, RTC_CNTL_OPTIONS0_REG);
 
-      regval  = getreg32(RTC_CNTL_SW_CPU_STALL_REG);
-      regval &= ~RTC_CNTL_SW_STALL_APPCPU_C1_M;
-      putreg32(regval, RTC_CNTL_SW_CPU_STALL_REG);
+  /* OpenOCD might have already enabled clock gating and taken APP CPU
+   * out of reset.  Don't reset the APP CPU if that's the case as this
+   * will clear the breakpoints that may have already been set.
+   */
 
-      regval  = getreg32(RTC_CNTL_OPTIONS0_REG);
-      regval &= ~RTC_CNTL_SW_STALL_APPCPU_C0_M;
-      putreg32(regval, RTC_CNTL_OPTIONS0_REG);
+  regval = getreg32(DPORT_APPCPU_CTRL_B_REG);
+  if ((regval & DPORT_APPCPU_CLKGATE_EN_M) == 0)
+    {
+      /* Enable clock gating for the APP CPU */
 
-      /* OpenOCD might have already enabled clock gating and taken APP CPU
-       * out of reset.  Don't reset the APP CPU if that's the case as this
-       * will clear the breakpoints that may have already been set.
-       */
+      regval |= DPORT_APPCPU_CLKGATE_EN;
+      putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
 
-      regval = getreg32(DPORT_APPCPU_CTRL_B_REG);
-      if ((regval & DPORT_APPCPU_CLKGATE_EN_M) == 0)
-        {
-          /* Enable clock gating for the APP CPU */
+      regval  = getreg32(DPORT_APPCPU_CTRL_C_REG);
+      regval &= ~DPORT_APPCPU_RUNSTALL;
+      putreg32(regval, DPORT_APPCPU_CTRL_C_REG);
 
-          regval |= DPORT_APPCPU_CLKGATE_EN;
-          putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
+      /* Reset the APP CPU */
 
-          regval  = getreg32(DPORT_APPCPU_CTRL_C_REG);
-          regval &= ~DPORT_APPCPU_RUNSTALL;
-          putreg32(regval, DPORT_APPCPU_CTRL_C_REG);
+      regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
+      regval |= DPORT_APPCPU_RESETTING;
+      putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
 
-          /* Reset the APP CPU */
-
-          regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
-          regval |= DPORT_APPCPU_RESETTING;
-          putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
-
-          regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
-          regval &= ~DPORT_APPCPU_RESETTING;
-          putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
-        }
-
-      /* Set the CPU1 start address */
-
-      ets_set_appcpu_boot_addr((uint32_t)xtensa_appcpu_start);
-
-      /* And wait until the APP CPU starts and releases the spinlock. */
-
-      spin_lock(&g_appcpu_interlock);
-
-      /* prev cpu boot done */
-
-      spin_unlock(&g_appcpu_interlock);
-      DEBUGASSERT(g_appcpu_started);
+      regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
+      regval &= ~DPORT_APPCPU_RESETTING;
+      putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
     }
+
+  /* Set the CPU1 start address */
+
+  ets_set_appcpu_boot_addr((uint32_t)xtensa_appcpu_start);
+
+  /* And wait until the APP CPU starts */
+
+  while (!g_appcpu_started);
+
+  /* prev cpu boot done */
 
   return OK;
 }


### PR DESCRIPTION
## Summary

What's really need is a done signal sent from the secondary cpu to the boot cpu, so let's simplify the logic by:

1. Change the spinlock to a bool flag
2. Set the flag to true in the secondary cpu
3. Wait the flag set in the boot cpu before continue booting

This also remove all bad usage of spinlock from the code base:

1. Lock spinlock in one thread, but unlock in a different thread
2. Lock spinlock twice in one thread, but unlock only once

## Impact

Normalize the spinlock usage to avoid the future abuse by copy/paste

## Testing

local
