### PR TITLE
xtensa: use misc register to implement up_this_task macro

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -172,6 +172,11 @@ config XTENSA_DCACHE_LOCK
 	---help---
 		Enable Xtensa D-Cache lock & unlock feature
 
+config XTENSA_PERCPU_TCB_IN_MISC0
+	bool "Use misc0 register to store the percpu tcb"
+	default n if ARCH_CHIP_ESP32
+	default y
+
 config XTENSA_ONESHOT
 	bool "Xtensa oneshot lower half driver"
 	default n

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -105,8 +105,12 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
 void IRAM_ATTR xtensa_appcpu_start(void)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = current_task(this_cpu());
   register uint32_t sp;
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(tcb);
 
   /* Move to the stack assigned to us by up_smp_start immediately.  Although
    * we were give a stack pointer at start-up, we don't know where that stack

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -104,8 +104,12 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
 void xtensa_appcpu_start(void)
 {
-  struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = current_task(this_cpu());
   register uint32_t sp;
+
+  /* Init idle task to percpu reg */
+
+  up_update_task(tcb);
 
   /* Move to the stack assigned to us by up_smp_start immediately.  Although
    * we were give a stack pointer at start-up, we don't know where that stack


### PR DESCRIPTION
## Summary

This is the follow-up work of https://github.com/apache/nuttx/pull/13726 (percpu reg store this_task) on xtensa.
To help accelerate this_task(), use misc0 register to store the current running task tcb pointer. 
And use the least significant bit of misc0 to indicate whether in interrupt context.

This feature is controlled by a config item `XTENSA_PERCPU_TCB_IN_MISC0`, which is currently off by default.

## Impact

sched

## Testing

`ostest` passed on these config: `esp32s3-devkit:smp`, `esp32s3-devkit:tickless`, `esp32s2-saola-1:ostest`,
with `XTENSA_PERCPU_TCB_IN_MISC0` on and off (totally 6 combinations).

This feature does not work with `esp32-devkitc:smp` plus `XTENSA_PERCPU_TCB_IN_MISC0` on, ostest fails at signal handler test.
Have no idea why it does not work with esp32, so set `XTENSA_PERCPU_TCB_IN_MISC0` to be off by default.
Maybe change it to `default n if ARCH_CHIP_ESP32` is a good idea?
