### PR TITLE
drivers/mtd/mtd_cfi: Add MTDIOC_ERASESTATE

### DIFF
--- a/drivers/mtd/mtd_cfi.c
+++ b/drivers/mtd/mtd_cfi.c
@@ -235,6 +235,13 @@ static int cfi_mtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = 0xff;
+          break;
+        }
+
       default:
         ret = -ENOTTY;
         break;


### PR DESCRIPTION
## Summary

drivers/mtd/mtd_cfi: Add MTDIOC_ERASESTATE

We need to give a default erase value when we register cfi flash for mtd devices
he pseudo-code is as follows：
register_cfi_driver(xxx)
find_mtddriver("xxx", &inode);
 mtdconfig_register(inode->u.i_mtd);
 
 https://github.com/Zhangshoukui/nuttx/blob/master/drivers/mtd/mtd_config.c#L1775C28-L1775C45

## Impact

None

## Testing

local test



