### PR TITLE
libc/semaphore: Read semaphore value by using NXSEM_COUNT macro

### DIFF
--- a/libs/libc/semaphore/sem_getvalue.c
+++ b/libs/libc/semaphore/sem_getvalue.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 #include <nuttx/semaphore.h>
+#include <nuttx/atomic.h>
 
 /****************************************************************************
  * Public Functions
@@ -64,7 +65,7 @@ int nxsem_get_value(FAR sem_t *sem, FAR int *sval)
 {
   if (sem != NULL && sval != NULL)
     {
-      *sval = sem->semcount;
+      *sval = atomic_read(NXSEM_COUNT(sem));
       return OK;
     }
 


### PR DESCRIPTION

## Summary

This is a small cleanup for libc nxsem_get_value, to use the provided macro to fetch the semaphore value instead of accessing semaphore internals directly outside of sched/semaphore.

## Impact

No functional impact

## Testing

This has obviously no functional impact, however, it has been tested together with all the changes in PR #16148 (in qemu and in real hardware).
