### PR TITLE
mpfs/mpfs_entrypoints.c: Change atomic_load > atomic_read

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_entrypoints.c
+++ b/arch/risc-v/src/mpfs/mpfs_entrypoints.c
@@ -270,7 +270,7 @@ bool mpfs_get_use_sbi(uint64_t hartid)
 
 int mpfs_cpus_booted(void)
 {
-  return atomic_load(&g_cpus_booted);
+  return atomic_read(&g_cpus_booted);
 }
 
 #endif /* CONFIG_MPFS_BOOTLOADER */


### PR DESCRIPTION
## Summary

Otherwise we get an undefined symbol error when LIBC_ARCH_ATOMIC is defined.

## Impact

MPFS bootloader only. 

## Testing

MPFS target with MPFS_BOOTLOADER=y

