### PR TITLE
nxgdb/irq: add irqinfo command

### DIFF
--- a/Documentation/guides/gdb/irqinfo.rst
+++ b/Documentation/guides/gdb/irqinfo.rst
@@ -1,0 +1,44 @@
+=======
+irqinfo
+=======
+
+``irqinfo`` is a custom GDB command that prints information about the IRQs in the system.
+The output includes the IRQ number, the number of times the IRQ has been triggered,
+the total time spent in the IRQ handler, the rate of the IRQ, the IRQ handler function,
+and the handler's argument.
+
+The argument is displayed as function if possible.
+
+It's similar to nsh command ``irqinfo`` but works in GDB. See :ref:`cmdirqinfo` for more information.
+
+The ``RATE`` column is not available.
+
+.. tip::
+    To show the ``COUNT`` column, you need to enable the ``CONFIG_SCHED_IRQMONITOR`` option in the NuttX configuration.
+
+Syntax
+------
+
+  ``irqinfo``
+
+
+Example
+-------
+.. code-block:: bash
+
+    (gdb) irqinfo
+    IRQ  COUNT      TIME   RATE   HANDLER                                          ARGUMENT
+    0    0          0      N/A    mps_reserved                             0x0 <sensor_unregister>
+    2    0          0      N/A    mps_nmi                                  0x0 <sensor_unregister>
+    3    0          0      N/A    arm_hardfault                            0x0 <sensor_unregister>
+    4    0          0      N/A    arm_memfault                             0x0 <sensor_unregister>
+    5    0          0      N/A    arm_busfault                             0x0 <sensor_unregister>
+    6    0          0      N/A    arm_usagefault                           0x0 <sensor_unregister>
+    11   1          0      N/A    arm_svcall                               0x0 <sensor_unregister>
+    12   0          0      N/A    arm_dbgmonitor                           0x0 <up_debugpoint_remove>
+    14   0          0      N/A    mps_pendsv                               0x0 <up_debugpoint_remove>
+    15   6581421    0      N/A    systick_interrupt                        0x100010c <g_systick_lower>
+    49   2          0      N/A    uart_cmsdk_tx_interrupt                  0x1000010 <g_uart0port>
+    50   0          0      N/A    uart_cmsdk_rx_interrupt                  0x1000010 <g_uart0port>
+    59   2          0      N/A    uart_cmsdk_ov_interrupt                  0x1000010 <g_uart0port>
+    (gdb)

--- a/Documentation/guides/gdbwithpython.rst
+++ b/Documentation/guides/gdbwithpython.rst
@@ -6,15 +6,15 @@ Introduction
 ============
 
 The NuttX kernel can be effectively debugged using GDB's Python extension.
-Commonly used classes and utilities are implemented in the nuttx/tools/gdb/nuttxgdb directory.
+Commonly used classes and utilities are implemented in the ``nuttx/tools/gdb/nuttxgdb`` directory.
 Users can also create custom Python scripts tailored to their debugging needs to analyze and troubleshoot the NuttX kernel more efficiently.
 
 Usage
 =====
 
-1. Compile NuttX with CONFIG_DEBUG_SYMBOLS=y enabled and change `CONFIG_DEBUG_SYMBOLS_LEVEL` to -g3.
+1. Compile NuttX with CONFIG_DEBUG_SYMBOLS=y enabled and change ``CONFIG_DEBUG_SYMBOLS_LEVEL`` to ``-g3``.
 2. Use GDB to debug the NuttX ELF binary (on a real device, a simulator, or with a coredump).
-3. Add the following argument to the GDB command line: `-ix="nuttx/tools/pynuttx/gdbinit.py"`
+3. Add the following argument to the GDB command line: ``-ix="nuttx/tools/pynuttx/gdbinit.py"``
 4. GDB will automatically load the Python script, enabling the use of custom commands.
 
 How to write a GDB python script
@@ -25,3 +25,24 @@ Here is an article that introduces the fundamental principles of Python in GDB. 
 
 For more documentation on gdb python, please refer to the official documentation of GDB.
 `GDB Python API <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Python-API.html#Python-API>`_.
