### PR TITLE
drivers/sensors/fakesensor: Add baro sensor type to fakesensor

### DIFF
--- a/drivers/sensors/fakesensor_uorb.c
+++ b/drivers/sensors/fakesensor_uorb.c
@@ -197,6 +197,20 @@ static inline void fakesensor_read_gyro(FAR struct fakesensor_s *sensor,
                     sizeof(struct sensor_gyro));
 }
 
+static inline void fakesensor_read_baro(FAR struct fakesensor_s *sensor,
+                                        uint64_t event_timestamp)
+{
+  struct sensor_baro baro;
+  char raw[50];
+
+  fakesensor_read_csv_line(&sensor->data, raw, sizeof(raw),
+                           sensor->raw_start);
+  sscanf(raw, "%f,%f\n", &baro.pressure, &baro.temperature);
+  baro.timestamp = event_timestamp;
+  sensor->lower.push_event(sensor->lower.priv, &baro,
+                           sizeof(struct sensor_baro));
+}
+
 static inline void fakesensor_read_gnss(FAR struct fakesensor_s *sensor)
 {
   char raw[150];
@@ -293,6 +307,10 @@ void fakesensor_push_event(FAR struct fakesensor_s *sensor,
 
     case SENSOR_TYPE_GYROSCOPE:
       fakesensor_read_gyro(sensor, event_timestamp);
+      break;
+
+    case SENSOR_TYPE_BAROMETER:
+      fakesensor_read_baro(sensor, event_timestamp);
       break;
 
     case SENSOR_TYPE_GNSS:


### PR DESCRIPTION
## Summary

Allow fakesensor to read baro data and publish it in the same way as the other supported fakesensor data types. Adds a single function that reads from a CSV file and publishes new data.

## Impact

Fakesensor now supports baro data. Slightly more convenient to debug systems that use barometers.

## Testing

Testing was performed on the NuttX simulator with the sim:nsh configuration (and run on Ubuntu - WSL2). The changes were tested by creating a fakesensor and providing a CSV file with sample barometric data. The data was then collected and printed using the `uorb_listener` application

```
nsh> uorb_listener -r 50 -n 10 sensor_baro0

Mointor objects num:1
object_name:sensor_baro, object_instance:0
sensor_baro(now:68460409):timestamp:68460374,pressure:976.869995,temperature:24.600000
sensor_baro(now:68490498):timestamp:68490460,pressure:976.880005,temperature:24.600000
sensor_baro(now:68530398):timestamp:68530364,pressure:976.669983,temperature:24.600000
sensor_baro(now:68560472):timestamp:68560437,pressure:976.830017,temperature:24.600000
sensor_baro(now:68590508):timestamp:68590473,pressure:976.809998,temperature:24.600000
sensor_baro(now:68630274):timestamp:68630246,pressure:976.440002,temperature:24.600000
sensor_baro(now:68660253):timestamp:68660234,pressure:975.960022,temperature:24.600000
sensor_baro(now:68690264):timestamp:68690245,pressure:975.880005,temperature:24.600000
sensor_baro(now:68720338):timestamp:68720314,pressure:976.340027,temperature:24.600000
sensor_baro(now:68750468):timestamp:68750426,pressure:975.659973,temperature:24.600000
Object name:sensor_baro0, recieved:10
Total number of received Message:10/10
```

