### PR TITLE
{bp-16085} arch/esp32s3: The MISO, MOSI and C/S are optional

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1126,7 +1126,7 @@ config ESP32S3_SPI_SLAVE_BUFSIZE
 config ESP32S3_SPI2_CSPIN
 	int "SPI2 CS Pin"
 	default 10
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI2_CLKPIN
 	int "SPI2 CLK Pin"
@@ -1136,12 +1136,12 @@ config ESP32S3_SPI2_CLKPIN
 config ESP32S3_SPI2_MOSIPIN
 	int "SPI2 MOSI Pin"
 	default 11
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI2_MISOPIN
 	int "SPI2 MISO Pin"
 	default 13
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI2_IO2PIN
 	int "SPI2 IO2 Pin"
@@ -1158,7 +1158,7 @@ config ESP32S3_SPI2_IO3PIN
 config ESP32S3_SPI3_CSPIN
 	int "SPI3 CS Pin"
 	default 10
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI3_CLKPIN
 	int "SPI3 CLK Pin"
@@ -1168,12 +1168,12 @@ config ESP32S3_SPI3_CLKPIN
 config ESP32S3_SPI3_MOSIPIN
 	int "SPI3 MOSI Pin"
 	default 7
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI3_MISOPIN
 	int "SPI3 MISO Pin"
 	default 2
-	range 0 48
+	range -1 48
 
 config ESP32S3_SPI3_IO2PIN
 	int "SPI3 IO2 Pin"

