### PR TITLE
fs/vfs/fs_poll: Add noinstrument_function to poll_notify function

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -272,6 +272,7 @@ void poll_default_cb(FAR struct pollfd *fds)
  *
  ****************************************************************************/
 
+noinstrument_function
 void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset)
 {
   int i;


### PR DESCRIPTION
## Summary

* fs/vfs/fs_poll: Add noinstrument_function to poll_notify function

Add the noinstrument_function attribute to the poll_notify function to avoid it looping if -finstrument-functions is set to the fs/vfs files.

## Impact

Impact on user:YES. Prevent a failure when instrumentation is enabled.

Impact on build: NO.

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

First of all, enable instrumentation for fs/vfs files with the following patch:
```
diff --git a/fs/vfs/Make.defs b/fs/vfs/Make.defs
index 30292d787f..e00b361407 100644
--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -22,6 +22,8 @@
 
 # Common file/socket descriptor support
 
+CFLAGS += -finstrument-functions
+
 CSRCS += fs_chstat.c fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c fs_epoll.c
 CSRCS += fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_pread.c fs_pwrite.c fs_read.c
```

Then, take the `esp32s3-devkit:tickless` default config and enable instrumentation and build it with the following commands:

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:tickless && \
kconfig-tweak -e CONFIG_SCHED_INSTRUMENTATION && \
kconfig-tweak -e CONFIG_SCHED_INSTRUMENTATION_DUMP && \
kconfig-tweak -e CONFIG_SCHED_INSTRUMENTATION_FILTER && \
kconfig-tweak -e CONFIG_SCHED_INSTRUMENTATION_FUNCTION && \
kconfig-tweak -e CONFIG_SYSTEM_TRACE && \
kconfig-tweak -e CONFIG_SYSTEM_SYSTEM && \
kconfig-tweak --set-val CONFIG_SYSTEM_NSH_PRIORITY 102 && \
kconfig-tweak -e CONFIG_DRIVERS_NOTE && \
kconfig-tweak -e CONFIG_DRIVERS_NOTECTL && \
kconfig-tweak -e CONFIG_DRIVERS_NOTERAM && \
kconfig-tweak --set-val CONFIG_DRIVERS_NOTERAM_BUFSIZE 32768 && \
kconfig-tweak -e CONFIG_DRIVERS_NOTERAM_DEFAULT_NOOVERWRITE && \
make olddefconfig && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BINDIR=./ -s -j$(nproc) && xtensa-esp32s3-elf-objdump -D nuttx  > objdump.flat && minicom -D /dev/ttyUSB0
```

### Running

#### Before this PR

Running it without this PR, the device fails to boot properly. It halts with the following serial log:
```
ESP-ROM:esp32s3-20210327                                                                                              
Build:Mar 27 2021                                                                                                     
rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fc94350,len:0xdec
load:0x40374000,len:0x539c
SHA-256 comparison failed:
Calculated: 662c19f6d3c8aa629f7a49122ddff861ccb85ccca96f9d347cd4082718ea9f31
Expected: 00000000309e0000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x40374df4
*** Booting NuttX ***
dram: lma 0x00000020 vma 0x3fc94350 len 0xdec    (3564)
iram: lma 0x00000e14 vma 0x40374000 len 0x539c   (21404)
padd: lma 0x000061c8 vma 0x00000000 len 0x9e30   (40496)
imap: lma 0x00010000 vma 0x42010000 len 0x20cc4  (134340)
padd: lma 0x00030ccc vma 0x00000000 len 0xf32c   (62252)
dmap: lma 0x00040000 vma 0x3c050000 len 0x9834   (38964)
total segments stored 6
```

By debugging it using GDB + OpenOCD, it can be seen that the function [`poll_notify`](https://github.com/apache/incubator-nuttx/blob/4e70cc1e696fd6de36da69019411869aeb2bfa73/fs/vfs/fs_poll.c#L275) keeps looping after instrumentation is enabled because this function itself is being instrumented. Check the following GDB backtrace at [`noteram_add`](https://github.com/apache/incubator-nuttx/blob/f22b93b337c2f9de457904596688a04bd1ce12e5/drivers/note/noteram_driver.c#L691):

```
Thread 1 "esp32s3.cpu0" hit Breakpoint 1, noteram_add (driver=0x3fc94b9c <g_note_drivers>, note=0x1, notelen=1070109696) at note/noteram_driver.c:693
+bt
#0  noteram_add (driver=0x3fc94b9c <g_note_drivers>, note=0x1, notelen=1070109696) at note/noteram_driver.c:693
#1  0x42014a98 in sched_note_event_ip (tag=0, ip=1107422816, event=31 '\037', buf=0x0, len=0)
    at note/note_driver.c:1524
#2  0x42014534 in note_driver_instrument_enter (this_fn=0x4201ee60 <poll_notify>, 
    call_site=0x42014981 <noteram_add+225>, arg=0x0) at note/note_initialize.c:60
#3  0x40379331 in __cyg_profile_func_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>)
    at misc/lib_instrument.c:70
