### PR TITLE
arch/risc-v/common: Fix unaligned stack access on 64-bit risc-v

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -218,26 +218,26 @@ handle_irq:
 
   setintstack t0, t1
 
-  addi       sp, sp, -16
-  REGSTORE   ra, 12(sp)
-  REGSTORE   s0, 8(sp)
-  add	       s0, sp, 16
+  addi       sp, sp, -(INT_REG_SIZE * 2)
+  REGSTORE   ra, INT_REG_SIZE(sp)
+  REGSTORE   s0, 0(sp)
+  add        s0, sp, (INT_REG_SIZE * 2)
 
   /* Call interrupt handler in C */
 
   jal        x1, riscv_dispatch_irq
 
-  REGLOAD    ra, 12(sp)
-  REGLOAD    s0, 8(sp)
-  add	       sp, sp, 16
+  REGLOAD    ra, INT_REG_SIZE(sp)
+  REGLOAD    s0, 0(sp)
+  add        sp, sp, (INT_REG_SIZE * 2)
 
 #else
   /* Reserve some space for current_regs if interrupt stack disabled */
 
-  addi       sp, sp, -16
-  REGSTORE   ra, 12(sp)
-  REGSTORE   s0, 8(sp)
-  add	       s0, sp, 16
+  addi       sp, sp, -(INT_REG_SIZE * 2)
+  REGSTORE   ra, INT_REG_SIZE(sp)
+  REGSTORE   s0, 0(sp)
+  add        s0, sp, (INT_REG_SIZE * 2)
 
   addi       sp, sp, -XCPTCONTEXT_SIZE
 
@@ -245,9 +245,9 @@ handle_irq:
 
   jal        x1, riscv_dispatch_irq
 
-  REGLOAD    ra, 12(sp)
-  REGLOAD    s0, 8(sp)
-  add	sp,sp,16
+  REGLOAD    ra, INT_REG_SIZE(sp)
+  REGLOAD    s0, 0(sp)
+  add        sp, sp, (INT_REG_SIZE * 2)
 
   /* Restore sp */
 


### PR DESCRIPTION

## Summary

This fixes a regression on those 64-bit risc-v systems, which can't do non-8-byte aligned accesses to the stack.

The issue was found on mpfs platform, which stopped booting after https://github.com/apache/nuttx/commit/b4174952843c2ffd9776d02bd4357b118e2c55b9

## Impact

Should have no functional impact, except for those systems which dont' boot

## Testing

Tested booting and ostest on rv-virt:nsh, rv-virt:nsh64 and on a custom mpfs board.

Tested backtrace functionality on rv-virt:nsh and rv-virt:nsh64 with the following config changes:

CONFIG_SCHED_BACKTRACE=y
CONFIG_FRAME_POINTER=y
CONFIG_DEBUG_SYMBOLS=y

and increased CONFIG_ARCH_INTERRUPTSTACK on rv-virt64.

**Backtrace tests:**

1. Added "*(int *)0 = 0;" into "hello" test application
2. Added "*(int *)0 = 0;" into timer interrupt code (set to trigger with a debug counter after 5secs from boot)

Filtered the backtrace dumps with "./tools/btdecode.sh addr2line dumpstack.txt nuttx" , where "dumpstack.txt" contains the output trace.

Here are the backtrace dumps from rv-virt:nsh:
1) hacked hello test app

`
Backtrace for task 2:
0x800228f8: sched_backtrace at sched_backtrace.c:106
0x80017758: sched_dumpstack at sched_dumpstack.c:71
0x80014302: dump_assert_info at assert.c:717
 (inlined by) _assert at assert.c:898
0x800077a4: riscv_exception at riscv_exception.c:135 (discriminator 4)
0x8000111c: irq_dispatch at irq_dispatch.c:160
0x80000dd4: riscv_doirq at riscv_doirq.c:113
0x80000d72: riscv_dispatch_irq at qemu_rv_irq_dispatch.c:140
0x80000186: exception_common at riscv_exception_common.S:230
0x8001a478: hello_main at hello_main.c:39
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75
0x8001a478: hello_main at hello_main.c:39
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75

Backtrace dump for all tasks:

Backtrace for task 2:
0x800228f8: sched_backtrace at sched_backtrace.c:106
0x80017758: sched_dumpstack at sched_dumpstack.c:71
0x80013f3e: dump_backtrace at assert.c:451
0x800146f0: nxsched_foreach at sched_foreach.c:69 (discriminator 2)
0x80014398: dump_fatal_info at assert.c:769
 (inlined by) _assert at assert.c:905
0x800077a4: riscv_exception at riscv_exception.c:135 (discriminator 4)
0x8000111c: irq_dispatch at irq_dispatch.c:160
0x80000dd4: riscv_doirq at riscv_doirq.c:113
0x80000d72: riscv_dispatch_irq at qemu_rv_irq_dispatch.c:140
0x80000186: exception_common at riscv_exception_common.S:230
0x8001a478: hello_main at hello_main.c:39
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75
0x8001a478: hello_main at hello_main.c:39
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75

Backtrace for task 1:
0x80007a18: sys_call0 at syscall.h:161
 (inlined by) up_switch_context at riscv_switchcontext.c:85
0x800148c0: nxsched_waitpid at sched_waitpid.c:165
0x800148d4: waitpid at sched_waitpid.c:618
0x800099c6: nsh_builtin at nsh_builtin.c:164
0x80008796: nsh_execute at nsh_parse.c:550
0x800090fc: nsh_parse_command at nsh_parse.c:2789
0x80009190: nsh_parse at nsh_parse.c:2978
0x80007d5e: nsh_session at nsh_session.c:246
0x80007b70: nsh_consolemain at nsh_consolemain.c:79
0x80007b2c: nsh_main at nsh_main.c:80
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75

Backtrace for task 0:
0x80007a70: up_idle at riscv_idle.c:77
0x80032bd0: ?? ??:0
0x80000d06: qemu_rv_start at qemu_rv_start.c:233 (discriminator 1)
0x80000048: _init at qemu_rv_head.S:90
`


