### PR TITLE
libc/strings: fix compile warning if enable -Wshadow

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -76,76 +76,51 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_BUILTIN_FFS
-static inline_function int ffs(int j)
-{
-  return __builtin_ffs(j);
-}
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffs(int j)
-{
-  return __builtin_ctz(j) + 1;
-}
-#else
 int ffs(int j);
+
+#ifdef CONFIG_HAVE_BUILTIN_FFS
+#  define ffs(j)  __builtin_ffs(j)
+#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+#  define ffs(j)  (__builtin_ctz(j) + 1)
 #endif
 
-#ifdef CONFIG_HAVE_BUILTIN_FFSL
-static inline_function int ffsl(long j)
-{
-  return __builtin_ffsl(j);
-}
-#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffsl(long j)
-{
-  return __builtin_ctzl(j) + 1;
-}
-#else
 int ffsl(long j);
+
+#ifdef CONFIG_HAVE_BUILTIN_FFSL
+#  define ffsl(j) __builtin_ffsl(j)
+#elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+#  define ffsl(j) (__builtin_ctzl(j) + 1)
 #endif
 
 #ifdef CONFIG_HAVE_LONG_LONG
-#  ifdef CONFIG_HAVE_BUILTIN_FFSLL
-static inline_function int ffsll(long long j)
-{
-    return __builtin_ffsll(j);
-}
-#  elif defined (CONFIG_HAVE_BUILTIN_CTZ)
-static inline_function int ffsll(long long j)
-{
-    return __builtin_ctzll(j) + 1;
-}
-#  else
+
 int ffsll(long long j);
+
+#  ifdef CONFIG_HAVE_BUILTIN_FFSLL
+#    define ffsll(j)  __builtin_ffsll(j)
+#  elif defined (CONFIG_HAVE_BUILTIN_CTZ)
+#    define ffsll(j)  (__builtin_ctzll(j) + 1)
 #  endif
+
 #endif
 
-#ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int fls(int j)
-{
-  return (8 * sizeof(int)) - __builtin_clz(j);
-}
-#else
 int fls(int j);
-#endif
 
 #ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int flsl(long j)
-{
-  return (8 * sizeof(long)) - __builtin_clzl(j);
-}
-#else
-int flsl(long j);
+#  define fls(j)  ((8 * sizeof(int)) - __builtin_clz(j))
 #endif
+
+int flsl(long j);
+
+#ifdef CONFIG_HAVE_BUILTIN_CLZ
+#  define flsl(j)  ((8 * sizeof(long)) - __builtin_clzl(j))
+#endif
+
+int flsll(long long j);
 
 #ifdef CONFIG_HAVE_LONG_LONG
 #  ifdef CONFIG_HAVE_BUILTIN_CLZ
-static inline_function int flsll(long long j)
-{
-  return (8 * sizeof(long long)) - __builtin_clzll(j);
-}
-#  else
-int flsll(long long j);
+#    define flsll(j)  ((8 * sizeof(long long)) - __builtin_clzll(j))
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

libc/strings: fix compile warning if enable -Wshadow

Replace inline functions with macros to avoid confilcts with builtin definition

```
nuttx/include/strings.h:80:28: warning: declaration of 'ffs' shadows a built-in function [-Wshadow]
   80 | static inline_function int ffs(int j)
      |                            ^~~
nuttx/include/strings.h:94:28: warning: declaration of 'ffsl' shadows a built-in function [-Wshadow]
   94 | static inline_function int ffsl(long j)
      |                            ^~~~
nuttx/include/strings.h:109:28: warning: declaration of 'ffsll' shadows a built-in function [-Wshadow]
  109 | static inline_function int ffsll(long long j)
      |                            ^~~~~
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check