### PR TITLE
cmake: Add utility target to update .config with minimal changes

### DIFF
--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -98,3 +98,14 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/defconfig
           ${NUTTX_DEFCONFIG}
   WORKING_DIRECTORY ${NUTTX_DIR})
+
+# utility target to update .config with minimal changes to meet dependencies
+add_custom_target(
+  olddefconfig
+  COMMAND ${CMAKE_COMMAND} -E env ${KCONFIG_ENV} olddefconfig
+  COMMAND ${CMAKE_COMMAND} -E remove -f
+          ${CMAKE_BINARY_DIR}/include/nuttx/config.h # invalidate existing
+                                                     # config
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
+  WORKING_DIRECTORY ${NUTTX_DIR}
+  USES_TERMINAL)


### PR DESCRIPTION
## Summary

Introduce the 'olddefconfig' target to streamline the process of updating the configuration file while ensuring dependencies are met.
    
*  Add 'olddefconfig' utility target to CMake build system
*  Updates .config with minimal changes to satisfy dependencies
*  Invalidates outdated config.h and triggers reconfiguration
*  Aligns CMake targets with existing Makefile behavior
 
## Impact
* New feature added?: YES - Adds 'olddefconfig' target for config management
* Impact on user?: YES - Users gain a tool to efficiently update configurations
* Impact on build?: YES - New target integrated into CMake build flow
* Impact on hardware?: NO
* Impact on documentation?: NO
* Impact on security?: NO
* Impact on compatibility?: NO - Enhances parity with Makefile without breaking changes

## Testing

cd cmake/build/dir

```
nx➜  build git:(main) ✗ kconfig-tweak --enable CONFIG_FRAME_POINTER
nx➜  build git:(main) ✗ make olddefconfig
-- Configuring done (0.3s)
-- Generating done (0.6s)
-- Build files have been written to: /home/huang/Work/nuttx-crates-index/build
Loaded configuration '/home/huang/Work/nuttx-crates-index/build/.config'
No change to configuration in '/home/huang/Work/nuttx-crates-index/build/.config'
Built target olddefconfig
```

