### PR TITLE
drivers/syslog: add ramlog write multiple bytes for interrupt handlers

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -74,6 +74,7 @@ static const struct syslog_channel_ops_s g_ramlog_channel_ops =
   ramlog_putc,
   ramlog_putc,
   NULL,
+  ramlog_write,
   ramlog_write
 };
 


### PR DESCRIPTION
## Summary

add ramlog write multiple bytes when in interrupt handlers

## Impact

syslog ramlog

## Testing

selftest


