### PR TITLE
board/arm/rp2040: support config st7789 reset gpio pin

### DIFF
--- a/boards/arm/rp2040/common/Kconfig
+++ b/boards/arm/rp2040/common/Kconfig
@@ -552,6 +552,12 @@ config RP2040_LCD_SPI_CH
 	range 0 1
 	---help---
 		Select SPI channel number to use LCD display.
+config LCD_ST7789_RST_GPIO
+	int "ST7789 LCD Reset gpio number"
+	default 12
+	range 0 21
+	---help---
+		Select Sitronix ST7789 TFT Controller Reset gpio.
 
 endif # LCD
 

--- a/boards/arm/rp2040/common/src/rp2040_st7789.c
+++ b/boards/arm/rp2040/common/src/rp2040_st7789.c
@@ -48,7 +48,7 @@
 
 #if LCD_SPI_PORTNO
 #define LCD_DC         CONFIG_RP2040_SPI1_RX_GPIO
-#define LCD_RST        12
+#define LCD_RST        CONFIG_LCD_ST7789_RST_GPIO
 #define LCD_BL         13
 #else
 #define LCD_DC         CONFIG_RP2040_SPI0_RX_GPIO
@@ -96,6 +96,7 @@ int board_lcd_initialize(void)
 
   rp2040_gpio_init(LCD_RST);
   rp2040_gpio_setdir(LCD_RST, true);
+  rp2040_gpio_put(LCD_RST, false);
   rp2040_gpio_put(LCD_RST, true);
 
   /* Set full brightness */


### PR DESCRIPTION

## Summary

support config st7789 reset gpio pin

## Impact

the LCD_RST gpio in number is define to gpio 12 in rp2040_st7789.c，add a Kconfig to support config the gpio pin number.

## Testing
I have tested the funtion on a Pico-ResTouch-LCD-2.8 https://www.waveshare.com/wiki/Pico-ResTouch-LCD-2.8.


