### PR TITLE
arch/arm64: fix boot stage prints with CONFIG_ARCH_EARLY_PRINT=y

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -365,15 +365,16 @@ out:
  */
 
 boot_stage_puts:
-    stp   xzr, x30, [sp, #-16]!
+    stp   x19, x30, [sp, #-16]!
+    mov   x19, x1
 1:
-    ldrb  w0, [x1], #1       /* Load next char */
+    ldrb  w0, [x19], #1      /* Load next char */
     cmp   w0, 0
     beq   2f                 /* Exit on nul */
     bl    arm64_lowputc
     b     1b                 /* Loop */
 2:
-    ldp   xzr, x30, [sp], #16
+    ldp   x19, x30, [sp], #16
     ret
 
 .type boot_stage_puts, %function;


### PR DESCRIPTION
## Summary

`boot_stage_puts` used by early assembly head, calls `arm64_lowputc()` for each character of the string to be printed in a loop. During that loop it uses `x1` as the pointer to the next character to be printed. However, `x1` is clobbered<sup>[1]</sup> by `arm64_lowputc()`, resulting in undefined behaviour (only the first character of the string is guaranteed to be printed).

Fix this by using `x19` instead.

[1] Observed clobbering behaviour with `arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64`.

## Impact

The change does not affect users, build processes, hardware, documentation or security compatibility.

The only notable effect should be the early console messages in arm64 builds being fully (and more reliably) visible when configured with `CONFIG_ARCH_EARLY_PRINT=y`.

## Testing

- Toolchain: `arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64`
- Target: `imx93evk:nsh`
- Extra config: `CONFIG_ARCH_EARLY_PRINT=y`

WIthout the change, early boot stage messages would appear as:
```
---[other messages here]
```

With the change, early boot stage messages are:
```
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize
[other messages here]
```