### PR TITLE
xtensa/esp32s2: enable sysclk and deassert reset signal for uart1

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.c
@@ -817,6 +817,7 @@ void esp32s2_lowsetup(void)
 
 #ifdef CONFIG_ESP32S2_UART1
 
+  esp32s2_lowputc_rst_peripheral(&g_uart1_config);
   esp32s2_lowputc_config_pins(&g_uart1_config);
 
 #endif

--- a/arch/xtensa/src/esp32s2/esp32s2_serial.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_serial.c
@@ -301,6 +301,8 @@ static int esp32s2_setup(struct uart_dev_s *dev)
 
   /* Initialize UART module */
 
+  esp32s2_lowputc_enable_sysclk(priv);
+
   /* Discard corrupt RX data */
 
   modifyreg32(UART_CONF0_REG(priv->id), 0, UART_ERR_WR_MASK_M);


### PR DESCRIPTION
The uart1 is found be in reset state, and the sysclk is not enabled for it.

## Summary

When enable `CONFIG_ESP32S2_UART1` and connect an external usb-uart converter to UART1(TXPIN=17,RXPIN=18), it's found that the host can't communicate with the esp32s2 board.

## Impact

esp32s2, uart1

## Testing

enable `CONFIG_ESP32S2_UART1`, connect an external usb-uart converter to UART1(TXPIN=17,RXPIN=18) to test.

1. board send
run this command on the board, and observe data on host machine (in another minicom)
```
nsh> echo abc >/dev/ttyS1
```
2. board receive
run this command on the board, and press some keys on host machine (in another minicom) to send
```
nsh> cat /dev/ttyS1 &
```

