### PR TITLE
boards/arm/stm32f401rc-rs485: Add support to BMP180 Sensor

### DIFF
--- a/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
+++ b/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
@@ -770,5 +770,93 @@ NSH commands::
        NuttShell (NSH) NuttX-12.7.0-RC0
        nsh> ws2812
 
+bmp180
+======
 
-       
+The BMP180 is a digital barometric pressure sensor that provides pressure and temperature readings
+over I2C. It is commonly used in weather monitoring, altimetry, and embedded sensor applications.
+
+This guide describes how to configure and use the BMP180 sensor in NuttX with two available drivers:
+the **regular driver** and the **UORB driver**. It also includes example NSH commands and the required
+hardware pin configuration.
+
+Initial Setup
+-------------
+
+Ensure the NuttShell (NSH) is configured either over USB Serial (configure ``usbnsh``) or via UART
+(configure ``nsh``) to perform board-level configuration.
+
+Regular Driver
+--------------
+
+This driver offers basic access to the BMP180 sensor values directly through a command-line utility.
+
+**Enable the following options using ``make menuconfig``:**
+
+::
+
+    CONFIG_ARCH_BOARD_COMMON=y
+    CONFIG_STM32_I2C1=y
+    CONFIG_EXAMPLES_BMP180=y
+    CONFIG_SENSORS=y
+    CONFIG_SENSORS_BMP180=y
+
+**NSH usage:**
+
+::
+
+    NuttShell (NSH) NuttX-12.8.0
+    nsh> bmp180
+    Pressure value = 93592
+    Pressure value = 93591
+    Pressure value = 93595
+
+This output shows raw pressure values (in Pascals).
+
+UORB Driver
+-----------
+
+This driver integrates the sensor into the UORB publish/subscribe system. It supports high-level
+features such as scheduling and multi-sensor handling.
+
+**Enable the following options using ``make menuconfig``:**
+
+::
+
+    CONFIG_ARCH_BOARD_COMMON=y
+    CONFIG_STM32_I2C1=y
+    CONFIG_LIBC_FLOATINGPOINT=y
+    CONFIG_SENSORS=y
+    CONFIG_SENSORS_BMP180=y
+    CONFIG_SENSORS_BMP180_UORB=y
+    CONFIG_SYSTEM_SENSORTEST=y
+    CONFIG_SYSTEM_SENSORTEST_PROGNAME="sensor"
+    CONFIG_SCHED_WORKQUEUE=y
+    CONFIG_SCHED_LPWORK=y
+
+**NSH usage:**
+
+::
+
+    NuttShell (NSH) NuttX-12.8.0
+    nsh> sensor baro0
+    SensorTest: Test /dev/uorb/sensor_baro0 with interval(1000000us), latency(0us)
+    baro0: timestamp:2170620000 value1:935.92 value2:224.00
+    baro0: timestamp:2171630000 value1:935.92 value2:224.00
+    baro0: timestamp:2172640000 value1:935.89 value2:224.00
+
+- ``value1`` corresponds to pressure in hPa (hectopascals).
+- ``value2`` corresponds to temperature in tenths of degrees Celsius (e.g., 224.00 = 22.4°C).
+
+Hardware Connections
+--------------------
+
+Connect the BMP180 sensor to the STM32 board using the I2C interface.
+
++--------+------+
+| SENSOR | PIN  |
++========+======+
+| SDA    | PB7  |
++--------+------+
+| SCL    | PB8  |
++--------+------+

--- a/boards/arm/stm32/common/src/stm32_bmp180.c
+++ b/boards/arm/stm32/common/src/stm32_bmp180.c
@@ -78,7 +78,6 @@
 int board_bmp180_initialize(int devno, int busno)
 {
   struct i2c_master_s *i2c;
-  char devpath[12];
   int ret;
 
   sninfo("Initializing BMP180!\n");
@@ -94,8 +93,14 @@ int board_bmp180_initialize(int devno, int busno)
 
   /* Then register the barometer sensor */
 
-  snprintf(devpath, sizeof(devpath), "/dev/press%d", devno);
-  ret = bmp180_register(devpath, i2c);
+  #ifdef CONFIG_SENSORS_BMP180_UORB
+    ret = bmp180_register_uorb(devno, i2c);
+  #else
+    char devpath[12];
+    snprintf(devpath, sizeof(devpath), "/dev/press%d", devno);
+    ret = bmp180_register(devpath, i2c);
+  #endif
+
   if (ret < 0)
     {
       snerr("ERROR: Error registering BM180\n");

--- a/boards/arm/stm32/stm32f401rc-rs485/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/stm32_bringup.c
@@ -89,6 +89,10 @@
 #include "stm32_ws2812.h"
 #endif
 
+#ifdef CONFIG_SENSORS_BMP180
+#include "stm32_bmp180.h"
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -351,6 +355,17 @@ int stm32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: stm32_gpio_initialize() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_BMP180
+  /* Initialize the BMP180 pressure sensor. */
+
+  ret = board_bmp180_initialize(0, 1);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize BMP180, error %d\n", ret);
+      return ret;
     }
 #endif
 


### PR DESCRIPTION
## Summary

This commit adds support for the BMP180 sensor on the STM32F401RC-RS485 board and updates the board documentation accordingly. It also enables the BMP180 UORB driver in the STM32 common logic.

## Impact

  * Is new feature added? Is existing feature changed? Yes, Added BMP180 support to STM32F401RC-RS485 and
  BMP180 UORB driver in the STM32 common logic. 
  * Impact on user (will user need to adapt to change)? Yes, users will be able to user BMP180 on STM32F401RC-RS485
  *  and BMP180 UORB on other STM32 boards.
  * Impact on build (will build process change)? No
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? Yes, STM32F401RC-RS485  and STM32 Common.
  * Impact on documentation (is update required / provided)? Yes, STM32F401RC-RS485 was updated.
  * Impact on security (any sort of implications)? No.
  * Impact on compatibility (backward/forward/interoperability)? No


## Testing
I confirm that changes are verified on local setup and works as intended:
* Build Host(s):  OS: Ubuntu 24.04, CPU:  Intel i7-8850H, Compiler: GCC 13.3.0
* Target(s): arch: arm, board: stm32f401rc-rs485, config: usbnsh
The test was done using two configurations:

Regular Driver:
CONFIG_ARCH_BOARD_COMMON=y
CONFIG_STM32_I2C1=y
CONFIG_EXAMPLES_BMP180=y
CONFIG_SENSORS=y
CONFIG_SENSORS_BMP180=y

```
NuttShell (NSH) NuttX-12.8.0
nsh> bmp180
Pressure value = 93592
Pressure value = 93591
Pressure value = 93595
```

UORB Driver: 
CONFIG_ARCH_BOARD_COMMON=y
CONFIG_STM32_I2C1=y
CONFIG_LIBC_FLOATINGPOINT=y
CONFIG_SENSORS=y
CONFIG_SENSORS_BMP180=y
CONFIG_SENSORS_BMP180_UORB=y
CONFIG_SYSTEM_SENSORTEST=y
CONFIG_SYSTEM_SENSORTEST_PROGNAME="sensor"
CONFIG_SCHED_WORKQUEUE=y
CONFIG_SCHED_LPWORK=y

```
NuttShell (NSH) NuttX-12.8.0
nsh> sensor baro0
SensorTest: Test /dev/uorb/sensor_baro0 with interval(1000000us), latency(0us)
baro0: timestamp:2170620000 value1:935.92 value2:224.00
baro0: timestamp:2171630000 value1:935.92 value2:224.00
baro0: timestamp:2172640000 value1:935.89 value2:224.00
```



