### PR TITLE
audio/pcm_decode: fix typo in assert condition

### DIFF
--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -804,7 +804,7 @@ static int pcm_shutdown(FAR struct audio_lowerhalf_s *dev)
   /* Defer the operation to the lower device driver */
 
   lower = priv->lower;
-  DEBUGASSERT(lower && lower->ops->start);
+  DEBUGASSERT(lower && lower->ops->shutdown);
 
   audinfo("Defer to lower shutdown\n");
   return lower->ops->shutdown(lower);


### PR DESCRIPTION
## Summary

audio/pcm_decode: fix typo in assert condition

should be shutdown not start

Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

N/A

## Testing

ci-check