### PR TITLE
sched/gettid: Move thread ID to TLS

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -155,9 +155,6 @@
  */
 
 #if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
-#  define _SCHED_GETTID()            nxsched_gettid()
-#  define _SCHED_GETPID()            nxsched_getpid()
-#  define _SCHED_GETPPID()           nxsched_getppid()
 #  define _SCHED_GETPARAM(t,p)       nxsched_get_param(t,p)
 #  define _SCHED_SETPARAM(t,p)       nxsched_set_param(t,p)
 #  define _SCHED_GETSCHEDULER(t)     nxsched_get_scheduler(t)
@@ -167,9 +164,6 @@
 #  define _SCHED_ERRNO(r)            (-(r))
 #  define _SCHED_ERRVAL(r)           (r)
 #else
-#  define _SCHED_GETTID()            gettid()
-#  define _SCHED_GETPID()            getpid()
-#  define _SCHED_GETPPID()           getppid()
 #  define _SCHED_GETPARAM(t,p)       sched_getparam(t,p)
 #  define _SCHED_SETPARAM(t,p)       sched_setparam(t,p)
 #  define _SCHED_GETSCHEDULER(t)     sched_getscheduler(t)
@@ -178,6 +172,16 @@
 #  define _SCHED_SETAFFINITY(t,c,m)  sched_setaffinity(t,c,m)
 #  define _SCHED_ERRNO(r)            errno
 #  define _SCHED_ERRVAL(r)           (-errno)
+#endif
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+#  define _SCHED_GETTID()            nxsched_gettid()
+#  define _SCHED_GETPID()            nxsched_getpid()
+#  define _SCHED_GETPPID()           nxsched_getppid()
+#else
+#  define _SCHED_GETTID()            gettid()
+#  define _SCHED_GETPID()            getpid()
+#  define _SCHED_GETPPID()           getppid()
 #endif
 
 #define TCB_PID_OFF                  offsetof(struct tcb_s, pid)

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -223,6 +223,7 @@ struct tls_info_s
 
   uint16_t tl_size;                    /* Actual size with alignments */
   int tl_errno;                        /* Per-thread error number */
+  pid_t tl_tid;                        /* Thread ID */
 };
 
 /****************************************************************************

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -29,7 +29,6 @@
 SYSCALL_LOOKUP1(_exit,                     1)
 SYSCALL_LOOKUP(_assert,                    4)
 SYSCALL_LOOKUP(getpid,                     0)
-SYSCALL_LOOKUP(gettid,                     0)
 SYSCALL_LOOKUP(prctl,                      2)
 
 #ifdef CONFIG_SCHED_HAVE_PARENT

--- a/libs/libc/sched/CMakeLists.txt
+++ b/libs/libc/sched/CMakeLists.txt
@@ -28,7 +28,8 @@ set(SRCS
     task_cancelpt.c
     task_setcancelstate.c
     task_setcanceltype.c
-    task_testcancel.c)
+    task_testcancel.c
+    task_gettid.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS sched_cpucount.c)

--- a/libs/libc/sched/Make.defs
+++ b/libs/libc/sched/Make.defs
@@ -25,7 +25,7 @@
 CSRCS += sched_getprioritymax.c sched_getprioritymin.c
 CSRCS += clock_getcpuclockid.c clock_getres.c
 CSRCS += task_cancelpt.c task_setcancelstate.c task_setcanceltype.c
-CSRCS += task_testcancel.c
+CSRCS += task_testcancel.c task_gettid.c
 
 ifeq ($(CONFIG_SMP),y)
 CSRCS += sched_cpucount.c

--- a/libs/libc/sched/task_gettid.c
+++ b/libs/libc/sched/task_gettid.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/task/task_gettid.c
+ * libs/libc/sched/task_gettid.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -24,20 +24,19 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <sys/types.h>
 #include <unistd.h>
-#include <sched.h>
-#include <errno.h>
 
-#include "sched/sched.h"
-#include "task/task.h"
+#include <nuttx/tls.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxsched_gettid
+ * Name: gettid
  *
  * Description:
  *   Get the thread ID of the currently executing thread.
@@ -50,44 +49,8 @@
  *
  ****************************************************************************/
 
