### PR TITLE
nuttx/clock: make NSEC_PER_USEC and others long

### DIFF
--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -1134,7 +1134,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %u ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %lu ticks. Error=%d\n",
             MSEC2TICK(block_time_ms), ret);
     }
 

--- a/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
@@ -490,7 +490,7 @@ static int wdt_lh_settimeout(struct watchdog_lowerhalf_s *lower,
 
       if (timeout == 0 || timeout > MWDT_MAX_TIMEOUT_MS)
         {
-          wderr("Cannot represent timeout=%" PRIu32 " > %" PRIu32 "\n",
+          wderr("Cannot represent timeout=%" PRIu32 " > %lu\n",
                 timeout, MWDT_MAX_TIMEOUT_MS);
           return -ERANGE;
         }

--- a/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c
@@ -1062,7 +1062,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (ret)
     {
-      wlerr("ERROR: Failed to wait sem in %u ticks. Error=%d\n",
+      wlerr("ERROR: Failed to wait sem in %lu ticks. Error=%d\n",
             MSEC2TICK(block_time_ms), ret);
     }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
@@ -494,7 +494,7 @@ static int wdt_lh_settimeout(struct watchdog_lowerhalf_s *lower,
 
       if (timeout == 0 || timeout > MWDT_MAX_TIMEOUT_MS)
         {
-          wderr("Cannot represent timeout=%" PRIu32 " > %" PRIu32 "\n",
+          wderr("Cannot represent timeout=%" PRIu32 " > %lu\n",
                 timeout, MWDT_MAX_TIMEOUT_MS);
           return -ERANGE;
         }

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -103,7 +103,7 @@
 
 #define NSEC_PER_SEC          1000000000L /* Seconds */
 #define USEC_PER_SEC             1000000L
-#define MSEC_PER_SEC                1000
+#define MSEC_PER_SEC                1000L
 #define DSEC_PER_SEC                  10
 #define HSEC_PER_SEC                   2
 
@@ -117,9 +117,9 @@
 #define MSEC_PER_DSEC                100
 
 #define NSEC_PER_MSEC            1000000L /* Milliseconds */
-#define USEC_PER_MSEC               1000
+#define USEC_PER_MSEC               1000L
 
-#define NSEC_PER_USEC               1000  /* Microseconds */
+#define NSEC_PER_USEC               1000L /* Microseconds */
 
 #define SEC_PER_MIN                   60
 #define NSEC_PER_MIN           (NSEC_PER_SEC * SEC_PER_MIN)


### PR DESCRIPTION
## Summary

Patch from mailing list https://lists.apache.org/thread/xzor3tjy9jozlmox82frd27v969b37l4
Author: Kerogit

On AVR architecture, the compiler apparently sometimes truncates NSEC_PER_TICK to 16bit value, leading to clock_time2ticks returning incorrect results. This was encountered while attempting to add tickless OS support for AVR architecture but seemed to affect non-tickless mode of operation as well.

This patch marks NSEC_PER_USEC (and to be safe, USEC_PER_MSEC and MSEC_PER_SEC too) as long.

## Impact
this change needs a thorough review, to make sure it doesn't accidentally break something

## Testing
CI



