### PR TITLE
Revert "arch/xtensa: set PS.EXCM initial value to 1 while new thread …

### DIFF
--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -235,11 +235,11 @@ void up_initial_state(struct tcb_s *tcb)
   /* Set initial PS to int level 0, user mode. */
 
 #ifdef __XTENSA_CALL0_ABI__
-  xcp->regs[REG_PS] = PS_UM | PS_EXCM;
+  xcp->regs[REG_PS] = PS_UM;
 
 #else
   /* For windowed ABI set WOE and CALLINC (pretend task was 'call4'd). */
 
-  xcp->regs[REG_PS] = PS_UM | PS_EXCM | PS_WOE | PS_CALLINC(1);
+  xcp->regs[REG_PS] = PS_UM | PS_WOE | PS_CALLINC(1);
 #endif
 }


### PR DESCRIPTION
## Summary

This reverts commit 3194ef0e7cb98e2d737eb6fbfcdfcd63959b1c5f.

since level-2 and above interrupt, PS.EXCM is still 1. window rotation related instruction is undefined behavior.

https://github.com/apache/nuttx/pull/15985#issuecomment-2728509964

## Impact

PS.EXCM initial value while new thread created.

## Testing

https://github.com/apache/nuttx/pull/15985#issuecomment-2732248819

