### PR TITLE
drivers/lcd/st7789: add option for SPI delay control

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -783,6 +783,38 @@ config LCD_ST7789_FREQUENCY
 	int "SPI Frequency"
 	default 1000000
 
+config LCD_ST7789_START_DELAY
+	int "ST7789 SPI start delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 60
+	---help---
+		The delay between CS active and first CLK. In ns.
+
+config LCD_ST7789_STOP_DELAY
+	int "ST7789 SPI stop delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 65
+	---help---
+		The delay between last CLK and CS inactive. In ns.
+
+config LCD_ST7789_CS_DELAY
+	int "ST7789 SPI chip select delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 40
+	---help---
+		The delay between CS inactive and CS active again. In ns.
+
+config LCD_ST7789_IFDELAY
+	int "ST7789 SPI frames delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 50
+	---help---
+		The delay between consecutive frames. In ns.
+
 endif # LCD_ST7789
 
 config LCD_GC9A01

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -315,6 +315,11 @@ static void st7789_select(FAR struct spi_dev_s *spi, int bits)
   SPI_SETMODE(spi, CONFIG_LCD_ST7789_SPIMODE);
   SPI_SETBITS(spi, bits);
   SPI_SETFREQUENCY(spi, CONFIG_LCD_ST7789_FREQUENCY);
+#ifdef CONFIG_SPI_DELAY_CONTROL
+  SPI_SETDELAY(spi, CONFIG_LCD_ST7789_START_DELAY,
+               CONFIG_LCD_ST7789_STOP_DELAY, CONFIG_LCD_ST7789_CS_DELAY,
+               CONFIG_LCD_ST7789_IFDELAY);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
It is now possible to configure SPI delays for st7789 controller if `CONFIG_SPI_DELAY_CONTROL` is set. Default values for SPI peripheral may be too long or too short, therefore the display controller set its own values as required. The default values in configuration are taken from the reference manual, but it is possible they may require tuning for different revisions or temperatures for example.

## Impact

None unless `CONFIG_SPI_DELAY_CONTROL` is set, otherwise the delays are determined by ST7789 config options. This brings new configuration options for ST7789, but these have no effect on current config files.

## Testing
Tested on 320 x 240 large display connected as 3 wire on SPI bus with DMA and 135 x 240 large display connected as 4 wire on SPI with DMA.