+
+Requirements
+============
+
+To use GDB with Python, the following requirements must be met:
+
+- Use GDB compiled with Python support, Python 3.8 or later
+- Install required Python packages: ``pip install -r tools/pynuttx/requirements.txt``
+- Compile NuttX with debug level 3: ``CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"``
+
+.. Warning::
+   The GDB Python API is not available in all versions of GDB. Make sure to use a version that supports Python.
+
+.. Warning::
+   NuttX must be compile with ``CONFIG_DEBUG_SYMBOLS=y`` and ``CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"`` to use GDB with Python.
+
+.. toctree::
+   :caption: GDB Plugin Commands
+   :maxdepth: 1
+
+   gdb/irqinfo.rst

--- a/Documentation/guides/gdbwithpython.rst
+++ b/Documentation/guides/gdbwithpython.rst
@@ -14,7 +14,7 @@ Usage
 
 1. Compile NuttX with CONFIG_DEBUG_SYMBOLS=y enabled and change `CONFIG_DEBUG_SYMBOLS_LEVEL` to -g3.
 2. Use GDB to debug the NuttX ELF binary (on a real device, a simulator, or with a coredump).
-3. Add the following argument to the GDB command line: `-ix="nuttx/tools/gdb/gdbinit.py"`
+3. Add the following argument to the GDB command line: `-ix="nuttx/tools/pynuttx/gdbinit.py"`
 4. GDB will automatically load the Python script, enabling the use of custom commands.
 
 How to write a GDB python script

--- a/Documentation/guides/qemugdb.rst
+++ b/Documentation/guides/qemugdb.rst
@@ -53,7 +53,7 @@ Start GDB to connect to QEMU
 
     .. code-block:: console
 
-      $ gdb-multiarch nuttx -ex "source tools/gdb/gdbinit.py" -ex "target remote 127.0.0.1:1234"
+      $ gdb-multiarch nuttx -ex "source tools/pynuttx/gdbinit.py" -ex "target remote 127.0.0.1:1234"
       Reading symbols from nuttx...
       Registering NuttX GDB commands from ~/nuttx/nuttx/tools/gdb/nuttxgdb
       set pagination off

--- a/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
+++ b/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
@@ -424,7 +424,7 @@ After building the kernel (and the applications, in kernel mode), use the toolch
 to debug RISC-V applications. For instance, if you are using the xPack's prebuilt toolchain,
 you can use the following command to start GDB::
 
-    $ riscv-none-elf-gdb-py3 -ix tools/gdb/gdbinit.py --tui nuttx
+    $ riscv-none-elf-gdb-py3 -ix tools/pynuttx/gdbinit.py --tui nuttx
 
 To use QEMU for debugging, one should add the parameters ``-s -S`` to the QEMU command line.
 

--- a/Documentation/quickstart/debugging.rst
+++ b/Documentation/quickstart/debugging.rst
@@ -244,12 +244,12 @@ The benefit is that it works also for the sim build where ``openocd`` is
 not applicable. For this to work, you will need to enable PROC filesystem support
 which will expose required task information (``CONFIG_FS_PROCFS=y``).
 
-To use this approach, you can load the ``nuttx/tools/gdb/gdbinit.py`` file. An
+To use this approach, you can load the ``nuttx/tools/pynuttx/gdbinit.py`` file. An
 easy way to do this is to add an extra command:
 
 .. code-block:: console
 
-  $ gdb nuttx -ix=tools/gdb/gdbinit.py
+  $ gdb nuttx -ix=tools/pynuttx/gdbinit.py
 
 gdb can need to set the current elf support architecture, for example,
 the prefix is arm-ebai-none-.

