### PR TITLE
usbhost: recognize sim usb cdcacm composite device

### DIFF
--- a/drivers/usbhost/usbhost_cdcacm.c
+++ b/drivers/usbhost/usbhost_cdcacm.c
@@ -376,11 +376,18 @@ static bool usbhost_txempty(FAR struct uart_dev_s *uartdev);
  * device.
  */
 
-static const struct usbhost_id_s g_id[4] =
+static const struct usbhost_id_s g_id[5] =
 {
   {
     USB_CLASS_CDC,          /* base     */
     CDC_SUBCLASS_NONE,      /* subclass */
+    CDC_PROTO_NONE,         /* proto    */
+    0,                      /* vid      */
+    0                       /* pid      */
+  },
+  {
+    USB_CLASS_CDC,          /* base     */
+    CDC_SUBCLASS_ACM,       /* subclass */
     CDC_PROTO_NONE,         /* proto    */
     0,                      /* vid      */
     0                       /* pid      */
@@ -414,7 +421,7 @@ static struct usbhost_registry_s g_cdcacm =
 {
   NULL,                   /* flink    */
   usbhost_create,         /* create   */
-  4,                      /* nids     */
+  5,                      /* nids     */
   &g_id[0]                /* id[]     */
 };
 

--- a/drivers/usbhost/usbhost_composite.c
+++ b/drivers/usbhost/usbhost_composite.c
@@ -590,15 +590,17 @@ int usbhost_composite(FAR struct usbhost_hubport_s *hport,
 
           if (desc->type == USB_DESC_TYPE_INTERFACE)
             {
-#ifdef CONFIG_DEBUG_ASSERTIONS
               FAR struct usb_ifdesc_s *ifdesc =
                 (FAR struct usb_ifdesc_s *)desc;
 
               DEBUGASSERT(ifdesc->ifno < 32);
-#endif
+
               /* Increment the count of interfaces */
 
-              nintfs++;
+              if (ifdesc->alt == 0)
+                {
+                  nintfs++;
+                }
             }
 
           /* Check for IAD descriptors that will be used when it is


### PR DESCRIPTION
## Summary

usb host support more cdcacm composite device descriptor.

## Impact

usb host cdcacm

## Testing

```
# Operation steps
1. Build and start sim usbhost:  sim:usbhost
2. Build and start sim usbdev in another terminal:  sim:usbdev
3. input "conn 1" in usbdev terminal
```

```
# the usb host logs before change: usbhost_findclass failed and there is no ttyACM0 device
$ sudo ./nuttx                                                                                                                                                                                                                                              
   usbhost_registerclass: Registering class:0x4007c5a0 nids:4
   
   NuttShell (NSH) NuttX-12.8.0
   nsh> sim_usbhost_waittask: connected
   sim_usbhost_enumerate: Enumerate the device
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0100 index: 0000 len: 0012
   usbhost_enumerate: maxpacksetsize: 64
   usbhost_devdesc: class:239 subclass:2 protocol:1 vid:1630 pid:0042
   sim_usbhost_ctrlin: type: 00 req: 05 value: 0001 index: 0000 len: 0000
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 0009
   usbhost_enumerate: sizeof config data: 149
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 0095
   sim_usbhost_ctrlin: type: 00 req: 09 value: 0001 index: 0000 len: 0000
   usbhost_findclass: Looking for class:2 subclass:2 protocol:0 vid:1630 pid:0042
   usbhost_findclass: Checking class:0x4007c5a0 nids:4
   usbhost_idmatch: Compare to class:2 subclass:0 protocol:0 vid:0000 pid:0000
   usbhost_idmatch: Compare to class:2 subclass:2 protocol:1 vid:0000 pid:0000
   usbhost_idmatch: Compare to class:255 subclass:0 protocol:0 vid:2c7c pid:0125
   usbhost_idmatch: Compare to class:255 subclass:2 protocol:0 vid:2c7c pid:0125
   usbhost_composite: ERROR: usbhost_findclass failed
    ......

   nsh> ls /dev
   /dev:
    console
    log
    null
    oneshot
    ptmx
    zero
   nsh>
```
```
#  the usb host logs after change: usbhost register ttyACM0 device
$ sudo ./nuttx 
   usbhost_registerclass: Registering class:0x4007c5a0 nids:5

   NuttShell (NSH) NuttX-12.8.0
   nsh> sim_usbhost_waittask: connected
   sim_usbhost_enumerate: Enumerate the device
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0100 index: 0000 len: 0012
   usbhost_enumerate: maxpacksetsize: 64
   usbhost_devdesc: class:239 subclass:2 protocol:1 vid:1630 pid:0042
   sim_usbhost_ctrlin: type: 00 req: 05 value: 0001 index: 0000 len: 0000
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 0009
   usbhost_enumerate: sizeof config data: 149
   sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 0095
   sim_usbhost_ctrlin: type: 00 req: 09 value: 0001 index: 0000 len: 0000
   usbhost_findclass: Looking for class:2 subclass:2 protocol:0 vid:1630 pid:0042
   usbhost_findclass: Checking class:0x4007c5a0 nids:5
   usbhost_idmatch: Compare to class:2 subclass:0 protocol:0 vid:0000 pid:0000
   usbhost_idmatch: Compare to class:2 subclass:2 protocol:0 vid:0000 pid:0000
   usbhost_allocclass: Allocated: 0x7df8da664f50
   ......
   usbhost_connect: Register device: /dev/ttyACM0
   ......
   usbhost_enumerate: usbhost_composite has bound the composite device

   nsh> ls /dev
   /dev:
    console
    log
    null
    oneshot
    ptmx
    ttyACM0
    zero
   nsh>
```
