### PR TITLE
drivers/sensors/lsm6dso32: fixed byte read command to include start condition

### DIFF
--- a/drivers/sensors/lsm6dso32_uorb.c
+++ b/drivers/sensors/lsm6dso32_uorb.c
@@ -386,7 +386,7 @@ static int lsm6dso32_read_bytes(FAR struct lsm6dso32_dev_s *priv,
 
   cmd[1].frequency = CONFIG_SENSORS_LSM6DSO32_I2C_FREQUENCY;
   cmd[1].addr = priv->addr;
-  cmd[1].flags = I2C_M_NOSTART | I2C_M_READ;
+  cmd[1].flags = I2C_M_READ;
   cmd[1].buffer = buf;
   cmd[1].length = nbytes;
 


### PR DESCRIPTION
## Summary

This issue was noticed while testing the LSM6DSO32 driver on the STM32H743 MCU, as part of issue #15826.

This is required to meet the communication requirements as per the LSM6DSO32 datasheet. It doesn't cause issues on some MCUs (RP2040), but prevents successful reads on others (STM32).

## Impact

Now this driver works correctly on all MCUs and follows the communication spec from the sensor datasheet.

## Testing

Here is an example output of the issue observed on the STM32H743. The added logging statements show that the buffers for x,y,z acceleration and temperature had the same contents before and after the I2C read operation.

```console
lsm6dso32_read_accel: x buffer: 0xFFFFF064
lsm6dso32_read_accel: y buffer: 0x2400
lsm6dso32_read_accel: z buffer: 0x0000
lsm6dso32_read_accel: Temp buffer: 0x0801
lsm6dso32_read_accel: Read raw x: 0xFFFFFF7B
lsm6dso32_read_accel: Read raw y: 0x01A3
lsm6dso32_read_accel: Read raw z: 0x0FD1
lsm6dso32_read_accel: Raw temp: 0x00CE
sensor_accel(now:165310000):timestamp:165310000,x:-0.159124,y:0.501299,z:4.844294,temperature:25.000000
```

After removing the `I2C_M_NOSTART` flag from the read operation, the buffers are actually written to and contain the correct data from the LSM6DSO32. The output is now realistic with close to 9.81m/s^2 in the Z axis:

```console
sensor_accel(now:50660000):timestamp:50660000,x:-0.320640,y:0.994223,z:9.633553,temperature:26.000000
lsm6dso32_read_accel: x buffer: 0xFFFFF064
lsm6dso32_read_accel: y buffer: 0x2400
lsm6dso32_read_accel: z buffer: 0x0000
lsm6dso32_read_accel: Temp buffer: 0x0801
lsm6dso32_read_accel: Read raw x: 0xFFFFFEDC
lsm6dso32_read_accel: Read raw y: 0x0354
lsm6dso32_read_accel: Read raw z: 0x1F75
lsm6dso32_read_accel: Raw temp: 0x0136
sensor_accel(now:50750000):timestamp:50750000,x:-0.349354,y:1.019348,z:9.634749,temperature:26.000000
```

I also re-confirmed that this change didn't break any existing functionality on the RP2040 MCU where it was working before, and have confirmed that the output is still correct:

```console
nsh> uorb_listener -r 10 -n 10 sensor_accel0

Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:12090000):timestamp:12090000,x:-0.204587,y:-0.174677,z:9.348805,temperature:23.000000
sensor_accel(now:12170000):timestamp:12170000,x:-0.186641,y:-0.169891,z:9.960175,temperature:23.000000
sensor_accel(now:12330000):timestamp:12330000,x:-0.189034,y:-0.173481,z:9.973335,temperature:23.000000
sensor_accel(now:12400000):timestamp:12400000,x:-0.203391,y:-0.191427,z:9.976925,temperature:23.000000
sensor_accel(now:12480000):timestamp:12480000,x:-0.202195,y:-0.186641,z:9.968550,temperature:23.000000
sensor_accel(now:12560000):timestamp:12560000,x:-0.196212,y:-0.198605,z:9.978121,temperature:23.000000
sensor_accel(now:12720000):timestamp:12720000,x:-0.191427,y:-0.185445,z:9.976925,temperature:23.000000
sensor_accel(now:12790000):timestamp:12790000,x:-0.210569,y:-0.212962,z:9.987692,temperature:23.000000
sensor_accel(now:12870000):timestamp:12870000,x:-0.197409,y:-0.174677,z:9.975728,temperature:23.000000
sensor_accel(now:12950000):timestamp:12950000,x:-0.202195,y:-0.193820,z:9.984103,temperature:23.000000
Object name:sensor_accel0, recieved:10
Total number of received Message:10/10
```