### PR TITLE
tools/checkpatch: Use gmake on BSD, make otherwise.

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -21,6 +21,11 @@
 
 TOOLDIR=$(dirname $0)
 
+case "$OSTYPE" in
+  *bsd*) MAKECMD=gmake;;
+  *) MAKECMD=make;;
+esac
+
 check=check_patch
 fail=0
 range=0
@@ -189,7 +194,7 @@ check_commit() {
   check_ranges <<< "$diffs"
 }
 
-make -C $TOOLDIR -f Makefile.host nxstyle 1>/dev/null
+$MAKECMD -C $TOOLDIR -f Makefile.host nxstyle 1>/dev/null
 
 if [ -z "$1" ]; then
   usage


### PR DESCRIPTION
## Summary

* BSD has its own BSD Make that is incompatible with GNU Make.
* When BSD is detected use (gnu) gmake in place of (bsd) make.
* This fixes nxstyle build inside tools/checkpatch.sh.

## Impact

* `tools/checkpatch.sh` now works correctly on BSD (`nxstyle` build).

## Testing

```
% uname -a
FreeBSD octagon 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64
```

Before:
```
% ../nuttx.git/tools/checkpatch.sh -f path/to/file.c
==> MAKE IS make
make: "/XXX/nuttx.git/tools/Makefile.host" line 25: Cannot open /tools/Config.mk
make: "/XXX/nuttx.git/tools/Makefile.host" line 29: Invalid line type
(..)
make: Fatal errors encountered -- cannot continue
```

After:
```
% uname -a
FreeBSD octagon 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64

octagon% ./tools/checkpatch.sh
USAGE: ./tools/checkpatch.sh [options] [list|-]

Options:
-h
-c spell check with codespell (install with: pip install codespell)
-u encoding check with cvt2utf (install with: pip install cvt2utf)
-r range check only (coupled with -p or -g)
-p <patch file names> (default)
-m Change-Id check in commit message (coupled with -g)
-g <commit list>
-f <file list>
-  read standard input mainly used by git pre-commit hook as below:
   git diff --cached | ./tools/checkpatch.sh -
Where a <commit list> is any syntax supported by git for specifying git revision, see GITREVISIONS(7)
Where a <patch file names> is a space separated list of patch file names or wildcard. or *.patch


$ uname -a
Linux octagon 5.15.0 FreeBSD 14.2-RELEASE-p1 GENERIC x86_64 GNU/Linux

$ ./tools/checkpatch.sh
USAGE: ./tools/checkpatch.sh [options] [list|-]

Options:
-h
-c spell check with codespell (install with: pip install codespell)
-u encoding check with cvt2utf (install with: pip install cvt2utf)
-r range check only (coupled with -p or -g)
-p <patch file names> (default)
-m Change-Id check in commit message (coupled with -g)
-g <commit list>
-f <file list>
-  read standard input mainly used by git pre-commit hook as below:
   git diff --cached | ./tools/checkpatch.sh -
Where a <commit list> is any syntax supported by git for specifying git revision, see GITREVISIONS(7)
Where a <patch file names> is a space separated list of patch file names or wildcard. or *.patch


% uname -a
Darwin XXX.local 24.3.0 Darwin Kernel Version 24.3.0: Thu Jan  2
20:24:23 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6020 arm64

% ./tools/checkpatch.sh
USAGE: ./tools/checkpatch.sh [options] [list|-]

Options:
-h
-c spell check with codespell (install with: pip install codespell)
-u encoding check with cvt2utf (install with: pip install cvt2utf)
-r range check only (coupled with -p or -g)
-p <patch file names> (default)
-m Change-Id check in commit message (coupled with -g)
-g <commit list>
-f <file list>
-  read standard input mainly used by git pre-commit hook as below:
   git diff --cached | ./tools/checkpatch.sh -
Where a <commit list> is any syntax supported by git for specifying
git revision, see GITREVISIONS(7)
Where a <patch file names> is a space separated list of patch file
names or wildcard. or *.patch
```