### PR TITLE
arch/arm64/imx9: Support for imx9 edgelock enclave

### DIFF
--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -86,6 +86,7 @@ endif
 ifeq ($(CONFIG_IMX9_BOOTLOADER), y)
   CHIP_CSRCS += imx9_system_ctl.c
   CHIP_CSRCS += imx9_trdc.c
+  CHIP_CSRCS += imx9_ele.c
 endif
 
 ifeq ($(CONFIG_IMX9_DDR_TRAINING),y)

--- a/arch/arm64/src/imx9/hardware/imx9_ele.h
+++ b/arch/arm64/src/imx9/hardware/imx9_ele.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm64/src/imx9/hardware/imx9_trdc.h
+ * arch/arm64/src/imx9/hardware/imx9_ele.h
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -20,8 +20,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_TRDC_H
-#define __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_TRDC_H
+#ifndef __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_ELE_H
+#define __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_ELE_H
 
 /****************************************************************************
  * Included Files
@@ -33,28 +33,48 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IMX9_TRDC_HWCFG0                (IMX9_TRDC_BASE + 0xf0)
+#define ELE_MAX_MSG             255U
+#define AHAB_VERSION            0x6
+#define AHAB_CMD_TAG            0x17
+#define AHAB_RESP_TAG           0xe1
+#define ELE_RELEASE_RDC_REQ     0xc4
+#define ELE_READ_FUSE_REQ       0x97
+#define ELE_GET_EVENTS          0xa2
+#define ELE_DERIVE_KEY_REQ      0xa9
+#define ELE_FWD_LIFECYCLE_UP    0x95
+#define ELE_OK                  0xd6
 
-#define IMX9_MBC0_MEM_GLBAC(n)          (0x20 + (n << 2))
-#define IMX9_MBC_MEM_BLK_CFG_0(m, n)    (0x200 * m + 0x40 + (n << 2))
-#define IMX9_MBC_MEM_BLK_CFG_I(m, n, i) (0x200 * m + 0x40 + (80 << 2) + (i - 1) * 0x28 + (n << 2))
-#define IMX9_MRC0_DOM_RGD_W(m, n)       (0x100 * m + 0x40 + (n << 3))
+#define ELE_MU_TCR (IMX9_S3MUA_BASE + 0x120)
+#define ELE_MU_TSR (IMX9_S3MUA_BASE + 0x124)
+#define ELE_MU_RCR (IMX9_S3MUA_BASE + 0x128)
+#define ELE_MU_RSR (IMX9_S3MUA_BASE + 0x12c)
 
-#define FSB_BASE                0x47510000UL
-#define FSB_SHADOW_OFF          0x8000UL
+#define ELE_RR_NUM        4
+#define ELE_TR_NUM        8
+#define ELE_MU_TR(i) (IMX9_S3MUA_BASE + 0x200 + (i) * 4)
+#define ELE_MU_RR(i) (IMX9_S3MUA_BASE + 0x280 + (i) * 4)
 
-#define BLK_CTRL_NS_ANOMIX_BASE  IMX9_BLK_CTRL_NS_AONMIX1_BASE
+#define FSB_LC_REG              0x4751041cUL
 
-#define DID_NUM 16
-#define MBC_MAX_NUM 4
-#define MRC_MAX_NUM 2
-#define MBC_NUM(HWCFG) ((HWCFG >> 16) & 0xF)
-#define MRC_NUM(HWCFG) ((HWCFG >> 24) & 0x1F)
+struct ele_header_t
+{
+  union
+    {
+      uint32_t data;
+      struct
+        {
+          uint32_t version : 8;
+          uint32_t size : 8;
+          uint32_t command : 8;
+          uint32_t tag : 8;
+        };
+    };
+};
 
-#define MBC_BLK_NUM(GLBCFG) (GLBCFG & 0x3FF)
-#define MRC_RGN_NUM(GLBCFG) (GLBCFG & 0x1F)
+struct ele_msg
+{
+  struct ele_header_t header;
+  uint32_t data[(ELE_MAX_MSG - 1)];
+};
 
-#define GLBAC_SETTING_MASK (0x7777)
-#define GLBAC_LOCK_MASK	BIT(31)
-
-#endif /* __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_TRDC_H */
+#endif /* __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX9_ELE_H */

