### PR TITLE
clock/clock_adjtime.c: fix compile errors

### DIFF
--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -36,6 +36,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "clock/clock.h"
 


### PR DESCRIPTION
## Summary
The missing `<nuttx/spinlock.h>` header caused following compile errors:

```
CC:  clock/clock_adjtime.c clock/clock_adjtime.c: In function 'adjtime_wdog_callback': clock/clock_adjtime.c:67:11: error: implicit declaration of function 'spin_lock_irqsave' [-Wimplicit-function-declaration]
   67 |   flags = spin_lock_irqsave(&g_adjtime_lock);
      |           ^~~~~~~~~~~~~~~~~
clock/clock_adjtime.c:78:3: error: implicit declaration of function 'spin_unlock_irqrestore' [-Wimplicit-function-declaration]
   78 |   spin_unlock_irqrestore(&g_adjtime_lock, flags);
```

## Impact
`clock/clock_adjtime.c` now compiles.

