### PR TITLE
nuttx/compiler: add support of deprecated attribute

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -563,6 +563,10 @@
 #    define tz_nonsecure_call  __attribute__((cmse_nonsecure_call))
 #  endif
 
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function  __attribute__((deprecated))
+
 /* SDCC-specific definitions ************************************************/
 
 #elif defined(SDCC) || defined(__SDCC)
@@ -730,6 +734,10 @@
 
 #  define no_builtin(n)
 
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
+
 /* Zilog-specific definitions ***********************************************/
 
 #elif defined(__ZILOG__)
@@ -881,6 +889,10 @@
 
 #  define no_builtin(n)
 
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
+
 /* ICCARM-specific definitions **********************************************/
 
 #elif defined(__ICCARM__)
@@ -960,6 +972,10 @@
 #  define return_address(x) 0
 
 #  define no_builtin(n)
+
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
 
 /* MSVC(Microsoft Visual C++)-specific definitions **************************/
 
@@ -1049,6 +1065,10 @@
 
 #  define no_builtin(n)
 
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
+
 /* TASKING (Infineon AURIX C/C++)-specific definitions **********************/
 
 #elif defined(__TASKING__)
@@ -1136,6 +1156,10 @@
 
 #  define no_builtin(n)
 
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
+
 /* Unknown compiler *********************************************************/
 
 #else
@@ -1213,6 +1237,10 @@
 #  define return_address(x) 0
 
 #  define no_builtin(n)
+
+/* Warning about usage of deprecated features. */
+
+#  define deprecated_function
 
 #endif
 


### PR DESCRIPTION
## Summary

nuttx/compiler: add support of deprecated attribute

Warning about usage of deprecated features.

since `__deprecated__` is a compiler built-in macro, so we define the deprecated with `__deprecated`

Break log:

```
| /usr/include/x86_64-linux-gnu/sys/cdefs.h:355:65: error: missing ')' after "__has_attribute"
|   355 | #if __GNUC_PREREQ (3,2) || __glibc_has_attribute (__deprecated__)
|       |                                                                 ^
| /usr/include/x86_64-linux-gnu/sys/cdefs.h:355:51: error: missing binary operator before token "("
|   355 | #if __GNUC_PREREQ (3,2) || __glibc_has_attribute (__deprecated__)
|       |                                                   ^~~~~~~~~~~~~~

```
Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check