### PR TITLE
arch/arm/max326xx: add max32690 gpio driver

### DIFF
--- a/arch/arm/src/max326xx/hardware/max326_gpio.h
+++ b/arch/arm/src/max326xx/hardware/max326_gpio.h
@@ -33,6 +33,8 @@
 #  include "hardware/max32620_30_gpio.h"
 #elif defined(CONFIG_ARCH_FAMILY_MAX32660)
 #  include "hardware/max32660_gpio.h"
+#elif defined(CONFIG_ARCH_FAMILY_MAX32690)
+#  include "hardware/max32690_gpio.h"
 #else
 #  error "Unsupported MAX326XX family"
 #endif

--- a/arch/arm/src/max326xx/max32660/max32660_gpio.h
+++ b/arch/arm/src/max326xx/max32660/max32660_gpio.h
@@ -175,4 +175,129 @@
 
 typedef uint16_t max326_pinset_t;
 
+#ifndef __ASSEMBLY__
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: max326_gpio_irqinitialize
+ *
+ * Description:
+ *   Initialize logic to support interrupting GPIO pins.  This function is
+ *   called by the OS initialization logic and is not a user interface.
+ *
+ * Assumptions:
+ *   Called early in the boot-up sequence
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MAX326XX_GPIOIRQ
+void max326_gpio_irqinitialize(void);
+#endif
+
+/****************************************************************************
+ * Name: max326_gpio_config
+ *
+ * Description:
+ *   Configure a GPIO pin based on bit-encoded description of the pin.
+ *
+ * Assumptions:
+ *   - The pin interrupt has been disabled and all interrupt related bits
+ *     have been set to zero by max436_gpio_config().
+ *   - We are called in a critical section.
+ *
+ ****************************************************************************/
+
+int max326_gpio_config(max326_pinset_t pinset);
+
+/****************************************************************************
+ * Name: max326_gpio_irqconfig
+ *
+ * Description:
+ *   Configure a pin for interrupt operation.  This function should not be
+ *   called directory but, rather, indirectly through max326_gpio_config().
+ *
+ ****************************************************************************/
+
+#if defined( CONFIG_MAX326XX_GPIOIRQ )
+void max326_gpio_irqconfig(max326_pinset_t pinset);
+#endif
+
+/****************************************************************************
+ * Name: max326_gpio_write
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void max326_gpio_write(max326_pinset_t pinset, bool value);
+
+/****************************************************************************
+ * Name: max326_gpio_read
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool max326_gpio_read(max326_pinset_t pinset);
+
+/****************************************************************************
+ * Name: max326_gpio_irqdisable
+ *
+ * Description:
+ *   Disable a GPIO pin interrupt.  This function should not be called
+ *   directly but, rather through up_disable_irq();
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MAX326XX_GPIOIRQ
+void max326_gpio_irqdisable(int irq);
+#endif
+
+/****************************************************************************
+ * Name: max326_gpio_irqenable
+ *
+ * Description:
+ *   Enable a GPIO pin interrupt.  This function should not be called
+ *   directly but, rather through up_enable_irq();
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MAX326XX_GPIOIRQ
+void max326_gpio_irqenable(int irq);
+#endif
+
+/****************************************************************************
+ * Function:  max326_gpio_dump
+ *
+ * Description:
+ *   Decode and dump all GPIO registers associated with the port and pin
+ *   numbers in the provided pinset.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_GPIO_INFO
+int max326_gpio_dump(max326_pinset_t pinset, const char *msg);
+#else
+#  define max326_gpio_dump(p,m)
+#endif
+
+#ifdef __cplusplus
+}
+
+#endif
+#endif /* __ASSEMBLY__ */
+
 #endif /* __ARCH_ARM_SRC_MAX326XX_MAX32660_MAX32660_GPIO_H */

