### PR TITLE
sched/wdog: Support for periodic wdog.

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -31,7 +31,6 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/clock.h>
-#include <nuttx/irq.h>
 #include <stdint.h>
 
 /****************************************************************************
@@ -88,6 +87,13 @@ struct wdog_s
   FAR void          *picbase;    /* PIC base address */
 #endif
   clock_t            expired;    /* Timer associated with the absoulute time */
+};
+
+struct wdog_period_s
+{
+  struct wdog_s      wdog;       /* Watchdog */
+  clock_t            period;     /* Period time in ticks */
+  wdentry_t          func;       /* Wrapped function to execute when delay expires */
 };
 
 /****************************************************************************
@@ -280,6 +286,34 @@ static inline int wd_start_realtime(FAR struct wdog_s *wdog,
 }
 
 /****************************************************************************
+ * Name: wd_start_period
+ *
+ * Description:
+ *   This function periodically adds a watchdog timer to the active timer.
+ *
+ * Input Parameters:
+ *   wdog     - Pointer of the periodic watchdog.
+ *   delay    - Delayed time in system ticks.
+ *   period   - Period in system ticks.
+ *   wdentry  - Function to call on timeout.
+ *   arg      - Parameter to pass to wdentry.
+ *
+ *   NOTE:  The parameter must be of type wdparm_t.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is return to
+ *   indicate the nature of any failure.
+ *
+ * Assumptions:
+ *   The watchdog routine runs in the context of the timer interrupt handler
+ *   and is subject to all ISR restrictions.
+ *
+ ****************************************************************************/
+
+int wd_start_period(FAR struct wdog_period_s *wdog, sclock_t delay,
+                    clock_t period, wdentry_t wdentry, wdparm_t arg);
+
+/****************************************************************************
  * Name: wd_cancel
  *
  * Description:
@@ -296,6 +330,26 @@ static inline int wd_start_realtime(FAR struct wdog_s *wdog,
  ****************************************************************************/
 
 int wd_cancel(FAR struct wdog_s *wdog);
+
+/****************************************************************************
+ * Name: wd_cancel_period
+ *
+ * Description:
+ *   This function cancels a currently running periodic watchdog timer.
+ *
+ * Input Parameters:
+ *   wdog_period - Pointer of the periodic watchdog.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success;  A negated errno value is returned to
+ *   indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+static inline int wd_cancel_period(FAR struct wdog_period_s *wdog_period)
+{
+  return wd_cancel(&wdog_period->wdog);
+}
 
 /****************************************************************************
  * Name: wd_gettime

--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -31,6 +31,7 @@
 
 #include <nuttx/compiler.h>
 #include <nuttx/clock.h>
+#include <errno.h>
 #include <stdint.h>
 
 /****************************************************************************
@@ -348,6 +349,12 @@ int wd_cancel(FAR struct wdog_s *wdog);
 
 static inline int wd_cancel_period(FAR struct wdog_period_s *wdog_period)
 {
+  if (!wdog_period)
+    {
+      return -EINVAL;
+    }
+
+  wdog_period->period = 0;
   return wd_cancel(&wdog_period->wdog);
 }
 

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -257,6 +257,7 @@ struct work_s
       clock_t qtime;             /* Time work queued */
     } s;
     struct wdog_s timer;         /* Delay expiry timer */
+    struct wdog_period_s ptimer; /* Period expiry timer */
   } u;
   worker_t  worker;              /* Work callback */
   FAR void *arg;                 /* Callback argument */
@@ -416,6 +417,43 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR struct work_s *work, worker_t worker,
                   FAR void *arg, clock_t delay);
