### PR TITLE
arch/risc-v/mpfs: Remove big kernel lock from several drivers

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -409,6 +409,7 @@ union wb_u
 
 struct mpfs_rqhead_s
 {
+  spinlock_t            qlock;         /* Lock to protect access to the queue */
   struct mpfs_req_s     *head;         /* Requests are added to the head of the list */
   struct mpfs_req_s     *tail;         /* Requests are removed from the tail of the list */
 };
@@ -417,6 +418,7 @@ struct mpfs_ep_s
 {
   struct usbdev_ep_s    ep;           /* Standard endpoint structure */
 
+  spinlock_t            eplock;       /* Lock for endpoint access */
   struct mpfs_usbdev_s  *dev;         /* Reference to private driver data */
   struct mpfs_rqhead_s  reqq;         /* Read/write request queue */
   struct mpfs_rqhead_s  pendq;        /* Write requests pending stall sent */
@@ -446,6 +448,10 @@ struct mpfs_usbdev_s
   /* The bound device class driver */
 
   struct usbdevclass_driver_s *driver;
+
+  /* Device specific fields */
+
+  spinlock_t           lock;          /* Device lock */
 
   /* USB-specific fields */
 

--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -421,6 +421,7 @@ struct mpfs_ep_s
   struct mpfs_rqhead_s  reqq;         /* Read/write request queue */
   struct mpfs_rqhead_s  pendq;        /* Write requests pending stall sent */
   struct usbdev_epdesc_s *descb[2];   /* Pointers to this endpoint descriptors */
+  uint32_t              linkdead;     /* Remote end has closed the connection */
   volatile uint8_t      epstate;      /* State of the endpoint (see enum mpfs_epstate_e) */
   uint8_t               stalled:1;    /* true: Endpoint is stalled */
   uint8_t               pending:1;    /* true: IN Endpoint stall is pending */

--- a/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
+++ b/arch/risc-v/src/mpfs/mpfs_sdio_dev.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/sdio.h>
+#include <nuttx/spinlock.h>
 #include <stdbool.h>
 #include <sys/types.h>
 
@@ -48,6 +49,7 @@ struct mpfs_dev_s
   const int wrcomplete_irq; /* Card write complete interrupt */
 #endif
   bool clk_enabled;        /* Clk state */
+  spinlock_t lock;         /* Lock for device access */
 
   /* eMMC / SD and HW parameters */
 

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -130,6 +130,8 @@
 #define MPFS_MIN_EP_FIFO_SIZE 8
 #define MPFS_USB_REG_MAX      0x2000
 
+#define LINKDEAD_THRESHOLD    20
+
 /* Request queue operations *************************************************/
 
 #define mpfs_rqempty(q)      ((q)->head == NULL)
@@ -228,6 +230,7 @@ static spinlock_t g_mpfs_modifyreg_lock = SP_UNLOCKED;
 
 static struct mpfs_usbdev_s g_usbd;
 static uint8_t g_clkrefs;
+static bool    g_linkdead;
 
 static const struct usbdev_epops_s g_epops =
 {
@@ -771,11 +774,26 @@ static int mpfs_req_wrsetup(struct mpfs_usbdev_s *priv,
 
   if (nbytes > packetsize)
     {
-      ret = mpfs_write_tx_fifo(buf, packetsize, epno);
-      if (ret != OK)
+      if (privep->linkdead < LINKDEAD_THRESHOLD)
         {
-          privep->epstate = USB_EPSTATE_IDLE;
-          return ret;
+          ret = mpfs_write_tx_fifo(buf, packetsize, epno);
+          if (ret != OK)
+            {
+              privep->linkdead++;
+              privep->epstate = USB_EPSTATE_IDLE;
+              return ret;
+            }
+          else
+            {
+              privep->linkdead = 0;
+            }
+        }
+      else
+        {
+          /* We're in trouble, remote has likely closed */
+
+          g_linkdead = true;
+          return -EIO;
         }
 
       if (epno == EP0)
@@ -796,11 +814,26 @@ static int mpfs_req_wrsetup(struct mpfs_usbdev_s *priv,
     }
   else
     {
-      ret = mpfs_write_tx_fifo(buf, nbytes, epno);
-      if (ret != OK)
+      if (privep->linkdead < LINKDEAD_THRESHOLD)
         {
-          privep->epstate = USB_EPSTATE_IDLE;
-          return ret;
+          ret = mpfs_write_tx_fifo(buf, nbytes, epno);
+          if (ret != OK)
+            {
+              privep->linkdead++;
+              privep->epstate = USB_EPSTATE_IDLE;
+              return ret;
+            }
+          else
+            {
+              privep->linkdead = 0;
+            }
+        }
+      else
+        {
+          /* We're in trouble, remote has likely closed */
+
+          g_linkdead = true;
+          return -EIO;
         }
     }
 
@@ -2443,6 +2476,8 @@ static void mpfs_reset(struct mpfs_usbdev_s *priv)
 
       mpfs_req_cancel(privep, -ESHUTDOWN);
 
+      privep->linkdead  = 0;
+
       /* Reset endpoint status */
 
       privep->stalled   = false;
@@ -3455,11 +3490,28 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
     {
       for (i = 0; i < MPFS_USB_NENDPOINTS; i++)
         {
+          /* Check if dead connections are back in business */
+
+          if (g_linkdead)
+            {
+              /* This releases all, which is a problem if only some
+               * endpoints are closed on the remote; whereas some
+               * are functioning; for example ACM and mass storage;
+               * now the functioning one likely marks the closed ones
+               * as no longer dead.
+               */
+
+              struct mpfs_ep_s *privep = &priv->eplist[i];
+              privep->linkdead = 0;
+            }
+
           if ((pending_rx_ep & (1 << i)) != 0)
             {
               mpfs_ep_rx_interrupt(priv, i);
             }
         }
+
+      g_linkdead = false;
     }
 
   if ((isr & SUSPEND_IRQ_MASK) != 0)


### PR DESCRIPTION
## Summary

This replaces the big kernel lock (enter/leave_critical_section()) with local spinlocks from all MPFS drivers that still use it. The reason is obviously to alleviate big kernel lock congestion which has a massive performance impact in SMP

## Impact

Only the MPFS target is impacted.
App impact: No
Doc impact: No
Build system impact: No

## Testing

Tested with private downstream MPFS target that uses all of the changed drivers.

