### PR TITLE
arch/arm: Fix crash when using memcpy/memset as RAMFUNCS

### DIFF
--- a/arch/arm/src/imx6/imx_boot.c
+++ b/arch/arm/src/imx6/imx_boot.c
@@ -361,6 +361,7 @@ static inline void imx_wdtdisable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void arm_boot(void)
 {
 #if defined(CONFIG_ARCH_RAMFUNCS)

--- a/arch/arm/src/imx9/imx9_start.c
+++ b/arch/arm/src/imx9/imx9_start.c
@@ -144,6 +144,7 @@ static inline void imx9_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   register const uint32_t *src;

--- a/arch/arm/src/imxrt/imxrt_start.c
+++ b/arch/arm/src/imxrt/imxrt_start.c
@@ -144,6 +144,7 @@ static inline void imxrt_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const register uint32_t *src;

--- a/arch/arm/src/kinetis/kinetis_start.c
+++ b/arch/arm/src/kinetis/kinetis_start.c
@@ -102,6 +102,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/lc823450/lc823450_start.c
+++ b/arch/arm/src/lc823450/lc823450_start.c
@@ -136,6 +136,7 @@ extern uint32_t _svect;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/mcx-nxxx/nxxx_start.c
+++ b/arch/arm/src/mcx-nxxx/nxxx_start.c
@@ -83,6 +83,7 @@ const uintptr_t g_idle_topstack = IDLE_STACK;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   register const uint32_t *src;

--- a/arch/arm/src/mx8mp/mx8mp_start.c
+++ b/arch/arm/src/mx8mp/mx8mp_start.c
@@ -79,6 +79,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -184,6 +184,7 @@ static inline void s32k1xx_mpu_config(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
 #ifdef CONFIG_BOOT_RUNFROMFLASH

--- a/arch/arm/src/s32k3xx/s32k3xx_start.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_start.c
@@ -133,6 +133,7 @@ extern uint8_t FLASH_END_ADDR[];
  *
  ****************************************************************************/
 
+osentry_function
 void s32k3xx_start(void)
 {
   register uint64_t *src;

--- a/arch/arm/src/sam34/sam_start.c
+++ b/arch/arm/src/sam34/sam_start.c
@@ -109,6 +109,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/sama5/sam_boot.c
+++ b/arch/arm/src/sama5/sam_boot.c
@@ -368,6 +368,7 @@ static inline void sam_wdtdisable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void arm_boot(void)
 {
 #ifdef CONFIG_ARCH_RAMFUNCS

--- a/arch/arm/src/samd5e5/sam_start.c
+++ b/arch/arm/src/samd5e5/sam_start.c
@@ -115,6 +115,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
 #if defined(CONFIG_BOOT_RUNFROMFLASH) || defined(CONFIG_ARCH_RAMFUNCS)

--- a/arch/arm/src/samv7/sam_start.c
+++ b/arch/arm/src/samv7/sam_start.c
@@ -149,6 +149,7 @@ static inline void sam_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -170,6 +170,7 @@ static inline void stm32_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/stm32h7/stm32_start.c
+++ b/arch/arm/src/stm32h7/stm32_start.c
@@ -179,6 +179,7 @@ static inline void stm32_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/xmc4/xmc4_start.c
+++ b/arch/arm/src/xmc4/xmc4_start.c
@@ -165,6 +165,7 @@ static inline void xmc4_flash_waitstates(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -1226,6 +1226,14 @@
 #  undef CONFIG_HAVE_LONG_DOUBLE
 #endif
 
+/* Decorators */
+
+#ifdef CONFIG_ARCH_RAMFUNCS
+#  define osentry_function no_builtin("memcpy") no_builtin("memset")
+#else
+#  define osentry_function
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Add `no_builtin` for `memcpy/memset` to the startup code of boards
with `CONFIG_ARCH_RAMFUNCS`, because certain compilers call `memcpy/memset`
instead of the explicit `for` loop. This will cause a crash if `memcpy/memset`
are mapped to RAM because the function that copies them to RAM is called later,
resulting in undefined code being executed.

## Impact
- Using `memcpy/memset` as RAMFUNCS is possible

## Testing

- The problem was observed with the following compiler: `arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009`
  - This is the default `arm-none-eabi-gcc` that is currently used on Ubuntu Noble 
- Was tested with a STM32F765

### Testing logs before
Before the patch there was a call to `memset` in the startup:
```
0  0x000006c4 in memset (s=0x20021b00 <g_intstackalloc>, c=c@entry=0, n=91844) at /home/alex/[...]/nuttx/libs/libc/string/lib_memset.c:73
#1  0x0800a804 in __start () at /home/alex/[...]/nuttx/arch/arm/src/stm32f7/stm32_start.c:194
#2  0x08000306 in ?? ()
```
As can be seen the address of `memset` it is in non initialized storage.

### Testing logs after
After the patch there is no more call to `memset/memcpy`:
```
#0  __start () at /home/alex/[...]/nuttx/arch/arm/src/stm32f7/stm32_start.c:196
#1  0x08000306 in ?? ()
```
```
   0x0800a834 <+80>:    bl      0x814039c <stm32_boardinitialize()>                                                                                                                                         
   0x0800a838 <+84>:    bl      0x800a884 <up_enable_icache>                                                                                                                                                
   0x0800a83c <+88>:    bl      0x800a8ac <up_enable_dcache>                                                                                                                                                
   0x0800a840 <+92>:    bl      0x800b894 <arm_earlyserialinit>                                                                                                                                             
   0x0800a844 <+96>:    bl      0x800d290 <nx_start>                                                                                                                                                        
=> 0x0800a848 <+100>:   str.w   r1, [r3], #4                                                                                                                                                                
   0x0800a84c <+104>:   b.n     0x800a7f0 <__start+12>
   0x0800a84e <+106>:   ldr.w   r0, [r2], #4
   0x0800a852 <+110>:   str.w   r0, [r3], #4
   0x0800a856 <+114>:   b.n     0x800a7fa <__start+22>
   0x0800a858 <+116>:   ldr.w   r0, [r2], #4
   0x0800a85c <+120>:   str.w   r0, [r3], #4
   0x0800a860 <+124>:   b.n     0x800a804 <__start+32>
```
This way a successful boot is possible.
