### PR TITLE
tools/testbuild.sh: fix line 385: /nuttx/nuttx.manifest: No such file or directory

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -379,7 +379,7 @@ function build_default {
     makefunc
   fi
 
-  if [ ${SAVEARTIFACTS} -eq 1 ]; then
+  if [ ${SAVEARTIFACTS} -eq 1 ] && [ ${fail} -eq 0 ]; then
     artifactconfigdir=$ARTIFACTDIR/$(echo $config | sed "s/:/\//")/
     mkdir -p $artifactconfigdir
     xargs -I "{}" cp "{}" $artifactconfigdir < $nuttx/nuttx.manifest
@@ -394,7 +394,7 @@ function build_cmake {
     fail=1
   fi
 
-  if [ ${SAVEARTIFACTS} -eq 1 ]; then
+  if [ ${SAVEARTIFACTS} -eq 1 ] && [ ${fail} -eq 0 ]; then
     artifactconfigdir=$ARTIFACTDIR/$(echo $config | sed "s/:/\//")/
     mkdir -p $artifactconfigdir
     cd $nuttx/build


### PR DESCRIPTION
## Summary

In case the build fails added control in the SAVE ARTIFACTS step to avoid this warning

`d/a/nuttx/nuttx/sources/nuttx/tools/testbuild.sh: line 385: /d/a/nuttx/nuttx/sources/nuttx/../nuttx/nuttx.manifest: No such file or directory`

https://github.com/apache/nuttx/actions/runs/14217018121/job/39836108310?pr=16113#step:9:1142

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
CI GitHub
https://github.com/simbit18/nuttx_test_pr/actions/runs/14218406807



