### PR TITLE
arch/xtensa: fix definition for `_int32_t` and `_uint32_t`

### DIFF
--- a/arch/xtensa/include/inttypes.h
+++ b/arch/xtensa/include/inttypes.h
@@ -33,89 +33,89 @@
 
 #define PRId8       "d"
 #define PRId16      "d"
-#define PRId32      "d"
+#define PRId32      "ld"
 #define PRId64      "lld"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
-#define PRIi32      "i"
+#define PRIi32      "li"
 #define PRIi64      "lli"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
-#define PRIo32      "o"
+#define PRIo32      "lo"
 #define PRIo64      "llo"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
-#define PRIu32      "u"
+#define PRIu32      "lu"
 #define PRIu64      "llu"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
-#define PRIx32      "x"
+#define PRIx32      "lx"
 #define PRIx64      "llx"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
-#define PRIX32      "X"
+#define PRIX32      "lX"
 #define PRIX64      "llX"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
-#define SCNd32      "d"
+#define SCNd32      "ld"
 #define SCNd64      "lld"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
-#define SCNi32      "i"
+#define SCNi32      "li"
 #define SCNi64      "lli"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
-#define SCNo32      "o"
+#define SCNo32      "lo"
 #define SCNo64      "llo"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
-#define SCNu32      "u"
+#define SCNu32      "lu"
 #define SCNu64      "llu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
-#define SCNx32      "x"
+#define SCNx32      "lx"
 #define SCNx64      "llx"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x
+#define INT32_C(x)  x ## ll
 #define INT64_C(x)  x ## ll
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
-#define UINT32_C(x) x ## u
+#define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
 
 #endif /* __ARCH_XTENSA_INCLUDE_INTTYPES_H */

--- a/arch/xtensa/include/types.h
+++ b/arch/xtensa/include/types.h
@@ -56,8 +56,8 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-typedef signed int         _int32_t;
-typedef unsigned int       _uint32_t;
+typedef long int           _int32_t;
+typedef long unsigned int  _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;

--- a/arch/xtensa/src/common/espressif/esp_adc.c
+++ b/arch/xtensa/src/common/espressif/esp_adc.c
@@ -565,7 +565,7 @@ static int esp_adc_oneshot_new_unit(struct adc_dev_s *dev)
 
   spin_unlock_irqrestore(&g_adc_common.esp_adc_spinlock, flags);
 
-  ainfo("unit %d freq %u\n", priv->unit, clk_src_freq_hz);
+  ainfo("unit %d freq %" PRIu32 "\n", priv->unit, clk_src_freq_hz);
   return OK;
 }
 

--- a/arch/xtensa/src/common/espressif/esp_loader.c
+++ b/arch/xtensa/src/common/espressif/esp_loader.c
@@ -209,7 +209,8 @@ int map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
           ram_segments++;
         }
 
-      ets_printf("%s: lma 0x%08x vma 0x%08x len 0x%-6x (%u)\n",
+      ets_printf("%s: lma 0x%08x vma 0x%08" PRIx32 " len 0x%-6" PRIx32 ""
+                 " (%" PRIu32 ")\n",
           IS_NONE(segment_hdr.load_addr) ? "???" :
             IS_RTC_FAST_IRAM(segment_hdr.load_addr) ||
             IS_RTC_FAST_DRAM(segment_hdr.load_addr) ||
@@ -266,12 +267,14 @@ int map_rom_segments(uint32_t app_drom_start, uint32_t app_drom_vaddr,
 #if defined (CONFIG_ESP32S2_APP_FORMAT_MCUBOOT) || \
     defined (CONFIG_ESP32S3_APP_FORMAT_MCUBOOT) || \
     defined (CONFIG_ESP32_APP_FORMAT_MCUBOOT)
-  ets_printf("IROM segment aligned lma 0x%08x vma 0x%08x len 0x%06x (%u)\n",
-      app_irom_start_aligned, app_irom_vaddr_aligned,
-      app_irom_size, app_irom_size);
-  ets_printf("DROM segment aligned lma 0x%08x vma 0x%08x len 0x%06x (%u)\n",
-      app_drom_start_aligned, app_drom_vaddr_aligned,
-      app_drom_size, app_drom_size);
+  ets_printf("IROM segment aligned lma 0x%08" PRIx32 " vma 0x%08" PRIx32 ""
+             " len 0x%06" PRIx32 " "\
+             "(%" PRIu32 ")\n", app_irom_start_aligned,
+             app_irom_vaddr_aligned, app_irom_size, app_irom_size);
+  ets_printf("DROM segment aligned lma 0x%08" PRIx32 " vma 0x%08" PRIx32 ""
+             " len 0x%06" PRIx32 " "\
+             "(%" PRIu32 ")\n", app_drom_start_aligned,
+              app_drom_vaddr_aligned, app_drom_size, app_drom_size);
 #endif
 
 #ifdef CONFIG_ARCH_CHIP_ESP32

--- a/arch/xtensa/src/common/espressif/esp_mcpwm.c
+++ b/arch/xtensa/src/common/espressif/esp_mcpwm.c
@@ -1143,7 +1143,7 @@ static int esp_motor_fault_configure(struct mcpwm_motor_lowerhalf_s *lower,
 
 #ifdef CONFIG_ESP_MCPWM_MOTOR
 static int esp_motor_set_duty_cycle(struct mcpwm_motor_lowerhalf_s *lower,
-  float duty)
+                                    float duty)
 {
   DEBUGASSERT(lower != NULL);
 
@@ -1158,7 +1158,7 @@ static int esp_motor_set_duty_cycle(struct mcpwm_motor_lowerhalf_s *lower,
   uint32_t pwm_count = -1 * lower->counter_peak * (duty - 1.0);
   mcpwm_ll_operator_set_compare_value(hal->dev, lower->operator_id,
                                       MCPWM_GENERATOR_0, pwm_count);
-  mtrinfo("Duty %f compare value set: %u\n", duty, pwm_count);
+  mtrinfo("Duty %f compare value set: %" PRIu32 "\n", duty, pwm_count);
 
   return OK;
 }
@@ -1924,7 +1924,7 @@ struct motor_lowerhalf_s *esp_motor_bdc_initialize(int channel,
       return NULL;
     }
 
-  mtrinfo("Channel %d initialized. GPIO: PWM_A: %d | PWM_B: %d | Freq: %d\n",
+  mtrinfo("Ch %d initialized GPIO: PWM_A %d | PWM_B %d | Freq %" PRIu32 "\n",
           lower->channel_id, lower->generator_pins[MCPWM_GENERATOR_0],
           lower->generator_pins[MCPWM_GENERATOR_1], lower->pwm_frequency);
   return (struct motor_lowerhalf_s *) lower;

--- a/arch/xtensa/src/common/espressif/esp_nxdiag.c
+++ b/arch/xtensa/src/common/espressif/esp_nxdiag.c
@@ -258,7 +258,7 @@ static ssize_t esp_nxdiag_read(struct file *filep,
     }
   else
     {
-      snprintf(tmp, tmp_arr_size, "Flash status: 0x%lx\n\n",
+      snprintf(tmp, tmp_arr_size, "Flash status: 0x%" PRIx32 "\n\n",
                (long unsigned int)flash_status);
       strcat(buffer, tmp);
     }

--- a/arch/xtensa/src/common/espressif/esp_openeth.c
+++ b/arch/xtensa/src/common/espressif/esp_openeth.c
@@ -250,7 +250,7 @@ static IRAM_ATTR int openeth_isr_handler(int irq, void *context, void *arg)
 
   if (status & OPENETH_INT_BUSY)
     {
-      ninfo("RX frame dropped (0x%x)", status);
+      ninfo("RX frame dropped (0x%" PRIx32 ")", status);
     }
 
   /* Clear interrupt */

--- a/arch/xtensa/src/common/espressif/esp_pcnt.c
+++ b/arch/xtensa/src/common/espressif/esp_pcnt.c
@@ -351,7 +351,7 @@ static int esp_pcnt_ioctl(struct cap_lowerhalf_s *dev, int cmd,
         ret = esp_pcnt_unit_register_event_callback(dev, handler);
         if (ret != OK)
           {
-            cperr("Could not register callback-%x to pcnt-%d!\n",
+            cperr("Could not register callback-%" PRIx32 " to pcnt-%d!\n",
                   (uint32_t)handler, priv->unit_id);
           }
 

--- a/arch/xtensa/src/common/espressif/esp_rmt.c
+++ b/arch/xtensa/src/common/espressif/esp_rmt.c
@@ -1437,7 +1437,7 @@ static int IRAM_ATTR rmt_driver_isr_default(int irq, void *context,
 
           rmt_ll_rx_reset_pointer(g_rmtdev_common.hal.regs, channel);
           rmtinfo("RMT RX channel %d error", channel);
-          rmtinfo("status: 0x%08x",
+          rmtinfo("status: 0x%08" PRIx32 "",
                   rmt_ll_rx_get_status_word(g_rmtdev_common.hal.regs,
                                             channel));
         }
@@ -1462,7 +1462,7 @@ static int IRAM_ATTR rmt_driver_isr_default(int irq, void *context,
 
           rmt_ll_tx_reset_pointer(g_rmtdev_common.hal.regs, channel);
           rmtinfo("RMT TX channel %d error", channel);
-          rmtinfo("status: 0x%08x",
+          rmtinfo("status: 0x%08" PRIx32 "",
                   rmt_ll_tx_get_status_word(g_rmtdev_common.hal.regs,
                                             channel));
         }

--- a/arch/xtensa/src/common/espressif/esp_wireless.c
+++ b/arch/xtensa/src/common/espressif/esp_wireless.c
@@ -1074,8 +1074,8 @@ int esp_phy_update_country_info(const char *country)
  *
  ****************************************************************************/
 
-int32_t esp_timer_create(const esp_timer_create_args_t *create_args,
-                         esp_timer_handle_t *out_handle)
+int esp_timer_create(const esp_timer_create_args_t *create_args,
+                     esp_timer_handle_t *out_handle)
 {
   int ret;
   struct rt_timer_args_s rt_timer_args;
@@ -1111,7 +1111,7 @@ int32_t esp_timer_create(const esp_timer_create_args_t *create_args,
  *
  ****************************************************************************/
 
-int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
+int esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
@@ -1135,7 +1135,7 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
  *
  ****************************************************************************/
 
-int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
+int esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
@@ -1158,7 +1158,7 @@ int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
  *
  ****************************************************************************/
 
-int32_t esp_timer_stop(esp_timer_handle_t timer)
+int esp_timer_stop(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
@@ -1181,7 +1181,7 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
  *
  ****************************************************************************/
 
-int32_t esp_timer_delete(esp_timer_handle_t timer)
+int esp_timer_delete(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
@@ -1499,7 +1499,7 @@ int esp_wireless_deinit(void)
  *
  ****************************************************************************/
 
-int32_t esp_wifi_init(const wifi_init_config_t *config)
+int esp_wifi_init(const wifi_init_config_t *config)
 {
   int32_t ret;
 
@@ -1520,7 +1520,7 @@ int32_t esp_wifi_init(const wifi_init_config_t *config)
   ret = coex_init();
   if (ret)
     {
-      wlerr("ERROR: Failed to initialize coex error=%d\n", ret);
+      wlerr("ERROR: Failed to initialize coex error=%ld\n", ret);
       return ret;
     }
 #endif
@@ -1534,7 +1534,7 @@ int32_t esp_wifi_init(const wifi_init_config_t *config)
   ret = esp_wifi_init_internal(config);
   if (ret)
     {
-      wlerr("Failed to initialize Wi-Fi error=%d\n", ret);
+      wlerr("Failed to initialize Wi-Fi error=%ld\n", ret);
       return ret;
     }
 
@@ -1551,7 +1551,7 @@ int32_t esp_wifi_init(const wifi_init_config_t *config)
   ret = esp_supplicant_init();
   if (ret)
     {
-      wlerr("Failed to initialize WPA supplicant error=%d\n", ret);
+      wlerr("Failed to initialize WPA supplicant error=%ld\n", ret);
       esp_wifi_deinit_internal();
       return ret;
     }
@@ -1573,7 +1573,7 @@ int32_t esp_wifi_init(const wifi_init_config_t *config)
  *
  ****************************************************************************/
 
-int32_t esp_wifi_deinit(void)
+int esp_wifi_deinit(void)
 {
   int ret;
 

--- a/arch/xtensa/src/common/espressif/esp_wireless.h
+++ b/arch/xtensa/src/common/espressif/esp_wireless.h
@@ -195,8 +195,8 @@ int phy_printf(const char *format, ...) printf_like(1, 2);
  *
  ****************************************************************************/
 
-int32_t esp_timer_create(const esp_timer_create_args_t *create_args,
-                         esp_timer_handle_t *out_handle);
+int esp_timer_create(const esp_timer_create_args_t *create_args,
+                     esp_timer_handle_t *out_handle);
 
 /****************************************************************************
  * Name: esp_timer_start_once
@@ -213,7 +213,7 @@ int32_t esp_timer_create(const esp_timer_create_args_t *create_args,
  *
  ****************************************************************************/
 
-int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us);
+int esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us);
 
 /****************************************************************************
  * Name: esp_timer_start_periodic
@@ -230,7 +230,7 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us);
  *
  ****************************************************************************/
 
-int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period);
+int esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period);
 
 /****************************************************************************
  * Name: esp_timer_stop
@@ -246,7 +246,7 @@ int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period);
  *
  ****************************************************************************/
 
-int32_t esp_timer_stop(esp_timer_handle_t timer);
+int esp_timer_stop(esp_timer_handle_t timer);
 
 /****************************************************************************
  * Name: esp_timer_delete
@@ -262,7 +262,7 @@ int32_t esp_timer_stop(esp_timer_handle_t timer);
  *
  ****************************************************************************/
 
-int32_t esp_timer_delete(esp_timer_handle_t timer);
+int esp_timer_delete(esp_timer_handle_t timer);
 
 /****************************************************************************
  * Name: esp_phy_update_country_info

--- a/arch/xtensa/src/common/espressif/esp_ws2812.c
+++ b/arch/xtensa/src/common/espressif/esp_ws2812.c
@@ -471,7 +471,7 @@ static ssize_t esp_write(struct file *filep, const char *data, size_t len)
       if (((position + len) / WS2812_RW_PIXEL_SIZE) > dev->nleds)
         {
           ledwarn("esp_ws2812 write truncated:\n\t\tLED position: %d\n"
-                  "\t\tLED requested to be written: %d\n"
+                  "\t\tLED requested to be written: %" PRIu32 "\n"
                   "\t\tLED strip LED count: %d\n"
                   "\t\tLED being written: %d\n",
                   position / WS2812_RW_PIXEL_SIZE,

--- a/arch/xtensa/src/common/xtensa_cpuinfo.c
+++ b/arch/xtensa/src/common/xtensa_cpuinfo.c
@@ -95,7 +95,7 @@ ssize_t up_show_cpuinfo(char *buf, size_t buf_size, off_t file_off)
 
   procfs_sprintf(buf, buf_size, &file_off,
                  "core ID\t\t: " XCHAL_CORE_ID "\n"
-                 "build ID\t: 0x%x\n"
+                 "build ID\t: %08x\n"
                  "config ID\t: %08" PRIx32 ":%08" PRIx32 "\n",
                  XCHAL_BUILD_UNIQUE_ID,
                  xtensa_getconfig0(), xtensa_getconfig1());

--- a/arch/xtensa/src/common/xtensa_debug.c
+++ b/arch/xtensa/src/common/xtensa_debug.c
@@ -462,7 +462,7 @@ uint32_t *xtensa_debug_handler(uint32_t *regs)
     }
   else
     {
-      _alert("Unhandled debug cause 0x%x\n", cause);
+      _alert("Unhandled debug cause 0x%" PRIx32 "\n", cause);
     }
 
   return regs;

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -312,47 +312,49 @@ struct irqstate_list_s
  */
 
 static xt_handler ble_set_isr(int n, xt_handler f, void *arg);
-static void ints_on(uint32_t mask);
+static void ints_on(unsigned int mask);
 static void IRAM_ATTR interrupt_disable(void);
 static void IRAM_ATTR interrupt_restore(void);
 static void IRAM_ATTR task_yield_from_isr(void);
 static void *semphr_create_wrapper(uint32_t max, uint32_t init);
 static void semphr_delete_wrapper(void *semphr);
-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw);
-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw);
-static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
-static int semphr_give_wrapper(void *semphr);
+static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr,
+                                                      void *hptw);
+static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr,
+                                                      void *hptw);
+static int32_t semphr_take_wrapper(void *semphr, uint32_t block_time_ms);
+static int32_t semphr_give_wrapper(void *semphr);
 static void *mutex_create_wrapper(void);
 static void mutex_delete_wrapper(void *mutex);
-static int mutex_lock_wrapper(void *mutex);
-static int mutex_unlock_wrapper(void *mutex);
+static int32_t mutex_lock_wrapper(void *mutex);
+static int32_t mutex_unlock_wrapper(void *mutex);
 static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size);
 static void queue_delete_wrapper(void *queue);
-static int queue_send_wrapper(void *queue,
+static int32_t queue_send_wrapper(void *queue,
                               void *item,
                               uint32_t block_time_ms);
-static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
-                                                 void *item,
-                                                 void *hptw);
-static int queue_recv_wrapper(void *queue,
-                              void *item,
-                              uint32_t block_time_ms);
-static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue,
-                                                 void *item,
-                                                 void *hptw);
-static int task_create_wrapper(void *task_func,
-                               const char *name,
-                               uint32_t stack_depth,
-                               void *param,
-                               uint32_t prio,
-                               void *task_handle,
-                               uint32_t core_id);
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
+                                                     void *item,
+                                                     void *hptw);
+static int32_t queue_recv_wrapper(void *queue,
+                                  void *item,
+                                  uint32_t block_time_ms);
+static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue,
+                                                     void *item,
+                                                     void *hptw);
+static int32_t task_create_wrapper(void *task_func,
+                                   const char *name,
+                                   uint32_t stack_depth,
+                                   void *param,
+                                   uint32_t prio,
+                                   void *task_handle,
+                                   uint32_t core_id);
 static void task_delete_wrapper(void *task_handle);
 static bool IRAM_ATTR is_in_isr_wrapper(void);
 static int IRAM_ATTR cause_sw_intr_to_core_wrapper(int core_id, int intr_no);
 static void *malloc_wrapper(size_t size);
 static void *malloc_internal_wrapper(size_t size);
-static int IRAM_ATTR read_mac_wrapper(uint8_t mac[6]);
+static int32_t IRAM_ATTR read_mac_wrapper(uint8_t mac[6]);
 static void IRAM_ATTR srand_wrapper(unsigned int seed);
 static int IRAM_ATTR rand_wrapper(void);
 static uint32_t IRAM_ATTR btdm_lpcycles_2_us(uint32_t cycles);
@@ -842,7 +844,7 @@ static xt_handler ble_set_isr(int n, xt_handler f, void *arg)
   adapter = kmm_malloc(tmp);
   if (!adapter)
     {
-      wlerr("Failed to alloc %d memory\n", tmp);
+      wlerr("Failed to alloc %" PRIu32 " memory\n", tmp);
       DEBUGPANIC();
       return NULL;
     }
@@ -875,7 +877,7 @@ static xt_handler ble_set_isr(int n, xt_handler f, void *arg)
  *
  ****************************************************************************/
 
-static void ints_on(uint32_t mask)
+static void ints_on(unsigned int mask)
 {
   uint32_t bit;
   int irq;
@@ -1051,7 +1053,8 @@ static void semphr_delete_wrapper(void *semphr)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   *(int *)hptw = 0;
 
@@ -1074,7 +1077,8 @@ static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   int ret;
   struct bt_sem_s *bt_sem = (struct bt_sem_s *)semphr;
@@ -1111,7 +1115,7 @@ static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
  *
  ****************************************************************************/
 
-static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
+static int32_t semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 {
   int ret;
   struct bt_sem_s *bt_sem = (struct bt_sem_s *)semphr;
@@ -1134,7 +1138,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %lu ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %" PRIu32 " ticks. Error=%d\n",
             MSEC2TICK(block_time_ms), ret);
     }
 
@@ -1155,7 +1159,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
  *
  ****************************************************************************/
 
-static int semphr_give_wrapper(void *semphr)
+static int32_t semphr_give_wrapper(void *semphr)
 {
   int ret;
   struct bt_sem_s *bt_sem = (struct bt_sem_s *)semphr;
@@ -1238,7 +1242,7 @@ static void mutex_delete_wrapper(void *mutex)
  *
  ****************************************************************************/
 
-static int mutex_lock_wrapper(void *mutex)
+static int32_t mutex_lock_wrapper(void *mutex)
 {
   int ret;
 
@@ -1265,7 +1269,7 @@ static int mutex_lock_wrapper(void *mutex)
  *
  ****************************************************************************/
 
-static int mutex_unlock_wrapper(void *mutex)
+static int32_t mutex_unlock_wrapper(void *mutex)
 {
   int ret;
 
@@ -1334,7 +1338,8 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
   else
     {
       wlerr("Failed to create queue cache."
-            " Please incresase BLE_TASK_EVENT_QUEUE_LEN to, at least, %d",
+            " Please incresase BLE_TASK_EVENT_QUEUE_LEN to,"
+            " at least, %" PRIu32 "",
             queue_len);
       return NULL;
     }
@@ -1382,8 +1387,8 @@ static void queue_delete_wrapper(void *queue)
  *
  ****************************************************************************/
 
-static int queue_send_wrapper(void *queue, void *item,
-                              uint32_t block_time_ms)
+static int32_t queue_send_wrapper(void *queue, void *item,
+                                  uint32_t block_time_ms)
 {
   return esp_queue_send_generic(queue, item, block_time_ms, 0);
 }
@@ -1405,9 +1410,9 @@ static int queue_send_wrapper(void *queue, void *item,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
-                                                 void *item,
-                                                 void *hptw)
+static int32_t IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
+                                                     void *item,
+                                                     void *hptw)
 {
   *((int *)hptw) = false;
   return esp_queue_send_generic(queue, item, 0, 0);
@@ -1429,7 +1434,7 @@ static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
  *
  ****************************************************************************/
 
-static int queue_recv_wrapper(void *queue, void *item,
+static int32_t queue_recv_wrapper(void *queue, void *item,
                               uint32_t block_time_ms)
 {
   ssize_t ret;
@@ -1490,9 +1495,9 @@ static int queue_recv_wrapper(void *queue, void *item,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue,
-                                                 void *item,
-                                                 void *hptw)
+static int32_t IRAM_ATTR queue_recv_from_isr_wrapper(void *queue,
+                                                     void *item,
+                                                     void *hptw)
 {
   DEBUGPANIC();
   return 0;
@@ -1518,10 +1523,10 @@ static int IRAM_ATTR queue_recv_from_isr_wrapper(void *queue,
  *
  ****************************************************************************/
 
-static int task_create_wrapper(void *task_func, const char *name,
-                               uint32_t stack_depth, void *param,
-                               uint32_t prio, void *task_handle,
-                               uint32_t core_id)
+static int32_t task_create_wrapper(void *task_func, const char *name,
+                                   uint32_t stack_depth, void *param,
+                                   uint32_t prio, void *task_handle,
+                                   uint32_t core_id)
 {
   return esp_task_create_pinned_to_core(task_func, name,
                                         stack_depth, param,
@@ -1651,7 +1656,7 @@ static void *malloc_internal_wrapper(size_t size)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR read_mac_wrapper(uint8_t mac[6])
+static int32_t IRAM_ATTR read_mac_wrapper(uint8_t mac[6])
 {
   return esp_read_mac(mac, ESP_MAC_BT);
 }
@@ -2644,7 +2649,7 @@ static void btdm_controller_mem_init(void)
   memcpy(_data_start_btdm, (void *)_data_start_btdm_rom,
          _data_end_btdm - _data_start_btdm);
 
-  wlinfo(".data initialise [0x%08x] <== [0x%08x]\n",
+  wlinfo(".data initialise [0x0x08%" PRIx32 "] <== [0x0x08%" PRIx32 "]\n",
          (uint32_t)_data_start_btdm, _data_start_btdm_rom);
 
   /* initial em, .bss section */
@@ -2659,7 +2664,8 @@ static void btdm_controller_mem_init(void)
           memset((void *)g_btdm_dram_available_region[i].start, 0x0,
                  g_btdm_dram_available_region[i].end - \
                  g_btdm_dram_available_region[i].start);
-          wlinfo(".bss initialise [0x%08x] - [0x%08x]\n",
+          wlinfo(".bss initialise [0x0x08%" PRIxPTR "] - "
+                 "[0x0x08%" PRIxPTR "]\n",
                  g_btdm_dram_available_region[i].start,
                  g_btdm_dram_available_region[i].end);
         }

--- a/arch/xtensa/src/esp32/esp32_efuse.c
+++ b/arch/xtensa/src/esp32/esp32_efuse.c
@@ -379,7 +379,8 @@ static int esp_efuse_fill_buff(uint32_t num_reg, int bit_offset,
   int sum_shift = 0;
   int shift_bit = (*bits_counter) % 8;
 
-  minfo("block = %d | num_reg = %d | bit_start = %d | bit_count = %d\n",
+  minfo("block = %" PRIu32 " | num_reg = %" PRIu32 ""
+        " | bit_start = %" PRIu32 " | bit_count = %d\n",
         efuse_block, num_reg, bit_start, bit_count);
 
   if (shift_bit != 0)

--- a/arch/xtensa/src/esp32/esp32_efuse.h
+++ b/arch/xtensa/src/esp32/esp32_efuse.h
@@ -53,7 +53,7 @@ typedef enum
  *  - other efuse component errors.
  */
 
-typedef int (*efuse_func_proc_t) (unsigned int num_reg,
+typedef int (*efuse_func_proc_t) (uint32_t num_reg,
                                   int starting_bit_num_in_reg,
                                   int num_bits_used_in_reg,
                                   void *arr, int *bits_counter);

--- a/arch/xtensa/src/esp32/esp32_freerun.c
+++ b/arch/xtensa/src/esp32/esp32_freerun.c
@@ -293,7 +293,7 @@ int esp32_freerun_counter(struct esp32_freerun_s *freerun,
   ts->tv_sec  = sec;
   ts->tv_nsec = (usec - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
 
-  tmrinfo("usec=%llu ts=(%lu, %lu)\n",
+  tmrinfo("usec=%llu ts=(%" PRIu32 ", %" PRIu32 ")\n",
           usec, (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
 
   return OK;

--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -1,7 +1,5 @@
 /****************************************************************************
- * arch/xtensa/src/common/espressif/esp_i2s.c
- *
- * SPDX-License-Identifier: Apache-2.0
+ * arch/xtensa/src/esp32/esp32_i2s.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -26,178 +24,87 @@
 
 #include <nuttx/config.h>
 
-#include <assert.h>
-#include <debug.h>
-#include <errno.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <math.h>
+#ifdef CONFIG_ESP32_I2S
 
-#include <nuttx/irq.h>
+#include <debug.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <time.h>
+#include <assert.h>
+
 #include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/clock.h>
+#include <nuttx/semaphore.h>
 #include <nuttx/spinlock.h>
-#include <arch/irq.h>
+#include <nuttx/mqueue.h>
+#include <nuttx/circbuf.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/audio/audio.h>
+#include <nuttx/audio/i2s.h>
+
+#include <arch/board/board.h>
+
+#include "esp32_i2s.h"
+#include "esp32_gpio.h"
+#include "esp32_irq.h"
+#include "esp32_dma.h"
 
 #include "xtensa.h"
-#include "esp_i2s.h"
-#if defined(CONFIG_ARCH_CHIP_ESP32S3)
-#include "esp32s3_gpio.h"
-#include "hardware/esp32s3_gpio_sigmap.h"
-#include "esp32s3_dma.h"
-#include "hardware/esp32s3_dma.h"
-#include "esp32s3_irq.h"
-#elif defined(CONFIG_ARCH_CHIP_ESP32S2)
-#include "esp32s2_gpio.h"
-#include "hardware/esp32s2_gpio_sigmap.h"
-#include "esp32s2_dma.h"
-#include "esp32s2_irq.h"
-#else
-#include "esp32_gpio.h"
-#include "esp32_dma.h"
-#include "esp32_irq.h"
-#endif
-
-#include "hal/i2s_hal.h"
-#include "hal/i2s_ll.h"
-#include "soc/i2s_periph.h"
-#include "soc/i2s_reg.h"
-#include "hal/i2s_types.h"
-#include "soc/gpio_sig_map.h"
-#include "periph_ctrl.h"
-#if defined(CONFIG_ARCH_CHIP_ESP32S3)
-#  include "soc/gdma_reg.h"
-#  include "soc/gdma_periph.h"
-#  include "hal/gdma_ll.h"
-#endif
-
-#include "esp_attr.h"
-#include "esp_bit_defs.h"
-#include "esp_cpu.h"
-#include "esp_rom_sys.h"
-#include "soc/soc.h"
-#include "hal/dma_types.h"
+#include "hardware/esp32_gpio_sigmap.h"
+#include "hardware/esp32_dport.h"
+#include "hardware/esp32_i2s.h"
+#include "hardware/esp32_soc.h"
+#include "hardware/esp32_iomux.h"
+#include "hardware/esp32_pinmap.h"
+#include "hardware/esp32_dma.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_CHIP_ESP32S3)
-#define esp_setup_irq             esp32s3_setup_irq
-#define esp_teardown_irq          esp32s3_teardown_irq
-#define esp_configgpio            esp32s3_configgpio
-#define esp_gpio_matrix_in        esp32s3_gpio_matrix_in
-#define esp_gpio_matrix_out       esp32s3_gpio_matrix_out
-#define esp_gpiowrite             esp32s3_gpiowrite
-#define esp_dma_init              esp32s3_dma_init
-#define esp_dma_request           esp32s3_dma_request
-#define esp_dma_setup             esp32s3_dma_setup
-#define esp_dma_load              esp32s3_dma_load
-#define esp_dma_enable            esp32s3_dma_enable
-#define ESP_IRQ_PRIORITY_DEFAULT  ESP32S3_INT_PRIO_DEF
-#define ESP_IRQ_TRIGGER_LEVEL     ESP32S3_CPUINT_LEVEL
-#define ESPRESSIF_DMA_BUFLEN_MAX  ESP32S3_DMA_BUFLEN_MAX
-#define ESPRESSIF_DMA_PERIPH_I2S  ESP32S3_DMA_PERIPH_I2S1
-#define ESP_SOURCE2IRQ            ESP32S3_PERIPH2IRQ
-#define esp_dmadesc_s             esp32s3_dmadesc_s
-#elif defined(CONFIG_ARCH_CHIP_ESP32S2)
-#define esp_setup_irq             esp32s2_setup_irq
-#define esp_teardown_irq          esp32s2_teardown_irq
-#define esp_configgpio            esp32s2_configgpio
-#define esp_gpio_matrix_in        esp32s2_gpio_matrix_in
-#define esp_gpio_matrix_out       esp32s2_gpio_matrix_out
-#define esp_gpiowrite             esp32s2_gpiowrite
-#define esp_dma_setup             esp32s2_dma_init
-#define ESP_SOURCE2IRQ            ESP32S2_PERIPH2IRQ
-#define esp_dmadesc_s             esp32s2_dmadesc_s
-#define ESPRESSIF_DMA_BUFLEN_MAX  ESP32S2_DMA_DATALEN_MAX
-#define ESP_IRQ_PRIORITY_DEFAULT  ESP32S2_INT_PRIO_DEF
-#define ESP_IRQ_TRIGGER_LEVEL     ESP32S2_CPUINT_LEVEL
-#define I2S0O_SD_OUT_IDX          I2S0O_DATA_OUT23_IDX
-#define I2S0I_SD_IN_IDX           I2S0I_DATA_IN15_IDX
-#define I2S0_MCLK_OUT_IDX         CLK_I2S_MUX_IDX
-#elif defined(CONFIG_ARCH_CHIP_ESP32)
-#define esp_setup_irq             esp32_setup_irq
-#define esp_teardown_irq          esp32_teardown_irq
-#define esp_configgpio            esp32_configgpio
-#define esp_gpio_matrix_in        esp32_gpio_matrix_in
-#define esp_gpio_matrix_out       esp32_gpio_matrix_out
-#define esp_gpiowrite             esp32_gpiowrite
-#define esp_dma_setup             esp32_dma_init
-#define esp_dmadesc_s             esp32_dmadesc_s
-#define ESP_SOURCE2IRQ            ESP32_PERIPH2IRQ
-#define ESPRESSIF_DMA_BUFLEN_MAX  ESP32_DMA_DATALEN_MAX
-#define I2S0O_SD_OUT_IDX          I2S0O_DATA_OUT23_IDX
-#define I2S0I_SD_IN_IDX           I2S0I_DATA_IN15_IDX
-#define I2S0_MCLK_OUT_IDX         -1
-#define I2S1O_SD_OUT_IDX          I2S1O_DATA_OUT23_IDX
-#define I2S1I_SD_IN_IDX           I2S1I_DATA_IN15_IDX
-#define I2S1_MCLK_OUT_IDX         -1
-#define ESP_IRQ_PRIORITY_DEFAULT  1
-#define ESP_IRQ_TRIGGER_LEVEL     ESP32_CPUINT_LEVEL
-#endif
-
-#if defined(CONFIG_ESPRESSIF_I2S0_DATA_BIT_WIDTH_8BIT) ||     \
-    defined(CONFIG_ESP32_I2S0_DATA_BIT_WIDTH_8BIT) ||         \
-    defined(CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH_8BIT)
-#  define ESPRESSIF_I2S0_DATA_BIT_WIDTH 8
-#elif defined(CONFIG_ESPRESSIF_I2S0_DATA_BIT_WIDTH_16BIT) ||  \
-      defined(CONFIG_ESP32_I2S0_DATA_BIT_WIDTH_16BIT) ||      \
-      defined(CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH_16BIT)
-#  define ESPRESSIF_I2S0_DATA_BIT_WIDTH 16
-#elif defined(CONFIG_ESPRESSIF_I2S0_DATA_BIT_WIDTH_24BIT) ||  \
-      defined(CONFIG_ESP32_I2S0_DATA_BIT_WIDTH_24BIT) ||      \
-      defined(CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH_24BIT)
-#  define ESPRESSIF_I2S0_DATA_BIT_WIDTH 24
-#elif defined(CONFIG_ESPRESSIF_I2S0_DATA_BIT_WIDTH_32BIT) ||  \
-      defined(CONFIG_ESP32_I2S0_DATA_BIT_WIDTH_32BIT) ||      \
-      defined(CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH_32BIT)
-#  define ESPRESSIF_I2S0_DATA_BIT_WIDTH 32
-#endif
-
-#if defined(CONFIG_ESPRESSIF_I2S1_DATA_BIT_WIDTH_8BIT) ||     \
-    defined(CONFIG_ESP32_I2S1_DATA_BIT_WIDTH_8BIT)
-#  define ESPRESSIF_I2S1_DATA_BIT_WIDTH 8
-#elif defined(CONFIG_ESPRESSIF_I2S1_DATA_BIT_WIDTH_16BIT) ||  \
-    defined(CONFIG_ESP32_I2S1_DATA_BIT_WIDTH_16BIT)
-#  define ESPRESSIF_I2S1_DATA_BIT_WIDTH 16
-#elif defined(CONFIG_ESPRESSIF_I2S1_DATA_BIT_WIDTH_24BIT) ||  \
-      defined(CONFIG_ESP32_I2S1_DATA_BIT_WIDTH_24BIT)
-#  define ESPRESSIF_I2S1_DATA_BIT_WIDTH 24
-#elif defined(CONFIG_ESPRESSIF_I2S1_DATA_BIT_WIDTH_32BIT) ||  \
-      defined(CONFIG_ESP32_I2S1_DATA_BIT_WIDTH_32BIT)
-#  define ESPRESSIF_I2S1_DATA_BIT_WIDTH 32
-#endif
-
 /* I2S DMA RX/TX description number */
 
 #define I2S_DMADESC_NUM                 (CONFIG_I2S_DMADESC_NUM)
+
+/* I2S Clock */
+
+#define I2S_LL_BASE_CLK                 (2 * APB_CLK_FREQ)
+#define I2S_LL_MCLK_DIVIDER_BIT_WIDTH   (6)
+#define I2S_LL_MCLK_DIVIDER_MAX         ((1 << I2S_LL_MCLK_DIVIDER_BIT_WIDTH) - 1)
 
 /* I2S DMA channel number */
 
 #define I2S_DMA_CHANNEL_MAX (2)
 
-#ifdef CONFIG_ESPRESSIF_I2S0_TX
+#ifdef CONFIG_ESP32_I2S0_TX
 #  define I2S0_TX_ENABLED 1
 #  define I2S_HAVE_TX 1
 #else
 #  define I2S0_TX_ENABLED 0
 #endif
 
-#ifdef CONFIG_ESPRESSIF_I2S0_RX
+#ifdef CONFIG_ESP32_I2S0_RX
 #  define I2S0_RX_ENABLED 1
 #  define I2S_HAVE_RX 1
 #else
 #  define I2S0_RX_ENABLED 0
 #endif
 
-#ifdef CONFIG_ESPRESSIF_I2S1_TX
+#ifdef CONFIG_ESP32_I2S1_TX
 #  define I2S1_TX_ENABLED 1
 #  define I2S_HAVE_TX 1
 #else
 #  define I2S1_TX_ENABLED 0
 #endif
 
-#ifdef CONFIG_ESPRESSIF_I2S1_RX
+#ifdef CONFIG_ESP32_I2S1_RX
 #  define I2S1_RX_ENABLED 1
 #  define I2S_HAVE_RX 1
 #else
@@ -207,108 +114,38 @@
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_DEBUG_I2S_INFO
-#  define CONFIG_ESPRESSIF_I2S_DUMPBUFFERS
+#  define CONFIG_ESP32_I2S_DUMPBUFFERS
 #else
-#    undef CONFIG_ESPRESSIF_I2S_DUMPBUFFERS
+#  undef CONFIG_ESP32_I2S_DUMPBUFFERS
+#endif
+
+#ifndef CONFIG_ESP32_I2S_MAXINFLIGHT
+#  define CONFIG_ESP32_I2S_MAXINFLIGHT 4
 #endif
 
 #define I2S_GPIO_UNUSED -1      /* For signals which are not used */
 
-#if CONFIG_ARCH_CHIP_ESP32
-#  define I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask) \
-    cfg.slot_mask = mask,                                                 \
-    cfg.ws_width = bits_per_sample,                                       \
-    cfg.ws_pol = false,                                                   \
-    cfg.bit_shift = true,                                                 \
-    cfg.msb_right = true                                                  \
-
-#  define I2S_STD_PCM_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask)   \
-    cfg.slot_mask = mask,                                               \
-    cfg.ws_width = 1,                                                   \
-    cfg.ws_pol = true,                                                  \
-    cfg.bit_shift = false,                                              \
-    cfg.msb_right = true                                                \
-
-#  define I2S_STD_MSB_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask)   \
-    cfg.slot_mask = mask,                                               \
-    cfg.ws_width = bits_per_sample,                                     \
-    cfg.ws_pol = false,                                                 \
-    cfg.bit_shift = false,                                              \
-    cfg.msb_right = true                                                \
-
-#endif /* CONFIG_ARCH_CHIP_ESP32 */
-
-#ifdef CONFIG_ARCH_CHIP_ESP32S2
-#define I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask) \
-    cfg.slot_mask = (mask),                                             \
-    cfg.ws_width = bits_per_sample,                                     \
-    cfg.ws_pol = false,                                                 \
-    cfg.bit_shift = true,                                               \
-    cfg.msb_right = true                                                \
-
-#define I2S_STD_PCM_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask)    \
-    cfg.slot_mask = (mask),                                            \
-    cfg.ws_width = 1,                                                  \
-    cfg.ws_pol = true,                                                 \
-    cfg.bit_shift = true,                                              \
-    cfg.msb_right = true                                               \
-
-#  define I2S_STD_MSB_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask)  \
-    cfg.slot_mask = (mask),                                            \
-    cfg.ws_width = bits_per_sample,                                    \
-    cfg.ws_pol = false,                                                \
-    cfg.bit_shift = false,                                             \
-    cfg.msb_right = true                                               \
-
-#endif /* CONFIG_ARCH_CHIP_ESP32S2 */
-
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-#  define I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask) \
-      cfg.slot_mask = I2S_STD_SLOT_BOTH,                                  \
-      cfg.ws_width = bits_per_sample,                                     \
-      cfg.ws_pol = false,                                                 \
-      cfg.bit_shift = true,                                               \
-      cfg.left_align = true,                                              \
-      cfg.big_endian = false,                                             \
-      cfg.bit_order_lsb = false                                           \
-
-#  define I2S_STD_MSB_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask)     \
-      cfg.slot_mask = I2S_STD_SLOT_BOTH,                                  \
-      cfg.ws_width = bits_per_sample,                                     \
-      cfg.ws_pol = false,                                                 \
-      cfg.bit_shift = false,                                              \
-      cfg.left_align = true,                                              \
-      cfg.big_endian = false,                                             \
-      cfg.bit_order_lsb = false                                           \
-
-#  define I2S_STD_PCM_SLOT_DEFAULT_CONFIG(cfg, bits_per_sample, mask) \
-      cfg.slot_mask = I2S_STD_SLOT_BOTH,                                    \
-      cfg.ws_width = 1,                                                     \
-      cfg.ws_pol = true,                                                    \
-      cfg.bit_shift = true,                                                 \
-      cfg.left_align = true,                                                \
-      cfg.big_endian = false,                                               \
-      cfg.bit_order_lsb = false                                             \
-
-#  define I2S_PDM_TX_SLOT_DEFAULT_CONFIG(cfg)                   \
-      cfg.sd_prescale = 0,                                      \
-      cfg.sd_scale = I2S_PDM_SIG_SCALING_MUL_1,                 \
-      cfg.hp_scale = I2S_PDM_SIG_SCALING_DIV_2,                 \
-      cfg.lp_scale = I2S_PDM_SIG_SCALING_MUL_1,                 \
-      cfg.sinc_scale = I2S_PDM_SIG_SCALING_MUL_1,               \
-      cfg.line_mode = I2S_PDM_TX_ONE_LINE_CODEC,                \
-      cfg.hp_en = true,                                         \
-      cfg.hp_cut_off_freq_hz = 35.5,                            \
-      cfg.sd_dither = 0,                                        \
-      cfg.sd_dither2 = 1                                        \
-
-#endif /* CONFIG_ARCH_CHIP_ESP32S3 */
-
-#define MIN(x,y) ((x)<(y)?(x):(y))
-
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
+/* Role of the I2S port */
+
+typedef enum
+{
+  I2S_ROLE_MASTER,  /* I2S controller master role, bclk and ws signal will be set to output */
+  I2S_ROLE_SLAVE    /* I2S controller slave role, bclk and ws signal will be set to input */
+} i2s_role_t;
+
+/* Data width of the I2S channel */
+
+typedef enum
+{
+  I2S_DATA_BIT_WIDTH_8BIT   = 8,    /* I2S channel data bit-width: 8 */
+  I2S_DATA_BIT_WIDTH_16BIT  = 16,   /* I2S channel data bit-width: 16 */
+  I2S_DATA_BIT_WIDTH_24BIT  = 24,   /* I2S channel data bit-width: 24 */
+  I2S_DATA_BIT_WIDTH_32BIT  = 32,   /* I2S channel data bit-width: 32 */
+} i2s_data_bit_width_t;
 
 /* Multiplier of MCLK to sample rate */
 
@@ -320,35 +157,21 @@ typedef enum
   I2S_MCLK_MULTIPLE_512 = 512,  /* mclk = sample_rate * 512 */
 } i2s_mclk_multiple_t;
 
-/* I2S Audio Standard Mode */
-
-typedef enum
-{
-  I2S_STD_PHILIPS = 0,
-  I2S_STD_MSB,
-  I2S_STD_PCM,
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  I2S_PDM,
-#endif
-} i2s_audio_mode_t;
-
 /* I2S Device hardware configuration */
 
-struct esp_i2s_config_s
+struct esp32_i2s_config_s
 {
-  uint32_t port;                    /* I2S port */
-  uint32_t role;                    /* I2S port role (master or slave) */
-  uint8_t data_width;               /* I2S sample data width */
-  uint32_t rate;                    /* I2S sample-rate */
-  uint32_t total_slot;              /* Total slot number */
+  uint32_t port;              /* I2S port */
+  uint32_t role;              /* I2S port role (master or slave) */
+  uint8_t data_width;         /* I2S sample data width */
+  uint32_t rate;              /* I2S sample-rate */
+  uint32_t total_slot;        /* Total slot number */
 
-  bool tx_en;                       /* Is TX enabled? */
-  bool rx_en;                       /* Is RX enabled? */
-  int8_t mclk_pin;                  /* MCLK pin, output */
+  bool is_apll;               /* Select APLL as the source clock */
 
-  int tx_clk_src;                   /* Select the I2S TX source clock */
-  int rx_clk_src;                   /* Select the I2S TX source clock */
-  int clk_hz;                       /* Clock speed in hz */
+  bool tx_en;                 /* Is TX enabled? */
+  bool rx_en;                 /* Is RX enabled? */
+  int8_t mclk_pin;            /* MCLK pin, output */
 
   /* BCLK pin, input in slave role, output in master role */
 
@@ -358,38 +181,42 @@ struct esp_i2s_config_s
 
   int8_t ws_pin;
 
-  int8_t dout_pin;                  /* DATA pin, output */
-  int8_t din_pin;                   /* DATA pin, input */
+  int8_t dout_pin;            /* DATA pin, output */
+  int8_t din_pin;             /* DATA pin, input */
 
-  uint32_t bclk_in_insig;           /* RX channel BCK signal (slave mode) index */
-  uint32_t bclk_in_outsig;          /* RX channel BCK signal (master mode) index */
-  uint32_t bclk_out_insig;          /* TX channel BCK signal (slave mode) index */
-  uint32_t bclk_out_outsig;         /* TX channel BCK signal (master mode) index */
-  uint32_t ws_in_insig;             /* RX channel WS signal (slave mode) index */
-  uint32_t ws_in_outsig;            /* RX channel WS signal (master mode) index */
-  uint32_t ws_out_insig;            /* TX channel WS signal (slave mode) index */
-  uint32_t ws_out_outsig;           /* TX channel WS signal (master mode) index */
-  uint32_t din_insig;               /* RX channel Data Input signal index */
-  uint32_t dout_outsig;             /* TX channel Data Output signal index */
-  uint32_t mclk_out_sig;            /* Master clock output index */
+  uint8_t periph;             /* peripher ID */
+  uint8_t irq;                /* Interrupt ID */
 
-  uint8_t  audio_std_mode;          /* Select audio standard (i2s_audio_mode_t) */
+  uint32_t bclk_in_insig;     /* RX channel BCK signal (slave mode) index */
+  uint32_t bclk_in_outsig;    /* RX channel BCK signal (master mode) index */
+  uint32_t bclk_out_insig;    /* TX channel BCK signal (slave mode) index */
+  uint32_t bclk_out_outsig;   /* TX channel BCK signal (master mode) index */
+  uint32_t ws_in_insig;       /* RX channel WS signal (slave mode) index */
+  uint32_t ws_in_outsig;      /* RX channel WS signal (master mode) index */
+  uint32_t ws_out_insig;      /* TX channel WS signal (slave mode) index */
+  uint32_t ws_out_outsig;     /* TX channel WS signal (master mode) index */
+  uint32_t din_insig;         /* RX channel Data Input signal index */
+  uint32_t dout_outsig;       /* TX channel Data Output signal index */
 
-  /* WS signal polarity, set true to enable high level first */
+  bool bit_shift;             /* Set to enable bit shift in Philips mode */
+  bool mono_en;               /* Set to enable mono mode on slot */
+
+  /* WS signal width (the number of bclk ticks that ws signal is high) */
+
+  uint32_t ws_width;
+
+  /* WS signal polarity, set true to enable high lever first */
 
   bool ws_pol;
-
-  i2s_hal_context_t *ctx;           /* Common layer struct */
-  i2s_hal_clock_info_t *clk_info;   /* Common layer clock info struct */
 };
 
-struct esp_buffer_s
+struct esp32_buffer_s
 {
-  struct esp_buffer_s *flink; /* Supports a singly linked list */
+  struct esp32_buffer_s *flink; /* Supports a singly linked list */
 
   /* The associated DMA in/outlink */
 
-  struct esp_dmadesc_s dma_link[I2S_DMADESC_NUM];
+  struct esp32_dmadesc_s dma_link[I2S_DMADESC_NUM];
 
   i2s_callback_t callback;      /* DMA completion callback */
   uint32_t timeout;             /* Timeout value of the DMA transfers */
@@ -406,7 +233,7 @@ struct esp_buffer_s
  * track of the bytes that were not written to the internal buffer yet.
  */
 
-struct esp_buffer_carry_s
+struct esp32_buffer_carry_s
 {
   uint32_t value;
   size_t bytes;
@@ -416,7 +243,7 @@ struct esp_buffer_carry_s
  * transport.
  */
 
-struct esp_transport_s
+struct esp32_transport_s
 {
   sq_queue_t pend;              /* A queue of pending transfers */
   sq_queue_t act;               /* A queue of active transfers */
@@ -425,50 +252,46 @@ struct esp_transport_s
 
   /* Bytes to be written at the beginning of the next DMA buffer */
 
-  struct esp_buffer_carry_s carry;
+  struct esp32_buffer_carry_s carry;
 };
 
 /* The state of the one I2S peripheral */
 
-struct esp_i2s_s
+struct esp32_i2s_s
 {
   struct i2s_dev_s  dev;        /* Externally visible I2S interface */
   mutex_t           lock;       /* Ensures mutually exclusive access */
+  int               cpuint;     /* I2S interrupt ID */
   uint8_t           cpu;        /* CPU ID */
   spinlock_t        slock;      /* Device specific lock. */
 
   /* Port configuration */
 
-  const struct esp_i2s_config_s *config;
+  const struct esp32_i2s_config_s *config;
 
   uint32_t    mclk_freq;      /* I2S actual master clock */
   uint32_t    mclk_multiple;  /* The multiple of mclk to the sample rate */
   uint32_t    channels;       /* Audio channels (1:mono or 2:stereo) */
   uint32_t    rate;           /* I2S actual configured sample-rate */
   uint32_t    data_width;     /* I2S actual configured data_width */
-  uint32_t    dma_channel;    /* I2S DMA channel being used */
 
 #ifdef I2S_HAVE_TX
-  struct esp_transport_s tx;  /* TX transport state */
+  struct esp32_transport_s tx;  /* TX transport state */
 
-  int  tx_irq;                    /* TX IRQ */
-  bool tx_started;                /* TX channel started */
+  bool tx_started;              /* TX channel started */
 #endif /* I2S_HAVE_TX */
 
 #ifdef I2S_HAVE_RX
-  struct esp_transport_s rx;  /* RX transport state */
+  struct esp32_transport_s rx;  /* RX transport state */
 
-  int  rx_irq;                    /* RX IRQ */
-  bool rx_started;                /* RX channel started */
+  bool rx_started;              /* RX channel started */
 #endif /* I2S_HAVE_RX */
-
-  bool streaming;                 /* Is I2S peripheral active? */
 
   /* Pre-allocated pool of buffer containers */
 
-  sem_t bufsem;                         /* Buffer wait semaphore */
-  struct esp_buffer_s *bf_freelist;     /* A list a free buffer containers */
-  struct esp_buffer_s containers[CONFIG_ESPRESSIF_I2S_MAXINFLIGHT];
+  sem_t bufsem;                       /* Buffer wait semaphore */
+  struct esp32_buffer_s *bf_freelist; /* A list a free buffer containers */
+  struct esp32_buffer_s containers[CONFIG_ESP32_I2S_MAXINFLIGHT];
 };
 
 /****************************************************************************
@@ -477,7 +300,7 @@ struct esp_i2s_s
 
 /* Register helpers */
 
-#ifdef CONFIG_ESPRESSIF_I2S_DUMPBUFFERS
+#ifdef CONFIG_ESP32_I2S_DUMPBUFFERS
 #  define       i2s_dump_buffer(m,b,s) lib_dumpbuffer(m,b,s)
 #else
 #  define       i2s_dump_buffer(m,b,s)
@@ -485,43 +308,42 @@ struct esp_i2s_s
 
 /* Buffer container helpers */
 
-static struct esp_buffer_s *
-                i2s_buf_allocate(struct esp_i2s_s *priv);
-static void     i2s_buf_free(struct esp_i2s_s *priv,
-                             struct esp_buffer_s *bfcontainer);
-static int      i2s_buf_initialize(struct esp_i2s_s *priv);
+static struct esp32_buffer_s *
+                i2s_buf_allocate(struct esp32_i2s_s *priv);
+static void     i2s_buf_free(struct esp32_i2s_s *priv,
+                             struct esp32_buffer_s *bfcontainer);
+static int      i2s_buf_initialize(struct esp32_i2s_s *priv);
 
 /* DMA support */
 
 #ifdef I2S_HAVE_TX
-static IRAM_ATTR int  i2s_txdma_setup(struct esp_i2s_s *priv,
-                                      struct esp_buffer_s *bfcontainer);
+static IRAM_ATTR int  i2s_txdma_setup(struct esp32_i2s_s *priv,
+                                      struct esp32_buffer_s *bfcontainer);
 static void           i2s_tx_worker(void *arg);
-static void           i2s_tx_schedule(struct esp_i2s_s *priv,
-                                      struct esp_dmadesc_s *outlink);
+static void           i2s_tx_schedule(struct esp32_i2s_s *priv,
+                                      struct esp32_dmadesc_s *outlink);
 #endif /* I2S_HAVE_TX */
 
 #ifdef I2S_HAVE_RX
-static IRAM_ATTR int  i2s_rxdma_setup(struct esp_i2s_s *priv,
-                                      struct esp_buffer_s *bfcontainer);
+static IRAM_ATTR int  i2s_rxdma_setup(struct esp32_i2s_s *priv,
+                                      struct esp32_buffer_s *bfcontainer);
 static void           i2s_rx_worker(void *arg);
-static void           i2s_rx_schedule(struct esp_i2s_s *priv,
-                                      struct esp_dmadesc_s *outlink);
+static void           i2s_rx_schedule(struct esp32_i2s_s *priv,
+                                      struct esp32_dmadesc_s *outlink);
 #endif /* I2S_HAVE_RX */
 
 /* I2S methods (and close friends) */
 
-static int32_t  i2s_check_mclkfrequency(struct esp_i2s_s *priv);
-static uint32_t i2s_set_datawidth(struct esp_i2s_s *priv);
-static void i2s_set_clock(struct esp_i2s_s *priv);
+static uint32_t i2s_set_datawidth(struct esp32_i2s_s *priv);
+static uint32_t i2s_set_clock(struct esp32_i2s_s *priv);
 static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
 static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency);
 static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 
 #ifdef I2S_HAVE_TX
-static void     i2s_tx_channel_start(struct esp_i2s_s *priv);
-static void     i2s_tx_channel_stop(struct esp_i2s_s *priv);
+static void     i2s_tx_channel_start(struct esp32_i2s_s *priv);
+static void     i2s_tx_channel_stop(struct esp32_i2s_s *priv);
 static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
 static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
 static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
@@ -531,11 +353,12 @@ static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 #endif /* I2S_HAVE_TX */
 
 #ifdef I2S_HAVE_RX
-static void     i2s_rx_channel_start(struct esp_i2s_s *priv);
-static void     i2s_rx_channel_stop(struct esp_i2s_s *priv);
+static void     i2s_rx_channel_start(struct esp32_i2s_s *priv);
+static void     i2s_rx_channel_stop(struct esp32_i2s_s *priv);
 static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
 static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
 static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static void     i2s_cleanup_queues(struct esp32_i2s_s *priv);
 static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                             i2s_callback_t callback, void *arg,
                             uint32_t timeout);
@@ -561,56 +384,44 @@ static const struct i2s_ops_s g_i2sops =
   .i2s_receive        = i2s_receive,
 #endif /* I2S_HAVE_RX */
 
-  .i2s_ioctl             = i2s_ioctl,
+  .i2s_ioctl          = i2s_ioctl,
   .i2s_getmclkfrequency  = i2s_getmclkfrequency,
   .i2s_setmclkfrequency  = i2s_setmclkfrequency,
 };
 
-#ifdef CONFIG_ESPRESSIF_I2S0
-
-i2s_hal_context_t ctx_i2s0 =
-{
-  0
-};
-
-i2s_hal_clock_info_t clk_info_i2s0 =
-{
-  0
-};
-
-static const struct esp_i2s_config_s esp_i2s0_config =
+#ifdef CONFIG_ESP32_I2S0
+static const struct esp32_i2s_config_s esp32_i2s0_config =
 {
   .port             = 0,
-#ifdef CONFIG_ESPRESSIF_I2S0_ROLE_MASTER
+#ifdef CONFIG_ESP32_I2S0_ROLE_MASTER
   .role             = I2S_ROLE_MASTER,
 #else
   .role             = I2S_ROLE_SLAVE,
-#endif /* CONFIG_ESPRESSIF_I2S0_ROLE_MASTER */
-  .data_width       = ESPRESSIF_I2S0_DATA_BIT_WIDTH,
-  .rate             = CONFIG_ESPRESSIF_I2S0_SAMPLE_RATE,
+#endif /* CONFIG_ESP32_I2S0_ROLE_MASTER */
+  .data_width       = CONFIG_ESP32_I2S0_DATA_BIT_WIDTH,
+  .rate             = CONFIG_ESP32_I2S0_SAMPLE_RATE,
   .total_slot       = 2,
   .tx_en            = I2S0_TX_ENABLED,
   .rx_en            = I2S0_RX_ENABLED,
-  .tx_clk_src       = I2S_CLK_SRC_PLL_160M,
-  .rx_clk_src       = I2S_CLK_SRC_PLL_160M,
-  .clk_hz           = (2 * APB_CLK_FREQ),
-#ifdef CONFIG_ESPRESSIF_I2S0_MCLK
-  .mclk_pin         = CONFIG_ESPRESSIF_I2S0_MCLKPIN,
+#ifdef CONFIG_ESP32_I2S0_MCLK
+  .mclk_pin         = CONFIG_ESP32_I2S0_MCLKPIN,
 #else
   .mclk_pin         = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S0_MCLK */
-  .bclk_pin         = CONFIG_ESPRESSIF_I2S0_BCLKPIN,
-  .ws_pin           = CONFIG_ESPRESSIF_I2S0_WSPIN,
-#ifdef CONFIG_ESPRESSIF_I2S0_DOUTPIN
-  .dout_pin         = CONFIG_ESPRESSIF_I2S0_DOUTPIN,
+#endif /* CONFIG_ESP32_I2S0_MCLK */
+  .bclk_pin         = CONFIG_ESP32_I2S0_BCLKPIN,
+  .ws_pin           = CONFIG_ESP32_I2S0_WSPIN,
+#ifdef CONFIG_ESP32_I2S0_DOUTPIN
+  .dout_pin         = CONFIG_ESP32_I2S0_DOUTPIN,
 #else
   .dout_pin         = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S0_DOUTPIN */
-#ifdef CONFIG_ESPRESSIF_I2S0_DINPIN
-  .din_pin          = CONFIG_ESPRESSIF_I2S0_DINPIN,
+#endif /* CONFIG_ESP32_I2S0_DOUTPIN */
+#ifdef CONFIG_ESP32_I2S0_DINPIN
+  .din_pin          = CONFIG_ESP32_I2S0_DINPIN,
 #else
   .din_pin          = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S0_DINPIN */
+#endif /* CONFIG_ESP32_I2S0_DINPIN */
+  .periph           = ESP32_PERIPH_I2S0,
+  .irq              = ESP32_IRQ_I2S0,
   .bclk_in_insig    = I2S0I_BCK_IN_IDX,
   .bclk_in_outsig   = I2S0I_BCK_OUT_IDX,
   .bclk_out_insig   = I2S0O_BCK_IN_IDX,
@@ -619,71 +430,58 @@ static const struct esp_i2s_config_s esp_i2s0_config =
   .ws_in_outsig     = I2S0I_WS_OUT_IDX,
   .ws_out_insig     = I2S0O_WS_IN_IDX,
   .ws_out_outsig    = I2S0O_WS_OUT_IDX,
-  .din_insig        = I2S0I_SD_IN_IDX,
-  .dout_outsig      = I2S0O_SD_OUT_IDX,
-  .mclk_out_sig     = I2S0_MCLK_OUT_IDX,
-  .audio_std_mode   = I2S_STD_PHILIPS,
-  .ctx              = &ctx_i2s0,
-  .clk_info         = &clk_info_i2s0,
+  .din_insig        = I2S0I_DATA_IN15_IDX,
+  .dout_outsig      = I2S0O_DATA_OUT23_IDX,
+  .bit_shift        = true,
+  .mono_en          = false,
+  .ws_width         = CONFIG_ESP32_I2S0_DATA_BIT_WIDTH,
 };
 
-static struct esp_i2s_s esp_i2s0_priv =
+static struct esp32_i2s_s esp32_i2s0_priv =
 {
   .dev =
   {
     .ops = &g_i2sops,
   },
   .lock = NXMUTEX_INITIALIZER,
-  .config = &esp_i2s0_config,
+  .config = &esp32_i2s0_config,
   .bufsem = SEM_INITIALIZER(0),
 };
-#endif /* CONFIG_ESPRESSIF_I2S0 */
+#endif /* CONFIG_ESP32_I2S0 */
 
-#ifdef CONFIG_ESPRESSIF_I2S1
-
-i2s_hal_context_t ctx_i2s1 =
-{
-  0
-};
-
-i2s_hal_clock_info_t clk_info_i2s1 =
-{
-  0
-};
-
-static const struct esp_i2s_config_s esp_i2s1_config =
+#ifdef CONFIG_ESP32_I2S1
+static const struct esp32_i2s_config_s esp32_i2s1_config =
 {
   .port             = 1,
-#ifdef CONFIG_ESPRESSIF_I2S1_ROLE_MASTER
+#ifdef CONFIG_ESP32_I2S1_ROLE_MASTER
   .role             = I2S_ROLE_MASTER,
 #else
   .role             = I2S_ROLE_SLAVE,
-#endif /* CONFIG_ESPRESSIF_I2S1_ROLE_MASTER */
-  .data_width       = ESPRESSIF_I2S1_DATA_BIT_WIDTH,
-  .rate             = CONFIG_ESPRESSIF_I2S1_SAMPLE_RATE,
+#endif /* CONFIG_ESP32_I2S1_ROLE_MASTER */
+  .data_width       = CONFIG_ESP32_I2S1_DATA_BIT_WIDTH,
+  .rate             = CONFIG_ESP32_I2S1_SAMPLE_RATE,
   .total_slot       = 2,
   .tx_en            = I2S1_TX_ENABLED,
   .rx_en            = I2S1_RX_ENABLED,
-  .tx_clk_src       = I2S_CLK_SRC_PLL_160M,
-  .rx_clk_src       = I2S_CLK_SRC_PLL_160M,
-  .clk_hz           = (2 * APB_CLK_FREQ),
-#ifdef CONFIG_ESPRESSIF_I2S1_MCLK
-  .mclk_pin         = CONFIG_ESPRESSIF_I2S1_MCLKPIN,
+#ifdef CONFIG_ESP32_I2S1_MCLK
+  .mclk_pin         = CONFIG_ESP32_I2S1_MCLKPIN,
 #else
   .mclk_pin         = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S1_MCLK */
-  .bclk_pin         = CONFIG_ESPRESSIF_I2S1_BCLKPIN,
-  .ws_pin           = CONFIG_ESPRESSIF_I2S1_WSPIN,
-#ifdef CONFIG_ESPRESSIF_I2S1_DOUTPIN
-  .dout_pin         = CONFIG_ESPRESSIF_I2S1_DOUTPIN,
+#endif /* CONFIG_ESP32_I2S1_MCLK */
+  .bclk_pin         = CONFIG_ESP32_I2S1_BCLKPIN,
+  .ws_pin           = CONFIG_ESP32_I2S1_WSPIN,
+#ifdef CONFIG_ESP32_I2S1_DOUTPIN
+  .dout_pin         = CONFIG_ESP32_I2S1_DOUTPIN,
 #else
   .dout_pin         = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S1_DOUTPIN */
-#ifdef CONFIG_ESPRESSIF_I2S1_DINPIN
-  .din_pin          = CONFIG_ESPRESSIF_I2S1_DINPIN,
+#endif /* CONFIG_ESP32_I2S1_DOUTPIN */
+#ifdef CONFIG_ESP32_I2S1_DINPIN
+  .din_pin          = CONFIG_ESP32_I2S1_DINPIN,
 #else
-  .din_pin          = I2S_GPIO_UNUSED,
-#endif /* CONFIG_ESPRESSIF_I2S1_DINPIN */
+  .din_pin         = I2S_GPIO_UNUSED,
+#endif /* CONFIG_ESP32_I2S1_DINPIN */
+  .periph           = ESP32_PERIPH_I2S1,
+  .irq              = ESP32_IRQ_I2S1,
   .bclk_in_insig    = I2S1I_BCK_IN_IDX,
   .bclk_in_outsig   = I2S1I_BCK_OUT_IDX,
   .bclk_out_insig   = I2S1O_BCK_IN_IDX,
@@ -692,25 +490,24 @@ static const struct esp_i2s_config_s esp_i2s1_config =
   .ws_in_outsig     = I2S1I_WS_OUT_IDX,
   .ws_out_insig     = I2S1O_WS_IN_IDX,
   .ws_out_outsig    = I2S1O_WS_OUT_IDX,
-  .din_insig        = I2S1I_SD_IN_IDX,
-  .dout_outsig      = I2S1O_SD_OUT_IDX,
-  .mclk_out_sig     = I2S1_MCLK_OUT_IDX,
-  .audio_std_mode   = I2S_STD_PHILIPS,
-  .ctx              = &ctx_i2s1,
-  .clk_info         = &clk_info_i2s1,
+  .din_insig        = I2S1I_DATA_IN15_IDX,
+  .dout_outsig      = I2S1O_DATA_OUT23_IDX,
+  .bit_shift        = true,
+  .mono_en          = false,
+  .ws_width         = CONFIG_ESP32_I2S1_DATA_BIT_WIDTH,
 };
 
-static struct esp_i2s_s esp_i2s1_priv =
+static struct esp32_i2s_s esp32_i2s1_priv =
 {
   .dev =
   {
     .ops = &g_i2sops,
   },
   .lock = NXMUTEX_INITIALIZER,
-  .config = &esp_i2s1_config,
+  .config = &esp32_i2s1_config,
   .bufsem = SEM_INITIALIZER(0),
 };
-#endif /* CONFIG_ESPRESSIF_I2S1 */
+#endif /* CONFIG_ESP32_I2S1 */
 
 /****************************************************************************
  * Private Functions
@@ -736,9 +533,9 @@ static struct esp_i2s_s esp_i2s1_priv =
  *
  ****************************************************************************/
 
-static struct esp_buffer_s *i2s_buf_allocate(struct esp_i2s_s *priv)
+static struct esp32_buffer_s *i2s_buf_allocate(struct esp32_i2s_s *priv)
 {
-  struct esp_buffer_s *bfcontainer;
+  struct esp32_buffer_s *bfcontainer;
   irqstate_t flags;
   int ret;
 
@@ -772,7 +569,7 @@ static struct esp_buffer_s *i2s_buf_allocate(struct esp_i2s_s *priv)
  *   Free buffer container by adding it to the head of the free list
  *
  * Input Parameters:
- *   priv        - Initialized I2S device structure.
+ *   priv - Initialized I2S device structure.
  *   bfcontainer - The buffer container to be freed
  *
  * Returned Value:
@@ -783,8 +580,8 @@ static struct esp_buffer_s *i2s_buf_allocate(struct esp_i2s_s *priv)
  *
  ****************************************************************************/
 
-static void i2s_buf_free(struct esp_i2s_s *priv,
-                         struct esp_buffer_s *bfcontainer)
+static void i2s_buf_free(struct esp32_i2s_s *priv,
+                         struct esp32_buffer_s *bfcontainer)
 {
   irqstate_t flags;
 
@@ -824,7 +621,7 @@ static void i2s_buf_free(struct esp_i2s_s *priv,
  *
  ****************************************************************************/
 
-static int i2s_buf_initialize(struct esp_i2s_s *priv)
+static int i2s_buf_initialize(struct esp32_i2s_s *priv)
 {
 #ifdef I2S_HAVE_TX
   priv->tx.carry.bytes = 0;
@@ -832,7 +629,7 @@ static int i2s_buf_initialize(struct esp_i2s_s *priv)
 #endif /* I2S_HAVE_TX */
 
   priv->bf_freelist = NULL;
-  for (int i = 0; i < CONFIG_ESPRESSIF_I2S_MAXINFLIGHT; i++)
+  for (int i = 0; i < CONFIG_ESP32_I2S_MAXINFLIGHT; i++)
     {
       i2s_buf_free(priv, &priv->containers[i]);
     }
@@ -859,9 +656,9 @@ static int i2s_buf_initialize(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static int IRAM_ATTR i2s_txdma_start(struct esp_i2s_s *priv)
+static int i2s_txdma_start(struct esp32_i2s_s *priv)
 {
-  struct esp_buffer_s *bfcontainer;
+  struct esp32_buffer_s *bfcontainer;
 
   /* If there is already an active transmission in progress, then bail
    * returning success.
@@ -879,23 +676,20 @@ static int IRAM_ATTR i2s_txdma_start(struct esp_i2s_s *priv)
       return OK;
     }
 
-  i2s_hal_tx_reset(priv->config->ctx);
-  i2s_hal_tx_reset_fifo(priv->config->ctx);
+  bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->tx.pend);
 
-  /* Start transmission if no data is already being transmitted */
+  /* If there isn't already an active transmission in progress,
+   * then start it.
+   */
 
-  bfcontainer = (struct esp_buffer_s *)sq_remfirst(&priv->tx.pend);
+  modifyreg32(I2S_OUT_LINK_REG(priv->config->port), I2S_OUTLINK_ADDR_M,
+              FIELD_TO_VALUE(I2S_OUTLINK_ADDR,
+              (uintptr_t) bfcontainer->dma_link));
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  esp_dma_load(bfcontainer->dma_link, priv->dma_channel, I2S_DIR_TX);
-  esp_dma_enable(priv->dma_channel, I2S_DIR_TX);
-#else
-  i2s_hal_tx_enable_dma(priv->config->ctx);
-  i2s_hal_tx_enable_intr(priv->config->ctx);
-  i2s_hal_tx_start_link(priv->config->ctx, (uint32_t) bfcontainer->dma_link);
-#endif
+  modifyreg32(I2S_OUT_LINK_REG(priv->config->port), I2S_OUTLINK_STOP,
+              I2S_OUTLINK_START);
 
-  i2s_hal_tx_start(priv->config->ctx);
+  modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_START);
 
   sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.act);
 
@@ -922,10 +716,9 @@ static int IRAM_ATTR i2s_txdma_start(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static int i2s_rxdma_start(struct esp_i2s_s *priv)
+static int i2s_rxdma_start(struct esp32_i2s_s *priv)
 {
-  struct esp_buffer_s *bfcontainer;
-  size_t eof_nbytes;
+  struct esp32_buffer_s *bfcontainer;
 
   /* If there is already an active transmission in progress, then bail
    * returning success.
@@ -943,30 +736,24 @@ static int i2s_rxdma_start(struct esp_i2s_s *priv)
       return OK;
     }
 
-  i2s_hal_rx_reset(priv->config->ctx);
-  i2s_hal_rx_reset_fifo(priv->config->ctx);
-
-  bfcontainer = (struct esp_buffer_s *)sq_remfirst(&priv->rx.pend);
+  bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->rx.pend);
 
   /* If there isn't already an active transmission in progress,
    * then start it.
    */
 
-  eof_nbytes = MIN(bfcontainer->nbytes, ESPRESSIF_DMA_BUFLEN_MAX);
+  modifyreg32(I2S_RXEOF_NUM_REG(priv->config->port), I2S_RX_EOF_NUM_M,
+              FIELD_TO_VALUE(I2S_RX_EOF_NUM,
+              (bfcontainer->nbytes / 4)));
 
-  i2s_ll_rx_set_eof_num(priv->config->ctx->dev, eof_nbytes);
+  modifyreg32(I2S_IN_LINK_REG(priv->config->port), I2S_INLINK_ADDR_M,
+              FIELD_TO_VALUE(I2S_INLINK_ADDR,
+              (uintptr_t) bfcontainer->dma_link));
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  esp_dma_load(bfcontainer->dma_link, priv->dma_channel, I2S_DIR_RX);
-  esp_dma_enable(priv->dma_channel, I2S_DIR_RX);
-#else
-  i2s_hal_rx_enable_dma(priv->config->ctx);
-  i2s_hal_rx_enable_intr(priv->config->ctx);
-  i2s_hal_rx_start_link(priv->config->ctx, (uint32_t) bfcontainer->dma_link);
-  i2s_ll_rx_set_eof_num(priv->config->ctx->dev, bfcontainer->nbytes);
-#endif
+  modifyreg32(I2S_IN_LINK_REG(priv->config->port), I2S_INLINK_STOP,
+              I2S_INLINK_START);
 
-  i2s_hal_rx_start(priv->config->ctx);
+  modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_START);
 
   sq_addlast((sq_entry_t *)bfcontainer, &priv->rx.act);
 
@@ -981,7 +768,7 @@ static int i2s_rxdma_start(struct esp_i2s_s *priv)
  *   Setup the next TX DMA transfer
  *
  * Input Parameters:
- *   priv        - Initialized I2S device structure.
+ *   priv - Initialized I2S device structure.
  *   bfcontainer - The buffer container to be set up
  *
  * Returned Value:
@@ -993,15 +780,15 @@ static int i2s_rxdma_start(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
-                                     struct esp_buffer_s *bfcontainer)
+static IRAM_ATTR int i2s_txdma_setup(struct esp32_i2s_s *priv,
+                                     struct esp32_buffer_s *bfcontainer)
 {
   int ret = OK;
   size_t carry_size;
   uint32_t bytes_queued;
   uint32_t data_copied;
   struct ap_buffer_s *apb;
-  struct esp_dmadesc_s *outlink;
+  struct esp32_dmadesc_s *outlink;
   apb_samp_t samp_size;
   irqstate_t flags;
   uint8_t *buf;
@@ -1020,9 +807,20 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
   samp_size = (apb->nbytes - apb->curbyte) + priv->tx.carry.bytes;
   carry_size = samp_size % bytes_per_sample;
 
-  /* Allocate the current audio buffer considering the remaining bytes
-   * carried from the last upper half audio buffer.
+  /* Padding contains the size (in bytes) to be skipped on the
+   * internal buffer do provide 1) the ability to handle mono
+   * audio files and 2) to correctly fill the buffer to 16 or 32-bits
+   * aligned positions.
    */
+
+  padding = priv->channels == 1 ?
+            ((priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+              I2S_DATA_BIT_WIDTH_16BIT : I2S_DATA_BIT_WIDTH_32BIT) / 8) : 0;
+
+  padding += priv->data_width != I2S_DATA_BIT_WIDTH_16BIT ?
+             (priv->data_width != I2S_DATA_BIT_WIDTH_32BIT ? 1 : 0) : 0;
+
+  /* Copy audio data into internal buffer */
 
   bfcontainer->buf = calloc(bfcontainer->nbytes, 1);
   if (bfcontainer->buf == NULL)
@@ -1033,14 +831,7 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
     }
 
   data_copied = 0;
-  buf = bfcontainer->buf;
-
-  /* Copy the remaining bytes from the last audio buffer to the current
-   * audio buffer. The remaining bytes are part of a sample that was split
-   * between the last and the current audio buffer. Also, copy the bytes
-   * from that split sample that are on the current buffer to the internal
-   * buffer.
-   */
+  buf = bfcontainer->buf + padding;
 
   if (priv->tx.carry.bytes)
     {
@@ -1048,21 +839,33 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
       buf += priv->tx.carry.bytes;
       data_copied += priv->tx.carry.bytes;
       memcpy(buf, samp, (bytes_per_sample - priv->tx.carry.bytes));
-      buf += (bytes_per_sample - priv->tx.carry.bytes);
+      buf += (bytes_per_sample - priv->tx.carry.bytes + padding);
       samp += (bytes_per_sample - priv->tx.carry.bytes);
       data_copied += (bytes_per_sample - priv->tx.carry.bytes);
     }
 
-  /* Copy the upper half buffer to the internal buffer considering that
-   * the current upper half buffer may not contain a complete sample at
-   * the end of the buffer (and those bytes needs to be carried to the
-   * next audio buffer).
+  /* If there is no need to add padding bytes, the memcpy may be done at
+   * once. Otherwise, the operation must add the padding bytes to each
+   * sample in the internal buffer.
    */
 
-  memcpy(buf, samp, samp_size - (data_copied + carry_size));
-  buf += samp_size - (data_copied + carry_size);
-  samp += samp_size - (data_copied + carry_size);
-  data_copied += samp_size - (data_copied + carry_size);
+  if (padding)
+    {
+      while (data_copied < (samp_size - carry_size))
+        {
+          memcpy(buf, samp, bytes_per_sample);
+          buf += (bytes_per_sample + padding);
+          samp += bytes_per_sample;
+          data_copied += bytes_per_sample;
+        }
+    }
+  else
+    {
+      memcpy(buf, samp, samp_size - (data_copied + carry_size));
+      buf += samp_size - (data_copied + carry_size);
+      samp += samp_size - (data_copied + carry_size);
+      data_copied += samp_size - (data_copied + carry_size);
+    }
 
   /* If the audio buffer's size is not a multiple of the sample size,
    * it's necessary to carry the remaining bytes that are part of what
@@ -1072,6 +875,7 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
    */
 
   priv->tx.carry.bytes = carry_size;
+
   if (priv->tx.carry.bytes)
     {
       memcpy((uint8_t *)&priv->tx.carry.value, samp, priv->tx.carry.bytes);
@@ -1085,26 +889,15 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
 
   /* Configure DMA stream */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  bytes_queued = esp_dma_setup((struct esp_dmadesc_s *)outlink,
-                               I2S_DMADESC_NUM,
-                               (uint8_t *) bfcontainer->buf,
-                               bfcontainer->nbytes,
-                               true,
-                               priv->dma_channel);
-#else
-  bytes_queued = esp_dma_setup((struct esp_dmadesc_s *)outlink,
-                               I2S_DMADESC_NUM,
-                               (uint8_t *) bfcontainer->buf,
-                               bfcontainer->nbytes);
-#endif
+  bytes_queued = esp32_dma_init(outlink, I2S_DMADESC_NUM,
+                                bfcontainer->buf, bfcontainer->nbytes);
 
   if (bytes_queued != bfcontainer->nbytes)
     {
       i2serr("Failed to enqueue I2S buffer "
              "(%" PRIu32 " bytes of %" PRIu32 ")\n",
              bytes_queued, bfcontainer->nbytes);
-      return -bytes_queued;
+      return bytes_queued;
     }
 
   flags = spin_lock_irqsave(&priv->slock);
@@ -1142,11 +935,11 @@ static IRAM_ATTR int i2s_txdma_setup(struct esp_i2s_s *priv,
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static int i2s_rxdma_setup(struct esp_i2s_s *priv,
-                           struct esp_buffer_s *bfcontainer)
+static int i2s_rxdma_setup(struct esp32_i2s_s *priv,
+                           struct esp32_buffer_s *bfcontainer)
 {
   int ret = OK;
-  struct esp_dmadesc_s *inlink;
+  struct esp32_dmadesc_s *inlink;
   uint32_t bytes_queued;
   irqstate_t flags;
 
@@ -1154,28 +947,28 @@ static int i2s_rxdma_setup(struct esp_i2s_s *priv,
 
   inlink = bfcontainer->dma_link;
 
+  /* Allocate the internal buffer for RX */
+
+  bfcontainer->buf = calloc(bfcontainer->nbytes, 1);
+  if (bfcontainer->buf == NULL)
+    {
+      i2serr("Failed to allocate the DMA internal buffer "
+             "[%" PRIu32 " bytes]", bfcontainer->nbytes);
+      return -ENOMEM;
+    }
+
   /* Configure DMA stream */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  bytes_queued = esp_dma_setup((struct esp_dmadesc_s *)inlink,
-                               I2S_DMADESC_NUM,
-                               (uint8_t *) bfcontainer->apb->samp,
-                               bfcontainer->nbytes,
-                               false,
-                               priv->dma_channel);
-#else
-  bytes_queued = esp_dma_setup((struct esp_dmadesc_s *)inlink,
-                               I2S_DMADESC_NUM,
-                               (uint8_t *) bfcontainer->apb->samp,
-                               bfcontainer->nbytes);
-#endif
+  bytes_queued = esp32_dma_init(inlink, I2S_DMADESC_NUM,
+                                bfcontainer->buf,
+                                bfcontainer->nbytes);
 
   if (bytes_queued != bfcontainer->nbytes)
     {
       i2serr("Failed to enqueue I2S buffer "
              "(%" PRIu32 " bytes of %" PRIu32 ")\n",
              bytes_queued, bfcontainer->nbytes);
-      return -bytes_queued;
+      return bytes_queued;
     }
 
   flags = spin_lock_irqsave(&priv->slock);
@@ -1214,12 +1007,11 @@ static int i2s_rxdma_setup(struct esp_i2s_s *priv,
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static void IRAM_ATTR i2s_tx_schedule(struct esp_i2s_s *priv,
-                                      struct esp_dmadesc_s *outlink)
+static void i2s_tx_schedule(struct esp32_i2s_s *priv,
+                            struct esp32_dmadesc_s *outlink)
 {
-  struct esp_buffer_s *bfcontainer;
-  struct esp_dmadesc_s *bfdesc;
-  dma_descriptor_t *bfdesc_ctrl;
+  struct esp32_buffer_s *bfcontainer;
+  struct esp32_dmadesc_s *bfdesc;
   int ret;
 
   /* Upon entry, the transfer(s) that just completed are the ones in the
@@ -1232,7 +1024,7 @@ static void IRAM_ATTR i2s_tx_schedule(struct esp_i2s_s *priv,
     {
       /* Remove the next buffer container from the tx.act list */
 
-      bfcontainer = (struct esp_buffer_s *)sq_peek(&priv->tx.act);
+      bfcontainer = (struct esp32_buffer_s *)sq_peek(&priv->tx.act);
 
       /* Check if the DMA descriptor that generated an EOF interrupt is the
        * last descriptor of the current buffer container's DMA outlink.
@@ -1244,8 +1036,7 @@ static void IRAM_ATTR i2s_tx_schedule(struct esp_i2s_s *priv,
       /* Find the last descriptor of the current buffer container */
 
       bfdesc = bfcontainer->dma_link;
-      bfdesc_ctrl = (dma_descriptor_t *)bfdesc;
-      while (!(bfdesc_ctrl->dw0.suc_eof))
+      while (!(bfdesc->ctrl & DMA_CTRL_EOF))
         {
           DEBUGASSERT(bfdesc->next);
           bfdesc = bfdesc->next;
@@ -1315,12 +1106,11 @@ static void IRAM_ATTR i2s_tx_schedule(struct esp_i2s_s *priv,
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static void i2s_rx_schedule(struct esp_i2s_s *priv,
-                            struct esp_dmadesc_s *inlink)
+static void i2s_rx_schedule(struct esp32_i2s_s *priv,
+                            struct esp32_dmadesc_s *inlink)
 {
-  struct esp_buffer_s *bfcontainer;
-  struct esp_dmadesc_s *bfdesc;
-  dma_descriptor_t *bfdesc_ctrl;
+  struct esp32_buffer_s *bfcontainer;
+  struct esp32_dmadesc_s *bfdesc;
   int ret;
 
   /* Upon entry, the transfer(s) that just completed are the ones in the
@@ -1333,16 +1123,21 @@ static void i2s_rx_schedule(struct esp_i2s_s *priv,
     {
       /* Remove the next buffer container from the rx.act list */
 
-      bfcontainer = (struct esp_buffer_s *)sq_peek(&priv->rx.act);
+      bfcontainer = (struct esp32_buffer_s *)sq_peek(&priv->rx.act);
+
+      /* Check if the DMA descriptor that generated an EOF interrupt is the
+       * last descriptor of the current buffer container's DMA inlink.
+       * REVISIT: what to do if we miss syncronization and the descriptor
+       * that generated the interrupt is different from the expected (the
+       * oldest of the list containing active transmissions)?
+       */
 
       /* Find the last descriptor of the current buffer container */
 
       bfdesc = bfcontainer->dma_link;
-      bfdesc_ctrl = (dma_descriptor_t *)bfdesc;
-
-      while (bfdesc->next != NULL &&
-             (bfdesc_ctrl->dw0.suc_eof))
+      while (!(bfdesc->ctrl & DMA_CTRL_EOF))
         {
+          DEBUGASSERT(bfdesc->next);
           bfdesc = bfdesc->next;
         }
 
@@ -1407,8 +1202,8 @@ static void i2s_rx_schedule(struct esp_i2s_s *priv,
 #ifdef I2S_HAVE_TX
 static void i2s_tx_worker(void *arg)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)arg;
-  struct esp_buffer_s *bfcontainer;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)arg;
+  struct esp32_buffer_s *bfcontainer;
   irqstate_t flags;
 
   DEBUGASSERT(priv);
@@ -1424,7 +1219,7 @@ static void i2s_tx_worker(void *arg)
    */
 
   i2sinfo("tx.act.head=%p tx.done.head=%p\n",
-          priv->tx.act.head, priv->tx.done.head);
+           priv->tx.act.head, priv->tx.done.head);
 
   /* Process each buffer in the tx.done queue */
 
@@ -1436,7 +1231,7 @@ static void i2s_tx_worker(void *arg)
        */
 
       flags = spin_lock_irqsave(&priv->slock);
-      bfcontainer = (struct esp_buffer_s *)sq_remfirst(&priv->tx.done);
+      bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->tx.done);
       spin_unlock_irqrestore(&priv->slock, flags);
 
       /* Perform the TX transfer done callback */
@@ -1473,10 +1268,8 @@ static void i2s_tx_worker(void *arg)
 #ifdef I2S_HAVE_RX
 static void i2s_rx_worker(void *arg)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)arg;
-  struct esp_buffer_s *bfcontainer;
-  struct esp_dmadesc_s *dmadesc;
-  dma_descriptor_t *dmadesc_ctrl;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)arg;
+  struct esp32_buffer_s *bfcontainer;
   irqstate_t flags;
 
   DEBUGASSERT(priv);
@@ -1492,7 +1285,7 @@ static void i2s_rx_worker(void *arg)
    */
 
   i2sinfo("rx.act.head=%p rx.done.head=%p\n",
-          priv->rx.act.head, priv->rx.done.head);
+           priv->rx.act.head, priv->rx.done.head);
 
   /* Process each buffer in the rx.done queue */
 
@@ -1504,31 +1297,113 @@ static void i2s_rx_worker(void *arg)
        */
 
       flags = spin_lock_irqsave(&priv->slock);
-      bfcontainer = (struct esp_buffer_s *)sq_remfirst(&priv->rx.done);
+      bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->rx.done);
       spin_unlock_irqrestore(&priv->slock, flags);
 
-      dmadesc = bfcontainer->dma_link;
-      dmadesc_ctrl = (dma_descriptor_t *)dmadesc;
+      apb_samp_t samp_size;
+      uint32_t data_copied;
+      uint8_t carry_bytes;
+      uint8_t padding;
+      uint8_t *buf;
+      uint8_t *samp;
 
-      bfcontainer->apb->nbytes = 0;
+      /* Padding contains the size (in bytes) to be skipped on the internal
+       * buffer - which store data aligned with 2 or 4 bytes - to correctly
+       * copy and fill the audio buffer according to the actual data width.
+       */
 
-      while (dmadesc != NULL && (dmadesc_ctrl->dw0.suc_eof))
+      padding = priv->data_width != I2S_DATA_BIT_WIDTH_16BIT ?
+                (priv->data_width != I2S_DATA_BIT_WIDTH_32BIT ? 1 : 0) : 0;
+
+      /* Get the transfer information, accounting for any data offset */
+
+      const apb_samp_t bytes_per_sample = priv->data_width / 8;
+      samp = &bfcontainer->apb->samp[bfcontainer->apb->curbyte];
+      samp_size = (bfcontainer->apb->nbytes - bfcontainer->apb->curbyte);
+
+      data_copied = 0;
+      buf = bfcontainer->buf;
+
+      /* Copy the remaining bytes from previous transfer and
+       * complete the sample so that the next memcpy is aligned
+       * with the sample size.
+       */
+
+      if (priv->rx.carry.bytes)
         {
-          bfcontainer->apb->nbytes += dmadesc_ctrl->dw0.length;
-          dmadesc = dmadesc->next;
+          memcpy(samp, &priv->rx.carry.value, priv->rx.carry.bytes);
+          samp += priv->rx.carry.bytes;
+          data_copied += priv->rx.carry.bytes;
+
+          memcpy(samp, buf, (bytes_per_sample - priv->rx.carry.bytes));
+          buf += (bytes_per_sample - priv->rx.carry.bytes);
+          samp += (bytes_per_sample - priv->rx.carry.bytes);
+          data_copied += (bytes_per_sample - priv->rx.carry.bytes);
         }
+
+      /* If there is no need to add padding bytes, the memcpy may be done at
+       * once. Otherwise, the operation must add the padding bytes to each
+       * sample in the internal buffer.
+       */
+
+      buf += padding;
+
+      if (padding)
+        {
+          while (data_copied + bytes_per_sample <= samp_size)
+            {
+              memcpy(samp, buf, bytes_per_sample);
+              buf += (bytes_per_sample + padding);
+              samp += bytes_per_sample;
+              data_copied += bytes_per_sample;
+            }
+
+          /* Store the carry bytes, if any */
+
+          carry_bytes = samp_size - data_copied;
+          memcpy(&priv->rx.carry.value, buf, carry_bytes);
+          priv->rx.carry.bytes = carry_bytes;
+        }
+      else
+        {
+          memcpy(samp, buf, samp_size - data_copied);
+          buf += samp_size - data_copied;
+          samp += samp_size - data_copied;
+          data_copied += samp_size - data_copied;
+        }
+
+      /* Calculate the audio buffer size from the internal buffer size.
+       * The internal I2S buffer size is calculated from I2S_RXEOF_NUM_REG,
+       * which returns the size in number of words.
+       */
+
+      bfcontainer->apb->nbytes =
+                  (getreg32(I2S_RXEOF_NUM_REG(priv->config->port)) * 4);
+
+      /* The internal buffer size must be divided by either 16 or 32 bits
+       * as the I2S peripheral aligns each sample to one of these boundaries.
+       * The result represents the number of samples on the internal buffer.
+       */
+
+      bfcontainer->apb->nbytes /=
+                  ((priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                   I2S_DATA_BIT_WIDTH_16BIT : I2S_DATA_BIT_WIDTH_32BIT) / 8);
+
+      /* Finally, calculate the number of bytes on the audio buffer */
+
+      bfcontainer->apb->nbytes *= bytes_per_sample;
+
+      DEBUGASSERT(bfcontainer->apb->nbytes == data_copied);
 
       /* Perform the RX transfer done callback */
 
       DEBUGASSERT(bfcontainer && bfcontainer->callback);
-
-      if (priv->streaming == false)
-        {
-          bfcontainer->apb->flags |= AUDIO_APB_FINAL;
-        }
-
       bfcontainer->callback(&priv->dev, bfcontainer->apb,
                             bfcontainer->arg, bfcontainer->result);
+
+      /* Release the internal buffer used by the DMA inlink */
+
+      free(bfcontainer->buf);
 
       /* Release our reference on the audio buffer. This may very likely
        * cause the audio buffer to be freed.
@@ -1558,66 +1433,53 @@ static void i2s_rx_worker(void *arg)
  *
  ****************************************************************************/
 
-static void i2s_configure(struct esp_i2s_s *priv)
+static void i2s_configure(struct esp32_i2s_s *priv)
 {
-  uint32_t tx_conf  = 0;
-  uint32_t rx_conf  = 0;
-  bool loopback = false;
-  i2s_hal_slot_config_t tx_slot_cfg =
-    {
-      0
-    };
-
-  i2s_hal_slot_config_t rx_slot_cfg =
-    {
-      0
-    };
-
   /* Set peripheral clock and clear reset */
 
-  periph_module_enable(i2s_periph_signal[priv->config->port].module);
+  if (priv->config->port == ESP32_I2S0)
+    {
+      modifyreg32(DPORT_PERIP_CLK_EN_REG, 0, DPORT_I2S0_CLK_EN);
+      modifyreg32(DPORT_PERIP_RST_EN_REG, 0, DPORT_I2S0_RST);
+      modifyreg32(DPORT_PERIP_RST_EN_REG, DPORT_I2S0_RST, 0);
+    }
+  else
+    {
+      modifyreg32(DPORT_PERIP_CLK_EN_REG, 0, DPORT_I2S1_CLK_EN);
+      modifyreg32(DPORT_PERIP_RST_EN_REG, 0, DPORT_I2S1_RST);
+      modifyreg32(DPORT_PERIP_RST_EN_REG, DPORT_I2S1_RST, 0);
+    }
 
-  i2s_hal_init(priv->config->ctx, priv->config->port);
-  i2s_ll_enable_clock(priv->config->ctx->dev);
+  /* I2S module general init, enable I2S clock */
+
+  if (!(getreg32(I2S_CLKM_CONF_REG(priv->config->port)) & I2S_CLK_ENA))
+    {
+      i2sinfo("Enabling I2S port clock...\n");
+      modifyreg32(I2S_CLKM_CONF_REG(priv->config->port), 0, I2S_CLK_ENA);
+      putreg32(0, I2S_CONF2_REG(priv->config->port));
+    }
 
   /* Configure multiplexed pins as connected on the board */
+
+  /* TODO: check for loopback mode */
 
   /* Enable TX channel */
 
   if (priv->config->dout_pin != I2S_GPIO_UNUSED)
     {
-      /* If TX channel is used, enable the clock source */
-
-      esp_gpiowrite(priv->config->dout_pin, 1);
-      esp_configgpio(priv->config->dout_pin, OUTPUT_FUNCTION_2);
-      esp_gpio_matrix_out(priv->config->dout_pin,
-                          priv->config->dout_outsig, 0, 0);
+      esp32_gpiowrite(priv->config->dout_pin, 1);
+      esp32_configgpio(priv->config->dout_pin, OUTPUT_FUNCTION_3);
+      esp32_gpio_matrix_out(priv->config->dout_pin,
+                            priv->config->dout_outsig, 0, 0);
     }
 
   /* Enable RX channel */
 
   if (priv->config->din_pin != I2S_GPIO_UNUSED)
     {
-      /* If RX channel is used, enable the clock source */
-
-      /* Check for loopback mode */
-
-      if (priv->config->dout_pin != I2S_GPIO_UNUSED &&
-          priv->config->din_pin == priv->config->dout_pin)
-        {
-          esp_configgpio(priv->config->din_pin,
-                         INPUT_FUNCTION_2 | OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->din_pin,
-                            priv->config->din_insig, 0);
-          esp_gpio_matrix_out(priv->config->din_pin,
-                              priv->config->dout_outsig, 0, 0);
-        }
-      else
-        {
-          esp_configgpio(priv->config->din_pin, INPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->din_pin,
-                             priv->config->din_insig, 0);
-        }
+      esp32_configgpio(priv->config->din_pin, INPUT_FUNCTION_3);
+      esp32_gpio_matrix_in(priv->config->din_pin,
+                           priv->config->din_insig, 0);
     }
 
   if (priv->config->role == I2S_ROLE_SLAVE)
@@ -1626,15 +1488,15 @@ static void i2s_configure(struct esp_i2s_s *priv)
         {
           /* For "tx + slave" mode, select TX signal index for ws and bck */
 
-          esp_gpiowrite(priv->config->ws_pin, 1);
-          esp_configgpio(priv->config->ws_pin, INPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->ws_pin,
-                             priv->config->ws_out_insig, 0);
+          esp32_gpiowrite(priv->config->ws_pin, 1);
+          esp32_configgpio(priv->config->ws_pin, INPUT_FUNCTION_3);
+          esp32_gpio_matrix_in(priv->config->ws_pin,
+                               priv->config->ws_out_insig, 0);
 
-          esp_gpiowrite(priv->config->bclk_pin, 1);
-          esp_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->bclk_pin,
-                             priv->config->bclk_out_insig, 0);
+          esp32_gpiowrite(priv->config->bclk_pin, 1);
+          esp32_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_3);
+          esp32_gpio_matrix_in(priv->config->bclk_pin,
+                               priv->config->bclk_out_insig, 0);
         }
       else
         {
@@ -1642,15 +1504,15 @@ static void i2s_configure(struct esp_i2s_s *priv)
            * index for ws and bck.
            */
 
-          esp_gpiowrite(priv->config->ws_pin, 1);
-          esp_configgpio(priv->config->ws_pin, INPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->ws_pin,
-                             priv->config->ws_in_insig, 0);
+          esp32_gpiowrite(priv->config->ws_pin, 1);
+          esp32_configgpio(priv->config->ws_pin, INPUT_FUNCTION_3);
+          esp32_gpio_matrix_in(priv->config->ws_pin,
+                               priv->config->ws_in_insig, 0);
 
-          esp_gpiowrite(priv->config->bclk_pin, 1);
-          esp_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_2);
-          esp_gpio_matrix_in(priv->config->bclk_pin,
-                             priv->config->bclk_in_insig, 0);
+          esp32_gpiowrite(priv->config->bclk_pin, 1);
+          esp32_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_3);
+          esp32_gpio_matrix_in(priv->config->bclk_pin,
+                               priv->config->bclk_in_insig, 0);
         }
     }
   else
@@ -1661,28 +1523,45 @@ static void i2s_configure(struct esp_i2s_s *priv)
 
       if (priv->config->mclk_pin != I2S_GPIO_UNUSED)
         {
+          bool is_i2s0 = priv->config->port == ESP32_I2S0 ? true : false;
+
           i2sinfo("Configuring GPIO%" PRIu8 " to output master clock\n",
                   priv->config->mclk_pin);
 
-          esp_gpiowrite(priv->config->mclk_pin, 1);
-          esp_configgpio(priv->config->mclk_pin, OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_out(priv->config->mclk_pin,
-                              priv->config->mclk_out_sig, 0, 0);
+          esp32_configgpio(priv->config->mclk_pin, OUTPUT_FUNCTION_2);
+          esp32_gpio_matrix_out(priv->config->mclk_pin,
+                                SIG_GPIO_OUT_IDX, 0, 0);
+
+          if (priv->config->mclk_pin == 0)
+            {
+              putreg32(priv->config->is_apll ?
+                       0xfff6 : (is_i2s0 ? 0xfff0 : 0xffff), PIN_CTRL);
+            }
+          else if (priv->config->mclk_pin == 1)
+            {
+              putreg32(priv->config->is_apll ?
+                       0xf6f6 : (is_i2s0 ? 0xf0f0 : 0xf0ff), PIN_CTRL);
+            }
+          else
+            {
+              putreg32(priv->config->is_apll ?
+                       0xff66 : (is_i2s0 ? 0xff00 : 0xff0f), PIN_CTRL);
+            }
         }
 
       if (priv->config->rx_en && !priv->config->tx_en)
         {
           /* For "rx + master" mode, select RX signal index for ws and bck */
 
-          esp_gpiowrite(priv->config->ws_pin, 1);
-          esp_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_out(priv->config->ws_pin,
-                                  priv->config->ws_in_outsig, 0, 0);
+          esp32_gpiowrite(priv->config->ws_pin, 1);
+          esp32_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_3);
+          esp32_gpio_matrix_out(priv->config->ws_pin,
+                                priv->config->ws_in_outsig, 0, 0);
 
-          esp_gpiowrite(priv->config->bclk_pin, 1);
-          esp_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_out(priv->config->bclk_pin,
-                              priv->config->bclk_in_outsig, 0, 0);
+          esp32_gpiowrite(priv->config->bclk_pin, 1);
+          esp32_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_3);
+          esp32_gpio_matrix_out(priv->config->bclk_pin,
+                                priv->config->bclk_in_outsig, 0, 0);
         }
       else
         {
@@ -1690,15 +1569,15 @@ static void i2s_configure(struct esp_i2s_s *priv)
            * index for ws and bck.
            */
 
-          esp_gpiowrite(priv->config->ws_pin, 1);
-          esp_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_out(priv->config->ws_pin,
-                              priv->config->ws_out_outsig, 0, 0);
+          esp32_gpiowrite(priv->config->ws_pin, 1);
+          esp32_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_3);
+          esp32_gpio_matrix_out(priv->config->ws_pin,
+                                priv->config->ws_out_outsig, 0, 0);
 
-          esp_gpiowrite(priv->config->bclk_pin, 1);
-          esp_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_2);
-          esp_gpio_matrix_out(priv->config->bclk_pin,
-                              priv->config->bclk_out_outsig, 0, 0);
+          esp32_gpiowrite(priv->config->bclk_pin, 1);
+          esp32_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_3);
+          esp32_gpio_matrix_out(priv->config->bclk_pin,
+                                priv->config->bclk_out_outsig, 0, 0);
         }
     }
 
@@ -1706,65 +1585,95 @@ static void i2s_configure(struct esp_i2s_s *priv)
 
   if (priv->config->tx_en && priv->config->rx_en)
     {
-      loopback = true;
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_SIG_LOOPBACK);
     }
-
-  i2s_ll_share_bck_ws(priv->config->ctx->dev, loopback);
+  else
+    {
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_SIG_LOOPBACK, 0);
+    }
 
   /* Configure the TX module */
 
   if (priv->config->tx_en)
     {
-      if (priv->channels == 1)
+      /* Reset I2S TX module */
+
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_RESET, 0);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), 0, I2S_OUT_RST);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), I2S_OUT_RST, 0);
+
+      /* Enable/disable I2S TX slave mode */
+
+      if (priv->config->role == I2S_ROLE_SLAVE)
         {
-          tx_slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_SLAVE_MOD);
         }
       else
         {
-          tx_slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+          modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_SLAVE_MOD, 0);
         }
 
-      tx_slot_cfg.data_bit_width = priv->config->data_width;
-      tx_slot_cfg.slot_bit_width = I2S_SLOT_BIT_WIDTH_AUTO;
+      /* Configure TX chan bit, audio data bit and mono mode.
+       * On ESP32, sample_bit should equals to data_bit.
+       */
+
+      /* Set TX data width */
+
       priv->data_width = priv->config->data_width;
+      i2s_set_datawidth(priv);
 
-      if (priv->config->audio_std_mode <= I2S_STD_PCM)
+      /* Set I2S tx chan mode */
+
+      modifyreg32(I2S_CONF_CHAN_REG(priv->config->port), I2S_TX_CHAN_MOD_M,
+                  FIELD_TO_VALUE(I2S_TX_CHAN_MOD, priv->config->mono_en ?
+                  4 : 0));
+
+      /* Enable/disable TX MSB shift, the data will be launch at the first
+       * BCK clock.
+       */
+
+      if (priv->config->bit_shift)
         {
-          i2s_ll_tx_enable_std(priv->config->ctx->dev);
-
-          if (priv->config->audio_std_mode == I2S_STD_PHILIPS)
-            {
-              I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(tx_slot_cfg.std,
-                                                  priv->data_width,
-                                                  I2S_STD_SLOT_BOTH);
-            }
-          else if (priv->config->audio_std_mode == I2S_STD_MSB)
-            {
-              I2S_STD_MSB_SLOT_DEFAULT_CONFIG(tx_slot_cfg.std,
-                                              priv->data_width,
-                                              I2S_STD_SLOT_BOTH);
-            }
-          else
-            {
-              I2S_STD_PCM_SLOT_DEFAULT_CONFIG(tx_slot_cfg.std,
-                                              priv->data_width,
-                                              I2S_STD_SLOT_BOTH);
-            }
-
-          i2s_hal_std_set_tx_slot(priv->config->ctx,
-                                  priv->config->role == I2S_ROLE_SLAVE,
-                                  &tx_slot_cfg);
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_MSB_SHIFT);
         }
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
       else
         {
-          i2s_ll_tx_enable_pdm(priv->config->ctx->dev);
-          I2S_PDM_TX_SLOT_DEFAULT_CONFIG(tx_slot_cfg.pdm_tx);
-          i2s_hal_pdm_set_tx_slot(priv->config->ctx,
-                                  priv->config->role == I2S_ROLE_SLAVE,
-                                  &tx_slot_cfg);
+          modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_MSB_SHIFT, 0);
         }
-#endif
+
+      /* Configure TX WS signal width. Set to to enable transmitter in PCM
+       * standard mode.
+       */
+
+      if (priv->config->ws_width == 1)
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0,
+                      I2S_TX_SHORT_SYNC);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port),
+                      I2S_TX_SHORT_SYNC, 0);
+        }
+
+      /* Set I2S tx right channel first */
+
+      if (priv->config->ws_pol == 1)
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0,
+                      I2S_TX_RIGHT_FIRST);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port),
+                      I2S_TX_RIGHT_FIRST, 0);
+        }
+
+      /* I2S tx fifo module force enable */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), 0,
+                  I2S_TX_FIFO_MOD_FORCE_EN);
 
       /* The default value for the master clock frequency (MCLK frequency)
        * can be set from the sample rate multiplied by a fixed value, known
@@ -1795,52 +1704,96 @@ static void i2s_configure(struct esp_i2s_s *priv)
 
   if (priv->config->rx_en)
     {
-      if (priv->channels == 1)
+      /* Reset I2S RX module */
+
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_RESET, 0);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), 0, I2S_IN_RST);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), I2S_IN_RST, 0);
+
+      /* Enable/disable I2S RX slave mode */
+
+      if (priv->config->role == I2S_ROLE_SLAVE)
         {
-          rx_slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_SLAVE_MOD);
         }
       else
         {
-          rx_slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
-        }
+          /* Since BCLK and WS are shared, only TX or RX can be master. In
+           * this case, force RX as slave to avoid conflict of clock signal.
+           */
 
-      rx_slot_cfg.data_bit_width = priv->config->data_width;
-      rx_slot_cfg.slot_bit_width = I2S_SLOT_BIT_WIDTH_AUTO;
-
-      if (priv->config->audio_std_mode <= I2S_STD_PCM)
-        {
-          i2s_ll_rx_enable_std(priv->config->ctx->dev);
-
-          if (priv->config->audio_std_mode == I2S_STD_PHILIPS)
+          if (priv->config->tx_en)
             {
-              I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(rx_slot_cfg.std,
-                                                  priv->data_width,
-                                                  I2S_STD_SLOT_BOTH);
-            }
-          else if (priv->config->audio_std_mode == I2S_STD_MSB)
-            {
-              I2S_STD_MSB_SLOT_DEFAULT_CONFIG(rx_slot_cfg.std,
-                                              priv->data_width,
-                                              I2S_STD_SLOT_BOTH);
+              modifyreg32(I2S_CONF_REG(priv->config->port), 0,
+                          I2S_RX_SLAVE_MOD);
             }
           else
             {
-              I2S_STD_PCM_SLOT_DEFAULT_CONFIG(tx_slot_cfg.std,
-                                              priv->data_width,
-                                              I2S_STD_SLOT_BOTH);
+              modifyreg32(I2S_CONF_REG(priv->config->port),
+                          I2S_RX_SLAVE_MOD, 0);
             }
-
-          i2s_hal_std_set_rx_slot(priv->config->ctx,
-                                  priv->config->role == I2S_ROLE_SLAVE,
-                                  &rx_slot_cfg);
         }
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
+
+      /* Congfigure RX chan bit, audio data bit and mono mode.
+       * On ESP32, sample_bit should equals to data_bit.
+       */
+
+      /* Set RX data width */
+
+      priv->data_width = priv->config->data_width;
+      i2s_set_datawidth(priv);
+
+      /* Set I2S RX chan mode */
+
+      modifyreg32(I2S_CONF_CHAN_REG(priv->config->port),
+                  I2S_RX_CHAN_MOD_M, 0);
+
+      /* Enable/disable RX MSB shift, the data will be read at the first
+       * BCK clock.
+       */
+
+      if (priv->config->bit_shift)
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_MSB_SHIFT);
+        }
       else
         {
-          i2serr("Due to the lack of `PDM to PCM` module, \
-                  PDM RX is not available\n");
+          modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_MSB_SHIFT, 0);
         }
-#endif
+
+      /* Configure RX WS signal width. Set to to enable receiver in PCM
+       * standard mode.
+       */
+
+      if (priv->config->ws_width == 1)
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0,
+                      I2S_RX_SHORT_SYNC);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port),
+                      I2S_RX_SHORT_SYNC, 0);
+        }
+
+      /* Set I2S RX right channel first */
+
+      if (priv->config->ws_pol == 1)
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0,
+                      I2S_RX_RIGHT_FIRST);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG(priv->config->port),
+                      I2S_RX_RIGHT_FIRST, 0);
+        }
+
+      /* I2S RX fifo module force enable */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), 0,
+                  I2S_RX_FIFO_MOD_FORCE_EN);
 
       /* The default value for the master clock frequency (MCLK frequency)
        * can be set from the sample rate multiplied by a fixed value, known
@@ -1869,58 +1822,6 @@ static void i2s_configure(struct esp_i2s_s *priv)
 }
 
 /****************************************************************************
- * Name: i2s_check_mclkfrequency
- *
- * Description:
- *   Check if MCLK frequency is compatible with the current data width and
- *   bits/sample set. Master clock should be multiple of the sample rate and
- *   bclk at the same time.
- *
- * Input Parameters:
- *   priv - Initialized I2S device structure.
- *
- * Returned Value:
- *   Returns the current master clock or a negated errno value on failure.
- *
- ****************************************************************************/
-
-static int32_t i2s_check_mclkfrequency(struct esp_i2s_s *priv)
-{
-  uint32_t mclk_freq;
-  uint32_t mclk_multiple = priv->mclk_multiple;
-  uint32_t bclk = priv->rate * priv->config->total_slot * priv->data_width;
-  int i;
-
-  /* If the master clock is divisible by both the sample rate and the bit
-   * clock, everything is as expected and we can return the current master
-   * clock frequency.
-   */
-
-  if (priv->mclk_freq % priv->rate == 0 && priv->mclk_freq % bclk == 0)
-    {
-      priv->mclk_multiple = priv->mclk_freq / priv->rate;
-      return priv->mclk_freq;
-    }
-
-  /* Select the lowest multiplier for setting the master clock */
-
-  for (mclk_multiple = I2S_MCLK_MULTIPLE_128;
-       mclk_multiple <= I2S_MCLK_MULTIPLE_512;
-       mclk_multiple += I2S_MCLK_MULTIPLE_128)
-    {
-      mclk_freq = priv->rate * mclk_multiple;
-      if (mclk_freq % priv->rate == 0 && mclk_freq % bclk == 0)
-        {
-          priv->mclk_multiple = mclk_multiple;
-          i2s_setmclkfrequency((struct i2s_dev_s *)priv, mclk_freq);
-          return priv->mclk_freq;
-        }
-    }
-
-  return -EINVAL;
-}
-
-/****************************************************************************
  * Name: i2s_set_datawidth
  *
  * Description:
@@ -1934,56 +1835,63 @@ static int32_t i2s_check_mclkfrequency(struct esp_i2s_s *priv)
  *
  ****************************************************************************/
 
-static uint32_t i2s_set_datawidth(struct esp_i2s_s *priv)
+static uint32_t i2s_set_datawidth(struct esp32_i2s_s *priv)
 {
-  int width;
 #ifdef I2S_HAVE_TX
   if (priv->config->tx_en)
     {
-      i2s_ll_tx_set_sample_bit(priv->config->ctx->dev,
-                               priv->data_width, priv->data_width);
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      i2s_ll_tx_set_half_sample_bit(priv->config->ctx->dev,
-                                    priv->data_width);
-#else
-      i2s_ll_tx_enable_msb_right(priv->config->ctx->dev, true);
-#endif
+      modifyreg32(I2S_SAMPLE_RATE_CONF_REG(priv->config->port),
+                  I2S_TX_BITS_MOD_M, FIELD_TO_VALUE(I2S_TX_BITS_MOD,
+                  priv->data_width));
 
-      if (priv->config->audio_std_mode != I2S_STD_PCM)
+      /* Set TX FIFO operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), I2S_TX_FIFO_MOD_M,
+                  priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                  FIELD_TO_VALUE(I2S_TX_FIFO_MOD,
+                                 0 + priv->config->mono_en) :
+                  FIELD_TO_VALUE(I2S_TX_FIFO_MOD,
+                                 2 + priv->config->mono_en));
+
+      /* I2S TX MSB right enable */
+
+      if (priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT)
         {
-          width = priv->data_width;
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_MSB_RIGHT);
         }
       else
         {
-          width = 1;
+          modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_MSB_RIGHT, 0);
         }
-
-      i2s_ll_tx_set_ws_width(priv->config->ctx->dev, width);
     }
 #endif /* I2S_HAVE_TX */
 
 #ifdef I2S_HAVE_RX
   if (priv->config->rx_en)
     {
-      i2s_ll_rx_set_sample_bit(priv->config->ctx->dev,
-                               priv->data_width, priv->data_width);
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      i2s_ll_rx_set_half_sample_bit(priv->config->ctx->dev,
-                                    priv->data_width);
-#else
-      i2s_ll_tx_enable_msb_right(priv->config->ctx->dev, true);
-#endif
+      modifyreg32(I2S_SAMPLE_RATE_CONF_REG(priv->config->port),
+                  I2S_RX_BITS_MOD_M, FIELD_TO_VALUE(I2S_RX_BITS_MOD,
+                  priv->data_width));
 
-      if (priv->config->audio_std_mode != I2S_STD_PCM)
+      /* Set RX FIFO operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), I2S_RX_FIFO_MOD_M,
+                  priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                  FIELD_TO_VALUE(I2S_RX_FIFO_MOD,
+                                 0 + priv->config->mono_en) :
+                  FIELD_TO_VALUE(I2S_RX_FIFO_MOD,
+                                 2 + priv->config->mono_en));
+
+      /* I2S RX MSB right enable */
+
+      if (priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT)
         {
-          width = priv->data_width;
+          modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_MSB_RIGHT);
         }
       else
         {
-          width = 1;
+          modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_MSB_RIGHT, 0);
         }
-
-      i2s_ll_rx_set_ws_width(priv->config->ctx->dev, width);
     }
 #endif /* I2S_HAVE_RX */
 
@@ -2000,19 +1908,31 @@ static uint32_t i2s_set_datawidth(struct esp_i2s_s *priv)
  *   priv - Initialized I2S device structure.
  *
  * Returned Value:
- *   None
+ *   Returns the resulting bitrate
  *
  ****************************************************************************/
 
-static void i2s_set_clock(struct esp_i2s_s *priv)
+static uint32_t i2s_set_clock(struct esp32_i2s_s *priv)
 {
+  uint32_t rate;
   uint32_t bclk;
   uint32_t mclk;
   uint32_t sclk;
   uint32_t mclk_div;
+  int denominator;
+  int numerator;
+  uint32_t regval;
+  uint32_t freq_diff;
   uint16_t bclk_div;
 
-  sclk = priv->config->clk_hz;
+  /* TODO: provide APLL clock support */
+
+  /* Disable APLL clock, I2S module will using PLL_D2_CLK(160M) as source
+   * clock.
+   */
+
+  modifyreg32(I2S_CLKM_CONF_REG(priv->config->port), I2S_CLKA_ENA, 0);
+  sclk = I2S_LL_BASE_CLK;
 
   /* fmclk = bck_div * fbclk = fsclk / (mclk_div + b / a)
    * mclk_div is the I2S clock divider's integral value
@@ -2022,8 +1942,7 @@ static void i2s_set_clock(struct esp_i2s_s *priv)
 
   if (priv->config->role == I2S_ROLE_MASTER)
     {
-      bclk = priv->rate * priv->config->total_slot *
-             priv->config->data_width;
+      bclk = priv->rate * priv->config->total_slot * priv->data_width;
       mclk = priv->mclk_freq;
       bclk_div = mclk / bclk;
     }
@@ -2032,8 +1951,7 @@ static void i2s_set_clock(struct esp_i2s_s *priv)
       /* For slave mode, mclk >= bclk * 8, so fix bclk_div to 2 first */
 
       bclk_div = 8;
-      bclk = priv->rate * priv->config->total_slot *
-              priv->config->data_width;
+      bclk = priv->rate * priv->config->total_slot * priv->data_width;
       mclk = bclk * bclk_div;
     }
 
@@ -2041,27 +1959,86 @@ static void i2s_set_clock(struct esp_i2s_s *priv)
 
   mclk_div = sclk / mclk;
 
-  i2sinfo("Clock division info: [sclk]%" PRIu32 " Hz [mdiv] %lu "
+  i2sinfo("Clock division info: [sclk] %" PRIu32 " Hz [mdiv] %" PRIu32\
           "[mclk] %" PRIu32 " Hz [bdiv] %" PRIu16 " [bclk] %" PRIu32 " Hz\n",
           sclk, mclk_div, mclk, bclk_div, bclk);
 
-  priv->config->clk_info->bclk = bclk;
-  priv->config->clk_info->bclk_div = bclk_div;
-  priv->config->clk_info->mclk = mclk;
-  priv->config->clk_info->mclk_div = mclk_div;
-  priv->config->clk_info->sclk = sclk;
+  freq_diff = abs((int)sclk - (int)(mclk * mclk_div));
+
+  denominator = 1;
+  numerator = 0;
+
+  if (freq_diff)
+    {
+      float decimal = freq_diff / (float)mclk;
+
+      /* Carry bit if the decimal is greater than
+       * 1.0 - 1.0 / (63.0 * 2) = 125.0 / 126.0
+       */
+
+      if (decimal > 125.0f / 126.0f)
+        {
+          mclk_div++;
+        }
+      else
+        {
+          uint32_t min = UINT32_MAX;
+
+          for (int a = 2; a <= I2S_LL_MCLK_DIVIDER_MAX; a++)
+            {
+              int b = (int)(a * (freq_diff / (double)mclk) + 0.5);
+              int ma = freq_diff * a;
+              int mb = mclk * b;
+              if (ma == mb)
+                {
+                  denominator = a;
+                  numerator = b;
+                  break;
+                }
+
+              if (abs((mb - ma)) < min)
+                {
+                  denominator = a;
+                  numerator = b;
+                  min = abs(mb - ma);
+                }
+            }
+        }
+    }
+
+  i2sinfo("Clock register: [mclk] %" PRIu32 " Hz [numerator] %d "
+          "[denominator] %d\n", mclk, numerator, denominator);
+
+  regval = getreg32(I2S_CLKM_CONF_REG(priv->config->port));
+  regval &= ~I2S_CLKM_DIV_NUM_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_NUM, mclk_div);
+  regval &= ~I2S_CLKM_DIV_B_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_B, numerator);
+  regval &= ~I2S_CLKM_DIV_A_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_A, denominator);
+  putreg32(regval, I2S_CLKM_CONF_REG(priv->config->port));
+
+  /* Set I2S TX bck div num */
 
 #ifdef I2S_HAVE_TX
-  i2s_hal_set_tx_clock(priv->config->ctx,
-                       priv->config->clk_info,
-                       priv->config->tx_clk_src);
+  modifyreg32(I2S_SAMPLE_RATE_CONF_REG(priv->config->port),
+              I2S_TX_BCK_DIV_NUM_M,
+              FIELD_TO_VALUE(I2S_TX_BCK_DIV_NUM, bclk_div));
 #endif /* I2S_HAVE_TX */
 
 #ifdef I2S_HAVE_RX
-  i2s_hal_set_rx_clock(priv->config->ctx,
-                       priv->config->clk_info,
-                       priv->config->rx_clk_src);
+  modifyreg32(I2S_SAMPLE_RATE_CONF_REG(priv->config->port),
+              I2S_RX_BCK_DIV_NUM_M,
+              FIELD_TO_VALUE(I2S_RX_BCK_DIV_NUM, bclk_div));
 #endif /* I2S_HAVE_RX */
+
+  /* Returns the actual sample rate */
+
+  bclk = sclk / (float)((mclk_div + numerator / (float)denominator) *
+                        bclk_div);
+  rate = bclk / (float)(priv->config->total_slot * priv->data_width);
+
+  return rate;
 }
 
 /****************************************************************************
@@ -2079,7 +2056,7 @@ static void i2s_set_clock(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static void i2s_tx_channel_start(struct esp_i2s_s *priv)
+static void i2s_tx_channel_start(struct esp32_i2s_s *priv)
 {
   if (priv->config->tx_en)
     {
@@ -2090,40 +2067,35 @@ static void i2s_tx_channel_start(struct esp_i2s_s *priv)
           return;
         }
 
+      /* Reset the TX channel */
+
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_RESET, 0);
+
       /* Reset the DMA operation */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_reset_channel(priv->dma_channel, true);
-#else
-      i2s_hal_tx_reset_dma(priv->config->ctx);
-#endif
-      /* Reset the TX channel */
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), 0, I2S_OUT_RST);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), I2S_OUT_RST, 0);
 
       /* Reset TX FIFO */
 
-      i2s_hal_tx_reset(priv->config->ctx);
-      i2s_hal_tx_reset_fifo(priv->config->ctx);
-
-      /* Set I2S_RX_UPDATE bit to update the configs.
-       * This bit is automatically cleared.
-       */
-
-      i2s_hal_tx_start(priv->config->ctx);
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_TX_FIFO_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_FIFO_RESET, 0);
 
       /* Enable DMA interrupt */
 
-      up_enable_irq(priv->tx_irq);
+      up_enable_irq(priv->config->irq);
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_enable_interrupt(priv->dma_channel, true,
-                                   GDMA_LL_EVENT_TX_TOTAL_EOF |
-                                   GDMA_LL_EVENT_TX_DESC_ERROR,
-                                   true);
-#else
-      i2s_hal_tx_enable_intr(priv->config->ctx);
-      i2s_hal_tx_enable_dma(priv->config->ctx);
-      i2s_hal_tx_start_link(priv->config->ctx, 0);
-#endif
+      modifyreg32(I2S_INT_ENA_REG(priv->config->port), 0,
+                  I2S_OUT_EOF_INT_ENA);
+
+      /* Enable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), 0, I2S_DSCR_EN);
+
+      /* Unset the DMA outlink */
+
+      putreg32(0, I2S_OUT_LINK_REG(priv->config->port));
 
       priv->tx_started = true;
 
@@ -2148,7 +2120,7 @@ static void i2s_tx_channel_start(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static void i2s_rx_channel_start(struct esp_i2s_s *priv)
+static void i2s_rx_channel_start(struct esp32_i2s_s *priv)
 {
   if (priv->config->rx_en)
     {
@@ -2159,40 +2131,35 @@ static void i2s_rx_channel_start(struct esp_i2s_s *priv)
           return;
         }
 
+      /* Reset the RX channel */
+
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_RESET, 0);
+
       /* Reset the DMA operation */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_reset_channel(priv->dma_channel, false);
-#else
-      i2s_hal_rx_reset_dma(priv->config->ctx);
-#endif
-
-      /* Reset the RX channel */
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), 0, I2S_IN_RST);
+      modifyreg32(I2S_LC_CONF_REG(priv->config->port), I2S_IN_RST, 0);
 
       /* Reset RX FIFO */
 
-      i2s_hal_rx_reset(priv->config->ctx);
-      i2s_hal_rx_reset_fifo(priv->config->ctx);
-
-      /* Set I2S_RX_UPDATE bit to update the configs.
-       * This bit is automatically cleared.
-       */
-
-      i2s_hal_rx_start(priv->config->ctx);
+      modifyreg32(I2S_CONF_REG(priv->config->port), 0, I2S_RX_FIFO_RESET);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_FIFO_RESET, 0);
 
       /* Enable DMA interrupt */
 
-      up_enable_irq(priv->rx_irq);
+      up_enable_irq(priv->config->irq);
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_enable_interrupt(priv->dma_channel, false,
-                                   GDMA_LL_EVENT_RX_SUC_EOF,
-                                   true);
-#else
-      i2s_hal_rx_enable_intr(priv->config->ctx);
-      i2s_hal_rx_enable_dma(priv->config->ctx);
-      i2s_hal_rx_start_link(priv->config->ctx, 0);
-#endif
+      modifyreg32(I2S_INT_ENA_REG(priv->config->port), 0,
+                  I2S_IN_SUC_EOF_INT_ENA);
+
+      /* Enable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), 0, I2S_DSCR_EN);
+
+      /* Unset the DMA outlink */
+
+      putreg32(0, I2S_IN_LINK_REG(priv->config->port));
 
       priv->rx_started = true;
 
@@ -2217,7 +2184,7 @@ static void i2s_rx_channel_start(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static void i2s_tx_channel_stop(struct esp_i2s_s *priv)
+static void i2s_tx_channel_stop(struct esp32_i2s_s *priv)
 {
   if (priv->config->tx_en)
     {
@@ -2230,25 +2197,23 @@ static void i2s_tx_channel_stop(struct esp_i2s_s *priv)
 
       /* Stop TX channel */
 
-      i2s_hal_tx_stop(priv->config->ctx);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_TX_START, 0);
 
       /* Stop outlink */
 
+      modifyreg32(I2S_OUT_LINK_REG(priv->config->port), I2S_OUTLINK_START,
+                  I2S_OUTLINK_STOP);
+
       /* Disable DMA interrupt */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_disable(priv->dma_channel, true);
-      esp32s3_dma_enable_interrupt(priv->dma_channel, true,
-                                   GDMA_LL_EVENT_TX_EOF, false);
-#else
-      i2s_hal_tx_stop_link(priv->config->ctx);
-      i2s_hal_tx_disable_intr(priv->config->ctx);
-      i2s_hal_tx_disable_dma(priv->config->ctx);
-#endif
+      modifyreg32(I2S_INT_ENA_REG(priv->config->port),
+                  I2S_OUT_EOF_INT_ENA, 0);
 
       /* Disable DMA operation mode */
 
-      up_disable_irq(priv->tx_irq);
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), I2S_DSCR_EN, 0);
+
+      up_disable_irq(priv->config->irq);
 
       priv->tx_started = false;
 
@@ -2273,7 +2238,7 @@ static void i2s_tx_channel_stop(struct esp_i2s_s *priv)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static void i2s_rx_channel_stop(struct esp_i2s_s *priv)
+static void i2s_rx_channel_stop(struct esp32_i2s_s *priv)
 {
   if (priv->config->rx_en)
     {
@@ -2286,25 +2251,23 @@ static void i2s_rx_channel_stop(struct esp_i2s_s *priv)
 
       /* Stop RX channel */
 
-      i2s_hal_rx_stop(priv->config->ctx);
+      modifyreg32(I2S_CONF_REG(priv->config->port), I2S_RX_START, 0);
 
       /* Stop outlink */
 
+      modifyreg32(I2S_IN_LINK_REG(priv->config->port), I2S_INLINK_START,
+                  I2S_INLINK_STOP);
+
       /* Disable DMA interrupt */
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-      esp32s3_dma_disable(priv->dma_channel, false);
-      esp32s3_dma_enable_interrupt(priv->dma_channel, false,
-                                   GDMA_LL_EVENT_RX_SUC_EOF, false);
-#else
-      i2s_hal_rx_stop_link(priv->config->ctx);
-      i2s_hal_rx_disable_intr(priv->config->ctx);
-      i2s_hal_rx_disable_dma(priv->config->ctx);
-#endif
+      modifyreg32(I2S_INT_ENA_REG(priv->config->port),
+                  I2S_IN_SUC_EOF_INT_ENA, 0);
 
       /* Disable DMA operation mode */
 
-      up_disable_irq(priv->rx_irq);
+      modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), I2S_DSCR_EN, 0);
+
+      up_disable_irq(priv->config->irq);
 
       priv->rx_started = false;
 
@@ -2318,7 +2281,7 @@ static void i2s_rx_channel_stop(struct esp_i2s_s *priv)
  * Name: i2s_interrupt
  *
  * Description:
- *   Common I2S interrupt handler
+ *   Common I2S DMA interrupt handler
  *
  * Input Parameters:
  *   irq     - Number of the IRQ that generated the interrupt
@@ -2332,78 +2295,42 @@ static void i2s_rx_channel_stop(struct esp_i2s_s *priv)
 
 static int i2s_interrupt(int irq, void *context, void *arg)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)arg;
-  uint32_t status = 0;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)arg;
+  struct esp32_dmadesc_s *cur = NULL;
 
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  struct esp_dmadesc_s *cur = NULL;
-#  ifdef I2S_HAVE_RX
-  status =  esp32s3_dma_get_interrupt(priv->dma_channel, false);
-  esp32s3_dma_clear_interrupt(priv->dma_channel, false, status);
-  if (priv->config->rx_en)
-    {
-      if (status & GDMA_LL_EVENT_RX_SUC_EOF)
-        {
-          cur = (struct esp_dmadesc_s *)
-                 esp32s3_dma_get_desc_addr(priv->dma_channel, true);
+  uint32_t status = getreg32(I2S_INT_ST_REG(priv->config->port));
 
-          /* Schedule completion of the transfer on the worker thread */
+  putreg32(UINT32_MAX, I2S_INT_CLR_REG(priv->config->port));
 
-          i2s_rx_schedule(priv, cur);
-        }
-    }
-#  endif
-
-#  ifdef I2S_HAVE_TX
-  status =  esp32s3_dma_get_interrupt(priv->dma_channel, true);
-  esp32s3_dma_clear_interrupt(priv->dma_channel, true, status);
+#ifdef I2S_HAVE_TX
   if (priv->config->tx_en)
     {
-      if (status & GDMA_LL_EVENT_TX_TOTAL_EOF)
+      if (status & I2S_OUT_EOF_INT_ST)
         {
-          cur = (struct esp_dmadesc_s *)
-                esp32s3_dma_get_desc_addr(priv->dma_channel, true);
+          cur = (struct esp32_dmadesc_s *)
+                getreg32(I2S_OUT_EOF_DES_ADDR_REG(priv->config->port));
 
           /* Schedule completion of the transfer on the worker thread */
 
           i2s_tx_schedule(priv, cur);
         }
     }
-#  endif
-#else
-  struct esp_dmadesc_s cur;
+#endif /* I2S_HAVE_TX */
 
-  status = i2s_hal_get_intr_status(priv->config->ctx);
-  i2s_hal_clear_intr_status(priv->config->ctx, UINT32_MAX);
-
-#  ifdef I2S_HAVE_RX
+#ifdef I2S_HAVE_RX
   if (priv->config->rx_en)
     {
-      if (status & I2S_LL_EVENT_RX_EOF)
+      if (status & I2S_IN_SUC_EOF_INT_ST)
         {
-          i2s_hal_get_out_eof_des_addr(priv->config->ctx, (uint32_t *) &cur);
+          cur = (struct esp32_dmadesc_s *)
+                getreg32(I2S_IN_EOF_DES_ADDR_REG(priv->config->port));
 
           /* Schedule completion of the transfer on the worker thread */
 
-          i2s_rx_schedule(priv, &cur);
+          i2s_rx_schedule(priv, cur);
         }
     }
-#  endif
-
-#  ifdef I2S_HAVE_TX
-  if (priv->config->tx_en)
-    {
-      if (status & I2S_LL_EVENT_TX_EOF)
-        {
-          i2s_hal_get_out_eof_des_addr(priv->config->ctx, (uint32_t *) &cur);
-
-          /* Schedule completion of the transfer on the worker thread */
-
-          i2s_tx_schedule(priv, &cur);
-        }
-    }
-#  endif
-#endif
+#endif /* I2S_HAVE_RX */
 
   return 0;
 }
@@ -2415,7 +2342,7 @@ static int i2s_interrupt(int irq, void *context, void *arg)
  *   Get the current master clock frequency.
  *
  * Input Parameters:
- *   dev - Device-specific state data
+ *   dev        - Device-specific state data
  *
  * Returned Value:
  *   Returns the current master clock.
@@ -2424,7 +2351,7 @@ static int i2s_interrupt(int irq, void *context, void *arg)
 
 static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   return priv->mclk_freq;
 }
@@ -2449,13 +2376,13 @@ static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   /* Check if the master clock frequency is beyond the highest possible
    * value and return an error.
    */
 
-  if (frequency >= (priv->config->clk_hz / 2))
+  if (frequency >= (I2S_LL_BASE_CLK / 2))
     {
       return -EINVAL;
     }
@@ -2472,7 +2399,7 @@ static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
  *   Set the I2S TX number of channels.
  *
  * Input Parameters:
- *   dev      - Device-specific state data
+ *   dev  - Device-specific state data
  *   channels - The I2S numbers of channels
  *
  * Returned Value:
@@ -2483,8 +2410,7 @@ static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
 #ifdef I2S_HAVE_TX
 static int i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
-  bool is_mono = true;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->tx_en)
     {
@@ -2493,24 +2419,7 @@ static int i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
           return -EINVAL;
         }
 
-      i2s_tx_channel_stop(priv);
-
       priv->channels = channels;
-
-      if (priv->channels > 1)
-        {
-          is_mono = false;
-        }
-
-      i2s_ll_tx_enable_mono_mode(priv->config->ctx->dev,
-                                 is_mono);
-
-      /* Set I2S_TX_UPDATE bit to update the configs.
-       * This bit is automatically cleared.
-       */
-
-      i2s_tx_channel_start(priv);
-
       return OK;
     }
 
@@ -2525,7 +2434,7 @@ static int i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
  *   Set the I2S RX number of channels.
  *
  * Input Parameters:
- *   dev      - Device-specific state data
+ *   dev  - Device-specific state data
  *   channels - The I2S numbers of channels
  *
  * Returned Value:
@@ -2536,8 +2445,7 @@ static int i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
 #ifdef I2S_HAVE_RX
 static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
-  bool is_mono = true;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->rx_en)
     {
@@ -2546,20 +2454,7 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
           return -EINVAL;
         }
 
-      i2s_rx_channel_stop(priv);
-
       priv->channels = channels;
-
-      if (priv->channels > 1)
-        {
-          is_mono = false;
-        }
-
-      i2s_ll_tx_enable_mono_mode(priv->config->ctx->dev,
-                                 is_mono);
-
-      i2s_rx_channel_start(priv);
-
       return OK;
     }
 
@@ -2581,14 +2476,14 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
  *   rate - The I2S sample rate in samples (not bits) per second
  *
  * Returned Value:
- *   OK on success, ERROR on fail
+ *   Returns the resulting bitrate
  *
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
 static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->tx_en)
     {
@@ -2596,19 +2491,14 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 
       priv->rate = rate;
 
-      if (i2s_check_mclkfrequency(priv) < OK)
-        {
-          return ERROR;
-        }
-
-      i2s_set_clock(priv);
+      rate = i2s_set_clock(priv);
 
       i2s_tx_channel_start(priv);
 
-      return OK;
+      return rate;
     }
 
-  return ERROR;
+  return 0;
 }
 #endif /* I2S_HAVE_TX */
 
@@ -2623,14 +2513,14 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *   rate - The I2S sample rate in samples (not bits) per second
  *
  * Returned Value:
- *   OK on success, ERROR on fail
+ *   Returns the resulting bitrate
  *
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
 static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->rx_en)
     {
@@ -2638,19 +2528,14 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 
       priv->rate = rate;
 
-      if (i2s_check_mclkfrequency(priv) < OK)
-        {
-          return ERROR;
-        }
-
-      i2s_set_clock(priv);
+      rate = i2s_set_clock(priv);
 
       i2s_rx_channel_start(priv);
 
-      return OK;
+      return rate;
     }
 
-  return ERROR;
+  return 0;
 }
 #endif /* I2S_HAVE_RX */
 
@@ -2673,7 +2558,7 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 #ifdef I2S_HAVE_TX
 static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->tx_en)
     {
@@ -2711,7 +2596,7 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 #ifdef I2S_HAVE_RX
 static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->rx_en)
     {
@@ -2757,41 +2642,51 @@ static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                     i2s_callback_t callback, void *arg, uint32_t timeout)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->tx_en)
     {
-      struct esp_buffer_s *bfcontainer;
+      struct esp32_buffer_s *bfcontainer;
       int ret = OK;
       uint32_t nbytes;
       uint32_t nsamp;
 
-      /* Check audio buffer data size from the upper half. If the buffer
-       * size is not a multiple of the data width, the remaining bytes
-       * must be sent along with the next audio buffer.
-       */
+      /* Check audio buffer data size */
 
       nbytes = (apb->nbytes - apb->curbyte) + priv->tx.carry.bytes;
 
-      nbytes -= (nbytes % (priv->data_width / 8));
+      /* If data width is 8, it is necessary to use a word of 16 bits;
+       * If data width is 24, it is necessary to use a word of 32 bits;
+       */
 
-      if (nbytes > (ESPRESSIF_DMA_BUFLEN_MAX * I2S_DMADESC_NUM))
+      nsamp = nbytes / (priv->data_width / 8);
+      nbytes = nsamp *
+              ((priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                I2S_DATA_BIT_WIDTH_16BIT : I2S_DATA_BIT_WIDTH_32BIT) / 8);
+
+      /* ESP32's I2S peripheral always consider two channels. If the source
+       * is mono, it is necessary to copy zero-ed data between each sample.
+       */
+
+      nbytes *= priv->channels == 1 ? 2 : 1;
+
+      /* Ensure nbytes is 4-byte aligned */
+
+      nbytes = ALIGN_UP(nbytes, sizeof(uintptr_t));
+
+      if (nbytes > (ESP32_DMA_DATALEN_MAX * I2S_DMADESC_NUM))
         {
           i2serr("Required buffer size can't fit into DMA outlink "
-                 "(exceeds in %" PRIu32 " bytes). Try to increase the "
-                 "number of the DMA descriptors (CONFIG_I2S_DMADESC_NUM).",
-                 nbytes - (ESPRESSIF_DMA_BUFLEN_MAX * I2S_DMADESC_NUM));
+                "(exceeds in %" PRIu32 " bytes). Try to increase the "
+                "number of the DMA descriptors (CONFIG_I2S_DMADESC_NUM).",
+                nbytes - (ESP32_DMA_DATALEN_MAX * I2S_DMADESC_NUM));
           return -EFBIG;
         }
 
       /* Allocate a buffer container in advance */
 
       bfcontainer = i2s_buf_allocate(priv);
-      if (bfcontainer == NULL)
-        {
-          i2serr("Failed to allocate the buffer container");
-          return -ENOMEM;
-        }
+      DEBUGASSERT(bfcontainer);
 
       /* Get exclusive access to the I2S driver data */
 
@@ -2866,33 +2761,41 @@ errout_with_buf:
 static int i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                        i2s_callback_t callback, void *arg, uint32_t timeout)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
   if (priv->config->rx_en)
     {
-      struct esp_buffer_s *bfcontainer;
+      struct esp32_buffer_s *bfcontainer;
       int ret = OK;
       uint32_t nbytes;
       uint32_t nsamp;
 
-      /* Check max audio buffer data size from the upper half and align the
-       * receiving buffer according to the data width.
-       */
+      /* Check max audio buffer data size */
 
       nbytes = apb->nmaxbytes;
 
-      nbytes -= (nbytes % (priv->data_width / 8));
+      /* If data width is 8, it is necessary to use a word of 16 bits;
+       * If data width is 24, it is necessary to use a word of 32 bits;
+       */
 
-      nbytes = MIN(nbytes, ESPRESSIF_DMA_BUFLEN_MAX);
+      nsamp = nbytes / (priv->data_width / 8);
+      nbytes = nsamp *
+              ((priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                I2S_DATA_BIT_WIDTH_16BIT : I2S_DATA_BIT_WIDTH_32BIT) / 8);
+
+      if (nbytes > (ESP32_DMA_DATALEN_MAX * I2S_DMADESC_NUM))
+        {
+          i2serr("Required buffer size can't fit into DMA inlink "
+                "(exceeds in %" PRIu32 " bytes). Try to increase the "
+                "number of the DMA descriptors (CONFIG_I2S_DMADESC_NUM).",
+                nbytes - (ESP32_DMA_DATALEN_MAX * I2S_DMADESC_NUM));
+          return -EFBIG;
+        }
 
       /* Allocate a buffer container in advance */
 
       bfcontainer = i2s_buf_allocate(priv);
-      if (bfcontainer == NULL)
-        {
-          i2serr("Failed to allocate the buffer container");
-          return -ENOMEM;
-        }
+      DEBUGASSERT(bfcontainer);
 
       /* Get exclusive access to the I2S driver data */
 
@@ -2923,8 +2826,7 @@ static int i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
         }
 
       i2sinfo("Prepared %d bytes to receive DMA buffers\n", apb->nmaxbytes);
-      i2s_dump_buffer("Recieved Audio pipeline buffer:",
-                      &apb->samp[apb->curbyte],
+      i2s_dump_buffer("Audio pipeline buffer:", &apb->samp[apb->curbyte],
                       apb->nbytes - apb->curbyte);
 
       nxmutex_unlock(&priv->lock);
@@ -2942,24 +2844,65 @@ errout_with_buf:
 #endif /* I2S_HAVE_RX */
 
 /****************************************************************************
+ * Name: i2s_cleanup_queues
+ *
+ * Description:
+ *   Wait for all buffers to be processed and free them after
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static void i2s_cleanup_queues(struct esp32_i2s_s *priv)
+{
+  irqstate_t flags;
+  struct esp32_buffer_s *bfcontainer;
+
+  while (sq_peek(&priv->rx.done) != NULL)
+    {
+      flags = enter_critical_section();
+      bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->rx.done);
+      leave_critical_section(flags);
+      bfcontainer->callback(&priv->dev, bfcontainer->apb,
+                            bfcontainer->arg, OK);
+      apb_free(bfcontainer->apb);
+      i2s_buf_free(priv, bfcontainer);
+    }
+
+  while (sq_peek(&priv->rx.act) != NULL)
+    {
+      flags = enter_critical_section();
+      bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->rx.act);
+      leave_critical_section(flags);
+      bfcontainer->callback(&priv->dev, bfcontainer->apb,
+                            bfcontainer->arg, OK);
+      apb_free(bfcontainer->apb);
+      i2s_buf_free(priv, bfcontainer);
+    }
+
+  while (sq_peek(&priv->rx.pend) != NULL)
+    {
+      flags = enter_critical_section();
+      bfcontainer = (struct esp32_buffer_s *)sq_remfirst(&priv->rx.pend);
+      leave_critical_section(flags);
+      bfcontainer->apb->flags |= AUDIO_APB_FINAL;
+      bfcontainer->callback(&priv->dev, bfcontainer->apb,
+                            bfcontainer->arg, OK);
+      apb_free(bfcontainer->apb);
+      i2s_buf_free(priv, bfcontainer);
+    }
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
  * Name: i2s_ioctl
  *
  * Description:
- *   Implement the lower-half logic ioctl commands
- *
- * Input parameters:
- *   dev - A reference to the lower-half I2S driver device
- *   cmd - The ioctl command
- *   arg - The argument accompanying the ioctl command
- *
- * Returned Value:
- *   OK on success; A negated errno value on failure.
+ *   Perform a device ioctl
  *
  ****************************************************************************/
 
 static int i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg)
 {
-  struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
   struct audio_buf_desc_s  *bufdesc;
   int ret = -ENOTTY;
 
@@ -2974,8 +2917,6 @@ static int i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg)
         {
           i2sinfo("AUDIOIOC_START\n");
 
-          priv->streaming = true;
-
           ret = OK;
         }
         break;
@@ -2985,17 +2926,19 @@ static int i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg)
        *   ioctl argument:  Audio session
        */
 
-#ifndef CONFIG_AUDIO_EXCLUDE_STOP
       case AUDIOIOC_STOP:
         {
           i2sinfo("AUDIOIOC_STOP\n");
 
-          priv->streaming = false;
+#ifdef I2S_HAVE_RX
+          struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
+
+          i2s_cleanup_queues(priv);
+#endif /* I2S_HAVE_RX */
 
           ret = OK;
         }
         break;
-#endif /* CONFIG_AUDIO_EXCLUDE_STOP */
 
       /* AUDIOIOC_ALLOCBUFFER - Allocate an audio buffer
        *
@@ -3050,143 +2993,56 @@ static int i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
-static int i2s_dma_setup(struct esp_i2s_s *priv)
+static int i2s_dma_setup(struct esp32_i2s_s *priv)
 {
   int ret;
-  int periph;
-#ifdef CONFIG_ARCH_CHIP_ESP32S3
-  int i2s_dma_dev;
-
-  i2s_dma_dev = ESPRESSIF_DMA_PERIPH_I2S;
-
-  /* Request a GDMA channel for the I2S peripheral */
-
-  esp_dma_init();
-  priv->dma_channel = esp_dma_request(i2s_dma_dev, 1, 1, false);
-  if (priv->dma_channel < 0)
-    {
-      i2serr("Failed to allocate GDMA channel\n");
-      return ERROR;
-    }
-
-  /* Set up to receive GDMA interrupts on the current CPU. Each TX/RX channel
-   * will be assigned to a different CPU interrupt.
-   */
-
-  priv->cpu = this_cpu();
-
-#  ifdef I2S_HAVE_TX
-  if (priv->config->tx_en)
-    {
-      periph =
-        gdma_periph_signals.groups[0].pairs[priv->dma_channel].tx_irq_id;
-      int cpuint = esp_setup_irq(priv->cpu,
-                                 periph, 1,
-                                 ESP_IRQ_TRIGGER_LEVEL);
-      if (cpuint < 0)
-        {
-          i2serr("Failed to allocate a CPU interrupt.\n");
-          return ERROR;
-        }
-
-      priv->tx_irq = ESP_SOURCE2IRQ(periph);
-      ret = irq_attach(priv->tx_irq, i2s_interrupt, priv);
-      if (ret != OK)
-        {
-          i2serr("Couldn't attach IRQ to handler.\n");
-          esp_teardown_irq(priv->cpu,
-                           periph,
-                           cpuint);
-          return ret;
-        }
-    }
-#  endif /* I2S_HAVE_TX */
-
-#  ifdef I2S_HAVE_RX
-  if (priv->config->rx_en)
-    {
-      periph =
-        gdma_periph_signals.groups[0].pairs[priv->dma_channel].rx_irq_id;
-      int cpuint = esp_setup_irq(priv->cpu,
-                                 periph, 1,
-                                 ESP_IRQ_TRIGGER_LEVEL);
-      if (cpuint < 0)
-        {
-          i2serr("Failed to allocate a CPU interrupt.\n");
-          return ERROR;
-        }
-
-      priv->rx_irq = ESP_SOURCE2IRQ(periph);
-      ret = irq_attach(priv->rx_irq, i2s_interrupt, priv);
-      if (ret != OK)
-        {
-          i2serr("Couldn't attach IRQ to handler.\n");
-          esp_teardown_irq(priv->cpu,
-                           periph,
-                           cpuint);
-          return ret;
-        }
-    }
-#  endif /* I2S_HAVE_RX */
-#else
 
   /* Clear the interrupts */
 
-  i2s_hal_clear_intr_status(priv->config->ctx, UINT32_MAX);
+  putreg32(UINT32_MAX, I2S_INT_CLR_REG(priv->config->port));
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
   priv->cpu = this_cpu();
-  periph = i2s_periph_signal[priv->config->port].irq;
-
-  int cpuint = esp_setup_irq(
-#  ifndef CONFIG_ARCH_CHIP_ESP32S2
-                              priv->cpu,
-#  endif
-                              periph, 1,
-                              ESP_IRQ_TRIGGER_LEVEL);
-  if (cpuint < 0)
+  priv->cpuint = esp32_setup_irq(priv->cpu, priv->config->periph,
+                                 1, ESP32_CPUINT_LEVEL);
+  if (priv->cpuint < 0)
     {
       i2serr("Failed to allocate a CPU interrupt.\n");
-      return ERROR;
+      return priv->cpuint;
     }
 
-  int irq = ESP_SOURCE2IRQ(periph);
-  ret = irq_attach(irq, i2s_interrupt, priv);
+  ret = irq_attach(priv->config->irq, i2s_interrupt, priv);
   if (ret != OK)
     {
       i2serr("Couldn't attach IRQ to handler.\n");
-      esp_teardown_irq(
-#ifndef CONFIG_ARCH_CHIP_ESP32S2
-                        priv->cpu,
-#endif
-                        periph,
-                        cpuint);
+      esp32_teardown_irq(priv->cpu,
+                         priv->config->periph,
+                         priv->cpuint);
       return ret;
     }
-#endif
 
   return OK;
 }
 
 /****************************************************************************
- * Name: esp_i2sbus_initialize
+ * Name: esp32_i2sbus_initialize
  *
  * Description:
  *   Initialize the selected I2S port
  *
  * Input Parameters:
- *   port - Port number (for hardware that has multiple I2S interfaces)
+ *   Port number (for hardware that has multiple I2S interfaces)
  *
  * Returned Value:
  *   Valid I2S device structure reference on success; a NULL on failure
  *
  ****************************************************************************/
 
-struct i2s_dev_s *esp_i2sbus_initialize(int port)
+struct i2s_dev_s *esp32_i2sbus_initialize(int port)
 {
   int ret;
-  struct esp_i2s_s *priv = NULL;
+  struct esp32_i2s_s *priv = NULL;
   irqstate_t flags;
 
   i2sinfo("port: %d\n", port);
@@ -3195,19 +3051,23 @@ struct i2s_dev_s *esp_i2sbus_initialize(int port)
 
   switch (port)
     {
-#ifdef CONFIG_ESPRESSIF_I2S0
-      case ESPRESSIF_I2S0:
-        priv = &esp_i2s0_priv;
+#ifdef CONFIG_ESP32_I2S0
+      case ESP32_I2S0:
+        priv = &esp32_i2s0_priv;
         break;
 #endif
-#ifdef CONFIG_ESPRESSIF_I2S1
-      case ESPRESSIF_I2S1:
-        priv = &esp_i2s1_priv;
+#ifdef CONFIG_ESP32_I2S1
+      case ESP32_I2S1:
+        priv = &esp32_i2s1_priv;
         break;
 #endif
       default:
         return NULL;
     }
+
+  flags = spin_lock_irqsave(&priv->slock);
+
+  i2s_configure(priv);
 
   /* Allocate buffer containers */
 
@@ -3216,10 +3076,6 @@ struct i2s_dev_s *esp_i2sbus_initialize(int port)
     {
       goto err;
     }
-
-  flags = spin_lock_irqsave(&priv->slock);
-
-  i2s_configure(priv);
 
   ret = i2s_dma_setup(priv);
   if (ret < 0)
@@ -3262,3 +3118,5 @@ err:
   spin_unlock_irqrestore(&priv->slock, flags);
   return NULL;
 }
+
+#endif /* CONFIG_ESP32_I2S */

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -699,7 +699,7 @@ void up_enable_irq(int irq)
 
       if (isr_in_iram && handler && !esp32_ptr_iram(handler))
         {
-          irqerr("Interrupt handler isn't in IRAM (%08" PRIx32 ")",
+          irqerr("Interrupt handler isn't in IRAM (0x08%" PRIx16 ")",
                  (intptr_t)handler);
           PANIC();
         }

--- a/arch/xtensa/src/esp32/esp32_oneshot.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot.c
@@ -249,7 +249,7 @@ int esp32_oneshot_start(struct esp32_oneshot_s *oneshot,
   uint64_t timeout_us;
   int ret = OK;
 
-  tmrinfo("handler=%p arg=%p, ts=(%lu, %lu)\n",
+  tmrinfo("handler=%p arg=%p, ts=(%" PRIu32 ", %" PRIu32 ")\n",
           handler, arg, (unsigned long)ts->tv_sec,
           (unsigned long)ts->tv_nsec);
   DEBUGASSERT(oneshot != NULL);

--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -173,7 +173,7 @@ static int esp32_max_lh_delay(struct oneshot_lowerhalf_s *lower,
   ts->tv_nsec = NSEC_PER_SEC - 1;
 
   tmrinfo("max sec=%" PRIu32 "\n", ts->tv_sec);
-  tmrinfo("max nsec=%ld\n", ts->tv_nsec);
+  tmrinfo("max nsec=%" PRId32 "\n", ts->tv_nsec);
 
   return OK;
 }

--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -626,7 +626,7 @@ static int esp32_part_ioctl(struct mtd_dev_s *dev, int cmd,
   int ret = OK;
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
 
-  finfo("INFO: cmd=%d(%x) arg=%lx\n", cmd, cmd, arg);
+  finfo("INFO: cmd=%d(%x) arg=%" PRIx32 "\n", cmd, cmd, arg);
 
   switch (_IOC_NR(cmd))
     {
@@ -771,9 +771,9 @@ static int partition_create_dev(const struct partition_info_priv *info,
   finfo("INFO: [label]:   %s\n", info->label);
   finfo("INFO: [type]:    %d\n", info->type);
   finfo("INFO: [subtype]: %d\n", info->subtype);
-  finfo("INFO: [offset]:  0x%08x\n", info->offset);
-  finfo("INFO: [size]:    0x%08x\n", info->size);
-  finfo("INFO: [flags]:   0x%08x\n", info->flags);
+  finfo("INFO: [offset]:  0x0x08%" PRIx32 "\n", info->offset);
+  finfo("INFO: [size]:    0x0x08%" PRIx32 "\n", info->size);
+  finfo("INFO: [flags]:   0x0x08%" PRIx32 "\n", info->flags);
   finfo("INFO: [mount]:   %s\n", path);
   if (flags & PARTITION_FLAG_ENCRYPTED)
     {

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -591,7 +591,7 @@ static int IRAM_ATTR esp32_sleep_start(uint32_t pd_flags)
   if (esp32_configure_cpu_freq(cur_freq) != OK)
     {
       pwrwarn("WARNING: Failed to restore CPU frequency"
-              "Configure cpu frequency %d.\n", cur_freq);
+              "Configure cpu frequency %" PRIu32 ".\n", cur_freq);
     }
 
   /* Re-enable UART output */

--- a/arch/xtensa/src/esp32/esp32_psram.c
+++ b/arch/xtensa/src/esp32/esp32_psram.c
@@ -1568,7 +1568,7 @@ psram_enable(int mode, int vaddrmode)   /* psram init */
             }
           else
             {
-              merr("Not a valid or known package id: %d", pkg_ver);
+              merr("Not a valid or known package id: %" PRIu32 "", pkg_ver);
               PANIC();
             }
         }
@@ -1678,7 +1678,7 @@ psram_enable(int mode, int vaddrmode)   /* psram init */
   psram_gpio_config(&psram_io, mode);
   psram_read_id(&s_psram_id);
 
-  minfo("psram ID = 0x%x\n", (uint32_t)s_psram_id);
+  minfo("psram ID = 0x%" PRIx32 "\n", (uint32_t)s_psram_id);
 
   if (!PSRAM_IS_VALID(s_psram_id))
     {

--- a/arch/xtensa/src/esp32/esp32_qencoder.c
+++ b/arch/xtensa/src/esp32/esp32_qencoder.c
@@ -414,55 +414,71 @@ static void esp32_dumpregs(struct esp32_lowerhalf_s *priv,
                            const char *msg)
 {
   sninfo("%s:\n", msg);
-  sninfo("  PCNT_U0_CONF0_REG: %08x PCNT_U1_CONF0_REG:  %08x\n",
+  sninfo("  PCNT_U0_CONF0_REG: 0x08%" PRIx32 ""
+         " PCNT_U1_CONF0_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF0_U(0)),
          getreg32(PCNT_CONF0_U(1)));
-  sninfo("  PCNT_U2_CONF0_REG: %08x PCNT_U3_CONF0_REG:  %08x\n",
+  sninfo("  PCNT_U2_CONF0_REG: 0x08%" PRIx32 ""
+         " PCNT_U3_CONF0_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF0_U(2)),
          getreg32(PCNT_CONF0_U(3)));
-  sninfo("  PCNT_U4_CONF0_REG: %08x PCNT_U5_CONF0_REG:  %08x\n",
+  sninfo("  PCNT_U4_CONF0_REG: 0x08%" PRIx32 ""
+         " PCNT_U5_CONF0_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF0_U(4)),
          getreg32(PCNT_CONF0_U(5)));
-  sninfo("  PCNT_U6_CONF0_REG: %08x PCNT_U7_CONF0_REG:  %08x\n",
+  sninfo("  PCNT_U6_CONF0_REG: 0x08%" PRIx32 ""
+         " PCNT_U7_CONF0_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF0_U(6)),
          getreg32(PCNT_CONF0_U(7)));
-  sninfo("  PCNT_U0_CONF1_REG: %08x PCNT_U1_CONF1_REG:  %08x\n",
+  sninfo("  PCNT_U0_CONF1_REG: 0x08%" PRIx32 ""
+         " PCNT_U1_CONF1_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF1_U(0)),
          getreg32(PCNT_CONF1_U(1)));
-  sninfo("  PCNT_U2_CONF1_REG: %08x PCNT_U3_CONF1_REG:  %08x\n",
+  sninfo("  PCNT_U2_CONF1_REG: 0x08%" PRIx32 ""
+         " PCNT_U3_CONF1_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF1_U(2)),
          getreg32(PCNT_CONF1_U(3)));
-  sninfo("  PCNT_U4_CONF1_REG: %08x PCNT_U5_CONF1_REG:  %08x\n",
+  sninfo("  PCNT_U4_CONF1_REG: 0x08%" PRIx32 ""
+         " PCNT_U5_CONF1_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF1_U(4)),
          getreg32(PCNT_CONF1_U(5)));
-  sninfo("  PCNT_U6_CONF1_REG: %08x PCNT_U7_CONF1_REG:  %08x\n",
+  sninfo("  PCNT_U6_CONF1_REG: 0x08%" PRIx32 ""
+         " PCNT_U7_CONF1_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF1_U(6)),
          getreg32(PCNT_CONF1_U(7)));
-  sninfo("  PCNT_U0_CONF2_REG: %08x PCNT_U1_CONF2_REG:  %08x\n",
+  sninfo("  PCNT_U0_CONF2_REG: 0x08%" PRIx32 ""
+         " PCNT_U1_CONF2_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF2_U(0)),
          getreg32(PCNT_CONF2_U(1)));
-  sninfo("  PCNT_U2_CONF2_REG: %08x PCNT_U3_CONF2_REG:  %08x\n",
+  sninfo("  PCNT_U2_CONF2_REG: 0x08%" PRIx32 ""
+         " PCNT_U3_CONF2_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF2_U(2)),
          getreg32(PCNT_CONF2_U(3)));
-  sninfo("  PCNT_U4_CONF2_REG: %08x PCNT_U5_CONF2_REG:  %08x\n",
+  sninfo("  PCNT_U4_CONF2_REG: 0x08%" PRIx32 ""
+         " PCNT_U5_CONF2_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF2_U(4)),
          getreg32(PCNT_CONF2_U(5)));
-  sninfo("  PCNT_U6_CONF2_REG: %08x PCNT_U7_CONF2_REG:  %08x\n",
+  sninfo("  PCNT_U6_CONF2_REG: 0x08%" PRIx32 ""
+         " PCNT_U7_CONF2_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CONF2_U(6)),
          getreg32(PCNT_CONF2_U(7)));
-  sninfo("  PCNT_U0_CNT_REG: %08x PCNT_U1_CNT_REG:  %08x\n",
+  sninfo("  PCNT_U0_CNT_REG: 0x08%" PRIx32 ""
+         " PCNT_U1_CNT_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CNT_U(0)),
          getreg32(PCNT_CNT_U(1)));
-  sninfo("  PCNT_U2_CNT_REG: %08x PCNT_U3_CNT_REG:  %08x\n",
+  sninfo("  PCNT_U2_CNT_REG: 0x08%" PRIx32 ""
+         " PCNT_U3_CNT_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CNT_U(2)),
          getreg32(PCNT_CNT_U(3)));
-  sninfo("  PCNT_U4_CNT_REG: %08x PCNT_U5_CNT_REG:  %08x\n",
+  sninfo("  PCNT_U4_CNT_REG: 0x08%" PRIx32 ""
+         " PCNT_U5_CNT_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CNT_U(4)),
          getreg32(PCNT_CNT_U(5)));
-  sninfo("  PCNT_U6_CNT_REG: %08x PCNT_U7_CNT_REG:  %08x\n",
+  sninfo("  PCNT_U6_CNT_REG: 0x08%" PRIx32 ""
+         " PCNT_U7_CNT_REG:  0x08%" PRIx32 "\n",
          getreg32(PCNT_CNT_U(6)),
          getreg32(PCNT_CNT_U(7)));
-  sninfo("  PCNT_CTRL_REF: %08x\n",
+  sninfo("  PCNT_CTRL_REF: 0x08%" PRIx32 "\n",
          getreg32(PCNT_CTRL_REG));
 }
 #endif

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -700,7 +700,7 @@ static void esp32_select_rtc_slow_clk(enum esp32_slow_clk_sel_e slow_clk)
         }
     }
   while (cal_val == 0);
-  rtcinfo("RTC_SLOW_CLK calibration value: %d\n", cal_val);
+  rtcinfo("RTC_SLOW_CLK calibration value: %" PRIu32 "\n", cal_val);
   putreg32((uint32_t)cal_val, RTC_SLOW_CLK_CAL_REG);
 }
 

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -659,7 +659,8 @@ static uint32_t esp32_spi_setfrequency(struct spi_dev_s *dev,
 
   putreg32(reg_val, SPI_CLOCK_REG(priv->config->id));
 
-  spiinfo("frequency=%d, actual=%d\n", priv->frequency, priv->actual);
+  spiinfo("frequency=%" PRIu32 ", actual=%" PRIu32 "\n",
+          priv->frequency, priv->actual);
 
   return priv->actual;
 }
@@ -1113,7 +1114,7 @@ static void esp32_spi_poll_exchange(struct esp32_spi_priv_s *priv,
 
           putreg32(w_wd, data_buf_reg);
 
-          spiinfo("send=0x%" PRIx32 " data_reg=0x%" PRIx32 "\n",
+          spiinfo("send=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
                   w_wd, data_buf_reg);
 
           /* Update data_buf_reg to point to the next data buffer register. */
@@ -1160,7 +1161,7 @@ static void esp32_spi_poll_exchange(struct esp32_spi_priv_s *priv,
             {
               uint32_t r_wd = getreg32(data_buf_reg);
 
-              spiinfo("recv=0x%" PRIx32 " data_reg=0x%" PRIx32 "\n",
+              spiinfo("recv=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
                       r_wd, data_buf_reg);
 
               memcpy(rp, &r_wd, sizeof(uint32_t));

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1166,14 +1166,14 @@ static int IRAM_ATTR esp32_writedata_encrypted(
 
   if (addr % SPI_FLASH_ENCRYPT_UNIT_SIZE)
     {
-      ferr("ERROR: address=0x%x is not %d-byte align\n",
+      ferr("ERROR: address=0x%" PRIx32 " is not %d-byte align\n",
            addr, SPI_FLASH_ENCRYPT_UNIT_SIZE);
       return -EINVAL;
     }
 
   if (size % SPI_FLASH_ENCRYPT_UNIT_SIZE)
     {
-      ferr("ERROR: size=%u is not %d-byte align\n",
+      ferr("ERROR: size=%" PRIu32 " is not %d-byte align\n",
            size, SPI_FLASH_ENCRYPT_UNIT_SIZE);
       return -EINVAL;
     }
@@ -1200,7 +1200,8 @@ static int IRAM_ATTR esp32_writedata_encrypted(
                             SPI_FLASH_ENCRYPT_UNIT_SIZE);
       if (ret)
         {
-          ferr("ERROR: Failed to write encrypted data @ 0x%x\n", addr);
+          ferr("ERROR: Failed to write encrypted data @ 0x%" PRIx32 "\n",
+               addr);
           goto exit;
         }
 
@@ -2322,7 +2323,8 @@ static int esp32_ioctl(struct mtd_dev_s *dev, int cmd,
               geo->neraseblocks = MTD_SIZE(priv) / MTD_ERASESIZE(priv);
               ret               = OK;
 
-              finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
+              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32 ""
+                    " neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
         }
@@ -2400,7 +2402,8 @@ static int esp32_ioctl_encrypt(struct mtd_dev_s *dev, int cmd,
               geo->neraseblocks = MTD_SIZE(priv) / geo->erasesize;
               ret               = OK;
 
-              finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
+              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32 ""
+                    " neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
         }
@@ -2714,12 +2717,12 @@ struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
   chip = priv->chip;
 
   finfo("ESP32 SPI Flash information:\n");
-  finfo("\tID = 0x%x\n", chip->device_id);
-  finfo("\tStatus mask = %x\n", chip->status_mask);
-  finfo("\tChip size = %d KB\n", chip->chip_size / 1024);
-  finfo("\tPage size = %d B\n", chip->page_size);
-  finfo("\tSector size = %d KB\n", chip->sector_size / 1024);
-  finfo("\tBlock size = %d KB\n", chip->block_size / 1024);
+  finfo("\tID = 0x%" PRIx32 "\n", chip->device_id);
+  finfo("\tStatus mask = %" PRIx32 "\n", chip->status_mask);
+  finfo("\tChip size = %" PRIu32 " KB\n", chip->chip_size / 1024);
+  finfo("\tPage size = %" PRIu32 " B\n", chip->page_size);
+  finfo("\tSector size = %" PRIu32 " KB\n", chip->sector_size / 1024);
+  finfo("\tBlock size = %" PRIu32 " KB\n", chip->block_size / 1024);
 
   ASSERT((mtd_offset + mtd_size) <= chip->chip_size);
   ASSERT((mtd_offset % chip->sector_size) == 0);
@@ -2734,8 +2737,8 @@ struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
       size = mtd_size;
     }
 
-  finfo("\tMTD offset = 0x%x\n", mtd_offset);
-  finfo("\tMTD size = 0x%x\n", size);
+  finfo("\tMTD offset = 0x%" PRIx32 "\n", mtd_offset);
+  finfo("\tMTD size = 0x%" PRIx32 "\n", size);
 
   startblock = MTD_SIZE2BLK(priv, mtd_offset);
   blocks = MTD_SIZE2BLK(priv, size);

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -319,7 +319,8 @@ int esp_spiram_test(void)
 
           if (errct < 4)
             {
-              merr("SPI SRAM error@%p:%08x/%08x \n", &spiram[p], spiram[p],
+              merr("SPI SRAM error@%p:0x08%" PRIxPTR "/0x08%" PRIxPTR " \n",
+                   &spiram[p], spiram[p],
                    p ^ 0xaaaaaaaa);
             }
         }

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -227,18 +227,19 @@ static noreturn_function void __esp32_start(void)
 
   chip_rev = esp_efuse_hal_chip_revision();
 
-  _info("ESP32 chip revision is v%d.%01d\n", chip_rev / 100, chip_rev % 100);
+  _info("ESP32 chip revision is v%" PRId32 ".%01ld\n",
+        chip_rev / 100, chip_rev % 100);
 
   if (chip_rev < 300)
     {
 #ifndef ESP32_IGNORE_CHIP_REVISION_CHECK
       ets_printf("ERROR: NuttX supports ESP32 chip revision >= v3.0"
-                 " (chip revision is v%d.%01d)\n",
+                 " (chip revision is v%" PRId32 ".%01ld)\n",
                  chip_rev / 100, chip_rev % 100);
       PANIC();
 #endif
       ets_printf("WARNING: NuttX supports ESP32 chip revision >= v3.0"
-                 " (chip is v%d.%01d).\n"
+                 " (chip is v%" PRId32 ".%01ld).\n"
                  "Ignoring this error and continuing because "
                  "`ESP32_IGNORE_CHIP_REVISION_CHECK` is set...\n"
                  "THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!\n",

--- a/arch/xtensa/src/esp32/esp32_twai.c
+++ b/arch/xtensa/src/esp32/esp32_twai.c
@@ -301,7 +301,7 @@ static void twai_printreg(uint32_t addr, uint32_t value)
 
   /* Show the register value read */
 
-  caninfo("%08x->%08x\n", addr, value);
+  caninfo("0x08%" PRIx32 "->0x08%" PRIx32 "\n", addr, value);
 }
 #endif
 
@@ -356,7 +356,7 @@ static void twai_putreg(uint32_t addr, uint32_t value)
 {
   /* Show the register value being written */
 
-  caninfo("%08x<-%08x\n", addr, value);
+  caninfo("0x08%" PRIx32 "<-0x08%" PRIx32 "\n", addr, value);
 
   /* Write the value */
 
@@ -659,7 +659,7 @@ static int esp32twai_ioctl(struct can_dev_s *dev, int cmd,
   struct twai_dev_s *priv = (struct twai_dev_s *)dev->cd_priv;
   int ret = -ENOTTY;
 
-  caninfo("TWAI%" PRIu8 " cmd=%04x arg=%lu\n", priv->port, cmd, arg);
+  caninfo("TWAI%" PRIu8 " cmd=%04x arg=%" PRIu32 "\n", priv->port, cmd, arg);
 
   /* Handle the command */
 

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
@@ -410,14 +410,14 @@ static int esp32_wdt_getstatus(struct watchdog_lowerhalf_s *lower,
  ****************************************************************************/
 
 static int esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
-                            uint32_t timeout)
+                                uint32_t timeout)
 {
   struct esp32_wdt_lowerhalf_s *priv =
     (struct esp32_wdt_lowerhalf_s *)lower;
   uint16_t rtc_cycles = 0;
   uint32_t rtc_ms_max = 0;
 
-  wdinfo("Entry: timeout=%d\n", timeout);
+  wdinfo("Entry: timeout=%" PRIx32 "\n", timeout);
   DEBUGASSERT(priv);
 
   /* Unlock WDT */
@@ -436,7 +436,7 @@ static int esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
 
       if (timeout == 0 || timeout > MAX_MWDT_TIMEOUT_MS)
         {
-          wderr("ERROR: Cannot represent timeout=%d > %d\n",
+          wderr("ERROR: Cannot represent timeout=%" PRIu32 " > %d\n",
                 timeout, MAX_MWDT_TIMEOUT_MS);
           return -ERANGE;
         }
@@ -458,7 +458,8 @@ static int esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
 
       if (timeout == 0 || timeout > rtc_ms_max)
         {
-          wderr("ERROR: Cannot represent timeout=%d > %d\n",
+          wderr("ERROR: Cannot represent timeout=%" PRIu32 ""
+                " > %" PRIu32 "\n",
                 timeout, rtc_ms_max);
           return -ERANGE;
         }

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -194,8 +194,10 @@ struct nvs_adpt
  ****************************************************************************/
 
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
-static int semphr_take_from_isr_wrapper(void *semphr, void *hptw);
-static int semphr_give_from_isr_wrapper(void *semphr, void *hptw);
+static int32_t semphr_take_from_isr_wrapper(void *semphr,
+                                            void *hptw);
+static int32_t semphr_give_from_isr_wrapper(void *semphr,
+                                            void *hptw);
 static int is_in_isr_wrapper(void);
 #endif /* CONFIG_ESPRESSIF_WIFI_BT_COEXIST */
 
@@ -240,8 +242,8 @@ static uint32_t esp_event_group_set_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick);
 static int32_t esp_task_create_pinned_to_core(void *task_func,
                                               const char *name,
@@ -258,7 +260,7 @@ static void esp_task_delay(uint32_t tick);
 static int32_t esp_task_ms_to_tick(uint32_t ms);
 static void *esp_task_get_current_task(void);
 static int32_t esp_task_get_max_priority(void);
-static void *esp_malloc(uint32_t size);
+static void *esp_malloc(size_t size);
 static void esp_free(void *ptr);
 static uint32_t esp_get_free_heap_size(void);
 static uint32_t esp_rand(void);
@@ -268,7 +270,7 @@ static void wifi_apb80m_request(void);
 static void wifi_apb80m_release(void);
 static void esp_phy_enable_wrapper(void);
 static void esp_phy_disable_wrapper(void);
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type);
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type);
 static void esp_timer_arm(void *timer, uint32_t tmout, bool repeat);
 static void esp_timer_disarm(void *timer);
 static void esp32_timer_done(void *timer);
@@ -280,32 +282,38 @@ static void wifi_clock_disable(void);
 static void wifi_rtc_enable_iso(void);
 static void wifi_rtc_disable_iso(void);
 static int64_t esp32_timer_get_time(void);
-static int32_t esp_nvs_set_i8(uint32_t handle, const char *key,
-                              int8_t value);
-static int32_t esp_nvs_get_i8(uint32_t handle, const char *key,
-                              int8_t *out_value);
-static int32_t esp_nvs_set_u8(uint32_t handle, const char *key,
-                              uint8_t value);
-static int32_t esp_nvs_get_u8(uint32_t handle, const char *key,
-                              uint8_t *out_value);
-static int32_t esp_nvs_set_u16(uint32_t handle, const char *key,
-                               uint16_t value);
-static int32_t esp_nvs_get_u16(uint32_t handle, const char *key,
-                               uint16_t *out_value);
-static int32_t esp_nvs_open(const char *name, uint32_t open_mode,
-                            uint32_t *out_handle);
+int32_t esp32_event_post(esp_event_base_t event_base,
+                         int32_t event_id,
+                         void *event_data,
+                         size_t event_data_size,
+                         uint32_t ticks);
+static int esp_nvs_set_i8(uint32_t handle, const char *key,
+                          int8_t value);
+static int esp_nvs_get_i8(uint32_t handle, const char *key,
+                          int8_t *out_value);
+static int esp_nvs_set_u8(uint32_t handle, const char *key,
+                          uint8_t value);
+static int esp_nvs_get_u8(uint32_t handle, const char *key,
+                          uint8_t *out_value);
+static int esp_nvs_set_u16(uint32_t handle, const char *key,
+                           uint16_t value);
+static int esp_nvs_get_u16(uint32_t handle, const char *key,
+                          uint16_t *out_value);
+static int esp_nvs_open(const char *name,
+                        unsigned int open_mode,
+                        uint32_t *out_handle);
 static void esp_nvs_close(uint32_t handle);
-static int32_t esp_nvs_commit(uint32_t handle);
-static int32_t esp_nvs_set_blob(uint32_t handle, const char *key,
-                                const void *value, size_t length);
-static int32_t esp_nvs_get_blob(uint32_t handle, const char *key,
-                                void *out_value, size_t *length);
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key);
-static int32_t esp_get_random(uint8_t *buf, size_t len);
-static int32_t esp_get_time(void *t);
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static int esp_nvs_commit(uint32_t handle);
+static int esp_nvs_set_blob(uint32_t handle, const char *key,
+                            const void *value, size_t length);
+static int esp_nvs_get_blob(uint32_t handle, const char *key,
+                            void *out_value, size_t *length);
+static int esp_nvs_erase_key(uint32_t handle, const char *key);
+static int esp_get_random(uint8_t *buf, size_t len);
+static int esp_get_time(void *t);
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args);
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...);
 static void *esp_malloc_internal(size_t size);
@@ -316,16 +324,16 @@ static void *esp_wifi_malloc(size_t size);
 static void *esp_wifi_realloc(void *ptr, size_t size);
 static void *esp_wifi_calloc(size_t n, size_t size);
 static void *esp_wifi_zalloc(size_t size);
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size);
+static void *esp_wifi_create_queue(int queue_len, int item_size);
 static void esp_wifi_delete_queue(void *queue);
 static int coex_init_wrapper(void);
 static void coex_deinit_wrapper(void);
 static int coex_enable_wrapper(void);
 static void coex_disable_wrapper(void);
 static uint32_t coex_status_get_wrapper(void);
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
                                          uint32_t duration);
-static int32_t coex_wifi_release_wrapper(uint32_t event);
+static int coex_wifi_release_wrapper(uint32_t event);
 static unsigned long esp_random_ulong(void);
 static int coex_wifi_channel_set_wrapper(uint8_t primary, uint8_t secondary);
 static int coex_event_duration_get_wrapper(uint32_t event,
@@ -486,7 +494,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs =
   ._task_get_max_priority = esp_task_get_max_priority,
   ._malloc = esp_malloc,
   ._free = esp_free,
-  ._event_post = esp_event_post,
+  ._event_post = esp32_event_post,
   ._get_free_heap_size = esp_get_free_heap_size,
   ._rand = esp_rand,
   ._dport_access_stall_other_cpu_start_wrap =
@@ -797,7 +805,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   struct irq_adpt *adapter;
   int irq = n + XTENSA_IRQ_FIRSTPERIPH;
 
-  wlinfo("n=%d f=%p arg=%p irq=%d\n", n, f, arg, irq);
+  wlinfo("n=%" PRId32 " f=%p arg=%p irq=%d\n", n, f, arg, irq);
 
   if (g_irqvector[irq].handler &&
       g_irqvector[irq].handler != irq_unexpected_isr)
@@ -811,7 +819,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   adapter = kmm_malloc(tmp);
   if (!adapter)
     {
-      wlerr("Failed to alloc %d memory\n", tmp);
+      wlerr("Failed to alloc %" PRIu32 " memory\n", tmp);
       PANIC();
       return;
     }
@@ -846,7 +854,7 @@ static void esp32_ints_on(uint32_t mask)
 {
   int irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=0x08%" PRIx32 " irq=%d\n", mask, irq);
 
   up_enable_irq(ESP32_IRQ_MAC);
 }
@@ -869,7 +877,7 @@ static void esp32_ints_off(uint32_t mask)
 {
   uint32_t irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=0x08%" PRIx32 " irq=%" PRIu32 "\n", mask, irq);
 
   up_disable_irq(ESP32_IRQ_MAC);
 }
@@ -1109,7 +1117,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t block_time_tick)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %u ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %" PRIu32 " ticks. Error=%d\n",
             block_time_tick, ret);
     }
 
@@ -1752,8 +1760,8 @@ static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits)
 
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick)
 {
   DEBUGPANIC();
@@ -1977,7 +1985,7 @@ static int32_t esp_task_get_max_priority(void)
  *
  ****************************************************************************/
 
-static void *esp_malloc(uint32_t size)
+static void *esp_malloc(size_t size)
 {
   return kmm_malloc(size);
 }
@@ -2266,7 +2274,7 @@ static void esp_evt_work_cb(void *arg)
                                    SI_QUEUE, &notify->work);
           if (ret < 0)
             {
-              wlwarn("nxsig_notification event ID=%d failed: %d\n",
+              wlwarn("nxsig_notification event ID=%" PRId32 " failed: %d\n",
                      evt_adpt->id, ret);
             }
         }
@@ -2295,7 +2303,8 @@ static void esp_evt_work_cb(void *arg)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   *(int *)hptw = 0;
 
@@ -2317,7 +2326,8 @@ static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   *(int *)hptw = 0;
 
@@ -2400,7 +2410,7 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
 }
 
 /****************************************************************************
- * Name: esp_event_post
+ * Name: esp32_event_post
  *
  * Description:
  *   Active work queue and let the work to process the cached event
@@ -2417,24 +2427,25 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
  *
  ****************************************************************************/
 
-int32_t esp_event_post(esp_event_base_t event_base,
-                       int32_t event_id,
-                       void *event_data,
-                       size_t event_data_size,
-                       uint32_t ticks)
+int32_t esp32_event_post(esp_event_base_t event_base,
+                         int32_t event_id,
+                         void *event_data,
+                         size_t event_data_size,
+                         uint32_t ticks)
 {
   size_t size;
   int32_t id;
   irqstate_t flags;
   struct evt_adpt *evt_adpt;
 
-  wlinfo("Event: base=%s id=%d data=%p data_size=%d ticks=%u\n", event_base,
-         event_id, event_data, event_data_size, ticks);
+  wlinfo("Event: base=%s id=%" PRId32 " data=%p data_size=%d "
+         "ticks=%" PRIu32 "\n",
+         event_base, event_id, event_data, event_data_size, ticks);
 
   id = esp_event_id_map(event_id);
   if (id < 0)
     {
-      wlinfo("No process event %d\n", event_id);
+      wlinfo("No process event %" PRId32 "\n", event_id);
       return -1;
     }
 
@@ -2599,7 +2610,7 @@ static void esp_phy_disable_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type)
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type)
 {
   return esp_read_mac(mac, type);
 }
@@ -2886,9 +2897,9 @@ int64_t esp32_timer_get_time(void)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_i8(uint32_t handle,
-                              const char *key,
-                              int8_t value)
+static int esp_nvs_set_i8(uint32_t handle,
+                          const char *key,
+                          int8_t value)
 {
   DEBUGPANIC();
 
@@ -2911,9 +2922,9 @@ static int32_t esp_nvs_set_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_i8(uint32_t handle,
-                              const char *key,
-                              int8_t *out_value)
+static int esp_nvs_get_i8(uint32_t handle,
+                          const char *key,
+                          int8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2936,9 +2947,9 @@ static int32_t esp_nvs_get_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t value)
+static int esp_nvs_set_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t value)
 {
   DEBUGPANIC();
 
@@ -2961,9 +2972,9 @@ static int32_t esp_nvs_set_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t *out_value)
+static int esp_nvs_get_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2986,9 +2997,9 @@ static int32_t esp_nvs_get_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t value)
+static int esp_nvs_set_u16(uint32_t handle,
+                           const char *key,
+                           uint16_t value)
 {
   DEBUGPANIC();
 
@@ -3011,9 +3022,9 @@ static int32_t esp_nvs_set_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t *out_value)
+static int esp_nvs_get_u16(uint32_t handle,
+                           const char *key,
+                           uint16_t *out_value)
 {
   DEBUGPANIC();
 
@@ -3036,9 +3047,9 @@ static int32_t esp_nvs_get_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_open(const char *name,
-                            uint32_t open_mode,
-                            uint32_t *out_handle)
+static int esp_nvs_open(const char *name,
+                        unsigned int open_mode,
+                        uint32_t *out_handle)
 {
   DEBUGPANIC();
 
@@ -3072,7 +3083,7 @@ static void esp_nvs_close(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_commit(uint32_t handle)
+static int esp_nvs_commit(uint32_t handle)
 {
   return 0;
 }
@@ -3094,10 +3105,10 @@ static int32_t esp_nvs_commit(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_blob(uint32_t handle,
-                                const char *key,
-                                const void *value,
-                                size_t length)
+static int esp_nvs_set_blob(uint32_t handle,
+                            const char *key,
+                            const void *value,
+                            size_t length)
 {
   DEBUGPANIC();
 
@@ -3121,10 +3132,10 @@ static int32_t esp_nvs_set_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_blob(uint32_t handle,
-                                const char *key,
-                                void *out_value,
-                                size_t *length)
+static int esp_nvs_get_blob(uint32_t handle,
+                            const char *key,
+                            void *out_value,
+                            size_t *length)
 {
   DEBUGPANIC();
 
@@ -3146,7 +3157,7 @@ static int32_t esp_nvs_get_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
+static int esp_nvs_erase_key(uint32_t handle, const char *key)
 {
   DEBUGPANIC();
 
@@ -3168,7 +3179,7 @@ static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
  *
  ****************************************************************************/
 
-static int32_t esp_get_random(uint8_t *buf, size_t len)
+static int esp_get_random(uint8_t *buf, size_t len)
 {
   esp_fill_random(buf, len);
 
@@ -3189,7 +3200,7 @@ static int32_t esp_get_random(uint8_t *buf, size_t len)
  *
  ****************************************************************************/
 
-static int32_t esp_get_time(void *t)
+static int esp_get_time(void *t)
 {
   int ret;
   struct timeval tv;
@@ -3245,7 +3256,7 @@ static uint32_t esp_rand(void)
  *
  ****************************************************************************/
 
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args)
 {
   esp_log_level_t max_level;
@@ -3282,7 +3293,7 @@ static void esp_log_writev_wrapper(uint32_t level, const char *tag,
  *
  ****************************************************************************/
 
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...)
 {
@@ -3558,7 +3569,7 @@ static void *esp_wifi_zalloc(size_t size)
  *
  ****************************************************************************/
 
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size)
+static void *esp_wifi_create_queue(int queue_len, int item_size)
 {
   wifi_static_queue_t *wifi_queue;
 
@@ -3733,7 +3744,7 @@ static IRAM_ATTR uint32_t coex_status_get_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
                                          uint32_t duration)
 {
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
@@ -3758,7 +3769,7 @@ static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
  *
  ****************************************************************************/
 
-static IRAM_ATTR int32_t coex_wifi_release_wrapper(uint32_t event)
+static IRAM_ATTR int coex_wifi_release_wrapper(uint32_t event)
 {
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
   return coex_wifi_release(event);
@@ -4212,7 +4223,8 @@ static int esp_wifi_auth_trans(uint32_t wifi_auth)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d", wifi_auth);
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
+              wifi_auth);
         break;
     }
 
@@ -4265,7 +4277,7 @@ static int esp_wifi_cipher_trans(uint32_t wifi_cipher)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d",
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
                wifi_cipher);
         break;
     }
@@ -4460,8 +4472,8 @@ int32_t esp_event_send_internal(esp_event_base_t event_base,
 {
   int32_t ret;
 
-  ret = esp_event_post(event_base, event_id, event_data,
-                       event_data_size, ticks_to_wait);
+  ret = esp32_event_post(event_base, event_id, event_data,
+                         event_data_size, ticks_to_wait);
 
   return ret;
 }
@@ -4810,7 +4822,7 @@ errout:
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len)
+int esp_wifi_sta_send_data(void *pbuf, size_t len)
 {
   int ret;
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.h
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.h
@@ -212,7 +212,7 @@ int esp_wifi_sta_stop(void);
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len);
+int esp_wifi_sta_send_data(void *pbuf, size_t len);
 
 /****************************************************************************
  * Name: esp_wifi_sta_register_recv_cb
@@ -550,7 +550,7 @@ int esp_wifi_softap_stop(void);
  *
  ****************************************************************************/
 
-int esp_wifi_softap_send_data(void *pbuf, uint32_t len);
+int esp_wifi_softap_send_data(void *pbuf, size_t len);
 
 /****************************************************************************
  * Name: esp_wifi_softap_register_recv_cb

--- a/arch/xtensa/src/esp32s2/esp32s2_i2s.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2s.c
@@ -1,0 +1,2747 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s2/esp32s2_i2s.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_ESP32S2_I2S
+
+#include <debug.h>
+#include <sys/types.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <time.h>
+#include <assert.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/clock.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/mqueue.h>
+#include <nuttx/circbuf.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/audio/audio.h>
+#include <nuttx/audio/i2s.h>
+
+#include <arch/board/board.h>
+
+#include "esp32s2_i2s.h"
+#include "esp32s2_gpio.h"
+#include "esp32s2_irq.h"
+#include "esp32s2_dma.h"
+
+#include "xtensa.h"
+#include "hardware/esp32s2_gpio_sigmap.h"
+#include "hardware/esp32s2_system.h"
+#include "hardware/esp32s2_i2s.h"
+#include "hardware/esp32s2_soc.h"
+#include "hardware/esp32s2_iomux.h"
+#include "hardware/esp32s2_pinmap.h"
+#include "hardware/esp32s2_dma.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* I2S DMA RX/TX description number */
+
+#define I2S_DMADESC_NUM                 (CONFIG_I2S_DMADESC_NUM)
+
+/* I2S Clock */
+
+#define I2S_LL_BASE_CLK                 (2 * APB_CLK_FREQ)
+#define I2S_LL_MCLK_DIVIDER_BIT_WIDTH   (6)
+#define I2S_LL_MCLK_DIVIDER_MAX         ((1 << I2S_LL_MCLK_DIVIDER_BIT_WIDTH) - 1)
+
+/* I2S DMA channel number */
+
+#define I2S_DMA_CHANNEL_MAX (2)
+
+#ifdef CONFIG_ESP32S2_I2S_TX
+#  define I2S_TX_ENABLED 1
+#  define I2S_HAVE_TX 1
+#else
+#  define I2S_TX_ENABLED 0
+#endif
+
+#ifdef CONFIG_ESP32S2_I2S_RX
+#  define I2S_RX_ENABLED 1
+#  define I2S_HAVE_RX 1
+#else
+#  define I2S_RX_ENABLED 0
+#endif
+
+/* Debug ********************************************************************/
+
+#ifdef CONFIG_DEBUG_I2S_INFO
+#  define CONFIG_ESP32S2_I2S_DUMPBUFFERS
+#else
+#  undef CONFIG_ESP32S2_I2S_DUMPBUFFERS
+#endif
+
+#ifndef CONFIG_ESP32S2_I2S_MAXINFLIGHT
+#  define CONFIG_ESP32S2_I2S_MAXINFLIGHT 4
+#endif
+
+#define I2S_GPIO_UNUSED -1      /* For signals which are not used */
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* Role of the I2S0 port */
+
+typedef enum
+{
+  I2S_ROLE_MASTER,  /* I2S controller master role, bclk and ws signal will be set to output */
+  I2S_ROLE_SLAVE    /* I2S controller slave role, bclk and ws signal will be set to input */
+} i2s_role_t;
+
+/* Data width of the I2S channel */
+
+typedef enum
+{
+  I2S_DATA_BIT_WIDTH_8BIT   = 8,    /* I2S channel data bit-width: 8 */
+  I2S_DATA_BIT_WIDTH_16BIT  = 16,   /* I2S channel data bit-width: 16 */
+  I2S_DATA_BIT_WIDTH_24BIT  = 24,   /* I2S channel data bit-width: 24 */
+  I2S_DATA_BIT_WIDTH_32BIT  = 32,   /* I2S channel data bit-width: 32 */
+} i2s_data_bit_width_t;
+
+/* Multiplier of MCLK to sample rate */
+
+typedef enum
+{
+  I2S_MCLK_MULTIPLE_128 = 128,  /* mclk = sample_rate * 128 */
+  I2S_MCLK_MULTIPLE_256 = 256,  /* mclk = sample_rate * 256 */
+  I2S_MCLK_MULTIPLE_384 = 384,  /* mclk = sample_rate * 384 */
+  I2S_MCLK_MULTIPLE_512 = 512,  /* mclk = sample_rate * 512 */
+} i2s_mclk_multiple_t;
+
+/* I2S Device hardware configuration */
+
+struct esp32s2_i2s_config_s
+{
+  uint32_t port;              /* I2S port */
+  uint32_t role;              /* I2S port role (master or slave) */
+  uint8_t data_width;         /* I2S sample data width */
+  uint32_t rate;              /* I2S sample-rate */
+  uint32_t total_slot;        /* Total slot number */
+
+  bool is_apll;               /* Select APLL as the source clock */
+
+  bool tx_en;                 /* Is TX enabled? */
+  bool rx_en;                 /* Is RX enabled? */
+  int8_t mclk_pin;            /* MCLK pin, output */
+
+  /* BCLK pin, input in slave role, output in master role */
+
+  int8_t bclk_pin;
+
+  /* WS pin, input in slave role, output in master role */
+
+  int8_t ws_pin;
+
+  int8_t dout_pin;            /* DATA pin, output */
+  int8_t din_pin;             /* DATA pin, input */
+
+  uint8_t periph;             /* peripher ID */
+  uint8_t irq;                /* Interrupt ID */
+
+  uint32_t bclk_in_insig;     /* RX channel BCK signal (slave mode) index */
+  uint32_t bclk_in_outsig;    /* RX channel BCK signal (master mode) index */
+  uint32_t bclk_out_insig;    /* TX channel BCK signal (slave mode) index */
+  uint32_t bclk_out_outsig;   /* TX channel BCK signal (master mode) index */
+  uint32_t ws_in_insig;       /* RX channel WS signal (slave mode) index */
+  uint32_t ws_in_outsig;      /* RX channel WS signal (master mode) index */
+  uint32_t ws_out_insig;      /* TX channel WS signal (slave mode) index */
+  uint32_t ws_out_outsig;     /* TX channel WS signal (master mode) index */
+  uint32_t din_insig;         /* RX channel Data Input signal index */
+  uint32_t dout_outsig;       /* TX channel Data Output signal index */
+  uint32_t mclk_out_sig;      /* Master clock output index */
+
+  bool bit_shift;             /* Set to enable bit shift in Philips mode */
+  bool mono_en;               /* Set to enable mono mode on slot */
+
+  /* WS signal width (the number of bclk ticks that ws signal is high) */
+
+  uint32_t ws_width;
+
+  /* WS signal polarity, set true to enable high lever first */
+
+  bool ws_pol;
+};
+
+struct esp32s2_buffer_s
+{
+  struct esp32s2_buffer_s *flink; /* Supports a singly linked list */
+
+  /* The associated DMA in/outlink */
+
+  struct esp32s2_dmadesc_s dma_link[I2S_DMADESC_NUM];
+
+  i2s_callback_t callback;      /* DMA completion callback */
+  uint32_t timeout;             /* Timeout value of the DMA transfers */
+  void *arg;                    /* Callback's argument */
+  struct ap_buffer_s *apb;      /* The audio buffer */
+  uint8_t *buf;                 /* The DMA's descriptor buffer */
+  uint32_t nbytes;              /* The DMA's descriptor buffer size */
+  int result;                   /* The result of the transfer */
+};
+
+/* Internal buffer must be aligned to the bytes_per_sample. Sometimes,
+ * however, the audio buffer is not aligned and additional bytes must
+ * be copied to be inserted on the next buffer. This structure keeps
+ * track of the bytes that were not written to the internal buffer yet.
+ */
+
+struct esp32s2_buffer_carry_s
+{
+  uint32_t value;
+  size_t bytes;
+};
+
+/* This structure describes the state of one receiver or transmitter
+ * transport.
+ */
+
+struct esp32s2_transport_s
+{
+  sq_queue_t pend;              /* A queue of pending transfers */
+  sq_queue_t act;               /* A queue of active transfers */
+  sq_queue_t done;              /* A queue of completed transfers */
+  struct work_s work;           /* Supports worker thread operations */
+
+  /* Bytes to be written at the beginning of the next DMA buffer */
+
+  struct esp32s2_buffer_carry_s carry;
+};
+
+/* The state of the one I2S peripheral */
+
+struct esp32s2_i2s_s
+{
+  struct i2s_dev_s  dev;        /* Externally visible I2S interface */
+  mutex_t           lock;       /* Ensures mutually exclusive access */
+  int               cpuint;     /* I2S interrupt ID */
+  uint8_t           cpu;        /* CPU ID */
+
+  /* Port configuration */
+
+  const struct esp32s2_i2s_config_s *config;
+
+  uint32_t    mclk_freq;      /* I2S actual master clock */
+  uint32_t    mclk_multiple;  /* The multiple of mclk to the sample rate */
+  uint32_t    channels;       /* Audio channels (1:mono or 2:stereo) */
+  uint32_t    rate;           /* I2S actual configured sample-rate */
+  uint32_t    data_width;     /* I2S actual configured data_width */
+
+#ifdef I2S_HAVE_TX
+  struct esp32s2_transport_s tx;  /* TX transport state */
+
+  bool tx_started;              /* TX channel started */
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  struct esp32s2_transport_s rx;  /* RX transport state */
+
+  bool rx_started;              /* RX channel started */
+#endif /* I2S_HAVE_RX */
+
+  /* Pre-allocated pool of buffer containers */
+
+  sem_t bufsem;                         /* Buffer wait semaphore */
+  struct esp32s2_buffer_s *bf_freelist; /* A list a free buffer containers */
+  struct esp32s2_buffer_s containers[CONFIG_ESP32S2_I2S_MAXINFLIGHT];
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* Register helpers */
+
+#ifdef CONFIG_ESP32S2_I2S_DUMPBUFFERS
+#  define       i2s_dump_buffer(m,b,s) lib_dumpbuffer(m,b,s)
+#else
+#  define       i2s_dump_buffer(m,b,s)
+#endif
+
+/* Buffer container helpers */
+
+static struct esp32s2_buffer_s *
+                i2s_buf_allocate(struct esp32s2_i2s_s *priv);
+static void     i2s_buf_free(struct esp32s2_i2s_s *priv,
+                             struct esp32s2_buffer_s *bfcontainer);
+static int      i2s_buf_initialize(struct esp32s2_i2s_s *priv);
+
+/* DMA support */
+
+#ifdef I2S_HAVE_TX
+static int  i2s_txdma_setup(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_buffer_s *bfcontainer);
+static void i2s_tx_worker(void *arg);
+static void i2s_tx_schedule(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_dmadesc_s *outlink);
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+static int  i2s_rxdma_setup(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_buffer_s *bfcontainer);
+static void i2s_rx_worker(void *arg);
+static void i2s_rx_schedule(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_dmadesc_s *outlink);
+#endif /* I2S_HAVE_RX */
+
+/* I2S methods (and close friends) */
+
+static uint32_t i2s_set_datawidth(struct esp32s2_i2s_s *priv);
+static uint32_t i2s_set_clock(struct esp32s2_i2s_s *priv);
+static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
+static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+                                     uint32_t frequency);
+static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
+
+#ifdef I2S_HAVE_TX
+static void     i2s_tx_channel_start(struct esp32s2_i2s_s *priv);
+static void     i2s_tx_channel_stop(struct esp32s2_i2s_s *priv);
+static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
+static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
+                         i2s_callback_t callback, void *arg,
+                         uint32_t timeout);
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+static void     i2s_rx_channel_start(struct esp32s2_i2s_s *priv);
+static void     i2s_rx_channel_stop(struct esp32s2_i2s_s *priv);
+static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
+static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
+                            i2s_callback_t callback, void *arg,
+                            uint32_t timeout);
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct i2s_ops_s g_i2sops =
+{
+#ifdef I2S_HAVE_TX
+  .i2s_txchannels     = i2s_txchannels,
+  .i2s_txsamplerate   = i2s_txsamplerate,
+  .i2s_txdatawidth    = i2s_txdatawidth,
+  .i2s_send           = i2s_send,
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  .i2s_rxchannels     = i2s_rxchannels,
+  .i2s_rxsamplerate   = i2s_rxsamplerate,
+  .i2s_rxdatawidth    = i2s_rxdatawidth,
+  .i2s_receive        = i2s_receive,
+#endif /* I2S_HAVE_RX */
+
+  .i2s_ioctl          = i2s_ioctl,
+  .i2s_getmclkfrequency  = i2s_getmclkfrequency,
+  .i2s_setmclkfrequency  = i2s_setmclkfrequency,
+};
+
+#ifdef CONFIG_ESP32S2_I2S
+static const struct esp32s2_i2s_config_s esp32s2_i2s0_config =
+{
+  .port             = 0,
+#ifdef CONFIG_ESP32S2_I2S_ROLE_MASTER
+  .role             = I2S_ROLE_MASTER,
+#else
+  .role             = I2S_ROLE_SLAVE,
+#endif /* CONFIG_ESP32S2_I2S_ROLE_MASTER */
+  .data_width       = CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH,
+  .rate             = CONFIG_ESP32S2_I2S_SAMPLE_RATE,
+  .total_slot       = 2,
+  .tx_en            = I2S_TX_ENABLED,
+  .rx_en            = I2S_RX_ENABLED,
+#ifdef CONFIG_ESP32S2_I2S_MCLK
+  .mclk_pin         = CONFIG_ESP32S2_I2S_MCLKPIN,
+#else
+  .mclk_pin         = I2S_GPIO_UNUSED,
+#endif /* CONFIG_ESP32S2_I2S_MCLK */
+  .bclk_pin         = CONFIG_ESP32S2_I2S_BCLKPIN,
+  .ws_pin           = CONFIG_ESP32S2_I2S_WSPIN,
+#ifdef CONFIG_ESP32S2_I2S_DOUTPIN
+  .dout_pin         = CONFIG_ESP32S2_I2S_DOUTPIN,
+#else
+  .dout_pin         = I2S_GPIO_UNUSED,
+#endif /* CONFIG_ESP32S2_I2S_DOUTPIN */
+#ifdef CONFIG_ESP32S2_I2S_DINPIN
+  .din_pin          = CONFIG_ESP32S2_I2S_DINPIN,
+#else
+  .din_pin          = I2S_GPIO_UNUSED,
+#endif /* CONFIG_ESP32S2_I2S_DINPIN */
+  .periph           = ESP32S2_PERIPH_I2S0,
+  .irq              = ESP32S2_IRQ_I2S0,
+  .bclk_in_insig    = I2S0I_BCK_IN_IDX,
+  .bclk_in_outsig   = I2S0I_BCK_OUT_IDX,
+  .bclk_out_insig   = I2S0O_BCK_IN_IDX,
+  .bclk_out_outsig  = I2S0O_BCK_OUT_IDX,
+  .ws_in_insig      = I2S0I_WS_IN_IDX,
+  .ws_in_outsig     = I2S0I_WS_OUT_IDX,
+  .ws_out_insig     = I2S0O_WS_IN_IDX,
+  .ws_out_outsig    = I2S0O_WS_OUT_IDX,
+  .din_insig        = I2S0I_DATA_IN15_IDX,
+  .dout_outsig      = I2S0O_DATA_OUT23_IDX,
+  .mclk_out_sig     = CLK_I2S_MUX_IDX,
+  .bit_shift        = true,
+  .mono_en          = false,
+  .ws_width         = CONFIG_ESP32S2_I2S_DATA_BIT_WIDTH,
+};
+
+static struct esp32s2_i2s_s esp32s2_i2s0_priv =
+{
+  .dev =
+  {
+    .ops = &g_i2sops
+  },
+  .lock = NXMUTEX_INITIALIZER,
+  .config = &esp32s2_i2s0_config,
+  .bufsem = SEM_INITIALIZER(0)
+};
+#endif /* CONFIG_ESP32S2_I2S */
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: i2s_buf_allocate
+ *
+ * Description:
+ *   Allocate a buffer container by removing the one at the head of the
+ *   free list
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   A non-NULL pointer to the allocate buffer container on success; NULL if
+ *   there are no available buffer containers.
+ *
+ * Assumptions:
+ *   The caller does NOT have exclusive access to the I2S state structure.
+ *   That would result in a deadlock!
+ *
+ ****************************************************************************/
+
+static struct esp32s2_buffer_s *i2s_buf_allocate(struct esp32s2_i2s_s *priv)
+{
+  struct esp32s2_buffer_s *bfcontainer;
+  irqstate_t flags;
+  int ret;
+
+  /* Set aside a buffer container.  By doing this, we guarantee that we will
+   * have at least one free buffer container.
+   */
+
+  ret = nxsem_wait_uninterruptible(&priv->bufsem);
+  if (ret < 0)
+    {
+      return NULL;
+    }
+
+  /* Get the buffer from the head of the free list */
+
+  flags = enter_critical_section();
+  bfcontainer = priv->bf_freelist;
+  DEBUGASSERT(bfcontainer);
+
+  /* Unlink the buffer from the freelist */
+
+  priv->bf_freelist = bfcontainer->flink;
+  leave_critical_section(flags);
+  return bfcontainer;
+}
+
+/****************************************************************************
+ * Name: i2s_buf_free
+ *
+ * Description:
+ *   Free buffer container by adding it to the head of the free list
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *   bfcontainer - The buffer container to be freed
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   The caller has exclusive access to the I2S state structure
+ *
+ ****************************************************************************/
+
+static void i2s_buf_free(struct esp32s2_i2s_s *priv,
+                         struct esp32s2_buffer_s *bfcontainer)
+{
+  irqstate_t flags;
+
+  /* Put the buffer container back on the free list (circbuf) */
+
+  flags = enter_critical_section();
+
+  bfcontainer->apb = NULL;
+  bfcontainer->buf = NULL;
+  bfcontainer->nbytes = 0;
+  bfcontainer->flink  = priv->bf_freelist;
+  priv->bf_freelist = bfcontainer;
+
+  leave_critical_section(flags);
+
+  /* Wake up any threads waiting for a buffer container */
+
+  nxsem_post(&priv->bufsem);
+}
+
+/****************************************************************************
+ * Name: i2s_buf_initialize
+ *
+ * Description:
+ *   Initialize the buffer container allocator by adding all of the
+ *   pre-allocated buffer containers to the free list
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ * Assumptions:
+ *   Called early in I2S initialization so that there are no issues with
+ *   concurrency.
+ *
+ ****************************************************************************/
+
+static int i2s_buf_initialize(struct esp32s2_i2s_s *priv)
+{
+#ifdef I2S_HAVE_TX
+  priv->tx.carry.bytes = 0;
+  priv->tx.carry.value = 0;
+#endif /* I2S_HAVE_TX */
+
+  priv->bf_freelist = NULL;
+
+  for (int i = 0; i < CONFIG_ESP32S2_I2S_MAXINFLIGHT; i++)
+    {
+      i2s_buf_free(priv, &priv->containers[i]);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: i2s_txdma_start
+ *
+ * Description:
+ *   Initiate the next TX DMA transfer. The DMA outlink was previously bound
+ *   so it is safe to start the next DMA transfer at interrupt level.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure
+ *
+ * Assumptions:
+ *   Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static int i2s_txdma_start(struct esp32s2_i2s_s *priv)
+{
+  struct esp32s2_buffer_s *bfcontainer;
+
+  /* If there is already an active transmission in progress, then bail
+   * returning success.
+   */
+
+  if (!sq_empty(&priv->tx.act))
+    {
+      return OK;
+    }
+
+  /* If there are no pending transfer, then bail returning success */
+
+  if (sq_empty(&priv->tx.pend))
+    {
+      return OK;
+    }
+
+  bfcontainer = (struct esp32s2_buffer_s *)sq_remfirst(&priv->tx.pend);
+
+  /* If there isn't already an active transmission in progress,
+   * then start it.
+   */
+
+  modifyreg32(I2S_OUT_LINK_REG, I2S_OUTLINK_ADDR_M,
+              FIELD_TO_VALUE(I2S_OUTLINK_ADDR,
+              (uintptr_t) bfcontainer->dma_link));
+
+  modifyreg32(I2S_OUT_LINK_REG, I2S_OUTLINK_STOP, I2S_OUTLINK_START);
+
+  modifyreg32(I2S_CONF_REG, 0, I2S_TX_START);
+
+  sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.act);
+
+  return OK;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rxdma_start
+ *
+ * Description:
+ *   Initiate the next RX DMA transfer. Assuming the DMA inlink is already
+ *   bound, it's safe to start the next DMA transfer in an interrupt context.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure
+ *
+ * Assumptions:
+ *   Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static int i2s_rxdma_start(struct esp32s2_i2s_s *priv)
+{
+  struct esp32s2_buffer_s *bfcontainer;
+
+  /* If there is already an active transmission in progress, then bail
+   * returning success.
+   */
+
+  if (!sq_empty(&priv->rx.act))
+    {
+      return OK;
+    }
+
+  /* If there are no pending transfer, then bail returning success */
+
+  if (sq_empty(&priv->rx.pend))
+    {
+      return OK;
+    }
+
+  bfcontainer = (struct esp32s2_buffer_s *)sq_remfirst(&priv->rx.pend);
+
+  /* If there isn't already an active transmission in progress,
+   * then start it.
+   */
+
+  modifyreg32(I2S_RXEOF_NUM_REG, I2S_RX_EOF_NUM_M,
+              FIELD_TO_VALUE(I2S_RX_EOF_NUM, bfcontainer->nbytes));
+
+  modifyreg32(I2S_IN_LINK_REG, I2S_INLINK_ADDR_M,
+              FIELD_TO_VALUE(I2S_INLINK_ADDR,
+              (uintptr_t) bfcontainer->dma_link));
+
+  modifyreg32(I2S_IN_LINK_REG, I2S_INLINK_STOP, I2S_INLINK_START);
+
+  modifyreg32(I2S_CONF_REG, 0, I2S_RX_START);
+
+  sq_addlast((sq_entry_t *)bfcontainer, &priv->rx.act);
+
+  return OK;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_txdma_setup
+ *
+ * Description:
+ *   Setup the next TX DMA transfer
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *   bfcontainer - The buffer container to be set up
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure
+ *
+ * Assumptions:
+ *   Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static int i2s_txdma_setup(struct esp32s2_i2s_s *priv,
+                           struct esp32s2_buffer_s *bfcontainer)
+{
+  int ret = OK;
+  size_t carry_size;
+  uint32_t bytes_queued;
+  uint32_t data_copied;
+  struct ap_buffer_s *apb;
+  struct esp32s2_dmadesc_s *outlink;
+  apb_samp_t samp_size;
+  irqstate_t flags;
+  uint8_t *buf;
+  uint8_t *samp;
+
+  DEBUGASSERT(bfcontainer && bfcontainer->apb);
+
+  apb = bfcontainer->apb;
+  outlink = bfcontainer->dma_link;
+
+  /* Get the transfer information, accounting for any data offset */
+
+  const apb_samp_t bytes_per_sample = priv->data_width / 8;
+  samp = &apb->samp[apb->curbyte];
+  samp_size = (apb->nbytes - apb->curbyte) + priv->tx.carry.bytes;
+  carry_size = samp_size % bytes_per_sample;
+
+  /* Allocate the current audio buffer considering the remaining bytes
+   * carried from the last upper half audio buffer.
+   */
+
+  bfcontainer->buf = calloc(bfcontainer->nbytes, 1);
+
+  data_copied = 0;
+  buf = bfcontainer->buf;
+
+  /* Copy the remaining bytes from the last audio buffer to the current
+   * audio buffer. The remaining bytes are part of a sample that was split
+   * between the last and the current audio buffer. Also, copy the bytes
+   * from that split sample that are on the current buffer to the internal
+   * buffer.
+   */
+
+  if (priv->tx.carry.bytes)
+    {
+      memcpy(buf, &priv->tx.carry.value, priv->tx.carry.bytes);
+      buf += priv->tx.carry.bytes;
+      data_copied += priv->tx.carry.bytes;
+      memcpy(buf, samp, (bytes_per_sample - priv->tx.carry.bytes));
+      buf += (bytes_per_sample - priv->tx.carry.bytes);
+      samp += (bytes_per_sample - priv->tx.carry.bytes);
+      data_copied += (bytes_per_sample - priv->tx.carry.bytes);
+    }
+
+  /* Copy the upper half buffer to the internal buffer considering that
+   * the current upper half buffer may not contain a complete sample at
+   * the end of the buffer (and those bytes needs to be carried to the
+   * next audio buffer).
+   */
+
+  memcpy(buf, samp, samp_size - (data_copied + carry_size));
+  buf += samp_size - (data_copied + carry_size);
+  samp += samp_size - (data_copied + carry_size);
+  data_copied += samp_size - (data_copied + carry_size);
+
+  /* If the audio buffer's size is not a multiple of the sample size,
+   * it's necessary to carry the remaining bytes that are part of what
+   * would be the last sample on this buffer. These bytes will then be
+   * saved and inserted at the beginning of the next DMA buffer to
+   * rebuild the sample correctly.
+   */
+
+  priv->tx.carry.bytes = carry_size;
+
+  if (priv->tx.carry.bytes)
+    {
+      memcpy(&priv->tx.carry.value, samp, priv->tx.carry.bytes);
+    }
+
+  /* Release our reference on the audio buffer. This may very likely
+   * cause the audio buffer to be freed.
+   */
+
+  apb_free(bfcontainer->apb);
+
+  /* Configure DMA stream */
+
+  bytes_queued = esp32s2_dma_init(outlink, I2S_DMADESC_NUM,
+                                  bfcontainer->buf, bfcontainer->nbytes);
+
+  if (bytes_queued != bfcontainer->nbytes)
+    {
+      i2serr("Failed to enqueue I2S buffer "
+             "(%" PRIu32 " bytes of %" PRIu32 ")\n",
+             bytes_queued, bfcontainer->nbytes);
+      return bytes_queued;
+    }
+
+  flags = enter_critical_section();
+
+  /* Add the buffer container to the end of the TX pending queue */
+
+  sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.pend);
+
+  /* Trigger DMA transfer if no transmission is in progress */
+
+  ret = i2s_txdma_start(priv);
+
+  leave_critical_section(flags);
+
+  return ret;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rxdma_setup
+ *
+ * Description:
+ *   Setup the next RX DMA transfer
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *   bfcontainer - The buffer container to be set up
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure
+ *
+ * Assumptions:
+ *   Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static int i2s_rxdma_setup(struct esp32s2_i2s_s *priv,
+                           struct esp32s2_buffer_s *bfcontainer)
+{
+  int ret = OK;
+  struct esp32s2_dmadesc_s *inlink;
+  uint32_t bytes_queued;
+  irqstate_t flags;
+
+  DEBUGASSERT(bfcontainer && bfcontainer->apb);
+
+  inlink = bfcontainer->dma_link;
+
+  /* Configure DMA stream */
+
+  bytes_queued = esp32s2_dma_init(inlink, I2S_DMADESC_NUM,
+                                  bfcontainer->apb->samp,
+                                  bfcontainer->nbytes);
+
+  if (bytes_queued != bfcontainer->nbytes)
+    {
+      i2serr("Failed to enqueue I2S buffer "
+             "(%" PRIu32 " bytes of %" PRIu32 ")\n",
+             bytes_queued, bfcontainer->nbytes);
+      return bytes_queued;
+    }
+
+  flags = enter_critical_section();
+
+  /* Add the buffer container to the end of the RX pending queue */
+
+  sq_addlast((sq_entry_t *)bfcontainer, &priv->rx.pend);
+
+  /* Trigger DMA transfer if no transmission is in progress */
+
+  ret = i2s_rxdma_start(priv);
+
+  leave_critical_section(flags);
+
+  return ret;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_tx_schedule
+ *
+ * Description:
+ *   An TX DMA completion has occurred.  Schedule processing on
+ *   the working thread.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *   outlink - DMA outlink descriptor that triggered the interrupt.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   - Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static void i2s_tx_schedule(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_dmadesc_s *outlink)
+{
+  struct esp32s2_buffer_s *bfcontainer;
+  struct esp32s2_dmadesc_s *bfdesc;
+  int ret;
+
+  /* Upon entry, the transfer(s) that just completed are the ones in the
+   * priv->tx.act queue.
+   */
+
+  /* Move all entries from the tx.act queue to the tx.done queue */
+
+  if (!sq_empty(&priv->tx.act))
+    {
+      /* Remove the next buffer container from the tx.act list */
+
+      bfcontainer = (struct esp32s2_buffer_s *)sq_peek(&priv->tx.act);
+
+      /* Check if the DMA descriptor that generated an EOF interrupt is the
+       * last descriptor of the current buffer container's DMA outlink.
+       * REVISIT: what to do if we miss syncronization and the descriptor
+       * that generated the interrupt is different from the expected (the
+       * oldest of the list containing active transmissions)?
+       */
+
+      /* Find the last descriptor of the current buffer container */
+
+      bfdesc = bfcontainer->dma_link;
+      while (!(bfdesc->ctrl & DMA_CTRL_EOF))
+        {
+          DEBUGASSERT(bfdesc->next);
+          bfdesc = bfdesc->next;
+        }
+
+      if (bfdesc == outlink)
+        {
+          sq_remfirst(&priv->tx.act);
+
+          /* Report the result of the transfer */
+
+          bfcontainer->result = OK;
+
+          /* Add the completed buffer container to the tail of the tx.done
+           * queue
+           */
+
+          sq_addlast((sq_entry_t *)bfcontainer, &priv->tx.done);
+
+          /* Check if the DMA is IDLE */
+
+          if (sq_empty(&priv->tx.act))
+            {
+              /* Then start the next DMA. */
+
+              i2s_txdma_start(priv);
+            }
+        }
+
+      /* If the worker has completed running, then reschedule the working
+       * thread.
+       */
+
+      if (work_available(&priv->tx.work))
+        {
+          /* Schedule the TX DMA done processing to occur on the worker
+           * thread.
+           */
+
+          ret = work_queue(HPWORK, &priv->tx.work, i2s_tx_worker, priv, 0);
+          if (ret != 0)
+            {
+              i2serr("ERROR: Failed to queue TX work: %d\n", ret);
+            }
+        }
+    }
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rx_schedule
+ *
+ * Description:
+ *   An RX DMA completion has occurred.  Schedule processing on
+ *   the working thread.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *   inlink - DMA inlink descriptor that triggered the interrupt.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   - Interrupts are disabled
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static void i2s_rx_schedule(struct esp32s2_i2s_s *priv,
+                            struct esp32s2_dmadesc_s *inlink)
+{
+  struct esp32s2_buffer_s *bfcontainer;
+  struct esp32s2_dmadesc_s *bfdesc;
+  int ret;
+
+  /* Upon entry, the transfer(s) that just completed are the ones in the
+   * priv->rx.act queue.
+   */
+
+  /* Move all entries from the rx.act queue to the rx.done queue */
+
+  if (!sq_empty(&priv->rx.act))
+    {
+      /* Remove the next buffer container from the rx.act list */
+
+      bfcontainer = (struct esp32s2_buffer_s *)sq_peek(&priv->rx.act);
+
+      /* Check if the DMA descriptor that generated an EOF interrupt is the
+       * last descriptor of the current buffer container's DMA inlink.
+       * REVISIT: what to do if we miss syncronization and the descriptor
+       * that generated the interrupt is different from the expected (the
+       * oldest of the list containing active transmissions)?
+       */
+
+      /* Find the last descriptor of the current buffer container */
+
+      bfdesc = bfcontainer->dma_link;
+      while (!(bfdesc->ctrl & DMA_CTRL_EOF))
+        {
+          DEBUGASSERT(bfdesc->next);
+          bfdesc = bfdesc->next;
+        }
+
+      if (bfdesc == inlink)
+        {
+          sq_remfirst(&priv->rx.act);
+
+          /* Report the result of the transfer */
+
+          bfcontainer->result = OK;
+
+          /* Add the completed buffer container to the tail of the rx.done
+           * queue
+           */
+
+          sq_addlast((sq_entry_t *)bfcontainer, &priv->rx.done);
+
+          /* Check if the DMA is IDLE */
+
+          if (sq_empty(&priv->rx.act))
+            {
+              /* Then start the next DMA. */
+
+              i2s_rxdma_start(priv);
+            }
+        }
+
+      /* If the worker has completed running, then reschedule the working
+       * thread.
+       */
+
+      if (work_available(&priv->rx.work))
+        {
+          /* Schedule the RX DMA done processing to occur on the worker
+           * thread.
+           */
+
+          ret = work_queue(HPWORK, &priv->rx.work, i2s_rx_worker, priv, 0);
+          if (ret != 0)
+            {
+              i2serr("ERROR: Failed to queue RX work: %d\n", ret);
+            }
+        }
+    }
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_tx_worker
+ *
+ * Description:
+ *   TX transfer done worker
+ *
+ * Input Parameters:
+ *   arg - the I2S device instance cast to void*
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static void i2s_tx_worker(void *arg)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)arg;
+  struct esp32s2_buffer_s *bfcontainer;
+  irqstate_t flags;
+
+  DEBUGASSERT(priv);
+
+  /* When the transfer was started, the active buffer containers were removed
+   * from the tx.pend queue and saved in the tx.act queue.  We get here when
+   * the DMA is finished.
+   *
+   * In any case, the buffer containers in tx.act will be moved to the end
+   * of the tx.done queue and tx.act will be emptied before this worker is
+   * started.
+   *
+   */
+
+  i2sinfo("tx.act.head=%p tx.done.head=%p\n",
+           priv->tx.act.head, priv->tx.done.head);
+
+  /* Process each buffer in the tx.done queue */
+
+  while (sq_peek(&priv->tx.done) != NULL)
+    {
+      /* Remove the buffer container from the tx.done queue.  NOTE that
+       * interrupts must be disabled to do this because the tx.done queue is
+       * also modified from the interrupt level.
+       */
+
+      flags = enter_critical_section();
+      bfcontainer = (struct esp32s2_buffer_s *)sq_remfirst(&priv->tx.done);
+      leave_critical_section(flags);
+
+      /* Perform the TX transfer done callback */
+
+      DEBUGASSERT(bfcontainer && bfcontainer->callback);
+      bfcontainer->callback(&priv->dev, bfcontainer->apb,
+                            bfcontainer->arg, bfcontainer->result);
+
+      /* Release the internal buffer used by the DMA outlink */
+
+      free(bfcontainer->buf);
+
+      /* And release the buffer container */
+
+      i2s_buf_free(priv, bfcontainer);
+    }
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rx_worker
+ *
+ * Description:
+ *   RX transfer done worker
+ *
+ * Input Parameters:
+ *   arg - the I2S device instance cast to void*
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static void i2s_rx_worker(void *arg)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)arg;
+  struct esp32s2_buffer_s *bfcontainer;
+  irqstate_t flags;
+
+  DEBUGASSERT(priv);
+
+  /* When the transfer was started, the active buffer containers were removed
+   * from the rx.pend queue and saved in the rx.act queue. We get here when
+   * the DMA is finished.
+   *
+   * In any case, the buffer containers in rx.act will be moved to the end
+   * of the rx.done queue and rx.act will be emptied before this worker is
+   * started.
+   *
+   */
+
+  i2sinfo("rx.act.head=%p rx.done.head=%p\n",
+           priv->rx.act.head, priv->rx.done.head);
+
+  /* Process each buffer in the rx.done queue */
+
+  while (sq_peek(&priv->rx.done) != NULL)
+    {
+      /* Remove the buffer container from the rx.done queue.  NOTE that
+       * interrupts must be disabled to do this because the rx.done queue is
+       * also modified from the interrupt level.
+       */
+
+      flags = enter_critical_section();
+      bfcontainer = (struct esp32s2_buffer_s *)sq_remfirst(&priv->rx.done);
+      leave_critical_section(flags);
+
+      bfcontainer->apb->nbytes = (getreg32(I2S_RXEOF_NUM_REG));
+
+      /* Perform the RX transfer done callback */
+
+      DEBUGASSERT(bfcontainer && bfcontainer->callback);
+      bfcontainer->callback(&priv->dev, bfcontainer->apb,
+                            bfcontainer->arg, bfcontainer->result);
+
+      /* Release our reference on the audio buffer. This may very likely
+       * cause the audio buffer to be freed.
+       */
+
+      apb_free(bfcontainer->apb);
+
+      /* And release the buffer container */
+
+      i2s_buf_free(priv, bfcontainer);
+    }
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_configure
+ *
+ * Description:
+ *   Configure I2S
+ *
+ * Input Parameters:
+ *   priv - Partially initialized I2S device structure.  This function
+ *          will complete the I2S specific portions of the initialization
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void i2s_configure(struct esp32s2_i2s_s *priv)
+{
+  /* Set peripheral clock and clear reset */
+
+  modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0, SYSTEM_I2S0_CLK_EN);
+  modifyreg32(SYSTEM_PERIP_RST_EN0_REG, 0, SYSTEM_I2S0_RST);
+  modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_I2S0_RST, 0);
+
+  /* I2S module general init, enable I2S clock */
+
+  if (!(getreg32(I2S_CLKM_CONF_REG) & I2S_CLK_EN))
+    {
+      i2sinfo("Enabling I2S port clock...\n");
+      modifyreg32(I2S_CLKM_CONF_REG, I2S_CLK_SEL_M,
+                  FIELD_TO_VALUE(I2S_CLK_SEL, 2));
+      modifyreg32(I2S_CLKM_CONF_REG, 0, I2S_CLK_EN);
+      putreg32(0, I2S_CONF2_REG);
+    }
+
+  /* Configure multiplexed pins as connected on the board */
+
+  /* TODO: check for loopback mode */
+
+  /* Enable TX channel */
+
+  if (priv->config->dout_pin != I2S_GPIO_UNUSED)
+    {
+      esp32s2_gpiowrite(priv->config->dout_pin, 1);
+      esp32s2_configgpio(priv->config->dout_pin, OUTPUT_FUNCTION_2);
+      esp32s2_gpio_matrix_out(priv->config->dout_pin,
+                              priv->config->dout_outsig, 0, 0);
+    }
+
+  /* Enable RX channel */
+
+  if (priv->config->din_pin != I2S_GPIO_UNUSED)
+    {
+      esp32s2_configgpio(priv->config->din_pin, INPUT_FUNCTION_2);
+      esp32s2_gpio_matrix_in(priv->config->din_pin,
+                             priv->config->din_insig, 0);
+    }
+
+  if (priv->config->role == I2S_ROLE_SLAVE)
+    {
+      if (priv->config->tx_en && !priv->config->rx_en)
+        {
+          /* For "tx + slave" mode, select TX signal index for ws and bck */
+
+          esp32s2_gpiowrite(priv->config->ws_pin, 1);
+          esp32s2_configgpio(priv->config->ws_pin, INPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_in(priv->config->ws_pin,
+                                 priv->config->ws_out_insig, 0);
+
+          esp32s2_gpiowrite(priv->config->bclk_pin, 1);
+          esp32s2_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_in(priv->config->bclk_pin,
+                                 priv->config->bclk_out_insig, 0);
+        }
+      else
+        {
+          /* For "tx + rx + slave" or "rx + slave" mode, select RX signal
+           * index for ws and bck.
+           */
+
+          esp32s2_gpiowrite(priv->config->ws_pin, 1);
+          esp32s2_configgpio(priv->config->ws_pin, INPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_in(priv->config->ws_pin,
+                                 priv->config->ws_in_insig, 0);
+
+          esp32s2_gpiowrite(priv->config->bclk_pin, 1);
+          esp32s2_configgpio(priv->config->bclk_pin, INPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_in(priv->config->bclk_pin,
+                                 priv->config->bclk_in_insig, 0);
+        }
+    }
+  else
+    {
+      /* Considering master role for the I2S port */
+
+      /* Set MCLK pin */
+
+      if (priv->config->mclk_pin != I2S_GPIO_UNUSED)
+        {
+          i2sinfo("Configuring GPIO%" PRIu8 " to output master clock\n",
+                  priv->config->mclk_pin);
+
+          esp32s2_gpiowrite(priv->config->mclk_pin, 1);
+          esp32s2_configgpio(priv->config->mclk_pin, OUTPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_out(priv->config->mclk_pin,
+                                  priv->config->mclk_out_sig, 0, 0);
+        }
+
+      if (priv->config->tx_en && !priv->config->rx_en)
+        {
+          /* For "tx + master" mode, select TX signal index for ws and bck */
+
+          esp32s2_gpiowrite(priv->config->ws_pin, 1);
+          esp32s2_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_out(priv->config->ws_pin,
+                                  priv->config->ws_out_outsig, 0, 0);
+
+          esp32s2_gpiowrite(priv->config->bclk_pin, 1);
+          esp32s2_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_out(priv->config->bclk_pin,
+                                  priv->config->bclk_out_outsig, 0, 0);
+        }
+      else
+        {
+          /* For "tx + rx + master" or "rx + master" mode, select RX signal
+           * index for ws and bck.
+           */
+
+          esp32s2_gpiowrite(priv->config->ws_pin, 1);
+          esp32s2_configgpio(priv->config->ws_pin, OUTPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_out(priv->config->ws_pin,
+                                  priv->config->ws_in_outsig, 0, 0);
+
+          esp32s2_gpiowrite(priv->config->bclk_pin, 1);
+          esp32s2_configgpio(priv->config->bclk_pin, OUTPUT_FUNCTION_2);
+          esp32s2_gpio_matrix_out(priv->config->bclk_pin,
+                                  priv->config->bclk_in_outsig, 0, 0);
+        }
+    }
+
+  /* Share BCLK and WS if in full-duplex mode */
+
+  if (priv->config->tx_en && priv->config->rx_en)
+    {
+      modifyreg32(I2S_CONF_REG, 0, I2S_SIG_LOOPBACK);
+    }
+  else
+    {
+      modifyreg32(I2S_CONF_REG, I2S_SIG_LOOPBACK, 0);
+    }
+
+  /* Configure the TX module */
+
+  if (priv->config->tx_en)
+    {
+      /* Reset I2S TX module */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_TX_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_TX_RESET, 0);
+      modifyreg32(I2S_LC_CONF_REG, 0, I2S_OUT_RST);
+      modifyreg32(I2S_LC_CONF_REG, I2S_OUT_RST, 0);
+
+      /* Enable/disable I2S TX slave mode */
+
+      if (priv->config->role == I2S_ROLE_SLAVE)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_TX_SLAVE_MOD);
+        }
+      else
+        {
+          /* Since BCLK and WS are shared, only TX or RX can be master. In
+           * this case, force TX as slave to avoid conflict of clock signal.
+           */
+
+          if (priv->config->rx_en)
+            {
+              modifyreg32(I2S_CONF_REG, 0, I2S_TX_SLAVE_MOD);
+            }
+          else
+            {
+              modifyreg32(I2S_CONF_REG, I2S_TX_SLAVE_MOD, 0);
+            }
+        }
+
+      /* Configure TX chan bit, audio data bit and mono mode.
+       * On ESP32-S2, sample_bit should equals to data_bit.
+       */
+
+      /* Set TX data width */
+
+      priv->data_width = priv->config->data_width;
+      i2s_set_datawidth(priv);
+
+      /* Set I2S tx chan mode */
+
+      modifyreg32(I2S_CONF_CHAN_REG, I2S_TX_CHAN_MOD_M,
+                  FIELD_TO_VALUE(I2S_TX_CHAN_MOD,
+                  priv->config->mono_en ? 4 : 0));
+
+      /* Enable/disable TX MSB shift, the data will be launch at the first
+       * BCK clock.
+       */
+
+      if (priv->config->bit_shift)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_TX_MSB_SHIFT);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_TX_MSB_SHIFT, 0);
+        }
+
+      /* Configure TX WS signal width. Set to to enable transmitter in PCM
+       * standard mode.
+       */
+
+      if (priv->config->ws_width == 1)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_TX_SHORT_SYNC);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_TX_SHORT_SYNC, 0);
+        }
+
+      /* Set I2S tx right channel first */
+
+      if (priv->config->ws_pol == 1)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_TX_RIGHT_FIRST);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_TX_RIGHT_FIRST, 0);
+        }
+
+      /* I2S tx fifo module force enable */
+
+      modifyreg32(I2S_FIFO_CONF_REG, 0, I2S_TX_FIFO_MOD_FORCE_EN);
+
+      /* The default value for the master clock frequency (MCLK frequency)
+       * can be set from the sample rate multiplied by a fixed value, known
+       * as MCLK multiplier. This multiplier, however, should be divisible
+       * by the number of bytes from a sample, i.e, for 24 bits, the
+       * multiplier should be divisible by 3. NOTE: the MCLK frequency can
+       * be adjusted on runtime, so this value remains valid only if the
+       * upper half does not implement the `i2s_setmclkfrequency` method.
+       */
+
+      if (priv->config->data_width == I2S_DATA_BIT_WIDTH_24BIT)
+        {
+          priv->mclk_multiple = I2S_MCLK_MULTIPLE_384;
+        }
+      else
+        {
+          priv->mclk_multiple = I2S_MCLK_MULTIPLE_256;
+        }
+
+      i2s_setmclkfrequency((struct i2s_dev_s *)priv, (priv->config->rate *
+                           priv->mclk_multiple));
+
+      priv->rate = priv->config->rate;
+      i2s_set_clock(priv);
+    }
+
+  /* Configure the RX module */
+
+  if (priv->config->rx_en)
+    {
+      /* Reset I2S RX module */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_RX_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_RX_RESET, 0);
+      modifyreg32(I2S_LC_CONF_REG, 0, I2S_IN_RST);
+      modifyreg32(I2S_LC_CONF_REG, I2S_IN_RST, 0);
+
+      /* Enable/disable I2S RX slave mode */
+
+      if (priv->config->role == I2S_ROLE_SLAVE)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_RX_SLAVE_MOD);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_RX_SLAVE_MOD, 0);
+        }
+
+      /* Congfigure RX chan bit, audio data bit and mono mode.
+       * On ESP32-S2, sample_bit should equals to data_bit.
+       */
+
+      /* Set RX data width */
+
+      priv->data_width = priv->config->data_width;
+      i2s_set_datawidth(priv);
+
+      /* Set I2S RX chan mode */
+
+      modifyreg32(I2S_CONF_CHAN_REG, I2S_RX_CHAN_MOD_M, 0);
+
+      /* Enable/disable RX MSB shift, the data will be read at the first
+       * BCK clock.
+       */
+
+      if (priv->config->bit_shift)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_RX_MSB_SHIFT);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_RX_MSB_SHIFT, 0);
+        }
+
+      /* Configure RX WS signal width. Set to to enable receiver in PCM
+       * standard mode.
+       */
+
+      if (priv->config->ws_width == 1)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_RX_SHORT_SYNC);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_RX_SHORT_SYNC, 0);
+        }
+
+      /* Set I2S RX right channel first */
+
+      if (priv->config->ws_pol == 1)
+        {
+          modifyreg32(I2S_CONF_REG, 0, I2S_RX_RIGHT_FIRST);
+        }
+      else
+        {
+          modifyreg32(I2S_CONF_REG, I2S_RX_RIGHT_FIRST, 0);
+        }
+
+      /* I2S RX fifo module force enable */
+
+      modifyreg32(I2S_FIFO_CONF_REG, 0, I2S_RX_FIFO_MOD_FORCE_EN);
+
+      /* The default value for the master clock frequency (MCLK frequency)
+       * can be set from the sample rate multiplied by a fixed value, known
+       * as MCLK multiplier. This multiplier, however, should be divisible
+       * by the number of bytes from a sample, i.e, for 24 bits, the
+       * multiplier should be divisible by 3. NOTE: the MCLK frequency can
+       * be adjusted on runtime, so this value remains valid only if the
+       * upper half does not implement the `i2s_setmclkfrequency` method.
+       */
+
+      if (priv->config->data_width == I2S_DATA_BIT_WIDTH_24BIT)
+        {
+          priv->mclk_multiple = I2S_MCLK_MULTIPLE_384;
+        }
+      else
+        {
+          priv->mclk_multiple = I2S_MCLK_MULTIPLE_256;
+        }
+
+      i2s_setmclkfrequency((struct i2s_dev_s *)priv, (priv->config->rate *
+                           priv->mclk_multiple));
+
+      priv->rate = priv->config->rate;
+      i2s_set_clock(priv);
+    }
+}
+
+/****************************************************************************
+ * Name: i2s_set_datawidth
+ *
+ * Description:
+ *   Set the I2S TX/RX data width.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   Returns the resulting data width
+ *
+ ****************************************************************************/
+
+static uint32_t i2s_set_datawidth(struct esp32s2_i2s_s *priv)
+{
+#ifdef I2S_HAVE_TX
+  if (priv->config->tx_en)
+    {
+      modifyreg32(I2S_SAMPLE_RATE_CONF_REG, I2S_TX_BITS_MOD_M,
+                  FIELD_TO_VALUE(I2S_TX_BITS_MOD, priv->data_width));
+
+      /* Set TX FIFO operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, I2S_TX_FIFO_MOD_M,
+                  priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                  FIELD_TO_VALUE(I2S_TX_FIFO_MOD,
+                                 0 + priv->config->mono_en) :
+                  FIELD_TO_VALUE(I2S_TX_FIFO_MOD,
+                                 2 + priv->config->mono_en));
+
+      /* I2S TX MSB right enable */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_TX_MSB_RIGHT);
+    }
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  if (priv->config->rx_en)
+    {
+      modifyreg32(I2S_SAMPLE_RATE_CONF_REG, I2S_RX_BITS_MOD_M,
+                  FIELD_TO_VALUE(I2S_RX_BITS_MOD, priv->data_width));
+
+      /* Set RX FIFO operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, I2S_RX_FIFO_MOD_M,
+                  priv->data_width <= I2S_DATA_BIT_WIDTH_16BIT ?
+                  FIELD_TO_VALUE(I2S_RX_FIFO_MOD,
+                                 0 + priv->config->mono_en) :
+                  FIELD_TO_VALUE(I2S_RX_FIFO_MOD,
+                                 2 + priv->config->mono_en));
+
+      /* I2S RX MSB right enable */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_RX_MSB_RIGHT);
+    }
+#endif /* I2S_HAVE_RX */
+
+  return priv->data_width;
+}
+
+/****************************************************************************
+ * Name: i2s_set_clock
+ *
+ * Description:
+ *   Set the I2S TX sample rate by adjusting I2S clock.
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   Returns the resulting bitrate
+ *
+ ****************************************************************************/
+
+static uint32_t i2s_set_clock(struct esp32s2_i2s_s *priv)
+{
+  uint32_t rate;
+  uint32_t bclk;
+  uint32_t mclk;
+  uint32_t sclk;
+  uint32_t mclk_div;
+  int denominator;
+  int numerator;
+  uint32_t regval;
+  uint32_t freq_diff;
+  uint16_t bclk_div;
+
+  /* TODO: provide APLL clock support */
+
+  sclk = I2S_LL_BASE_CLK;
+
+  /* fmclk = bck_div * fbclk = fsclk / (mclk_div + b / a)
+   * mclk_div is the I2S clock divider's integral value
+   * b is the fraction clock divider's numerator value
+   * a is the fraction clock divider's denominator value
+   */
+
+  if (priv->config->role == I2S_ROLE_MASTER)
+    {
+      bclk = priv->rate * priv->config->total_slot * priv->data_width;
+      mclk = priv->mclk_freq;
+      bclk_div = mclk / bclk;
+    }
+  else
+    {
+      /* For slave mode, mclk >= bclk * 8, so fix bclk_div to 2 first */
+
+      bclk_div = 8;
+      bclk = priv->rate * priv->config->total_slot * priv->data_width;
+      mclk = bclk * bclk_div;
+    }
+
+  /* Calculate the nearest integer value of the I2S clock divider */
+
+  mclk_div = sclk / mclk;
+
+  i2sinfo("Clock division info: [sclk]%" PRIu32 " Hz [mdiv] %" PRIu32
+          "[mclk] %" PRIu32 " Hz [bdiv] %d [bclk] %" PRIu32 " Hz\n",
+          sclk, mclk_div, mclk, bclk_div, bclk);
+
+  freq_diff = abs((int)sclk - (int)(mclk * mclk_div));
+
+  denominator = 1;
+  numerator = 0;
+
+  if (freq_diff)
+    {
+      float decimal = freq_diff / (float)mclk;
+
+      /* Carry bit if the decimal is greater than
+       * 1.0 - 1.0 / (63.0 * 2) = 125.0 / 126.0
+       */
+
+      if (decimal > 125.0f / 126.0f)
+        {
+          mclk_div++;
+        }
+      else
+        {
+          uint32_t min = UINT32_MAX;
+
+          for (int a = 2; a <= I2S_LL_MCLK_DIVIDER_MAX; a++)
+            {
+              int b = (int)(a * (freq_diff / (double)mclk) + 0.5);
+              int ma = freq_diff * a;
+              int mb = mclk * b;
+              if (ma == mb)
+                {
+                  denominator = a;
+                  numerator = b;
+                  break;
+                }
+
+              if (abs((mb - ma)) < min)
+                {
+                  denominator = a;
+                  numerator = b;
+                  min = abs(mb - ma);
+                }
+            }
+        }
+    }
+
+  i2sinfo("Clock register: [mclk] %" PRIu32 " Hz [numerator] %d "
+          "[denominator] %d\n", mclk, numerator, denominator);
+
+  regval = getreg32(I2S_CLKM_CONF_REG);
+  regval &= ~I2S_CLKM_DIV_NUM_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_NUM, mclk_div);
+  regval &= ~I2S_CLKM_DIV_B_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_B, numerator);
+  regval &= ~I2S_CLKM_DIV_A_M;
+  regval |= FIELD_TO_VALUE(I2S_CLKM_DIV_A, denominator);
+  putreg32(regval, I2S_CLKM_CONF_REG);
+
+  /* Set I2S TX bck div num */
+
+#ifdef I2S_HAVE_TX
+  modifyreg32(I2S_SAMPLE_RATE_CONF_REG, I2S_TX_BCK_DIV_NUM_M,
+              FIELD_TO_VALUE(I2S_TX_BCK_DIV_NUM, bclk_div));
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  modifyreg32(I2S_SAMPLE_RATE_CONF_REG, I2S_RX_BCK_DIV_NUM_M,
+              FIELD_TO_VALUE(I2S_RX_BCK_DIV_NUM, bclk_div));
+#endif /* I2S_HAVE_RX */
+
+  /* Returns the actual sample rate */
+
+  bclk = sclk / (float)((mclk_div + numerator / (float)denominator) *
+                        bclk_div);
+  rate = bclk / (float)(priv->config->total_slot * priv->data_width);
+
+  return rate;
+}
+
+/****************************************************************************
+ * Name: i2s_tx_channel_start
+ *
+ * Description:
+ *   Start TX channel for the I2S port
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static void i2s_tx_channel_start(struct esp32s2_i2s_s *priv)
+{
+  if (priv->config->tx_en)
+    {
+      if (priv->tx_started)
+        {
+          i2swarn("TX channel was previously started\n");
+          return;
+        }
+
+      /* Reset the TX channel */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_TX_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_TX_RESET, 0);
+
+      /* Reset the DMA operation */
+
+      modifyreg32(I2S_LC_CONF_REG, 0, I2S_OUT_RST);
+      modifyreg32(I2S_LC_CONF_REG, I2S_OUT_RST, 0);
+
+      /* Reset TX FIFO */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_TX_FIFO_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_TX_FIFO_RESET, 0);
+
+      /* Enable DMA interrupt */
+
+      up_enable_irq(priv->config->irq);
+
+      modifyreg32(I2S_INT_ENA_REG, 0, I2S_OUT_EOF_INT_ENA);
+
+      /* Enable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, 0, I2S_DSCR_EN);
+
+      /* Unset the DMA outlink */
+
+      putreg32(0, I2S_OUT_LINK_REG);
+
+      priv->tx_started = true;
+
+      i2sinfo("Started TX channel on I2S0\n");
+    }
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rx_channel_start
+ *
+ * Description:
+ *   Start RX channel for the I2S port
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static void i2s_rx_channel_start(struct esp32s2_i2s_s *priv)
+{
+  if (priv->config->rx_en)
+    {
+      if (priv->rx_started)
+        {
+          i2swarn("RX channel was previously started\n");
+          return;
+        }
+
+      /* Reset the RX channel */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_RX_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_RX_RESET, 0);
+
+      /* Reset the DMA operation */
+
+      modifyreg32(I2S_LC_CONF_REG, 0, I2S_IN_RST);
+      modifyreg32(I2S_LC_CONF_REG, I2S_IN_RST, 0);
+
+      /* Reset RX FIFO */
+
+      modifyreg32(I2S_CONF_REG, 0, I2S_RX_FIFO_RESET);
+      modifyreg32(I2S_CONF_REG, I2S_RX_FIFO_RESET, 0);
+
+      /* Enable DMA interrupt */
+
+      up_enable_irq(priv->config->irq);
+
+      modifyreg32(I2S_INT_ENA_REG, 0, I2S_IN_SUC_EOF_INT_ENA);
+
+      /* Enable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, 0, I2S_DSCR_EN);
+
+      /* Unset the DMA inlink */
+
+      putreg32(0, I2S_IN_LINK_REG);
+
+      priv->rx_started = true;
+
+      i2sinfo("Started RX channel on I2S0\n");
+    }
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_tx_channel_stop
+ *
+ * Description:
+ *   Stop TX channel for the I2S port
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static void i2s_tx_channel_stop(struct esp32s2_i2s_s *priv)
+{
+  if (priv->config->tx_en)
+    {
+      if (!priv->tx_started)
+        {
+          i2swarn("TX channel was previously stopped\n");
+          return;
+        }
+
+      /* Stop TX channel */
+
+      modifyreg32(I2S_CONF_REG, I2S_TX_START, 0);
+
+      /* Stop outlink */
+
+      modifyreg32(I2S_OUT_LINK_REG, I2S_OUTLINK_START, I2S_OUTLINK_STOP);
+
+      /* Disable DMA interrupt */
+
+      modifyreg32(I2S_INT_ENA_REG, I2S_OUT_EOF_INT_ENA, 0);
+
+      /* Disable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, I2S_DSCR_EN, 0);
+
+      up_disable_irq(priv->config->irq);
+
+      priv->tx_started = false;
+
+      i2sinfo("Stopped TX channel on I2S0\n");
+    }
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rx_channel_stop
+ *
+ * Description:
+ *   Stop RX channel for the I2S port
+ *
+ * Input Parameters:
+ *   priv - Initialized I2S device structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static void i2s_rx_channel_stop(struct esp32s2_i2s_s *priv)
+{
+  if (priv->config->rx_en)
+    {
+      if (!priv->rx_started)
+        {
+          i2swarn("RX channel was previously stopped\n");
+          return;
+        }
+
+      /* Stop RX channel */
+
+      modifyreg32(I2S_CONF_REG, I2S_RX_START, 0);
+
+      /* Stop outlink */
+
+      modifyreg32(I2S_IN_LINK_REG, I2S_INLINK_START, I2S_INLINK_STOP);
+
+      /* Disable DMA interrupt */
+
+      modifyreg32(I2S_INT_ENA_REG, I2S_IN_SUC_EOF_INT_ENA, 0);
+
+      /* Disable DMA operation mode */
+
+      modifyreg32(I2S_FIFO_CONF_REG, I2S_DSCR_EN, 0);
+
+      up_disable_irq(priv->config->irq);
+
+      priv->rx_started = false;
+
+      i2sinfo("Stopped RX channel on I2S0\n");
+    }
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_interrupt
+ *
+ * Description:
+ *   Common I2S DMA interrupt handler
+ *
+ * Input Parameters:
+ *   irq     - Number of the IRQ that generated the interrupt
+ *   context - Interrupt register state save info
+ *   arg     - I2S controller private data
+ *
+ * Returned Value:
+ *   Standard interrupt return value.
+ *
+ ****************************************************************************/
+
+static int i2s_interrupt(int irq, void *context, void *arg)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)arg;
+  struct esp32s2_dmadesc_s *cur = NULL;
+
+  uint32_t status = getreg32(I2S_INT_ST_REG);
+
+  putreg32(UINT32_MAX, I2S_INT_CLR_REG);
+
+#ifdef I2S_HAVE_TX
+  if (priv->config->tx_en)
+    {
+      if (status & I2S_OUT_EOF_INT_ST)
+        {
+          cur = (struct esp32s2_dmadesc_s *)
+                getreg32(I2S_OUT_EOF_DES_ADDR_REG);
+
+          /* Schedule completion of the transfer on the worker thread */
+
+          i2s_tx_schedule(priv, cur);
+        }
+    }
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  if (priv->config->rx_en)
+    {
+      if (status & I2S_IN_SUC_EOF_INT_ST)
+        {
+          cur = (struct esp32s2_dmadesc_s *)
+                getreg32(I2S_IN_EOF_DES_ADDR_REG);
+
+          /* Schedule completion of the transfer on the worker thread */
+
+          i2s_rx_schedule(priv, cur);
+        }
+    }
+#endif /* I2S_HAVE_RX */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: i2s_getmclkfrequency
+ *
+ * Description:
+ *   Get the current master clock frequency.
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *
+ * Returned Value:
+ *   Returns the current master clock.
+ *
+ ****************************************************************************/
+
+static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  return priv->mclk_freq;
+}
+
+/****************************************************************************
+ * Name: i2s_setmclkfrequency
+ *
+ * Description:
+ *   Set the master clock frequency. Usually, the MCLK is a multiple of the
+ *   sample rate. Most of the audio codecs require setting specific MCLK
+ *   frequency according to the sample rate.
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *   frequency  - The I2S master clock's frequency
+ *
+ * Returned Value:
+ *   Returns the resulting master clock or a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+                                     uint32_t frequency)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  /* Check if the master clock frequency is beyond the highest possible
+   * value and return an error.
+   */
+
+  if (frequency >= (I2S_LL_BASE_CLK / 2))
+    {
+      return -EINVAL;
+    }
+
+  priv->mclk_freq = frequency;
+
+  return frequency;
+}
+
+/****************************************************************************
+ * Name: i2s_txchannels
+ *
+ * Description:
+ *   Set the I2S TX number of channels.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   channels - The I2S numbers of channels
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static int i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->tx_en)
+    {
+      if (channels != 1 && channels != 2)
+        {
+          return -EINVAL;
+        }
+
+      i2s_tx_channel_stop(priv);
+
+      priv->channels = channels;
+
+      modifyreg32(I2S_CONF_REG, priv->channels == 1 ? 0 : I2S_TX_DMA_EQUAL,
+                  priv->channels == 1 ? I2S_TX_DMA_EQUAL : 0);
+
+      i2s_tx_channel_start(priv);
+
+      return OK;
+    }
+
+  return -ENOTTY;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rxchannels
+ *
+ * Description:
+ *   Set the I2S RX number of channels.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   channels - The I2S numbers of channels
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->rx_en)
+    {
+      if (channels != 1 && channels != 2)
+        {
+          return -EINVAL;
+        }
+
+      i2s_rx_channel_stop(priv);
+
+      priv->channels = channels;
+
+      modifyreg32(I2S_CONF_REG, priv->channels == 1 ? 0 : I2S_RX_DMA_EQUAL,
+                  priv->channels == 1 ? I2S_RX_DMA_EQUAL : 0);
+
+      i2s_rx_channel_start(priv);
+
+      return OK;
+    }
+
+  return -ENOTTY;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_txsamplerate
+ *
+ * Description:
+ *   Set the I2S TX sample rate.  NOTE:  This will have no effect if (1) the
+ *   driver does not support an I2S transmitter or if (2) the sample rate is
+ *   driven by the I2S frame clock.  This may also have unexpected side-
+ *   effects of the TX sample is coupled with the RX sample rate.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   rate - The I2S sample rate in samples (not bits) per second
+ *
+ * Returned Value:
+ *   Returns the resulting bitrate
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->tx_en)
+    {
+      i2s_tx_channel_stop(priv);
+
+      priv->rate = rate;
+
+      rate = i2s_set_clock(priv);
+
+      i2s_tx_channel_start(priv);
+
+      return rate;
+    }
+
+  return 0;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rxsamplerate
+ *
+ * Description:
+ *   Set the I2S RX sample rate.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   rate - The I2S sample rate in samples (not bits) per second
+ *
+ * Returned Value:
+ *   Returns the resulting bitrate
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->rx_en)
+    {
+      i2s_rx_channel_stop(priv);
+
+      priv->rate = rate;
+
+      rate = i2s_set_clock(priv);
+
+      i2s_rx_channel_start(priv);
+
+      return rate;
+    }
+
+  return 0;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_txdatawidth
+ *
+ * Description:
+ *   Set the I2S TX data width.  The TX bitrate is determined by
+ *   sample_rate * data_width.
+ *
+ * Input Parameters:
+ *   dev   - Device-specific state data
+ *   width - The I2S data with in bits.
+ *
+ * Returned Value:
+ *   Returns the resulting data width
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->tx_en)
+    {
+      i2s_tx_channel_stop(priv);
+
+      priv->data_width = bits;
+
+      i2s_set_datawidth(priv);
+
+      i2s_tx_channel_start(priv);
+
+      return bits;
+    }
+
+  return 0;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_rxdatawidth
+ *
+ * Description:
+ *   Set the I2S RX data width.  The RX bitrate is determined by
+ *   sample_rate * data_width.
+ *
+ * Input Parameters:
+ *   dev   - Device-specific state data
+ *   width - The I2S data with in bits.
+ *
+ * Returned Value:
+ *   Returns the resulting data width
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->rx_en)
+    {
+      i2s_rx_channel_stop(priv);
+
+      priv->data_width = bits;
+
+      i2s_set_datawidth(priv);
+
+      i2s_rx_channel_start(priv);
+
+      return bits;
+    }
+
+  return 0;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_send
+ *
+ * Description:
+ *   Send a block of data on I2S.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   apb      - A pointer to the audio buffer from which to send data
+ *   callback - A user provided callback function that will be called at
+ *              the completion of the transfer.
+ *   arg      - An opaque argument that will be provided to the callback
+ *              when the transfer complete
+ *   timeout  - The timeout value to use.  The transfer will be cancelled
+ *              and an ETIMEDOUT error will be reported if this timeout
+ *              elapsed without completion of the DMA transfer.  Units
+ *              are system clock ticks.  Zero means no timeout.
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_TX
+static int i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
+                    i2s_callback_t callback, void *arg, uint32_t timeout)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->tx_en)
+    {
+      struct esp32s2_buffer_s *bfcontainer;
+      int ret = OK;
+      uint32_t nbytes;
+
+      /* Check audio buffer data size from the upper half. If the buffer
+       * size is not a multiple of the data width, the remaining bytes
+       * must be sent along with the next audio buffer.
+       */
+
+      nbytes = (apb->nbytes - apb->curbyte) + priv->tx.carry.bytes;
+
+      nbytes -= (nbytes % (priv->data_width / 8));
+
+      if (nbytes > (ESP32S2_DMA_DATALEN_MAX * I2S_DMADESC_NUM))
+        {
+          i2serr("Required buffer size can't fit into DMA outlink "
+                "(exceeds in %" PRIu32 " bytes). Try to increase the "
+                "number of the DMA descriptors (CONFIG_I2S_DMADESC_NUM).",
+                nbytes - (ESP32S2_DMA_DATALEN_MAX * I2S_DMADESC_NUM));
+          return -EFBIG;
+        }
+
+      /* Allocate a buffer container in advance */
+
+      bfcontainer = i2s_buf_allocate(priv);
+      DEBUGASSERT(bfcontainer);
+
+      /* Get exclusive access to the I2S driver data */
+
+      ret = nxmutex_lock(&priv->lock);
+      if (ret < 0)
+        {
+          goto errout_with_buf;
+        }
+
+      /* Add a reference to the audio buffer */
+
+      apb_reference(apb);
+
+      /* Initialize the buffer container structure */
+
+      bfcontainer->callback = callback;
+      bfcontainer->timeout  = timeout;
+      bfcontainer->arg      = arg;
+      bfcontainer->apb      = apb;
+      bfcontainer->nbytes   = nbytes;
+      bfcontainer->result   = -EBUSY;
+
+      ret = i2s_txdma_setup(priv, bfcontainer);
+
+      if (ret != OK)
+        {
+          goto errout_with_buf;
+        }
+
+      i2sinfo("Queued %d bytes into DMA buffers\n", apb->nbytes);
+      i2s_dump_buffer("Audio pipeline buffer:", &apb->samp[apb->curbyte],
+                        apb->nbytes - apb->curbyte);
+
+      nxmutex_unlock(&priv->lock);
+
+      return OK;
+
+errout_with_buf:
+      nxmutex_unlock(&priv->lock);
+      i2s_buf_free(priv, bfcontainer);
+      return ret;
+    }
+
+  return -ENOTTY;
+}
+#endif /* I2S_HAVE_TX */
+
+/****************************************************************************
+ * Name: i2s_receive
+ *
+ * Description:
+ *   Receive a block of data on I2S.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   apb      - A pointer to the audio buffer in which to receive data
+ *   callback - A user provided callback function that will be called at
+ *              the completion of the transfer.
+ *   arg      - An opaque argument that will be provided to the callback
+ *              when the transfer complete
+ *   timeout  - The timeout value to use.  The transfer will be cancelled
+ *              and an ETIMEDOUT error will be reported if this timeout
+ *              elapsed without completion of the DMA transfer.  Units
+ *              are system clock ticks.  Zero means no timeout.
+ *
+ * Returned Value:
+ *   OK on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef I2S_HAVE_RX
+static int i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
+                       i2s_callback_t callback, void *arg, uint32_t timeout)
+{
+  struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
+
+  if (priv->config->rx_en)
+    {
+      struct esp32s2_buffer_s *bfcontainer;
+      int ret = OK;
+      uint32_t nbytes;
+
+      /* Check max audio buffer data size from the upper half and align the
+       * receiving buffer according to the data width.
+       */
+
+      nbytes = apb->nmaxbytes;
+
+      nbytes -= (nbytes % (priv->data_width / 8));
+
+      if (nbytes > (ESP32S2_DMA_DATALEN_MAX * I2S_DMADESC_NUM))
+        {
+          i2serr("Required buffer size can't fit into DMA inlink "
+                "(exceeds in %" PRIu32 " bytes). Try to increase the "
+                "number of the DMA descriptors (CONFIG_I2S_DMADESC_NUM).",
+                nbytes - (ESP32S2_DMA_DATALEN_MAX * I2S_DMADESC_NUM));
+          return -EFBIG;
+        }
+
+      /* Allocate a buffer container in advance */
+
+      bfcontainer = i2s_buf_allocate(priv);
+      DEBUGASSERT(bfcontainer);
+
+      /* Get exclusive access to the I2S driver data */
+
+      ret = nxmutex_lock(&priv->lock);
+      if (ret < 0)
+        {
+          goto errout_with_buf;
+        }
+
+      /* Add a reference to the audio buffer */
+
+      apb_reference(apb);
+
+      /* Initialize the buffer container structure */
+
+      bfcontainer->callback = callback;
+      bfcontainer->timeout  = timeout;
+      bfcontainer->arg      = arg;
+      bfcontainer->apb      = apb;
+      bfcontainer->nbytes   = nbytes;
+      bfcontainer->result   = -EBUSY;
+
+      ret = i2s_rxdma_setup(priv, bfcontainer);
+
+      if (ret != OK)
+        {
+          goto errout_with_buf;
+        }
+
+      i2sinfo("Prepared %d bytes to receive DMA buffers\n", apb->nmaxbytes);
+      i2s_dump_buffer("Audio pipeline buffer:", &apb->samp[apb->curbyte],
+                      apb->nbytes - apb->curbyte);
+
+      nxmutex_unlock(&priv->lock);
+
+      return OK;
+
+errout_with_buf:
+      nxmutex_unlock(&priv->lock);
+      i2s_buf_free(priv, bfcontainer);
+      return ret;
+    }
+
+  return -ENOTTY;
+}
+#endif /* I2S_HAVE_RX */
+
+/****************************************************************************
+ * Name: i2s_ioctl
+ *
+ * Description:
+ *   Perform a device ioctl
+ *
+ ****************************************************************************/
+
+static int i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg)
+{
+  struct audio_buf_desc_s  *bufdesc;
+  int ret = -ENOTTY;
+
+  switch (cmd)
+    {
+      /* AUDIOIOC_START - Start the audio stream.
+       *
+       *   ioctl argument:  Audio session
+       */
+
+      case AUDIOIOC_START:
+        {
+          i2sinfo("AUDIOIOC_START\n");
+
+          ret = OK;
+        }
+        break;
+
+      /* AUDIOIOC_ALLOCBUFFER - Allocate an audio buffer
+       *
+       *   ioctl argument:  pointer to an audio_buf_desc_s structure
+       */
+
+      case AUDIOIOC_ALLOCBUFFER:
+        {
+          i2sinfo("AUDIOIOC_ALLOCBUFFER\n");
+
+          bufdesc = (struct audio_buf_desc_s *) arg;
+          ret = apb_alloc(bufdesc);
+        }
+        break;
+
+      /* AUDIOIOC_FREEBUFFER - Free an audio buffer
+       *
+       *   ioctl argument:  pointer to an audio_buf_desc_s structure
+       */
+
+      case AUDIOIOC_FREEBUFFER:
+        {
+          i2sinfo("AUDIOIOC_FREEBUFFER\n");
+
+          bufdesc = (struct audio_buf_desc_s *) arg;
+          DEBUGASSERT(bufdesc->u.buffer != NULL);
+          apb_free(bufdesc->u.buffer);
+          ret = sizeof(struct audio_buf_desc_s);
+        }
+        break;
+
+      default:
+        break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: i2s_dma_setup
+ *
+ * Description:
+ *   Configure the DMA for the I2S peripheral
+ *
+ * Input Parameters:
+ *   priv - Partially initialized I2S device structure. This function
+ *          will complete the I2S specific portions of the initialization
+ *          regarding the DMA operation.
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static int i2s_dma_setup(struct esp32s2_i2s_s *priv)
+{
+  int ret;
+
+  /* Clear the interrupts */
+
+  putreg32(UINT32_MAX, I2S_INT_CLR_REG);
+
+  /* Set up to receive peripheral interrupts on the current CPU */
+
+  priv->cpu = this_cpu();
+  priv->cpuint = esp32s2_setup_irq(priv->config->periph, 1,
+                                   ESP32S2_CPUINT_LEVEL);
+  if (priv->cpuint < 0)
+    {
+      i2serr("Failed to allocate a CPU interrupt.\n");
+      return priv->cpuint;
+    }
+
+  ret = irq_attach(priv->config->irq, i2s_interrupt, priv);
+  if (ret != OK)
+    {
+      i2serr("Couldn't attach IRQ to handler.\n");
+      esp32s2_teardown_irq(priv->config->periph, priv->cpuint);
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32s2_i2sbus_initialize
+ *
+ * Description:
+ *   Initialize the I2S peripheral
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Valid I2S device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct i2s_dev_s *esp32s2_i2sbus_initialize(void)
+{
+  int ret;
+  struct esp32s2_i2s_s *priv = NULL;
+  irqstate_t flags;
+
+  /* Statically allocated I2S' device strucuture */
+
+  priv = &esp32s2_i2s0_priv;
+
+  flags = enter_critical_section();
+
+  i2s_configure(priv);
+
+  /* Allocate buffer containers */
+
+  ret = i2s_buf_initialize(priv);
+  if (ret < 0)
+    {
+      goto err;
+    }
+
+  ret = i2s_dma_setup(priv);
+  if (ret < 0)
+    {
+      goto err;
+    }
+
+#ifdef I2S_HAVE_TX
+  /* Start TX channel */
+
+  if (priv->config->tx_en)
+    {
+      priv->tx_started = false;
+      i2s_tx_channel_start(priv);
+    }
+#endif /* I2S_HAVE_TX */
+
+#ifdef I2S_HAVE_RX
+  /* Start RX channel */
+
+  if (priv->config->rx_en)
+    {
+      priv->rx_started = false;
+      i2s_rx_channel_start(priv);
+    }
+#endif /* I2S_HAVE_RX */
+
+  leave_critical_section(flags);
+
+  /* Success exit */
+
+  i2sinfo("I2S0 was successfully initialized\n");
+
+  return &priv->dev;
+
+  /* Failure exit */
+
+err:
+  leave_critical_section(flags);
+  return NULL;
+}
+
+#endif /* CONFIG_ESP32S2_I2S */

--- a/arch/xtensa/src/esp32s2/esp32s2_rtc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rtc.c
@@ -946,7 +946,7 @@ static void esp32s2_select_rtc_slow_clk(enum esp32s2_slow_clk_sel_e slow_clk)
       retry_32k_xtal++;
     }
   while (cal_val == 0 && retry_32k_xtal < RETRY_CAL_EXT);
-  rtcinfo("RTC_SLOW_CLK calibration value: %d\n", cal_val);
+  rtcinfo("RTC_SLOW_CLK calibration value: %" PRIu32 "\n", cal_val);
   putreg32((uint32_t)cal_val, RTC_SLOW_CLK_CAL_REG);
 }
 

--- a/arch/xtensa/src/esp32s2/esp32s2_spi.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spi.c
@@ -1276,7 +1276,7 @@ static void esp32s2_spi_poll_exchange(struct esp32s2_spi_priv_s *priv,
             {
               uintptr_t r_wd = getreg32(data_buf_reg);
 
-              spiinfo("recv=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
+              spiinfo("recv=0x%" PRIxPTR " data_reg=0x%" PRIxPTR "\n",
                       r_wd, data_buf_reg);
 
               memcpy(rp, &r_wd, sizeof(uintptr_t));

--- a/arch/xtensa/src/esp32s2/esp32s2_touch.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_touch.c
@@ -562,7 +562,7 @@ uint32_t esp32s2_touchreadraw(enum touch_pad_e tp)
   uint32_t value = touch_lh_read_raw_data(tp);
 #endif
 
-  iinfo("Touch pad %d value: %u\n", tp, value);
+  iinfo("Touch pad %d value: %" PRIu32 "\n", tp, value);
 
   return value;
 }
@@ -593,7 +593,7 @@ uint32_t esp32s2_touchbenchmark(enum touch_pad_e tp)
 
   leave_critical_section(flags);
 
-  iinfo("Touch pad %d benchmark value: %u\n", tp, value);
+  iinfo("Touch pad %d benchmark value: %" PRIu32 "\n", tp, value);
 
   return value;
 }
@@ -624,7 +624,7 @@ void esp32s2_touchsetthreshold(enum touch_pad_e tp, uint32_t threshold)
 
   leave_critical_section(flags);
 
-  iinfo("Touch pad %d threshold set to: %u\n", tp, threshold);
+  iinfo("Touch pad %d threshold set to: %" PRIu32 "\n", tp, threshold);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
@@ -227,8 +227,8 @@ static uint32_t esp_event_group_set_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick);
 static int32_t esp_task_create_pinned_to_core(void *task_func,
                                               const char *name,
@@ -245,7 +245,7 @@ static void esp_task_delay(uint32_t tick);
 static int32_t esp_task_ms_to_tick(uint32_t ms);
 static void *esp_task_get_current_task(void);
 static int32_t esp_task_get_max_priority(void);
-static void *esp_malloc(uint32_t size);
+static void *esp_malloc(size_t size);
 static void esp_free(void *ptr);
 static uint32_t esp_get_free_heap_size(void);
 static uint32_t esp_rand(void);
@@ -254,7 +254,7 @@ static void wifi_apb80m_release(void);
 static void IRAM_ATTR esp_empty_wrapper(void);
 static void esp_phy_enable_wrapper(void);
 static void esp_phy_disable_wrapper(void);
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type);
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type);
 static void esp_timer_arm(void *timer, uint32_t tmout, bool repeat);
 static void esp_timer_disarm(void *timer);
 static void esp32s2_timer_done(void *timer);
@@ -264,35 +264,40 @@ static void wifi_reset_mac(void);
 static void wifi_clock_enable(void);
 static void wifi_clock_disable(void);
 static int64_t esp32s2_timer_get_time(void);
-static int32_t esp_nvs_set_i8(uint32_t handle, const char *key,
-                              int8_t value);
-static int32_t esp_nvs_get_i8(uint32_t handle, const char *key,
-                              int8_t *out_value);
-static int32_t esp_nvs_set_u8(uint32_t handle, const char *key,
-                              uint8_t value);
-static int32_t esp_nvs_get_u8(uint32_t handle, const char *key,
-                              uint8_t *out_value);
-static int32_t esp_nvs_set_u16(uint32_t handle, const char *key,
-                               uint16_t value);
-static int32_t esp_nvs_get_u16(uint32_t handle, const char *key,
-                               uint16_t *out_value);
-static int32_t esp_nvs_open(const char *name, uint32_t open_mode,
-                            uint32_t *out_handle);
+static int esp_nvs_set_i8(uint32_t handle, const char *key,
+                          int8_t value);
+static int esp_nvs_get_i8(uint32_t handle, const char *key,
+                          int8_t *out_value);
+static int esp_nvs_set_u8(uint32_t handle, const char *key,
+                          uint8_t value);
+static int esp_nvs_get_u8(uint32_t handle, const char *key,
+                          uint8_t *out_value);
+static int esp_nvs_set_u16(uint32_t handle, const char *key,
+                           uint16_t value);
+static int esp_nvs_get_u16(uint32_t handle, const char *key,
+                           uint16_t *out_value);
+static int esp_nvs_open(const char *name, unsigned int open_mode,
+                        uint32_t *out_handle);
 static void esp_nvs_close(uint32_t handle);
-static int32_t esp_nvs_commit(uint32_t handle);
-static int32_t esp_nvs_set_blob(uint32_t handle, const char *key,
-                                const void *value, size_t length);
-static int32_t esp_nvs_get_blob(uint32_t handle, const char *key,
-                                void *out_value, size_t *length);
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key);
-static int32_t esp_get_random(uint8_t *buf, size_t len);
-static int32_t esp_get_time(void *t);
+static int esp_nvs_commit(uint32_t handle);
+static int esp_nvs_set_blob(uint32_t handle, const char *key,
+                            const void *value, size_t length);
+static int esp_nvs_get_blob(uint32_t handle, const char *key,
+                            void *out_value, size_t *length);
+static int esp_nvs_erase_key(uint32_t handle, const char *key);
+static int esp_get_random(uint8_t *buf, size_t len);
+static int esp_get_time(void *t);
 static uint32_t esp_clk_slowclk_cal_get_wrapper(void);
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args);
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...);
+int32_t esp32s2_event_post(esp_event_base_t event_base,
+                           int32_t event_id,
+                           void *event_data,
+                           size_t event_data_size,
+                           uint32_t ticks);
 static void *esp_malloc_internal(size_t size);
 static void *esp_realloc_internal(void *ptr, size_t size);
 static void *esp_calloc_internal(size_t n, size_t size);
@@ -301,16 +306,16 @@ static void *esp_wifi_malloc(size_t size);
 static void *esp_wifi_realloc(void *ptr, size_t size);
 static void *esp_wifi_calloc(size_t n, size_t size);
 static void *esp_wifi_zalloc(size_t size);
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size);
+static void *esp_wifi_create_queue(int queue_len, int item_size);
 static void esp_wifi_delete_queue(void *queue);
 static int coex_init_wrapper(void);
 static void coex_deinit_wrapper(void);
 static int coex_enable_wrapper(void);
 static void coex_disable_wrapper(void);
 static uint32_t coex_status_get_wrapper(void);
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
                                      uint32_t duration);
-static int32_t coex_wifi_release_wrapper(uint32_t event);
+static int coex_wifi_release_wrapper(uint32_t event);
 static unsigned long esp_random_ulong(void);
 static int coex_wifi_channel_set_wrapper(uint8_t primary, uint8_t secondary);
 static int coex_event_duration_get_wrapper(uint32_t event,
@@ -442,7 +447,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs =
   ._task_get_max_priority = esp_task_get_max_priority,
   ._malloc = esp_malloc,
   ._free = esp_free,
-  ._event_post = esp_event_post,
+  ._event_post = esp32s2_event_post,
   ._get_free_heap_size = esp_get_free_heap_size,
   ._rand = esp_rand,
   ._dport_access_stall_other_cpu_start_wrap = esp_empty_wrapper,
@@ -746,7 +751,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   struct irq_adpt *adapter;
   int irq = n + XTENSA_IRQ_FIRSTPERIPH;
 
-  wlinfo("n=%d f=%p arg=%p", n, f, arg);
+  wlinfo("n=%ld f=%p arg=%p", n, f, arg);
 
   if (g_irqvector[irq].handler &&
       g_irqvector[irq].handler != irq_unexpected_isr)
@@ -760,7 +765,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   adapter = kmm_malloc(tmp);
   if (!adapter)
     {
-      wlerr("Failed to alloc %d memory\n", tmp);
+      wlerr("Failed to alloc %" PRIu32 " memory\n", tmp);
       PANIC();
       return;
     }
@@ -803,7 +808,7 @@ static void esp32s2_ints_on(uint32_t mask)
 {
   int irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=%08lx irq=%d\n", mask, irq);
 
   up_enable_irq(ESP32S2_IRQ_MAC);
   up_enable_irq(ESP32S2_IRQ_PWR);
@@ -827,7 +832,7 @@ static void esp32s2_ints_off(uint32_t mask)
 {
   uint32_t irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=%08" PRIu32 " irq=%" PRIu32 "\n", mask, irq);
 
   up_disable_irq(ESP32S2_IRQ_MAC);
   up_disable_irq(ESP32S2_IRQ_PWR);
@@ -1068,7 +1073,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t block_time_tick)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %u ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %" PRIu32 " ticks. Error=%d\n",
             block_time_tick, ret);
     }
 
@@ -1711,8 +1716,8 @@ static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits)
 
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick)
 {
   DEBUGPANIC();
@@ -1936,7 +1941,7 @@ static int32_t esp_task_get_max_priority(void)
  *
  ****************************************************************************/
 
-static void *esp_malloc(uint32_t size)
+static void *esp_malloc(size_t size)
 {
   return kmm_malloc(size);
 }
@@ -2204,7 +2209,7 @@ static void esp_evt_work_cb(void *arg)
                                    SI_QUEUE, &notify->work);
           if (ret < 0)
             {
-              wlwarn("nxsig_notification event ID=%d failed: %d\n",
+              wlwarn("nxsig_notification event ID=%ld failed: %d\n",
                      evt_adpt->id, ret);
             }
         }
@@ -2271,7 +2276,7 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
 }
 
 /****************************************************************************
- * Name: esp_event_post
+ * Name: esp32s2_event_post
  *
  * Description:
  *   Active work queue and let the work to process the cached event
@@ -2288,24 +2293,25 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
  *
  ****************************************************************************/
 
-int32_t esp_event_post(esp_event_base_t event_base,
-                       int32_t event_id,
-                       void *event_data,
-                       size_t event_data_size,
-                       uint32_t ticks)
+int32_t esp32s2_event_post(esp_event_base_t event_base,
+                           int32_t event_id,
+                           void *event_data,
+                           size_t event_data_size,
+                           uint32_t ticks)
 {
   size_t size;
   int32_t id;
   irqstate_t flags;
   struct evt_adpt *evt_adpt;
 
-  wlinfo("Event: base=%s id=%d data=%p data_size=%d ticks=%u\n", event_base,
-         event_id, event_data, event_data_size, ticks);
+  wlinfo("Event: base=%s id=%" PRId32 " data=%p data_size=%d "
+         "ticks=%" PRIu32 "\n",
+         event_base, event_id, event_data, event_data_size, ticks);
 
   id = esp_event_id_map(event_id);
   if (id < 0)
     {
-      wlinfo("No process event %d\n", event_id);
+      wlinfo("No process event %ld\n", event_id);
       return -1;
     }
 
@@ -2454,7 +2460,7 @@ static void esp_phy_disable_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type)
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type)
 {
   return esp_read_mac(mac, type);
 }
@@ -2717,9 +2723,9 @@ int64_t esp32s2_timer_get_time(void)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_i8(uint32_t handle,
-                              const char *key,
-                              int8_t value)
+static int esp_nvs_set_i8(uint32_t handle,
+                          const char *key,
+                          int8_t value)
 {
   DEBUGPANIC();
 
@@ -2742,9 +2748,9 @@ static int32_t esp_nvs_set_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_i8(uint32_t handle,
-                              const char *key,
-                              int8_t *out_value)
+static int esp_nvs_get_i8(uint32_t handle,
+                          const char *key,
+                          int8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2767,9 +2773,9 @@ static int32_t esp_nvs_get_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t value)
+static int esp_nvs_set_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t value)
 {
   DEBUGPANIC();
 
@@ -2792,9 +2798,9 @@ static int32_t esp_nvs_set_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t *out_value)
+static int esp_nvs_get_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2817,9 +2823,9 @@ static int32_t esp_nvs_get_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t value)
+static int esp_nvs_set_u16(uint32_t handle,
+                           const char *key,
+                           uint16_t value)
 {
   DEBUGPANIC();
 
@@ -2842,9 +2848,9 @@ static int32_t esp_nvs_set_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t *out_value)
+static int esp_nvs_get_u16(uint32_t handle,
+                          const char *key,
+                          uint16_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2867,9 +2873,9 @@ static int32_t esp_nvs_get_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_open(const char *name,
-                            uint32_t open_mode,
-                            uint32_t *out_handle)
+static int esp_nvs_open(const char *name,
+                        unsigned int open_mode,
+                        uint32_t *out_handle)
 {
   DEBUGPANIC();
 
@@ -2903,7 +2909,7 @@ static void esp_nvs_close(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_commit(uint32_t handle)
+static int esp_nvs_commit(uint32_t handle)
 {
   return 0;
 }
@@ -2925,10 +2931,10 @@ static int32_t esp_nvs_commit(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_blob(uint32_t handle,
-                                const char *key,
-                                const void *value,
-                                size_t length)
+static int esp_nvs_set_blob(uint32_t handle,
+                            const char *key,
+                            const void *value,
+                            size_t length)
 {
   DEBUGPANIC();
 
@@ -2952,10 +2958,10 @@ static int32_t esp_nvs_set_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_blob(uint32_t handle,
-                                const char *key,
-                                void *out_value,
-                                size_t *length)
+static int esp_nvs_get_blob(uint32_t handle,
+                            const char *key,
+                            void *out_value,
+                            size_t *length)
 {
   DEBUGPANIC();
 
@@ -2977,7 +2983,7 @@ static int32_t esp_nvs_get_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
+static int esp_nvs_erase_key(uint32_t handle, const char *key)
 {
   DEBUGPANIC();
 
@@ -2999,7 +3005,7 @@ static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
  *
  ****************************************************************************/
 
-static int32_t esp_get_random(uint8_t *buf, size_t len)
+static int esp_get_random(uint8_t *buf, size_t len)
 {
   esp_fill_random(buf, len);
 
@@ -3020,7 +3026,7 @@ static int32_t esp_get_random(uint8_t *buf, size_t len)
  *
  ****************************************************************************/
 
-static int32_t esp_get_time(void *t)
+static int esp_get_time(void *t)
 {
   int ret;
   struct timeval tv;
@@ -3109,7 +3115,7 @@ static uint32_t esp_clk_slowclk_cal_get_wrapper(void)
  *
  ****************************************************************************/
 
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args)
 {
   esp_log_level_t max_level;
@@ -3146,7 +3152,7 @@ static void esp_log_writev_wrapper(uint32_t level, const char *tag,
  *
  ****************************************************************************/
 
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...)
 {
@@ -3422,7 +3428,7 @@ static void *esp_wifi_zalloc(size_t size)
  *
  ****************************************************************************/
 
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size)
+static void *esp_wifi_create_queue(int queue_len, int item_size)
 {
   wifi_static_queue_t *wifi_queue;
 
@@ -3579,8 +3585,8 @@ static IRAM_ATTR uint32_t coex_status_get_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
-                                         uint32_t duration)
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+                                     uint32_t duration)
 {
   return 0;
 }
@@ -3600,7 +3606,7 @@ static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
  *
  ****************************************************************************/
 
-static IRAM_ATTR int32_t coex_wifi_release_wrapper(uint32_t event)
+static IRAM_ATTR int coex_wifi_release_wrapper(uint32_t event)
 {
   return 0;
 }
@@ -4008,7 +4014,8 @@ static int esp_wifi_auth_trans(uint32_t wifi_auth)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d", wifi_auth);
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
+              wifi_auth);
         break;
     }
 
@@ -4061,7 +4068,7 @@ static int esp_wifi_cipher_trans(uint32_t wifi_cipher)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d",
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
                wifi_cipher);
         break;
     }
@@ -4256,8 +4263,8 @@ int32_t esp_event_send_internal(esp_event_base_t event_base,
 {
   int32_t ret;
 
-  ret = esp_event_post(event_base, event_id, event_data,
-                       event_data_size, ticks_to_wait);
+  ret = esp32s2_event_post(event_base, event_id, event_data,
+                           event_data_size, ticks_to_wait);
 
   return ret;
 }
@@ -4606,7 +4613,7 @@ errout:
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len)
+int esp_wifi_sta_send_data(void *pbuf, size_t len)
 {
   int ret;
 

--- a/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.h
@@ -200,7 +200,7 @@ int esp_wifi_sta_stop(void);
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len);
+int esp_wifi_sta_send_data(void *pbuf, size_t len);
 
 /****************************************************************************
  * Name: esp_wifi_sta_register_recv_cb

--- a/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
@@ -1062,7 +1062,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %lu ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %" PRIu32 " ticks. Error=%d\n",
             MSEC2TICK(block_time_ms), ret);
     }
 
@@ -1261,7 +1261,8 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
   else
     {
       wlerr("Failed to create queue cache."
-            " Please incresase BLE_TASK_EVENT_QUEUE_LEN to, at least, %d",
+            " Please incresase BLE_TASK_EVENT_QUEUE_LEN to, at least, "
+            "%" PRIu32 "",
             queue_len);
       return NULL;
     }

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -638,7 +638,7 @@ void up_enable_irq(int irq)
 
       if (isr_in_iram && handler && !esp32s3_ptr_iram(handler))
         {
-          irqerr("Interrupt handler isn't in IRAM (%08" PRIx32 ")",
+          irqerr("Interrupt handler isn't in IRAM (%08" PRIxPTR ")",
                  (intptr_t)handler);
           PANIC();
         }

--- a/arch/xtensa/src/esp32s3/esp32s3_lcd.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_lcd.c
@@ -859,7 +859,7 @@ static void esp32s3_lcd_enableclk(void)
     clk_b = clk_a = 0;
 #endif
 
-  lcdinfo("PCLK=%d/(%d + %d/%d)\n", ESP32S3_LCD_CLK_MHZ,
+  lcdinfo("PCLK=%d/(%d + %" PRIu32 "/%" PRIu32 ")\n", ESP32S3_LCD_CLK_MHZ,
           ESP32S3_LCD_CLK_N, clk_b, clk_a);
 
   periph_module_enable(PERIPH_LCD_CAM_MODULE);

--- a/arch/xtensa/src/esp32s3/esp32s3_ledc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_ledc.c
@@ -510,7 +510,7 @@ static void setup_timer(struct esp32s3_ledc_s *priv)
   if (integral_prescaler == 0) integral_prescaler = 1;
 
   pwminfo("PWM timer%" PRIu8 " frequency=%0.4f reload=%" PRIu32 " shift=%"
-          PRIu32 " prescaler=%0.4f\n",
+          PRIu8 " prescaler=%0.4f\n",
           priv->num, (float)pwmclk / reload / ((float)prescaler),
           reload, shift, (float)prescaler);
 

--- a/arch/xtensa/src/esp32s3/esp32s3_psram_quad.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_psram_quad.c
@@ -422,7 +422,7 @@ int psram_enable(int mode, int vaddrmode)
       psram_read_id(SPI1_NUM, &g_psram_id);
       if (!PSRAM_IS_VALID(g_psram_id))
         {
-          merr("PSRAM ID read error: 0x%08x", g_psram_id);
+          merr("PSRAM ID read error: 0x%08" PRIx32 "", g_psram_id);
           return -EFAULT;
         }
     }
@@ -564,4 +564,3 @@ int psram_get_available_size(uint32_t *out_size_bytes)
   *out_size_bytes = g_psram_size;
   return (g_psram_size ? OK : -EINVAL);
 }
-

--- a/arch/xtensa/src/esp32s3/esp32s3_rtc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_rtc.c
@@ -907,7 +907,7 @@ static void esp32s3_select_rtc_slow_clk(enum esp32s3_slow_clk_sel_e slow_clk)
       retry_32k_xtal++;
     }
   while (cal_val == 0 && retry_32k_xtal < RETRY_CAL_EXT);
-  rtcinfo("RTC_SLOW_CLK calibration value: %d\n", cal_val);
+  rtcinfo("RTC_SLOW_CLK calibration value: %" PRIu32 "\n", cal_val);
   putreg32((uint32_t)cal_val, RTC_SLOW_CLK_CAL_REG);
 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_sdmmc.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_sdmmc.c
@@ -526,7 +526,7 @@ static int esp32s3_ciu_sendcmd(uint32_t cmd, uint32_t arg)
     {
       if (watchtime - clock_systime_ticks() > SDCARD_CMDTIMEOUT)
         {
-          mcerr("TMO Timed out (%08X)\n",
+          mcerr("TMO Timed out (%08" PRIX32 ")\n",
                 esp32s3_getreg(ESP32S3_SDMMC_CMD));
           return 1;
         }
@@ -539,7 +539,7 @@ static int esp32s3_ciu_sendcmd(uint32_t cmd, uint32_t arg)
   esp32s3_putreg(arg, ESP32S3_SDMMC_CMDARG);
   esp32s3_putreg(cmd, ESP32S3_SDMMC_CMD);
 
-  mcinfo("cmd=0x%x arg=0x%x\n", cmd, arg);
+  mcinfo("cmd=0x%" PRIx32 " arg=0x%" PRIx32 "\n", cmd, arg);
 
   return 0;
 }
@@ -971,7 +971,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
             {
               /* Terminate the transfer with an error */
 
-              mcerr("ERROR: Data CRC failure, pending=%08x remaining: %d\n",
+              mcerr("ERROR: Data CRC failure, pending=%08" PRIx32 " "
+                    "remaining: %d\n",
                     pending, priv->remaining);
 
               esp32s3_endtransfer(priv,
@@ -984,7 +985,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
             {
               /* Terminate the transfer with an error */
 
-              mcerr("ERROR: Data timeout, pending=%08x remaining: %d\n",
+              mcerr("ERROR: Data timeout, pending=%08" PRIx32 " "
+                    "remaining: %d\n",
                     pending, priv->remaining);
 
               esp32s3_endtransfer(priv,
@@ -997,7 +999,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
             {
               /* Terminate the transfer with an error */
 
-              mcerr("ERROR: RX FIFO overrun, pending=%08x remaining: %d\n",
+              mcerr("ERROR: RX FIFO overrun, pending=%08" PRIx32 " "
+                    "remaining: %d\n",
                     pending, priv->remaining);
 
               esp32s3_endtransfer(priv,
@@ -1010,7 +1013,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
             {
               /* Terminate the transfer with an error */
 
-              mcerr("ERROR: TX FIFO underrun, pending=%08x remaining: %d\n",
+              mcerr("ERROR: TX FIFO underrun, pending=%08" PRIx32 " "
+                    "remaining: %d\n",
                     pending, priv->remaining);
 
               esp32s3_endtransfer(priv,
@@ -1023,7 +1027,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
             {
               /* Terminate the transfer with an error */
 
-              mcerr("ERROR: Start bit, pending=%08x remaining: %d\n",
+              mcerr("ERROR: Start bit, pending=%08" PRIx32 " "
+                    "remaining: %d\n",
                     pending, priv->remaining);
 
               esp32s3_endtransfer(priv,
@@ -1061,7 +1066,8 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
 
               /* Wake the thread up */
 
-              mcerr("ERROR: Response error, pending=%08x\n", pending);
+              mcerr("ERROR: Response error, pending=%08" PRIx32 "\n",
+                    pending);
               esp32s3_endwait(priv, SDIOWAIT_RESPONSEDONE | SDIOWAIT_ERROR);
             }
 
@@ -1096,7 +1102,7 @@ static int esp32s3_interrupt(int irq, void *context, void *arg)
   pending = esp32s3_getreg(ESP32S3_SDMMC_IDSTS);
   if ((pending & priv->dmamask) != 0)
     {
-      mcerr("ERROR: IDTS=%08lx\n", (unsigned long)pending);
+      mcerr("ERROR: IDTS=%08" PRIx32 "\n", (unsigned long)pending);
 
       /* Clear the pending interrupts */
 
@@ -1684,7 +1690,7 @@ static int esp32s3_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
   struct esp32s3_dev_s *priv = (struct esp32s3_dev_s *)dev;
   uint32_t regval = 0;
 
-  mcinfo("cmd=%04x arg=%04x\n", cmd, arg);
+  mcinfo("cmd=%04lx arg=%04lx\n", cmd, arg);
 
   if (cmd == MMCSD_CMD12)
     {
@@ -1814,7 +1820,7 @@ static int esp32s3_recvsetup(struct sdio_dev_s *dev, uint8_t *buffer,
   uint32_t regval;
 #endif
 
-  mcinfo("nbytes=%ld\n", (long) nbytes);
+  mcinfo("nbytes=%" PRId32 "\n", (long) nbytes);
 
   DEBUGASSERT(priv != NULL && buffer != NULL && nbytes > 0);
   DEBUGASSERT(((uint32_t)buffer & 3) == 0);
@@ -1880,7 +1886,7 @@ static int esp32s3_sendsetup(struct sdio_dev_s *dev, const uint8_t *buffer,
   uint32_t regval;
 #endif
 
-  mcinfo("nbytes=%ld\n", (long)nbytes);
+  mcinfo("nbytes=%" PRId32 "\n", (long)nbytes);
 
   DEBUGASSERT(priv != NULL && buffer != NULL && nbytes > 0);
   DEBUGASSERT(((uint32_t)buffer & 3) == 0);
@@ -1990,7 +1996,7 @@ static int esp32s3_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
   volatile int32_t timeout;
   clock_t watchtime;
 
-  mcinfo("cmd=%04x\n", cmd);
+  mcinfo("cmd=%04lx\n", cmd);
 
   switch (cmd & MMCSD_RESPONSE_MASK)
     {
@@ -2021,7 +2027,7 @@ static int esp32s3_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
     {
       if (clock_systime_ticks() - watchtime > timeout)
         {
-          mcerr("ERROR: Timeout cmd: %04x STA: %08x RINTSTS: %08x\n",
+          mcerr("ERROR: Timeout cmd: %04lx STA: %08lx RINTSTS: %08lx\n",
                 cmd, esp32s3_getreg(ESP32S3_SDMMC_STATUS),
                 esp32s3_getreg(ESP32S3_SDMMC_RINTSTS));
 
@@ -2033,7 +2039,7 @@ static int esp32s3_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
 
   if (esp32s3_getreg(ESP32S3_SDMMC_RINTSTS) & SDCARD_INT_RESPERR)
     {
-      mcerr("ERROR: SDMMC failure cmd: %04x STA: %08x RINTSTS: %08x\n",
+      mcerr("ERROR: SDMMC failure cmd: %04lx STA: %08lx RINTSTS: %08lx\n",
             cmd, esp32s3_getreg(ESP32S3_SDMMC_STATUS),
             esp32s3_getreg(ESP32S3_SDMMC_RINTSTS));
       ret = -EIO;
@@ -2071,7 +2077,7 @@ static int esp32s3_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
   uint32_t regval;
   int ret = OK;
 
-  mcinfo("cmd=%04x\n", cmd);
+  mcinfo("cmd=%04lx\n", cmd);
 
   /* R1  Command response (48-bit)
    *     47        0               Start bit
@@ -2108,7 +2114,7 @@ static int esp32s3_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R1B_RESPONSE &&
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R6_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%04x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%04lx\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2119,12 +2125,12 @@ static int esp32s3_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
       regval = esp32s3_getreg(ESP32S3_SDMMC_RINTSTS);
       if ((regval & SDMMC_INT_RTO) != 0)
         {
-          mcerr("ERROR: Command timeout: %08x\n", regval);
+          mcerr("ERROR: Command timeout: %08lx\n", regval);
           ret = -ETIMEDOUT;
         }
       else if ((regval & SDMMC_INT_RCRC) != 0)
         {
-          mcerr("ERROR: CRC failure: %08x\n", regval);
+          mcerr("ERROR: CRC failure: %08lx\n", regval);
           ret = -EIO;
         }
     }
@@ -2136,7 +2142,7 @@ static int esp32s3_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
   esp32s3_putreg(SDCARD_RESPDONE_CLEAR | SDCARD_CMDDONE_CLEAR,
                  ESP32S3_SDMMC_RINTSTS);
   *rshort = esp32s3_getreg(ESP32S3_SDMMC_RESP0);
-  mcinfo("CRC=%04x\n", *rshort);
+  mcinfo("CRC=%04lx\n", *rshort);
 
   return ret;
 }
@@ -2169,7 +2175,7 @@ static int esp32s3_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
   uint32_t regval;
   int ret = OK;
 
-  mcinfo("cmd=%04x\n", cmd);
+  mcinfo("cmd=%04lx\n", cmd);
 
   /* R2  CID, CSD register (136-bit)
    *     135       0               Start bit
@@ -2185,7 +2191,7 @@ static int esp32s3_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
 
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R2_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%04x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%04lx\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2196,12 +2202,12 @@ static int esp32s3_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
       regval = esp32s3_getreg(ESP32S3_SDMMC_RINTSTS);
       if (regval & SDMMC_INT_RTO)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08lx\n", regval);
           ret = -ETIMEDOUT;
         }
       else if (regval & SDMMC_INT_RCRC)
         {
-          mcerr("ERROR: CRC fail STA: %08x\n", regval);
+          mcerr("ERROR: CRC fail STA: %08lx\n", regval);
           ret = -EIO;
         }
     }
@@ -2249,7 +2255,7 @@ static int esp32s3_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
   uint32_t regval;
   int ret = OK;
 
-  mcinfo("cmd=%04x\n", cmd);
+  mcinfo("cmd=%04lx\n", cmd);
 
   /* R3  OCR (48-bit)
    *     47        0               Start bit
@@ -2266,7 +2272,7 @@ static int esp32s3_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R3_RESPONSE &&
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R7_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%04x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%04lx\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2279,7 +2285,7 @@ static int esp32s3_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
       regval = esp32s3_getreg(ESP32S3_SDMMC_RINTSTS);
       if (regval & SDMMC_INT_RTO)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08lx\n", regval);
           ret = -ETIMEDOUT;
         }
     }
@@ -2742,7 +2748,7 @@ static int esp32s3_dmasendsetup(struct sdio_dev_s *dev,
 
   DEBUGASSERT(priv != NULL);
 
-  mcinfo("buflen=%lu\n", (unsigned long)buflen);
+  mcinfo("buflen=%" PRIu32 "\n", (unsigned long)buflen);
   DEBUGASSERT(buffer != NULL && buflen > 0 && ((uint32_t)buffer & 3) == 0);
 
   /* Save the destination buffer information for use by the interrupt

--- a/arch/xtensa/src/esp32s3/esp32s3_spi_timing.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi_timing.c
@@ -1013,11 +1013,11 @@ static void sweep_for_success_sample_points(const uint8_t *reference_data,
       if (memcmp(reference_data, read_data, sizeof(read_data)) == 0)
         {
           out_array[config_idx] = 1;
-          minfo("%d, good\n", config_idx);
+          minfo("%" PRIu32 ", good\n", config_idx);
         }
       else
         {
-          minfo("%d, bad\n", config_idx);
+          minfo("%" PRIu32 ", bad\n", config_idx);
         }
     }
 }
@@ -1156,7 +1156,7 @@ static uint32_t select_best_tuning_config_dtr(tuning_config_s *config,
       /* tuning is FAIL, select default point, and generate a warning */
 
       best_point = config->default_config_id;
-      minfo("tuning fail, best point is fallen back to index %d\n",
+      minfo("tuning fail, best point is fallen back to index %" PRIu32 "\n",
             best_point);
     }
   else if (consecutive_length <= 4)
@@ -1164,14 +1164,14 @@ static uint32_t select_best_tuning_config_dtr(tuning_config_s *config,
       /* consecutive length :  3 or 4 */
 
       best_point = end - 1;
-      minfo("tuning success, best point is index %d\n", best_point);
+      minfo("tuning success, best point is index %" PRIu32 "\n", best_point);
     }
   else
     {
       /* consecutive point list length equals 5 */
 
       best_point = end - 2;
-      minfo("tuning success, best point is index %d\n", best_point);
+      minfo("tuning success, best point is index %" PRIu32 "\n", best_point);
     }
 
   return best_point;
@@ -1216,7 +1216,7 @@ static void select_best_tuning_config(tuning_config_s *config,
                                                  end);
 #endif
       g_flash_timing_tuning_config = config->config_table[best_point];
-      minfo("Flash timing tuning index: %d\n", best_point);
+      minfo("Flash timing tuning index: %" PRIu32 "\n", best_point);
     }
   else
     {
@@ -1228,7 +1228,7 @@ static void select_best_tuning_config(tuning_config_s *config,
                                                  end);
 #endif
       g_psram_timing_tuning_config = config->config_table[best_point];
-      minfo("PSRAM timing tuning index: %d\n", best_point);
+      minfo("PSRAM timing tuning index: %" PRIu32 "\n", best_point);
     }
 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.c
@@ -407,7 +407,7 @@ int IRAM_ATTR esp_spiram_init_cache(void)
       abort();
     }
 
-  minfo("PSRAM available size = %d\n", psram_size);
+  minfo("PSRAM available size = %" PRIu32 "\n", psram_size);
   mapped_vaddr_size = mmu_valid_space(&g_mapped_vaddr_start);
 
   if ((SPIRAM_VADDR_OFFSET + SPIRAM_VADDR_MAP_SIZE) > 0)
@@ -420,7 +420,8 @@ int IRAM_ATTR esp_spiram_init_cache(void)
                                 SPIRAM_VADDR_MAP_SIZE;
       if (target_mapped_vaddr_start < g_mapped_vaddr_start)
         {
-          mwarn("Invalid target vaddr = 0x%x, change vaddr to: 0x%x\n",
+          mwarn("Invalid target vaddr = 0x%" PRIx32 ", "
+                "change vaddr to: 0x%" PRIx32 "\n",
                 target_mapped_vaddr_start, g_mapped_vaddr_start);
           target_mapped_vaddr_start = g_mapped_vaddr_start;
           ret = ERROR;
@@ -429,7 +430,8 @@ int IRAM_ATTR esp_spiram_init_cache(void)
       if (target_mapped_vaddr_end >
          (g_mapped_vaddr_start + mapped_vaddr_size))
         {
-          mwarn("Invalid vaddr map size: 0x%x, change vaddr end: 0x%x\n",
+          mwarn("Invalid vaddr map size: 0x%x, change vaddr end: "
+                "0x%" PRIx32 "\n",
                 SPIRAM_VADDR_MAP_SIZE,
                 g_mapped_vaddr_start + mapped_vaddr_size);
           target_mapped_vaddr_end = g_mapped_vaddr_start + mapped_vaddr_size;
@@ -448,8 +450,8 @@ int IRAM_ATTR esp_spiram_init_cache(void)
       /* Decide these logics when there's a real PSRAM with larger size */
 
       g_mapped_size = mapped_vaddr_size;
-      mwarn("Virtual address not enough for PSRAM, only %d size is mapped!",
-            g_mapped_size);
+      mwarn("Virtual address not enough for PSRAM, only %" PRIu32 " "
+            "size is mapped!", g_mapped_size);
       ret = ERROR;
     }
   else
@@ -457,7 +459,8 @@ int IRAM_ATTR esp_spiram_init_cache(void)
       g_mapped_size = psram_size;
     }
 
-  minfo("Virtual address size = 0x%x, start: 0x%x, end: 0x%x\n",
+  minfo("Virtual address size = 0x%" PRIx32 ", start: 0x%" PRIx32 ", "
+        "end: 0x%" PRIx32 "\n",
          mapped_vaddr_size, g_mapped_vaddr_start,
          g_mapped_vaddr_start + g_mapped_size);
 
@@ -665,7 +668,8 @@ int IRAM_ATTR esp_spiram_init(void)
     }
 #endif
 
-  minfo("Found %dMB SPI RAM device\n", psram_physical_size / (1024 * 1024));
+  minfo("Found %" PRIu32 "MB SPI RAM device\n",
+        psram_physical_size / (1024 * 1024));
   minfo("Speed: %dMHz\n", CONFIG_ESP32S3_SPIRAM_SPEED);
   minfo("Initialized, cache is in %s mode.\n",
                  (PSRAM_MODE == PSRAM_VADDR_MODE_EVENODD) ?

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -198,8 +198,8 @@ struct nvs_adpt
  ****************************************************************************/
 
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
-static int semphr_take_from_isr_wrapper(void *semphr, void *hptw);
-static int semphr_give_from_isr_wrapper(void *semphr, void *hptw);
+static int32_t semphr_take_from_isr_wrapper(void *semphr, void *hptw);
+static int32_t semphr_give_from_isr_wrapper(void *semphr, void *hptw);
 static int is_in_isr_wrapper(void);
 #endif /* CONFIG_ESPRESSIF_WIFI_BT_COEXIST */
 
@@ -244,8 +244,8 @@ static uint32_t esp_event_group_set_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits);
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick);
 static int32_t esp_task_create_pinned_to_core(void *task_func,
                                               const char *name,
@@ -257,12 +257,17 @@ static int32_t esp_task_create_pinned_to_core(void *task_func,
 static int32_t esp_task_create(void *task_func, const char *name,
                                uint32_t stack_depth, void *param,
                                uint32_t prio, void *task_handle);
+static int32_t esp32s3_event_post(esp_event_base_t event_base,
+                                  int32_t event_id,
+                                  void *event_data,
+                                  size_t event_data_size,
+                                  uint32_t ticks);
 static void esp_task_delete(void *task_handle);
 static void esp_task_delay(uint32_t tick);
 static int32_t esp_task_ms_to_tick(uint32_t ms);
 static void *esp_task_get_current_task(void);
 static int32_t esp_task_get_max_priority(void);
-static void *esp_malloc(uint32_t size);
+static void *esp_malloc(size_t size);
 static void esp_free(void *ptr);
 static uint32_t esp_get_free_heap_size(void);
 static uint32_t esp_rand(void);
@@ -272,7 +277,7 @@ static void wifi_apb80m_request(void);
 static void wifi_apb80m_release(void);
 static void esp_phy_enable_wrapper(void);
 static void esp_phy_disable_wrapper(void);
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type);
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type);
 static void esp_timer_arm(void *timer, uint32_t tmout, bool repeat);
 static void esp_timer_disarm(void *timer);
 static void esp32s3_timer_done(void *timer);
@@ -284,33 +289,33 @@ static void wifi_clock_disable(void);
 static void wifi_rtc_enable_iso(void);
 static void wifi_rtc_disable_iso(void);
 static int64_t esp32s3_timer_get_time(void);
-static int32_t esp_nvs_set_i8(uint32_t handle, const char *key,
-                              int8_t value);
-static int32_t esp_nvs_get_i8(uint32_t handle, const char *key,
-                              int8_t *out_value);
-static int32_t esp_nvs_set_u8(uint32_t handle, const char *key,
-                              uint8_t value);
-static int32_t esp_nvs_get_u8(uint32_t handle, const char *key,
-                              uint8_t *out_value);
-static int32_t esp_nvs_set_u16(uint32_t handle, const char *key,
-                               uint16_t value);
-static int32_t esp_nvs_get_u16(uint32_t handle, const char *key,
-                               uint16_t *out_value);
-static int32_t esp_nvs_open(const char *name, uint32_t open_mode,
-                            uint32_t *out_handle);
+static int esp_nvs_set_i8(uint32_t handle, const char *key,
+                          int8_t value);
+static int esp_nvs_get_i8(uint32_t handle, const char *key,
+                          int8_t *out_value);
+static int esp_nvs_set_u8(uint32_t handle, const char *key,
+                          uint8_t value);
+static int esp_nvs_get_u8(uint32_t handle, const char *key,
+                          uint8_t *out_value);
+static int esp_nvs_set_u16(uint32_t handle, const char *key,
+                           uint16_t value);
+static int esp_nvs_get_u16(uint32_t handle, const char *key,
+                           uint16_t *out_value);
+static int esp_nvs_open(const char *name, unsigned int open_mode,
+                        uint32_t *out_handle);
 static void esp_nvs_close(uint32_t handle);
-static int32_t esp_nvs_commit(uint32_t handle);
-static int32_t esp_nvs_set_blob(uint32_t handle, const char *key,
+static int esp_nvs_commit(uint32_t handle);
+static int esp_nvs_set_blob(uint32_t handle, const char *key,
                                 const void *value, size_t length);
-static int32_t esp_nvs_get_blob(uint32_t handle, const char *key,
+static int esp_nvs_get_blob(uint32_t handle, const char *key,
                                 void *out_value, size_t *length);
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key);
-static int32_t esp_get_random(uint8_t *buf, size_t len);
-static int32_t esp_get_time(void *t);
+static int esp_nvs_erase_key(uint32_t handle, const char *key);
+static int esp_get_random(uint8_t *buf, size_t len);
+static int esp_get_time(void *t);
 static uint32_t esp_clk_slowclk_cal_get_wrapper(void);
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args);
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...);
 static void *esp_malloc_internal(size_t size);
@@ -321,16 +326,16 @@ static void *esp_wifi_malloc(size_t size);
 static void *esp_wifi_realloc(void *ptr, size_t size);
 static void *esp_wifi_calloc(size_t n, size_t size);
 static void *esp_wifi_zalloc(size_t size);
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size);
+static void *esp_wifi_create_queue(int queue_len, int item_size);
 static void esp_wifi_delete_queue(void *queue);
 static int coex_init_wrapper(void);
 static void coex_deinit_wrapper(void);
 static int coex_enable_wrapper(void);
 static void coex_disable_wrapper(void);
 static uint32_t coex_status_get_wrapper(void);
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
                                      uint32_t duration);
-static int32_t coex_wifi_release_wrapper(uint32_t event);
+static int coex_wifi_release_wrapper(uint32_t event);
 static unsigned long esp_random_ulong(void);
 static int coex_wifi_channel_set_wrapper(uint8_t primary, uint8_t secondary);
 static int coex_event_duration_get_wrapper(uint32_t event,
@@ -487,7 +492,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs =
   ._task_get_max_priority = esp_task_get_max_priority,
   ._malloc = esp_malloc,
   ._free = esp_free,
-  ._event_post = esp_event_post,
+  ._event_post = esp32s3_event_post,
   ._get_free_heap_size = esp_get_free_heap_size,
   ._rand = esp_rand,
   ._dport_access_stall_other_cpu_start_wrap =
@@ -791,7 +796,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   struct irq_adpt *adapter;
   int irq = n + XTENSA_IRQ_FIRSTPERIPH;
 
-  wlinfo("n=%d f=%p arg=%p", n, f, arg);
+  wlinfo("n=%" PRId32 " f=%p arg=%p", n, f, arg);
 
   if (g_irqvector[irq].handler &&
       g_irqvector[irq].handler != irq_unexpected_isr)
@@ -805,7 +810,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   adapter = kmm_malloc(tmp);
   if (!adapter)
     {
-      wlerr("Failed to alloc %d memory\n", tmp);
+      wlerr("Failed to alloc %" PRIu32 " memory\n", tmp);
       PANIC();
       return;
     }
@@ -848,7 +853,7 @@ static void esp32s3_ints_on(uint32_t mask)
 {
   int irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=%08" PRIx32 " irq=%d\n", mask, irq);
 
   up_enable_irq(ESP32S3_IRQ_MAC);
   up_enable_irq(ESP32S3_IRQ_PWR);
@@ -872,7 +877,7 @@ static void esp32s3_ints_off(uint32_t mask)
 {
   uint32_t irq = __builtin_ffs(mask) - 1;
 
-  wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
+  wlinfo("INFO mask=%08" PRIx32 " irq=%" PRIu32 "\n", mask, irq);
 
   up_disable_irq(ESP32S3_IRQ_MAC);
 }
@@ -1112,7 +1117,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t block_time_tick)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %u ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %" PRIu32 " ticks. Error=%d\n",
             block_time_tick, ret);
     }
 
@@ -1755,8 +1760,8 @@ static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits)
 
 static uint32_t esp_event_group_wait_bits(void *event,
                                           uint32_t bits_to_wait_for,
-                                          int32_t clear_on_exit,
-                                          int32_t wait_for_all_bits,
+                                          int clear_on_exit,
+                                          int wait_for_all_bits,
                                           uint32_t block_time_tick)
 {
   DEBUGPANIC();
@@ -1980,7 +1985,7 @@ static int32_t esp_task_get_max_priority(void)
  *
  ****************************************************************************/
 
-static void *esp_malloc(uint32_t size)
+static void *esp_malloc(size_t size)
 {
   return kmm_malloc(size);
 }
@@ -2269,7 +2274,7 @@ static void esp_evt_work_cb(void *arg)
                                    SI_QUEUE, &notify->work);
           if (ret < 0)
             {
-              wlwarn("nxsig_notification event ID=%d failed: %d\n",
+              wlwarn("nxsig_notification event ID=%" PRId32 " failed: %d\n",
                      evt_adpt->id, ret);
             }
         }
@@ -2298,7 +2303,8 @@ static void esp_evt_work_cb(void *arg)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   *(int *)hptw = 0;
 
@@ -2320,7 +2326,8 @@ static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr, void *hptw)
+static int32_t IRAM_ATTR semphr_give_from_isr_wrapper(void *semphr,
+                                                      void *hptw)
 {
   *(int *)hptw = 0;
 
@@ -2403,7 +2410,7 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
 }
 
 /****************************************************************************
- * Name: esp_event_post
+ * Name: esp32s3_event_post
  *
  * Description:
  *   Active work queue and let the work to process the cached event
@@ -2420,24 +2427,25 @@ static void IRAM_ATTR wifi_clear_intr(uint32_t intr_source,
  *
  ****************************************************************************/
 
-int32_t esp_event_post(esp_event_base_t event_base,
-                       int32_t event_id,
-                       void *event_data,
-                       size_t event_data_size,
-                       uint32_t ticks)
+int32_t esp32s3_event_post(esp_event_base_t event_base,
+                           int32_t event_id,
+                           void *event_data,
+                           size_t event_data_size,
+                           uint32_t ticks)
 {
   size_t size;
   int32_t id;
   irqstate_t flags;
   struct evt_adpt *evt_adpt;
 
-  wlinfo("Event: base=%s id=%d data=%p data_size=%d ticks=%u\n", event_base,
-         event_id, event_data, event_data_size, ticks);
+  wlinfo("Event: base=%s id=%" PRId32 " data=%p data_size=%d "
+         "ticks=%" PRIu32 "\n",
+         event_base, event_id, event_data, event_data_size, ticks);
 
   id = esp_event_id_map(event_id);
   if (id < 0)
     {
-      wlinfo("No process event %d\n", event_id);
+      wlinfo("No process event %" PRId32 "\n", event_id);
       return -1;
     }
 
@@ -2602,7 +2610,7 @@ static void esp_phy_disable_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t esp_wifi_read_mac(uint8_t *mac, uint32_t type)
+static int esp_wifi_read_mac(uint8_t *mac, unsigned int type)
 {
   return esp_read_mac(mac, type);
 }
@@ -2889,9 +2897,9 @@ int64_t esp32s3_timer_get_time(void)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_i8(uint32_t handle,
-                              const char *key,
-                              int8_t value)
+static int esp_nvs_set_i8(uint32_t handle,
+                          const char *key,
+                          int8_t value)
 {
   DEBUGPANIC();
 
@@ -2914,9 +2922,9 @@ static int32_t esp_nvs_set_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_i8(uint32_t handle,
-                              const char *key,
-                              int8_t *out_value)
+static int esp_nvs_get_i8(uint32_t handle,
+                          const char *key,
+                          int8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2939,9 +2947,9 @@ static int32_t esp_nvs_get_i8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t value)
+static int esp_nvs_set_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t value)
 {
   DEBUGPANIC();
 
@@ -2964,9 +2972,9 @@ static int32_t esp_nvs_set_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u8(uint32_t handle,
-                              const char *key,
-                              uint8_t *out_value)
+static int esp_nvs_get_u8(uint32_t handle,
+                          const char *key,
+                          uint8_t *out_value)
 {
   DEBUGPANIC();
 
@@ -2989,9 +2997,9 @@ static int32_t esp_nvs_get_u8(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t value)
+static int esp_nvs_set_u16(uint32_t handle,
+                           const char *key,
+                           uint16_t value)
 {
   DEBUGPANIC();
 
@@ -3014,9 +3022,9 @@ static int32_t esp_nvs_set_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_u16(uint32_t handle,
-                               const char *key,
-                               uint16_t *out_value)
+static int esp_nvs_get_u16(uint32_t handle,
+                           const char *key,
+                           uint16_t *out_value)
 {
   DEBUGPANIC();
 
@@ -3039,9 +3047,9 @@ static int32_t esp_nvs_get_u16(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_open(const char *name,
-                            uint32_t open_mode,
-                            uint32_t *out_handle)
+static int esp_nvs_open(const char *name,
+                        unsigned int open_mode,
+                        uint32_t *out_handle)
 {
   DEBUGPANIC();
 
@@ -3075,7 +3083,7 @@ static void esp_nvs_close(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_commit(uint32_t handle)
+static int esp_nvs_commit(uint32_t handle)
 {
   return 0;
 }
@@ -3097,7 +3105,7 @@ static int32_t esp_nvs_commit(uint32_t handle)
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_set_blob(uint32_t handle,
+static int esp_nvs_set_blob(uint32_t handle,
                                 const char *key,
                                 const void *value,
                                 size_t length)
@@ -3124,7 +3132,7 @@ static int32_t esp_nvs_set_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_get_blob(uint32_t handle,
+static int esp_nvs_get_blob(uint32_t handle,
                                 const char *key,
                                 void *out_value,
                                 size_t *length)
@@ -3149,7 +3157,7 @@ static int32_t esp_nvs_get_blob(uint32_t handle,
  *
  ****************************************************************************/
 
-static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
+static int esp_nvs_erase_key(uint32_t handle, const char *key)
 {
   DEBUGPANIC();
 
@@ -3171,7 +3179,7 @@ static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
  *
  ****************************************************************************/
 
-static int32_t esp_get_random(uint8_t *buf, size_t len)
+static int esp_get_random(uint8_t *buf, size_t len)
 {
   esp_fill_random(buf, len);
 
@@ -3192,7 +3200,7 @@ static int32_t esp_get_random(uint8_t *buf, size_t len)
  *
  ****************************************************************************/
 
-static int32_t esp_get_time(void *t)
+static int esp_get_time(void *t)
 {
   int ret;
   struct timeval tv;
@@ -3281,7 +3289,7 @@ static uint32_t esp_clk_slowclk_cal_get_wrapper(void)
  *
  ****************************************************************************/
 
-static void esp_log_writev_wrapper(uint32_t level, const char *tag,
+static void esp_log_writev_wrapper(unsigned int level, const char *tag,
                                    const char *format, va_list args)
 {
   esp_log_level_t max_level;
@@ -3318,7 +3326,7 @@ static void esp_log_writev_wrapper(uint32_t level, const char *tag,
  *
  ****************************************************************************/
 
-static void esp_log_write_wrapper(uint32_t level,
+static void esp_log_write_wrapper(unsigned int level,
                                   const char *tag,
                                   const char *format, ...)
 {
@@ -3594,7 +3602,7 @@ static void *esp_wifi_zalloc(size_t size)
  *
  ****************************************************************************/
 
-static void *esp_wifi_create_queue(int32_t queue_len, int32_t item_size)
+static void *esp_wifi_create_queue(int queue_len, int item_size)
 {
   wifi_static_queue_t *wifi_queue;
 
@@ -3769,8 +3777,8 @@ static IRAM_ATTR uint32_t coex_status_get_wrapper(void)
  *
  ****************************************************************************/
 
-static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
-                                         uint32_t duration)
+static int coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
+                                     uint32_t duration)
 {
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
   return coex_wifi_request(event, latency, duration);
@@ -3794,7 +3802,7 @@ static int32_t coex_wifi_request_wrapper(uint32_t event, uint32_t latency,
  *
  ****************************************************************************/
 
-static IRAM_ATTR int32_t coex_wifi_release_wrapper(uint32_t event)
+static IRAM_ATTR int coex_wifi_release_wrapper(uint32_t event)
 {
 #ifdef CONFIG_ESPRESSIF_WIFI_BT_COEXIST
   return coex_wifi_release(event);
@@ -4252,7 +4260,8 @@ static int esp_wifi_auth_trans(uint32_t wifi_auth)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d", wifi_auth);
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
+              wifi_auth);
         break;
     }
 
@@ -4305,7 +4314,7 @@ static int esp_wifi_cipher_trans(uint32_t wifi_cipher)
         break;
 
       default:
-        wlerr("Failed to transfer wireless authmode: %d",
+        wlerr("Failed to transfer wireless authmode: %" PRIu32 "",
                wifi_cipher);
         break;
     }
@@ -4500,8 +4509,8 @@ int32_t esp_event_send_internal(esp_event_base_t event_base,
 {
   int32_t ret;
 
-  ret = esp_event_post(event_base, event_id, event_data,
-                       event_data_size, ticks_to_wait);
+  ret = esp32s3_event_post(event_base, event_id, event_data,
+                           event_data_size, ticks_to_wait);
 
   return ret;
 }
@@ -4850,7 +4859,7 @@ errout:
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len)
+int esp_wifi_sta_send_data(void *pbuf, size_t len)
 {
   int ret;
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.h
@@ -200,7 +200,7 @@ int esp_wifi_sta_stop(void);
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(void *pbuf, uint32_t len);
+int esp_wifi_sta_send_data(void *pbuf, size_t len);
 
 /****************************************************************************
  * Name: esp_wifi_sta_register_recv_cb

--- a/boards/xtensa/esp32/esp32-audio-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-audio-kit/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/esp32-lyrat/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-lyrat/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/esp32-pico-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-pico-kit/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_gpio.c
@@ -215,7 +215,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32gpio->id]);
 
   *value = esp32_gpioread(g_gpioinputs[esp32gpio->id]);
   return OK;

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_gpio.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32s3gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s3gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32s3gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32s3gpio->id]);
 
   *value = esp32s3_gpioread(g_gpioinputs[esp32s3gpio->id]);
   return OK;

--- a/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_gpio.c
+++ b/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_gpio.c
@@ -211,7 +211,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32s3gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s3gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32s3gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32s3gpio->id]);
 
   *value = esp32s3_gpioread(g_gpioinputs[esp32s3gpio->id]);
   return OK;

--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_gpio.c
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_gpio.c
@@ -214,7 +214,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32s3gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s3gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32s3gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32s3gpio->id]);
 
   *value = esp32s3_gpioread(g_gpioinputs[esp32s3gpio->id]);
   return OK;

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_gpio.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_gpio.c
@@ -209,7 +209,7 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
 
   DEBUGASSERT(esp32s3gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s3gpio->id < BOARD_NGPIOIN);
-  gpioinfo("Reading... pin %d\n", g_gpioinputs[esp32s3gpio->id]);
+  gpioinfo("Reading... pin %" PRIu32 "\n", g_gpioinputs[esp32s3gpio->id]);
 
   *value = esp32s3_gpioread(g_gpioinputs[esp32s3gpio->id]);
   return OK;


### PR DESCRIPTION
## Summary

Modify `types.h` and `inttypes.h` to use the correct `_int32_t` and `_uint32_t` types, on Xtensa arch.

This PR solves an issue first mentioned in #15755.

Type is now defined according to recent compiler versions.

On xtensa-esp32-gcc version 8.4.0 we have:
```
#define __INT32_TYPE__ int
#define __UINT32_TYPE__ unsigned int
```

While version 12.2.0 has:
```
#define __INT32_TYPE__ long int
#define __UINT32_TYPE__ long unsigned int
```

Due to this type modification, many logging calls had to be fixed with the proper format specifiers: %u, %lu, %ld, etc across arch and board files.

## Impact

- Impact on user: No.
- Impact on build: Yes, but all fixes are present in this PR.
- Impact on hardware: Yes, Xtensa devices only.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: Yes, improves compatibility since it uses the proper int types as specified by the compiler.

## Testing

Most tests done on Espressif's internal CI. Each build that failed had the error fixed, resulting in the commits of this PR.
Since errors are all logging related, the build system should catch everything.

Tested build on all defconfigs for:
- esp32-devkitc
- esp32-ethernet-kit
- esp32-lyrat
- esp32-pico-kit
- esp32-wrover-kit
- esp32s2-saola-1
- esp32s3-devkit
- esp32s3-korvo-2
- esp32s3-lcd-ev