### PR TITLE
syslog/rpmsg_server: fix build break if enable SYSLOG_RPMSG/SYSLOG_RPMSG_SERVER

### DIFF
--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -63,8 +63,8 @@ struct syslog_rpmsg_server_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void syslog_rpmsg_write(FAR const char *buf1, size_t len1,
-                               FAR const char *buf2, size_t len2);
+static void syslog_rpmsg_write_internal(FAR const char *buf1, size_t len1,
+                                        FAR const char *buf2, size_t len2);
 static bool syslog_rpmsg_ns_match(FAR struct rpmsg_device *rdev,
                                   FAR void *priv_, FAR const char *name,
                                   uint32_t dest);
@@ -131,8 +131,9 @@ static int syslog_rpmsg_file_ioctl(FAR struct file *filep, int cmd,
 }
 #endif
 
-static void syslog_rpmsg_write(FAR const char *buf1, size_t len1,
-                               FAR const char *buf2, size_t len2)
+static void
+syslog_rpmsg_write_internal(FAR const char *buf1, size_t len1,
+                            FAR const char *buf2, size_t len2)
 {
   FAR const char *nl;
   size_t len;
@@ -178,7 +179,7 @@ static void syslog_rpmsg_ept_release(FAR struct rpmsg_endpoint *ept)
 
   if (priv->nextpos)
     {
-      syslog_rpmsg_write(priv->tmpbuf, priv->nextpos, "\n", 1);
+      syslog_rpmsg_write_internal(priv->tmpbuf, priv->nextpos, "\n", 1);
     }
 
 #ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
@@ -244,8 +245,9 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
 
           if (priv->nextpos)
             {
-              syslog_rpmsg_write(priv->tmpbuf, priv->nextpos,
-                                 msg->data, printed);
+              syslog_rpmsg_write_internal(priv->tmpbuf,
+                                          priv->nextpos,
+                                          msg->data, printed);
               priv->nextpos = 0;
             }
           else


### PR DESCRIPTION
## Summary

syslog/rpmsg_server: fix build break if enable SYSLOG_RPMSG/SYSLOG_RPMSG_SERVER

```
syslog/syslog_rpmsg_server.c:66:13: error: conflicting types for 'syslog_rpmsg_write';
      have 'void(const char *, size_t,  const char *, size_t)' {aka 'void(const char *, unsigned int,  const char *, unsigned int)'}
   66 | static void syslog_rpmsg_write(FAR const char *buf1, size_t len1,
      |             ^~~~~~~~~~~~~~~~~~
In file included from syslog/syslog_rpmsg_server.c:36:
nuttx/include/nuttx/syslog/syslog_rpmsg.h:51:9: note: previous declaration of
  'syslog_rpmsg_write' with type 'ssize_t(const syslog_channel_t *, const char *, size_t)' {aka 'int(const struct syslog_channel_s *, const char *, unsigned int)'}
   51 | ssize_t syslog_rpmsg_write(FAR syslog_channel_t *channel,
      |         ^~~~~~~~~~~~~~~~~~

```
Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

enable SYSLOG_RPMSG/SYSLOG_RPMSG_SERVER


