### PR TITLE
bluetooth: miss carrier_[on/off] in bt_netdev

### DIFF
--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -663,6 +663,9 @@ static int btnet_ifup(FAR struct net_driver_s *netdev)
              netdev->d_mac.radio.nv_addr[4], netdev->d_mac.radio.nv_addr[5]);
 #endif
 
+      /* The interface is now up */
+
+      netdev_carrier_on(netdev);
       ret = OK;
     }
 
@@ -687,6 +690,7 @@ static int btnet_ifup(FAR struct net_driver_s *netdev)
 
 static int btnet_ifdown(FAR struct net_driver_s *netdev)
 {
+  netdev_carrier_off(netdev);
   return OK;
 }
 


### PR DESCRIPTION

## Summary
bluetooth: miss carrier_[on/off] in bt_netdev
fix regression from https://github.com/apache/nuttx/pull/15237


## Impact

bluetooth

## Testing
ci


