### PR TITLE
 docs: enhance Rust guide

### DIFF
--- a/Documentation/guides/rust.rst
+++ b/Documentation/guides/rust.rst
@@ -32,6 +32,8 @@ Supported Platforms
 - ARMv8-M
 - RISCV32
 - RISCV64
+- X86
+- X86_64
 
 Getting Started
 ===============

--- a/Documentation/guides/rust.rst
+++ b/Documentation/guides/rust.rst
@@ -92,3 +92,43 @@ Build the NuttX image and run it on your target platform:
     Hello world from tokio!
 
 Congratulations! You have successfully built and run a Rust application on NuttX.
+
+Specifying Target CPU for Optimization
+======================================
+To optimize your Rust application for a specific CPU, you can use the `RUSTFLAGS` environment variable to specify the target CPU. This can significantly improve performance by enabling CPU-specific optimizations.
+
+The `RUSTFLAGS` environment variable is particularly useful when you are working with CPUs that share the same Instruction Set Architecture (ISA) but have different microarchitectures. For example, both the Cortex-M33 and Cortex-M55 share the `thumbv8m.main` target name, but they have different performance characteristics and features. By specifying the actual CPU core, you can take advantage of the specific optimizations and features of the target CPU, leading to better performance and efficiency.
+
+For instance, if you are targeting a Cortex-M33, you would set the `RUSTFLAGS` environment variable as follows:
+
+.. code-block:: bash
+
+    export RUSTFLAGS="-C target-cpu=cortex-m33"
+
+And for a Cortex-M55, you would use:
+
+.. code-block:: bash
+
+    export RUSTFLAGS="-C target-cpu=cortex-m55"
+
+This ensures that the Rust compiler generates optimized code tailored to the specific CPU core, rather than a generic ISA.
+
+1. Set the `RUSTFLAGS` environment variable to include the `--target-cpu` flag:
+
+.. code-block:: bash
+
+    export RUSTFLAGS="-C target-cpu=your_cpu_model"
+
+Replace `your_cpu_model` with the specific CPU model you are targeting. For example, for an ARM Cortex-M4, you would use:
+
+.. code-block:: bash
+
+    export RUSTFLAGS="-C target-cpu=cortex-m4"
+
+2. Build your NuttX image with the specified target CPU:
+
+.. code-block:: bash
+
+    make
+
+This will ensure that the Rust compiler generates optimized code for the specified CPU.


### PR DESCRIPTION
docs: enhance Rust guide with CPU optimization instructions
## Summary
- Added a section to the Rust guide that explains how to use the `RUSTFLAGS` environment variable to specify the target CPU for optimization.
- Provides examples and instructions for setting `RUSTFLAGS` for different CPU models, such as Cortex-M33 and Cortex-M55, to generate performance-optimized code.
    
## Impact
- Enhances the developer's ability to produce more efficient Rust applications on NuttX by leveraging CPU-specific optimizations.
- No runtime or functional changes; only documentation improvements to guide users in optimizing their build configurations for specific hardware.

## Test
local document build