### PR TITLE
Documentation/uorb: fix typo in uorb chapter

### DIFF
--- a/Documentation/applications/system/uorb/index.rst
+++ b/Documentation/applications/system/uorb/index.rst
@@ -28,7 +28,7 @@ For example, if the accelerometer sensor has a sampling rate of 50Hz
 and a maximum publication delay of 100ms, the hardware generates an
 interrupt every 100ms, publishing 5 data points each time (100/(1000/50)).
 
-**Two Tpyes**
+**Two Types**
 ^^^^^^^^^^^^^
 
 Additionally, NuttX categorizes topics into two types: 


### PR DESCRIPTION
## Summary

Documentation/uorb: fix typo in uorb chapter

fix typo "Two Tpyes" -> "Two Types"

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check