### PR TITLE
arch/x86_64: Implement TSC frequency query via CPUID 0x40000010

### DIFF
--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -240,6 +240,7 @@
 #  define X86_64_CPUID_07_AVX512VL     (1 << 31)
 #define X86_64_CPUID_XSAVE             0x0d
 #define X86_64_CPUID_TSC               0x15
+#define X86_64_CPUID_TSC_VMWARE        0x40000010
 #define X86_64_CPUID_EXTINFO           0x80000001
 #  define X86_64_CPUID_EXTINFO_RDTSCP  (1 << 27)
 

--- a/arch/x86_64/src/common/x86_64_internal.h
+++ b/arch/x86_64/src/common/x86_64_internal.h
@@ -193,6 +193,16 @@ extern uint8_t _etbss[];           /* End+1 of .tbss */
  * Inline Functions
  ****************************************************************************/
 
+static inline void x86_64_cpuid(uint32_t leaf, uint32_t subleaf,
+                                uint32_t *eax, uint32_t *ebx,
+                                uint32_t *ecx, uint32_t *edx)
+{
+  __asm__ volatile("cpuid"
+                   : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+                   : "a" (leaf), "c" (subleaf)
+                   : "memory");
+}
+
 #ifdef CONFIG_ARCH_KERNEL_STACK
 static inline_function uint64_t *x86_64_get_ktopstk(void)
 {

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -88,6 +88,13 @@ config ARCH_INTEL64_CORE_FREQ_KHZ
 		to set the TSC deadline timer frequency. If set to 0 we try to get
 		frequency from CPUID.
 
+config ARCH_INTEL64_TSC_FREQ_VMWARE
+	bool "Use CPUID 0x40000010 to get CPU Core frequency"
+	default n
+	depends on ARCH_INTEL64_CORE_FREQ_KHZ = 0
+	---help---
+		Use CPUID 0x40000010 defined by VMware to get CPU Core frequency
+		in virtualized environments.
 endif
 
 if ARCH_INTEL64_TSC


### PR DESCRIPTION
## Summary

This commit introduces support for querying TSC frequency using CPUID 0x40000010.

## Impact

Only affects TSC frequency on x86/64 platforms: when `CONFIG_ARCH_INTEL64_TSC_FREQ_VMWARE` is enabled, TSC frequency is obtained through CPUID `X86_64_CPUID_TSC_VMWARE`.

## Testing

Tested on QEMU/x86_64 and real x86_64 machine running ACRN Hypervisor.

This function can be tested with the following command: `sudo qemu-system-x86_64 -enable-kvm -cpu host,+invtsc,+vmware-cpuid-freq -m 2G -kernel nuttx -nographic -serial mon:stdio -s`

