### PR TITLE
Nxgdb mm minor fixes

### DIFF
--- a/tools/pynuttx/nxgdb/memdump.py
+++ b/tools/pynuttx/nxgdb/memdump.py
@@ -190,7 +190,7 @@ def parse_memdump_log(logfile, filters=None) -> Generator[MMNodeDump, None, None
     with open(logfile) as f:
         for line in f:
             match = re.search(
-                r"\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+((?:\s+0x[0-9a-fA-F]+)+)", line
+                r"(\d+)\s+(\d+)\s+(\d+)\s+(\d+)((?:\s+0x[0-9a-fA-F]+)+)", line
             )
             if not match:
                 continue

--- a/tools/pynuttx/nxgdb/mm.py
+++ b/tools/pynuttx/nxgdb/mm.py
@@ -479,6 +479,7 @@ class MMNode(gdb.Value, p.MMFreeNode):
     @property
     def nextnode(self) -> MMNode:
         if not self.nodesize:
+            gdb.write(f"\n\x1b[31;1m Node corrupted: {self} \x1b[m\n")
             return None
 
         addr = int(self.address) + self.nodesize

--- a/tools/pynuttx/nxgdb/mm.py
+++ b/tools/pynuttx/nxgdb/mm.py
@@ -128,6 +128,16 @@ class MemPoolBlock:
             )
         return self._backtrace
 
+    @property
+    def prevnode(self) -> MemPoolBlock:
+        addr = self.address - self.nodesize
+        return MemPoolBlock(addr, self.blocksize, self.overhead)
+
+    @property
+    def nextnode(self) -> MemPoolBlock:
+        addr = self.address + self.nodesize
+        return MemPoolBlock(addr, self.blocksize, self.overhead)
+
     def read_memory(self) -> memoryview:
         return gdb.selected_inferior().read_memory(self.address, self.blocksize)
 


### PR DESCRIPTION

## Summary

1. Add property of prevnode, nextnode to mempool block to make it has same behavior with heap node.
In this way, the memory analysis can have a unified way to inspect memory, no matter for heap or pool.
3. Add warning if corrupted memory node(with 0 size) found.
If the nodesize is 0, we cannot iterate to next node, siliently return None will cause memleak command to generate false positive report with no warnings.
Add log to indicate such case.

4. fix regular expression to parse memory dump log
There could be only one space ahead of address.

## Impact

Now a warning is printed on corrupted memory node.
memdump log parsing will work insided GDB too.

## Testing

Tested with below memory dump log, now it can parse correctly.
```
[2025-01-09 21:53:13] [12/23 07:42:07] [85] [ap]    PID        Size Overhead    Sequence    Address Backtrace
[2025-01-09 21:53:13] [12/23 07:42:07] [85] [ap]     13         112       48       16388 0x3c395f20 0x2c21d0b8 0x2c1f7b0a 0x2c1fd094 0x2c56e22e 0x2c7b4f12 0x2c31525c 0x2c31604c 0x2c31610e 
[2025-01-09 21:53:13] [12/23 07:42:07] [85] [ap]      0         112       48           6 0x3c395eb0 0x2c21ce08 0x2c21ce58 0x2c7d7902 0x2c1fd638 
[2025-01-09 21:53:13] [12/23 07:42:07] [85] [ap]      0         112       48           8 0x3c395e40 0x2c21ce08 0x2c21ce58 0x2c205970 0x2c1fd678 
[2025-01-09 21:53:13] [12/23 07:42:07] [85] [ap]      0         112       48           9 0x3c395dd0 0x2c21ce08 0x2c21ce58 0x2c1fd736 
```