-pid_t nxsched_gettid(void)
+pid_t gettid(void)
 {
-  FAR struct tcb_s *rtcb;
-
-  /* Get the TCB at the head of the ready-to-run task list.  That
-   * will usually be the currently executing task.  There are two
-   * exceptions to this:
-   *
-   * 1. Early in the start-up sequence, the ready-to-run list may be
-   *    empty!  In this case, of course, the CPU0 start-up/IDLE thread with
-   *    pid == 0 must be running, and
-   * 2. As described above, during certain context-switching conditions the
-   *    task at the head of the ready-to-run list may not actually be
-   *    running.
-   */
-
-  rtcb = this_task();
-  if (rtcb != NULL)
-    {
-      /* Check if the task is actually running */
-
-      if (rtcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Yes.. Return the task ID from the TCB at the head of the
-           * ready-to-run task list
-           */
-
-          return rtcb->pid;
-        }
-
-      /* No.. return -ESRCH to indicate this condition */
-
-      return (pid_t)-ESRCH;
-    }
-
-  /* We must have been called earlier in the start up sequence from the
-   * start-up/IDLE thread before the ready-to-run list has been initialized.
-   */
-
-  return 0;
+  FAR struct tls_info_s *tls = tls_get_info();
+  return tls->tl_tid;
 }

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -281,15 +281,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
     }
 #endif
 
-  /* Initialize thread local storage */
-
-  ret = tls_init_info(&ptcb->cmn);
-  if (ret != OK)
-    {
-      errcode = -ret;
-      goto errout_with_tcb;
-    }
-
   /* Should we use the priority and scheduler specified in the pthread
    * attributes?  Or should we use the current thread's priority and
    * scheduler?
@@ -394,6 +385,15 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   if (ret != OK)
     {
       errcode = EBUSY;
+      goto errout_with_tcb;
+    }
+
+  /* Initialize thread local storage */
+
+  ret = tls_init_info(&ptcb->cmn);
+  if (ret != OK)
+    {
+      errcode = -ret;
       goto errout_with_tcb;
     }
 

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -168,18 +168,18 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       goto errout_with_group;
     }
 
-  /* Initialize thread local storage */
+  /* Initialize the task control block */
 
-  ret = tls_init_info(&tcb->cmn);
+  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
+                               entry, ttype);
   if (ret < OK)
     {
       goto errout_with_group;
     }
 
-  /* Initialize the task control block */
+  /* Initialize thread local storage */
 
-  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
-                               entry, ttype);
+  ret = tls_init_info(&tcb->cmn);
   if (ret < OK)
     {
       goto errout_with_group;

--- a/sched/tls/tls_initinfo.c
+++ b/sched/tls/tls_initinfo.c
@@ -73,5 +73,10 @@ int tls_init_info(FAR struct tcb_s *tcb)
   /* Attach per-task info in group to TLS */
 
   info->tl_task = tcb->group->tg_info;
+
+  /* Thread ID */
+
+  info->tl_tid = tcb->pid;
+
   return OK;
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -48,7 +48,6 @@
 "getppid","unistd.h","defined(CONFIG_SCHED_HAVE_PARENT)","pid_t"
 "getsockname","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getsockopt","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","FAR void *","FAR socklen_t *"
-"gettid","unistd.h","","pid_t"
 "gettimeofday","sys/time.h","","int","FAR struct timeval *","FAR struct timezone *"
 "getuid","unistd.h","defined(CONFIG_SCHED_USER_IDENTITY)","uid_t"
 "inotify_add_watch","sys/inotify.h","defined(CONFIG_FS_NOTIFY)","int","int","FAR const char *","uint32_t"


### PR DESCRIPTION
## Summary

There is no need for a gettid() syscall, as the thread ID is stable through the life of the process. It is safe to put a copy of TID to TLS. This way a user processes can access TID quickly via its own stack, instead of having to use an expensive syscall.

## Impact

Impact is to gettid() system call, this patch removes the call gate to kernel and moves the data into TLS for quick userspace access.

## Testing

rv-virt:knsh64 + ostest
