### PR TITLE
Documentation:Fix Seeed Studio XIAO nRF52840

### DIFF
--- a/Documentation/platforms/arm/nrf52/boards/xiao-nrf52840/index.rst
+++ b/Documentation/platforms/arm/nrf52/boards/xiao-nrf52840/index.rst
@@ -1,6 +1,6 @@
-=============
-XIAO nRF52840
-=============
+==========================
+Seeed Studio XIAO nRF52840
+==========================
 
 The `Seeed Studio XIAO nRF52840 <https://wiki.seeedstudio.com/XIAO_BLE/>`_ is a general purpose board supplied by
 Seeed Studio and it is compatible with the Nordic nRF52840 ecosystem as they share the same MCU.


### PR DESCRIPTION
## Summary
Change XIAO nRF52840 name at Documentation to
match product name and other Seeed Studio boards.

## Impact
This PR makes easier to users to find out the Seeed Studio XIAO nRF52840 
at Documentation by using the correct name.

## Testing
Built the documentation and check it locally:
![image](https://github.com/user-attachments/assets/bc031049-6e77-4fcc-b70b-1c5393d7134a)