+
+/****************************************************************************
+ * Name: work_queue_period/work_queue_wq_period
+ *
+ * Description:
+ *   Queue work to be performed periodically.  All queued work will be
+ *   performed on the worker thread of execution (not the caller's).
+ *
+ *   The work structure is allocated and must be initialized to all zero by
+ *   the caller.  Otherwise, the work structure is completely managed by the
+ *   work queue logic.  The caller should never modify the contents of the
+ *   work queue structure directly.  If work_queue() is called before the
+ *   previous work has been performed and removed from the queue, then any
+ *   pending work will be canceled and lost.
+ *
+ * Input Parameters:
+ *   qid    - The work queue ID (must be HPWORK or LPWORK)
+ *   wqueue - The work queue handle
+ *   work   - The work structure to queue
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
+ *            it is invoked.
+ *   delay  - Delay (in clock ticks) from the time queue until the worker
+ *            is invoked. Zero means to perform the work immediately.
+ *   period - Period (in clock ticks).
+ *
+ * Returned Value:
+ *   Zero on success, a negated errno on failure
+ *
+ ****************************************************************************/
+
+int work_queue_period(int qid, FAR struct work_s *work, worker_t worker,
+                      FAR void *arg, clock_t delay, clock_t period);
+int work_queue_wq_period(FAR struct kwork_wqueue_s *wqueue,
+                         FAR struct work_s *work, worker_t worker,
+                         FAR void *arg, clock_t delay, clock_t period);
 
 /****************************************************************************
  * Name: work_queue_pri

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -419,7 +419,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR void *arg, clock_t delay);
 
 /****************************************************************************
- * Name: work_queue_period/work_queue_wq_period
+ * Name: work_queue_period/work_queue_period_wq
  *
  * Description:
  *   Queue work to be performed periodically.  All queued work will be
@@ -451,7 +451,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
 
 int work_queue_period(int qid, FAR struct work_s *work, worker_t worker,
                       FAR void *arg, clock_t delay, clock_t period);
-int work_queue_wq_period(FAR struct kwork_wqueue_s *wqueue,
+int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
                          FAR struct work_s *work, worker_t worker,
                          FAR void *arg, clock_t delay, clock_t period);
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -118,9 +118,12 @@ static void wdentry_period(wdparm_t arg)
    * we need to use `expired - 1` here to avoid time drift.
    */
 
-  wd_start_abstick(&wdperiod->wdog,
-                   wdperiod->wdog.expired + wdperiod->period - 1,
-                   wdentry_period, wdperiod->wdog.arg);
+  if (wdperiod->period != 0)
+    {
+      wd_start_abstick(&wdperiod->wdog,
+                       wdperiod->wdog.expired + wdperiod->period - 1,
+                       wdentry_period, wdperiod->wdog.arg);
+    }
 }
 
 /****************************************************************************

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -95,6 +95,35 @@ static unsigned int g_wdtimernested;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: wdentry_period
+ *
+ * Description:
+ *   Periodic watchdog timer callback function.
+ *
+ * Input Parameters:
+ *   arg - The argument of the wdog callback.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void wdentry_period(wdparm_t arg)
+{
+  FAR struct wdog_period_s *wdperiod = (FAR struct wdog_period_s *)arg;
+
+  wdperiod->func(wdperiod->wdog.arg);
+
+  /* Since we set `ticks++` at `wd_start_abstick`,
+   * we need to use `expired - 1` here to avoid time drift.
+   */
+
+  wd_start_abstick(&wdperiod->wdog,
+                   wdperiod->wdog.expired + wdperiod->period - 1,
+                   wdentry_period, wdperiod->wdog.arg);
+}
+
+/****************************************************************************
  * Name: wd_expiration
  *
  * Description:
@@ -150,6 +179,9 @@ static inline_function void wd_expiration(clock_t ticks)
       func = wdog->func;
       arg = wdog->arg;
       wdog->func = NULL;
+
+      arg = func != wdentry_period ? wdog->arg :
+            (wdparm_t)list_container_of(wdog, struct wdog_period_s, wdog);
 
       /* Execute the watchdog function */
 
@@ -394,6 +426,45 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
 
   return wd_start_abstick(wdog, clock_systime_ticks() + delay,
                           wdentry, arg);
+}
+
+/****************************************************************************
+ * Name: wd_start_period
+ *
+ * Description:
+ *   This function periodically adds a watchdog timer to the active timer.
+ *
+ * Input Parameters:
+ *   wdog     - Pointer of the periodic watchdog.
+ *   delay    - Delayed time in system ticks.
+ *   period   - Period in system ticks.
+ *   wdentry  - Function to call on timeout.
+ *   arg      - Parameter to pass to wdentry.
+ *
+ *   NOTE:  The parameter must be of type wdparm_t.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is return to
+ *   indicate the nature of any failure.
+ *
+ * Assumptions:
+ *   The watchdog routine runs in the context of the timer interrupt handler
+ *   and is subject to all ISR restrictions.
+ *
+ ****************************************************************************/
+
+int wd_start_period(FAR struct wdog_period_s *wdog, sclock_t delay,
+                    clock_t period, wdentry_t wdentry, wdparm_t arg)
+{
+  if (!wdog || !period || !wdentry)
+    {
+      return -EINVAL;
+    }
+
+  wdog->func   = wdentry;
+  wdog->period = period;
+
+  return wd_start(&wdog->wdog, delay, wdentry_period, arg);
 }
 
 /****************************************************************************

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -106,7 +106,7 @@ static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_queue_period/work_queue_wq_period
+ * Name: work_queue_period/work_queue_period_wq
  *
  * Description:
  *   Queue work to be performed periodically.  All queued work will be
@@ -136,7 +136,7 @@ static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
  *
  ****************************************************************************/
 
