### PR TITLE
nxgdb/mm: show pool expand queue size

### DIFF
--- a/tools/pynuttx/nxgdb/mm.py
+++ b/tools/pynuttx/nxgdb/mm.py
@@ -184,6 +184,10 @@ class MemPool(Value, p.MemPool):
             yield (int(entry) - blks * blksize, int(entry))
 
     @property
+    def nqueue(self) -> int:
+        return lists.sq_count(self.equeue)
+
+    @property
     def size(self) -> int:
         """Real block size including backtrace overhead"""
         if not self._blksize:
@@ -643,7 +647,7 @@ class MMPoolInfo(gdb.Command):
 
         name_max = max(len(pool.name) for pool in pools) + 11  # 11: "@0x12345678"
         formatter = (
-            "{:>%d} {:>11} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}\n" % name_max
+            "{:>%d} {:>11} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}\n" % name_max
         )
         head = (
             "",
@@ -655,6 +659,7 @@ class MMPoolInfo(gdb.Command):
             "nfree",
             "nifree",
             "nwaiter",
+            "nqueue",
         )
 
         gdb.write(formatter.format(*head))
@@ -670,5 +675,6 @@ class MMPoolInfo(gdb.Command):
                     pool.nfree,
                     pool.nifree,
                     pool.nwaiter,
+                    pool.nqueue,
                 )
             )


### PR DESCRIPTION
## Summary
nqueue has been added to output.

E.g.
```
(gdb) mm pool
Total 16 pools
                      total blocksize     bsize  overhead     nused     nfree    nifree   nwaiter    nqueue
 Umem@0x10048dc        4068        16        16         0         3       251         0         0         1
 Umem@0x100493c        4068        32        32         0         3       124         0         0         1
 Umem@0x100499c        4036        48        48         0        10        74         0         0         1
 Umem@0x10049fc        4036        64        64         0         1        62         0         0         1
 Umem@0x1004a5c           0        80        80         0         0         0         0         0         0
 Umem@0x1004abc           0        96        96         0         0         0         0         0         0
 Umem@0x1004b1c           0       112       112         0         0         0         0         0         0
 Umem@0x1004b7c           0       128       128         0         0         0         0         0         0
 Umem@0x1004bdc           0       144       144         0         0         0         0         0         0
 Umem@0x1004c3c           0       160       160         0         0         0         0         0         0
 Umem@0x1004c9c           0       176       176         0         0         0         0         0         0
 Umem@0x1004cfc           0       192       192         0         0         0         0         0         0
 Umem@0x1004d5c        3956       208       208         0         1        18         0         0         1
 Umem@0x1004dbc           0       224       224         0         0         0         0         0         0
 Umem@0x1004e1c           0       240       240         0         0         0         0         0         0
 Umem@0x1004e7c           0       256       256         0         0         0         0         0         0
(gdb)
```

## Impact

One more column to the output message, makes it easier to inspect pool status.

## Testing

Tested with qemu.
```
cmake -Bbuild -GNinja -DBOARD_CONFIG=mps3-an547:nsh nuttx
ninja -C build
```

Make sure to enable pool.
```patch
diff --git a/boards/arm/mps/mps3-an547/configs/nsh/defconfig b/boards/arm/mps/mps3-an547/configs/nsh/defconfig
index 5ffdb8ae4c9..244f0d06da7 100644
--- a/boards/arm/mps/mps3-an547/configs/nsh/defconfig
+++ b/boards/arm/mps/mps3-an547/configs/nsh/defconfig
+CONFIG_DEBUG_SYMBOLS_LEVEL="-g3"
+CONFIG_MM_HEAP_MEMPOOL_THRESHOLD=256

```

Run qemu:
```
qemu-system-arm -M mps3-an547 -m 2G -nographic -kernel build/nuttx -gdb tcp::1127
```

Connect to qemu and loading GDB plugin.
```
 gdb-multiarch build/nuttx -ex "tar rem:1127" -ex "source nuttx/tools/pynuttx/gdbinit.py"
```

