### PR TITLE
lcd/st7789: fix incorrect buffer count for 3 wire RAM write

### DIFF
--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -584,19 +584,22 @@ static void st7789_wrram(FAR struct st7789_dev_s *dev,
   size_t i;
 #ifdef CONFIG_LCD_ST7789_3WIRE
   size_t j;
+  size_t rowsiz;
 #endif
 
   st7789_sendcmd(dev, ST7789_RAMWR);
 
 #ifdef CONFIG_LCD_ST7789_3WIRE
-  if (count == 1)
+  rowsiz = ST7789_XRES * ST7789_BYTESPP;
+
+  if (count == 1 && size > rowsiz)
     {
       /* We cannot send the entire buffer at once, split it to
        * separate rows.
        */
 
-      count = ST7789_YRES;
-      size = ST7789_XRES * ST7789_BYTESPP;
+      count = size / rowsiz;
+      size = rowsiz;
     }
 
   st7789_select(dev->spi, LCD_ST7789_SPI_BITS);
@@ -607,7 +610,7 @@ static void st7789_wrram(FAR struct st7789_dev_s *dev,
     {
       /* Copy data to rowbuff and add 9th bit */
 
-      for (j = 0; j < ST7789_XRES * ST7789_BYTESPP; j += 2)
+      for (j = 0; j < size; j += 2)
         {
           /* Take care of correct byte order. */
 


### PR DESCRIPTION
## Summary
If `st7789_wrram` is called with `count = 1`, then the entire buffer should be sent. However, in 3 wire mode, the driver has to send the buffer row by row because of additional data flag. The number of rows (count) can't be `ST7789_YRES` in this case, but only the number of rows in the buffer (this is write size / row size , where row size is `ST7789_XRES * ST7789_BYTESPP`). This also applies only if we want to write size larger than row size, because `st7789_putrun` allows to write just a part of a row.

This fixes the incorrect behavior of the display in 3 wire mode if the display is split into more buffer writes (as in LCD driver for example, FB driver did not face this issue).

## Impact

Fixes the behavior of the display with LCD driver if the buffer is less than the entire display size (usually the case in LVGL library). This was initially my fault when introducing the support for 3 wire communication, I had done tests only with FB driver back then and there was no issue with FB driver.

## Testing

Tested with 3 scenarios:
- multiple buffers, each 60 rows large (against LVGL), LCD driver
- single buffer for the entire display, LCD driver
- FB driver

Tested on 320 x 240 large display connected as 3 wire on SPI bus with DMA.


