### PR TITLE
[Draft]libs/instrument: add instrument level check to avoid nesting loops

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -717,6 +717,9 @@ struct tcb_s
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
   spinlock_t mutex_lock;
 #endif
+
+  atomic_t instr_level_enter;
+  atomic_t instr_level_exit;
 };
 
 /* struct task_tcb_s ********************************************************/


### PR DESCRIPTION
## Summary

libs/instrument: add instrument level check to avoid nesting loops

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, enable vfs instrument functions

```
diff --git a/fs/vfs/Make.defs b/fs/vfs/Make.defs
index 30292d787f..e00b361407 100644
--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -22,6 +22,8 @@
 
 # Common file/socket descriptor support
 
+CFLAGS += -finstrument-functions
+
 CSRCS += fs_chstat.c fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c fs_epoll.c
 CSRCS += fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_pread.c fs_pwrite.c fs_read.c
```

```
$ git diff .
diff --git a/boards/sim/sim/sim/configs/nsh/defconfig b/boards/sim/sim/sim/configs/nsh/defconfig
index 8517209444..496336d268 100644
--- a/boards/sim/sim/sim/configs/nsh/defconfig
+++ b/boards/sim/sim/sim/configs/nsh/defconfig
@@ -24,6 +24,7 @@ CONFIG_DEBUG_FEATURES=y
 CONFIG_DEBUG_SYMBOLS=y
 CONFIG_DEV_GPIO=y
 CONFIG_DEV_LOOP=y
+CONFIG_DRIVERS_NOTE=y
 CONFIG_ETC_FATDEVNO=2
 CONFIG_ETC_ROMFS=y
 CONFIG_ETC_ROMFSDEVNO=1
@@ -64,6 +65,14 @@ CONFIG_READLINE_TABCOMPLETION=y
 CONFIG_SCHED_BACKTRACE=y
 CONFIG_SCHED_EVENTS=y
 CONFIG_SCHED_HAVE_PARENT=y
+CONFIG_SCHED_INSTRUMENTATION=y
+CONFIG_SCHED_INSTRUMENTATION_DUMP=y
+CONFIG_SCHED_INSTRUMENTATION_FILTER=y
+CONFIG_SCHED_INSTRUMENTATION_FUNCTION=y
+CONFIG_SCHED_INSTRUMENTATION_HEAP=y
+CONFIG_SCHED_INSTRUMENTATION_PREEMPTION=y
+CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
+CONFIG_SCHED_INSTRUMENTATION_WDOG=y
 CONFIG_SCHED_WAITPID=y
 CONFIG_SIM_HOSTFS=y
 CONFIG_SIM_WALLTIME_SIGNAL=y

```