### PR TITLE
tools/ci/testrun/script/test_framework/test_cmocka: skip Skip failed …

### DIFF
--- a/tools/ci/testrun/script/test_framework/test_cmocka.py
+++ b/tools/ci/testrun/script/test_framework/test_cmocka.py
@@ -48,7 +48,7 @@ def test_cmocka(p):
 
     p.sendCommand(f"echo {cmocka_test_start}")
     ret = p.sendCommand(
-        "cmocka --skip test_case_posix_timer|test_case_oneshot|write_default|read_default|burst_test|gpiotest01|"
+        "cmocka --skip drivertest_pm|drivertest_posix_timer|drivertest_block*|"
         "test_playback.*|test_interaction.*|test_stress.*|test_capture.*",
         "Cmocka Test Completed",
         timeout=1200,


### PR DESCRIPTION
## Summary

[BUG] CI Test sim:citest fails intermittently for Linux sim-01 nuttx#16088 https://gist.github.com/lupyuen/849562eaf87b93411098c96ada4d43c5

nsh> cmocka --skip test_case_posix_timer|test_case_oneshot|write_default|read_default|burst_test|gpiotest01|test_playback.*|test_interaction.*|test_stress.*|test_capture.* Cmocka Test Start.
Missing <source>
Usage: cmocka_driver_block -m <source>
Where:
  -m <source> Block device or mtd device mount location.
...
[ RUN      ] drivertest_pm
[  ERROR   ] --- 0 != 3
[   LINE   ] --- drivertest_pm.c:199: error: Failure!
[  FAILED  ] drivertest_pm
[==========] tests: 1 test(s) run.
[  PASSED  ] 0 test(s).
[  FAILED  ] tests: 1 test(s), listed below:
[  FAILED  ] drivertest_pm
...
[ RUN      ] drivertest_posix_timer
[  ERROR   ] --- 2019 is not within the range [1990, 2010]
[   LINE   ] --- drivertest_posix_timer.c:162: error: Failure!
[  FAILED  ] drivertest_posix_timer
[==========] tests: 1 test(s) run.
[  PASSED  ] 0 test(s).
[  FAILED  ] tests: 1 test(s), listed below:
[  FAILED  ] drivertest_posix_timer
## Impact
CI 

## Testing

CI


