### PR TITLE
libc/libcxx: fix failures with GCC 14

### DIFF
--- a/libs/libxx/libcxx/0001-libc-Fix-failures-with-GCC-14-92663.patch
+++ b/libs/libxx/libcxx/0001-libc-Fix-failures-with-GCC-14-92663.patch
@@ -1,0 +1,35 @@
+From cb7a03b41fff563c0cbb5145eed09f9b17edf9e2 Mon Sep 17 00:00:00 2001
+From: Nikolas Klauser <nikolasklauser@berlin.de>
+Date: Sat, 1 Jun 2024 12:20:41 +0200
+Subject: [PATCH]  [libc++] Fix failures with GCC 14 (#92663)
+
+Fixes #91831
+
+Signed-off-by: chao an <anchao.archer@bytedance.com>
+
+---
+ libcxx/include/__type_traits/remove_pointer.h                | 5 +++++
+ 11 files changed, 22 insertions(+), 8 deletions(-)
+
+diff --git libcxx/include/__type_traits/remove_pointer.h b/libcxx/include/__type_traits/remove_pointer.h
+index 54390a1939f7..1048f67055a2 100644
+--- libcxx/include/__type_traits/remove_pointer.h
++++ libcxx/include/__type_traits/remove_pointer.h
+@@ -23,8 +23,13 @@ struct remove_pointer {
+   using type _LIBCPP_NODEBUG = __remove_pointer(_Tp);
+ };
+
++#  ifdef _LIBCPP_COMPILER_GCC
++template <class _Tp>
++using __remove_pointer_t = typename remove_pointer<_Tp>::type;
++#  else
+ template <class _Tp>
+ using __remove_pointer_t = __remove_pointer(_Tp);
++#  endif
+ #else
+ // clang-format off
+ template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer                      {typedef _LIBCPP_NODEBUG _Tp type;};
+
+--
+2.43.0
+

--- a/libs/libxx/libcxx/CMakeLists.txt
+++ b/libs/libxx/libcxx/CMakeLists.txt
@@ -52,7 +52,9 @@ if(CONFIG_LIBCXX)
         -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
         ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-fix-ld-errors.patch && patch -p1
         -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
-        ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-build-error-about-__GLIBC__.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-build-error-about-__GLIBC__.patch &&
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-libc-Fix-failures-with-GCC-14-92663.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/libs/libxx/libcxx/Make.defs
+++ b/libs/libxx/libcxx/Make.defs
@@ -36,6 +36,7 @@ libcxx/libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(Q) patch -p0 < libcxx/0001-libcxx-remove-mach-time-h.patch -d libcxx
 	$(Q) patch -p0 < libcxx/0001-libcxx-fix-ld-errors.patch -d libcxx
 	$(Q) patch -p0 < libcxx/0001-Fix-build-error-about-__GLIBC__.patch -d libcxx
+	$(Q) patch -p0 < libcxx/0001-libc-Fix-failures-with-GCC-14-92663.patch -d libcxx
 
 endif
 


### PR DESCRIPTION
## Summary

libc/libcxx: fix failures with GCC 14

```
CXX:  libcxx/libcxx/src/random.cpp In file included from nuttx/include/libcxx/__filesystem/filesystem_error.h:15,
                 from nuttx/include/libcxx/__filesystem/directory_entry.h:20,
                 from nuttx/include/libcxx/filesystem:539,
                 from nuttx/include/libcxx/fstream:192,
                 from libcxx/libcxx/src/ios.instantiations.cpp:10:
nuttx/include/libcxx/__filesystem/path.h: In instantiation of 'std::__1::__fs::filesystem::path::_EnableIfPathable<_Source> std::__1::__fs::filesystem::path::append(const _Source&) [with _Source = std::__1::basic_string<char>]':
nuttx/include/libcxx/__filesystem/path.h:623:30: error: use of built-in trait '__remove_pointer(typename std::__1::decay<_Tp>::type)' in function signature; use library traits instead
  623 |   _EnableIfPathable<_Source> append(const _Source& __src) {
      |                              ^~~~~~
```

Pick the change from llvm-project:

https://github.com/llvm/llvm-project/pull/92663

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

libcxx with GCC-14