### PR TITLE
boards/arm/rp2040/common: Add weak_function to SPI common logic

### DIFF
--- a/boards/arm/rp2040/common/src/rp2040_spi.c
+++ b/boards/arm/rp2040/common/src/rp2040_spi.c
@@ -70,8 +70,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_RP2040_SPI0
-void rp2040_spi0select(struct spi_dev_s *dev, uint32_t devid,
-                       bool selected)
+void weak_function rp2040_spi0select(struct spi_dev_s *dev,
+                                     uint32_t devid,
+                                     bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
           selected ? "assert" : "de-assert");
@@ -79,7 +80,8 @@ void rp2040_spi0select(struct spi_dev_s *dev, uint32_t devid,
   rp2040_gpio_put(CONFIG_RP2040_SPI0_CS_GPIO, !selected);
 }
 
-uint8_t rp2040_spi0status(struct spi_dev_s *dev, uint32_t devid)
+uint8_t weak_function rp2040_spi0status(struct spi_dev_s *dev,
+                                        uint32_t devid)
 {
   uint8_t ret = 0;
 
@@ -90,7 +92,8 @@ uint8_t rp2040_spi0status(struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int rp2040_spi0cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int weak_function rp2040_spi0cmddata(struct spi_dev_s *dev,
+                                     uint32_t devid, bool cmd)
 {
 #ifdef CONFIG_LCD_ST7789
   if (devid == SPIDEV_DISPLAY(0))
@@ -111,8 +114,9 @@ int rp2040_spi0cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_RP2040_SPI1
-void rp2040_spi1select(struct spi_dev_s *dev, uint32_t devid,
-                       bool selected)
+void weak_function rp2040_spi1select(struct spi_dev_s *dev,
+                                     uint32_t devid,
+                                     bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
           selected ? "assert" : "de-assert");
@@ -120,7 +124,8 @@ void rp2040_spi1select(struct spi_dev_s *dev, uint32_t devid,
   rp2040_gpio_put(CONFIG_RP2040_SPI1_CS_GPIO, !selected);
 }
 
-uint8_t rp2040_spi1status(struct spi_dev_s *dev, uint32_t devid)
+uint8_t weak_function rp2040_spi1status(struct spi_dev_s *dev,
+                                        uint32_t devid)
 {
   uint8_t ret = 0;
 
@@ -131,7 +136,8 @@ uint8_t rp2040_spi1status(struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int rp2040_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int weak_function rp2040_spi1cmddata(struct spi_dev_s *dev,
+                                     uint32_t devid, bool cmd)
 {
 #if defined (CONFIG_LCD_ST7789) || defined (CONFIG_LCD_ST7735) || defined (CONFIG_LCD_GC9A01)
   if (devid == SPIDEV_DISPLAY(0))


### PR DESCRIPTION
## Summary

Board logic change.
This PR adds weak_function attributes to the RP2040 common SPI board logic.
This allows board developers to override and extend the SPI board logic.

## Impact

This allows board developers to add custom SPI logic such as adding additional chip select pins.
Adding new SPI devices such as displays or custom SPI devices like external boards is now possible.

External custom boards will have the biggest impact, as these are typically not pushed.

## Testing

This has been tested by building the code on linux with raspberrypi-pico:nsh config.
I also tested it on a custom board and it works.
However, my knowledge is not very big about compiler compatibility when weak_function is used.

Please let me know if there are issues.

