### PR TITLE
samv7/sam_1wire.c: fix compilation warnings

### DIFF
--- a/arch/arm/src/samv7/sam_1wire.c
+++ b/arch/arm/src/samv7/sam_1wire.c
@@ -51,6 +51,7 @@
 #include "hardware/sam_uart.h"
 #include "sam_gpio.h"
 #include "sam_serial.h"
+#include "sam_periphclks.h"
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION

## Summary
Fixes

```
chip/sam_1wire.c:921:7: warning: implicit declaration of function 'sam_usart0_enableclk' [-Wimplicit-function-declaration]
  921 |       sam_usart0_enableclk();
```

The same warning applied for other uart/usart peripherals configured as 1 wire.

