### PR TITLE
arch/{rp2040|rp23xx}: remove ADC option from Kconfig

### DIFF
--- a/arch/arm/src/rp2040/Kconfig
+++ b/arch/arm/src/rp2040/Kconfig
@@ -617,14 +617,6 @@ config RP2040_ADC
 
 if RP2040_ADC
 
-config ADC
-	bool "Include ADC device driver"
-	default n
-	---help---
-		Additional ADC device drivers can be set under the
-		"Analog-to-Digital Conversion" item in the
-		"Device Driver/Analog Device Support" menu.
-
 if ADC
 
 config RPC2040_ADC_CHANNEL0

--- a/arch/arm/src/rp23xx/Kconfig
+++ b/arch/arm/src/rp23xx/Kconfig
@@ -741,14 +741,6 @@ config RP23XX_ADC
 
 if RP23XX_ADC
 
-config ADC
-	bool "Include ADC device driver"
-	default n
-	---help---
-		Additional ADC device drivers can be set under the
-		"Analog-to-Digital Conversion" item in the
-		"Device Driver/Analog Device Support" menu.
-
 if ADC
 
 config RP23XX_ADC_CHANNEL0


### PR DESCRIPTION
## Summary
Remove duplicated "config ADC" option which is already defined in `drivers/analog/Kconfig`.

## Impact

probably none

## Testing

CI


