### PR TITLE
xtensa/esp32: set cpuint to initial value after deallocate

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -733,6 +733,7 @@ static int esp32_wdt_setisr(struct esp32_wdt_dev_s *dev, xcpt_t handler,
               up_disable_irq(wdt->irq);
               esp32_teardown_irq(wdt->cpu, wdt->periph, wdt->cpuint);
               irq_detach(wdt->irq);
+              wdt->cpuint = -ENOMEM;
             }
 
           goto errout;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Please to https://github.com/apache/nuttx/pull/15433

cpuint was allocated when register wdt handler, but not deallocated when unregister, which cause debug assert when checking `DEBUGASSERT((*freeints & bitmask) == 0)`, so set cpuint to initial value after deallocate.

This PR just cherry-picked the fix in esp32s3_wdt.c to esp32_wdt.c.

## Impact

Impact watchdog handler register/unregister on ESP32

## Testing

same to  https://github.com/apache/nuttx/pull/15433


