### PR TITLE
espressif: Enable SPI Flash's MTD block driver for all supported SoCs

### DIFF
--- a/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
@@ -379,6 +379,13 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
 #endif
 
   return ret;

--- a/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
@@ -465,6 +465,13 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
 #endif
 
   return ret;

--- a/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
@@ -379,6 +379,13 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
 #endif
 
   return ret;

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -429,6 +429,13 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
 #endif
 
   return ret;

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
@@ -338,6 +338,13 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
 #endif
 
   return ret;

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -333,6 +333,14 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
+
 #ifdef CONFIG_MTD_PARTITION
   ret = parse_mtd_partition(mtd, NULL, NULL);
   if (ret < 0)


### PR DESCRIPTION
## Summary

This PR enables the SPI Flash's MTD block driver, which enables testing the SPI Flash device without any associated filesystems. ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6, and ESP32-H2 can be tested with MTD's benchmark and testing application introduced by https://github.com/apache/nuttx-apps/pull/3033.

## Impact

Impact on user: YES. MTD's benchmark and testing application can be used with the MTD-based SPI flash partition.

Impact on build: NO.

Impact on hardware: YES. MTD-based SPI flash partition is exposed as a block device at `/dev/mtdblock0`.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Just unset any other filesystems and check for the MTD-based device at `/dev/mtdblock`. For ESP32-S3, for instance:

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:spiflash && kconfig-tweak -d ESP32S3_SPIFLASH_SMARTFS && kconfig-tweak --set-val CONFIG_ESP32S3_SPIFLASH_MTD_BLKSIZE 4096  && kconfig-tweak -e CONFIG_BENCHMARK_MTD && make olddefconfig && ESP_HAL_3RDPARTY_URL="git@github.com:tmedicci/esp-hal-3rdparty.git" make flash ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom -D /dev/ttyUSB0
```

### Running

The MTD-based device can be checked with `ls /dev/` and the MTD benchmark/testing application with `mtd /dev/mtdblock0`.

### Results

```
nsh> ls /dev
/dev:
 console
 esp32s3flash
 mtdblock0
 null
 ttyS0
 zero
nsh> mtd /dev/mtdblock0
FLASH device parameters:
   Sector size:        4096
   Sector count:        256
   Erase block:        1000
   Total size:      1048576

Starting write operation...

Write operation completed in 5.07 seconds
Total bytes written: 1048576
Transfer rate [write]: 201.97 KiB/s

Starting read operation...

Read operation completed in 0.25 seconds
Total bytes read: 1048576
Transfer rate [read]: 4096.00 KiB/s

Data verification successful: read data matches written data
```