### PR TITLE
arch/arm64: generate error if context size is not aligned to 16bytes

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -228,6 +228,10 @@
 #define XCPTCONTEXT_REGS    (ARM64_CONTEXT_REGS + FPU_CONTEXT_REGS)
 #define XCPTCONTEXT_SIZE    (8 * XCPTCONTEXT_REGS)
 
+#if XCPTCONTEXT_SIZE % 16 != 0
+#  error "ARM64_CONTEXT_REGS and FPU_CONTEXT_REGS must be an even number to ensure the stack is aligned to 16 bytes"
+#endif
+
 /* Friendly register names */
 
 #define REG_FP              REG_X29


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Make sure the registers context size is aligned to 16bytes as required by armv8-a. 
This issue has been reported earlier, thus make sense to make sure it won't happen in future.

## Impact

No impact on existing code.

## Testing

Tested with qemu build and pass.
```
 cmake -Bbuild -GNinja -DBOARD_CONFIG=qemu-armv8a:nsh_smp nuttx
```

If `ARM64_CONTEXT_REGS` is configured to wrong value like `37`. It reports error.
```
In file included from /home/neo/projects/nuttx/nuttx/include/nuttx/irq.h:39,
                 from /home/neo/projects/nuttx/nuttx/sched/signal/sig_allocpendingsigaction.c:32:
/home/neo/projects/nuttx/build/include/arch/irq.h:165:4: error: #error "ARM64_CONTEXT_REGS must be even to make stack aligned to 16 bytes"
  165 | #  error "ARM64_CONTEXT_REGS must be even to make stack aligned to 16 bytes"
      |    ^~~~~
ninja: build stopped: subcommand failed

