### PR TITLE
armv7a kernel build bugfix, when shm & arm_addrenv_create_region

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv_shm.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_shm.c
@@ -126,6 +126,10 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
           /* Initialize the page table */
 
           memset(l2table, 0, ENTRIES_PER_L2TABLE * sizeof(uint32_t));
+
+          /* In case first time set shm l1 entry */
+
+          mmu_l1_setentry(paddr, vaddr, MMU_L1_PGTABFLAGS);
         }
       else
         {
@@ -133,7 +137,7 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
            * table entry.
            */
 
-          paddr = (uintptr_t)l1entry & ~SECTION_MASK;
+          paddr = (uintptr_t)l1entry;
           flags = enter_critical_section();
 
           /* Get the virtual address corresponding to the physical page\
@@ -148,7 +152,7 @@ int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
       DEBUGASSERT(get_l2_entry(l2table, vaddr) == 0);
 
       paddr = *pages++;
-      set_l2_entry(l2table, paddr, vaddr, MMU_MEMFLAGS);
+      set_l2_entry(l2table, paddr, vaddr, MMU_L2_UDATAFLAGS);
       nmapped++;
       vaddr += MM_PGSIZE;
 
@@ -224,7 +228,7 @@ int up_shmdt(uintptr_t vaddr, unsigned int npages)
        * table entry.
        */
 
-       paddr = (uintptr_t)l1entry & ~SECTION_MASK;
+       paddr = (uintptr_t)l1entry;
        flags = enter_critical_section();
 
       /* Get the virtual address corresponding to the physical page

--- a/arch/arm/src/armv7-a/arm_addrenv_utils.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_utils.c
@@ -66,6 +66,7 @@ int arm_addrenv_create_region(uintptr_t **list, unsigned int listlen,
   uint32_t *l2table;
   size_t nmapped;
   unsigned int npages;
+  unsigned int nlist;
   unsigned int i;
   unsigned int j;
 
@@ -92,8 +93,9 @@ int arm_addrenv_create_region(uintptr_t **list, unsigned int listlen,
    * the L1 page table).
    */
 
+  nlist = (npages + ENTRIES_PER_L2TABLE - 1) / ENTRIES_PER_L2TABLE;
   nmapped = 0;
-  for (i = 0; i < npages; i += ENTRIES_PER_L2TABLE)
+  for (i = 0; i < nlist; i++)
     {
       /* Allocate one physical page for the L2 page table */
 


### PR DESCRIPTION
## Summary
bugfix when test features in kernel build

## Impact
fix when change CONFIG_ARCH_TEXT_NPAGES to 512 will cause crash in arm_addrenv_create_region with armv7a,
fix shm crash when use fb_demo in goldfish armv7a kernel build

## Testing
ci-test, qemu-armv7a knsh & ostest, goldfish-armv7a fb_demo