2) hacked "riscv_mtimer_start"

`
Backtrace dump for all tasks:

Backtrace for task 1:
0x80007a38: sys_call0 at syscall.h:161
 (inlined by) up_switch_context at riscv_switchcontext.c:85
0x800047a2: uart_readv at serial.c:1252
0x8000f9fc: file_readv_compat at fs_read.c:104
 (inlined by) file_readv at fs_read.c:197
0x8000fa9a: nx_readv at fs_read.c:280
0x8000fac0: readv at fs_read.c:345
0x8000faf8: read at fs_read.c:380
0x80007e00: readline_getc at readline_fd.c:77
0x8000942c: readline_common at readline_common.c:517
0x80007eb0: readline_fd at readline_fd.c:236
0x80007ca6: nsh_session at nsh_session.c:230
0x80007b90: nsh_consolemain at nsh_consolemain.c:79
0x80007b4c: nsh_main at nsh_main.c:80
0x80005500: nxtask_startup at task_startup.c:72
0x80002048: nxtask_start at task_start.c:75

Backtrace for task 0:
0x80022918: sched_backtrace at sched_backtrace.c:106
0x80017778: sched_dumpstack at sched_dumpstack.c:71
0x80013f5e: dump_backtrace at assert.c:451
0x80014710: nxsched_foreach at sched_foreach.c:69 (discriminator 2)
0x800143b8: dump_fatal_info at assert.c:769
 (inlined by) _assert at assert.c:905
0x800077c4: riscv_exception at riscv_exception.c:135 (discriminator 4)
0x8000111c: irq_dispatch at irq_dispatch.c:160
0x80000dd4: riscv_doirq at riscv_doirq.c:113
0x80000d72: riscv_dispatch_irq at qemu_rv_irq_dispatch.c:140
0x80000186: exception_common at riscv_exception_common.S:230
0x800075a2: riscv_mtimer_start at riscv_mtimer.c:233
0x80003ef6: oneshot_callback at arch_alarm.c:128
0x8000742a: riscv_mtimer_interrupt at riscv_mtimer.c:339
0x8000111c: irq_dispatch at irq_dispatch.c:160
0x80000dd4: riscv_doirq at riscv_doirq.c:113
0x80000d72: riscv_dispatch_irq at qemu_rv_irq_dispatch.c:140
0x80000186: exception_common at riscv_exception_common.S:230
0x80007a90: up_idle at riscv_idle.c:77
0x80032bf0: ?? ??:0
0x80000d06: qemu_rv_start at qemu_rv_start.c:233 (discriminator 1)
0x80000048: _init at qemu_rv_head.S:90
0x800075a2: riscv_mtimer_start at riscv_mtimer.c:233
0x80003ef6: oneshot_callback at arch_alarm.c:128
0x8000742a: riscv_mtimer_interrupt at riscv_mtimer.c:339
0x8000111c: irq_dispatch at irq_dispatch.c:160
0x80000dd4: riscv_doirq at riscv_doirq.c:113
0x80000d72: riscv_dispatch_irq at qemu_rv_irq_dispatch.c:140
0x80000186: exception_common at riscv_exception_common.S:230
0x80007a90: up_idle at riscv_idle.c:77
0x80032bf0: ?? ??:0
0x80000d06: qemu_rv_start at qemu_rv_start.c:233 (discriminator 1)
0x80000048: _init at qemu_rv_head.S:90
`

The results are similar for rv-virt:nsh64
