### PR TITLE
libs/libc/modlib/modlib_bind.c: Fix system crash if modlib_bind fails

### DIFF
--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -938,7 +938,7 @@ int modlib_bind(FAR struct module_s *modp,
   ret = modlib_findsymtab(loadinfo);
   if (ret < 0)
     {
-      return ret;
+      goto errout_with_addrenv;
     }
 
   /* Process relocations in every allocated section */
@@ -989,7 +989,7 @@ int modlib_bind(FAR struct module_s *modp,
 
           if (ret < 0)
             {
-              return ret;
+              goto errout_with_addrenv;
             }
         }
       else
@@ -1042,7 +1042,7 @@ int modlib_bind(FAR struct module_s *modp,
 
       if (ret < 0)
         {
-          return ret;
+          goto errout_with_addrenv;
         }
     }
 
@@ -1075,6 +1075,8 @@ int modlib_bind(FAR struct module_s *modp,
       up_coherent_dcache(loadinfo->sectalloc[i], loadinfo->shdr[i].sh_size);
     }
 #endif
+
+errout_with_addrenv:
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (loadinfo->addrenv != NULL)


### PR DESCRIPTION
## Summary

Addrenv is changed to the newly created process' one in the beginning of modlib_bind, and needs to be changed back always when returning from the function; also in error cases.

This fixes a system crash in case where linking of a new process fails in modlib_bind. In the error case the modlib_bind returned with error code, but with wrong address environment.

## Impact

Fixes a crashing bug in platforms using CONFIG_ARCH_ADDRENV.

## Testing

Tested on imx93 and mpfs platforms.
