### PR TITLE
Add FT5X06 support for szpi-esp32s3

### DIFF
--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/Make.defs
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/Make.defs
@@ -56,3 +56,7 @@ endif
 ifeq ($(CONFIG_LCD),y)
 CSRCS += esp32s3_board_lcd.c
 endif
+
+ifeq ($(CONFIG_INPUT_FT5X06),y)
+CSRCS += esp32s3_ft5x06.c
+endif

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
@@ -40,6 +40,9 @@
 #define GPIO_LCD_RST        (-1)
 #define SZPI_LCD_CS_PATH    "/dev/gpio0"
 
+#define FT5X06_I2C_ADDRESS  (0x38)
+#define FT5X06_FREQUENCY    (400000)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -184,6 +187,10 @@ int esp_openeth_initialize(void);
 
 #ifdef CONFIG_IOEXPANDER_PCA9557
 int esp32s3_pca9557_initialize(void);
+#endif
+
+#ifdef CONFIG_INPUT_FT5X06
+int esp32s3_ft5x06_initialize(void);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -315,6 +315,14 @@ int esp32s3_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_INPUT_FT5X06
+  ret = esp32s3_ft5x06_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize FT5X06 driver: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_SENSORS_BMP180
   /* Try to register BMP180 device in I2C0 */
 

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <debug.h>
+#include <assert.h>
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/input/ft5x06.h>
+
+#include "esp32s3_i2c.h"
+#include "esp32s3-szpi.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_FT5X06_POLLMODE
+#error "Only support poll mode currently!"
+#endif
+
+#define ESP32S3_FT5X06_I2C_PORT (0)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct ft5x06_config_s g_ft5x06_config =
+{
+  .address   = FT5X06_I2C_ADDRESS,
+  .frequency = FT5X06_FREQUENCY,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int esp32s3_ft5x06_initialize(void)
+{
+  FAR struct i2c_master_s *i2c;
+  int ret;
+
+  i2c = esp32s3_i2cbus_initialize(ESP32S3_FT5X06_I2C_PORT);
+  if (!i2c)
+    {
+      i2cerr("Initialize I2C bus failed!\n");
+      return -EINVAL;
+    }
+
+  ret = ft5x06_register(i2c, &g_ft5x06_config, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to register FT5X06 driver: %d\n", ret);
+    }
+
+  return 0;
+}

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -1084,12 +1084,9 @@ int ft5x06_register(FAR struct i2c_master_s *i2c,
   /* Debug-only sanity checks */
 
   DEBUGASSERT(i2c != NULL && config != NULL && minor >= 0 && minor < 100);
-#ifdef CONFIG_FT5X06_POLLMODE
-  DEBUGASSERT(config->wakeup != NULL && config->nreset != NULL);
-#else
+#ifndef CONFIG_FT5X06_POLLMODE
   DEBUGASSERT(config->attach != NULL && config->enable != NULL &&
-              config->clear  != NULL && config->wakeup != NULL &&
-              config->nreset != NULL);
+              config->clear  != NULL);
 #endif
 
   /* Create and initialize a FT5x06 device driver instance */


### PR DESCRIPTION
## Summary
Add FT5X06 support for szpi-esp32s3.
1. drivers/ft5x06: Remove unused wakeup and nreset check of FT5X06.
2. boards/szpi-esp32s3: Add support for FT5X06 touchscreen driver.

For hardware details, please ref to https://wiki.lckfb.com/zh-hans/szpi-esp32s3/open-source-hardware/.
New configuration("lckfb-szpi-esp32s3:ft5x06" maybe) and doc will be added in the near future if needed.
## Impact
1. drivers/ft5x06
2. boards/szpi-esp32s3

## Testing
1. The config "lckfb-szpi-esp32s3:lvgl" with FT5X06 enabled
    ```bash
    # Build & Burn
    ./tools/configure.sh -l lckfb-szpi-esp32s3:lvgl
    make flash -j$(nproc) ESPTOOL_PORT=/dev/ttyUSB0
    ```
    ```diff
    +CONFIG_FT5X06_POLLMODE=y
    +CONFIG_FT5X06_SINGLEPOINT=y
    +CONFIG_FT5X06_SWAPXY=y
    +CONFIG_INPUT=y
    +CONFIG_INPUT_FT5X06=y
    ```
2. CI

