### PR TITLE
sensors/lsm6dso32: Fixed typo in device address registration.

### DIFF
--- a/drivers/sensors/lsm6dso32_uorb.c
+++ b/drivers/sensors/lsm6dso32_uorb.c
@@ -1833,7 +1833,7 @@ int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
   int gyro_pid;
 
   DEBUGASSERT(i2c != NULL);
-  DEBUGASSERT(addr == 0x6b || addr == 0x6c);
+  DEBUGASSERT(addr == 0x6b || addr == 0x6a);
 
   /* If HPWORK is not enabled and the attach functions are not NULL, let the
    * user know that HPWORK is required for interrupts.


### PR DESCRIPTION
## Summary

Resolves issue where invalid address 0x6c was included instead of 0x6a.

## Impact

Boards using 0x6a as the address will no longer receive a DEBUGASSERT failure when registering this driver.

## Testing

Tests performed on InSpace's flight computer where the LSM6DSO32 IMU uses 0x6a as the address. This board is STM32 based. Here are the registration logs output:

```console
sensor_custom_register: Registering /dev/uorb/sensor_gyro0
sensor_custom_register: Registering /dev/uorb/sensor_accel0
lsm6dso32_register: LSM6DSO32 gyro interrupt handler attached to INT1.
lsm6dso32_register: LSM6DSO32 accel interrupt handler attached to INT2.
lsm6dso32_register: LSM6DSO32 driver registered!
```