### PR TITLE
{bp-15963} fs/virtio-9p:When virtio-9p is not supported, return -ENODEV

### DIFF
--- a/fs/v9fs/virtio_9p.c
+++ b/fs/v9fs/virtio_9p.c
@@ -127,6 +127,13 @@ static int virtio_9p_create(FAR struct v9fs_transport_s **transport,
   priv->transport.ops = &g_virtio_9p_transport_ops;
   *transport = &priv->transport;
   ret = virtio_register_driver(&priv->vdrv);
+  if (priv->vdev == NULL)
+    {
+      /* No corresponding driver was found, we should return an error */
+
+      ret = -ENODEV;
+    }
+
   if (ret < 0)
     {
       fs_heap_free(priv);


### PR DESCRIPTION
## Summary
  When the operating environment does not support virtio-9p and the virtio-9p server driver is not provided, -ENODEV should be returned for virtio-9p to avoid crash caused by continued execution.

## Impact

RELEASE

## Testing

CI