--- a/arch/arm/src/max326xx/max32690/max32690_gpio.c
+++ b/arch/arm/src/max326xx/max32690/max32690_gpio.c
@@ -1,0 +1,444 @@
+/****************************************************************************
+ * arch/arm/src/max326xx/max32690/max32690_gpio.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/spinlock.h>
+
+#include "arm_internal.h"
+#include "max326_gpio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+spinlock_t g_max32690_gpio_lock = SP_UNLOCKED;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: max32690_default
+ *
+ * Description:
+ *   Configure a pin as a default GPIO input as it was on reset
+ *
+ ****************************************************************************/
+
+static void max32690_default(max32690_gpio_regs_t *gpio,
+                             max32690_pinconfig_t *conf)
+{
+    uint32_t pinmask = 1 << conf->pin;
+
+      /* Disable interrupts and wake-up events */
+
+    gpio->inten_clr =  pinmask;  /* Pin interrupt disabled triggered */
+    gpio->intmode  &= ~pinmask;  /* Level triggered */
+    gpio->intpol   &= ~pinmask;  /* Input low triggers */
+    gpio->dualedge &= ~pinmask;  /* Disable dual edge */
+    gpio->wken_clr  =  pinmask;  /* Disable wakeup */
+
+      /* Make the pins an input an clear output value */
+
+    gpio->outen_clr =  pinmask;  /* Disable output drivers */
+    gpio->out_clr   =  pinmask;  /* Set the output value to zero */
+
+      /* Set alternate functions to I/O */
+
+    gpio->en0_set   =  pinmask;
+    gpio->en1_clr   =  pinmask;
+    gpio->en2_clr   =  pinmask;
+
+      /* enable input connection to pin */
+
+    gpio->inen     |= pinmask;
+
+      /* Reset drive strength */
+
+    gpio->ds0      &= ~pinmask;
+    gpio->ds1      &= ~pinmask;
+
+      /* Disable pull up and pull down */
+
+    gpio->padctrl0 &= ~pinmask;
+    gpio->ps       &= ~pinmask;
+
+      /* Set VVoltage to V_DDIOH */
+
+    gpio->vssel |= pinmask;
+
+      /* Disable slew and hysteresis */
+
+    gpio->hysen    &= ~pinmask;
+    gpio->srsel    &= ~pinmask;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: max32690_get_gpio_bank_regptr
+ *
+ * Description:
+ *   Get the GPIO access struct address based in the GPIO Bank
+ *
+ ****************************************************************************/
+
+max32690_gpio_regs_t *max32690_get_gpio_bank_regptr(int bank)
+{
+    max32690_gpio_regs_t *gpio_regs = 0;
+
+    switch (bank)
+    {
+        case 0:
+            gpio_regs = (max32690_gpio_regs_t *)MAX326_GPIO0_BASE;
+            break;
+        case 1:
+            gpio_regs = (max32690_gpio_regs_t *)MAX326_GPIO1_BASE;
+            break;
+        case 2:
+            gpio_regs = (max32690_gpio_regs_t *)MAX326_GPIO2_BASE;
+            break;
+        case 3:
+            gpio_regs = (max32690_gpio_regs_t *)MAX326_GPIO3_BASE;
+            break;
+    }
+
+    DEBUGASSERT(gpio_regs != 0);
+
+    return gpio_regs;
+}
+
+static
+void set_pin_electrical_characteristics(max32690_gpio_regs_t *gpio,
+                                        uint16_t conf,
+                                        uint32_t pinmask)
+{
+      /* Enable slew and hysteresis */
+
+      if ((conf & GPIO_SLEW) != 0)
+    {
+        gpio->srsel |= pinmask;
+    }
+
+      if ((conf & GPIO_HYSTERESIS) != 0)
+    {
+        gpio->hysen |= pinmask;
+    }
+
+    switch (conf & GPIO_DRIVE_MASK)
+        {
+            case GPIO_DRIVE_0_V_DIO:
+                gpio->ds1   &= ~pinmask;
+                gpio->ds0   &= ~pinmask;
+                gpio->vssel &= ~pinmask;
+                break;
+
+            case GPIO_DRIVE_1_V_DIO:
+                gpio->ds1   &= ~pinmask;
+                gpio->ds0   |=  pinmask;
+                gpio->vssel &= ~pinmask;
+                break;
+
+            case GPIO_DRIVE_2_V_DIO:
+                gpio->ds1   |=  pinmask;
+                gpio->ds0   &= ~pinmask;
+                gpio->vssel &= ~pinmask;
+                break;
+
+            case GPIO_DRIVE_3_V_DIO:
+                gpio->ds1   |= pinmask;
+                gpio->ds0   |= pinmask;
+                gpio->vssel &= ~pinmask;
+                break;
+
+            case GPIO_DRIVE_0_V_DIO_H:
+                gpio->ds1   &= ~pinmask;
+                gpio->ds0   &= ~pinmask;
+                gpio->vssel |=  pinmask;
+                break;
+
+            case GPIO_DRIVE_1_V_DIO_H:
+                gpio->ds1   &= ~pinmask;
+                gpio->ds0   |=  pinmask;
+                gpio->vssel |=  pinmask;
+                break;
+
+            case GPIO_DRIVE_2_V_DIO_H:
+                gpio->ds1   |=  pinmask;
+                gpio->ds0   &= ~pinmask;
+                gpio->vssel |=  pinmask;
+                break;
+
+            case GPIO_DRIVE_3_V_DIO_H:
+                gpio->ds1   |= pinmask;
+                gpio->ds0   |= pinmask;
+                gpio->vssel |=  pinmask;
+                break;
+
+            default:
+                DEBUGPANIC();
+                return;
+        }
+
+    switch (conf & GPIO_IN_MODE_MASK)
+        {
+            case GPIO_FLOAT:
+                gpio->padctrl1 &= ~pinmask;
+                gpio->padctrl0 &= ~pinmask;
+                break;
+
+            case GPIO_PULLUP_WEAK:
+                gpio->padctrl1 &= ~pinmask;
+                gpio->padctrl0 |=  pinmask;
+                gpio->ps       &= ~pinmask;
+                gpio->vssel    &= ~pinmask;
+                break;
+
+            case GPIO_PULLUP_STRONG:
+                gpio->padctrl1 &= ~pinmask;
+                gpio->padctrl0 |=  pinmask;
+                gpio->ps       |=  pinmask;
+                gpio->vssel    &= ~pinmask;
+                break;
+
+            case GPIO_PULL_DOWN_WEAK:
+                gpio->padctrl1 |=  pinmask;
+                gpio->padctrl0 &= ~pinmask;
+                gpio->ps       &= ~pinmask;
+                gpio->vssel    |=  pinmask;
+                break;
+
+            case GPIO_PULL_DOWN_STRONG:
+                gpio->padctrl1 |=  pinmask;
+                gpio->padctrl0 &= ~pinmask;
+                gpio->ps       |=  pinmask;
+                gpio->vssel    |= ~pinmask;
+                break;
+
+            default:
+                DEBUGPANIC();
+                return;
+        }
+}
+
+/****************************************************************************
+ * Name: max32690_gpio_config
+ *
+ * Description:
+ *   Configure a GPIO pin. Config based on bit-encoded descriptions.
+ *
+ ****************************************************************************/
+
+int  max32690_gpio_config(max32690_pinconfig_t pinconf)
+{
+    irqstate_t flags;
+    uint32_t pinmask;
+
+    DEBUGASSERT(pinconf.pin <= GPIO_PINMAX);
+    pinmask = 1 << pinconf.pin;
+
+      /* Modification of all registers must be atomic */
+
+    flags = spin_lock_irqsave(&g_max32690_gpio_lock);
+
+    max32690_gpio_regs_t *gpio;
+    gpio = max32690_get_gpio_bank_regptr(pinconf.gpio_bank);
+
+      /* First, force the pin configuration to the default generic
+       * input state.
+       * So that we know we are starting from a known state.
+       */
+
+    max32690_default(gpio, &pinconf);
+
+      /* Then perform the actual pin configuration.  We need only
+       * to set values that are not in the default, reset state.
+       */
+
+      /* Handle the pin function */
+
+    switch (pinconf.config & GPIO_FUNC_MASK)
+    {
+        case GPIO_IO:
+
+            /* first change to I/O */
+
+            gpio->en0_set = pinmask;
+            gpio->en1_clr = pinmask;
+            gpio->en2_clr = pinmask;
+
+            set_pin_electrical_characteristics(gpio, pinconf.config,
+                                               pinmask);
+
+            if ((pinconf.config & GPIO_OUTPUT_MODE) == GPIO_OUTPUT_MODE)
+            {
+                gpio->outen_set  = pinmask;   /* enable pin output mode */
+            }
+
+            if ((pinconf.config & GPIO_VALUE_ONE) == GPIO_VALUE_ONE)
+            {
+                gpio->out_set = pinmask;      /* Set output high */
+            }
+
+            break;
+
+      case GPIO_ALT1:
+
+            /* first change to I/O (transition to AF1) */
+
+            gpio->en0_set = pinmask;
+
+            gpio->en1_clr = pinmask;
+            gpio->en2_clr = pinmask;
+
+            set_pin_electrical_characteristics(gpio, pinconf.config,
+                                               pinmask);
+
+            /* now disable en0 to switch to alternate mode */
+
+            gpio->en0_clr = pinmask;
+
+            if ((pinconf.config & GPIO_OUTPUT_MODE) == GPIO_OUTPUT_MODE)
+            {
+                gpio->outen_set  = pinmask;   /* enable pin output mode */
+            }
+
+            break;
+
+      case GPIO_ALT2:
+
+            /* first change to I/O (transition to AF2) */
+
+            gpio->en0_set = pinmask;
+
+            gpio->en1_set = pinmask;
+            gpio->en2_clr = pinmask;
+
+            set_pin_electrical_characteristics(gpio, pinconf.config,
+                                               pinmask);
+
+            /* now disable en0 to switch to alternate mode */
+
+            gpio->en0_clr = pinmask;
+
+            if ((pinconf.config & GPIO_OUTPUT_MODE) == GPIO_OUTPUT_MODE)
+            {
+                gpio->outen_set  = pinmask;   /* enable pin output mode */
+            }
+
+            break;
+
+      case GPIO_ALT3:
+
+            /* first change to I/O (transition to AF3) */
+
+            gpio->en0_set = pinmask;
+
+            gpio->en1_clr = pinmask;
+            gpio->en2_set = pinmask;
+
+            set_pin_electrical_characteristics(gpio, pinconf.config,
+                                               pinmask);
+
+            /* now disable en0 to switch to alternate mode */
+
+            gpio->en0_clr = pinmask;
+
+            if ((pinconf.config & GPIO_OUTPUT_MODE) == GPIO_OUTPUT_MODE)
+            {
+                gpio->outen_set  = pinmask;   /* enable pin output mode */
+            }
+
+            break;
+
+        default:
+            DEBUGPANIC();
+            return ERROR;
+    }
+
+    spin_unlock_irqrestore(&g_max32690_gpio_lock, flags);
+    return OK;
+}
+
+/****************************************************************************
+ * Name: max32690_gpio_write
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void max32690_gpio_write(max32690_pinconfig_t pinconfig, bool value)
+{
+    DEBUGASSERT(pinconfig.gpio_bank <= 3);
+    DEBUGASSERT(pinconfig.pin <= GPIO_PINMAX);
+
+      /* Modification of registers areatomic */
+
+    max32690_gpio_regs_t *gpio;
+    gpio = max32690_get_gpio_bank_regptr(pinconfig.gpio_bank);
+
+      if (value)
+    {
+        gpio->out_set = 1 << pinconfig.pin;
+    }
+    else
+    {
+        gpio->out_clr = 1 << pinconfig.pin;
+    }
+}
+
+/****************************************************************************
+ * Name: max32690_gpio_read
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool max32690_gpio_read(max32690_pinconfig_t pinconfig)
+{
+    DEBUGASSERT(pinconfig.gpio_bank <= 3);
+    DEBUGASSERT(pinconfig.pin <= GPIO_PINMAX);
+
+    max32690_gpio_regs_t *gpio;
+    gpio = max32690_get_gpio_bank_regptr(pinconfig.gpio_bank);
+
+      return (gpio->in & (1 << pinconfig.pin)) != 0;
+}
+

--- a/arch/arm/src/max326xx/max32690/max32690_gpio.h
+++ b/arch/arm/src/max326xx/max32690/max32690_gpio.h
@@ -1,0 +1,281 @@
+/****************************************************************************
+ * arch/arm/src/max326xx/max32690/max32690_gpio.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_MAX326XX_MAX32690_MAX32690_GPIO_H
+#define __ARCH_ARM_SRC_MAX326XX_MAX32690_MAX32690_GPIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Bit-encoded input to max32690_gpio_config() ******************************/
+
+/* 16-Bit Encoding:  DDDW RRRV HSII IMFF
+ *
+ *   Drive Strength:        DDD
+ *   Wakeup:                W
+ *   Pin Pull Up/Down:      RRR
+ *   Initial Value:         V (output pins)
+ *   Input Hysteresis:      H
+ *   Slew Rate:             S
+ *   Interrupt Mode:        III
+ *   Pin Mode:              M
+ *   Pin Function:          FF
+ */
+
+/* Drive Strength:
+ *
+ * DDD. .... .... ....
+ */
+
+#define GPIO_DRIVE_SHIFT         ( 13 )                      /* Bits 15-13: Drive strength */
+#define GPIO_DRIVE_MASK          ( 7 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_0_V_DIO_H   ( 0 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_1_V_DIO_H   ( 1 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_2_V_DIO_H   ( 2 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_3_V_DIO_H   ( 3 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_0_V_DIO     ( 4 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_1_V_DIO     ( 5 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_2_V_DIO     ( 6 << GPIO_DRIVE_SHIFT )
+#  define GPIO_DRIVE_3_V_DIO     ( 7 << GPIO_DRIVE_SHIFT )
+
+/* Wake-UP:
+ *
+ * ...W .... .... ....
+ */
+
+#define GPIO_WAKEUP              ( 1 << 12 )                 /* Bit 12: Wakeup Enable */
+
+/* Pin Pull Up/Down: PP
+ *
+ * .... RRR. .... ....
+ */
+
+#define GPIO_IN_MODE_SHIFT       ( 9 )                       /* Bits 11-9: Pin pull up/down mode */
+#define GPIO_IN_MODE_MASK        ( 7 << GPIO_IN_MODE_SHIFT )
+#  define GPIO_FLOAT             ( 0 << GPIO_IN_MODE_SHIFT )    /* Neither pull-up nor -down */
+#  define GPIO_PULLUP_WEAK       ( 1 << GPIO_IN_MODE_SHIFT )    /* Weak Pull-up resistor enabled     ( 1 M Ω to V DDIO )  */
+#  define GPIO_PULLUP_STRONG     ( 2 << GPIO_IN_MODE_SHIFT )    /* Strong Pull-up resistor enabled   ( 25 K Ω to V DDIO )  */
+#  define GPIO_PULL_DOWN_WEAK    ( 3 << GPIO_IN_MODE_SHIFT )    /* Weak Pull-down resistor enabled   ( 1 M Ω to V DDIOH ) ?? not GND */
+#  define GPIO_PULL_DOWN_STRONG  ( 4 << GPIO_IN_MODE_SHIFT )    /* Strong Pull-down resistor enabled ( 25 K Ω to V DDIO ) ?? not GND */
+
+/* Initial value: V
+ *
+ * .... ...V .... ....
+ */
+
+#define GPIO_VALUE_ONE           ( 1 << 8 )                  /* Bit 8: Initial GPIO output value */
+
+/* Input Hysteresis:
+ *
+ * .... .... H... ....
+ */
+
+#define GPIO_HYSTERESIS          ( 1 << 7 )                  /* Bit 7: Input hysteresis */
+
+/* Slew Rate:
+ *
+ * .... .... .S.. ....
+ */
+
+#define GPIO_SLEW                ( 1 << 6 )                  /* Bit 6: Slew rate mode */
+
+/* Interrupt Mode:
+ *
+ * .... .... ..II I...
+ */
+
+#define GPIO_INT_SHIFT           ( 3 )                       /* Bit 5-3: Initial GPIO output value */
+#define GPIO_INT_MASK            ( 7 << GPIO_INT_SHIFT )
+#  define GPIO_INTRE             ( 0 << GPIO_INT_SHIFT )
+#  define GPIO_INTFE             ( 1 << GPIO_INT_SHIFT )
+#  define GPIO_INTBOTH           ( 2 << GPIO_INT_SHIFT )
+#  define GPIO_INTLOW            ( 3 << GPIO_INT_SHIFT )
+#  define GPIO_INTHIGH           ( 4 << GPIO_INT_SHIFT )
+
+/* Pin Mode bits
+ *
+ *  ... .... .... .M..
+ */
+
+#  define GPIO_OUTPUT_MODE       ( 1 << 2 )                  /* Bits 2: Pin Input / Output mode */
+
+/* Pin Function bits:
+ *
+ *  .... .... .... ..FF
+ */
+
+#define GPIO_FUNC_MASK           ( 3 )                       /* Bits 1-0 GPIO Mask */
+#  define GPIO_IO                ( 0 )
+#  define GPIO_ALT1              ( 1 )
+#  define GPIO_ALT2              ( 2 )
+#  define GPIO_ALT3              ( 3 )
+
+#  define GPIO_PINMIN       0
+#  define GPIO_PINMAX       31
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef void (*gpio_irq_function_t)(int bank, int pin);
+
+typedef struct
+{
+    uint8_t gpio_bank;
+    uint8_t pin;
+    uint16_t config;
+    gpio_irq_function_t irq_handler;
+} max32690_pinconfig_t;
+
+#define __RW  volatile
+#define __RO  volatile const
+
+typedef struct
+{
+    __RW uint32_t en0;                  /* Offset 0x00: GPIO EN0 Register */
+    __RW uint32_t en0_set;              /* Offset 0x04: GPIO EN0_SET Register */
+    __RW uint32_t en0_clr;              /* Offset 0x08: GPIO EN0_CLR Register */
+    __RW uint32_t outen;                /* Offset 0x0C: GPIO OUTEN Register */
+    __RW uint32_t outen_set;            /* Offset 0x10: GPIO OUTEN_SET Register */
+    __RW uint32_t outen_clr;            /* Offset 0x14: GPIO OUTEN_CLR Register */
+    __RW uint32_t out;                  /* Offset 0x18: GPIO OUT Register */
+    __RW uint32_t out_set;              /* Offset 0x1C: GPIO OUT_SET Register */
+    __RW uint32_t out_clr;              /* Offset 0x20: GPIO OUT_CLR Register */
+    __RO uint32_t in;                   /* Offset 0x24: GPIO IN Register */
+    __RW uint32_t intmode;              /* Offset 0x28: GPIO INTMODE Register */
+    __RW uint32_t intpol;               /* Offset 0x2C: GPIO INTPOL Register */
+    __RW uint32_t inen;                 /* Offset 0x30: GPIO INEN Register */
+    __RW uint32_t inten;                /* Offset 0x34: GPIO INTEN Register */
+    __RW uint32_t inten_set;            /* Offset 0x38: GPIO INTEN_SET Register */
+    __RW uint32_t inten_clr;            /* Offset 0x3C: GPIO INTEN_CLR Register */
+    __RO uint32_t intfl;                /* Offset 0x40: GPIO INTFL Register */
+    __RO uint32_t rsv_0x44;
+    __RW uint32_t intfl_clr;            /* Offset 0x48: GPIO INTFL_CLR Register */
+    __RW uint32_t wken;                 /* Offset 0x4C: GPIO WKEN Register */
+    __RW uint32_t wken_set;             /* Offset 0x50: GPIO WKEN_SET Register */
+    __RW uint32_t wken_clr;             /* Offset 0x54: GPIO WKEN_CLR Register */
+    __RO uint32_t rsv_0x58;
+    __RW uint32_t dualedge;             /* Offset 0x5C: GPIO DUALEDGE Register */
+    __RW uint32_t padctrl0;             /* Offset 0x60: GPIO PADCTRL0 Register */
+    __RW uint32_t padctrl1;             /* Offset 0x64: GPIO PADCTRL1 Register */
+    __RW uint32_t en1;                  /* Offset 0x68: GPIO EN1 Register */
+    __RW uint32_t en1_set;              /* Offset 0x6C: GPIO EN1_SET Register */
+    __RW uint32_t en1_clr;              /* Offset 0x70: GPIO EN1_CLR Register */
+    __RW uint32_t en2;                  /* Offset 0x74: GPIO EN2 Register */
+    __RW uint32_t en2_set;              /* Offset 0x78: GPIO EN2_SET Register */
+    __RW uint32_t en2_clr;              /* Offset 0x7C: GPIO EN2_CLR Register */
+    __RO uint32_t rsv_0x80_0xa7[10];
+    __RW uint32_t hysen;                /* Offset 0xA8: GPIO HYSEN Register */
+    __RW uint32_t srsel;                /* Offset 0xAC: GPIO SRSEL Register */
+    __RW uint32_t ds0;                  /* Offset 0xB0: GPIO DS0 Register */
+    __RW uint32_t ds1;                  /* Offset 0xB4: GPIO DS1 Register */
+    __RW uint32_t ps;                   /* Offset 0xB8: GPIO PS Register */
+    __RO uint32_t rsv_0xbc;
+    __RW uint32_t vssel;                /* Offset 0xC0: GPIO VSSEL Register */
+} max32690_gpio_regs_t;
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: max32690_get_gpio_bank_regptr
+ *
+ * Description:
+ *   Get the GPIO access struct address based in the GPIO Bank
+ *
+ ****************************************************************************/
+
+max32690_gpio_regs_t *max32690_get_gpio_bank_regptr(int bank);
+
+/****************************************************************************
+ * Name: max32690_gpio_config
+ *
+ * Description:
+ *   Configure a GPIO pin. Config based on bit-encoded descriptions.
+ *
+ ****************************************************************************/
+
+int  max32690_gpio_config(max32690_pinconfig_t pinconf);
+
+/****************************************************************************
+ * Name: max32690_gpio_read
+ *
+ * Description:
+ *   Read one or zero from the selected GPIO pin
+ *
+ ****************************************************************************/
+
+bool max32690_gpio_read(max32690_pinconfig_t pinconf);
+
+/****************************************************************************
+ * Name: max32690_gpio_write
+ *
+ * Description:
+ *   Write one or zero to the selected GPIO pin
+ *
+ ****************************************************************************/
+
+void max32690_gpio_write(max32690_pinconfig_t pinconf, bool value);
+
+/****************************************************************************
+ * Name: max32690_gpio_irqconfig
+ *
+ * Description:
+ *   Enable a GPIO pin interrupt.
+ *
+ ****************************************************************************/
+
+void max32690_gpio_irq_enable(max32690_pinconfig_t pinconf);
+
+/****************************************************************************
+ * Name: max32690_gpio_irqdisable
+ *
+ * Description:
+ *   Disable a GPIO pin interrupt.
+ *
+ ****************************************************************************/
+
+void max32690_gpio_irq_disable(max32690_pinconfig_t pinconf);
+
+#ifdef __cplusplus
+}
+
+#endif
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_ARM_SRC_MAX326XX_MAX32690_MAX32690_GPIO_H */

