### PR TITLE
arch/armv8-r: Enable fpu before arm_el_init

### DIFF
--- a/arch/arm/src/armv8-r/arm_head.S
+++ b/arch/arm/src/armv8-r/arm_head.S
@@ -212,6 +212,10 @@ __cpu0_start:
 	ldr		r0, =HACTLR_INIT
 	mcr		CP15_HACTLR(r0)  /* Enable EL1 access all IMP DEFINED registers */
 
+#ifdef CONFIG_ARCH_FPU
+	bl		arm_fpuconfig
+#endif
+
 	/* Initialize .bss and .data assumt that RAM that is ready to use. */
 	bl		arm_data_initialize
 
@@ -238,9 +242,6 @@ __cpu0_start:
 	mcr		CP15_VBAR(r0)
 
 	bl		sctlr_initialize
-#ifdef CONFIG_ARCH_FPU
-	bl		arm_fpuconfig
-#endif
 	bl		arm_boot
 
 	mov		lr, #0				/* LR = return address (none) */


### PR DESCRIPTION

## Summary
In the arm_el_init function, the FPU might be used, for example, the assembly optimization of memcpy uses FPU and NEON instructions and registers.
Therefore, it's important to initialize the
FPU as early as possible to prevent system hangs that could occur if the FPU is used without being initialized.


## Impact
arch/arm/armv8-r  arch init

## Testing

cortex-r52


