### PR TITLE
boards/linum-stm32h753bi: optimize display timings and memory config

### DIFF
--- a/boards/arm/stm32h7/linum-stm32h753bi/include/board.h
+++ b/boards/arm/stm32h7/linum-stm32h753bi/include/board.h
@@ -533,20 +533,21 @@
  * FMC_SDTR_TRC  - Row to collumn delay
  */
 
-#define BOARD_FMC_SDTR1  (FMC_SDTR_TMRD(2)| /* tMRD     = 2CLK */ \
-                          FMC_SDTR_TXSR(9)| /* tXSR min = ns */ \
-                          FMC_SDTR_TRCD(8)| /* tRCD min = ns */ \
-                          FMC_SDTR_TRAS(6)| /* tRAS min = ns */ \
-                          FMC_SDTR_TWR(4)|  /* tWR      = ns */ \
-                          FMC_SDTR_TRP(2)|  /* tRP  min = ns */ \
-                          FMC_SDTR_TRC(8))  /* tRC  min = ns */
+ #define BOARD_FMC_SDTR1  (FMC_SDTR_TMRD(2)| /* tMRD     = 2CLK */ \
+                           FMC_SDTR_TXSR(6)| /* tXSR min = ns */ \
+                           FMC_SDTR_TRAS(4)| /* tRAS min = ns */ \
+                           FMC_SDTR_TRC(6)|  /* tRC  min = ns */ \
+                           FMC_SDTR_TWR(2)|  /* tWR      = ns */ \
+                           FMC_SDTR_TRP(2)|  /* tRP  min = ns */ \
+                           FMC_SDTR_TRCD(2)) /* tRCD min = ns */
 
 #define BOARD_FMC_SDRAM_REFR_CYCLES  4096
 #define BOARD_FMC_SDRAM_REFR_PERIOD  64
 #define BOARD_FMC_SDRAM_AUTOREFRESH  8
-#define BOARD_FMC_SDRAM_MODE         (FMC_SDCMR_MRD_BURST_LENGTH_1| \
+#define BOARD_FMC_SDRAM_MODE         (FMC_SDCMR_MRD_BURST_LENGTH_4| \
                                       FMC_SDCMR_MRD_BURST_TYPE_SEQUENTIAL| \
                                       FMC_SDCMR_MRD_CAS_LATENCY_3| \
+                                      FMC_SDCMR_MRD_OPERATING_MODE_STANDARD |\
                                       FMC_SDCMR_MRD_WRITEBURST_MODE_SINGLE)
 
 #define BOARD_FMC_GPIO_CONFIGS \
@@ -635,28 +636,28 @@
 
 #define BOARD_LTDC_OUTPUT_BPP           16
 #define BOARD_LTDC_HFP                  160
-#define BOARD_LTDC_HBP                  160 /* AccumulatedHBP */
-#define BOARD_LTDC_VFP                  1
-#define BOARD_LTDC_VBP                  23  /* AccumulatedVBP */
+#define BOARD_LTDC_HBP                  160
+#define BOARD_LTDC_VFP                  12
+#define BOARD_LTDC_VBP                  23
 
-#define BOARD_LTDC_HSYNC                1   /* HorizontalSync */
-#define BOARD_LTDC_VSYNC                1   /* VerticalSync */
+#define BOARD_LTDC_HSYNC                1
+#define BOARD_LTDC_VSYNC                1
 
 /* Pixel Clock Polarity */
 
-#define BOARD_LTDC_GCR_PCPOL            0 /* !LTDC_GCR_PCPOL */
+#define BOARD_LTDC_GCR_PCPOL            0
 
 /* Data Enable Polarity */
 
-#define BOARD_LTDC_GCR_DEPOL            0 /* !LTDC_GCR_DEPOL */
+#define BOARD_LTDC_GCR_DEPOL            0
 
 /* Vertical Sync Polarity */
 
-#define BOARD_LTDC_GCR_VSPOL            0 /* !LTDC_GCR_VSPOL */
+#define BOARD_LTDC_GCR_VSPOL            0
 
 /* Horizontal Sync Polarity */
 
-#define BOARD_LTDC_GCR_HSPOL            0 /* !LTDC_GCR_HSPOL */
+#define BOARD_LTDC_GCR_HSPOL            0
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION
## Summary

optimize display timings and memory configuration to linum-stm32h753bi board.

## Impact

-  Optimize FMC/SDRAM configuration for faster memory access
- Improve overall display performance for LVGL applications

These changes aim to enhance the FPS in LVGL benchmark demos, 
for some screen tests it was possible double the fps.

## Testing
build the example bellow and execute the lvgl beanchmark demo.

```
nuttx$ ./tools/configure.sh linum-stm32h753bi:lvgl
nsh> lvgl benchmark
```