### PR TITLE
arch/arm/sama5/spi: fix ifdelay setup in spi_setdelay call

### DIFF
--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -1142,7 +1142,7 @@ static int spi_setdelay(struct spi_dev_s *dev, uint32_t startdelay,
   regval |= (uint32_t) dlybs << SPI_CSR_DLYBS_SHIFT;
   spi_putreg(spi, regval, offset);
 
-  /* stopdelay = DLYBCT: Delay Between Consecutive Transfers.
+  /* ifdelay = DLYBCT: Delay Between Consecutive Transfers.
    * This field defines the delay between two consecutive transfers with the
    * same peripheral without removing the chip select. The delay is always
    * inserted after each transfer and before removing the chip select if
@@ -1156,11 +1156,11 @@ static int spi_setdelay(struct spi_dev_s *dev, uint32_t startdelay,
    */
 
   dlybct  = SAM_SPI_CLOCK;
-  dlybct *= stopdelay;
+  dlybct *= ifdelay;
   dlybct /= 1000000000;
   dlybct /= 32;
 
-  if ((dlybct == 0) && (stopdelay > 0))
+  if ((dlybct == 0) && (ifdelay > 0))
     {
       dlybct++;
     }


### PR DESCRIPTION
## Summary
ifdelay description (delay between frames) matches the DLYBCT field (delay between consecutive transfers without removing chip select) much better compared to stopdelay (delay between last CLK and CS inactive). The option for stopdelay does not seem to be configurable in SAMA5 peripheral.

## Impact
Should be minimal, most of the drivers do not use `spi_setdelay` at all and even if, this is configurable option disabled by default.

## Testing
CI passed, I don't have a physical board to test this. This is the same change as in https://github.com/apache/nuttx/pull/15900, the peripherals are mostly the same.


