### PR TITLE
CI: Improved speed to build nuttx on MSYS2 job

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -20,9 +20,9 @@
 # under the License.
 #
 ############################################################################
+
 set -e
 set -o xtrace
-
 
 CID=$(cd "$(dirname "$0")" && pwd)
 CIWORKSPACE=$(cd "${CID}"/../../../ && pwd -P)
@@ -144,11 +144,7 @@ function run_builds {
     ncpus=$(grep -c ^processor /proc/cpuinfo)
   fi
 
-  if [ "X$osname" == "Xmsys2" ]; then
-    export MAKEFLAGS="-j"
-  else
-    options+="-j ${ncpus}"
-  fi
+  options+="-j ${ncpus}"
 
   for build in "${builds[@]}"; do
     "${nuttx}"/tools/testbuild.sh ${options} -e "-Wno-cpp -Werror" "${build}"

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -228,4 +228,8 @@ fi
 
 echo "  Refreshing..."
 
+if [ "X$wenv" == "Xmsys" ]; then
+${MAKECMD} olddefconfig || { echo "ERROR: failed to refresh"; exit 1; }
+else
 ${MAKECMD} olddefconfig $* || { echo "ERROR: failed to refresh"; exit 1; }
+fi


### PR DESCRIPTION
## Summary

After [MSYS2](https://github.com/msys2/setup-msys2/releases/tag/v2.27.0) updated the package on GitHub
there was a slowdown in building NuttX in the MSYS2 job.

It went from an average of 6 minutes to 10 minutes !!!

The purpose of this PR is to speed up the build to decrease the usage of the Windows runner.

Modified Files
tools/ci/cibuild.sh

tools/sethost.sh

make olddefconfig -j 4 -> make olddefconfig
workaround for remove
```
  Cleaning...
  Configuring...
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule. 
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```

before the change
![2025022211](https://github.com/user-attachments/assets/6a7b99d4-a776-462b-b92e-f9bbae81198c)

https://github.com/NuttX/nuttx/actions/runs/13472281038/job/37647297902#logs


after the change
![2025022219](https://github.com/user-attachments/assets/11fb6a32-4431-46f1-a967-d88d760d6b19)
https://github.com/NuttX/nuttx/actions/runs/13475897767/job/37655044076#logs

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

We tested on the local platform MSYS2 and GitHub

![20250325](https://github.com/user-attachments/assets/b89f976d-46bf-4642-85ed-f20f43819b9d)


(https://github.com/simbit18/nuttx_test_pr/actions/runs/14058716583/job/39364107803#logs)


