### PR TITLE
boards/stm32f0l0g0: unify liker scripts

### DIFF
--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/scripts/flash.ld
@@ -57,30 +57,26 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > flash
 
-    .init_section :
-    {
+    .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab :
-    {
+    .ARM.extab ALIGN(4): {
         *(.ARM.extab*)
     } > flash
 
-    __exidx_start = ABSOLUTE(.);
-    .ARM.exidx :
-    {
+    .ARM.exidx : ALIGN(4) {
+        __exidx_start = ABSOLUTE(.);
         *(.ARM.exidx*)
+        __exidx_end = ABSOLUTE(.);
     } > flash
-    __exidx_end = ABSOLUTE(.);
 
     _eronly = ABSOLUTE(.);
 
-    .data :
-    {
+    .data : ALIGN(4) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
@@ -89,8 +85,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .bss :
-    {
+    .bss : ALIGN(4) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
@@ -57,30 +57,26 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > flash
 
-    .init_section :
-    {
+    .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab :
-    {
+    .ARM.extab ALIGN(4): {
         *(.ARM.extab*)
     } > flash
 
-    __exidx_start = ABSOLUTE(.);
-    .ARM.exidx :
-    {
+    .ARM.exidx : ALIGN(4) {
+        __exidx_start = ABSOLUTE(.);
         *(.ARM.exidx*)
+        __exidx_end = ABSOLUTE(.);
     } > flash
-    __exidx_end = ABSOLUTE(.);
 
     _eronly = ABSOLUTE(.);
 
-    .data :
-    {
+    .data : ALIGN(4) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
@@ -89,8 +85,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .bss :
-    {
+    .bss : ALIGN(4) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
@@ -57,30 +57,26 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > flash
 
-    .init_section :
-    {
+    .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab :
-    {
+    .ARM.extab ALIGN(4): {
         *(.ARM.extab*)
     } > flash
 
-    __exidx_start = ABSOLUTE(.);
-    .ARM.exidx :
-    {
+    .ARM.exidx : ALIGN(4) {
+        __exidx_start = ABSOLUTE(.);
         *(.ARM.exidx*)
+        __exidx_end = ABSOLUTE(.);
     } > flash
-    __exidx_end = ABSOLUTE(.);
 
     _eronly = ABSOLUTE(.);
 
-    .data :
-    {
+    .data : ALIGN(4) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
@@ -89,8 +85,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .bss :
-    {
+    .bss : ALIGN(4) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
@@ -63,19 +63,19 @@ SECTIONS
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab : {
+    .ARM.extab ALIGN(4): {
         *(.ARM.extab*)
     } > flash
 
-    __exidx_start = ABSOLUTE(.);
     .ARM.exidx : {
+        __exidx_start = ABSOLUTE(.);
         *(.ARM.exidx*)
+        __exidx_end = ABSOLUTE(.);
     } > flash
-    __exidx_end = ABSOLUTE(.);
 
     _eronly = ABSOLUTE(.);
 
-    .data : {
+    .data : ALIGN(4) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
@@ -84,7 +84,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .bss : {
+    .bss : ALIGN(4) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
@@ -56,26 +56,26 @@ SECTIONS
         _etext = ABSOLUTE(.);
     } > flash
 
-    .init_section : {
+    .init_section : ALIGN(4) {
         _sinit = ABSOLUTE(.);
         KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab : {
+    .ARM.extab ALIGN(4): {
         *(.ARM.extab*)
     } > flash
 
-    __exidx_start = ABSOLUTE(.);
-    .ARM.exidx : {
+    .ARM.exidx : ALIGN(4) {
+        __exidx_start = ABSOLUTE(.);
         *(.ARM.exidx*)
+        __exidx_end = ABSOLUTE(.);
     } > flash
-    __exidx_end = ABSOLUTE(.);
 
     _eronly = ABSOLUTE(.);
 
-    .data : {
+    .data : ALIGN(4) {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
         *(.gnu.linkonce.d.*)
@@ -84,7 +84,7 @@ SECTIONS
         _edata = ABSOLUTE(.);
     } > sram AT > flash
 
-    .bss : {
+    .bss : ALIGN(4) {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)


### PR DESCRIPTION
## Summary

Unify liker scripts for all stm32f0l0g0.
This fixes crash due to unaligned access to rodata for these boards.

## Impact

fix crash when initializing rodata and unify linker scripts

## Testing

custom application with nucleo-c071rb

