### PR TITLE
imx9: scmi: update to scmi 3.2 spec

### DIFF
--- a/arch/arm/src/imx9/imx9_scmi.c
+++ b/arch/arm/src/imx9/imx9_scmi.c
@@ -995,6 +995,7 @@ int32_t imx9_scmi_pinctrlconfigset(uint32_t channel, uint32_t identifier,
       {
         uint32_t header;
         uint32_t identifier;
+        uint32_t function_id;
         uint32_t attributes;
         scmi_pin_config_t configs[SCMI_PINCTRL_MAX_CONFIGS_T];
       } msg_tpinctrld6_t;


### PR DESCRIPTION
## Summary

The SCMI implementation for the iMX95 is updated to match the
SCMI 3.2 specification.

The SCMI implementation was based on an early unreleased version
of the BSP that has a slighty different API. Currently NuttX imx95 target is not compatible
with the latest BSP and results in pin control configurations not being made.

## Impact

Pin control settings sent over SCMI now functions properly with the latest BSP

## Testing

imx95-evk:nsh

enable CONFIG_IMX9_IOMUX_OVER_SCMI



