### PR TITLE
arch: cxd56xx: Fix i2c bus freeze at i2c initialization

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_i2c.c
+++ b/arch/arm/src/cxd56xx/cxd56_i2c.c
@@ -723,6 +723,10 @@ static int cxd56_i2c_reset(struct i2c_master_s *dev)
 
   nxmutex_lock(&priv->lock);
 
+  /* Disable clock gating (clock enable) */
+
+  cxd56_i2c_clock_gate_disable(priv->port);
+
   /* Use GPIO configuration to un-wedge the bus */
 
   cxd56_i2c_pincontrol(priv->port, false);
@@ -794,6 +798,11 @@ static int cxd56_i2c_reset(struct i2c_master_s *dev)
       up_udelay(10);
     }
 
+  /* Disable input of SCL and SDA pins */
+
+  cxd56_gpio_config(scl_gpio, false);
+  cxd56_gpio_config(sda_gpio, false);
+
   /* Generate a start followed by a stop to reset slave
    * state machines.
    */
@@ -819,6 +828,10 @@ out:
   /* Revert the GPIO configuration. */
 
   cxd56_i2c_pincontrol(priv->port, true);
+
+  /* Enable clock gating (clock disable) */
+
+  cxd56_i2c_clock_gate_enable(priv->port);
 
   /* Release the port for re-use by other clients */
 

--- a/arch/arm/src/cxd56xx/cxd56_i2c.c
+++ b/arch/arm/src/cxd56xx/cxd56_i2c.c
@@ -1140,10 +1140,6 @@ struct i2c_master_s *cxd56_i2cbus_initialize(int port)
 
   cxd56_i2c_setfrequency(priv, I2C_DEFAULT_FREQUENCY);
 
-  /* Configure pin */
-
-  cxd56_i2c_pincontrol(port, true);
-
   /* Attach Interrupt Handler */
 
   irq_attach(priv->irqid, cxd56_i2c_interrupt, priv);
@@ -1163,6 +1159,10 @@ struct i2c_master_s *cxd56_i2cbus_initialize(int port)
   /* Enable clock gating (clock disable) */
 
   cxd56_i2c_clock_gate_enable(port);
+
+  /* Configure pin */
+
+  cxd56_i2c_pincontrol(port, true);
 
   nxmutex_unlock(&priv->lock);
   return &priv->dev;


### PR DESCRIPTION
## Summary
During I2C communication between non-Spresense devices is performed,
the I2C bus may freeze after initialization of the Spresense I2C.

As a workaround, 
* switch the pin mode to I2C at the end of the i2c initialization function.
* add clock gating process and disable GPIO input to the I2C reset function.

## Impact
Only for spresense board

## Testing

