### PR TITLE
arch/xtensa: Add --print-memory-usage to LDFLAGS in Toolchain.defs

### DIFF
--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -181,6 +181,8 @@ NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 
+LDFLAGS += --print-memory-usage
+
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),)
     ifeq ($(GCCVER),)

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -185,6 +185,8 @@ NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 
+LDFLAGS += --print-memory-usage
+
 ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
   ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),)
     ifeq ($(GCCVER),)


### PR DESCRIPTION
## Summary
- Added `--print-memory-usage` to `LDFLAGS` in `Toolchain.defs` for both `lx6` and `lx7` architectures
- This flag enables memory usage reporting during the linking phase, providing better visibility into memory allocation

## Impact
- No functional changes - the flag only adds additional debug information during the build process
- Improves debugging and optimization capabilities by providing detailed memory usage statistics
- Maintains compatibility with existing build configurations and toolchains

## Testing
Test result on esp32s3:
```
Memory region         Used Size  Region Size  %age Used
             ROM:      556116 B   16777184 B      3.31%
     iram0_0_seg:       23296 B       304 KB      7.48%
     irom0_0_seg:      621652 B   16777184 B      3.71%
     dram0_0_seg:       85780 B       288 KB     29.09%
     drom0_0_seg:      157180 B   16777184 B      0.94%
    rtc_iram_seg:           0 B       8168 B      0.00%
    rtc_data_seg:           0 B       8168 B      0.00%
rtc_reserved_seg:           0 B         24 B      0.00%
    rtc_slow_seg:           0 B         8 KB      0.00%
```

