### PR TITLE
Use small lock to protect resources related to tickless.

### DIFF
--- a/arch/arm/src/nrf52/nrf52_tickless_rtc.c
+++ b/arch/arm/src/nrf52/nrf52_tickless_rtc.c
@@ -34,6 +34,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "hardware/nrf52_rtc.h"
@@ -91,6 +92,7 @@ struct nrf52_tickless_dev_s
   uint32_t periods;            /* how many times the timer overflowed */
   bool alarm_set;              /* is the alarm set? */
   struct timespec alarm;       /* absolute time of alarm */
+  spinlock_t lock;             /* spinlock for this structure */
 };
 
 /****************************************************************************
@@ -188,6 +190,28 @@ static void rtc_prepare_alarm(void)
 }
 
 /****************************************************************************
+ * Name: up_alarm_cancel_nolock
+ *
+ * Description:
+ *   Unlocked version of the public function up_alarm_cancel().
+ *
+ ****************************************************************************/
+
+static int up_alarm_cancel_nolock(struct timespec *ts)
+{
+  uint32_t counter;
+
+  NRF52_RTC_DISABLEINT(g_tickless_dev.rtc, NRF52_RTC_EVT_COMPARE0);
+  NRF52_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
+  rtc_counter_to_ts(counter, ts);
+
+  NRF52_RTC_ACKINT(g_tickless_dev.rtc, NRF52_RTC_EVT_COMPARE0);
+  g_tickless_dev.alarm_set = false;
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: rtc_handler
  ****************************************************************************/
 
@@ -195,7 +219,7 @@ static int rtc_handler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
 
   /* if the timer wrapped-around */
 
@@ -225,14 +249,14 @@ static int rtc_handler(int irq, void *context, void *arg)
 
       /* cancel alarm and get current time */
 
-      up_alarm_cancel(&now);
+      up_alarm_cancel_nolock(&now);
 
       /* let scheduler now of alarm firing */
 
       nxsched_alarm_expiration(&now);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
   return OK;
 }
@@ -247,21 +271,14 @@ static int rtc_handler(int irq, void *context, void *arg)
 
 int up_alarm_cancel(struct timespec *ts)
 {
-  uint32_t counter;
+  int ret;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
+  ret = up_alarm_cancel_nolock(ts);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
-  NRF52_RTC_DISABLEINT(g_tickless_dev.rtc, NRF52_RTC_EVT_COMPARE0);
-  NRF52_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
-  rtc_counter_to_ts(counter, ts);
-
-  NRF52_RTC_ACKINT(g_tickless_dev.rtc, NRF52_RTC_EVT_COMPARE0);
-  g_tickless_dev.alarm_set = false;
-
-  leave_critical_section(flags);
-
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -271,7 +288,7 @@ int up_alarm_cancel(struct timespec *ts)
 int up_alarm_start(const struct timespec *ts)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev->lock);
 
   /* remember the alarm time */
 
@@ -280,7 +297,7 @@ int up_alarm_start(const struct timespec *ts)
 
   rtc_prepare_alarm();
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev->lock, flags);
 
   return OK;
 }
@@ -294,12 +311,12 @@ int up_timer_gettime(struct timespec *ts)
   uint32_t counter;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev->lock);
 
   NRF52_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
   rtc_counter_to_ts(counter, ts);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev->lock, flags);
 
   return OK;
 }
@@ -315,6 +332,10 @@ void up_timer_initialize(void)
   memset(&g_tickless_dev, 0, sizeof(struct nrf52_tickless_dev_s));
 
   g_tickless_dev.rtc = nrf52_rtc_init(CONFIG_NRF52_SYSTIMER_RTC_INSTANCE);
+
+  /* Initialize spinlock */
+
+  spin_lock_init(&g_tickless_dev.lock);
 
   /* Ensure we have support for the selected RTC instance */
 

--- a/arch/arm/src/nrf91/nrf91_tickless_rtc.c
+++ b/arch/arm/src/nrf91/nrf91_tickless_rtc.c
@@ -34,6 +34,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_internal.h"
 #include "hardware/nrf91_rtc.h"
