### PR TITLE
drivers/rpmsg/Kconfig: Add SPI dependency for RPMSG_PORT_SPI

### DIFF
--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -40,6 +40,7 @@ config RPMSG_PORT
 config RPMSG_PORT_SPI
 	bool "Rpmsg SPI Port Driver Support"
 	default n
+	depends on SPI
 	select RPMSG_PORT
 	---help---
 		Rpmsg SPI Port driver used for cross chip communication.


### PR DESCRIPTION

## Summary
drivers/rpmsg/Kconfig: Add SPI dependency for RPMSG_PORT_SPI

If SPI dependency is not set, the following warning will be generated during compilation:

[109/1450] Building C object drivers/CMakeFiles/drivers.dir/rpmsg/rpmsg_port_spi.c.o /data/code/nuttxspace/nuttx/drivers/rpmsg/rpmsg_port_spi.c: In function ‘rpmsg_port_spi_exchange’: /data/code/nuttxspace/nuttx/drivers/rpmsg/rpmsg_port_spi.c:233:3: warning: implicit declaration of function ‘SPI_EXCHANGE’ [-Wimplicit-function-declaration]
  233 |   SPI_EXCHANGE(rpspi->spi, txhdr, rpspi->rxhdr,
      |   ^~~~~~~~~~~~
[1450/1450] Pac SIM with dynamic libs in nuttx.tgz

## Impact

Fix compilation warning issues

## Testing

N/A


