### PR TITLE
samv7/pwm: add support for latched fault inputs

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -857,6 +857,15 @@ config SAMV7_PWM0_PA9_POL
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
 
+config SAMV7_PWM0_PA9_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
 endif
 
 config SAMV7_PWM0_PD8
@@ -871,6 +880,15 @@ config SAMV7_PWM0_PD8_POL
 	---help---
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
+
+config SAMV7_PWM0_PD8_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
 
 endif
 
@@ -887,27 +905,101 @@ config SAMV7_PWM0_PD9_POL
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
 
+config SAMV7_PWM0_PD9_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
 endif
 
 config SAMV7_PWM0_PMC
 	bool "External fault input from PMC"
 	default n
 
+if SAMV7_PWM0_PMC
+
+config SAMV7_PWM0_PMC_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
 config SAMV7_PWM0_AFEC0
 	bool "External fault input from AFEC0"
 	default n
+
+if SAMV7_PWM0_AFEC0
+
+config SAMV7_PWM0_AFEC0_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
 
 config SAMV7_PWM0_AFEC1
 	bool "External fault input from AFEC1"
 	default n
 
+if SAMV7_PWM0_AFEC1
+
+config SAMV7_PWM0_AFEC1_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
 config SAMV7_PWM0_ACC
 	bool "External fault input from ACC"
 	default n
 
+if SAMV7_PWM0_ACC
+
+config SAMV7_PWM0_ACC_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
 config SAMV7_PWM0_TIM0
 	bool "External fault input from Timer 0"
 	default n
+
+if SAMV7_PWM0_TIM0
+
+config SAMV7_PWM0_TIM0_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
 
 endmenu
 
@@ -1118,6 +1210,15 @@ config SAMV7_PWM1_PA21_POL
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
 
+config SAMV7_PWM1_PA21_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
 endif
 
 config SAMV7_PWM1_PA26
@@ -1132,6 +1233,15 @@ config SAMV7_PWM1_PA26_POL
 	---help---
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
+
+config SAMV7_PWM1_PA26_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
 
 endif
 
@@ -1148,30 +1258,103 @@ config SAMV7_PWM1_PA28_POL
 		Fault input is by default active on high level. This config
 		inverts the logic and makes fault active on low level.
 
+config SAMV7_PWM1_PA28_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
 endif
 
 config SAMV7_PWM1_PMC
 	bool "External fault input from PMC"
 	default n
 
+if SAMV7_PWM1_PMC
+
+config SAMV7_PWM1_PMC_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
 config SAMV7_PWM1_AFEC0
 	bool "External fault input from AFEC0"
 	default n
+
+if SAMV7_PWM1_AFEC0
+
+config SAMV7_PWM1_AFEC0_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
 
 config SAMV7_PWM1_AFEC1
 	bool "External fault input from AFEC1"
 	default n
 
+if SAMV7_PWM1_AFEC1
+
+config SAMV7_PWM1_AFEC1_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
 config SAMV7_PWM1_ACC
 	bool "External fault input from ACC"
 	default n
+
+if SAMV7_PWM1_ACC
+
+config SAMV7_PWM1_ACC_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
 
 config SAMV7_PWM1_TIM0
 	bool "External fault input from Timer 0"
 	default n
 
-endmenu
+if SAMV7_PWM1_TIM0
 
