### PR TITLE
{bp-15941} arch/risc-v/common: Fix unaligned stack access on 64-bit risc-v

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -218,26 +218,26 @@ handle_irq:
 
   setintstack t0, t1
 
-  addi       sp, sp, -16
-  REGSTORE   ra, 12(sp)
-  REGSTORE   s0, 8(sp)
-  add	       s0, sp, 16
+  addi       sp, sp, -(INT_REG_SIZE * 2)
+  REGSTORE   ra, INT_REG_SIZE(sp)
+  REGSTORE   s0, 0(sp)
+  add        s0, sp, (INT_REG_SIZE * 2)
 
   /* Call interrupt handler in C */
 
   jal        x1, riscv_dispatch_irq
 
-  REGLOAD    ra, 12(sp)
-  REGLOAD    s0, 8(sp)
-  add	       sp, sp, 16
+  REGLOAD    ra, INT_REG_SIZE(sp)
+  REGLOAD    s0, 0(sp)
+  add        sp, sp, (INT_REG_SIZE * 2)
 
 #else
   /* Reserve some space for current_regs if interrupt stack disabled */
 
-  addi       sp, sp, -16
-  REGSTORE   ra, 12(sp)
-  REGSTORE   s0, 8(sp)
-  add	       s0, sp, 16
+  addi       sp, sp, -(INT_REG_SIZE * 2)
+  REGSTORE   ra, INT_REG_SIZE(sp)
+  REGSTORE   s0, 0(sp)
+  add        s0, sp, (INT_REG_SIZE * 2)
 
   addi       sp, sp, -XCPTCONTEXT_SIZE
 
@@ -245,9 +245,9 @@ handle_irq:
 
   jal        x1, riscv_dispatch_irq
 
-  REGLOAD    ra, 12(sp)
-  REGLOAD    s0, 8(sp)
-  add	sp,sp,16
+  REGLOAD    ra, INT_REG_SIZE(sp)
+  REGLOAD    s0, 0(sp)
+  add        sp, sp, (INT_REG_SIZE * 2)
 
   /* Restore sp */
 


### PR DESCRIPTION
## Summary
This fixes a crash at boot on 64-bit risc-v systems which need to store 64-bit registers to the stack aligned to 8 byte boundary.

Specifically, this uses 8 bytes to store ra and s0 on rv32 and 16 bytes on rv64, and does the register stores and loads properly aligned acc. to the register size.

## Impact

RELEASE

## Testing

CI

