### PR TITLE
arch/arm/samv7/spi: fix ifdelay setup in spi_setdelay call

### DIFF
--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -1157,7 +1157,7 @@ static int spi_setdelay(struct spi_dev_s *dev, uint32_t startdelay,
   regval |= (uint32_t) dlybs << SPI_CSR_DLYBS_SHIFT;
   spi_putreg(spi, regval, offset);
 
-  /* stopdelay = DLYBCT: Delay Between Consecutive Transfers.
+  /* ifdelay = DLYBCT: Delay Between Consecutive Transfers.
    * This field defines the delay between two consecutive transfers with the
    * same peripheral without removing the chip select. The delay is always
    * inserted after each transfer and before removing the chip select if
@@ -1171,7 +1171,7 @@ static int spi_setdelay(struct spi_dev_s *dev, uint32_t startdelay,
    */
 
   dlybct  = SAM_SPI_CLOCK;
-  dlybct *= stopdelay;
+  dlybct *= ifdelay;
   dlybct /= 1000000000;
   dlybct /= 32;
   regval  = spi_getreg(spi, offset);


### PR DESCRIPTION
## Summary
`ifdelay` description (delay between frames) matches the DLYBCT field (delay between consecutive transfers without removing chip select) much better compared to `stopdelay` (delay between last CLK and CS innactive). The option for `stopdelay` does not seem to be configurable in SAMv7 peripheral.

## Impact
Should be minimal, most of the drivers do not use `spi_setdelay` at all and even if, this is configurable option disabled by default.

## Testing
Tested with ST7789 display, the delay is set up. The delay is put between the consecutive transfers, so the effect now matches the description.


