### PR TITLE
serial:gdbstub need enable irq

### DIFF
--- a/drivers/serial/serial_gdbstub.c
+++ b/drivers/serial/serial_gdbstub.c
@@ -80,7 +80,7 @@ static void uart_gdbstub_attach(FAR struct uart_gdbstub_s *uart_gdbstub,
 
   uart_setup(dev);
   uart_attach(dev);
-  uart_disablerxint(dev);
+  uart_enablerxint(dev);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

bug fix, gdbstub can't use

## Impact

gdbstub

## Testing

gdbstub demo on stm32


