### PR TITLE
{bp-15920] arch/risc-v/espressif: Remove usb serial workaround for esp32 modules

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_usbserial.c
+++ b/arch/risc-v/src/common/espressif/esp_usbserial.c
@@ -216,14 +216,10 @@ static void esp_shutdown(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-/* Workaround: This function does not work when optimization is different
- * from O0. This modification will be removed once a final solution is
- * implemented.
- */
-
-__attribute__((optimize("O0")))
 static void esp_txint(struct uart_dev_s *dev, bool enable)
 {
+  usb_serial_jtag_ll_txfifo_flush();
+
   if (enable)
     {
       usb_serial_jtag_ll_ena_intr_mask(


### PR DESCRIPTION
## Summary
This commit includes a change to the esp_txint function in the arch/risc-v/src/common/espressif/esp_usbserial.c file. The change primarily involves removing an optimization workaround and adding a call to flush the transmit FIFO.

After this change the usbserial config is able to work using all optimization levels.

Changes in esp_txint function:

Removed the __attribute__((optimize("O0"))) workaround. Added a call to usb_serial_jtag_ll_txfifo_flush() at the beginning of the function.

## Impact

RELEASE

## Testing

CI