### PR TITLE
feat: add arch depends for aurix tc397 board

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -2202,6 +2202,7 @@ config ARCH_BOARD_SABRE_6QUAD
 
 config ARCH_BOARD_TC397
 	bool "Infineon's AURIX TC397 board: KIT_A2G_TC397_5V_TFT"
+	depends on ARCH_CHIP_TC397
 	---help---
 		This options selects support for NuttX on the Infineon's AURIX board
 		board featuring the TC397 6Quad CPU.


### PR DESCRIPTION
## Summary
While digging through code I've noticed that tricore board option was present on a stm32 chip config.
This is due to a missing depends on statement.
Mostly a preference/esthetic change?

## Impact
None regarding build process
tricore board will only show (in menuconfig) if tricore chip (tc397) arch is also selected.

## Testing
Manually.
Checked that the option is present if tc397 chip is selected, hidden otherwise.

