### PR TITLE
arch/esp32_spi: Add check to see if the TX_FIFO is empty

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -849,6 +849,7 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
   const uintptr_t spi_miso_dlen_reg = SPI_MISO_DLEN_REG(id);
   const uintptr_t spi_user_reg = SPI_USER_REG(id);
   const uintptr_t spi_cmd_reg = SPI_CMD_REG(id);
+  const uintptr_t spi_dma_rstatus = SPI_DMA_RSTATUS_REG(id);
 
   DEBUGASSERT((txbuffer != NULL) || (rxbuffer != NULL));
 
@@ -938,6 +939,16 @@ static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
       else
         {
           esp32_spi_reset_regbits(spi_user_reg, SPI_USR_MISO_M);
+        }
+
+      if (priv->config->flags & ESP32_SPI_IO_W)
+        {
+          /* Wait until SPI TX FIFO is not empty */
+
+          while ((getreg32(spi_dma_rstatus) & SPI_DMA_TX_FIFO_EMPTY) != 0)
+            {
+              ;
+            }
         }
 
       esp32_spi_set_regbits(spi_cmd_reg, SPI_USR_M);

--- a/arch/xtensa/src/esp32/hardware/esp32_spi.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_spi.h
@@ -2782,6 +2782,8 @@
 #define SPI_DMA_RSTATUS_OFFSET  (0x148)
 #define SPI_DMA_RSTATUS_REG(i)  (REG_SPI_BASE(i) + SPI_DMA_RSTATUS_OFFSET)
 
+#define SPI_DMA_TX_FIFO_EMPTY   (BIT(31))
+
 /* SPI_DMA_OUT_STATUS : RO ;bitpos:[31:0] ;default: 32'b0 ; */
 
 /* Description: spi dma read data from memory status. */


### PR DESCRIPTION
## Summary
arch/esp32_spi: Add check to see if the TX_FIFO is empty to avoid sending empty data

## Impact
New Feature/Change: Issue fix (no new feature).
User Impact: No
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: Only ESP32; other architectures unaffected.
Security: No
Compatibility: Backward-compatible; no breaking changes.
## Testing
ESP32-DevKitC, NuttX with SPI configurations, ESP32 as SPI master device send data.




