### PR TITLE
Documentation/games: Add snake game docs

### DIFF
--- a/Documentation/applications/games/snake/index.rst
+++ b/Documentation/applications/games/snake/index.rst
@@ -1,0 +1,32 @@
+=========================
+``snake`` Snake
+=========================
+
+Snake is a classic game, especially popular on old phones. The game is played on a
+matrix (e.g., 6x6, 8x8) with blocks (cells) of different colors to represent
+the snake and food objects.
+
+The goal of the game is to eat food as much as possible without running into yourself.
+After eating food, the snake's tail increases by one until the size of the snake
+equals the size of the game board.
+
+The game starts with a one-length snake, and the player can move through the board's edges.
+When the snake reaches the edge, it reappears on the opposite side.
+
+Basic Test
+----------
+
+To play game, you need to have a led matrix (e.g. ws2812) for output
+and four gpio pins to input.
+
+Alternatively, you can give inputs using serial console by changing settings.
+
+Then you can configure and compile the game to play in your board,
+i.e. for ESP32-Devkitc there is already an example::
+
+
+    $ ./tools/configure.sh esp32-devkitc:snake
+    $ make -j flash ESPTOOL_PORT=/dev/ttyUSB0
+    $ minicom
+    nsh> snake
+


### PR DESCRIPTION
## Summary

Related to https://github.com/apache/nuttx-apps/pull/3028

Add snake game documentation.

* Documentation/games: Add snake game docs

## Impact

Documentation

Impact on user: No, added feature is not effecting current status

Impact on build: No, 

Impact on hardware: No

Impact on documentation: Yes, missing documentation added

Impact on security: No

Impact on compatibility: No, added feature is not effecting current status

## Testing

### Building

To test docs [NuttX doc build](https://nuttx.apache.org/docs/latest/contributing/documentation.html) guide followed and output checked

```
make distclean && ./tools/configure.sh esp32-devkitc:snake && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BAUD=921600 && picocom /dev/ttyUSB0 -b 115200
```

### Running

`snake` command used to run.

### Results

LED matrix will light up with 2 leds (cyan and red) to demonstrate snake and food.