### PR TITLE
drivers/wireless/lpwan/rn2xx3: Fix UART dependency

### DIFF
--- a/drivers/wireless/lpwan/Kconfig
+++ b/drivers/wireless/lpwan/Kconfig
@@ -8,7 +8,7 @@ if DRIVERS_LPWAN
 config LPWAN_RN2XX3
 	bool "Microchip RN2xx3 driver support"
 	default n
-	depends on UART
+    depends on SERIAL
 	---help---
 		Enable driver support for the RN2xx3 LoRa radio transceiver family.
 


### PR DESCRIPTION
## Summary

There is no 'UART' symbol to depend on, so this PR updates that dependency to the correct one, `SERIAL`.

## Impact

Users can now actually select this driver.

## Testing

Before this change, the RN2XX3 does not show up under the LPWAN configuration menu. After this change, it does for devices with `SERIAL`, and it builds successfully when selected. Testing performed with an STM32H743 image.

![image](https://github.com/user-attachments/assets/1d232f61-2bee-4a12-9044-1e3d08fa877f)