### PR TITLE
net/socket/getsockopt: move the options check to the upper layer

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -83,13 +83,6 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 {
   FAR struct socket_conn_s *conn = psock->s_conn;
 
-  /* Verify that the socket option if valid (but might not be supported ) */
-
-  if (!value || !value_len)
-    {
-      return -EINVAL;
-    }
-
   /* Process the options always handled locally */
 
   switch (option)
@@ -270,6 +263,13 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
                      FAR void *value, FAR socklen_t *value_len)
 {
   int ret = -ENOPROTOOPT;
+
+  /* Verify that the socket option is valid (but might not be supported ) */
+
+  if (value == NULL || value_len == NULL || *value_len == 0)
+    {
+      return -EINVAL;
+    }
 
   /* Verify that the sockfd corresponds to valid, allocated socket */
 


### PR DESCRIPTION
## Summary
check parameters at the top level to avoid errors when assigning values in si_getsockopt.


## Impact
N/A

## Testing
qemu:local


