### PR TITLE
tools/host_info_dump.py: fix UnboundLocalError: local variable 'vendor_specific_module_path' referenced before assignment

### DIFF
--- a/tools/host_info_dump.py
+++ b/tools/host_info_dump.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# tools/host_sysinfo.py
+# tools/host_info_dump.py
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -462,13 +462,12 @@ def generate_header(args):
         )[-1]
         if "esp" in arch_chip:
             vendor_specific_module_path = os.path.abspath("./tools/espressif")
-
-        sys.path.append(os.path.abspath(vendor_specific_module_path))
-        vendor_specific_module = importlib.import_module("chip_info")
-        get_vendor_info = getattr(vendor_specific_module, "get_vendor_info")
-        vendor_output, vendor_build_output = get_vendor_info(info["NUTTX_CONFIG"])
-        output += vendor_output
-        build_output += vendor_build_output
+            sys.path.append(os.path.abspath(vendor_specific_module_path))
+            vendor_specific_module = importlib.import_module("chip_info")
+            get_vendor_info = getattr(vendor_specific_module, "get_vendor_info")
+            vendor_output, vendor_build_output = get_vendor_info(info["NUTTX_CONFIG"])
+            output += vendor_output
+            build_output += vendor_build_output
 
     verbose(info, build_output)
 


### PR DESCRIPTION
## Summary

fix

```
Traceback (most recent call last):
  File "/home/ubuntu20042/nuttxspace/nuttx/tools/host_info_dump.py", line 575, in <module>
    header = generate_header(args)
  File "/home/ubuntu20042/nuttxspace/nuttx/tools/host_info_dump.py", line 466, in generate_header
    sys.path.append(os.path.abspath(vendor_specific_module_path))
UnboundLocalError: local variable 'vendor_specific_module_path' referenced before assignment make: *** [tools/Unix.mk:644: host_info] Error 1
```
## Impact

Impact on user: This PR fix make host_info.

Impact on build:  NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

local Ubuntu Linux

tools/configure.sh -l sim:nsh

**make host_info**

**Without this PR**

```
ubuntu20042@Unuttx:~/nuttxspace/nuttx$ make host_info
file sysinfo.h not exists
Traceback (most recent call last):
  File "/home/ubuntu20042/nuttxspace/nuttx/tools/host_info_dump.py", line 575, in <module>
    header = generate_header(args)
  File "/home/ubuntu20042/nuttxspace/nuttx/tools/host_info_dump.py", line 466, in generate_header
    sys.path.append(os.path.abspath(vendor_specific_module_path))
UnboundLocalError: local variable 'vendor_specific_module_path' referenced before assignment
make: *** [tools/Unix.mk:644: host_info] Error 1
```


**With this PR**

```
ubuntu20042@Unuttx:~/nuttxspace/nuttx$ make host_info
file sysinfo.h not exists
NuttX CFLAGS:
  --g\
  -fomit-frame-pointer
  -fprofile-arcs
  -ftest-coverage
  -fno-inline
  -fno-common
  -fvisibility=hidden
  -ffunction-sections
  -fdata-sections
  -Wall
  -Wstrict-prototypes
  .....

```