### PR TITLE
{bp-16028} include/nuttx/math.h: add missing HUGE_VALF and HUGE_VALL

### DIFF
--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -80,9 +80,11 @@
 
 #define INFINITY_F ((float)INFINITY)
 #define NAN_F      ((float)(INFINITY * 0.0F))
+#define HUGE_VALF  ((float)INFINITY)
 
 #define INFINITY_L ((long double)INFINITY)
 #define NAN_L      ((long double)(INFINITY * 0.0F))
+#define HUGE_VALL  ((long double)INFINITY)
 
 #define isnan(x)   ((x) != (x))
 #define isnanf(x)  ((x) != (x))


### PR DESCRIPTION
## Summary
add missing HUGE_VALF and HUGE_VALL definitions to NuttX math.h

## Impact

RELEASE

## Testing

CI

