### PR TITLE
Update usbhost_hidkbd.c

### DIFF
--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -617,7 +617,7 @@ static const uint8_t ucmap[USBHID_NUMSCANCODES] =
   0,    0,       0,      0,      0,    0,    0,      0,    /* 0xa0-0xa7: Out,Oper,Clear,CrSel,Excel,(reserved) */
   0,    0,       0,      0,      0,    0,    0,      0,    /* 0xa8-0xaf: (reserved) */
   0,    0,       0,      0,      0,    0,    '(',    ')',  /* 0xb0-0xb7: 00,000,ThouSeparator,DecSeparator,CurrencyUnit,SubUnit,(,) */
-  '{',  '}',    '\t',    \177,   'A',  'B',  'C',    'D',  /* 0xb8-0xbf: {,},tab,backspace,A-D */
+  '{',  '}',    '\t',    '\177',   'A',  'B',  'C',    'D',  /* 0xb8-0xbf: {,},tab,backspace,A-D */
   'F',  'F',     0,      '^',    '%',  '<', '>',     '&',  /* 0xc0-0xc7: E-F,XOR,^,%,<,>,& */
   0,    '|',     0,      ':',    '%',  ' ', '@',     '!',  /* 0xc8-0xcf: &&,|,||,:,#, ,@,! */
   0,    0,       0,      0,      0,    0,   0,       0,    /* 0xd0-0xd7: Memory Store,Recall,Clear,Add,Subtract,Multiply,Divide,+/- */


### PR DESCRIPTION
## Summary

ESP32-S3

There were missing quotes for key "backspace" for scancodes. It caused an error in cmake. Maybe I'm doing something wrong because I never used an embedded system before, but I still wanted to share it.  \177 -> '\177'. USB_ALLSCANCODES

## Impact

Only only occurs when the config option all scan codes is enabled for hid devices.  It prevents from doing the command make to deploy nuttx. (Sorry this is my first time doing C I don't know the terms)

## Testing

BEFORE : 

Register: nsh
Register: sh
CC:  usbhost/usbhost_hidkbd.c usbhost/usbhost_hidkbd.c:620:26: error: stray '\' in program
  620 |   '{',  '}',    '\t',    \177,   'A',  'B',  'C',    'D',  /* 0xb8-0xbf: {,},tab,backspace,A-D */
      |                          ^
make[1]: *** [Makefile:109: usbhost_hidkbd.o] Error 1
make: *** [tools/LibTargets.mk:107: drivers/libdrivers.a] Error 2

AFTER:

no error



