### PR TITLE
{bp-15965} net/can: Fix NULL dereference for I/O Block

### DIFF
--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -138,7 +138,8 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
            * create timestamp and copy to iob
            */
 
-          if (_SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMP))
+          if (_SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMP) &&
+            (dev->d_iob != NULL))
             {
               struct timeval tv;
               FAR struct timespec *ts = (FAR struct timespec *)&tv;


### PR DESCRIPTION
## Summary
In a recent patch the socketcan timestamp generation was moved to add it also when there is an active reader (previously the timestamp was only added before storing the CAN frame in the read-ahead list).

It was working fine but I realized that the can_callback function is also called when sending frames. In this case, the IO block is not allocated yet and the code breaks.

This PR is to only generate the timestamp if the IO block is not NULL (reading path) and skip it when it is NULL (sending path)

## Impact

RELEASE

## Testing

CI
