### PR TITLE
arch/risc-v/src/mpfs: Move PLIC interrupt enable/disable to mpfs_plic and handle pending interrupts

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_plic.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_plic.h
@@ -38,6 +38,10 @@
 #define MPFS_PLIC_IP4        (MPFS_PLIC_BASE + 0x001010)
 #define MPFS_PLIC_I51        (MPFS_PLIC_BASE + 0x001014)
 
+#define MPFS_PLIC_PRIO_DIS   0
+#define MPFS_PLIC_PRIO_MIN   1
+#define MPFS_PLIC_PRIO_MAX   7
+
 #define MPFS_HART_MIE_OFFSET (0x100)
 #define MPFS_HART_SIE_OFFSET (0x80)
 

--- a/arch/risc-v/src/mpfs/mpfs_plic.h
+++ b/arch/risc-v/src/mpfs/mpfs_plic.h
@@ -88,4 +88,30 @@ uintptr_t mpfs_plic_get_claimbase(uintptr_t hartid);
 
 uintptr_t mpfs_plic_get_thresholdbase(void);
 
+/****************************************************************************
+ * Name: mpfs_plic_disable_irq(int extirq)
+ *
+ * Description:
+ *   Disable interrupt on all harts
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpfs_plic_disable_irq(int extirq);
+
+/****************************************************************************
+ * Name: mpfs_plic_clear_and_enable_irq
+ *
+ * Description:
+ *   Enable interrupt; if it is pending, clear it first
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void mpfs_plic_clear_and_enable_irq(int extirq);
+
 #endif /* __ARCH_RISC_V_SRC_MPFS_MPFS_PLIC_H */


### PR DESCRIPTION

## Summary

- Move PLIC interrupt enable and disable functions into mpfs_plic.c
- Remove race conditions between irq enable/disable by adding spinlock
  - An interrupt may trigger on one hart in the middle of enabling the interrupts - then the interrupt handler might call up_disable_irq.

- When enabling interrupts, always clear pending interrupt:

A pending interrupt would trigger immediately when enabling the interrupt source, but this is not expected. The interrupt source is level sensitive, so it should only trigger if the source is active at the time when it is enabled. Not if it was active sometime in the past but inactive at the time when the IRQ is enabled.

The issue becomes with devices where the interrupt source (the line connected to the PLIC) can't be masked / controlled, but the IRQ itself needs to be just enabled/disabled at the times when you know the line status is valid. If the source toggles while the PLIC interrupt is disabled or the interrupt is disabled when the line is active, the interrupt would always trigger right away when next time enabling the IRQ even if the irq source is inactive at that time.

The way how PLIC is designed is such that a pending interrupt can't be cleared. Clearing a pending interrupt can only be done by handling the interrupt (claiming it, and then acking it). Claiming an interrupt is only legal when the interrupt is enabled.

The issue with such pending interrupts is now handled as follows:

1. When enabling interrupts, check if there is a pending one, and do the following steps for the pending irq
2. Raise the priority of the pending interrupt to the maximum. This moves the pending irq to the head of the claim queue in PLIC when the source is enabled
3. Enable the PLIC irq source for the pending one on the current hart (the irq suorce needs to be enabled for steps 4. and 5)
4. Claim the next interrupt from PLIC (this is now always the pending one, due to 2. and no other hart has claimed it since all sources on other harts are disabled)
5. Ack the pending IRQ
6. Lower the PLIC IRQ priority back to normal
7. Proceed on enabling the interrupts on the other harts.

## Impact

Impacts only MPFS targets. Fixes issues when trying to disable PLIC interrupt from interrupt handler, and issues of receiving an extra interrupt when enabling interrupts.

## Testing

Desk-tested on a custom MPFS board and on a Microchip MPFS Icicle board, using CONFIG_BUILD_FLAT and both CONFIG_SMP=y and CONFIG_SMP=n
