### PR TITLE
arch/arm/stm32l4: Add CMakeLists for the STM32L4

### DIFF
--- a/arch/arm/src/stm32l4/CMakeLists.txt
+++ b/arch/arm/src/stm32l4/CMakeLists.txt
@@ -1,0 +1,199 @@
+# ##############################################################################
+# arch/arm/src/stm32l4/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS)
+
+list(
+  APPEND
+  SRCS
+  stm32l4_allocateheap.c
+  stm32l4_exti_gpio.c
+  stm32l4_gpio.c
+  stm32l4_irq.c
+  stm32l4_lowputc.c
+  stm32l4_rcc.c
+  stm32l4_serial.c
+  stm32l4_start.c
+  stm32l4_waste.c
+  stm32l4_uid.c
+  stm32l4_spi.c
+  stm32l4_i2c.c
+  stm32l4_lse.c
+  stm32l4_lsi.c
+  stm32l4_pwr.c
+  stm32l4_tim.c
+  stm32l4_flash.c
+  stm32l4_dfumode.c)
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS stm32l4_idle.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32l4_tim_lowerhalf.c)
+endif()
+
+if(NOT CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS stm32l4_timerisr.c)
+else()
+  list(APPEND SRCS stm32l4_tickless.c)
+endif()
+
+if(CONFIG_STM32L4_ONESHOT)
+  list(APPEND SRCS stm32l4_oneshot.c stm32l4_oneshot_lowerhalf.c)
+endif()
+
+if(CONFIG_STM32L4_FREERUN)
+  list(APPEND SRCS stm32l4_freerun.c)
+endif()
+
+if(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS stm32l4_userspace.c stm32l4_mpuinit.c)
+endif()
+
+if(CONFIG_STM32L4_HAVE_HSI48)
+  list(APPEND SRCS stm32l4_hsi48.c)
+endif()
+
+if(CONFIG_STM32L4_ADC)
+  list(APPEND SRCS stm32l4_adc.c)
+endif()
+
+if(CONFIG_STM32L4_DAC)
+  list(APPEND SRCS stm32l4_dac.c)
+endif()
+
+if(CONFIG_STM32L4_DFSDM)
+  list(APPEND SRCS stm32l4_dfsdm.c)
+endif()
+
+if(CONFIG_STM32L4_DMA)
+  list(APPEND SRCS stm32l4_dma.c)
+endif()
+
+if(CONFIG_USBDEV)
+  if(CONFIG_STM32L4_USBFS)
+    list(APPEND SRCS stm32l4_usbdev.c)
+  endif()
+  if(CONFIG_STM32L4_OTGFS)
+    list(APPEND SRCS stm32l4_otgfsdev.c)
+  endif()
+endif()
+
+if(CONFIG_USBHOST)
+  if(CONFIG_STM32L4_OTGFS)
+    list(APPEND SRCS stm32l4_otgfshost.c)
+  endif()
+endif()
+
+if(CONFIG_USBHOST)
+  if(CONFIG_USBHOST_TRACE)
+    list(APPEND SRCS stm32l4_usbhost_trace.c)
+  else()
+    if(CONFIG_DEBUG_USB)
+      list(APPEND SRCS stm32l4_usbhost_trace.c)
+    endif()
+  endif()
+endif()
+
+if(CONFIG_PM)
+  list(APPEND SRCS stm32l4_pmlpr.c stm32l4_pmsleep.c stm32l4_pmstandby.c
+       stm32l4_pmstop.c)
+
+  if(NOT CONFIG_ARCH_CUSTOM_PMINIT)
+    list(APPEND SRCS stm32l4_pminitialize.c)
+  endif()
+endif()
+
+if(CONFIG_STM32L4_PWR)
+  list(APPEND SRCS stm32l4_exti_pwr.c)
+endif()
+
+if(CONFIG_STM32L4_RTC)
+  if(CONFIG_RTC_ALARM)
+    list(APPEND SRCS stm32l4_exti_alarm.c)
+  endif()
+  if(CONFIG_RTC_PERIODIC)
+    list(APPEND SRCS stm32l4_exti_wakeup.c)
+  endif()
+  if(CONFIG_RTC_DRIVER)
+    list(APPEND SRCS stm32l4_rtc_lowerhalf.c stm32l4_rtc.c)
+  endif()
+endif()
+
+if(CONFIG_DEBUG_FEATURES)
+  list(APPEND SRCS stm32l4_dumpgpio.c)
+endif()
+
+if(CONFIG_STM32L4_COMP)
+  list(APPEND SRCS stm32l4_comp.c stm32l4_exti_comp.c)
+endif()
+
+if(CONFIG_STM32L4_RNG)
+  list(APPEND SRCS stm32l4_rng.c)
+endif()
+
+if(CONFIG_STM32L4_SAI)
+  list(APPEND SRCS stm32l4_sai.c)
+endif()
+
+if(CONFIG_STM32L4_LPTIM)
+  list(APPEND SRCS stm32l4_lptim.c)
+endif()
+
+if(CONFIG_STM32L4_PWM)
+  list(APPEND SRCS stm32l4_pwm.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32l4_qencoder.c)
+endif()
+
+if(CONFIG_STM32L4_QSPI)
+  list(APPEND SRCS stm32l4_qspi.c)
+endif()
+
+if(CONFIG_STM32L4_CAN)
+  list(APPEND SRCS stm32l4_can.c)
+endif()
+
+if(CONFIG_STM32L4_FIREWALL)
+  list(APPEND SRCS stm32l4_firewall.c)
+endif()
+
+if(CONFIG_STM32L4_IWDG)
+  list(APPEND SRCS stm32l4_iwdg.c)
+endif()
+
+if(CONFIG_STM32L4_IWDG)
+  list(APPEND SRCS stm32l4_iwdg.c)
+endif()
+
+if(CONFIG_STM32L4_SDMMC1)
+  list(APPEND SRCS stm32l4_sdmmc.c)
+endif()
+
+if(CONFIG_STM32L4_1WIREDRIVER)
+  list(APPEND SRCS stm32l4_1wire.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/stm32l4/nucleo-l476rg/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l476rg/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l476rg/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/nucleo-l476rg/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/CMakeLists.txt
@@ -1,0 +1,117 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l476rg/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_spi.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_WL_CC1101)
+  list(APPEND SRCS stm32_cc1101.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+  if(CONFIG_INPUT_AJOYSTICK)
+    list(APPEND SRCS stm32_ajoystick.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_CAN)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS stm32_spimmcsd.c)
+endif()
+
+if(CONFIG_LCD_PCD8544)
+  list(APPEND SRCS stm32_pcd8544.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_SENSORS_HTS221)
+  list(APPEND SRCS stm32_lsm6dsl.c)
+endif()
+
+if(CONFIG_SENSORS_LSM303AGR)
+  list(APPEND SRCS stm32_lsm303agr.c)
+endif()
+
+if(CONFIG_SENSORS_AS726X)
+  list(APPEND SRCS stm32_as726x.c)
+endif()
+
+if(CONFIG_SENSORS_BMP180)
+  list(APPEND SRCS stm32_bmp180.c)
+endif()
+
+if(CONFIG_SENSORS_BMP280)
+  list(APPEND SRCS stm32_bmp280.c)
+endif()
+
+if(CONFIG_SENSORS_MPU9250)
+  list(APPEND SRCS stm32_mpu9250.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+  if(CONFIG_BOARDCTL_IOCTL)
+    list(APPEND SRCS stm32_ioctl.c)
+  endif()
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(NOT CONFIG_STM32_ETHMAC)
+  if(CONFIG_NETDEVICES)
+    list(APPEND SRCS stm32_netinit.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/l476rg.ld")


### PR DESCRIPTION
## Summary

This pull request adds CMakeLists.txt files required to build for the `stm32l4` arch, specifically the `stm32l476rg` board.

## Impact

There should be no adverse effects from this. Build details and flags were adapted from the existing Makefiles, using the `stm32f7` platform as a reference. 

## Testing

### Host

* OS: Arch Linux
* CPU: amd64
* Toolchain: `arm-none-eabi-*`

### Target

* Arch: STM32L4
* Board: `nucleo-l476rg`
* Config: `nsh`

### Before Changes

This target did not exist for CMake builds. I can provide Make results on request.

### Setup

```sh
[pryre@ren] pms-r01> mkdir build
[pryre@ren] pms-r01> set -x NUTTX_DIR platform/nuttx
```

### Make

```sh

[pryre@ren] nuttx> 
./tools/configure.sh -l nucleo-l476rg:nsh
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /---/pms-r01/platform/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /---/pms-r01/platform/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /---/pms-r01/platform/nuttx-apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /---/pms-r01/platform/nuttx/boards/arm/stm32l4/nucleo-l476rg/include
LN: drivers/platform to /---/pms-r01/platform/nuttx/drivers/dummy
LN: include/arch/chip to /---/pms-r01/platform/nuttx/arch/arm/include/stm32l4
LN: arch/arm/src/chip to /---/pms-r01/platform/nuttx/arch/arm/src/stm32l4
LN: arch/arm/src/board to /---/pms-r01/platform/nuttx/boards/arm/stm32l4/nucleo-l476rg/src
mkkconfig in /---/pms-r01/platform/nuttx-apps/audioutils
mkkconfig in /---/pms-r01/platform/nuttx-apps/benchmarks
mkkconfig in /---/platform/nuttx-apps/boot
mkkconfig in /---/pms-r01/platform/nuttx-apps/canutils
mkkconfig in /---/pms-r01/platform/nuttx-apps/crypto
mkkconfig in /---/pms-r01/platform/nuttx-apps/database
mkkconfig in /---/pms-r01/platform/nuttx-apps/examples/mcuboot
mkkconfig in /---/pms-r01/platform/nuttx-apps/examples/module
mkkconfig in /---/pms-r01/platform/nuttx-apps/examples/rust
mkkconfig in /---/pms-r01/platform/nuttx-apps/examples/sotest
mkkconfig in /---/pms-r01/platform/nuttx-apps/examples
mkkconfig in /---/pms-r01/platform/nuttx-apps/fsutils
mkkconfig in /---/pms-r01/platform/nuttx-apps/games
mkkconfig in /---/pms-r01/platform/nuttx-apps/graphics
mkkconfig in /---/pms-r01/platform/nuttx-apps/industry
mkkconfig in /---/pms-r01/platform/nuttx-apps/inertial
mkkconfig in /---/pms-r01/platform/nuttx-apps/interpreters/luamodules
mkkconfig in /---/pms-r01/platform/nuttx-apps/interpreters
mkkconfig in /---/pms-r01/platform/nuttx-apps/logging
mkkconfig in /---/pms-r01/platform/nuttx-apps/lte
mkkconfig in /---/pms-r01/platform/nuttx-apps/math
mkkconfig in /---/pms-r01/platform/nuttx-apps/mlearning
mkkconfig in /---/pms-r01/platform/nuttx-apps/netutils
mkkconfig in /---/pms-r01/platform/nuttx-apps/sdr
mkkconfig in /---/pms-r01/platform/nuttx-apps/system
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/arch
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/cxx
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/drivers
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/fs
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/libc
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/mm
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing/sched
mkkconfig in /---/pms-r01/platform/nuttx-apps/testing
mkkconfig in /---/pms-r01/platform/nuttx-apps/videoutils
mkkconfig in /---/pms-r01/platform/nuttx-apps/wireless/bluetooth
mkkconfig in /---/pms-r01/platform/nuttx-apps/wireless/ieee802154
mkkconfig in /---/pms-r01/platform/nuttx-apps/wireless
mkkconfig in /---/pms-r01/platform/nuttx-apps
Loaded configuration '.config'
Configuration saved to '.config'
[pryre@ren] nuttx> 
make
Create version.h
LN: platform/board to /---/pms-r01/platform/nuttx-apps/platform/dummy
Register: alarm
Register: rand
Register: nsh
Register: sh
Register: ostest
CC:  chip/stm32l4_gpio.c chip/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
CPP:  /---/pms-r01/platform/nuttx/boards/arm/stm32l4/nucleo-l476rg/scripts/l476rg.ld-> /---LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      215448 B       512 KB     41.09%
            sram:        9680 B        96 KB      9.85%
CP: nuttx.hex
CP: nuttx.bin
```


### CMake

```sh
[pryre@ren] pms-r01> cmake $NUTTX_DIR -B build -DBOARD_CONFIG=nucleo-l476rg:nsh -GNinja
-- Initializing NuttX
  Select HOST_LINUX=y
--   CMake:  3.31.6
--   Ninja:  1.12.1
--   Board:  nucleo-l476rg
--   Config: nsh
--   Appdir: /---/pms-r01/platform/nuttx-apps
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/arm-none-eabi-gcc
-- Configuring done (6.0s)
-- Generating done (1.0s)
-- Build files have been written to: /---/pms-r01/build
```

### Build

```sh
[pryre@ren] pms-r01> ninja -C build
ninja: Entering directory `build'
[26/1135] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
/---/pms-r01/platform/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1132/1135] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      215300 B       512 KB     41.07%
            sram:        9676 B        96 KB      9.84%
[1135/1135] Generating System.map
```

### Run

Device can be flashed and presents a prompt as expected.