### PR TITLE
feat(arch/xensa): add CONFIG_SPIRAM_MEMTEST from ESP-IDF

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -2091,6 +2091,15 @@ config ESP32_SPIRAM_IGNORE_NOTFOUND
 		panic. If this is enabled, booting will complete but no PSRAM
 		will be available.
 
+config ESP32_SPIRAM_MEMTEST
+	bool "Run write-read test on SPIRAM during startup"
+	default y
+	depends on ESP32_SPIRAM_BOOT_INIT
+	---help---
+		If enabled, SPI RAM will be tested during initial boot.
+		Disabling this test will reduce startup time at the expense
+		of testing the external memory.
+
 config ESP32_SPIRAM_2T_MODE
 	bool "Enable SPI PSRAM 2T mode"
 	depends on ESP32_SPIRAM

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -257,11 +257,13 @@ static noreturn_function void __esp32_start(void)
   else
     {
       esp_spiram_init_cache();
+#  if defined(CONFIG_ESP32_SPIRAM_MEMTEST)
       if (esp_spiram_test() != OK)
         {
           ets_printf("SPIRAM test failed\n");
           PANIC();
         }
+#  endif // CONFIG_ESP32_SPIRAM_MEMTEST
     }
 
   /* Set external memory bss section to zero */

--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -943,6 +943,15 @@ config ESP32S2_SPIRAM_IGNORE_NOTFOUND
 		panic. If this is enabled, booting will complete but no PSRAM
 		will be available.
 
+config ESP32S2_SPIRAM_MEMTEST
+	bool "Run write-read test on SPIRAM during startup"
+	default y
+	depends on ESP32S2_SPIRAM_BOOT_INIT
+	---help---
+		If enabled, SPI RAM will be tested during initial boot.
+		Disabling this test will reduce startup time at the expense
+		of testing the external memory.
+
 endmenu # SPI RAM Configuration
 
 menu "RTC Configuration"

--- a/arch/xtensa/src/esp32s2/esp32s2_start.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_start.c
@@ -404,7 +404,13 @@ static void noreturn_function IRAM_ATTR __esp32s2_start(void)
   else
     {
       esp_spiram_init_cache();
-      esp_spiram_test();
+#  if defined(CONFIG_ESP32S2_SPIRAM_MEMTEST)
+      if (esp_spiram_test() != OK)
+        {
+            ets_printf("SPIRAM test failed\n");
+            PANIC();
+        }
+#  endif // CONFIG_ESP32S2_SPIRAM_MEMTEST
     }
 #endif
 

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -962,6 +962,15 @@ config ESP32S3_SPIRAM_IGNORE_NOTFOUND
 		panic. If this is enabled, booting will complete but no PSRAM
 		will be available.
 
+config ESP32S3_SPIRAM_MEMTEST
+	bool "Write-Read test on SPIRAM during startup"
+	default y
+	depends on ESP32S3_SPIRAM_BOOT_INIT
+	---help---
+		If enabled, SPI RAM will be tested during initial boot.
+		Disabling this test will reduce startup time at the expense
+		of testing the external memory.
+
 endmenu # SPI RAM Configuration
 
 menu "Memory Configuration"

--- a/arch/xtensa/src/esp32s3/esp32s3_start.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_start.c
@@ -407,11 +407,13 @@ noinstrument_function void noreturn_function IRAM_ATTR __esp32s3_start(void)
           PANIC();
         }
 
+#  if defined(CONFIG_ESP32S3_SPIRAM_MEMTEST)
       if (esp_spiram_test() != OK)
         {
           ets_printf("SPIRAM test failed\n");
           PANIC();
         }
+#  endif  // CONFIG_ESP32S3_SPIRAM_MEMTEST
     }
 #endif
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

A trivial change. Considering the CONFIG item is from [the ESP-IDF performance tuning guide,](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/performance/speed.html#improving-startup-time), it would be beneficial to include it in Nuttx as well. Begin by adding it to 'arch/xtensa', which currently lacks it.

## Impact
- One more option for startup performance tuning.

## Testing
- build against
  - esp32-devkitc:psram
  - _Skipped ESP32S2 since no existing board configure has SPIRAM enabled._
  - esp32s3-devkit:psram_quad


