### PR TITLE
littlefs/cmake: fix compilation flag issue

### DIFF
--- a/fs/littlefs/CMakeLists.txt
+++ b/fs/littlefs/CMakeLists.txt
@@ -49,7 +49,7 @@ if(CONFIG_FS_LITTLEFS)
     FetchContent_MakeAvailable(littlefs)
   endif()
 
-  target_compile_definitions(
+  target_compile_options(
     fs
     PRIVATE
       $<$<NOT:$<BOOL:${CONFIG_FS_LITTLEFS_HAS_LFS_DEFINES}>>:-DLFS_TRACE=finfo>


### PR DESCRIPTION
## Summary

This fixes a build issue on Ubuntu 22.04 with cmake 3.22.1 for `qemu-armv7a:rpproxy_ivmshmem`:

```
$ cmake --version
cmake version 3.22.1

$ ninja
[129/1346] Building C object fs/CMakeFiles/fs.dir/fs_heap.c.obj
FAILED: fs/CMakeFiles/fs.dir/fs_heap.c.obj
/usr/bin/arm-none-eabi-gcc -D-DLFS_ASSERT=DEBUGASSERT -D-DLFS_CONFIG=/home/yf/Projects/Nuttx/nuttx/fs/littlefs/lfs_vfs.h -D-DLFS_DEBUG=finfo -D-DLFS_ERROR=ferr -D-DLFS_TRACE=finfo -D-DLFS_WARN=fwarn -DLFS_ATTR_MAX=1022 -DLFS_FILE_MAX=2147483647 -DLFS_NAME_MAX=32 -D__KERNEL__ -D__NuttX__ -I/home/yf/Projects/Nuttx/nuttx/openamp/open-amp/lib/include -I/home/yf/Projects/Nuttx/nuttx/fs/littlefs -I/home/yf/Projects/Nuttx/nuttx/fs -I/home/yf/Projects/Nuttx/nuttx/sched -isystem /home/yf/Projects/Nuttx/nuttx/include -isystem /tmp/aaa/include -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -fno-common -Wall -Wshadow -Wundef -nostdlib -fno-omit-frame-pointer -fno-optimize-sibling-calls -fstack-protector-all -funwind-tables -fasynchronous-unwind-tables -mthumb -Wa,-mthumb -Wa,-mimplicit-it=always -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -Wno-psabi -fdiagnostics-color=always -fmacro-prefix-map=/home/yf/Projects/Nuttx/nuttx= -fmacro-prefix-map=/home/yf/Projects/Nuttx/apps= -fmacro-prefix-map=/home/yf/Projects/Nuttx/nuttx/boards/arm/qemu/qemu-armv7a= -fmacro-prefix-map=/home/yf/Projects/Nuttx/nuttx/arch/arm/src/qemu= -Wno-shadow @fs/CMakeFiles/fs.dir/fs_heap.c.obj.rsp -MD -MT fs/CMakeFiles/fs.dir/fs_heap.c.obj -MF fs/CMakeFiles/fs.dir/fs_heap.c.obj.d -o fs/CMakeFiles/fs.dir/fs_heap.c.obj -c /home/yf/Projects/Nuttx/nuttx/fs/fs_heap.c
<command-line>: error: macro names must be identifiers
<command-line>: error: macro names must be identifiers

```

## Impacts

LittleFS CMake build system users


## Testing

- checked with qemu-armv7a:rpproxy_ivshmem
- CI checks.
