### PR TITLE
{bp-15922} arch/arm, risc-v: Fix typos in Code Comments

### DIFF
--- a/arch/arm/src/qemu/qemu_allocateheap.c
+++ b/arch/arm/src/qemu/qemu_allocateheap.c
@@ -65,8 +65,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/bl808/bl808_allocateheap.c
+++ b/arch/risc-v/src/bl808/bl808_allocateheap.c
@@ -65,8 +65,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/bl808/bl808_start.c
+++ b/arch/risc-v/src/bl808/bl808_start.c
@@ -224,7 +224,7 @@ void bl808_start_s(int mhartid)
 
   showprogress('B');
 
-  /* Do board initialization */
+  /* TODO: Additional initialization */
 
   showprogress('C');
 

--- a/arch/risc-v/src/bl808/chip.h
+++ b/arch/risc-v/src/bl808/chip.h
@@ -49,8 +49,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/c906/c906_allocateheap.c
+++ b/arch/risc-v/src/c906/c906_allocateheap.c
@@ -63,8 +63,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/jh7110/chip.h
+++ b/arch/risc-v/src/jh7110/chip.h
@@ -49,8 +49,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/jh7110/jh7110_allocateheap.c
+++ b/arch/risc-v/src/jh7110/jh7110_allocateheap.c
@@ -65,8 +65,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/jh7110/jh7110_start.c
+++ b/arch/risc-v/src/jh7110/jh7110_start.c
@@ -99,7 +99,7 @@ void jh7110_start_s(int mhartid)
 
   showprogress('B');
 
-  /* Do board initialization */
+  /* TODO: Additional initialization */
 
   showprogress('C');
 

--- a/arch/risc-v/src/k210/chip.h
+++ b/arch/risc-v/src/k210/chip.h
@@ -43,8 +43,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/k230/chip.h
+++ b/arch/risc-v/src/k230/chip.h
@@ -51,8 +51,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/k230/k230_allocateheap.c
+++ b/arch/risc-v/src/k230/k230_allocateheap.c
@@ -75,8 +75,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/litex/chip.h
+++ b/arch/risc-v/src/litex/chip.h
@@ -40,7 +40,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/mpfs/chip.h
+++ b/arch/risc-v/src/mpfs/chip.h
@@ -44,8 +44,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/mpfs/mpfs_allocateheap.c
+++ b/arch/risc-v/src/mpfs/mpfs_allocateheap.c
@@ -75,8 +75,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/qemu-rv/chip.h
+++ b/arch/risc-v/src/qemu-rv/chip.h
@@ -51,8 +51,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_allocateheap.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_allocateheap.c
@@ -75,8 +75,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -197,7 +197,7 @@ void qemu_rv_start(int mhartid, const char *dtb)
 
   showprogress('B');
 
-  /* Do board initialization */
+  /* TODO: Additional initialization */
 
   showprogress('C');
 

--- a/arch/risc-v/src/sg2000/chip.h
+++ b/arch/risc-v/src/sg2000/chip.h
@@ -49,8 +49,8 @@
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the  "top" the correct interrupt stack
- *   for the current CPU.
+ *   Set the current stack pointer to the "top" of the correct interrupt
+ *   stack for the current CPU.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/sg2000/sg2000_allocateheap.c
+++ b/arch/risc-v/src/sg2000/sg2000_allocateheap.c
@@ -65,8 +65,8 @@
  *   IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
  *   Heap.  Extends to the end of User SRAM.
  *
- *   The following memory map is assumed for the protect build.
- *   The kernel and user space have it's own dedicated heap space.
+ *   The following memory map is assumed for the protected build.
+ *   The kernel and user space have their own dedicated heap spaces.
  *
  *   User .data region         Size determined at link time
  *   User .bss region          Size determined at link time

--- a/arch/risc-v/src/sg2000/sg2000_start.c
+++ b/arch/risc-v/src/sg2000/sg2000_start.c
@@ -223,7 +223,7 @@ void sg2000_start_s(int mhartid)
 
   showprogress('B');
 
-  /* Do board initialization */
+  /* TODO: Additional initialization */
 
   showprogress('C');
 


### PR DESCRIPTION
## Summary
This PR fixes the typos in the Code Comments of chip.h, allocateheap.c and start.c. The typos were discovered here:
- https://github.com/apache/nuttx/pull/15921

## Impact

RELEASE

## Testing

CI

