### PR TITLE
coredump:adjust BOARD_COREDUMP_COMPRESSION

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4834,9 +4834,8 @@ config BOARD_COREDUMP_FULL
 
 config BOARD_COREDUMP_COMPRESSION
 	bool "Enable Core Dump compression"
-	default y
-	select LIBC_LZF
-	depends on !BOARD_CRASHDUMP_NONE
+	default BOARD_COREDUMP_SYSLOG
+	depends on LIBC_LZF && !BOARD_CRASHDUMP_NONE
 	---help---
 		Enable LZF compression algorithm for core dump content
 


### PR DESCRIPTION
## Summary
  In order to reduce the cost of using coredump, we disable `BOARD_COREDUMP_COMPRESSION` by default when it is not necessary.
  So I adjusted the conditions for enable of `BOARD_COREDUMP_COMPRESSION`

## Impact
  `BOARD_COREDUMP_COMPRESSION` depends on `LIBC_LZF`, not select it, and when `BOARD_COREDUMP_SYSLOG` is enabled, it will be turned on by default

## Testing
  This tweak works fine in my environment and it is enabled/off as expected


