### PR TITLE
tools/bdf-converter: Fix loop termination condition.

### DIFF
--- a/tools/bdf-converter.c
+++ b/tools/bdf-converter.c
@@ -391,12 +391,12 @@ static void bdf_getglyphbitmap(FILE *file, glyphinfo_t *ginfo)
 {
   char line[BDF_MAX_LINE_LENGTH];
   uint64_t *bitmap;
-  bool readingbitmap;
+  int readingbitmap;
 
   bitmap = ginfo->bitmap;
-  readingbitmap = true;
+  readingbitmap = ginfo->bb_h;
 
-  while (readingbitmap)
+  while (readingbitmap > 0)
     {
       if (fgets(line, BDF_MAX_LINE_LENGTH, file) != NULL)
         {
@@ -404,20 +404,21 @@ static void bdf_getglyphbitmap(FILE *file, glyphinfo_t *ginfo)
 
           if (strcmp(line, "ENDCHAR") == 0)
             {
-              readingbitmap = false;
+              readingbitmap = 0;
             }
           else
             {
               char *endptr;
               *bitmap = strtoul(line, &endptr, 16);
               bitmap++;
+              readingbitmap--;
             }
         }
       else
         {
           /* error condition */
 
-          readingbitmap = false;
+          readingbitmap = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Changing readingbitmap from bool to int, initializing it to the number of bitmaps allocated, decrementing it each time a bitmap is consumed, and using it as the termination condition for the while loop, ensures that loop termination does not depend on data from the file.

Note: Patch provided by @hartmannathan.

## Impact

Fix user controllable chunk allocation condition when crafted input file is provided.

## Testing

```
% uname -a
FreeBSD octagon 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64
% cd tools
% gcc -o bdf-converter bdf-converter.c
% ./bdf-converter invalid.tff
Generated "nxfonts_myfont.h"
% cat nxfonts_myfont.h
%
```

