### PR TITLE
cmake/pic: sync pic related compiler flags from makefile

### DIFF
--- a/Documentation/platforms/arm/mps/boards/mps3-an547/index.rst
+++ b/Documentation/platforms/arm/mps/boards/mps3-an547/index.rst
@@ -40,7 +40,7 @@ Configuring and Running (Single Core)
      make -j20
      mkdir -p pic
      arm-none-eabi-strip --remove-section=.rel.text --remove-section=.comment --strip-unneeded nuttx -o pic/boot
-     genromfs -a -f 128 ../romfs.img -d pic
+     genromfs -a 128 -f ../romfs.img -d pic
      make distclean -j20
      ./tools/configure.sh mps3-an547:bl
      make -j20
@@ -48,6 +48,11 @@ Configuring and Running (Single Core)
      -kernel nuttx.bin -gdb tcp::1127 \
      -device loader,file=../romfs.img,addr=0x60000000
      bl> boot /pic/boot
+     modlib_init...
+     modlib_load...
+     modlib_bind...
+     add-symbol-file ap.elf -s .text 0x60001080 -s .data 0x21000000
+
      ap> ostest
 
 Precautions

--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -240,6 +240,13 @@ if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
 endif()
 
+set(PICFLAGS -fpic -fPIE -mno-pic-data-is-text-relative -msingle-pic-base)
+
+if(CONFIG_BUILD_PIC)
+  add_compile_options(${PICFLAGS} -mpic-register=r9)
+  add_link_options(-Wl,--emit-relocs)
+endif()
+
 add_compile_options(
   -Wno-attributes -Wno-unknown-pragmas
   $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>


### PR DESCRIPTION
## Summary

1. cmake/pic: sync pic related compiler flags from makefile

PIC(Position-Independent-Code) board could work on cmake:

cmake -B ap -DBOARD_CONFIG=mps3-an547:ap -GNinja

2. mps/mps3-an547: correct command line of genromfs

genromfs -a 128 -f ../romfs.img -d pic

f: -f output
a: -a alignment

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

cmake -B ap -DBOARD_CONFIG=mps3-an547:ap -GNinja
cmake -B ap -DBOARD_CONFIG=mps3-an547:bl -GNinja

```
$ qemu-system-arm -M mps3-an547 -m 2G -nographic      -kernel bl/nuttx.bin -gdb tcp::1127      -device loader,file=romfs.img,addr=0x60000000
NuttShell (NSH) NuttX-10.4.0
bl> boot /pic/boot
modlib_init...
modlib_load...
modlib_bind...
add-symbol-file ap.elf -s .text 0x60001080 -s .data 0x21000000

NuttShell (NSH) NuttX-10.4.0
ap> 
```

