### PR TITLE
syslog: add an option to completely disable syslog logic

### DIFF
--- a/drivers/syslog/CMakeLists.txt
+++ b/drivers/syslog/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_SYSLOG_INTBUFFER)
   list(APPEND SRCS syslog_intbuffer.c)
 endif()
 
-if(NOT CONFIG_ARCH_SYSLOG)
+if(CONFIG_SYSLOG)
   list(APPEND SRCS syslog_initialize.c)
 endif()
 

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -27,6 +27,16 @@ config SYSLOG_TO_SCHED_NOTE
 	---help---
 		If this option is enabled, syslog will be redirected to sched_note,
 		It uses the sched_note_printf macro to replace syslog
+
+config SYSLOG_NONE
+	bool "Disable system logging"
+	---help---
+		System logging is disabled and all calls to syslog() are replaced with
+		an empty function. This option can be useful for small systems when we don't
+		have any logging support, so we can get rid of unused logic.
+		This way the final image also won't contain the strings that are present
+		in syslog().
+
 endchoice
 
 config SYSLOG_CHARDEV

--- a/libs/libc/syslog/CMakeLists.txt
+++ b/libs/libc/syslog/CMakeLists.txt
@@ -23,3 +23,7 @@
 if(CONFIG_SYSLOG)
   target_sources(c PRIVATE lib_setlogmask.c lib_syslog.c)
 endif()
+
+if(CONFIG_SYSLOG_NONE)
+  target_sources(c PRIVATE lib_syslog_none.c)
+endif()

--- a/libs/libc/syslog/Make.defs
+++ b/libs/libc/syslog/Make.defs
@@ -26,6 +26,10 @@ ifeq ($(CONFIG_SYSLOG),y)
 CSRCS += lib_syslog.c lib_setlogmask.c
 endif
 
+ifeq ($(CONFIG_SYSLOG_NONE),y)
+CSRCS += lib_syslog_none.c
+endif
+
 # Add the syslog directory to the build
 
 DEPPATH += --dep-path syslog

--- a/libs/libc/syslog/lib_syslog_none.c
+++ b/libs/libc/syslog/lib_syslog_none.c
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * libs/libc/syslog/lib_syslog_none.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <syslog.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: syslog/vsyslog
+ *
+ * Description:
+ *   These are empty syslog function used when CONFIG_SYSLOG_NONE option
+ *   is selected. This way we can completely remove the syslog logic and its
+ *   associated strings from the image.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void syslog(int priority, FAR const IPTR char *fmt, ...)
+{
+  UNUSED(priority);
+  UNUSED(fmt);
+}
+
+void vsyslog(int priority, FAR const IPTR char *fmt, va_list ap)
+{
+  UNUSED(priority);
+  UNUSED(fmt);
+  UNUSED(ap);
+}


### PR DESCRIPTION
## Summary

Add an option to completely disable syslog() and replace it with an empty functions. This option can be useful for small systems when we don't have any logging support, but compiler is not able to remove useless code.

This way the final image also won't contain the strings that are present in syslog() calls when compiler optimization is enabled (for example from /boards where syslog is often used instead of debug macros). 

## Impact

new option that must be explicitly selected by the user. No impact on code and configs.

## Testing

some random upstream configuration compiled without warnings
