### PR TITLE
ptmx: When alloc minor, skip the start addr if it has been used

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -151,7 +151,7 @@ static int ptmx_minor_allocate(void)
        * prevent (unexpected) infinite loops.
        */
 
-      if (startaddr == minor)
+      if (startaddr == g_ptmx.px_next)
         {
           /* We are back where we started... the are no free device address */
 


### PR DESCRIPTION
## Summary

The alloctab can be looped, if the first check the corresponding bit is set, it will not continue to loop

## Impact

ptmx

## Testing

selftest


