### PR TITLE
arch/xtensa/src/common: Make esp32 wlan device configurable

### DIFF
--- a/arch/xtensa/src/common/espressif/Kconfig
+++ b/arch/xtensa/src/common/espressif/Kconfig
@@ -575,6 +575,12 @@ menuconfig ESPRESSIF_WIFI_BT_COEXIST
 menu "Wi-Fi Configuration"
 	depends on ESPRESSIF_WIFI
 
+config ESPRESSIF_WLAN
+        bool "WLAN"
+	default y
+	---help---
+	        Enable WLAN support
+
 menu "ESP WPA-Supplicant"
 
 config WPA_WAPI_PSK

--- a/arch/xtensa/src/common/espressif/Make.defs
+++ b/arch/xtensa/src/common/espressif/Make.defs
@@ -74,8 +74,8 @@ endif
 
 ifeq ($(CONFIG_ESPRESSIF_WIRELESS),y)
 CHIP_CSRCS += esp_wireless.c
-ifeq ($(CONFIG_ESPRESSIF_WIFI),y)
 CHIP_CSRCS += esp_wifi_utils.c
+ifeq ($(CONFIG_ESPRESSIF_WLAN),y)
 CHIP_CSRCS += esp_wlan.c
 endif
 endif

--- a/boards/xtensa/esp32/esp32-2432S028/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-2432S028/src/esp32_bringup.c
@@ -59,7 +59,7 @@
 #  include "esp32_board_spiflash.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -187,11 +187,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif
@@ -386,4 +386,3 @@ int esp32_bringup(void)
   UNUSED(ret);
   return OK;
 }
-

--- a/boards/xtensa/esp32/esp32-audio-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-audio-kit/src/esp32_bringup.c
@@ -68,7 +68,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -213,11 +213,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif
@@ -444,4 +444,3 @@ int esp32_bringup(void)
   UNUSED(ret);
   return OK;
 }
-

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -74,7 +74,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -357,11 +357,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -67,7 +67,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -174,11 +174,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32/esp32-lyrat/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-lyrat/src/esp32_bringup.c
@@ -68,7 +68,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -214,11 +214,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif
@@ -445,4 +445,3 @@ int esp32_bringup(void)
   UNUSED(ret);
   return OK;
 }
-

--- a/boards/xtensa/esp32/esp32-pico-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-pico-kit/src/esp32_bringup.c
@@ -67,7 +67,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -245,11 +245,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_bringup.c
@@ -71,7 +71,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -225,11 +225,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -67,7 +67,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -213,11 +213,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif
@@ -407,4 +407,3 @@ int esp32_bringup(void)
   UNUSED(ret);
   return OK;
 }
-

--- a/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_bringup.c
@@ -75,7 +75,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -218,11 +218,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
       return ret;
     }

--- a/boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_bringup.c
@@ -79,7 +79,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIRELESS
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -291,11 +291,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIRELESS
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_bringup.c
@@ -75,7 +75,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -218,11 +218,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
       return ret;
     }

--- a/boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_bringup.c
@@ -75,7 +75,7 @@
 #  include "esp32_ble.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32_board_wlan.h"
 #endif
 
@@ -294,11 +294,11 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bringup.c
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bringup.c
@@ -50,7 +50,7 @@
 #  include "esp32s2_tim_lowerhalf.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s2_board_wlan.h"
 #endif
 
@@ -317,11 +317,11 @@ int esp32s2_bringup(void)
 
 #ifdef CONFIG_ESPRESSIF_WIRELESS
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -211,11 +211,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -44,7 +44,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -447,11 +447,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -202,11 +202,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -395,11 +395,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -287,11 +287,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -44,7 +44,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -392,11 +392,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WIFI
+#ifdef CONFIG_ESPRESSIF_WLAN
   ret = board_wlan_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
              ret);
     }
 #endif


### PR DESCRIPTION
## Summary

Add the possibility to configure (disable) the wlan device on esp32. By default this is enabled so it does not change the present behavior. This is added to allow disabling in some future configuration (e.g. when only espnow is used as the network device).

## Impact

*Impact on users: None,
*Impact on build process: None,
*Impact on hardware: None,
*Impact on documentation: None,
*Impact on security: None,
*Impact on compatibility: None,

## Testing

*The changes were tested on esp32-devkitc:wifi. All wifi operations (wapi, renew, telnet, ping) performed as expected.