### PR TITLE
binfmt/copyaction: fix prev->flink did not use from kmalloc.

### DIFF
--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -177,7 +177,8 @@ void binfmt_freeargv(FAR char * const *argv);
  *   do not have any real option other than to copy the callers action list.
  *
  * Input Parameters:
- *   copy     - Pointer of file actions
+ *   copy     - Pointer of the copied output file actions
+ *   actions  - Pointer of file actions to be copy
  *
  * Returned Value:
  *   A non-zero copy is returned on success.

--- a/binfmt/binfmt_copyactions.c
+++ b/binfmt/binfmt_copyactions.c
@@ -52,7 +52,8 @@
  *   do not have any real option other than to copy the callers action list.
  *
  * Input Parameters:
- *   copy     - Pointer of file actions
+ *   copy     - Pointer of the copied output file actions
+ *   actions  - Pointer of file actions to be copy
  *
  * Returned Value:
  *   A non-zero copy is returned on success.
@@ -107,6 +108,11 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
     {
       return -ENOMEM;
     }
+
+  /* We need to copy and re-organize the flink chain,  be care not modify
+   * the actions it self,  the prev have to point to the last time foreach
+   * item.
+   */
 
   for (entry = (FAR struct spawn_general_file_action_s *)actions,
        prev = NULL; entry != NULL; entry = entry->flink)

--- a/binfmt/binfmt_copyactions.c
+++ b/binfmt/binfmt_copyactions.c
@@ -109,7 +109,7 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
     }
 
   for (entry = (FAR struct spawn_general_file_action_s *)actions,
-       prev = NULL; entry != NULL; prev = entry, entry = entry->flink)
+       prev = NULL; entry != NULL; entry = entry->flink)
     {
       switch (entry->action)
         {
@@ -122,6 +122,7 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
                 prev->flink = (FAR void *)close;
               }
 
+            prev   = (FAR void *)close;
             buffer = close + 1;
             break;
 
@@ -134,6 +135,7 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
                 prev->flink = (FAR void *)dup2;
               }
 
+            prev   = (FAR void *)dup2;
             buffer = dup2 + 1;
             break;
 
@@ -149,6 +151,7 @@ int binfmt_copyactions(FAR const posix_spawn_file_actions_t **copy,
 
             strcpy(open->path, tmp->path);
 
+            prev   = (FAR void *)open;
             buffer = (FAR char *)buffer +
                      ALIGN_UP(SIZEOF_OPEN_FILE_ACTION_S(strlen(tmp->path)),
                               sizeof(FAR void *));


### PR DESCRIPTION
## Summary
We should not modify the input actions, casing when kernel build, userspace call posix_spawn touch kernel address.

with current code, within posix_spawn will modify the file_actions input from user space, we should not purpose to change it, also the flink in actions copy out is not correct.

## Impact
fix when do adb shell in goldfish v7a kernel build, crash in posix_spawn_file_actions_destroy

## Testing
ci-test, arm-v7a ostest, goldfish v7a adbd