@@ -89,6 +90,7 @@ struct nrf91_tickless_dev_s
   uint32_t periods;            /* how many times the timer overflowed */
   bool alarm_set;              /* is the alarm set? */
   struct timespec alarm;       /* absolute time of alarm */
+  spinlock_t lock;             /* spinlock for this structure */
 };
 
 /****************************************************************************
@@ -186,6 +188,28 @@ static void rtc_prepare_alarm(void)
 }
 
 /****************************************************************************
+ * Name: up_alarm_cancel_nolock
+ *
+ * Description:
+ *   Unlocked version of the public function up_alarm_cancel().
+ *
+ ****************************************************************************/
+
+int up_alarm_cancel_nolock(struct timespec *ts)
+{
+  uint32_t counter;
+
+  NRF91_RTC_DISABLEINT(g_tickless_dev.rtc, NRF91_RTC_EVT_COMPARE0);
+  NRF91_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
+  rtc_counter_to_ts(counter, ts);
+
+  NRF91_RTC_ACKINT(g_tickless_dev.rtc, NRF91_RTC_EVT_COMPARE0);
+  g_tickless_dev.alarm_set = false;
+
+  return OK;
+}
+
+/****************************************************************************
  * Name: rtc_handler
  ****************************************************************************/
 
@@ -193,7 +217,7 @@ static int rtc_handler(int irq, void *context, void *arg)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
 
   /* if the timer wrapped-around */
 
@@ -223,14 +247,14 @@ static int rtc_handler(int irq, void *context, void *arg)
 
       /* cancel alarm and get current time */
 
-      up_alarm_cancel(&now);
+      up_alarm_cancel_nolock(&now);
 
       /* let scheduler now of alarm firing */
 
       nxsched_alarm_expiration(&now);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
   return OK;
 }
@@ -245,21 +269,14 @@ static int rtc_handler(int irq, void *context, void *arg)
 
 int up_alarm_cancel(struct timespec *ts)
 {
-  uint32_t counter;
+  int ret;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
+  ret = up_alarm_cancel_nolock(ts);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
-  NRF91_RTC_DISABLEINT(g_tickless_dev.rtc, NRF91_RTC_EVT_COMPARE0);
-  NRF91_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
-  rtc_counter_to_ts(counter, ts);
-
-  NRF91_RTC_ACKINT(g_tickless_dev.rtc, NRF91_RTC_EVT_COMPARE0);
-  g_tickless_dev.alarm_set = false;
-
-  leave_critical_section(flags);
-
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -269,7 +286,7 @@ int up_alarm_cancel(struct timespec *ts)
 int up_alarm_start(const struct timespec *ts)
 {
   irqstate_t flags;
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
 
   /* remember the alarm time */
 
@@ -278,7 +295,7 @@ int up_alarm_start(const struct timespec *ts)
 
   rtc_prepare_alarm();
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
   return OK;
 }
@@ -292,12 +309,12 @@ int up_timer_gettime(struct timespec *ts)
   uint32_t counter;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless_dev.lock);
 
   NRF91_RTC_GETCOUNTER(g_tickless_dev.rtc, &counter);
   rtc_counter_to_ts(counter, ts);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless_dev.lock, flags);
 
   return OK;
 }
@@ -313,6 +330,10 @@ void up_timer_initialize(void)
   memset(&g_tickless_dev, 0, sizeof(struct nrf91_tickless_dev_s));
 
   g_tickless_dev.rtc = nrf91_rtc_init(CONFIG_NRF91_SYSTIMER_RTC_INSTANCE);
+
+  /* Initialize spinlock */
+
+  spin_lock_init(&g_tickless_dev.lock);
 
   /* Ensure we have support for the selected RTC instance */
 

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -88,6 +88,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <debug.h>
 
 #include "arm_internal.h"
@@ -136,6 +137,7 @@ struct stm32_tickless_s
   volatile bool pending;       /* True: pending task */
   uint32_t period;             /* Interval period */
   uint32_t base;
