### PR TITLE
libs/libnx: do not generate resource if CONFIG_NX is not enabled

### DIFF
--- a/libs/libnx/Makefile
+++ b/libs/libnx/Makefile
@@ -46,6 +46,8 @@ all: $(BIN)
 .PHONY : context depend clean distclean gensources gen1bppsources gen2bppsource \
 	 gen4bppsource gen8bppsource gen16bppsource gen24bppsource gen32bppsources genfontsources
 
+ifeq ($(CONFIG_NXFONTS),y)
+
 gen1bppsources:
 	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
 
@@ -200,6 +202,9 @@ ifeq ($(CONFIG_NXFONT_TOM_THUMB_4X6),y)
 endif
 
 gensources: gen1bppsources gen2bppsource gen4bppsource gen8bppsource gen16bppsource gen24bppsource gen32bppsources genfontsources
+else
+gensources:
+endif
 
 $(AOBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)


### PR DESCRIPTION
## Summary

libs/libnx: do not generate resource if CONFIG_NX is not enabled

To avoid generate resource if CONFIG_NX is disabled:
```
| $ make -j12
| Create version.h
| CPP:  nxfonts_convert.c-> nxfonts_convert_8bpp.i
| CPP:  nxfonts_convert.c-> nxfonts_convert_24bpp.i
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

./tools/configure.sh sim/libcxxtest
