### PR TITLE
boards/szpi-esp32s3: Set LCD default backlight brightness

### DIFF
--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
@@ -39,6 +39,9 @@
 #define GPIO_LCD_DC         (39)
 #define GPIO_LCD_RST        (-1)
 #define SZPI_LCD_CS_PATH    "/dev/gpio0"
+#define SZPI_LCD_PWM_PATH   "/dev/pwm0"
+#define SZPI_LCD_PWM_FREQ   (100)
+#define SZPI_LCD_PWM_DUTY   (0xe666)       /* 0x1 ~ 0xffff */
 
 #define FT5X06_I2C_ADDRESS  (0x38)
 #define FT5X06_FREQUENCY    (400000)

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_board_spi.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_board_spi.c
@@ -90,23 +90,24 @@ int esp32s3_spi2_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #if defined(CONFIG_ESP32S3_SPI2) && defined(CONFIG_ESP32S3_SPI_UDCS)
 void esp32s3_spi2_select(struct spi_dev_s *dev, uint32_t devid, bool select)
 {
+  struct file f;
   ssize_t n;
-  int fd;
+  int ret;
 
-  fd = nx_open(SZPI_LCD_CS_PATH, O_RDWR);
-  if (fd < 0)
+  ret = file_open(&f, SZPI_LCD_CS_PATH, O_RDWR);
+  if (ret < 0)
     {
       spierr("open C/S pin failed\n");
       return;
     }
 
-  n = nx_write(fd, select ? "0" : "1", 1);
+  n = file_write(&f, select ? "0" : "1", 1);
   if (n != 1)
     {
       spierr("write C/S pin failed\n");
     }
 
-  nx_close(fd);
+  file_close(&f);
 }
 #endif
 

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c
@@ -63,7 +63,7 @@ static const struct ft5x06_config_s g_ft5x06_config =
 
 int esp32s3_ft5x06_initialize(void)
 {
-  FAR struct i2c_master_s *i2c;
+  struct i2c_master_s *i2c;
   int ret;
 
   i2c = esp32s3_i2cbus_initialize(ESP32S3_FT5X06_I2C_PORT);

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_pca9557.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_pca9557.c
@@ -83,8 +83,8 @@ struct pca9557_config_s g_pca9557_config =
 
 int esp32s3_pca9557_initialize(void)
 {
-  FAR struct ioexpander_dev_s *ioe;
-  FAR struct i2c_master_s *i2c;
+  struct ioexpander_dev_s *ioe;
+  struct i2c_master_s *i2c;
   int ret;
 
   i2c = esp32s3_i2cbus_initialize(ESP32S3_PCA9557_I2C_PORT);


### PR DESCRIPTION
## Summary
Set LCD default backlight brightness of szpi-esp32s3 to about 10%.
Users can set brightness at runtime throug "pwm" command or customed application by controlling "/dev/pwm0".
## Impact
- boards/szpi-esp32s3
## Testing
Test OK on both "lcd" and "lvgl" configuration.
```bash
./tools/configure.sh -l lckfb-szpi-esp32s3:lcd
make flash -j$(nproc) ESPTOOL_PORT=/dev/ttyUSB0

./tools/configure.sh -l lckfb-szpi-esp32s3:lvgl
make flash -j$(nproc) ESPTOOL_PORT=/dev/ttyUSB0
```