### PR TITLE
Documentation/benchmarks/mtd: Add MTD transfer rate test app docs.

### DIFF
--- a/Documentation/applications/benchmarks/mtd/index.rst
+++ b/Documentation/applications/benchmarks/mtd/index.rst
@@ -1,0 +1,31 @@
+============================================
+``mtd`` MTD test and transfer rate benchmark
+============================================
+
+This testing/benchmark application performs an erase/write operation to
+evaluate write transfer rate and then reads the written content back to
+evaluate the read transfer rate. Finally, it compares the read data with
+the previously written data to ensure the MTD device is working as expected.
+
+EXAMPLE::
+
+  nsh> mtd /dev/mtdblock0
+  FLASH Test on device with:
+    Sector size:        4096
+    Sector count:        256
+    Erase block:        4096
+    Total size:      1048576
+
+  Starting write operation...
+
+  Write operation completed in 5.46 seconds
+  Total bytes written: 1048576
+  Transfer rate [write]: 187.55 KiB/s
+
+  Starting read operation...
+
+  Read operation completed in 0.11 seconds
+  Total bytes read: 1048576
+  Transfer rate [read]: 9309.09 KiB/s
+
+  Data verification successful: read data matches written data


### PR DESCRIPTION
## Summary

Add documentation entry for the `mtd` application (https://github.com/apache/nuttx-apps/pull/3033).

## Impact

Impact on user: NO.

Impact on build: NO.

Impact on hardware: NO.

Impact on documentation: YES.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Build the documentation with:

```
$ cd Documentation; make HTML
Removing everything under '_build'...
Running Sphinx v8.1.3
loading translations [en]... done
Converting `source_suffix = ['.rst', '.md']` to `source_suffix = {'.rst': 'restructuredtext', '.md': 'restructuredtext'}`.
myst v4.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 1231 source files that are out of date
updating environment: [new config] 1231 added, 0 changed, 0 removed
reading sources... [100%] substitutions
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/components/drivers/special/power/pm/index.rst: document is referenced in multiple toctrees: ['components/drivers/special/power/index', 'guides/changing_systemclockconfig'], selecting: guides/changing_systemclockconfig <- components/drivers/special/power/pm/index
/home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/goldfish/goldfish_timer.rst: document is referenced in multiple toctrees: ['platforms/arm/goldfish/index', 'platforms/arm/index'], selecting: platforms/arm/index <- platforms/arm/goldfish/goldfish_timer
/home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/platforms/arm/nrf52/ieee802154.rst: document is referenced in multiple toctrees: ['platforms/arm/index', 'platforms/arm/nrf52/index'], selecting: platforms/arm/nrf52/index <- platforms/arm/nrf52/ieee802154
/home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/platforms/sim/network_linux.rst: document is referenced in multiple toctrees: ['platforms/index', 'platforms/sim/index'], selecting: platforms/sim/index <- platforms/sim/network_linux
/home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/platforms/sim/network_vpnkit.rst: document is referenced in multiple toctrees: ['platforms/index', 'platforms/sim/index'], selecting: platforms/sim/index <- platforms/sim/network_vpnkit
done
preparing documents... done
copying assets... 
copying downloadable files... [100%] platforms/xtensa/esp32s2/boards/esp32s2-saola-1/tone.wav
copying static files... 
Writing evaluated template result to /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/_build/html/_static/language_data.js
Writing evaluated template result to /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/_build/html/_static/documentation_options.js
Writing evaluated template result to /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/_build/html/_static/basic.css
Writing evaluated template result to /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/_build/html/_static/js/versions.js
Writing evaluated template result to /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace/nuttx/Documentation/_build/html/_static/copybutton.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [100%] substitutions
generating indices... genindex done
writing additional pages... search done
copying images... [ 78%] platforms/xtensa/esp32/boards/esp32-lyrat/esp32-lyrat-v4.3-electrical-block-diagram-with-wrovcopying images... [ 91%] platforms/xtensa/esp32s3/boards/esp32s3-korvo-2/esp32-s3-korvo-2-v3.0-electrical-block-diagracopying images... [ 96%] platforms/xtensa/esp32s3/boards/esp32s3-korvo-2/esp32-s3-korvo-2-v3.0-aec-signal-collection.pcopying images... [100%] _static/images/menuconfig-debug.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.
```