--- a/arch/arm/src/max326xx/max32690/max32690_gpioirq.c
+++ b/arch/arm/src/max326xx/max32690/max32690_gpioirq.c
@@ -1,0 +1,254 @@
+/****************************************************************************
+ * arch/arm/src/max326xx/max32690/max32690_gpioirq.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
+
+#include "arm_internal.h"
+#include "max326_gpio.h"
+
+extern spinlock_t g_max32690_gpio_lock;
+
+typedef struct
+{
+    uint32_t int_enabled;
+
+    gpio_irq_function_t irq_handler[32];
+}gpio_interrupt_infos;
+
+static gpio_interrupt_infos irq_infos[4];
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: max326_gpio0_interrupt
+ *
+ * Description:
+ *   GPIO0 pin interrupt handler.
+ *
+ ****************************************************************************/
+
+static int max32690_gpio_interrupt(int irq, void *context, void *arg)
+{
+    uint32_t bank = (uint32_t)arg;
+
+    max32690_gpio_regs_t *gpio = max32690_get_gpio_bank_regptr(bank);
+
+      while (gpio->intfl)
+        {
+          uint32_t bit_pos = 31 - __builtin_clz(gpio->intfl); /* highest bit set */
+          uint32_t mask = 1U << bit_pos;                      /* mask for the set bit */
+
+          if (gpio->intfl & mask)
+            {
+              gpio->intfl_clr = mask;
+
+              if (irq_infos[bank].irq_handler[bit_pos] != 0)
+                {
+                   irq_infos[bank].irq_handler[bit_pos](bank, bit_pos);
+                }
+            }
+        }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: max326_gpio_irqconfig
+ *
+ * Description:
+ *   Configure a pin for interrupt operation.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+void max32690_gpio_irq_enable(max32690_pinconfig_t pinconf)
+{
+  uint32_t pinmask;
+  uint32_t intmode;
+  uint32_t intpol;
+  uint32_t intdual;
+
+  max32690_gpio_regs_t *gpio;
+  gpio = max32690_get_gpio_bank_regptr(pinconf.gpio_bank);
+
+  irqstate_t flags = spin_lock_irqsave(&g_max32690_gpio_lock);
+
+  DEBUGASSERT(pinconf.pin <= GPIO_PINMAX);
+  pinmask = 1 << pinconf.pin;
+
+  intmode = 0;
+  intpol  = 0;
+  intdual = 0;
+
+  switch (pinconf.config & GPIO_INT_MASK)
+    {
+      default:
+        DEBUGPANIC();
+        return;
+
+      case GPIO_INTFE:     /* Edge triggered, falling edge */
+        intmode = pinmask; /* Edge triggered */
+        break;
+
+      case GPIO_INTRE:     /* Edge triggered, rising edge */
+        intmode = pinmask; /* Edge triggered */
+        intpol  = pinmask; /* Rising edge */
+        break;
+
+      case GPIO_INTBOTH:   /* Edge triggered, both edges */
+        intmode = pinmask; /* Edge triggered */
+        intdual = pinmask; /* Both edges */
+        break;
+
+      case GPIO_INTLOW:    /* Level triggered, low level */
+        break;
+
+      case GPIO_INTHIGH:   /* Level triggered, high level */
+        intpol  = pinmask; /* High level */
+        break;
+    }
+
+  /* Configure the interrupt modes */
+
+  gpio->intmode &= ~pinmask;
+  gpio->intmode |= intmode;
+
+  gpio->intpol &= ~pinmask;
+  gpio->intpol |= intpol;
+
+  gpio->dualedge &= ~pinmask;
+  gpio->dualedge |= intdual;
+
+  /* enable gpio the interrupt */
+
+  gpio->inten_set |= pinmask;
+
+  int bank = pinconf.gpio_bank;
+  irq_infos[bank].irq_handler[pinconf.pin] = pinconf.irq_handler;
+
+  /* enable the interupt for the gpio bank */
+
+  if (irq_infos[pinconf.gpio_bank].int_enabled == 0)
+  {
+      switch (pinconf.gpio_bank)
+      {
+        case 0:
+            irq_attach(MAX32690_IRQ_GPIO0, max32690_gpio_interrupt,
+                (void *)0);
+            up_enable_irq(MAX32690_IRQ_GPIO0);
+            break;
+        case 1:
+            irq_attach(MAX32690_IRQ_GPIO1, max32690_gpio_interrupt,
+                (void *)1);
+            up_enable_irq(MAX32690_IRQ_GPIO1);
+            break;
+        case 2:
+            irq_attach(MAX32690_IRQ_GPIO2, max32690_gpio_interrupt,
+                (void *)2);
+            up_enable_irq(MAX32690_IRQ_GPIO2);
+            break;
+        case 3:
+            irq_attach(MAX32690_IRQ_GPIO3, max32690_gpio_interrupt,
+                (void *)3);
+            up_enable_irq(MAX32690_IRQ_GPIO3);
+            break;
+        default:
+            DEBUGPANIC();
+            return;
+        }
+    }
+
+    spin_unlock_irqrestore(&g_max32690_gpio_lock, flags);
+}
+
+/****************************************************************************
+ * Name: max326_gpio_irqdisable
+ *
+ * Description:
+ *   Disable a GPIO pin interrupt.
+ *   This function should not be called directly but,
+ *   rather through up_disable_irq();
+ *
+ * Assumptions:
+ *   We are in a critical section.
+ *
+ ****************************************************************************/
+
+void max32690_gpio_irq_disable(max32690_pinconfig_t pinconf)
+{
+      max32690_gpio_regs_t *gpio;
+      uint32_t pinmask = 1 << pinconf.pin;
+
+      gpio = max32690_get_gpio_bank_regptr(pinconf.gpio_bank);
+
+      gpio->inten_clr |= pinmask;
+
+      /* critical section */
+
+      irqstate_t flags = spin_lock_irqsave(&g_max32690_gpio_lock);
+
+      irq_infos[pinconf.gpio_bank].irq_handler[pinconf.pin] = 0;
+
+      if (gpio->inten == 0)
+        {
+          switch (pinconf.gpio_bank)
+          {
+            case 0:
+              irq_detach(MAX32690_IRQ_GPIO0);
+              up_disable_irq(MAX32690_IRQ_GPIO0);
+              break;
+            case 1:
+              irq_detach(MAX32690_IRQ_GPIO1);
+              up_disable_irq(MAX32690_IRQ_GPIO1);
+              break;
+            case 2:
+              irq_detach(MAX32690_IRQ_GPIO2);
+              up_disable_irq(MAX32690_IRQ_GPIO2);
+              break;
+            case 3:
+              irq_detach(MAX32690_IRQ_GPIO3);
+              up_disable_irq(MAX32690_IRQ_GPIO3);
+              break;
+          }
+        }
+
+      spin_unlock_irqrestore(&g_max32690_gpio_lock, flags);
+}
+

--- a/arch/arm/src/max326xx/max326_gpio.h
+++ b/arch/arm/src/max326xx/max326_gpio.h
@@ -34,12 +34,12 @@
 
 #include "hardware/max326_gpio.h"
 
-/* Bit-encoded input to max326_gpio_config() ********************************/
-
 #if defined(CONFIG_ARCH_FAMILY_MAX32620) || defined(CONFIG_ARCH_FAMILY_MAX32630)
 #  include "max32620_30/max32620_30_gpio.h"
 #elif defined(CONFIG_ARCH_FAMILY_MAX32660)
 #  include "max32660/max32660_gpio.h"
+#elif defined(CONFIG_ARCH_FAMILY_MAX32690)
+#  include "max32690/max32690_gpio.h"
 #else
 #  error "Unsupported MAX326XX family"
 #endif
@@ -51,129 +51,5 @@
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-#ifndef __ASSEMBLY__
-#undef EXTERN
-#if defined(__cplusplus)
-#define EXTERN extern "C"
-extern "C"
-{
-#else
-#define EXTERN extern
-#endif
-
-/****************************************************************************
- * Public Functions Prototypes
- ****************************************************************************/
-
-/****************************************************************************
- * Name: max326_gpio_irqinitialize
- *
- * Description:
- *   Initialize logic to support interrupting GPIO pins.  This function is
- *   called by the OS initialization logic and is not a user interface.
- *
- * Assumptions:
- *   Called early in the boot-up sequence
- *
- ****************************************************************************/
-
-#ifdef CONFIG_MAX326XX_GPIOIRQ
-void max326_gpio_irqinitialize(void);
-#endif
-
-/****************************************************************************
- * Name: max326_gpio_config
- *
- * Description:
- *   Configure a GPIO pin based on bit-encoded description of the pin.
- *
- * Assumptions:
- *   - The pin interrupt has been disabled and all interrupt related bits
- *     have been set to zero by max436_gpio_config().
- *   - We are called in a critical section.
- *
- ****************************************************************************/
-
-int max326_gpio_config(max326_pinset_t pinset);
-
-/****************************************************************************
- * Name: max326_gpio_irqconfig
- *
- * Description:
- *   Configure a pin for interrupt operation.  This function should not be
- *   called directory but, rather, indirectly through max326_gpio_config().
- *
- ****************************************************************************/
-
-#ifdef CONFIG_MAX326XX_GPIOIRQ
-void max326_gpio_irqconfig(max326_pinset_t pinset);
-#endif
-
-/****************************************************************************
- * Name: max326_gpio_write
- *
- * Description:
- *   Write one or zero to the selected GPIO pin
- *
- ****************************************************************************/
-
-void max326_gpio_write(max326_pinset_t pinset, bool value);
-
-/****************************************************************************
- * Name: max326_gpio_read
- *
- * Description:
- *   Read one or zero from the selected GPIO pin
- *
- ****************************************************************************/
-
-bool max326_gpio_read(max326_pinset_t pinset);
-
-/****************************************************************************
- * Name: max326_gpio_irqdisable
- *
- * Description:
- *   Disable a GPIO pin interrupt.  This function should not be called
- *   directly but, rather through up_disable_irq();
- *
- ****************************************************************************/
-
-#ifdef CONFIG_MAX326XX_GPIOIRQ
-void max326_gpio_irqdisable(int irq);
-#endif
-
-/****************************************************************************
- * Name: max326_gpio_irqenable
- *
- * Description:
- *   Enable a GPIO pin interrupt.  This function should not be called
- *   directly but, rather through up_enable_irq();
- *
- ****************************************************************************/
-
-#ifdef CONFIG_MAX326XX_GPIOIRQ
-void max326_gpio_irqenable(int irq);
-#endif
-
-/****************************************************************************
- * Function:  max326_gpio_dump
- *
- * Description:
- *   Decode and dump all GPIO registers associated with the port and pin
- *   numbers in the provided pinset.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_DEBUG_GPIO_INFO
-int max326_gpio_dump(max326_pinset_t pinset, const char *msg);
-#else
-#  define max326_gpio_dump(p,m)
-#endif
-
-#ifdef __cplusplus
-}
-#endif
-#endif /* __ASSEMBLY__ */
 
 #endif /* __ARCH_ARM_SRC_MAX326XX_MAX326_GPIO_H */


### PR DESCRIPTION
definitions for the max32660 moved to max32660_gpio.h

the max32690 has much more options for the gpios
so this is a complete new driver

## Summary

adds support for the max32690 gpios

## Impact

should have no impact

## Testing

driver works on my dev board