+config SAMV7_PWM1_TIM0_LATCHED
+	bool "Latched fault"
+	default n
+	---help---
+		When this option is selected, the fault input remains active until it
+		is cleared by the software. When this option is not selected, the
+		fault is cleared once the fault input changes its polarity level back
+		to normal state.
+
+endif
+
+endmenu
 
 config SAMV7_PWM1_EVENT0
 	bool "Generate trigger on Event Line 0"

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -100,6 +100,7 @@ struct sam_pwm_fault_s
 {
   uint8_t source;                 /* Source of fault input */
   uint8_t polarity;
+  uint8_t latched;                /* Latched fault inputs */
   gpio_pinset_t gpio_0;           /* GPIO 1 fault input */
   gpio_pinset_t gpio_1;           /* GPIO 2 fault input */
   gpio_pinset_t gpio_2;           /* GPIO 3 fault input */
@@ -234,6 +235,7 @@ static struct sam_pwm_fault_s g_pwm0_fault =
 {
   .source = PWM0_FAULTS,
   .polarity = PWM0_POL,
+  .latched = PWM0_LATCH,
   .gpio_0 = GPIO_PWMC0_FI0,
   .gpio_1 = GPIO_PWMC0_FI1,
   .gpio_2 = GPIO_PWMC0_FI2,
@@ -378,6 +380,7 @@ static struct sam_pwm_fault_s g_pwm1_fault =
 {
   .source = PWM1_FAULTS,
   .polarity = PWM1_POL,
+  .latched = PWM1_LATCH,
   .gpio_0 = GPIO_PWMC1_FI0,
   .gpio_1 = GPIO_PWMC1_FI1,
   .gpio_2 = GPIO_PWMC1_FI2,
@@ -889,7 +892,8 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
    * is set via configuration options.
    */
 
-  regval = FMR_FPOL_SEL(priv->fault->polarity);
+  regval = FMR_FPOL_SEL(priv->fault->polarity) |
+           FMR_FMOD_SEL(priv->fault->latched);
   pwm_putreg(priv, SAMV7_PWM_FMR, regval);
 
   /* Force both outputs to 0 if fault occurs */

--- a/arch/arm/src/samv7/sam_pwm.h
+++ b/arch/arm/src/samv7/sam_pwm.h
@@ -99,9 +99,15 @@
 #else
 #define PWM0_PA9_POL 1
 #endif
+#ifdef CONFIG_SAMV7_PWM0_PA9_LATCHED
+#define PWM0_PA9_LATCH 1
+#else
+#define PWM0_PA9_LATCH 0
+#endif
 #else
 #define PWM0_PA9 0
 #define PWM0_PA9_POL 0
+#define PWM0_PA9_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_PD8
@@ -111,9 +117,15 @@
 #else
 #define PWM0_PD8_POL (1 << 1)
 #endif
+#ifdef CONFIG_SAMV7_PWM0_PD8_LATCHED
+#define PWM0_PD8_LATCH (1 << 1)
+#else
+#define PWM0_PD8_LATCH 0
+#endif
 #else
 #define PWM0_PD8 0
 #define PWM0_PD8_POL 0
+#define PWM0_PD8_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_PD9
@@ -123,39 +135,75 @@
 #else
 #define PWM0_PD9_POL (1 << 2)
 #endif
+#ifdef CONFIG_SAMV7_PWM0_PD9_LATCHED
+#define PWM0_PD9_LATCH (1 << 2)
+#else
+#define PWM0_PD9_LATCH 0
+#endif
 #else
 #define PWM0_PD9 0
 #define PWM0_PD9_POL 0
+#define PWM0_PD9_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_PMC
 #define PWM0_PMC (1 << 3)
+#ifdef CONFIG_SAMV7_PWM0_PMC_LATCHED
+#define PWM0_PMC_LATCH (1 << 3)
+#else
+#define PWM0_PMC_LATCH 0
+#endif
 #else
 #define PWM0_PMC 0
+#define PWM0_PMC_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_AFEC0
 #define PWM0_AFEC0 (1 << 4)
+#ifdef CONFIG_SAMV7_PWM0_AFEC0_LATCHED
+#define PWM0_AFEC0_LATCH (1 << 4)
+#else
+#define PWM0_AFEC0_LATCH 0
+#endif
 #else
 #define PWM0_AFEC0 0
+#define PWM0_AFEC0_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_AFEC1
 #define PWM0_AFEC1 (1 << 5)
+#ifdef CONFIG_SAMV7_PWM0_AFEC1_LATCHED
+#define PWM0_AFEC1_LATCH (1 << 5)
+#else
+#define PWM0_AFEC1_LATCH 0
+#endif
 #else
 #define PWM0_AFEC1 0
+#define PWM0_AFEC1_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_ACC
 #define PWM0_ACC (1 << 6)
+#ifdef CONFIG_SAMV7_PWM0_ACC_LATCHED
+#define PWM0_ACC_LATCH (1 << 6)
+#else
+#define PWM0_ACC_LATCH 0
+#endif
 #else
 #define PWM0_ACC 0
+#define PWM0_ACC_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM0_TIM0
 #define PWM0_TIM0 (1 << 7)
+#ifdef CONFIG_SAMV7_PWM0_TIM0_LATCHED
+#define PWM0_TIM0_LATCH (1 << 7)
+#else
+#define PWM0_TIM0_LATCH 0
+#endif
 #else
 #define PWM0_TIM0 0
+#define PWM0_TIM0_LATCH 0
 #endif
 
 #define PWM0_FAULTS (PWM0_PA9 + PWM0_PD8 + PWM0_PD9 + PWM0_PMC + \
@@ -165,6 +213,10 @@
                      PWM0_PMC + PWM0_AFEC0 + PWM0_AFEC1 + PWM0_ACC + \
                      PWM0_TIM0)
 
+#define PWM0_LATCH  (PWM0_PA9_LATCH + PWM0_PD8_LATCH + PWM0_PD9_LATCH + \
+                     PWM0_PMC_LATCH + PWM0_AFEC0_LATCH + PWM0_AFEC1_LATCH + \
+                     PWM0_ACC_LATCH + PWM0_TIM0_LATCH)
+
 #ifdef CONFIG_SAMV7_PWM1_PA21
 #define PWM1_PA21 1
 #ifdef CONFIG_SAMV7_PWM1_PA21_POL
@@ -172,9 +224,15 @@
 #else
 #define PWM1_PA21_POL 1
 #endif
+#ifdef CONFIG_SAMV7_PWM1_PA21_LATCHED
+#define PWM1_PA21_LATCH 1
+#else
+#define PWM1_PA21_LATCH 0
+#endif
 #else
 #define PWM1_PA21 0
 #define PWM1_PA21_POL 0
+#define PWM1_PA21_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_PA26
@@ -184,9 +242,15 @@
 #else
 #define PWM1_PA26_POL (1 << 1)
 #endif
+#ifdef CONFIG_SAMV7_PWM1_PA26_LATCHED
+#define PWM1_PA26_LATCH (1 << 1)
+#else
+#define PWM1_PA26_LATCH 0
+#endif
 #else
 #define PWM1_PA26 0
 #define PWM1_PA26_POL 0
+#define PWM1_PA26_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_PA28
@@ -196,39 +260,75 @@
 #else
 #define PWM1_PA28_POL (1 << 2)
 #endif
+#ifdef CONFIG_SAMV7_PWM1_PA28_LATCHED
+#define PWM1_PA28_LATCH (1 << 2)
+#else
+#define PWM1_PA28_LATCH 0
+#endif
 #else
 #define PWM1_PA28 0
 #define PWM1_PA28_POL 0
+#define PWM1_PA28_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_PMC
 #define PWM1_PMC (1 << 3)
+#ifdef CONFIG_SAMV7_PWM1_PMC_LATCHED
+#define PWM1_PMC_LATCH (1 << 3)
+#else
+#define PWM1_PMC_LATCH 0
+#endif
 #else
 #define PWM1_PMC 0
+#define PWM1_PMC_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_AFEC0
 #define PWM1_AFEC0 (1 << 4)
+#ifdef CONFIG_SAMV7_PWM1_AFEC0_LATCHED
+#define PWM1_AFEC0_LATCH (1 << 4)
+#else
+#define PWM1_AFEC0_LATCH 0
+#endif
 #else
 #define PWM1_AFEC0 0
+#define PWM1_AFEC0_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_AFEC1
 #define PWM1_AFEC1 (1 << 5)
+#ifdef CONFIG_SAMV7_PWM1_AFEC1_LATCHED
+#define PWM1_AFEC1_LATCH (1 << 5)
+#else
+#define PWM1_AFEC1_LATCH 0
+#endif
 #else
 #define PWM1_AFEC1 0
+#define PWM1_AFEC1_LATCH 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_ACC
 #define PWM1_ACC (1 << 6)
+#ifdef CONFIG_SAMV7_PWM1_ACC_LATCHED
+#define PWM1_ACC_LATCH (1 << 6)
 #else
+#define PWM1_ACC_LATCH 0
+#endif
+#else
+#define PWM1_ACC_LATCH 0
 #define PWM1_ACC 0
 #endif
 
 #ifdef CONFIG_SAMV7_PWM1_TIM0
 #define PWM1_TIM0 (1 << 7)
+#ifdef CONFIG_SAMV7_PWM1_TIM0_LATCHED
+#define PWM1_TIM0_LATCH (1 << 7)
+#else
+#define PWM1_TIM0_LATCH 0
+#endif
 #else
 #define PWM1_TIM0 0
+#define PWM1_TIM0_LATCH 0
 #endif
 
 #define PWM1_FAULTS (PWM1_PA21 + PWM1_PA26 + PWM1_PA28 + PWM1_PMC + \
@@ -237,6 +337,10 @@
 #define PWM1_POL    (PWM1_PA21_POL + PWM1_PA26_POL + PWM1_PA28_POL + \
                      PWM1_PMC + PWM1_AFEC0 + PWM1_AFEC1 + PWM1_ACC + \
                      PWM1_TIM0)
+
+#define PWM1_LATCH  (PWM1_PA21_LATCH + PWM1_PA26_LATCH + PWM1_PA28_LATCH + \
+                     PWM1_PMC_LATCH + PWM1_AFEC0_LATCH + PWM1_AFEC1_LATCH + \
+                     PWM1_ACC_LATCH + PWM1_TIM0_LATCH)
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary
This adds configuration option for every fault input, that can be latched (kept even after the input value is below the threshold) or volatile (PWM is automatically enabled once the output polarity goes back to the normal state).

## Impact
Fault inputs on SAMv7 PWM can now be configured as non volatile.
