### PR TITLE
libs/libc/semaphore: Fix DEBUGASSERTS

### DIFF
--- a/libs/libc/semaphore/sem_trywait.c
+++ b/libs/libc/semaphore/sem_trywait.c
@@ -106,13 +106,12 @@ int sem_trywait(FAR sem_t *sem)
 
 int nxsem_trywait(FAR sem_t *sem)
 {
-  DEBUGASSERT(sem != NULL);
-
   /* This API should not be called from the idleloop or interrupt */
 
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask() ||
-              up_interrupt_context());
+  DEBUGASSERT(sem != NULL);
+  DEBUGASSERT(!up_interrupt_context());
+  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask());
 #endif
 
   /* We don't do atomic fast path in case of LIBC_ARCH_ATOMIC because that

--- a/libs/libc/semaphore/sem_wait.c
+++ b/libs/libc/semaphore/sem_wait.c
@@ -134,13 +134,12 @@ errout_with_cancelpt:
 
 int nxsem_wait(FAR sem_t *sem)
 {
-  DEBUGASSERT(sem != NULL);
-
   /* This API should not be called from the idleloop or interrupt */
 
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask() ||
-              up_interrupt_context());
+  DEBUGASSERT(sem != NULL);
+  DEBUGASSERT(!up_interrupt_context());
+  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask());
 #endif
 
   /* We don't do atomic fast path in case of LIBC_ARCH_ATOMIC because that


### PR DESCRIPTION

## Summary

The DEBUGASSERTS in nxsem_wait and nxsem_trywait are non-functional, they don't check anything. These were broken in previous commits.

## Impact

No functional impact, unless someone adds bugs and has CONFIG_DEBUG_ASSERTIONS enabled.

## Testing

Tested that the code doesn't assert with CONFIG_DEBUG_ASSERTIONS enabled in rv_virt:nsh64 , mpfs and imx9 targets
