### PR TITLE
fs/procfs: fix potential null pointer access in procfs_opendir

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -714,8 +714,12 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
                * derived from struct procfs_dir_priv_s as dir.
                */
 
-              DEBUGASSERT(g_procfs_entries[x].ops != NULL &&
-                          g_procfs_entries[x].ops->opendir != NULL);
+              DEBUGASSERT(g_procfs_entries[x].ops != NULL);
+
+              if (g_procfs_entries[x].ops->opendir == NULL)
+                {
+                  return -ENOENT;
+                }
 
               ret = g_procfs_entries[x].ops->opendir(relpath, dir);
               if (ret == OK)


### PR DESCRIPTION
Some entries have the opendir function set to NULL, for example g_mount_operations.

A null pointer dereference can be triggered by an opendir("/proc/fs/blocks") for example.

## Testing

I tested this with the PX4 fork (https://github.com/PX4/NuttX), 10.3.0, on an STM32F7 board.


