### PR TITLE
samv7/pwm: fix incorrect write of CMRx register

### DIFF
--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -762,7 +762,7 @@ static void pwm_set_polarity(struct pwm_lowerhalf_s *dev, uint8_t channel,
                              uint8_t cpol, uint8_t dcpol)
 {
   struct sam_pwm_s *priv = (struct sam_pwm_s *)dev;
-  uint16_t regval;
+  uint32_t regval;
 
   /* Can't change polarity, if the channel is enabled! */
 
@@ -841,10 +841,10 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
       channel = priv->channels[i].channel;
 
 #ifdef CONFIG_PWM_DEADTIME
-      regval |= CMR_DTE;
+      pwm_putreg(priv, SAMV7_PWM_CMRX + (channel * CHANNEL_OFFSET), CMR_DTE);
+#else
+      pwm_putreg(priv, SAMV7_PWM_CMRX + (channel * CHANNEL_OFFSET), 0);
 #endif
-
-      pwm_putreg(priv, SAMV7_PWM_CMRX + (channel * CHANNEL_OFFSET), regval);
 
       /* Reset duty cycle register */
 


### PR DESCRIPTION
## Summary
DTE (dead time enable) is the 17th bit in CMRx (channel mode) register. Function `pwm_set_polarity` did however read and write this register as 16 bit large, therefore dead time generation was always disabled. This fixes the issue, `pwm_set_polarity` now reads the register as 32 large.

Also set the initial value of CMRx correctly in `pwm_setup`.

## Impact
SAMv7 PWM driver now has correctly enabled dead time generation. No impact on configuration/setup.

## Testing
Dead time was not generated at all before this fix. Now the generated pulse with dead time looks correct at the oscilloscope.


