### PR TITLE
drivers/audio/es8311: set proper format specifier for logging

### DIFF
--- a/drivers/audio/es8311.c
+++ b/drivers/audio/es8311.c
@@ -498,12 +498,13 @@ static int es8311_getcoeff(FAR struct es8311_dev_s *priv,
       if (priv->mclk == es8311_coeff_div[i].mclk &&
           samplerate == es8311_coeff_div[i].rate)
         {
-          audinfo("MCLK: %d, samplerate: %d\n", priv->mclk, samplerate);
+          audinfo("MCLK: %" PRIu32 ", samplerate: %" PRIu32 "\n",
+                  priv->mclk, samplerate);
           return i;
         }
     }
 
-  auderr("MCLK = %d and samplerate = %d not supported.\n",
+  auderr("MCLK = %" PRIu32 " and samplerate = %" PRIu32 " not supported.\n",
          priv->mclk, samplerate);
 
   return -EINVAL;
@@ -775,7 +776,7 @@ static int es8311_setsamplerate(FAR struct es8311_dev_s *priv)
     }
   else
     {
-      audinfo("Sample rate set to: %d.\n", priv->samprate);
+      audinfo("Sample rate set to: %" PRIu32 ".\n", priv->samprate);
       return OK;
     }
 }


### PR DESCRIPTION
## Summary

Use `PRIu32` instead of `%d`/`%u` for `uint32_t` to avoid build warnings on different architectures.

This is required as part of an effort to fix #15755.

## Impact

- Impact on user: No.
- Impact on build: Yes, removes build warnings due to wrong data type depending on architecture.
- Impact on hardware: No.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: No.

## Testing

### Building
- ./tools/configure.sh esp32s3-korvo-2:audio
- make

### Results
Before this change:
```
CC:  i2s/i2schar.c In file included from audio/es8311.c:34:
audio/es8311.c: In function 'es8311_getcoeff':
audio/es8311.c:501:19: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  501 |           audinfo("MCLK: %d, samplerate: %d\n", priv->mclk, samplerate);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                     |
      |                                                     uint32_t {aka long unsigned int}
audio/es8311.c:501:27: note: format string is defined here
  501 |           audinfo("MCLK: %d, samplerate: %d\n", priv->mclk, samplerate);
      |                          ~^
      |                           |
      |                           int
      |                          %ld
```

Now:
no build warnings.
