### PR TITLE
arch/arm64 Fix the SP unalignment issues

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -154,10 +154,11 @@
 #define REG_SP_EL0          (34)
 #define REG_EXE_DEPTH       (35)
 #define REG_SCTLR_EL1       (36)
+#define REG_RESERVED        (37)
 
 /* In Armv8-A Architecture, the stack must align with 16 byte */
 
-#define ARM64_CONTEXT_REGS  (37)
+#define ARM64_CONTEXT_REGS  (38)
 #define ARM64_CONTEXT_SIZE  (8 * ARM64_CONTEXT_REGS)
 
 #ifdef CONFIG_ARCH_FPU


### PR DESCRIPTION
## Summary

zynq-mpsoc and zcu111 borad was broken by #15437, because #15437 changes ARM64_CONTEXT_REGS from 36 to 37, resulting in the stack no longer being 16-byte aligned which appears to violate the ARMv8-A architecture's requirement for 16-byte stack alignment. this PR changes ARM64_CONTEXT_REGS to 38 to fix the issues #15747.

## Impact

Impact on user: YES, this PR changes ARM64_CONTEXT_REGS from 37 to 38 will consume 8 byte more memary, but the mpact is acceptable.
Impact on build: NO, this PR just changes the value of ARM64_CONTEXT_REGS.
Impact on hardware: YES. This impacts all the arm64 hardware,  but tested and passed on ZCU111 board.
Impact on documentation: NO,  there's no functionality or usage changes, so the documentation does not need to bo modified.
Impact on security: YES, this PR improved security.
Impact on compatibility:YES, this PR fixed uncompatibility of zynq-mpsoc and zcu111 borad.

## Testing

Build Host(s): Linux Ubuntu 22.04, x86_64, Linaro GCC 7.3-2018.04-rc3.
Target(s): Zynq UltraScale+ MPSoC ZCU111 board.
Testing logs:

**nsh:**

1 tools/configure.sh zcu111:nsh
2 make
3 flash to the QSPI flash of ZCU111 and boot:

```
Xilinx Zynq MP First Stage Boot Loader 
Release 2018.3   Dec 16 2024  -  19:57:38
NOTICE:  BL31: Built : 09:38:30, Dec 20 2024
- Ready to Boot Primary CPU
- Boot from EL1
- Boot to C runtime for OS Initialize
nx_start: Entry
NuttShell (NSH) NuttX-10.2.0
nsh> nx_start: CPU0: Beginning Idle Loop
nsh> 
nsh> 
```

**JTAG:**

1 tools/configure.sh zcu111:jtag
2 make
3 download to the ZCU111 by JTAG and run:

```
- Ready to Boot Primary CPU
- Boot from EL3
- Boot to C runtime for OS Initialize
nx_start: Entry
up_allocate_heap: heap_start=0x0x183000, heap_size=0x7fd7d000
gic_validate_dist_version: GICv2 detected
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
work_start_highpri: Starting high-priority kernel worker thread(s)
nxtask_activate: hpwork pid=1,TCB=0x1835b0
nx_start_application: Starting init thread
task_spawn: name=nsh_main entry=0x11cfd8 file_actions=0 attr=0x181d30 argv=0x181d50
nxtask_activate: nsh_main pid=2,TCB=0x185ac0
lib_cxx_initialize: _sinit: 0x15dc34 _einit: 0x15dc34

NuttShell (NSH) NuttX-10.2.0
nsh> nx_start: CPU0: Beginning Idle Loop
nsh> 
nsh> 
```


