### PR TITLE
nuttx/compiler: fix build warning on GCC14

### DIFF
--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -42,33 +42,13 @@
 #define SP_UNLOCKED 0  /* The Un-locked state */
 #define SP_LOCKED   1  /* The Locked state */
 
-/* Memory barriers for use with NuttX spinlock logic
- *
- * Data Memory Barrier (DMB) acts as a memory barrier. It ensures that all
- * explicit memory accesses that appear in program order before the DMB
- * instruction are observed before any explicit memory accesses that appear
- * in program order after the DMB instruction. It does not affect the
- * ordering of any other instructions executing on the processor
- *
- *   dmb st - Data memory barrier.  Wait for stores to complete.
- *
- * Data Synchronization Barrier (DSB) acts as a special kind of memory
- * barrier. No instruction in program order after this instruction executes
- * until this instruction completes. This instruction completes when: (1) All
- * explicit memory accesses before this instruction complete, and (2) all
- * Cache, Branch predictor and TLB maintenance operations before this
- * instruction complete.
- *
- *   dsb sy - Data syncrhonization barrier.  Assures that the CPU waits until
- *            all memory accesses are complete
- */
-
-#define UP_DSB() __asm__ __volatile__ ("dsb sy" : : : "memory")
-#define UP_DMB() __asm__ __volatile__ ("dmb st" : : : "memory")
-
 #ifdef CONFIG_ARM_HAVE_WFE_SEV
-#define UP_WFE() __asm__ __volatile__ ("wfe" : : : "memory")
-#define UP_SEV() __asm__ __volatile__ ("sev" : : : "memory")
+#  ifndef UP_WFE
+#    define UP_WFE() __asm__ __volatile__ ("wfe" : : : "memory")
+#  endif
+#  ifndef UP_SEV
+#    define UP_SEV() __asm__ __volatile__ ("sev" : : : "memory")
+#  endif
 #endif
 
 /****************************************************************************

--- a/arch/or1k/include/mor1kx/irq.h
+++ b/arch/or1k/include/mor1kx/irq.h
@@ -228,8 +228,7 @@ static inline_function void up_irq_restore(irqstate_t flags)
 
 /* Enable IRQs */
 
-static inline_function void up_irq_enable(void) always_inline_function;
-static inline_function void up_irq_enable(void)
+static always_inline_function void up_irq_enable(void)
 {
   irqstate_t flags;
   mfspr(SPR_SYS_SR, flags);

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -73,8 +73,8 @@ struct xtensa_windowregs_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void inline get_window_regs(struct xtensa_windowregs_s *frame)
-always_inline_function;
+always_inline_function static
+void get_window_regs(struct xtensa_windowregs_s *frame);
 
 /****************************************************************************
  * Private Functions
@@ -89,7 +89,8 @@ always_inline_function;
  ****************************************************************************/
 
 #ifndef __XTENSA_CALL0_ABI__
-static void get_window_regs(struct xtensa_windowregs_s *frame)
+always_inline_function static
+void get_window_regs(struct xtensa_windowregs_s *frame)
 {
   __asm__ __volatile__("\trsr %0, WINDOWSTART\n": "=r"(frame->windowstart));
   __asm__ __volatile__("\trsr %0, WINDOWBASE\n": "=r"(frame->windowbase));

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -251,7 +251,7 @@
  * noinline_function indicates that the function should never be inlined.
  */
 
-#  define always_inline_function __attribute__((always_inline,no_instrument_function))
+#  define always_inline_function __attribute__((always_inline,no_instrument_function)) inline
 #  define inline_function __attribute__((always_inline)) inline
 #  define noinline_function __attribute__((noinline))
 
@@ -1087,7 +1087,7 @@
 #  define end_packed_struct             __attribute__((packed))
 #  define reentrant_function
 #  define naked_function
-#  define always_inline_function        __attribute__((always_inline,no_instrument_function))
+#  define always_inline_function        __attribute__((always_inline,no_instrument_function)) inline
 #  define inline_function               __attribute__((always_inline)) inline
 #  define noinline_function             __attribute__((noinline))
 #  define noinstrument_function


### PR DESCRIPTION
## Summary

arm/memory_barrier: fix build warning on GCC14

```
nuttx/include/arch/spinlock.h:66:9: warning: "UP_DSB" redefined
   66 | #define UP_DSB() __asm__ __volatile__ ("dsb sy" : : : "memory")
      |         ^~~~~~
In file included from nuttx/include/arch/barriers.h:37,
                 from nuttx/include/arch/spinlock.h:34:
nuttx/include/arch/armv8-m/barriers.h:42:9: note: this is the location of the previous definition
   42 | #define UP_DSB()  arm_dsb(15)
      |         ^~~~~~
nuttx/include/arch/spinlock.h:67:9: warning: "UP_DMB" redefined
   67 | #define UP_DMB() __asm__ __volatile__ ("dmb st" : : : "memory")
      |         ^~~~~~
nuttx/include/arch/armv8-m/barriers.h:41:9: note: this is the location of the previous definition
   41 | #define UP_DMB()  arm_dmb()
      |         ^~~~~~
```

nuttx/compiler: fix build warning on GCC14

```
nuttx/include/arch/armv8-m/irq.h:496:36: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  496 | static always_inline_function bool up_interrupt_context(void)
      |                                    ^~~~~~~~~~~~~~~~~~~~
nuttx/include/arch/armv8-m/irq.h:490:41: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  490 | static always_inline_function uintptr_t up_getusrsp(void *regs)
      |                                         ^~~~~~~~~~~
nuttx/include/arch/armv8-m/irq.h:477:40: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  477 | static always_inline_function uint32_t up_getsp(void)
      |                                        ^~~~~~~~
nuttx/include/arch/armv8-m/irq.h:451:40: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  451 | static always_inline_function uint32_t getpsp(void)
      |                                        ^~~~~~
nuttx/include/arch/armv8-m/irq.h:441:36: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  441 | static always_inline_function void setcontrol(uint32_t control)
      |                                    ^~~~~~~~~~
nuttx/include/arch/armv8-m/irq.h:428:40: warning: 'always_inline' function might not be inlinable unless also declared 'inline' [-Wattributes]
  428 | static always_inline_function uint32_t getcontrol(void)
      |                                        ^~~~~~~~~~
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check