### PR TITLE
arch/xtensa: set PS.EXCM initial value to 1 while new thread created

### DIFF
--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -235,11 +235,11 @@ void up_initial_state(struct tcb_s *tcb)
   /* Set initial PS to int level 0, user mode. */
 
 #ifdef __XTENSA_CALL0_ABI__
-  xcp->regs[REG_PS] = PS_UM;
+  xcp->regs[REG_PS] = PS_UM | PS_EXCM;
 
 #else
   /* For windowed ABI set WOE and CALLINC (pretend task was 'call4'd). */
 
-  xcp->regs[REG_PS] = PS_UM | PS_WOE | PS_CALLINC(1);
+  xcp->regs[REG_PS] = PS_UM | PS_EXCM | PS_WOE | PS_CALLINC(1);
 #endif
 }


### PR DESCRIPTION
## Summary

To avoid level-1 interrupt break retrieve PC/A0/SP/A2 register, PS.EXCM set to 1 by CPU HW while handling exception/interrupt.

But if context switching happens and new thread created, the thread initial value of PS.EXCM is used.

Same behevior as ESP-IDF code:
https://github.com/espressif/esp-idf/blob/master/
components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c#L366

## Impact

PS.EXCM initial value while new thread created.

## Testing

tested by internal test case as below code

```
static void *BusyThread(void *arg) {
  (void)arg;  // Avoid compiler warning
  while (1) {
  }
  return NULL;
}

//-----------------------------------------------------------------------------
static void *DebugTestThread(void *arg) {
  printf("Test Thread\n");
  return NULL;
}

//-----------------------------------------------------------------------------
static void *TimeSliceThread(void *arg) {
  printf("Start TimeSliceThread\n");
  while (1) {
    usleep(500 * 1000);
  }
  return NULL;
}

//-----------------------------------------------------------------------------
int main(int argc, char *argv[]) {

  // Start priority=120 thread to induce Time Slice
  pthread_t thread;
  pthread_attr_t attr;
  struct sched_param param;

  pthread_attr_init(&attr);
  pthread_attr_getschedparam(&attr, &param);
  param.sched_priority = 120;
  pthread_attr_setschedparam(&attr, &param);
  pthread_create(&thread, &attr, TimeSliceThread, NULL);

  printf("\n\n******** Test Start ********\n");

  pthread_t busy_thread;
  pthread_create(&busy_thread, NULL, BusyThread, NULL);

  pthread_t test_thread;
  while(1) {
    pthread_create(&test_thread, NULL, DebugTestThread, NULL);
    pthread_join(test_thread, NULL);
  }
}
```

without this PR, the system freeze with 100% reproduce rate.
```
[2025-02-04 12:36:42.816] nsh> test
[2025-02-04 12:36:46.754] Start TimeSliceThread
[2025-02-04 12:36:46.754]
[2025-02-04 12:36:46.754]
[2025-02-04 12:36:46.754] ******** Test Start ********
[2025-02-04 12:36:46.944] Test Thread
・・・
[2025-02-04 12:38:59.005] Test Thread
[2025-02-04 12:38:59.504] Test Thread
[2025-02-04 12:39:00.019] Test Thread　                   <=== freeze after this output.
[2025-02-04 12:42:56.523] ets Jul 29 2019 12:21:46        <=== reboot manually
[2025-02-04 12:42:56.523]
[2025-02-04 12:42:56.523] rst:0x1 (POWERON_RESET),boot:0x17 (SPI_FAST_FLASH_BOOT)
[2025-02-04 12:42:56.543] configsip: 0, SPIWP:0xee
```