### PR TITLE
arch/arm: guard .thumb_func use

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -990,7 +990,6 @@ config ARCH_ARMV7R
 	default n
 	select ARCH_HAVE_CPUINFO
 	select ARCH_HAVE_PERF_EVENTS
-	select ARM_THUMB if BUILD_PROTECTED
 
 config ARCH_CORTEXR4
 	bool

--- a/arch/arm/src/common/gnu/arm_signal_handler.S
+++ b/arch/arm/src/common/gnu/arm_signal_handler.S
@@ -68,10 +68,12 @@
  ****************************************************************************/
 
 	.text
-#ifdef __ghs__
+#ifdef CONFIG_ARM_THUMB
+#  ifdef __ghs__
 	.thumb
-#else
+#  else
 	.thumb_func
+#  endif
 #endif
 	.globl	up_signal_handler
 #ifdef __ghs__


### PR DESCRIPTION
# Summary

This guards use of thumb_func with ARM_THUMB so that PROTECTED build can work in non-THUMB mode.

# Impacts

arm 32 bit devices w/o ARM_THUMB can do signal handling in PROTECTED mode now.

# Testing

- local checks with qemu-armv7r:pnsh, qemu-armv7a:knsh with ARM_THUMB off, with apt-installed `gcc-arm-none-eabi` toolchain 10.3.1 on Ubuntu 22.04.

- CI checks
