### PR TITLE
include/stdlib.h: define system()'s prototype for the flat build

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -183,7 +183,7 @@ void      _Exit(int status) noreturn_function;
  * standards compatibility.
  */
 
-#ifndef __KERNEL__
+#if !defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
 int       system(FAR const char *cmd);
 #endif
 


### PR DESCRIPTION
## Summary

* include/stdlib.h: define system()'s prototype for the flat build

The `$(APPDIR)` folder is added to the `$(KERNDEPDIRS)` when `CONFIG_BUILD_KERNEL=y`. The `depend` phase iterates over the `$(KERNDEPDIRS)` folders and executes the `depend` recipe of these folders (including the apps' recipes) with the `__KERNEL__` macro defined, which prevents `system()`'s prototype from being declared.

## Impact

Impact architectures that build App's dependencies (the `depend` recipe) with `CONFIG_SYSTEM_SYSTEM=y`. This is the case, for instance, when building Python's library with support to the `system()` function.

This PR closes https://github.com/apache/nuttx/issues/15721

## Testing

Internal CI testing + `rv-virt:python` with `system()` support:

```
make -j distclean && ./tools/configure.sh rv-virt:python && kconfig-tweak -e SYSTEM_SYSTEM && kconfig-tweak -e EXAMPLES_SYSTEM && make olddefconfig && make
```

Before this PR, it failed with:

```
/home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace_alfa/apps/interpreters/python/Python/Modules/posixmodule.c:6026:14: error: implicit declaration of function 'system' [-Werror=implicit-function-declaration]
 6026 |     result = system(bytes);
      |              ^~~~~~
cc1: some warnings being treated as errors
```