### PR TITLE
riscv/esp32c6: Fix issue related esp32c6 usbserial driver.

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_usbserial.c
+++ b/arch/risc-v/src/common/espressif/esp_usbserial.c
@@ -216,6 +216,12 @@ static void esp_shutdown(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
+/* Workaround: This function does not work when optimization is different
+ * from O0. This modification will be removed once a final solution is
+ * implemented.
+ */
+
+__attribute__((optimize("O0")))
 static void esp_txint(struct uart_dev_s *dev, bool enable)
 {
   if (enable)


### PR DESCRIPTION
Ths commit disable code optimization responsible for esp32c6 interruption serial register changes. Without this optimization, usbserial driver doesn't word. This is work around meanwhile we find properly fix.

## Summary

This change disable compile optimization for function esp_txint, used in usbserial driver. This change was discussed in the issue: https://github.com/apache/nuttx/issues/15656.
Before this change, when you input any character to the console and press "enter", console will stuck.

## Impact

Do usbserial feature for esp32c6 work properly

## Testing

Use esp32c6 usbserial config. Build and flash. You will be able to use usb as serial console.


