### PR TITLE
imx95: make gpio irq configurable per bank

### DIFF
--- a/arch/arm/src/imx9/Kconfig
+++ b/arch/arm/src/imx9/Kconfig
@@ -375,6 +375,27 @@ config IMX9_GPIO_IRQ
 	bool "GPIO Interrupt Support"
 	default n
 
+menu "GPIO Interrupt Configuration"
+	depends on IMX9_GPIO_IRQ
+
+config IMX9_GPIO1_IRQ
+	bool "GPIO1 Interrupt"
+	default n
+
+config IMX9_GPIO2_IRQ
+	bool "GPIO2 Interrupt"
+	default n
+
+config IMX9_GPIO3_IRQ
+	bool "GPIO3 Interrupt"
+	default n
+
+config IMX9_GPIO4_IRQ
+	bool "GPIO4 Interrupt"
+	default n
+
+endmenu # GPIO Interrupt Configuration
+
 config IMX9_LPI2C
 	bool "LPI2C support"
 	default n

--- a/arch/arm/src/imx9/imx9_gpioirq.c
+++ b/arch/arm/src/imx9/imx9_gpioirq.c
@@ -172,21 +172,29 @@ void imx9_gpioirq_initialize(void)
 
   /* Attach the common GPIO interrupt handler and enable the interrupt */
 
+#ifdef CONFIG_IMX9_GPIO1_IRQ
   DEBUGVERIFY(irq_attach(IMX9_IRQ_GPIO1_0,
                          imx9_gpio_interrupt, (void *)GPIO_PORT1));
   up_enable_irq(IMX9_IRQ_GPIO1_0);
+#endif
 
+#ifdef CONFIG_IMX9_GPIO2_IRQ
   DEBUGVERIFY(irq_attach(IMX9_IRQ_GPIO2_0,
                          imx9_gpio_interrupt, (void *)GPIO_PORT2));
   up_enable_irq(IMX9_IRQ_GPIO2_0);
+#endif
 
+#ifdef CONFIG_IMX9_GPIO3_IRQ
   DEBUGVERIFY(irq_attach(IMX9_IRQ_GPIO3_0,
                          imx9_gpio_interrupt, (void *)GPIO_PORT3));
   up_enable_irq(IMX9_IRQ_GPIO3_0);
+#endif
 
+#ifdef CONFIG_IMX9_GPIO4_IRQ
   DEBUGVERIFY(irq_attach(IMX9_IRQ_GPIO4_0,
                          imx9_gpio_interrupt, (void *)GPIO_PORT4));
   up_enable_irq(IMX9_IRQ_GPIO4_0);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

This fixes crashes caused by receiving interrupt from unused/unassigned GPIO banks.

This is because on the IMX95 you can map the GPIO banks between A55, M7 and M33 cores. 
Thus disallowing a specific to access a particular GPIO bank.

This patch makes it configurable compile-time so that the M7 only access the GPIO it's assigned too.

## Impact

IMX95 Arch only

## Testing

Tested on IMX95-EVK board

