### PR TITLE
Add a selection for SPI after selecting RPMSG_PORT_SPI

### DIFF
--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -41,6 +41,7 @@ config RPMSG_PORT_SPI
 	bool "Rpmsg SPI Port Driver Support"
 	default n
 	select RPMSG_PORT
+	select SPI
 	---help---
 		Rpmsg SPI Port driver used for cross chip communication.
 


### PR DESCRIPTION

## Summary

If you do not configure SPI after configuring RPMSG_PORT_SPI, the following warning will be generated during compilation:

[109/1450] Building C object drivers/CMakeFiles/drivers.dir/rpmsg/rpmsg_port_spi.c.o /data/code/nuttxspace/nuttx/drivers/rpmsg/rpmsg_port_spi.c: In function ‘rpmsg_port_spi_exchange’: /data/code/nuttxspace/nuttx/drivers/rpmsg/rpmsg_port_spi.c:233:3: warning: implicit declaration of function ‘SPI_EXCHANGE’ [-Wimplicit-function-declaration]
  233 |   SPI_EXCHANGE(rpspi->spi, txhdr, rpspi->rxhdr,
      |   ^~~~~~~~~~~~
[1450/1450] Pac SIM with dynamic libs in nuttx.tgz

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

Fix compilation warning issues

## Testing

N/A


