### PR TITLE
{bp-16018} arch/arm: add missing itm_syslog.h include

### DIFF
--- a/arch/arm/src/at32/at32_start.c
+++ b/arch/arm/src/at32/at32_start.c
@@ -30,6 +30,7 @@
 #include <debug.h>
 #include <nuttx/init.h>
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "nvic.h"
 #include "mpu.h"
 

--- a/arch/arm/src/cxd32xx/cxd32_start.c
+++ b/arch/arm/src/cxd32xx/cxd32_start.c
@@ -37,6 +37,7 @@
 
 #include "chip.h"
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "init/init.h"
 
 #include "cxd32_uart.h"

--- a/arch/arm/src/eoss3/eoss3_start.c
+++ b/arch/arm/src/eoss3/eoss3_start.c
@@ -32,6 +32,7 @@
 #include <nuttx/init.h>
 
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "nvic.h"
 #include "nuttx/irq.h"
 

--- a/arch/arm/src/gd32f4/gd32f4xx_start.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_start.c
@@ -33,6 +33,7 @@
 #include <nuttx/init.h>
 
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "nvic.h"
 #include "mpu.h"
 

--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -34,6 +34,7 @@
 
 #include "arch/board/board.h"
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "nvic.h"
 #include "mpu.h"
 

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -36,6 +36,7 @@
 #include <arch/board/board.h>
 
 #include "arm_internal.h"
+#include "itm_syslog.h"
 #include "nvic.h"
 #include "mpu.h"
 


### PR DESCRIPTION
## Summary
add missing itm_syslog.h include for archs that use itm_syslog_initialize() to fix compiler errors:

  error: implicit declaration of function 'itm_syslog_initialize'

Issue reported by rentzboy in https://github.com/apache/nuttx/issues/16017

## Impact

RELEASE

## Testing

CI
