### PR TITLE
drivers/thermal: Update state when temp is stable

### DIFF
--- a/drivers/thermal/thermal_step_wise.c
+++ b/drivers/thermal/thermal_step_wise.c
@@ -134,6 +134,10 @@ static unsigned int get_target_state(FAR struct thermal_instance_s *instance,
                 return validate_state(instance, throttle, cur_state, 1);
               }
           }
+        else
+          {
+            return validate_state(instance, throttle, cur_state, -1);
+          }
         break;
 
       default:


### PR DESCRIPTION
## Summary
Update state when temp is stable, fix cooling state not decreasing error when the temperature is kept at low trip(stable, not dropping).

## Impact
drivers/thermal;

## Testing
Test on "sim:thermal", log is from /proc/thermal/cpu-thermal.
Please see [thermal/thermal_dummy.c](https://github.com/apache/nuttx/blob/master/drivers/thermal/thermal_dummy.c#L111) for trip point details.
```bash
# The temperature decreasing from 71 to 65 and then kept.
z:cpu-thermal t:71 t:1 h:16 l:0 c:fan0 s:16|16

# Without this patch, the cooling state of "fan0" will be kept at 15, even if the temperature is at a lower trip:
z:cpu-thermal t:65 t:1 h:16 l:0 c:fan0 s:15|15
... ...
z:cpu-thermal t:65 t:1 h:16 l:0 c:fan0 s:15|15

# With this patch, the cooling state of "fan0" was continually decreasing to zero according to current trip point:
z:cpu-thermal t:65 t:1 h:16 l:0 c:fan0 s:15|15
... ...
z:cpu-thermal t:65 t:1 h:16 l:0 c:fan0 s:0|0
```
