### PR TITLE
drivers/thermal/core: Fix work not queued after getting temperature fails

### DIFF
--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -835,7 +835,7 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
   if (ret < 0)
     {
       therr("Failed to get temperature from zone %s \n", zdev->name);
-      goto unlock;
+      goto delayed_work;
     }
 
   zdev->last_temperature = zdev->temperature;
@@ -895,6 +895,8 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
                  trip_low, trip_high, zdev->name);
         }
     }
+
+delayed_work:
 
   /* Update worker invoke delay */
 


### PR DESCRIPTION
## Summary
Fix work not queued after getting temperature fails, the work will be stopped after `get_temp()` fails.

## Impact
drivers/thermal

## Testing
1. sim:thermal with mod below PASSED:
```diff
 static int dummy_zdev_get_temp(FAR struct thermal_zone_device_s *zdev,
                                FAR int *temp)
 {
+  return ERROR;
```
2. CI