### PR TITLE
sched: simplify call of get current tcb

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -86,7 +86,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   struct lib_syslograwstream_s stream;
   int ret = 0;
 #ifdef CONFIG_SYSLOG_PROCESS_NAME
-  FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid());
+  FAR struct tcb_s *tcb = nxsched_self();
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
   struct timespec ts;

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -111,12 +111,15 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
   if (pid == 0)
     {
-      pid = nxsched_gettid();
+      tcb = this_task();
+    }
+  else
+    {
+      tcb = nxsched_get_tcb(pid);
     }
 
   /* Verify that the pid corresponds to a real task */
 
-  tcb = nxsched_get_tcb(pid);
   if (!tcb)
     {
       return -ESRCH;


### PR DESCRIPTION
## Summary

sched: simplify call of get current tcb

Replace get current tcb method from nxsched_get_tcb(nxsched_gettid()) to this_task(),
change two function calls with inline function to improve performance:

FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid());
FAR struct tcb_s *tcb = this_task();

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh,ostest