### PR TITLE
arch/mpfs/usb: Align usb_ctrlreq_s properly to 32-bit boundary

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -455,6 +455,7 @@ struct mpfs_usbdev_s
 
   /* USB-specific fields */
 
+  aligned_data(4)
   struct usb_ctrlreq_s ctrl;          /* Last EP0 request */
   uint8_t              devstate;      /* State of the device (see enum mpfs_devstate_e) */
   uint8_t              prevstate;     /* Previous state of the device before SUSPEND */


### PR DESCRIPTION
## Summary

This fixes a crash in the boot in non-smp mpfs configurations.

The alignment of the ctrlreq was correct by luck, and was broken when the spinlock was added to the structure.

In non-smp configurations the spinlock_t is 8 bits, which changed the alignment of the ctrlreq.

## Impact

Impacts only MPFS targets where CONFIG_SMP is not set. Fixes a system crash in usb driver for those targets.

## Testing

Tested on a custom HW and on Microchip MPFS Icicle kit (icicle:hwtest target).