#4  0x4201ee85 in poll_notify (afds=0x3fc94b98 <g_noteram_driver+48>, nfds=1, eventset=1) at vfs/fs_poll.c:282
#5  0x42014981 in noteram_add (driver=0x3fc94b68 <g_noteram_driver>, note=<optimized out>, notelen=20)
    at note/noteram_driver.c:741
#6  0x42014a98 in sched_note_event_ip (tag=0, ip=1107422816, event=31 '\037', buf=0x0, len=0)
    at note/note_driver.c:1524
#7  0x42014534 in note_driver_instrument_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>, arg=0x0) at note/note_initialize.c:60
#8  0x40379331 in __cyg_profile_func_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>) at misc/lib_instrument.c:70
#9  0x4201ee85 in poll_notify (afds=0x3fc94b98 <g_noteram_driver+48>, nfds=1, eventset=1) at vfs/fs_poll.c:282
#10 0x42014981 in noteram_add (driver=0x3fc94b68 <g_noteram_driver>, note=<optimized out>, notelen=20) at note/noteram_driver.c:741
#11 0x42014a98 in sched_note_event_ip (tag=0, ip=1107422816, event=31 '\037', buf=0x0, len=0) at note/note_driver.c:1524
#12 0x42014534 in note_driver_instrument_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>, arg=0x0) at note/note_initialize.c:60
#13 0x40379331 in __cyg_profile_func_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>) at misc/lib_instrument.c:70
#14 0x4201ee85 in poll_notify (afds=0x3fc94b98 <g_noteram_driver+48>, nfds=1, eventset=1) at vfs/fs_poll.c:282
#15 0x42014981 in noteram_add (driver=0x3fc94b68 <g_noteram_driver>, note=<optimized out>, notelen=20) at note/noteram_driver.c:741
#16 0x42014a98 in sched_note_event_ip (tag=0, ip=1107422816, event=31 '\037', buf=0x0, len=0) at note/note_driver.c:1524
#17 0x42014534 in note_driver_instrument_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>, arg=0x0) at note/note_initialize.c:60
#18 0x40379331 in __cyg_profile_func_enter (this_fn=0x4201ee60 <poll_notify>, call_site=0x42014981 <noteram_add+225>) at misc/lib_instrument.c:70
#19 0x4201ee85 in poll_notify (afds=0x3fc94b98 <g_noteram_driver+48>, nfds=1, eventset=1) at vfs/fs_poll.c:282
#20 0x42014981 in noteram_add (driver=0x3fc94b68 <g_noteram_driver>, note=<optimized out>, notelen=20) at note/noteram_driver.c:741
#21 0x42014a98 in sched_note_event_ip (tag=0, ip=1107428816, event=31 '\037', buf=0x0, len=0) at note/note_driver.c:1524
#22 0x42014534 in note_driver_instrument_enter (this_fn=0x420205d0 <register_driver>, call_site=0x42014999 <noteram_register+21>, arg=0x0) at note/note_initialize.c:60
#23 0x40379331 in __cyg_profile_func_enter (this_fn=0x420205d0 <register_driver>, call_site=0x42014999 <noteram_register+21>) at misc/lib_instrument.c:70
#24 0x420205ee in register_driver (path=0x3c0501bb "/dev/note/ram", fops=0x3c0501e0 <g_noteram_fops>, mode=438, priv=0x3fc94b68 <g_noteram_driver>) at driver/fs_registerdriver.c:68
#25 0x42014999 in noteram_register () at note/noteram_driver.c:1318
#26 0x4201454a in note_initialize () at note/note_initialize.c:153
#27 0x42014487 in drivers_initialize () at drivers_initialize.c:152
#28 0x42012186 in nx_start () at init/nx_start.c:697
#29 0x40374dee in __esp32s3_start () at chip/esp32s3_start.c:447
#30 0x40374eae in __start () at chip/esp32s3_start.c:500
```

Eventually, the stack would overflow and the firmware will crash. To avoid it, just disable instrumentation for `poll_notify`

### Results

By applying this patch, the device boots successfully:
```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fc94350,len:0xdec
load:0x40374000,len:0x539c
SHA-256 comparison failed:
Calculated: 97d616d462ad4ac173f88e9f2f1d2343ee71a5bc0f453d20237d1778180b4939
Expected: 00000000309e0000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x40374df4
*** Booting NuttX ***
dram: lma 0x00000020 vma 0x3fc94350 len 0xdec    (3564)
iram: lma 0x00000e14 vma 0x40374000 len 0x539c   (21404)
padd: lma 0x000061c8 vma 0x00000000 len 0x9e30   (40496)
imap: lma 0x00010000 vma 0x42010000 len 0x20c84  (134276)
padd: lma 0x00030c8c vma 0x00000000 len 0xf36c   (62316)
dmap: lma 0x00040000 vma 0x3c050000 len 0x9834   (38964)
total segments stored 6

NuttShell (NSH) NuttX-10.4.0
nsh> 
```