--- a/arch/arm64/src/imx9/imx9_ele.c
+++ b/arch/arm64/src/imx9/imx9_ele.c
@@ -1,0 +1,319 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_ele.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <nuttx/arch.h>
+#include <nuttx/clock.h>
+#include <debug.h>
+
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm64_internal.h"
+#include "imx9_ele.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define mmio_read_32(c)                       getreg32(c)
+#define mmio_write_32(c, v)                   putreg32(v, c)
+#define mmio_clrbits_32(addr, clear)          modifyreg32(addr, clear, 0)
+#define mmio_setbits_32(addr, set)            modifyreg32(addr, 0, set)
+#define mmio_clrsetbits_32(addr, clear, set)  modifyreg32(addr, clear, set)
+
+#define upper_32_bits(n) ((uint32_t)(((n) >> 16) >> 16))
+#define lower_32_bits(n) ((uint32_t)(n))
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct ele_msg msg;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_ele_sendmsg
+ *
+ * Description:
+ *   This function communicates with the Advanced High Assurance Boot (AHAB)
+ *   image that should reside in the particular address. This function
+ *   sends a message to AHAB.
+ *
+ * Input Parameters:
+ *   msg_ptr         -  Message to send
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void imx9_ele_sendmsg(struct ele_msg *msg_ptr)
+{
+  /* Check that ele is ready to receive */
+
+  while (!((1) & getreg32(ELE_MU_TSR)));
+
+  /* write header to slog 0 */
+
+  putreg32(msg_ptr->header.data, ELE_MU_TR(0));
+
+  /* write data */
+
+  for (int i = 1; i < msg_ptr->header.size; i++)
+    {
+      int tx_channel;
+
+      tx_channel = i % ELE_TR_NUM;
+      while (!((1 << tx_channel) & getreg32(ELE_MU_TSR)));
+
+      /* Write data */
+
+      putreg32(msg_ptr->data[i - 1], ELE_MU_TR(tx_channel));
+    }
+}
+
+/****************************************************************************
+ * Name: imx9_ele_receivemsg
+ *
+ * Description:
+ *   This function communicates with the Advanced High Assurance Boot (AHAB)
+ *   image that should reside in the particular address. This function
+ *   receives message from AHAB.
+ *
+ * Input Parameters:
+ *   msg_ptr         -  receive message buffer
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void imx9_ele_receivemsg(struct ele_msg *msg_ptr)
+{
+  /* Check if data ready */
+
+  while (!((1) & getreg32(ELE_MU_RSR)));
+
+  /* Read Header from slot 0 */
+
+  msg_ptr->header.data = getreg32(ELE_MU_RR(0));
+
+  for (int i = 1; i < msg_ptr->header.size; i++)
+    {
+      /* Check if empty */
+
+      int rx_channel = (i) % ELE_RR_NUM;
+      while (!((1 << rx_channel) & getreg32(ELE_MU_RSR)));
+
+      /* Read data */
+
+      msg_ptr->data[i - 1] = getreg32(ELE_MU_RR(rx_channel));
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void imx9_ele_init(void)
+{
+  putreg32(0, ELE_MU_TCR);
+  putreg32(0, ELE_MU_RCR);
+}
+
+int imx9_ele_release_rdc(uint32_t rdc_id)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 2;
+  msg.header.command = ELE_RELEASE_RDC_REQ;
+  msg.data[0] = rdc_id;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+uint32_t imx9_ele_read_common_fuse(uint32_t fuse_id)
+{
+  uint32_t value = 0;
+
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 2;
+  msg.header.command = ELE_READ_FUSE_REQ;
+  msg.data[0] = fuse_id;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      value = msg.data[1];
+    }
+
+  return value;
+}
+
+int imx9_ele_get_key(uint8_t *key, size_t key_size,
+                     uint8_t *ctx, size_t ctx_size)
+{
+  if (!key)
+    {
+      _err("Invalid key parameter\n");
+      return -EINVAL;
+    }
+
+  if (!ctx)
+    {
+      _err("Invalid context parameter\n");
+      return -EINVAL;
+    }
+
+  if ((key_size != 16) && (key_size != 32))
+    {
+      _err("Invalid key size\n");
+      return -EINVAL;
+    }
+
+  if (!IS_ALIGNED((uintptr_t)key, ARMV8A_DCACHE_LINESIZE))
+    {
+      _err("Invalid key alignment\n");
+      return -EINVAL;
+    }
+
+  if (!IS_ALIGNED((uintptr_t)ctx, ARMV8A_DCACHE_LINESIZE))
+    {
+      _err("Invalid context alignment\n");
+      return -EINVAL;
+    }
+
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 7;
+  msg.header.command = ELE_DERIVE_KEY_REQ;
+  msg.data[0] = upper_32_bits((ulong)key);
+  msg.data[1] = lower_32_bits((ulong)key);
+  msg.data[2] = upper_32_bits((ulong)ctx);
+  msg.data[3] = lower_32_bits((ulong)ctx);
+  msg.data[4] = ((ctx_size << 16) | key_size);
+
+  uint32_t crc = msg.header.data;
+  for (uint32_t i = 0; i < msg.header.size - 2; i++)
+    {
+      crc ^= msg.data[i];
+    }
+
+  msg.data[5] = crc;
+
+  up_flush_dcache((uintptr_t)ctx, (uintptr_t)(ctx + ctx_size));
+  up_invalidate_dcache((uintptr_t)key, (uintptr_t)(key + key_size));
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  up_invalidate_dcache((uintptr_t)key, (uintptr_t)(key + key_size));
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size)
+{
+  size_t events_num;
+  size_t i;
+
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 1;
+  msg.header.command = ELE_GET_EVENTS;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      events_num = msg.data[1] & 0xffff;
+      if (buffer)
+        {
+          for (i = 0; (i < buffer_size) && (i < events_num); i++)
+            {
+              buffer[i] =  msg.data[i + 2];
+            }
+
+          return (int)i;
+        }
+      else
+        {
+          return (int)events_num;
+        }
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_close_device(void)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 2;
+  msg.header.command = ELE_FWD_LIFECYCLE_UP;
+  msg.data[0] = 0x08;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+uint32_t imx9_ele_get_lifecycle(void)
+{
+  return (getreg32(FSB_LC_REG) & 0x3ff);
+}
+

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -1,0 +1,166 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_ele.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H
+#define __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "hardware/imx9_ele.h"
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_ele_init
+ *
+ * Description:
+ *   This function disable interrupts from AHAB
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void imx9_ele_init(void);
+
+/****************************************************************************
+ * Name: imx9_ele_release_rdc
+ *
+ * Description:
+ *   Trusted Resource Domain Controller AHAB interface.  This function
+ *   communicates with the Advanced High Assurance Boot (AHAB) image that
+ *   should reside in the particular address. This releases particular
+ *   resources.
+ *
+ * Input Parameters:
+ *   xrdc    -  RDC index
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_release_rdc(uint32_t rdc_id);
+
+/****************************************************************************
+ * Name: imx9_ele_read_common_fuse
+ *
+ * Description:
+ *   Trusted Resource Domain Controller AHAB interface.  This function
+ *   communicates with the Advanced High Assurance Boot (AHAB) image that
+ *   should reside in the particular address. This reads particular
+ *   fuse
+ *
+ * Input Parameters:
+ *   fuse_id    -  Fuse ID
+ *
+ * Returned Value:
+ *   Fuse value. Returns zero if read failed.
+ *
+ ****************************************************************************/
+
+uint32_t imx9_ele_read_common_fuse(uint32_t fuse_id);
+
+/****************************************************************************
+ * Name: imx9_ele_get_key
+ *
+ * Description:
+ *   Trusted Resource Domain Controller AHAB interface.  This function
+ *   communicates with the Advanced High Assurance Boot (AHAB) image that
+ *   should reside in the particular address. This returns HW unique
+ *   key value.
+ *
+ * Input Parameters:
+ *   key           -  Key buffer, must be cache line aligned
+ *   key_size      -  Key size in bytes, must be 16 or 32
+ *   ctx           -  Context buffer, must be cache line aligned
+ *   ctx_size      -  Context buffer size
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_key(uint8_t *key, size_t key_size,
+                     uint8_t *ctx, size_t ctx_size);
+
+/****************************************************************************
+ * Name: imx9_ele_get_events
+ *
+ * Description:
+ *   Trusted Resource Domain Controller AHAB interface.  This function
+ *   communicates with the Advanced High Assurance Boot (AHAB) image that
+ *   should reside in the particular address. This returns ELE events.
+ *
+ * Input Parameters:
+ *   buffer        -  Event buffer
+ *   buffer_size   -  Event buffer size
+ *
+ * Returned Value:
+ *  Zero (OK) is returned if no envents success. A negated errno value
+ *  is returned on failure. Positive value is number of events read.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size);
+
+/****************************************************************************
+ * Name: imx9_ele_close_device
+ *
+ * Description:
+ *   Trusted Resource Domain Controller AHAB interface.  This function
+ *   communicates with the Advanced High Assurance Boot (AHAB) image that
+ *   should reside in the particular address. This sets device to
+ *   OEM close state. This operation is irreversible.
+ *
+ * Returned Value:
+ *  Zero (OK) is returned if no envents success. A negated errno value
+ *  is returned on failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_close_device(void);
+
+/****************************************************************************
+ * Name: imx9_ele_get_lifecycle
+ *
+ * Description:
+ *   This returns devices lifecycle value
+ *
+ * Returned Value:
+ *  Lifecycle value
+ *
+ ****************************************************************************/
+
+uint32_t imx9_ele_get_lifecycle(void);
+
+#endif /* __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H */

--- a/tools/imx9/Config.mk
+++ b/tools/imx9/Config.mk
@@ -38,7 +38,7 @@ ifeq ($(CONFIG_IMX9_BOOTLOADER),y)
 	FILE_3_PATH = $(BASE_PATH)$(FILE_3)
 	FILE_EXE = $(BASE_PATH)mkimage_imx9
 	AHAB_BASE_URL = https://www.nxp.com/lgfiles/NMG/MAD/YOCTO
-	AHAB = firmware-ele-imx-0.1.1
+	AHAB = firmware-ele-imx-1.3.0-17945fc
 	AHAB_BINARY = $(AHAB).bin
 	AHAB_PATH = $(BASE_PATH)$(AHAB_BINARY)
 	FSPI_HEADER = fspi_header
@@ -84,7 +84,6 @@ define POSTBUILD
 	$(Q) sh tools$(DELIM)imx9$(DELIM)fspi_fcb_gen.sh tools$(DELIM)imx9$(DELIM)/fspi_header
 	$(Q) tools$(DELIM)imx9$(DELIM)mkimage_imx9$(HOSTEXEEXT) -soc IMX9 -dev flexspi -append $(BASE_PATH)$(AHAB)$(DELIM)mx93a1-ahab-container.img -c -ap nuttx.bin a55 0x2049a000 -fcb fcb.bin 0x204F0000 -out flash.bin 1>/dev/null 2>&1
 	$(Q) mv flash.bin flash.tmp
-
 	$(Q) echo "Append FCB to flash.bin"
 	$(Q) dd if=fcb.bin of=flash.bin bs=1k seek=1
 	$(Q) dd if=flash.tmp of=flash.bin bs=1k seek=4

--- a/tools/imx9/Makefile.host
+++ b/tools/imx9/Makefile.host
@@ -46,6 +46,6 @@ endif
 	$(call DELFILE, build_info.h)
 	$(call DELFILE, fspi_fcb_gen.sh)
 	$(call DELFILE, fspi_header)
-	$(call DELFILE, firmware-ele-imx-0.1.1.bin)
-	$(call DELDIR, firmware-ele-imx-0.1.1)
+	$(call DELFILE, firmware-ele-imx-1.3.0-17945fc.bin)
+	$(call DELDIR, firmware-ele-imx-1.3.0-17945fc)
 	$(call CLEAN)


### PR DESCRIPTION
## Summary

Moved imx9 edgelock enclave (ELE) handling from imx9_trdc.c to own imx9_ele.c file.
Add some new messages to ele API.
Updated ele fw version to 1.3.0.
Fix channel bug on imx9_ele_sendmsg() and imx9_ele_receivemsg()


## Impact

Impacts only imx93 bootloader sw.
New features, no impact on existing features.

## Testing

Tested with custom imx93 hardware
