### PR TITLE
xtensa/esp32[s2|c3|c6|h2]: fix sched_[lock|unlock] boot crash

### DIFF
--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
@@ -74,6 +74,8 @@ SECTIONS
     *(.iram1.*)
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)
 
     *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
@@ -194,6 +196,8 @@ SECTIONS
     *(.dram1.*)
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
+    *libsched.a:sched_lock.*(.rodata .rodata.*)
+    *libsched.a:sched_unlock.*(.rodata .rodata.*)
 
     *libarch.a:*(.rodata.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.rodata .rodata.*)

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
@@ -74,6 +74,8 @@ SECTIONS
     *(.iram1.*)
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)
 
     *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
@@ -218,6 +220,8 @@ SECTIONS
     *(.dram1.*)
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
+    *libsched.a:sched_lock.*(.rodata .rodata.*)
+    *libsched.a:sched_unlock.*(.rodata .rodata.*)
 
     *libarch.a:*(.rodata.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.rodata .rodata.*)

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
@@ -74,6 +74,8 @@ SECTIONS
     *(.iram1.*)
 
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)
 
     *libarch.a:*(.text.esprv_intc_int_get_type .literal.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.text .text.* .literal .literal.*)
@@ -213,6 +215,8 @@ SECTIONS
     *(.dram1.*)
 
     *libsched.a:irq_dispatch.*(.rodata .rodata.*)
+    *libsched.a:sched_lock.*(.rodata .rodata.*)
+    *libsched.a:sched_unlock.*(.rodata .rodata.*)
 
     *libarch.a:*(.rodata.esprv_intc_int_get_type)
     *libarch.a:*riscv_doirq.*(.rodata .rodata.*)

--- a/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
@@ -172,6 +172,11 @@ SECTIONS
     *libarch.a:*cpu_region_protect.*(.text .text.* .literal .literal.*)
 
     *libc.a:sq_remlast.*(.literal .text .literal.* .text.*)
+
+    *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
+    *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)
+
     *(.wifirxiram .wifirxiram.*)
     *(.wifi0iram  .wifi0iram.*)
     *(.wifiorslpiram .wifiorslpiram.*)
@@ -318,6 +323,10 @@ SECTIONS
     *libarch.a:*log.*(.rodata .rodata.*)
     *libarch.a:*log_noos.*(.rodata .rodata.*)
     *libarch.a:*cpu_region_protect.*(.rodata .rodata.*)
+
+    *libsched.a:irq_dispatch.*(.rodata .rodata.*)
+    *libsched.a:sched_lock.*(.rodata .rodata.*)
+    *libsched.a:sched_unlock.*(.rodata .rodata.*)
 
     . = ALIGN(4);
     _edata = ABSOLUTE(.);


### PR DESCRIPTION
## Summary

- xtensa/esp32[s2|c3|c6|h2]: fix sched_[lock|unlock] boot crash
 - Move the code to iram0 since sched_lock/sched_unlock is called in the early boot phase.

## Impact

Closes https://github.com/apache/nuttx/issues/15688 fixing the boot problem

## Testing

Internal CI testing + building the following defconfigs ensuring they are booting successfully:
- `esp32s2-saola-1:nsh`
- `esp32c3-generic:nsh`
- `esp32c6-devkitc:nsh`
- `esp32h2-devkit:nsh`