### PR TITLE
arch/risc-v: Fix wrong source name in make script

### DIFF
--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -104,7 +104,11 @@ CMN_ASRCS += riscv_vpu.S
 endif
 
 ifeq ($(CONFIG_ARCH_RV_HAVE_APLIC),y)
-CMN_CSRCS += riscv_aia.c
+CMN_CSRCS += riscv_aplic.c
+endif
+
+ifeq ($(CONFIG_ARCH_RV_HAVE_IMSIC),y)
+CMN_CSRCS += riscv_imsic.c
 endif
 
 ifeq ($(CONFIG_RISCV_SEMIHOSTING_HOSTFS),y)


### PR DESCRIPTION
## Summary

AIA releted source files in the Make.defs are not right. Replace them with the right source.

Fixes: #12804

## Impact

This should have no impact.
