### PR TITLE
drivers/net: change format specifiers macros on lan9250 driver

### DIFF
--- a/drivers/net/lan9250.c
+++ b/drivers/net/lan9250.c
@@ -617,7 +617,9 @@ static void lan9250_wait_ready(FAR struct lan9250_driver_s *priv,
 
   if (timeout)
     {
-      nerr("ERROR: wait register:0x%02x, mask:0x%08x, expected:0x%08x\n",
+      nerr("ERROR: wait register:0x%02" PRIx32 \
+           ", mask:0x%08" PRIx32 \
+           ", expected:0x%08" PRIx32 "\n",
             address, mask, expected);
     }
 }
@@ -734,7 +736,8 @@ static void lan9250_wait_mac_ready(FAR struct lan9250_driver_s *priv,
 
   if (timeout)
     {
-      nerr("ERROR: wait MAC register:0x%02x, mask:0x%08x, expected:0x%08x\n",
+      nerr("ERROR: wait MAC register:0x%02" PRIx32 \
+           ", mask:0x%08" PRIx32 ", expect:0x%08" PRIx32 "\n",
             address, mask, expected);
     }
 }
@@ -1178,11 +1181,11 @@ static int lan9250_reset(FAR struct lan9250_driver_s *priv)
   regval = lan9250_get_reg(priv, LAN9250_CIARR);
   if ((regval & CIARR_CID_M) != CIARR_CID_V)
     {
-      nerr("ERROR: Bad Rev ID: %08x\n", regval);
+      nerr("ERROR: Bad Rev ID: %08" PRIx32 "\n", regval);
       return -ENODEV;
     }
 
-  ninfo("Rev ID: %08x\n", regval & CIARR_CREV_M);
+  ninfo("Rev ID: %08" PRIx32 "\n", regval & CIARR_CREV_M);
 
   /* Configure TX FIFO size mode to be 8:
    *
@@ -1809,7 +1812,7 @@ static void lan9250_int_worker(FAR void *arg)
        * settings.
        */
 
-      ninfo("Interrupt status: %08x\n", regval);
+      ninfo("Interrupt status: %08" PRIx32 "\n", regval);
 
 #if LAN9250_INT_SOURCE & IER_SW
       if ((regval & ISR_SW) != 0)


### PR DESCRIPTION
This fixes build warnings when different archs are used. Simply changes "lx" to "PRIx32" when using uint32_t.

## Summary

Changed format specifiers from `%08x` to `PRIx32` for better compatibility.
Affects only a few log lines.

This is required since I'm working on a fix for #15755. 

Example of warning when applying the new data types for ESP32S3:
```
In file included from net/lan9250.c:34:
net/lan9250.c: In function 'lan9250_wait_ready':
net/lan9250.c:620:12: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  620 |       nerr("ERROR: wait register:0x%02x, mask:0x%08x, expected:0x%08x\n",
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  621 |             address, mask, expected);
      |                      ~~~~
      |                      |
      |                      uint32_t {aka long unsigned int}
net/lan9250.c:620:52: note: format string is defined here
  620 |       nerr("ERROR: wait register:0x%02x, mask:0x%08x, expected:0x%08x\n",
      |                                                 ~~~^
      |                                                    |
      |                                                    unsigned int
      |                                                 %08lx
```

Using format specifier macros solves this, as it becomes architecture independent.

## Impact

Impact on user: NO.

Impact on build: This will throw erros when fixing #15755. It can be merged now since it won't affect current builds. 

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

This test simply builds the binary and checks for compilation errors.
Unfortunately I don't have this device to test (requires external LAN9250). If someone has, please speak up!

### Building
1. ./tools/configure.sh esp32s3-devkit:eth_lan9250
2. make

### Results
No build errors.

```
CPP:  /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.api.ld-> /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.api.ldCPP:  /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.libgcc.ld-> /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.libCPP:  /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld-> /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.newCPP:  /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.version.ld-> /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.veCPP:  /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/soc/esp32s3/ld/esp32s3.peripherals.ld-> /home/fdcavalcanti/nuttxspace3/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/soc/esp32s3/ld/esp32s3.peripherals.ldLD: nuttx
Memory region         Used Size  Region Size  %age Used
             ROM:      299075 B    4194272 B      7.13%
     iram0_0_seg:       20992 B       304 KB      6.74%
     irom0_0_seg:      364611 B    4194272 B      8.69%
     dram0_0_seg:       33392 B       288 KB     11.32%
     drom0_0_seg:      115912 B    4194272 B      2.76%
    rtc_iram_seg:          0 GB       8168 B      0.00%
    rtc_data_seg:          0 GB       8168 B      0.00%
rtc_reserved_seg:          0 GB         24 B      0.00%
    rtc_slow_seg:          0 GB         8 KB      0.00%
CP: nuttx.hex
MKIMAGE: ESP32-S3 binary
esptool.py -c esp32s3 elf2image --ram-only-header -fs 4MB -fm dio -ff 40m -o nuttx.bin nuttx
esptool.py v4.8.1
Creating esp32s3 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Merged 1 ELF section
Successfully created esp32s3 image.
Generated: nuttx.bin
esptool.py -c esp32s3 merge_bin --output nuttx.merged.bin --fill-flash-size 4MB -fm dio -ff 40m  0x0000 nuttx.bin
esptool.py v4.8.1
Wrote 0x400000 bytes to file nuttx.merged.bin, ready to flash to offset 0x0
Generated: nuttx.merged.bin
```