### PR TITLE
arch/risc-v/mpfs ethernet improvements

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -767,6 +767,13 @@ endchoice # GMAC speed
 
 endif # !MPFS_MAC_AUTONEG
 
+config MPFS_ETHMAC_HPWORK
+	bool "Use HP workqueue"
+	default n
+	depends on MPFS_ETHMAC
+	---help---
+		Select HPWORK workqueue for eth ISR work
+
 config MPFS_ETHMAC_MDC_CLOCK_SOURCE_HZ
 	int "MDC Clock Source (Hz)"
 	default 125000000

--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -700,6 +700,14 @@ config MPFS_PHYINIT
 	---help---
 		call mpfs_phy_boardinitialize() on init
 
+config MPFS_PHY_RX_TIMEOUT_WA
+	int "RX restart timeout workaround"
+	default 0
+	---help---
+		This is a workaround for LAN8742A rev A and B silicon errata.
+		Reset ETH interface in case no RX packets have been received
+		in configured time. Set to 0 to disable.
+
 config MPFS_ETH0_PHY_KSZ9477
 	bool "Use ksz9477 switch as an SGMII PHY for ETH0"
 	default n

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -63,6 +63,8 @@
 #include "hardware/mpfs_ethernet.h"
 #include "hardware/mpfs_mpucfg.h"
 
+#define SIZE_ALIGNED_64(m) (((m) + (0x3f)) & ~0x3f)
+
 #if defined(CONFIG_MPFS_ETH0_PHY_KSZ9477) ||\
     defined(CONFIG_MPFS_ETH1_PHY_KSZ9477)
 #  if !defined(CONFIG_MPFS_MAC_SGMII)
@@ -129,20 +131,17 @@
 #  define CONFIG_MPFS_ETHMAC_NTXBUFFERS  (8)
 #endif
 
-/* GMAC buffer sizes
- * REVISIT: do we want to make GMAC_RX_UNITSIZE configurable?
- * issue when using the MTU size receive block
- */
-
-#define GMAC_RX_UNITSIZE  (512)                  /* Fixed size for RX buffer */
-#define GMAC_TX_UNITSIZE  CONFIG_NET_ETH_PKTSIZE /* MAX size for Ethernet packet */
-
 /* The MAC can support frame lengths up to 1536 bytes */
 
 #define GMAC_MAX_FRAMELEN (1536)
 #if CONFIG_NET_ETH_PKTSIZE > GMAC_MAX_FRAMELEN
 #  error CONFIG_NET_ETH_PKTSIZE is too large
 #endif
+
+/* Max size of RX and TX buffers */
+
+#define GMAC_RX_UNITSIZE SIZE_ALIGNED_64(GMAC_MAX_FRAMELEN)
+#define GMAC_TX_UNITSIZE SIZE_ALIGNED_64(CONFIG_NET_ETH_PKTSIZE)
 
 /* for DMA dma_rxbuf_size */
 

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -2246,7 +2246,8 @@ static int mpfs_phyfind(struct mpfs_ethmac_s *priv, uint8_t *phyaddr)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_NET) && defined(CONFIG_DEBUG_INFO)
+#if defined(CONFIG_DEBUG_NET) && defined(CONFIG_DEBUG_INFO) && \
+  defined(ETH_HAS_MDIO_PHY)
 static void mpfs_phydump(struct mpfs_ethmac_s *priv)
 {
   uint16_t phyval;
@@ -2601,6 +2602,8 @@ static void mpfs_linkspeed(struct mpfs_ethmac_s *priv)
 
   mac_putreg(priv, NETWORK_CONFIG, regval);
   mac_putreg(priv, NETWORK_CONTROL, ncr);
+
+  mpfs_phydump(priv);
 }
 #endif
 

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -100,8 +100,6 @@
 
 #  if defined(CONFIG_MPFS_ETHMAC_HPWORK)
 #    define ETHWORK HPWORK
-#  elif defined(CONFIG_MPFS_ETHMAC_LPWORK)
-#    define ETHWORK LPWORK
 #  else
 #    define ETHWORK LPWORK
 #  endif
@@ -272,6 +270,7 @@ struct mpfs_ethmac_s
   struct wdog_s txtimeout;                       /* TX timeout timer */
   struct work_s irqwork;                         /* For deferring interrupt work to the work queue */
   struct work_s pollwork;                        /* For deferring poll work to the work queue */
+  struct work_s timeoutwork;                     /* For managing timeouts */
 
   /* This holds the information visible to the NuttX network */
 
@@ -2888,7 +2887,7 @@ static void mpfs_txtimeout_expiry(wdparm_t arg)
 
   /* Schedule to perform the TX timeout processing on the worker thread. */
 
-  work_queue(ETHWORK, &priv->irqwork, mpfs_txtimeout_work, priv, 0);
+  work_queue(LPWORK, &priv->timeoutwork, mpfs_txtimeout_work, priv, 0);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -3368,6 +3368,17 @@ static int mpfs_phyinit(struct mpfs_ethmac_s *priv)
 {
   int ret = -EINVAL;
 
+#ifdef CONFIG_MPFS_PHYINIT
+  /* Perform any necessary, board-specific PHY initialization */
+
+  ret = mpfs_phy_boardinitialize(priv->intf);
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to initialize the PHY: %d\n", ret);
+      return ret;
+    }
+#endif
+
 #ifdef ETH_HAS_MDIO_PHY
 
   /* Configure PHY clocking */
@@ -3518,30 +3529,10 @@ static int mpfs_ethconfig(struct mpfs_ethmac_s *priv)
 
   ninfo("Entry\n");
 
-#ifdef CONFIG_MPFS_PHYINIT
-  /* Perform any necessary, board-specific PHY initialization */
-
-  ret = mpfs_phy_boardinitialize(priv->intf);
-  if (ret < 0)
-    {
-      nerr("ERROR: Failed to initialize the PHY: %d\n", ret);
-      return ret;
-    }
-#endif
-
   /* Reset the Ethernet block */
 
   ninfo("Reset the Ethernet block\n");
   mpfs_ethreset(priv);
-
-  /* Initialize the PHY */
-
-  ninfo("Initialize the PHY\n");
-  ret = mpfs_phyinit(priv);
-  if (ret < 0)
-    {
-      return ret;
-    }
 
   /* Initialize the MAC and DMA */
 


### PR DESCRIPTION
## Summary

This updates the mpfs_ethernet driver by picking the following corrections from TII/SSRC branches:
- Always use LPWORK queue for txtimeout handling. Txtimeout does lengthy operations such as initializing/polling PHY, so it is never good to put that into HPWORK
- Change the default workqueue for ethernet driver to LPWORK. Add a Kconfig variable to put it into HPWORK if needed
- Add a configurable recovery workaround for old LAN8742A cable diagnostics errata
- Optimize ifup, which did phyinit twice for no reason
- Set the GMAC_RX_UNITSIZE to the maximum frame length, this can't be configured smaller.

## Impact

Impacts only MPFS ethernet, improves reliability.

user changes: NO
build process changes: NO
documentation updates: NO
security implications: NO

## Testing

Build Host: Ubuntu 22.04
Target: icicle:hwtest & 3 custom HW designs.