-int work_queue_wq_period(FAR struct kwork_wqueue_s *wqueue,
+int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
                          FAR struct work_s *work, worker_t worker,
                          FAR void *arg, clock_t delay, clock_t period)
 {
@@ -208,7 +208,7 @@ out:
 int work_queue_period(int qid, FAR struct work_s *work, worker_t worker,
                       FAR void *arg, clock_t delay, clock_t period)
 {
-  return work_queue_wq_period(work_qid2wq(qid), work, worker,
+  return work_queue_period_wq(work_qid2wq(qid), work, worker,
                               arg, delay, period);
 }
 
@@ -246,7 +246,7 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
                   FAR struct work_s *work, worker_t worker,
                   FAR void *arg, clock_t delay)
 {
-  return work_queue_wq_period(wqueue, work, worker, arg, delay, 0);
+  return work_queue_period_wq(wqueue, work, worker, arg, delay, 0);
 }
 
 int work_queue(int qid, FAR struct work_s *work, worker_t worker,

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -106,10 +106,10 @@ static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_queue/work_queue_wq
+ * Name: work_queue_period/work_queue_wq_period
  *
  * Description:
- *   Queue work to be performed at a later time.  All queued work will be
+ *   Queue work to be performed periodically.  All queued work will be
  *   performed on the worker thread of execution (not the caller's).
  *
  *   The work structure is allocated and must be initialized to all zero by
@@ -129,15 +129,16 @@ static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
  *            it is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.
+ *   period - Period (in clock ticks).
  *
  * Returned Value:
  *   Zero on success, a negated errno on failure
  *
  ****************************************************************************/
 
-int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
-                  FAR struct work_s *work, worker_t worker,
-                  FAR void *arg, clock_t delay)
+int work_queue_wq_period(FAR struct kwork_wqueue_s *wqueue,
+                         FAR struct work_s *work, worker_t worker,
+                         FAR void *arg, clock_t delay, clock_t period)
 {
   irqstate_t flags;
   int ret = OK;
@@ -187,15 +188,65 @@ int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
     {
       queue_work(wqueue, work);
     }
+  else if (period == 0)
+    {
+      ret = wd_start(&work->u.timer, delay,
+                     work_timer_expiry, (wdparm_t)work);
+    }
   else
     {
-      wd_start(&work->u.timer, delay, work_timer_expiry, (wdparm_t)work);
+      ret = wd_start_period(&work->u.ptimer, delay, period,
+                            work_timer_expiry, (wdparm_t)work);
     }
 
 out:
   spin_unlock_irqrestore(&wqueue->lock, flags);
   sched_unlock();
   return ret;
+}
+
+int work_queue_period(int qid, FAR struct work_s *work, worker_t worker,
+                      FAR void *arg, clock_t delay, clock_t period)
+{
+  return work_queue_wq_period(work_qid2wq(qid), work, worker,
+                              arg, delay, period);
+}
+
+/****************************************************************************
+ * Name: work_queue/work_queue_wq
+ *
+ * Description:
+ *   Queue work to be performed at a later time.  All queued work will be
+ *   performed on the worker thread of execution (not the caller's).
+ *
+ *   The work structure is allocated and must be initialized to all zero by
+ *   the caller.  Otherwise, the work structure is completely managed by the
+ *   work queue logic.  The caller should never modify the contents of the
+ *   work queue structure directly.  If work_queue() is called before the
+ *   previous work has been performed and removed from the queue, then any
+ *   pending work will be canceled and lost.
+ *
+ * Input Parameters:
+ *   qid    - The work queue ID (must be HPWORK or LPWORK)
+ *   wqueue - The work queue handle
+ *   work   - The work structure to queue
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
+ *            it is invoked.
+ *   delay  - Delay (in clock ticks) from the time queue until the worker
+ *            is invoked. Zero means to perform the work immediately.
+ *
+ * Returned Value:
+ *   Zero on success, a negated errno on failure
+ *
+ ****************************************************************************/
+
+int work_queue_wq(FAR struct kwork_wqueue_s *wqueue,
+                  FAR struct work_s *work, worker_t worker,
+                  FAR void *arg, clock_t delay)
+{
+  return work_queue_wq_period(wqueue, work, worker, arg, delay, 0);
 }
 
 int work_queue(int qid, FAR struct work_s *work, worker_t worker,


### PR DESCRIPTION
## Summary

This commit added support for periodic wdog.

## Impact

This commit added `wd_start_period` and `wd_cancel_period` functions, which has no effect on original implementation.

## Testing

Tested on QEMU/x86_64.

