### PR TITLE
drivers/mtd/gd55: fix uninitialised variables 

### DIFF
--- a/drivers/mtd/gd55.c
+++ b/drivers/mtd/gd55.c
@@ -524,7 +524,7 @@ static int gd55_command_address(FAR struct gd55_dev_s *priv, uint8_t cmd,
 static int gd55_read_bytes(FAR struct gd55_dev_s *priv, FAR uint8_t *buffer,
                            off_t address, size_t buflen)
 {
-  bool                  mode_4byte_addr;
+  bool                  mode_4byte_addr = false;
   int                   ret;
   struct qspi_meminfo_s meminfo;
 
@@ -580,7 +580,7 @@ static int gd55_write_page(FAR struct gd55_dev_s *priv,
   struct qspi_meminfo_s meminfo;
   uint8_t               status;
   unsigned int          npages;
-  int                   ret;
+  int                   ret = OK;
   int                   i;
 
   npages = (buflen >> GD55_PAGE_SHIFT);


### PR DESCRIPTION
## Summary

Using this driver for mtd flash operations I indentified a couple if unitialised variables that caused issues.

## Impact
No negative impact, but fixes problems encountered during use of this driver

## Testing

This was tested on my custom board with a SAMA5D27C-D1G processor and a 1Gbit GD55 NOR flash device.

