### PR TITLE
Add support to Serial Error Reporting ioctl

### DIFF
--- a/Documentation/components/drivers/character/serial.rst
+++ b/Documentation/components/drivers/character/serial.rst
@@ -43,3 +43,8 @@ Serial Device Drivers
    ``arch/arm/src/lpc214x/lpc214x_serial.c``,
    ``arch/z16/src/z16f/z16f_serial.c``, etc.
 
+Serial Error Reporting
+----------------------
+
+It is possible to check if there are some frame, parity, overrun, break, or
+other error using the ioctl TIOCGICOUNT just like on Linux.

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -234,6 +234,13 @@ config SERIAL_IFLOWCONTROL_UPPER_WATERMARK
 
 endif # SERIAL_IFLOWCONTROL_WATERMARKS
 
+config SERIAL_TIOCGICOUNT
+	bool "Support TIOCGICOUNT (U[S]ART Error Report)"
+	default n
+	---help---
+		The ioctl TIOCGICOUNT is used to collect errors from serial ports
+                such as frame error, overrun, parity, etc.
+
 config SERIAL_TIOCSERGSTRUCT
 	bool "Support TIOCSERGSTRUCT"
 	default n

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -283,6 +283,20 @@ struct uart_ops_s
                           FAR const void *buf, size_t len);
 };
 
+/* This structure is used for U(S)ART frame, overrun, parity and brk error
+ * counters. This way applications will know if the UART communition is
+ * having some trouble.
+ */
+
+struct serial_icounter_s
+{
+  uint32_t frame;
+  uint32_t overrun;
+  uint32_t parity;
+  uint32_t brk;
+  uint32_t buf_overrun;
+};
+
 /* This is the device structure used by the driver.  The caller of
  * uart_register() must allocate and initialize this structure.  The
  * calling logic need only set all fields to zero except:


### PR DESCRIPTION
## Summary

*These commits add support to serial error reporting using the TIOCGICOUNT ioctl and an example implementation for STM32.

## Impact

*Users will be able to get information about U[S]ART communication errors

## Testing

*STM32F4Discovery board

