### PR TITLE
h7: eth: add checks for PHYID in stm32_phyinit

### DIFF
--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -107,6 +107,64 @@
 #  endif
 #endif
 
+#if defined(CONFIG_ETH0_PHY_AM79C874)
+#  define STM32H7_PHYID1       MII_PHYID1_AM79C874
+#  define STM32H7_PHYID2       MII_PHYID2_AM79C874
+#elif defined(CONFIG_ETH0_PHY_AR8031)
+#  define STM32H7_PHYID1       MII_PHYID1_AR8031
+#  define STM32H7_PHYID2       MII_PHYID2_AR8031
+#elif defined(CONFIG_ETH0_PHY_KS8721)
+#  define STM32H7_PHYID1       MII_PHYID1_KS8721
+#  define STM32H7_PHYID2       MII_PHYID2_KS8721
+#elif defined(CONFIG_ETH0_PHY_KSZ8041)
+#  define STM32H7_PHYID1       MII_PHYID1_KSZ8041
+#  define STM32H7_PHYID2       MII_PHYID2_KSZ8041
+#elif defined(CONFIG_ETH0_PHY_KSZ8051)
+#  define STM32H7_PHYID1       MII_PHYID1_KSZ8051
+#  define STM32H7_PHYID2       MII_PHYID2_KSZ8051
+#elif defined(CONFIG_ETH0_PHY_KSZ8061)
+#  define STM32H7_PHYID1       MII_PHYID1_KSZ8061
+#  define STM32H7_PHYID2       MII_PHYID2_KSZ8061
+#elif defined(CONFIG_ETH0_PHY_KSZ8081)
+#  define STM32H7_PHYID1       MII_PHYID1_KSZ8081
+#  define STM32H7_PHYID2       MII_PHYID2_KSZ8081
+#elif defined(CONFIG_ETH0_PHY_DP83848C)
+#  define STM32H7_PHYID1       MII_PHYID1_DP83848C
+#  define STM32H7_PHYID2       MII_PHYID2_DP83848C
+#elif defined(CONFIG_ETH0_PHY_DP83825I)
+#  define STM32H7_PHYID1       MII_PHYID1_DP83825I
+#  define STM32H7_PHYID2       MII_PHYID2_DP83825I
+#elif defined(CONFIG_ETH0_PHY_TJA1100)
+#  define STM32H7_PHYID1       MII_PHYID1_TJA1100
+#  define STM32H7_PHYID2       MII_PHYID2_TJA1100
+#elif defined(CONFIG_ETH0_PHY_TJA1101)
+#  define STM32H7_PHYID1       MII_PHYID1_TJA1101
+#  define STM32H7_PHYID2       MII_PHYID2_TJA1101
+#elif defined(CONFIG_ETH0_PHY_TJA1103)
+#  define STM32H7_PHYID1       MII_PHYID1_TJA1103
+#  define STM32H7_PHYID2       MII_PHYID2_TJA1103
+#elif defined(CONFIG_ETH0_PHY_LAN8720)
+#  define STM32H7_PHYID1       MII_PHYID1_LAN8720
+#  define STM32H7_PHYID2       MII_PHYID2_LAN8720
+#elif defined(CONFIG_ETH0_PHY_LAN8740)
+#  define STM32H7_PHYID1       MII_PHYID1_LAN8740
+#  define STM32H7_PHYID2       MII_PHYID2_LAN8740
+#elif defined(CONFIG_ETH0_PHY_LAN8740A)
+#  define STM32H7_PHYID1       MII_PHYID1_LAN8740A
+#  define STM32H7_PHYID2       MII_PHYID2_LAN8740A
+#elif defined(CONFIG_ETH0_PHY_LAN8742A)
+#  define STM32H7_PHYID1       MII_PHYID1_LAN8742A
+#  define STM32H7_PHYID2       MII_PHYID2_LAN8742A
+#elif defined(CONFIG_ETH0_PHY_DM9161)
+#  define STM32H7_PHYID1       MII_PHYID1_DM9161
+#  define STM32H7_PHYID2       MII_PHYID2_DM9161
+#elif defined(CONFIG_ETH0_PHY_YT8512)
+#  define STM32H7_PHYID1       MII_PHYID1_YT8512
+#  define STM32H7_PHYID2       MII_PHYID2_YT8512
+#else
+#  warning "No PHY specified!"
+#endif
+
 #ifndef CONFIG_STM32H7_PHYADDR
 #  error "CONFIG_STM32H7_PHYADDR must be defined in the NuttX configuration"
 #endif
@@ -3335,7 +3393,10 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
     {
       up_mdelay(10);
       to -= 10;
+      phyval = 0xffff;
       ret = stm32_phyread(CONFIG_STM32H7_PHYADDR, MII_MCR, &phyval);
+
+      ninfo("MII_MCR: phyval: %u ret: %d\n", phyval, ret);
     }
   while (phyval & MII_MCR_RESET && to > 0);
 
