### PR TITLE
drivers/audio/es8388: set proper format specifier macro for logging

### DIFF
--- a/drivers/audio/es8388.c
+++ b/drivers/audio/es8388.c
@@ -530,7 +530,7 @@ static void es8388_setmclkfrequency(FAR struct es8388_dev_s *priv)
 
   if (priv->mclk)
     {
-      audinfo("MCLK Freq: %u\n", priv->mclk);
+      audinfo("MCLK Freq: %" PRIu32"\n", priv->mclk);
 
       int ret = I2S_SETMCLKFREQUENCY(priv->i2s, priv->mclk);
 
@@ -748,7 +748,7 @@ static void es8388_setsamplerate(FAR struct es8388_dev_s *priv)
       es8388_writereg(priv, ES8388_DACCONTROL2, ES8388_DACFSRATIO(regval));
     }
 
-  audinfo("Sample rate set to %d\n", priv->samprate);
+  audinfo("Sample rate set to %" PRIu32 "\n", priv->samprate);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Use `PRIu32` instead of `%u` for `uint32_t` to avoid build warnings on different architectures.

This is required as part of an effort to fix #15755.

## Impact

- Impact on user: No.
- Impact on build: Yes, removes build warnings due to wrong data type depending on architecture.
- Impact on hardware: No.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: No.

## Testing

### Building

- ./tools/configure.sh esp32s3-korvo-2:audio
- make

### Results

Before this change:

```
In file included from audio/es8388.c:41:
audio/es8388.c: In function 'es8388_setmclkfrequency':
audio/es8388.c:533:15: error: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  533 |       audinfo("MCLK Freq: %u\n", priv->mclk);
      |               ^~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                      |
      |                                      uint32_t {aka long unsigned int}
audio/es8388.c:533:28: note: format string is defined here
  533 |       audinfo("MCLK Freq: %u\n", priv->mclk);
      |                           ~^
      |                            |
      |                            unsigned int
      |                           %lu
```

Now:
no build warnings.
