### PR TITLE
boards/nucleo-f302r8: add ADC support

### DIFF
--- a/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
+++ b/boards/arm/stm32/nucleo-f302r8/src/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 
 if(CONFIG_BOARD_STM32_IHM07M1)
   list(APPEND SRCS stm32_foc_ihm07m1.c)
+else()
+  if(CONFIG_ADC)
+    list(APPEND SRCS stm32_adc.c)
+  endif()
 endif()
 
 if(CONFIG_STM32_CAN)

--- a/boards/arm/stm32/nucleo-f302r8/src/Make.defs
+++ b/boards/arm/stm32/nucleo-f302r8/src/Make.defs
@@ -48,6 +48,10 @@ endif
 
 ifeq ($(CONFIG_BOARD_STM32_IHM07M1),y)
 CSRCS += stm32_foc_ihm07m1.c
+else
+ifeq ($(CONFIG_ADC),y)
+CSRCS += stm32_adc.c
+endif
 endif
 
 ifeq ($(CONFIG_STM32_CAN),y)

--- a/boards/arm/stm32/nucleo-f302r8/src/stm32_adc.c
+++ b/boards/arm/stm32/nucleo-f302r8/src/stm32_adc.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * boards/arm/stm32/nucleo-f302r8/src/stm32_adc.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+
+#include <nuttx/analog/adc.h>
+
+#include "stm32.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_STM32_ADC1
+#  error ADC1 support must be enabled
+#endif
+
+#ifndef CONFIG_STM32_ADC1_DMA
+#  error ADC1 DMA support must be enabled
+#endif
+
+#define ADC1_NCHANNELS 4
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Use CN8 pins 35, 36, 37 and 38 */
+
+static const uint8_t  g_adc1_chanlist[ADC1_NCHANNELS] =
+{
+  6, 7, 8, 9
+};
+
+static const uint32_t g_adc1_pinlist[ADC1_NCHANNELS]  =
+{
+  GPIO_ADC1_IN6,                /* PC0 */
+  GPIO_ADC1_IN7,                /* PC1 */
+  GPIO_ADC1_IN8,                /* PC2 */
+  GPIO_ADC1_IN9,                /* PC3 */
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_adc_setup
+ *
+ * Description:
+ *   Initialize ADC and register the ADC driver.
+ *
+ ****************************************************************************/
+
+int stm32_adc_setup(void)
+{
+  struct adc_dev_s *adc;
+  int ret;
+  int i;
+
+  /* Configure the pins as analog inputs for the selected channels */
+
+  for (i = 0; i < ADC1_NCHANNELS; i++)
+    {
+      stm32_configgpio(g_adc1_pinlist[i]);
+    }
+
+  /* Call stm32_adcinitialize() to get an instance of the ADC interface */
+
+  adc = stm32_adcinitialize(1, g_adc1_chanlist, ADC1_NCHANNELS);
+  if (adc == NULL)
+    {
+      aerr("ERROR: Failed to get ADC interface\n");
+      return -ENODEV;
+    }
+
+  /* Register the ADC driver at "/dev/adc0" */
+
+  ret = adc_register("/dev/adc0", adc);
+  if (ret < 0)
+    {
+      aerr("ERROR: adc_register failed: %d\n", ret);
+      return ret;
+    }
+
+  return OK;
+}


### PR DESCRIPTION
## Summary
Add ADC support for nucleo-f302r8.
CN8 pins 35, 36, 37 and 38 are used.

## Impact

ADC can be used with nucleo-f302r8

## Testing
nucleo-f302r8 with custom example



