### PR TITLE
boards/imx6: Add support for mounting tmpfs file system

### DIFF
--- a/boards/arm/imx6/sabre-6quad/src/imx_bringup.c
+++ b/boards/arm/imx6/sabre-6quad/src/imx_bringup.c
@@ -49,6 +49,17 @@ int imx_bringup(void)
 {
   int ret;
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_FS_PROCFS
   /* Mount the procfs file system */
 


### PR DESCRIPTION
**Summary:**  
* Automatically mount tmpfs during board bring-up when configured  
* Modifies board bring-up code to handle tmpfs initialization  
* Checks for `CONFIG_FS_TMPFS` and mounts tmpfs at `CONFIG_LIBC_TMPDIR`  
* Includes error logging for mount failures  

**Impact:**  
* **New feature added?** YES - Adds automatic tmpfs mounting support for the i.MX6 Sabre board.  
* **Impact on user?** YES - Users enabling `CONFIG_FS_TMPFS` no longer need to manually mount tmpfs.  
* **Impact on build?** NO - No build system changes; relies on existing configuration.  
* **Impact on hardware?** NO - Purely software/filesystem functionality.  
* **Impact on documentation?** NO - No documentation updates included in this change.  
* **Impact on security?** NO - Does not introduce security risks beyond tmpfs’s inherent behavior.  
* **Impact on compatibility?** NO - Backward-compatible; only affects users enabling `CONFIG_FS_TMPFS`.  

**Test:**
Running: qemu-system-arm -M sabrelite -smp 1 -kernel /home/huang/Work/nuttx-crates-index/build/nuttx -nographic
```
NuttShell (NSH) NuttX-12.8.0
nsh> ls
/:
 dev/
 proc/
 tmp/
nsh> 
```