### PR TITLE
arch/sim: Add i2c setup and shutdown interface

### DIFF
--- a/arch/sim/src/sim/posix/sim_i2c.h
+++ b/arch/sim/src/sim/posix/sim_i2c.h
@@ -73,6 +73,8 @@ struct i2c_ops_s
 #ifdef CONFIG_I2C_RESET
   int (*reset)(struct i2c_master_s *dev);
 #endif
+  int (*setup)(struct i2c_master_s *dev);
+  int (*shutdown)(struct i2c_master_s *dev);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

arch/sim: Add i2c setup and shutdown interface
https://github.com/apache/nuttx/pull/12848/commits/12b4340b009d55f30508b1ebb1da1c4faec674a7

This interface is required if you want to open an i2c node directly on the sim

## Impact

sim_i2c

## Testing

CI

