### PR TITLE
drivers/lcd/st7789: Support mirror V

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -749,6 +749,10 @@ config LCD_ST7789_MIRRORY
 	bool "ST7789 Mirror Y"
 	default n
 
+config LCD_ST7789_MIRRORV
+	bool "ST7789 Mirror V"
+	default n
+
 config LCD_ST7789_INVCOLOR
 	bool "ST7789 Invert Color"
 	default y

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -477,7 +477,11 @@ static void st7789_setorientation(FAR struct st7789_dev_s *dev)
 
 #endif
 
-  /* Mirror X/Y for current setting */
+  /* Mirror X/Y/V for current setting */
+
+#ifdef CONFIG_LCD_ST7789_MIRRORV
+  madctl ^= 0x20;
+#endif
 
 #ifdef CONFIG_LCD_ST7789_MIRRORX
   madctl ^= 0x40;


### PR DESCRIPTION
## Summary
Support mirror V, mirror X and V can rotate the screen 90 degrees.

## Impact
- drivers/lcd/st7789

## Testing
```bash
# Build & Burn
./tools/configure.sh -l lckfb-szpi-esp32s3:lvgl
make flash -j$(nproc) ESPTOOL_PORT=/dev/ttyUSB0
```
- Config lckfb-szpi-esp32s3:lvgl
  ![image](https://github.com/user-attachments/assets/4f042975-2b69-45b7-b6a3-0b8409294989)

- Config lckfb-szpi-esp32s3:lvgl whit changes below
  ```diff
  +CONFIG_LCD_ST7789_MIRRORV=y
  +CONFIG_LCD_ST7789_MIRRORX=y
  ```
  ![image](https://github.com/user-attachments/assets/473b9119-6d9c-4988-a34f-e67638beab61)