### PR TITLE
sched/init: Fix build error with CONFIG_BOARD_CRASHDUMP_CUSTOM

### DIFF
--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -322,7 +322,7 @@ static inline void nx_start_application(void)
   board_late_initialize();
 #endif
 
-#ifndef CONFIG_BOARD_CRASHDUMP_NONE
+#ifdef CONFIG_COREDUMP
   coredump_initialize();
 #endif
 


### PR DESCRIPTION
## Summary
Fix build error with the following condition.
- CONFIG_BOARD_CRASHDUMP_CUSTOM=y
- CONFIG_COREDUMP=n

The condition for calling `coredump_initialize()` is incorrect.
CONFIG_BOARD_CRASHDUMP_CUSTOM is not dependent on CONFIG_COREDUMP.

## Impact

## Testing

