### PR TITLE
sixlowpan: improve tcp support.

### DIFF
--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -463,6 +463,12 @@ static int ipv6_in(FAR struct net_driver_s *dev)
         if ((dev->d_len > 0 && dev->d_lltype == NET_LL_IEEE802154) ||
             (dev->d_len > 0 && dev->d_lltype == NET_LL_PKTRADIO))
           {
+            /* tcp_ipv6_input() can update dev->d_iob. Update ipv6 to ensure
+             * using the correct data.
+             */
+
+            ipv6 = IPv6BUF;
+
             /* Let 6LoWPAN handle the TCP output */
 
             sixlowpan_tcp_send(dev, dev, ipv6);


### PR DESCRIPTION
Update the handling of tcp packets over sixlowpan. `tcp_ipv6_input()` can update the dev->d_iob, so use this to send the response.

## Summary

When using tcp over sixlowpan (e.g. for telnet) the handling of packets trough `tcp_ipv6_input()` can modify `dev->d_iob`. The PR makes sure that the correct `dev->d_iob` is used as returned packets. 

## Impact

Allows using tcp over sixlowpan, e.g. telnet over sixlowpan. No impact on build system or other parts.

## Testing

Verified on esp32 using espnow as packet radio with telnetd and telnet.