### PR TITLE
tools/mksyscall: fix 106: Unexpected end of line: "FAR char * co"

### DIFF
--- a/tools/csvparser.h
+++ b/tools/csvparser.h
@@ -34,7 +34,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define LINESIZE      (PATH_MAX > 256 ? PATH_MAX : 256)
+#define LINESIZE      (PATH_MAX > 512 ? PATH_MAX : 512)
 
 #define MAX_FIELDS    16
 #define MAX_PARMSIZE  256


### PR DESCRIPTION
## Summary

Line 106 of the **syscall/syscall.csv** file exceeds the 256 character limit

```
106: Unexpected end of line: "FAR char * co"
make[1]: *** [makefile:108: .context] Error 4
make[1]: Leaving directory 'C:/nxtest/nuttx/syscall'
make: *** [tools/Win.mk:468: syscall\.context] Error 2

```
fixed **tools/csvparser.h** from

#define LINESIZE      (PATH_MAX > 256 ? PATH_MAX : 256)

to

#define LINESIZE      (PATH_MAX > 512 ? PATH_MAX : 512)

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
local 

**Without this PR**
generate **105** files with error

mksyscall.exe -p syscall.csv
106: Unexpected end of line: "FAR char * co"
106: Unexpected end of line: "FAR char * co"

**With this PR** 
generate **214** files without error

mksyscall.exe -p syscall.csv


