### PR TITLE
Sched small sem cleanups

### DIFF
--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -92,7 +92,8 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 #if defined(CONFIG_PRIORITY_INHERITANCE) || defined(CONFIG_PRIORITY_PROTECT)
   if (attr)
     {
-      status = mutex_set_protocol(&mutex->mutex, attr->proto);
+      status = mutex_set_protocol(&mutex->mutex,
+                                  SEM_TYPE_MUTEX | attr->proto);
       if (status < 0)
         {
           mutex_destroy(&mutex->mutex);

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -303,6 +303,8 @@ static void nxsig_stop_task(int signo)
 
   if ((group->tg_waitflags & WUNTRACED) != 0)
     {
+      int semvalue;
+
       /* Return zero for exit status (we are not exiting, however) */
 
       if (group->tg_statloc != NULL)
@@ -319,11 +321,13 @@ static void nxsig_stop_task(int signo)
 
       /* Wakeup any tasks waiting for this task to exit or stop. */
 
-      while (group->tg_exitsem.semcount < 0)
+      nxsem_get_value(&group->tg_exitsem, &semvalue);
+      while (semvalue < 0)
         {
           /* Wake up the thread */
 
           nxsem_post(&group->tg_exitsem);
+          nxsem_get_value(&group->tg_exitsem, &semvalue);
         }
     }
 #endif

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -315,6 +315,7 @@ static inline void nxtask_signalparent(FAR struct tcb_s *ctcb, int status)
 static inline void nxtask_exitwakeup(FAR struct tcb_s *tcb, int status)
 {
   FAR struct task_group_s *group = tcb->group;
+  int semvalue;
 
   /* Have we already left the group? */
 
@@ -360,11 +361,13 @@ static inline void nxtask_exitwakeup(FAR struct tcb_s *tcb, int status)
           group->tg_statloc   = NULL;
           group->tg_waitflags = 0;
 
-          while (group->tg_exitsem.semcount < 0)
+          nxsem_get_value(&group->tg_exitsem, &semvalue);
+          while (semvalue < 0)
             {
               /* Wake up the thread */
 
               nxsem_post(&group->tg_exitsem);
+              nxsem_get_value(&group->tg_exitsem, &semvalue);
             }
         }
     }


### PR DESCRIPTION

## Summary

This PR has two commits for sched:
- Set the mutex flag for pthread semaphores also when the PRIORITY_INHERITANCE flag is enabled. This has no functional impact for now, but it should still be set for the future if the semaphore is mutex to allow later optimizations
- Instead of accessing "semcount" directly from outside sched/semaphore, use the existing nxsem_get_value interface.

## Impact

No functional impact

## Testing

Tested on QEMU rv_virt:nsh64, rv_virt:nsh, i.MX93 (arm64) and MPFS (riscv 64-bit).
