### PR TITLE
Nxgdb memleak optimization

### DIFF
--- a/tools/pynuttx/nxgdb/memleak.py
+++ b/tools/pynuttx/nxgdb/memleak.py
@@ -114,7 +114,9 @@ class MMLeak(gdb.Command):
         sorted_addr = set()
         t = time.time()
         print("Gather memory nodes...", flush=True, end="")
-        for node in memdump.dump_nodes(heaps, {"no_pid": mm.PID_MM_MEMPOOL}):
+        for node in memdump.dump_nodes(
+            heaps, {"no_pid": mm.PID_MM_MEMPOOL, "used": True}
+        ):
             nodes_dict[node.address] = node
             sorted_addr.add(node.address)
 

--- a/tools/pynuttx/nxgdb/memleak.py
+++ b/tools/pynuttx/nxgdb/memleak.py
@@ -131,19 +131,34 @@ class MMLeak(gdb.Command):
 
         longsize = utils.get_long_type().sizeof
 
+        checked_ptr = {}
+
         def pointers(node: memdump.MMNodeDump) -> Generator[int, None, None]:
             # Return all possible pointers stored in this node
             size = node.nodesize - node.overhead
             memory = node.read_memory()
+            prev_mem = None
             while size > 0:
                 size -= longsize
-                ptr = int.from_bytes(memory[size : size + longsize], "little")
+                mem = memory[size : size + longsize]
+                if mem == prev_mem:
+                    continue
+
+                prev_mem = mem
+                ptr = int.from_bytes(mem, "little")
+                if ptr in checked_ptr:
+                    continue
+
+                checked_ptr[ptr] = True
+
                 if any(region["start"] <= ptr < region["end"] for region in regions):
                     yield ptr
 
         print("Leak analyzing...", flush=True, end="")
         t = time.time()
         for good in good_nodes:
+            if not sorted_addr:  # All nodes are checked
+                break
             for ptr in pointers(good):
                 if not (idx := bisect.bisect_right(sorted_addr, ptr)):
                     continue


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR includes two changes to `nxgdb` memleak command.
1. Fix that we only need to check used node again leak, excluding free nodes.
2. Optimize memleak check performance by 35%, tested on an internal project that has 128MB memory.

The optimization uses below methods.
1. Use memoryview to avoid creating int objects, reducing overhead
2. Store checked pointers in a dictionary for efficient lookups, improving performance.
3. While dictionary operations have some cost, the overall speedup is significant.
    
## Impact

Memleak check now should be faster on system has larger memory.

## Testing


Tested internally with a coredump.

