### PR TITLE
boards/arm/nrf52/nrf52840-dk: add GPIO driver based on leds and buttons

### DIFF
--- a/boards/arm/nrf52/nrf52840-dk/Kconfig
+++ b/boards/arm/nrf52/nrf52840-dk/Kconfig
@@ -9,4 +9,11 @@ config NRF52840DK_HIGHPRI
 	bool "High priority interrupt test"
 	default n
 
+config NRF52840DK_BTNLEDS_GPIO
+	bool "Export board LEDS and BUTTONS as GPIO"
+	default n
+	depends on !ARCH_LEDS && !ARCH_BUTTONS && GPIO_LOWER_HALF && DEV_GPIO
+	---help---
+		Export board LEDS and buttons as GPIOs.
+
 endif

--- a/boards/arm/nrf52/nrf52840-dk/src/CMakeLists.txt
+++ b/boards/arm/nrf52/nrf52840-dk/src/CMakeLists.txt
@@ -36,6 +36,10 @@ if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS nrf52_buttons.c)
 endif()
 
+if(CONFIG_NRF52840DK_BTNLEDS_GPIO)
+  list(APPEND SRCS nrf52_gpio.c)
+endif()
+
 if(CONFIG_NRF52_SPI_MASTER)
   list(APPEND SRCS nrf52_spi.c)
 endif()

--- a/boards/arm/nrf52/nrf52840-dk/src/Make.defs
+++ b/boards/arm/nrf52/nrf52840-dk/src/Make.defs
@@ -38,6 +38,10 @@ ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += nrf52_buttons.c
 endif
 
+ifeq ($(CONFIG_NRF52840DK_BTNLEDS_GPIO),y)
+CSRCS += nrf52_gpio.c
+endif
+
 ifeq ($(CONFIG_NRF52_SPI_MASTER),y)
 CSRCS += nrf52_spi.c
 endif

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52840-dk.h
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52840-dk.h
@@ -203,5 +203,17 @@ int nrf52_adc_setup(void);
 int nrf52_mx25_initialize(void);
 #endif
 
+/****************************************************************************
+ * Name: nrf52_gpioleds_initialize
+ *
+ * Description:
+ *   Initialize GPIO devices with board LEDS and buttons.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NRF52840DK_BTNLEDS_GPIO
+int nrf52_gpioleds_initialize(void);
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __BOARDS_ARM_NRF52_NRF52840_DK_SRC_NRF52840_DK_H */

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
@@ -173,6 +173,15 @@ int nrf52_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_NRF52840DK_BTNLEDS_GPIO
+  ret = nrf52_gpioleds_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: nrf52_gpioleds_initialize() failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_INPUT_BUTTONS
   /* Register the BUTTON driver */
 

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_gpio.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_gpio.c
@@ -1,0 +1,191 @@
+/****************************************************************************
+ * boards/arm/nrf52/nrf52840-dk/src/nrf52_gpio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/ioexpander/gpio.h>
+
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+#include "nrf52840-dk.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct nrf52gpio_dev_s
+{
+  struct gpio_dev_s gpio;
+  uint8_t           id;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct gpio_operations_s gpin_ops =
+{
+  .go_read   = gpin_read,
+  .go_write  = NULL,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+
+static const struct gpio_operations_s gpout_ops =
+{
+  .go_read   = gpout_read,
+  .go_write  = gpout_write,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+
+/* Buttons as inputs */
+
+static const uint32_t g_gpioinputs[NUM_BUTTONS] =
+{
+  GPIO_BUTTON1,
+  GPIO_BUTTON2,
+  GPIO_BUTTON3,
+  GPIO_BUTTON4
+};
+
+static struct nrf52gpio_dev_s g_gpin[NUM_BUTTONS];
+
+/* Leds as outputs */
+
+static const uint32_t g_gpiooutputs[BOARD_NLEDS] =
+{
+#if 0 < BOARD_NLEDS
+  GPIO_LED1,
+#endif
+#if 1 < BOARD_NLEDS
+  GPIO_LED2,
+#endif
+#if 2 < BOARD_NLEDS
+  GPIO_LED3,
+#endif
+#if 3 < BOARD_NLEDS
+  GPIO_LED4,
+#endif
+};
+
+static struct nrf52gpio_dev_s g_gpout[BOARD_NLEDS];
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
+{
+  struct nrf52gpio_dev_s *io = (struct nrf52gpio_dev_s *)dev;
+
+  *value = nrf52_gpio_read(g_gpioinputs[io->id]);
+  return OK;
+}
+
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
+{
+  struct nrf52gpio_dev_s *io = (struct nrf52gpio_dev_s *)dev;
+
+  *value = nrf52_gpio_read(g_gpiooutputs[io->id]);
+  return OK;
+}
+
+static int gpout_write(struct gpio_dev_s *dev, bool value)
+{
+  struct nrf52gpio_dev_s *io = (struct nrf52gpio_dev_s *)dev;
+
+  nrf52_gpio_write(g_gpiooutputs[io->id], value);
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf52_gpioleds_initialize
+ *
+ * Description:
+ *   Initialize GPIO devices with board LEDS and buttons.
+ *
+ ****************************************************************************/
+
+int nrf52_gpioleds_initialize(void)
+{
+  int i;
+  int pincount = 0;
+
+  /* Inputs */
+
+  for (i = 0; i < NUM_BUTTONS; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
+      g_gpin[i].gpio.gp_ops     = &gpin_ops;
+      g_gpin[i].id              = i;
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
+
+      /* Configure the pin that will be used as input */
+
+      nrf52_gpio_config(g_gpioinputs[i]);
+
+      pincount++;
+    }
+
+  /* Outputs */
+
+  for (i = 0; i < BOARD_NLEDS; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
+      g_gpout[i].gpio.gp_ops     = &gpout_ops;
+      g_gpout[i].id              = i;
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
+
+      /* Configure the pin that will be used as input */
+
+      nrf52_gpio_config(g_gpiooutputs[i]);
+
+      pincount++;
+    }
+
+  return OK;
+}

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_userleds.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_userleds.c
@@ -36,7 +36,7 @@
 #include "arm_internal.h"
 #include "nrf52840-dk.h"
 
-#ifndef CONFIG_ARCH_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && !defined(CONFIG_NRF52840DK_LEDS_GPIO)
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -147,4 +147,4 @@ void board_userled_all(uint32_t ledset)
     }
 }
 
-#endif /* !CONFIG_ARCH_LEDS */
+#endif /* !defined(CONFIG_ARCH_LEDS) && !defined(CONFIG_NRF52840DK_LEDS_GPIO) */


### PR DESCRIPTION
## Summary

* boards/arm/nrf52/nrf52840-dk: add GPIO driver based on leds and buttons
With this change we can use on board leds and buttons with gpio driver

## Impact

leds and buttons can be used with gpio driver when `CONFIG_NRF52840DK_BTNLEDS_GPIO=y`

## Testing

nrf52840-dk with custom app that use gpio driver interface

