### PR TITLE
[bp-16079} arch/arm/src/samv7: enable GPIO clock even if interrupt not enabled

### DIFF
--- a/arch/arm/src/samv7/sam_gpio.c
+++ b/arch/arm/src/samv7/sam_gpio.c
@@ -38,6 +38,7 @@
 
 #include "arm_internal.h"
 #include "sam_gpio.h"
+#include "sam_periphclks.h"
 #include "hardware/sam_pio.h"
 #include "hardware/sam_matrix.h"
 
@@ -471,17 +472,31 @@ static inline int sam_configperiph(uintptr_t base, uint32_t pin,
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_SAMV7_ERASE_ENABLE) || \
-    !defined(CONFIG_SAMV7_JTAG_FULL_ENABLE)
 void sam_gpioinit(void)
 {
+#if !defined(CONFIG_SAMV7_ERASE_ENABLE) || \
+    !defined(CONFIG_SAMV7_JTAG_FULL_ENABLE)
   uint32_t regval;
 
   regval  = getreg32(SAM_MATRIX_CCFG_SYSIO);
   regval |= (SYSIO_ERASE_BIT | SYSIO_BITS);
   putreg32(regval, SAM_MATRIX_CCFG_SYSIO);
-}
 #endif
+
+  sam_pioa_enableclk();
+#if SAMV7_NPIO > 1
+  sam_piob_enableclk();
+#endif
+#if SAMV7_NPIO > 2
+  sam_pioc_enableclk();
+#endif
+#if SAMV7_NPIO > 3
+  sam_piod_enableclk();
+#endif
+#if SAMV7_NPIO > 4
+  sam_pioe_enableclk();
+#endif
+}
 
 /****************************************************************************
  * Name: sam_configgpio

--- a/arch/arm/src/samv7/sam_gpio.h
+++ b/arch/arm/src/samv7/sam_gpio.h
@@ -265,12 +265,7 @@ static inline int sam_gpio_pinmask(gpio_pinset_t cfgset)
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_SAMV7_ERASE_ENABLE) || \
-    !defined(CONFIG_SAMV7_JTAG_FULL_ENABLE)
 void sam_gpioinit(void);
-#else
-#  define sam_gpioinit()
-#endif
 
 /****************************************************************************
  * Name: sam_gpioirqinitialize

--- a/arch/arm/src/samv7/sam_gpioirq.c
+++ b/arch/arm/src/samv7/sam_gpioirq.c
@@ -39,7 +39,6 @@
 
 #include "arm_internal.h"
 #include "sam_gpio.h"
-#include "sam_periphclks.h"
 #include "hardware/sam_pmc.h"
 #include "hardware/sam_pio.h"
 
@@ -235,10 +234,6 @@ void sam_gpioirqinitialize(void)
   /* Configure GPIOA interrupts */
 
 #ifdef CONFIG_SAMV7_GPIOA_IRQ
-  /* Enable GPIOA clocking */
-
-  sam_pioa_enableclk();
-
   /* Clear and disable all GPIOA interrupts */
 
   getreg32(SAM_PIOA_ISR);
@@ -253,10 +248,6 @@ void sam_gpioirqinitialize(void)
   /* Configure GPIOB interrupts */
 
 #ifdef CONFIG_SAMV7_GPIOB_IRQ
-  /* Enable GPIOB clocking */
-
-  sam_piob_enableclk();
-
   /* Clear and disable all GPIOB interrupts */
 
   getreg32(SAM_PIOB_ISR);
@@ -271,10 +262,6 @@ void sam_gpioirqinitialize(void)
   /* Configure GPIOC interrupts */
 
 #ifdef CONFIG_SAMV7_GPIOC_IRQ
-  /* Enable GPIOC clocking */
-
-  sam_pioc_enableclk();
-
   /* Clear and disable all GPIOC interrupts */
 
   getreg32(SAM_PIOC_ISR);
@@ -289,10 +276,6 @@ void sam_gpioirqinitialize(void)
   /* Configure GPIOD interrupts */
 
 #ifdef CONFIG_SAMV7_GPIOD_IRQ
-  /* Enable GPIOD clocking */
-
-  sam_piod_enableclk();
-
   /* Clear and disable all GPIOD interrupts */
 
   getreg32(SAM_PIOD_ISR);
@@ -307,10 +290,6 @@ void sam_gpioirqinitialize(void)
   /* Configure GPIOE interrupts */
 
 #ifdef CONFIG_SAMV7_GPIOE_IRQ
-  /* Enable GPIOE clocking */
-
-  sam_pioe_enableclk();
-
   /* Clear and disable all GPIOE interrupts */
 
   getreg32(SAM_PIOE_ISR);


### PR DESCRIPTION
## Summary
GPIO peripheral clocks have to be enabled even if interrupt support on the peripheral is not enabled, otherwise GPIO input will not work. This is probably caused by input filters that need clock signal.

This commit moves the clock enable call from interrupt specific function to common initialization function that is called from _start entry point function.

## Impact

RELEASE

## Testing

CI
