### PR TITLE
arch/risc-v/Kconfig: Select ARCH_RV_CPUID_MAP for all mpfs targets

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -212,6 +212,7 @@ config ARCH_CHIP_MPFS
 	select ARCH_HAVE_SPI_CS_CONTROL
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_S_MODE
+	select ARCH_RV_CPUID_MAP
 	select ONESHOT
 	select ALARM_ARCH
 	---help---


### PR DESCRIPTION
The default mapping functions are needed for mpfs

## Summary

Introducing the new Kconfig flags ARCH_RV_CPUID_MAP broke all mpfs targets, except if running on E51 monitor core, by removing the riscv_hartid_to_cpuid and riscv_cpuid_to_hartid functions. The application U54 harts are the harts 1-4.

Make mpfs bootable again by enabling the flag for all the MPFS targets.

This was requested to be separated from https://github.com/apache/nuttx/pull/15753

## Impact

All  mpfs targets, make them boot again.

## Testing

Tested on Microchip Icicle board w. MPFS250T-ES soc
