### PR TITLE
driver/mtd: ramtron multi-device spi bus support

### DIFF
--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -510,12 +510,13 @@ void rammtd_uninitialize(FAR struct mtd_dev_s *dev);
  *   Create and initialize a Ramtron MTD device instance.
  *
  * Input Parameters:
- *   start - Address of the beginning of the allocated RAM regions.
- *   size  - The size in bytes of the allocated RAM region.
+ *   dev  - Pointer to the SPI device instance.
+ *   spi_devid - SPI device ID to manage CS lines in board
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *ramtron_initialize(FAR struct spi_dev_s *dev);
+FAR struct mtd_dev_s *ramtron_initialize(FAR struct spi_dev_s *dev,
+                                         uint16_t spi_devid);
 
 /****************************************************************************
  * Name: sst25_initialize


### PR DESCRIPTION
Adds a device ID to `ramtron_initialize`, which is stored in the `ramtron_dev_s` structure. This ID is used when calling SPI_SELECT to board specific logic to allow chip select on the SPI bus.

This change is NOT backwards compatible, as it changes the function signature of `ramtron_initialize`.

This implementation is based on the handling of chip select in `nuttx/drivers/mtd/sst26.c:sst26_initialize_spi()`.

Additional Changes:
  - Add MB85RS64V to ramtron supported parts list.

Additional contributors: @ArrestedLightning 

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change makes the ramtron driver compatible with boards that have more than one memory device per SPI peripheral. Its implementation is based on other mtd drivers such as `sst26.c`.

Before this change the ramtron driver exclusively called `SPIDEV_FLASH(0)`. With this change, the SPI device ID is provided during initialization and used with `SPIDEV_FLASH` calls in the driver. This allows control over chip select in board specific code. 

## Impact

This change **breaks backwards compatibility:** it changes the function signature of `ramtron_initialize` from `ramtron_initialize(FAR struct spi_dev_s *)` to `ramtron_initialize(FAR struct spi_dev_s *, uint16_t)`.

## Testing

Target used for testing is a custom board:
- CPU: STM32H753BIT6
- FRAM and FLASH on SPI4
  - FRAM chip: MB85RS256B
  - FLASH chip: MX25L25645G

Build Host:
- Ubuntu 24.04
- Arm GNU Toolchain 13.3.rel1 x86_64 arm-none-eabi