### PR TITLE
drivers/net: update format specifier on lan9250 driver

### DIFF
--- a/drivers/net/lan9250.c
+++ b/drivers/net/lan9250.c
@@ -617,7 +617,7 @@ static void lan9250_wait_ready(FAR struct lan9250_driver_s *priv,
 
   if (timeout)
     {
-      nerr("ERROR: wait register:0x%02" PRIx32 \
+      nerr("ERROR: wait register:0x%04" PRIx16 \
            ", mask:0x%08" PRIx32 \
            ", expected:0x%08" PRIx32 "\n",
             address, mask, expected);
@@ -736,7 +736,7 @@ static void lan9250_wait_mac_ready(FAR struct lan9250_driver_s *priv,
 
   if (timeout)
     {
-      nerr("ERROR: wait MAC register:0x%02" PRIx32 \
+      nerr("ERROR: wait MAC register:0x%02" PRIx8 \
            ", mask:0x%08" PRIx32 ", expect:0x%08" PRIx32 "\n",
             address, mask, expected);
     }


### PR DESCRIPTION
## Summary

Fix print statement for uint8 and uint16 types.
Required due to efforts on fixing #15755 .

I had recently sent a PR on this same driver but missed a couple of lines.

Error example:
```
In file included from net/lan9250.c:34:
net/lan9250.c: In function 'lan9250_wait_ready':
net/lan9250.c:620:12: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  620 |       nerr("ERROR: wait register:0x%02x, mask:0x%08x, expected:0x%08x\n",
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  621 |             address, mask, expected);
      |                      ~~~~
      |                      |
      |                      uint32_t {aka long unsigned int}
net/lan9250.c:620:52: note: format string is defined here
  620 |       nerr("ERROR: wait register:0x%02x, mask:0x%08x, expected:0x%08x\n",
      |                                                 ~~~^
      |                                                    |
      |                                                    unsigned int
      |                                                 %08lx
```


## Impact

- Impact on user: NO.
- Impact on build: This will throw erros when fixing https://github.com/apache/nuttx/issues/15755. It can be merged now since it won't affect current builds.
- Impact on hardware: NO.
- Impact on documentation: NO.
- Impact on security: NO.
- Impact on compatibility: NO.

## Testing

This test simply builds the binary and checks for compilation errors.
Unfortunately I don't have this device to test (requires external LAN9250). If someone has, please speak up!

### Building

- ./tools/configure.sh esp32s3-devkit:eth_lan9250
- make

### Results

No build errors.