+  spinlock_t lock;             /* Spinock for this structure */
 #ifdef CONFIG_SCHED_TICKLESS_ALARM
   uint64_t last_alrm;
 #endif
@@ -404,6 +406,115 @@ static uint64_t stm32_get_counter(void)
 }
 
 /****************************************************************************
+ * Name: up_timer_cancel_nolock
+ *
+ * Description:
+ *   Unlocked version of the public function up_timer_cancel().
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_SCHED_TICKLESS_ALARM
+static int up_timer_cancel_nolock(struct timespec *ts)
+{
+  uint64_t usec;
+  uint64_t sec;
+  uint64_t nsec;
+  uint32_t count;
+  uint32_t period;
+
+  /* Was the timer running? */
+
+  if (!g_tickless.pending)
+    {
+      /* No.. Just return zero timer remaining and successful cancellation.
+       * This function may execute at a high rate with no timer running
+       * (as when pre-emption is enabled and disabled).
+       */
+
+      if (ts)
+        {
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+        }
+
+      return OK;
+    }
+
+  /* Yes.. Get the timer counter and period registers and disable the compare
+   * interrupt.
+   */
+
+  tmrinfo("Cancelling...\n");
+
+  /* Disable the interrupt. */
+
+  stm32_tickless_disableint(g_tickless.channel);
+
+  count  = STM32_TIM_GETCOUNTER(g_tickless.tch);
+  period = g_tickless.period;
+
+  g_tickless.pending = false;
+
+  /* Did the caller provide us with a location to return the time
+   * remaining?
+   */
+
+  if (ts != NULL)
+    {
+      /* Yes.. then calculate and return the time remaining on the
+       * oneshot timer.
+       */
+
+      tmrinfo("period=%lu count=%lu\n",
+             (unsigned long)period, (unsigned long)count);
+
+#ifndef HAVE_32BIT_TICKLESS
+      if (count > period)
+        {
+          /* Handle rollover */
+
+          period += UINT16_MAX;
+        }
+      else if (count == period)
+#else
+      if (count >= period)
+#endif
+        {
+          /* No time remaining */
+
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+          return OK;
+        }
+
+      /* The total time remaining is the difference.  Convert that
+       * to units of microseconds.
+       *
+       *   frequency = ticks / second
+       *   seconds   = ticks * frequency
+       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
+       */
+
+      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
+                    g_tickless.frequency;
+
+      /* Return the time remaining in the correct form */
+
+      sec         = usec / USEC_PER_SEC;
+      nsec        = ((usec) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+
+      ts->tv_sec  = (time_t)sec;
+      ts->tv_nsec = (unsigned long)nsec;
+
+      tmrinfo("remaining (%lu, %lu)\n",
+             (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
+    }
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -572,6 +683,7 @@ void up_timer_initialize(void)
   g_tickless.pending   = false;
   g_tickless.period    = 0;
   g_tickless.overflow  = 0;
+  g_tickless.lock      = SP_UNLOCKED;
 
   tmrinfo("timer=%d channel=%d frequency=%lu Hz\n",
            g_tickless.timer, g_tickless.channel, g_tickless.frequency);
@@ -681,7 +793,7 @@ int up_timer_gettime(struct timespec *ts)
    * be lost.
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(&g_tickless.lock);
 
   overflow = g_tickless.overflow;
   counter  = STM32_TIM_GETCOUNTER(g_tickless.tch);
@@ -708,7 +820,7 @@ int up_timer_gettime(struct timespec *ts)
       g_tickless.overflow = overflow;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
   tmrinfo("counter=%lu (%lu) overflow=%lu, pending=%i\n",
          (unsigned long)counter,  (unsigned long)verify,
@@ -828,105 +940,14 @@ void up_timer_getmask(clock_t *mask)
 #ifndef CONFIG_SCHED_TICKLESS_ALARM
 int up_timer_cancel(struct timespec *ts)
 {
+  int ret;
   irqstate_t flags;
-  uint64_t usec;
-  uint64_t sec;
-  uint64_t nsec;
-  uint32_t count;
-  uint32_t period;
 
-  /* Was the timer running? */
+  flags = spin_lock_irqsave(&g_tickless.lock);
+  ret = up_timer_cancel_nolock(ts);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
-  flags = enter_critical_section();
-  if (!g_tickless.pending)
-    {
-      /* No.. Just return zero timer remaining and successful cancellation.
-       * This function may execute at a high rate with no timer running
-       * (as when pre-emption is enabled and disabled).
-       */
-
-      if (ts)
-        {
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-        }
-
-      leave_critical_section(flags);
-      return OK;
-    }
-
-  /* Yes.. Get the timer counter and period registers and disable the compare
-   * interrupt.
-   */
-
-  tmrinfo("Cancelling...\n");
-
-  /* Disable the interrupt. */
-
-  stm32_tickless_disableint(g_tickless.channel);
-
-  count  = STM32_TIM_GETCOUNTER(g_tickless.tch);
-  period = g_tickless.period;
-
-  g_tickless.pending = false;
-  leave_critical_section(flags);
-
-  /* Did the caller provide us with a location to return the time
-   * remaining?
-   */
-
-  if (ts != NULL)
-    {
-      /* Yes.. then calculate and return the time remaining on the
-       * oneshot timer.
-       */
-
-      tmrinfo("period=%lu count=%lu\n",
-             (unsigned long)period, (unsigned long)count);
-
-#ifndef HAVE_32BIT_TICKLESS
-      if (count > period)
-        {
-          /* Handle rollover */
-
-          period += UINT16_MAX;
-        }
-      else if (count == period)
-#else
-      if (count >= period)
-#endif
-        {
-          /* No time remaining */
-
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-          return OK;
-        }
-
-      /* The total time remaining is the difference.  Convert that
-       * to units of microseconds.
-       *
-       *   frequency = ticks / second
-       *   seconds   = ticks * frequency
-       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
-       */
-
-      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
-                    g_tickless.frequency;
-
-      /* Return the time remaining in the correct form */
-
-      sec         = usec / USEC_PER_SEC;
-      nsec        = ((usec) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
-
-      ts->tv_sec  = (time_t)sec;
-      ts->tv_nsec = (unsigned long)nsec;
-
-      tmrinfo("remaining (%lu, %lu)\n",
-             (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
-    }
-
-  return OK;
+  return ret;
 }
 #endif
 
@@ -970,13 +991,13 @@ int up_timer_start(const struct timespec *ts)
 
   /* Was an interval already running? */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless.lock);
   if (g_tickless.pending)
     {
       /* Yes.. then cancel it */
 
       tmrinfo("Already running... cancelling\n");
-      up_timer_cancel(NULL);
+      up_timer_cancel_nolock(NULL);
     }
 
   /* Express the delay in microseconds */
@@ -1020,7 +1041,7 @@ int up_timer_start(const struct timespec *ts)
   stm32_tickless_enableint(g_tickless.channel);
 
   g_tickless.pending = true;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
   return OK;
 }
 #endif
@@ -1033,7 +1054,7 @@ int up_alarm_start(const struct timespec *ts)
                 NSEC_PER_TICK;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless.lock);
 
   STM32_TIM_SETCOMPARE(g_tickless.tch, CONFIG_STM32F7_TICKLESS_CHANNEL, tm);
 
@@ -1059,7 +1080,7 @@ int up_alarm_start(const struct timespec *ts)
                            tm);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32h7/stm32_tickless.c
+++ b/arch/arm/src/stm32h7/stm32_tickless.c
@@ -72,6 +72,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/timers/arch_timer.h>
 #include <debug.h>
 #include <arch/board/board.h>
@@ -123,6 +124,7 @@ struct stm32_tickless_s
   volatile bool pending;       /* True: pending task */
   uint32_t period;             /* Interval period */
   uint32_t base;
+  spinlock_t lock;             /* Spinlock for this structure */
 #ifdef CONFIG_SCHED_TICKLESS_ALARM
   uint64_t last_alrm;
 #endif
@@ -391,6 +393,115 @@ static uint64_t stm32_get_counter(void)
 }
 
 /****************************************************************************
+ * Name: up_timer_cancel_nolock
+ *
+ * Description:
+ *   Unlocked version of the public function up_timer_cancel().
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_SCHED_TICKLESS_ALARM
+int up_timer_cancel_nolock(struct timespec *ts)
+{
+  uint64_t usec;
+  uint64_t sec;
+  uint64_t nsec;
+  uint32_t count;
+  uint32_t period;
+
+  /* Was the timer running? */
+
+  if (!g_tickless.pending)
+    {
+      /* No.. Just return zero timer remaining and successful cancellation.
+       * This function may execute at a high rate with no timer running
+       * (as when pre-emption is enabled and disabled).
+       */
+
+      if (ts != NULL)
+        {
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+        }
+
+      return OK;
+    }
+
+  /* Yes.. Get the timer counter and period registers and disable the compare
+   * interrupt.
+   */
+
+  tmrinfo("Cancelling...\n");
+
+  /* Disable the interrupt. */
+
+  stm32_tickless_disableint(g_tickless.channel);
+
+  count  = STM32_TIM_GETCOUNTER(g_tickless.tch);
+  period = g_tickless.period;
+
+  g_tickless.pending = false;
+
+  /* Did the caller provide us with a location to return the time
+   * remaining?
+   */
+
+  if (ts != NULL)
+    {
+      /* Yes.. then calculate and return the time remaining on the
+       * oneshot timer.
+       */
+
+      tmrinfo("period=%lu count=%lu\n",
+             (unsigned long)period, (unsigned long)count);
+
+#ifndef HAVE_32BIT_TICKLESS
+      if (count > period)
+        {
+          /* Handle rollover */
+
+          period += UINT16_MAX;
+        }
+      else if (count == period)
+#else
+      if (count >= period)
+#endif
+        {
+          /* No time remaining */
+
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+          return OK;
+        }
+
+      /* The total time remaining is the difference.  Convert that
+       * to units of microseconds.
+       *
+       *   frequency = ticks / second
+       *   seconds   = ticks * frequency
+       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
+       */
+
+      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
+                    g_tickless.frequency;
+
+      /* Return the time remaining in the correct form */
+
+      sec         = usec / USEC_PER_SEC;
+      nsec        = ((usec) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+
+      ts->tv_sec  = (time_t)sec;
+      ts->tv_nsec = (unsigned long)nsec;
+
+      tmrinfo("remaining (%lu, %lu)\n",
+             (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
+    }
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -541,6 +652,7 @@ void up_timer_initialize(void)
   g_tickless.pending   = false;
   g_tickless.period    = 0;
   g_tickless.overflow  = 0;
+  g_tickless.lock      = SP_UNLOCKED;
 
   tmrinfo("timer=%d channel=%d frequency=%lu Hz\n",
           g_tickless.timer, g_tickless.channel, g_tickless.frequency);
@@ -655,7 +767,7 @@ int up_timer_gettime(struct timespec *ts)
    * be lost.
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(&g_tickless.lock);
 
   overflow = g_tickless.overflow;
   counter  = STM32_TIM_GETCOUNTER(g_tickless.tch);
@@ -682,7 +794,7 @@ int up_timer_gettime(struct timespec *ts)
       g_tickless.overflow = overflow;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
   tmrinfo("counter=%lu (%lu) overflow=%lu, pending=%i\n",
          (unsigned long)counter,  (unsigned long)verify,
@@ -802,105 +914,14 @@ void up_timer_getmask(clock_t *mask)
 #ifndef CONFIG_SCHED_TICKLESS_ALARM
 int up_timer_cancel(struct timespec *ts)
 {
+  int ret;
   irqstate_t flags;
-  uint64_t usec;
-  uint64_t sec;
-  uint64_t nsec;
-  uint32_t count;
-  uint32_t period;
 
-  /* Was the timer running? */
+  flags = spin_lock_irqsave(&g_tickless.lock);
+  ret = up_timer_cancel_nolock(ts);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
-  flags = enter_critical_section();
-  if (!g_tickless.pending)
-    {
-      /* No.. Just return zero timer remaining and successful cancellation.
-       * This function may execute at a high rate with no timer running
-       * (as when pre-emption is enabled and disabled).
-       */
-
-      if (ts != NULL)
-        {
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-        }
-
-      leave_critical_section(flags);
-      return OK;
-    }
-
-  /* Yes.. Get the timer counter and period registers and disable the compare
-   * interrupt.
-   */
-
-  tmrinfo("Cancelling...\n");
-
-  /* Disable the interrupt. */
-
-  stm32_tickless_disableint(g_tickless.channel);
-
-  count  = STM32_TIM_GETCOUNTER(g_tickless.tch);
-  period = g_tickless.period;
-
-  g_tickless.pending = false;
-  leave_critical_section(flags);
-
-  /* Did the caller provide us with a location to return the time
-   * remaining?
-   */
-
-  if (ts != NULL)
-    {
-      /* Yes.. then calculate and return the time remaining on the
-       * oneshot timer.
-       */
-
-      tmrinfo("period=%lu count=%lu\n",
-             (unsigned long)period, (unsigned long)count);
-
-#ifndef HAVE_32BIT_TICKLESS
-      if (count > period)
-        {
-          /* Handle rollover */
-
-          period += UINT16_MAX;
-        }
-      else if (count == period)
-#else
-      if (count >= period)
-#endif
-        {
-          /* No time remaining */
-
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-          return OK;
-        }
-
-      /* The total time remaining is the difference.  Convert that
-       * to units of microseconds.
-       *
-       *   frequency = ticks / second
-       *   seconds   = ticks * frequency
-       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
-       */
-
-      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
-                    g_tickless.frequency;
-
-      /* Return the time remaining in the correct form */
-
-      sec         = usec / USEC_PER_SEC;
-      nsec        = ((usec) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
-
-      ts->tv_sec  = (time_t)sec;
-      ts->tv_nsec = (unsigned long)nsec;
-
-      tmrinfo("remaining (%lu, %lu)\n",
-             (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
-    }
-
-  return OK;
+  return ret;
 }
 #endif
 
@@ -944,13 +965,13 @@ int up_timer_start(const struct timespec *ts)
 
   /* Was an interval already running? */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless.lock);
   if (g_tickless.pending)
     {
       /* Yes.. then cancel it */
 
       tmrinfo("Already running... cancelling\n");
-      up_timer_cancel(NULL);
+      up_timer_cancel_nolock(NULL);
     }
 
   /* Express the delay in microseconds */
@@ -994,7 +1015,7 @@ int up_timer_start(const struct timespec *ts)
   stm32_tickless_enableint(g_tickless.channel);
 
   g_tickless.pending = true;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
   return OK;
 }
 #endif
@@ -1007,7 +1028,7 @@ int up_alarm_start(const struct timespec *ts)
                 NSEC_PER_TICK;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless.lock);
 
   STM32_TIM_SETCOMPARE(g_tickless.tch, CONFIG_STM32H7_TICKLESS_CHANNEL, tm);
 
@@ -1033,7 +1054,7 @@ int up_alarm_start(const struct timespec *ts)
                            tm);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
   return OK;
 }
 

--- a/arch/arm/src/stm32wb/stm32wb_tickless.c
+++ b/arch/arm/src/stm32wb/stm32wb_tickless.c
@@ -69,6 +69,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <debug.h>
 
 #include "arm_internal.h"
@@ -108,6 +109,7 @@ struct stm32wb_tickless_s
   volatile bool pending;             /* True: pending task */
   uint32_t period;                   /* Interval period */
   uint32_t base;
+  spinlock_t lock;                   /* Spinock for this structure */
 };
 
 /****************************************************************************
@@ -330,6 +332,113 @@ static int stm32wb_tickless_handler(int irq, void *context, void *arg)
 }
 
 /****************************************************************************
+ * Name: up_timer_cancel_nolock
+ *
+ * Description:
+ *   Unlocked version of the public function up_timer_cancel().
+ *
+ ****************************************************************************/
+
+int up_timer_cancel_nolock(struct timespec *ts)
+{
+  uint64_t usec;
+  uint64_t sec;
+  uint64_t nsec;
+  uint32_t count;
+  uint32_t period;
+
+  /* Was the timer running? */
+
+  if (!g_tickless.pending)
+    {
+      /* No.. Just return zero timer remaining and successful cancellation.
+       * This function may execute at a high rate with no timer running
+       * (as when pre-emption is enabled and disabled).
+       */
+
+      if (ts)
+        {
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+        }
+
+      return OK;
+    }
+
+  /* Yes.. Get the timer counter and period registers and disable the compare
+   * interrupt.
+   */
+
+  tmrinfo("Cancelling...\n");
+
+  /* Disable the interrupt. */
+
+  stm32wb_tickless_disableint(g_tickless.channel);
+
+  count  = STM32WB_TIM_GETCOUNTER(g_tickless.tch);
+  period = g_tickless.period;
+
+  g_tickless.pending = false;
+
+  /* Did the caller provide us with a location to return the time
+   * remaining?
+   */
+
+  if (ts != NULL)
+    {
+      /* Yes.. then calculate and return the time remaining on the
+       * oneshot timer.
+       */
+
+      tmrinfo("period=%lu count=%lu\n",
+              (unsigned long)period, (unsigned long)count);
+
+#ifndef HAVE_32BIT_TICKLESS
+      if (count > period)
+        {
+          /* Handle rollover */
+
+          period += UINT16_MAX;
+        }
+      else if (count == period)
+#else
+      if (count >= period)
+#endif
+        {
+          /* No time remaining */
+
+          ts->tv_sec  = 0;
+          ts->tv_nsec = 0;
+          return OK;
+        }
+
+      /* The total time remaining is the difference.  Convert that
+       * to units of microseconds.
+       *
+       *   frequency = ticks / second
+       *   seconds   = ticks * frequency
+       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
+       */
+
+      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
+                    g_tickless.frequency;
+
+      /* Return the time remaining in the correct form */
+
+      sec         = usec / USEC_PER_SEC;
+      nsec        = (usec - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+
+      ts->tv_sec  = (time_t)sec;
+      ts->tv_nsec = (unsigned long)nsec;
+
+      tmrinfo("remaining (%lu, %lu)\n",
+              (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -398,6 +507,7 @@ void up_timer_initialize(void)
   g_tickless.pending   = false;
   g_tickless.period    = 0;
   g_tickless.overflow  = 0;
+  g_tickless.lock      = SP_UNLOCKED;
 
   tmrinfo("timer=%d channel=%d frequency=%lu Hz\n",
            g_tickless.timer, g_tickless.channel, g_tickless.frequency);
@@ -498,7 +608,7 @@ int up_timer_gettime(struct timespec *ts)
    * be lost.
    */
 
-  flags    = enter_critical_section();
+  flags    = spin_lock_irqsave(&g_tickless.lock);
 
   overflow = g_tickless.overflow;
   counter  = STM32WB_TIM_GETCOUNTER(g_tickless.tch);
@@ -525,7 +635,7 @@ int up_timer_gettime(struct timespec *ts)
       g_tickless.overflow = overflow;
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
   tmrinfo("counter=%lu (%lu) overflow=%lu, pending=%i\n",
           (unsigned long)counter,  (unsigned long)verify,
@@ -644,105 +754,14 @@ void up_timer_getmask(clock_t *mask)
 
 int up_timer_cancel(struct timespec *ts)
 {
+  int ret;
   irqstate_t flags;
-  uint64_t usec;
-  uint64_t sec;
-  uint64_t nsec;
-  uint32_t count;
-  uint32_t period;
 
-  /* Was the timer running? */
+  flags = spin_lock_irqsave(&g_tickless.lock);
+  ret = up_timer_cancel_nolock(ts);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
 
-  flags = enter_critical_section();
-  if (!g_tickless.pending)
-    {
-      /* No.. Just return zero timer remaining and successful cancellation.
-       * This function may execute at a high rate with no timer running
-       * (as when pre-emption is enabled and disabled).
-       */
-
-      if (ts)
-        {
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-        }
-
-      leave_critical_section(flags);
-      return OK;
-    }
-
-  /* Yes.. Get the timer counter and period registers and disable the compare
-   * interrupt.
-   */
-
-  tmrinfo("Cancelling...\n");
-
-  /* Disable the interrupt. */
-
-  stm32wb_tickless_disableint(g_tickless.channel);
-
-  count  = STM32WB_TIM_GETCOUNTER(g_tickless.tch);
-  period = g_tickless.period;
-
-  g_tickless.pending = false;
-  leave_critical_section(flags);
-
-  /* Did the caller provide us with a location to return the time
-   * remaining?
-   */
-
-  if (ts != NULL)
-    {
-      /* Yes.. then calculate and return the time remaining on the
-       * oneshot timer.
-       */
-
-      tmrinfo("period=%lu count=%lu\n",
-              (unsigned long)period, (unsigned long)count);
-
-#ifndef HAVE_32BIT_TICKLESS
-      if (count > period)
-        {
-          /* Handle rollover */
-
-          period += UINT16_MAX;
-        }
-      else if (count == period)
-#else
-      if (count >= period)
-#endif
-        {
-          /* No time remaining */
-
-          ts->tv_sec  = 0;
-          ts->tv_nsec = 0;
-          return OK;
-        }
-
-      /* The total time remaining is the difference.  Convert that
-       * to units of microseconds.
-       *
-       *   frequency = ticks / second
-       *   seconds   = ticks * frequency
-       *   usecs     = (ticks * USEC_PER_SEC) / frequency;
-       */
-
-      usec        = (((uint64_t)(period - count)) * USEC_PER_SEC) /
-                    g_tickless.frequency;
-
-      /* Return the time remaining in the correct form */
-
-      sec         = usec / USEC_PER_SEC;
-      nsec        = (usec - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
-
-      ts->tv_sec  = (time_t)sec;
-      ts->tv_nsec = (unsigned long)nsec;
-
-      tmrinfo("remaining (%lu, %lu)\n",
-              (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
-    }
-
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -784,13 +803,13 @@ int up_timer_start(const struct timespec *ts)
 
   /* Was an interval already running? */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_tickless.lock);
   if (g_tickless.pending)
     {
       /* Yes.. then cancel it */
 
       tmrinfo("Already running... cancelling\n");
-      up_timer_cancel(NULL);
+      up_timer_cancel_nolock(NULL);
     }
 
   /* Express the delay in microseconds */
@@ -833,7 +852,7 @@ int up_timer_start(const struct timespec *ts)
   stm32wb_tickless_enableint(g_tickless.channel);
 
   g_tickless.pending = true;
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_tickless.lock, flags);
   return OK;
 }
 #endif /* CONFIG_SCHED_TICKLESS */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use small lock to protect resources related to tickless.

## Impact

arm/src/imxrt/imxrt_tickless.c
arm/src/lpc43xx/lpc43_tickless_rit.c
arm/src/lpc54xx/lpc54_tickless.c
arm/src/nrf52/nrf52_tickless_rtc.c
arm/src/nrf53/nrf53_tickless_rtc.c
arm/src/nrf91/nrf91_tickless_rtc.c
arm/src/stm32/stm32_tickless.c
arm/src/stm32f7/stm32_tickless.c
arm/src/stm32h7/stm32_tickless.c
arm/src/stm32wb/stm32wb_tickless.c
arm/src/xmc4/xmc4_tickless.c
risc-v/src/esp32c3-legacy/esp32c3_tickless.c
risc-v/src/litex/litex_tickless.c
xtensa/src/esp32/esp32_tickless.c
xtensa/src/esp32s3/esp32s3_tickless.c

## Testing

CI