@@ -3348,6 +3409,40 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
     {
       ninfo("Phy reset in %d ms\n", PHY_RESET_DELAY - to);
     }
+
+  ret = stm32_phyread(CONFIG_STM32H7_PHYADDR, MII_PHYID1, &phyval);
+
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to read PHYID1: %d\n", ret);
+      return ret;
+    }
+
+  if (phyval != STM32H7_PHYID1)
+    {
+      nerr("ERROR: Incorrect PHYID1: %u expected: %u\n",
+            phyval, STM32H7_PHYID1);
+      return -ENXIO;
+    }
+
+  ninfo("MII_PHYID1: phyval: %u ret: %d\n", phyval, ret);
+
+  ret = stm32_phyread(CONFIG_STM32H7_PHYADDR, MII_PHYID2, &phyval);
+
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to read PHYID2: %d\n", ret);
+      return ret;
+    }
+
+  if ((phyval & 0xfff0) != (STM32H7_PHYID2 & 0xfff0))
+    {
+      nerr("ERROR: Incorrect PHYID2: %u expected: %u\n",
+            phyval, STM32H7_PHYID2);
+      return -ENXIO;
+    }
+
+  ninfo("MII_PHYID2: phyval: %u ret: %d\n", phyval, ret);
 
 #ifdef CONFIG_STM32H7_ETHMAC_REGDEBUG
   stm32_phyregdump();
@@ -3378,6 +3473,7 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
         }
       else if ((phyval & MII_MSR_LINKSTATUS) != 0)
         {
+          ninfo("MII_MSR: phyval: %u ret: %d \n", phyval, ret);
           break;
         }
 

--- a/include/nuttx/net/mii.h
+++ b/include/nuttx/net/mii.h
@@ -396,6 +396,13 @@
 #define DP83840_PHYADDR_DUPLEX       (1 << 7)
 #define DP83840_PHYADDR_SPEED        (1 << 6)
 
+/* Davicom DM9161  **********************************************************/
+
+/* DM9161  MII ID1/2 register bits */
+
+#define MII_PHYID1_DM9161            0x0181
+#define MII_PHYID2_DM9161            0xB800
+
 /* National Semiconductor DP83848C ******************************************/
 
 /* DP83848C MII ID1/2 register bits */


### PR DESCRIPTION
## Summary
 
 Check PHYID1 and PHYID2 for the configured PHY during init. Drivers on some of the other targets do this.

## Impact
 
 Fixes bug where stm32_phyinit will succeed even when no PHY is connected. This is because there is no check that a PHY is actually communicating and returning data. 

## Testing
 
 Tested on an [ARKV6X](https://arkelectron.com/product/arkv6x/) running PX4 main. This uses an STM32H743IIK processor.

Here is a snippet from the driver with debugging enabled
```
tm32_ifup: Bringing up: 192.168.0.4
stm32_ethconfig: Reset the Ethernet block
stm32_ethconfig: Initialize the PHY
stm32_phyinit: MII_MCR: phyval: 0 ret: 0
stm32_phyinit: Phy reset in 10 ms
stm32_phyinit: ERROR: Incorrect PHYID1: 0 expected: 7
netinit_monitor: Entry
netdev_ifr_ioctl: cmd: 1819
netdev_ifr_ioctl: cmd: 1828
netdev_ifr_ioctl: cmd: 1829
netinit_monitor: eth0: devup=0 PHY address=00 MSR=ffff
netinit_monitor: Bringing the link up
netdev_ifr_ioctl: cmd: 1818
stm32_ifup: Bringing up: 192.168.0.4
stm32_ethconfig: Reset the Ethernet block
stm32_ethconfig: Initialize the PHY
stm32_phyinit: MII_MCR: phyval: 0 ret: 0
stm32_phyinit: Phy reset in 10 ms
stm32_phyinit: ERROR: Incorrect PHYID1: 0 expected: 7
netinit_monitor: ERROR: ioctl(SIOCSIFFLAGS) failed: -6
netinit_monitor: ERROR: Aborting
netinit_thread: Exit
```

**Before this PR** it would succeed
```
stm32_ifup: Bringing up: 192.168.0.4
stm32_ethconfig: Reset the Ethernet block
stm32_ethconfig: Initialize the PHY
stm32_phyinit: Phy reset in 10 ms
stm32_phyinit: PHYSR[31]: ffff
stm32_phyinit: Duplex: FULL Speed: 100 MBps
stm32_ethconfig: Initialize the MAC and DMA
stm32_ethconfig: Enable normal operation
stm32_macaddress: eth0 MAC: ce:f1:92:f9:9c:2b
```
