### PR TITLE
nuttx/spinlock: Define spinlock_t as size 0 if spinlocks are not used

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -126,6 +126,7 @@ void sched_note_spinlock_unlock(FAR volatile spinlock_t *spinlock);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_SPINLOCK
 #if defined(CONFIG_ARCH_HAVE_TESTSET)
 spinlock_t up_testset(FAR volatile spinlock_t *lock);
 #else
@@ -147,6 +148,7 @@ static inline spinlock_t up_testset(FAR volatile spinlock_t *lock)
 
   return ret;
 }
+#endif
 #endif
 
 /****************************************************************************

--- a/include/nuttx/spinlock_type.h
+++ b/include/nuttx/spinlock_type.h
@@ -50,10 +50,18 @@ typedef atomic_t rwlock_t;
 #endif
 
 #ifndef CONFIG_SPINLOCK
-#  define SP_UNLOCKED 0  /* The Un-locked state */
-#  define SP_LOCKED   1  /* The Locked state */
+#  define SP_LOCKED      SP_UNLOCKED
+#  define SP_UNLOCKED    \
+     (struct spinlock_s) \
+     {                   \
+       .lock = {}        \
+     }
 
-typedef uint8_t spinlock_t;
+struct spinlock_s
+{
+  uint8_t lock[0];
+};
+typedef struct spinlock_s spinlock_t;
 #elif defined(CONFIG_TICKET_SPINLOCK)
 
 typedef struct spinlock_s


### PR DESCRIPTION
## Summary

Saves 1 byte per spinlock, if spinlocks are not used.

## Impact

Reduce RAM usage by 1 byte per defined spinlock, if CONFIG_SPINLOCK=n.

## Testing

rv-virt:nsh64 + ostest
CI pass

## Comparison
BEFORE:
$ riscv64-unknown-elf-size nuttx
   text	   data	    bss	    dec	    hex	filename
 199100	   1513	  14960	 215573	  34a15	nuttx

AFTER:
$ riscv64-unknown-elf-size nuttx
   text	   data	    bss	    dec	    hex	filename
 199072	   1505	  14960	 215537	  349f1	nuttx



