### PR TITLE
drivers/sensors/ms56xx: Use nxsig_usleep for long delays.

### DIFF
--- a/drivers/sensors/ms56xx_uorb.c
+++ b/drivers/sensors/ms56xx_uorb.c
@@ -286,7 +286,7 @@ static inline void baro_measure_read(FAR struct ms56xx_dev_s *priv,
 
   /* Wait data acquisition */
 
-  up_udelay(10000);
+  nxsig_usleep(10000);
 
   /* Send command to start a read sequence */
 
@@ -323,7 +323,7 @@ static inline void baro_measure_read(FAR struct ms56xx_dev_s *priv,
 
   /* Wait data acquisition */
 
-  up_udelay(10000);
+  nxsig_usleep(10000);
 
   /* Send command to start a read sequence */
 
@@ -437,7 +437,7 @@ static int ms56xx_initialize(FAR struct ms56xx_dev_s *priv)
 
   /* We have to wait before the prom is ready is be read */
 
-  up_udelay(10000);
+  nxsig_usleep(10000);
 
   for (i = 0; i < 8; i++)
     {


### PR DESCRIPTION
## Summary

Longer delays (10ms) are performed with `nxsig_usleep()` instead of `up_udelay()`.

## Impact

The waiting process in this driver is now more efficient since it does not rely on busy waiting using a loop for its longer delays.

## Testing

Testing was performed on a custom STM32H743 flight computer where an issue was first observed with incorrect pressure readings because of an incorrect `CONFIG_BOARD_LOOPSPERMSEC` value. This closes #15826.

With the new changes, pressure is read correctly:

```console
NuttShell (NSH) NuttX-12.8.0
nsh> uorb_listener -r 50 -n 10 sensor_baro0

Mointor objects num:1
object_name:sensor_baro, object_instance:0
sensor_baro(now:7900000):timestamp:7900000,pressure:1003.309998,temperature:21.230000
sensor_baro(now:7970000):timestamp:7970000,pressure:1003.309998,temperature:21.280001
sensor_baro(now:8040000):timestamp:8040000,pressure:1003.330017,temperature:21.309999
sensor_baro(now:8110000):timestamp:8110000,pressure:1003.309998,temperature:21.340000
sensor_baro(now:8180000):timestamp:8180000,pressure:1003.340027,temperature:21.360001
sensor_baro(now:8250000):timestamp:8250000,pressure:1003.320007,temperature:21.370001
sensor_baro(now:8320000):timestamp:8320000,pressure:1003.340027,temperature:21.389999
sensor_baro(now:8390000):timestamp:8390000,pressure:1003.349976,temperature:21.400000
sensor_baro(now:8460000):timestamp:8460000,pressure:1003.349976,temperature:21.410000
sensor_baro(now:8530000):timestamp:8530000,pressure:1003.330017,temperature:21.420000
Object name:sensor_baro0, recieved:10
Total number of received Message:10/10
```