--- a/tools/pynuttx/nxgdb/irq.py
+++ b/tools/pynuttx/nxgdb/irq.py
@@ -1,0 +1,80 @@
+############################################################################
+# tools/pynuttx/nxgdb/irq.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+from __future__ import annotations
+
+from typing import List
+
+import gdb
+
+from . import utils
+from .protocols import irq as p
+
+g_irqvector = utils.parse_and_eval("g_irqvector")
+NR_IRQS = utils.nitems(g_irqvector)
+CONFIG_SCHED_IRQMONITOR = utils.has_field(g_irqvector, "count")
+
+
+class IRQInfo(utils.Value, p.IRQInfo):
+    def __init__(self, irq: gdb.Value):
+        super().__init__(irq)
+
+    @property
+    def count(self) -> int:
+        return self["count"] if CONFIG_SCHED_IRQMONITOR else -1
+
+    @property
+    def time(self) -> int:
+        return self["time"] if CONFIG_SCHED_IRQMONITOR else -1
+
+    @property
+    def start(self) -> int:
+        return self["start"] if CONFIG_SCHED_IRQMONITOR else -1
+
+
+def get_irqs() -> List[IRQInfo]:
+    return (IRQInfo(irq) for irq in utils.ArrayIterator(g_irqvector))
+
+
+class IRQInfoDump(gdb.Command):
+    """Dump irqinfo"""
+
+    formatter = "{:<4} {:<10} {:<6} {:<6} {:<48} {} "
+    header = ("IRQ", "COUNT", "TIME", "RATE", "HANDLER", "ARGUMENT")
+
+    def __init__(self):
+        super().__init__("irqinfo", gdb.COMMAND_USER)
+
+    def invoke(self, arg: str, from_tty: bool) -> None:
+        irq_unexpected_isr = utils.gdb_eval_or_none("irq_unexpected_isr")
+
+        print(self.formatter.format(*self.header))
+        for i, irq in enumerate(get_irqs()):
+            if not irq.handler or (int(irq.handler) & ~0x01) == irq_unexpected_isr:
+                continue
+
+            handler = irq.handler.format_string(styling=True, address=False).strip("<>")
+            irq_arg = irq.arg.format_string(styling=True)
+
+            print(
+                self.formatter.format(i, irq.count, irq.time, "N/A", handler, irq_arg)
+            )

--- a/tools/pynuttx/nxgdb/protocols/irq.py
+++ b/tools/pynuttx/nxgdb/protocols/irq.py
@@ -1,0 +1,35 @@
+############################################################################
+# tools/pynuttx/nxgdb/protocols/irq.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+from __future__ import annotations
+
+from .value import Value
+
+
+class IRQInfo(Value):
+    """struct irq_info_s"""
+
+    handler: Value
+    arg: Value
+    start: Value
+    time: Value
+    count: Value


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Similar to nsh command, `irqinfo` shows the registered IRQ callbacks and arguements.
Arguements is shown as a function when possible.
If intrumentation is enabled, it also prints the IRQ count etc.

```
(gdb) irqinfo
IRQ  COUNT      TIME   RATE   HANDLER                                          ARGUMENT
0    0          0      N/A    mps_reserved                             0x0 <sensor_unregister>
2    0          0      N/A    mps_nmi                                  0x0 <sensor_unregister>
3    0          0      N/A    arm_hardfault                            0x0 <sensor_unregister>
4    0          0      N/A    arm_memfault                             0x0 <sensor_unregister>
5    0          0      N/A    arm_busfault                             0x0 <sensor_unregister>
6    0          0      N/A    arm_usagefault                           0x0 <sensor_unregister>
11   1          0      N/A    arm_svcall                               0x0 <sensor_unregister>
12   0          0      N/A    arm_dbgmonitor                           0x0 <up_debugpoint_remove>
14   0          0      N/A    mps_pendsv                               0x0 <up_debugpoint_remove>
15   6581421    0      N/A    systick_interrupt                        0x100010c <g_systick_lower>
49   2          0      N/A    uart_cmsdk_tx_interrupt                  0x1000010 <g_uart0port>
50   0          0      N/A    uart_cmsdk_rx_interrupt                  0x1000010 <g_uart0port>
59   2          0      N/A    uart_cmsdk_ov_interrupt                  0x1000010 <g_uart0port>
(gdb)

```
## Impact

New feature.

## Testing

Tested with qemu live debugging.

