### PR TITLE
[bp-16015} tools/checkpatch: Use gmake on BSD, make otherwise.

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -21,6 +21,11 @@
 
 TOOLDIR=$(dirname $0)
 
+case "$OSTYPE" in
+  *bsd*) MAKECMD=gmake;;
+  *) MAKECMD=make;;
+esac
+
 check=check_patch
 fail=0
 range=0
@@ -189,7 +194,7 @@ check_commit() {
   check_ranges <<< "$diffs"
 }
 
-make -C $TOOLDIR -f Makefile.host nxstyle 1>/dev/null
+$MAKECMD -C $TOOLDIR -f Makefile.host nxstyle 1>/dev/null
 
 if [ -z "$1" ]; then
   usage


### PR DESCRIPTION
## Summary
* BSD has its own BSD Make that is incompatible with GNU Make.
* When BSD is detected use (gnu) gmake in place of (bsd) make.
* This fixes nxstyle build inside tools/checkpatch.sh.

## Impact

RELEASE

## Testing

CI

