### PR TITLE
 arch/arm/stm32: fix stm32f1xx alarm support 

### DIFF
--- a/arch/arm/src/stm32/stm32_alarm.h
+++ b/arch/arm/src/stm32/stm32_alarm.h
@@ -43,6 +43,14 @@
 
 typedef void (*alarmcb_t)(void);
 
+/* Structure used to pass parameters to query an alarm */
+
+struct alm_rdalarm_s
+{
+  int ar_id;                    /* enum alm_id_e */
+  FAR struct rtc_time *ar_time; /* Argument for storing ALARM RTC time */
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -89,6 +97,22 @@ int stm32_rtc_setalarm(const struct timespec *tp, alarmcb_t callback);
  ****************************************************************************/
 
 int stm32_rtc_cancelalarm(void);
+
+/****************************************************************************
+ * Name: stm32_rtc_rdalarm
+ *
+ * Description:
+ *   Query an alarm configured in hardware.
+ *
+ * Input Parameters:
+ *  alminfo - Information about the alarm configuration.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int stm32_rtc_rdalarm(FAR struct alm_rdalarm_s *alminfo);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
@@ -745,9 +745,16 @@ static int stm32_rdalarm(struct rtc_lowerhalf_s *lower,
   irqstate_t flags;
 
   DEBUGASSERT(lower != NULL && alarminfo != NULL && alarminfo->time != NULL);
+#if defined(CONFIG_STM32_STM32F4XXX) || defined(CONFIG_STM32_STM32L15XX)
   DEBUGASSERT(alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB);
 
   if (alarminfo->id == RTC_ALARMA || alarminfo->id == RTC_ALARMB)
+#else
+  DEBUGASSERT(alarminfo->id >= 0 && alarminfo->id < CONFIG_RTC_NALARMS);
+
+  if (alarminfo != NULL && alarminfo->id >= 0 &&
+      alarminfo->id < CONFIG_RTC_NALARMS)
+#endif
     {
       /* Disable pre-emption while we do this so that we don't have to worry
        * about being suspended and working on an old time.


### PR DESCRIPTION
Summary: 
stm32: support querying a previously set RTC alarm In the STM32F1xx series

Impact:
When using the stm32f1xx series MCU, the alarm function can be used, but when we enabled the CONFIG_RTC_ALARM configuration, an error was reported due to the inability to find the specific implementation of rdalarm.

Testing: 
In our own projects, we have done alarm verification using the STM32F103RE..