--- a/arch/xtensa/src/esp32s3/esp32s3_spi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi.c
@@ -493,11 +493,16 @@ static inline bool esp32s3_spi_iomux(struct esp32s3_spi_priv_s *priv)
 
   if (cfg->id == 2)
     {
-      if (cfg->mosi_pin == SPI2_IOMUX_MOSIPIN &&
+      if (
+#if CONFIG_ESP32S3_SPI2_MOSIPIN >= 0
+          cfg->mosi_pin == SPI2_IOMUX_MOSIPIN &&
+#endif
 #ifndef CONFIG_ESP32S3_SPI_SWCS
           cfg->cs_pin == SPI2_IOMUX_CSPIN &&
 #endif
+#if CONFIG_ESP32S3_SPI2_MISOPIN >= 0
           cfg->miso_pin == SPI2_IOMUX_MISOPIN &&
+#endif
           cfg->clk_pin == SPI2_IOMUX_CLKPIN)
         {
           mapped = true;
@@ -590,7 +595,10 @@ static void esp32s3_spi_select(struct spi_dev_s *dev,
 #if SPI_HAVE_SWCS
   struct esp32s3_spi_priv_s *priv = (struct esp32s3_spi_priv_s *)dev;
 
-  esp32s3_gpiowrite(priv->config->cs_pin, !selected);
+  if (priv->config->cs_pin >= 0)
+    {
+      esp32s3_gpiowrite(priv->config->cs_pin, !selected);
+    }
 #endif
 
   spiinfo("devid: %08" PRIx32 " CS: %s\n",
@@ -1415,14 +1423,57 @@ static int esp32s3_spi_init(struct spi_dev_s *dev)
   const struct esp32s3_spi_config_s *config = priv->config;
   uint32_t regval;
 
-  esp32s3_gpiowrite(config->cs_pin, true);
-  esp32s3_gpiowrite(config->mosi_pin, true);
-  esp32s3_gpiowrite(config->miso_pin, true);
+  if (config->cs_pin >= 0)
+    {
+      esp32s3_gpiowrite(config->cs_pin, true);
+    }
+#ifdef CONFIG_ESP32S3_SPI_UDCS
+#ifdef CONFIG_ESP32S3_SPI2
+  else if (config->id == ESP32S3_SPI2)
+    {
+      esp32s3_spi2_select(dev, config->id, false);
+    }
+#endif
+#ifdef CONFIG_ESP32S3_SPI3
+  else if (config->id == ESP32S3_SPI3)
+    {
+      esp32s3_spi3_select(dev, config->id, false);
+    }
+#endif
+#endif
+
+  if (config->mosi_pin >= 0)
+    {
+      esp32s3_gpiowrite(config->mosi_pin, true);
+    }
+
+  if (config->miso_pin >= 0)
+    {
+      esp32s3_gpiowrite(config->miso_pin, true);
+    }
+
   esp32s3_gpiowrite(config->clk_pin, true);
 
 #if SPI_HAVE_SWCS
-  esp32s3_configgpio(config->cs_pin, OUTPUT_FUNCTION_1);
-  esp32s3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+  if (config->cs_pin >= 0)
+    {
+      esp32s3_configgpio(config->cs_pin, OUTPUT_FUNCTION_1);
+      esp32s3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+    }
+#ifdef CONFIG_ESP32S3_SPI_UDCS
+#ifdef CONFIG_ESP32S3_SPI2
+  else if (config->id == ESP32S3_SPI2)
+    {
+      esp32s3_spi2_select(dev, config->id, false);
+    }
+#endif
+#ifdef CONFIG_ESP32S3_SPI3
+  else if (config->id == ESP32S3_SPI3)
+    {
+      esp32s3_spi3_select(dev, config->id, false);
+    }
+#endif
+#endif
 #endif
 
   /* SPI3 doesn't have IOMUX, if SPI3 is enabled use GPIO Matrix for both */
@@ -1430,14 +1481,24 @@ static int esp32s3_spi_init(struct spi_dev_s *dev)
   if (esp32s3_spi_iomux(priv))
     {
 #if !SPI_HAVE_SWCS
-      esp32s3_configgpio(config->cs_pin, OUTPUT_FUNCTION_5);
-      esp32s3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+      if (config->cs_pin >= 0)
+        {
+          esp32s3_configgpio(config->cs_pin, OUTPUT_FUNCTION_5);
+          esp32s3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+        }
 #endif
-      esp32s3_configgpio(config->mosi_pin, OUTPUT_FUNCTION_5);
-      esp32s3_gpio_matrix_out(config->mosi_pin, SIG_GPIO_OUT_IDX, 0, 0);
 
-      esp32s3_configgpio(config->miso_pin, INPUT_FUNCTION_5 | PULLUP);
-      esp32s3_gpio_matrix_out(config->miso_pin, SIG_GPIO_OUT_IDX, 0, 0);
+      if (config->mosi_pin >= 0)
+        {
+          esp32s3_configgpio(config->mosi_pin, OUTPUT_FUNCTION_5);
+          esp32s3_gpio_matrix_out(config->mosi_pin, SIG_GPIO_OUT_IDX, 0, 0);
+        }
+
+      if (config->miso_pin >= 0)
+        {
+          esp32s3_configgpio(config->miso_pin, INPUT_FUNCTION_5 | PULLUP);
+          esp32s3_gpio_matrix_out(config->miso_pin, SIG_GPIO_OUT_IDX, 0, 0);
+        }
 
       esp32s3_configgpio(config->clk_pin, OUTPUT_FUNCTION_5);
       esp32s3_gpio_matrix_out(config->clk_pin, SIG_GPIO_OUT_IDX, 0, 0);
@@ -1445,14 +1506,25 @@ static int esp32s3_spi_init(struct spi_dev_s *dev)
   else
     {
 #if !SPI_HAVE_SWCS
-      esp32s3_configgpio(config->cs_pin, OUTPUT);
-      esp32s3_gpio_matrix_out(config->cs_pin, config->cs_outsig, 0, 0);
+      if (config->cs_pin >= 0)
+        {
+          esp32s3_configgpio(config->cs_pin, OUTPUT);
+          esp32s3_gpio_matrix_out(config->cs_pin, config->cs_outsig, 0, 0);
+        }
 #endif
-      esp32s3_configgpio(config->mosi_pin, OUTPUT);
-      esp32s3_gpio_matrix_out(config->mosi_pin, config->mosi_outsig, 0, 0);
 
-      esp32s3_configgpio(config->miso_pin, INPUT | PULLUP);
-      esp32s3_gpio_matrix_in(config->miso_pin, config->miso_insig, 0);
+      if (config->mosi_pin >= 0)
+        {
+          esp32s3_configgpio(config->mosi_pin, OUTPUT);
+          esp32s3_gpio_matrix_out(config->mosi_pin,
+                                  config->mosi_outsig, 0, 0);
+        }
+
+      if (config->miso_pin >= 0)
+        {
+          esp32s3_configgpio(config->miso_pin, INPUT | PULLUP);
+          esp32s3_gpio_matrix_in(config->miso_pin, config->miso_insig, 0);
+        }
 
       esp32s3_configgpio(config->clk_pin, OUTPUT);
       esp32s3_gpio_matrix_out(config->clk_pin, config->clk_outsig, 0, 0);


### PR DESCRIPTION
## Summary
The MISO or MOSI pin is optional.
The C/S pin is unnecessary when `ESP32S3_SPI_UDCS` is enabled.

## Impact

RELEASE

## Testing

CI