### PR TITLE
libc/wcsrtombs: Fix the wcsrtombs() according to the POSIX standard

### DIFF
--- a/libs/libc/wchar/lib_wcsrtombs.c
+++ b/libs/libc/wchar/lib_wcsrtombs.c
@@ -40,5 +40,14 @@
 size_t wcsrtombs(FAR char *dst, FAR const wchar_t **src,
                  size_t len, FAR mbstate_t *ps)
 {
-  return wcsnrtombs(dst, src, SIZE_MAX, len, ps);
+  size_t ret;
+
+  ret = wcsnrtombs(dst, src, SIZE_MAX, len, ps);
+
+  if (dst != NULL && ret != (size_t)-1 && ret != len)
+    {
+      dst[ret] = '\0';
+    }
+
+  return ret;
 }


### PR DESCRIPTION
## Summary

* libc/wcsrtombs: Fix the wcsrtombs() according to the POSIX standard

According to https://pubs.opengroup.org/onlinepubs/9799919799/, the expected behavior for the `wcstombs()` function is that it should convert the wide-character codes stopping conversion either when a character sequence exceeds the limit of `n` total bytes or if a null byte is stored. In the first case, the null-terminated value should not be appended to the dst buffer.

Currently, no null-terminator is appended to the dst buffer, even when it's expected to be appended, generating erroneous output.

This can be checked with the application at https://github.com/apache/nuttx-apps/pull/2986. Please note that the same application can be built in the host system and the expected output checked against NuttX's current behavior.

## Impact

The current implementation of `wcstombs` impacts all architectures. If the `dst` buffer is zero-filled before the operation, it would not generate trouble while checking for the null-terminated string. However, this may not be true if the buffer contains random data. This PR fixes the erroneous implementation. Please note that it should be fixed at `wcstombs`, once the `wcsnrtombs` (called by the previous function) is not expected to append the null-terminator.

## Testing

This depends on the testing application at https://github.com/apache/nuttx-apps/pull/2986

### On NuttX:

Internal CI testing + `rv-virt:nsh`:

Build with: 

```
make -j distclean && ./tools/configure.sh rv-virt:nsh && kconfig-tweak -e LIBC_LOCALE && kconfig-tweak -e TESTING_WCSTOMBS && make olddefconfig && make
```

Run with:
```
$ qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 1 -bios none -kernel nuttx -nographic
ABC
NuttShell (NSH) NuttX-10.4.0
nsh> wcstombs
wcstombs Test application:

Test Scenario: len is bigger than the size of the converted string. Expected the null-terminator at the end of the converted string.
Return code: 13
dst buffer (as uint8_t array): 48 65 6c 6c 6f 2c 20 77 6f 72 6c 64 21 00 
The character just after the return value is the null terminating character.

Test Scenario: len is exactly the size of the converted string. Do not expected the null-terminator at the end of the converted string.
Return code: 13
dst buffer (as uint8_t array): 48 65 6c 6c 6f 2c 20 77 6f 72 6c 64 21 aa 
The character just after the return value is the expected 0xaa value. No null-terminator.

Test Scenario: len is smaller than the size of the converted  string. Do not expected the null-terminator at the end of the converted string.
Return code: 12
dst buffer (as uint8_t array): 48 65 6c 6c 6f 2c 20 77 6f 72 6c 64 aa aa 
The character just after the return value is the expected 0xaa value. No null-terminator.
nsh> 
```

### On host system

The application at https://github.com/apache/nuttx-apps/pull/2986 can be built with:
```
gcc -o wcstombs_example ../apps/testing/libc/wcstombs/wcstombs_main.c
```

Its output should be the same on target and host.