### PR TITLE
wireless/bluetooth: bt_hcicore and bt_uart related fixes.

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -162,6 +162,14 @@ static void btuart_rxwork(FAR void *arg)
       else if (data[0] == H4_ACL)
         {
           pktlen = hdr->acl.len;
+
+          if (pktlen + H4_HEADER_SIZE + hdrlen >
+              CONFIG_BLUETOOTH_UART_RXBUFSIZE)
+            {
+              wlwarn("WARNING: H4 packet is too long\n");
+              break;
+            }
+
           type = BT_ACL_IN;
         }
       else

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1802,6 +1802,12 @@ int bt_receive(FAR struct bt_driver_s *btdev, enum bt_buf_type_e type,
   struct bt_buf_s *buf;
   int ret;
 
+  if (len + BLUETOOTH_H4_HDRLEN > CONFIG_IOB_BUFSIZE)
+    {
+      wlerr("ERROR: Data too long\n");
+      return -EINVAL;
+    }
+
   wlinfo("data %p len %zu\n", data, len);
 
   /* Critical command complete/status events use the high priority work

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -2017,6 +2017,12 @@ int bt_hci_cmd_send_sync(uint16_t opcode, FAR struct bt_buf_s *buf,
           ret = 0;
         }
     }
+  else
+    {
+      wlerr("ERROR:  Failed get response\n");
+      nxsem_destroy(&sync_sem);
+      return -EIO;
+    }
 
   /* Note: if ret < 0 the packet might just be delayed and could still
    * be sent.  We cannot decrease the ref count since it if it was sent


### PR DESCRIPTION
## Summary

Bluetooth HCI and UART driver fixes.

## Impact

Wireless / Bluetooth: HCI and UART.

## Testing

Build verified by @cederom on ESP32-DevkitC and Nucleo-WB55RG. Runtime verification by external party.

```
% uname -a
FreeBSD XXX 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64

% git log -5 --oneline
2209ce8002 (HEAD -> 20250325-cederom-wireless_bluetooth_fixes, cederom/20250325-cederom-wireless_bluetooth_fixes)  wireless/bt_hcicore: Fix H4 header and data buffer length verification.
0d141f6285 wireless/bt_hcicore: Fix buffer type confusion on missing response.
c63a85239b wireless/bt_uart: Fix ACL data buffer length verification.
1b9e6a8563 (origin/master, origin/HEAD, master) boards/nucleo-c092rc: add minimal NSH configuration
e474569472 boards/nucleo-c071rb: add minimal NSH configuration
```

```
% ./tools/configure.sh -B esp32-devkitc:ble
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
CP: arch/dummy/Kconfig to /XXX/nuttx.git/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /XXX/nuttx.git/boards/dummy/dummy_kconfig
LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
LN: include/arch to arch/xtensa/include
LN: include/arch/board to /XXX/nuttx.git/boards/xtensa/esp32/esp32-devkitc/include
LN: drivers/platform to /XXX/nuttx.git/drivers/dummy
LN: include/arch/chip to /XXX/nuttx.git/arch/xtensa/include/esp32
LN: arch/xtensa/src/chip to /XXX/nuttx.git/arch/xtensa/src/esp32
LN: arch/xtensa/src/board to /XXX/nuttx.git/boards/xtensa/esp32/esp32-devkitc/../common
LN: arch/xtensa/src/board/board to /XXX/nuttx.git/boards/xtensa/esp32/esp32-devkitc/src
mkkconfig in /XXX/nuttx-apps.git/audioutils
mkkconfig in /XXX/nuttx-apps.git/benchmarks
mkkconfig in /XXX/nuttx-apps.git/boot
mkkconfig in /XXX/nuttx-apps.git/canutils
mkkconfig in /XXX/nuttx-apps.git/crypto
mkkconfig in /XXX/nuttx-apps.git/database
mkkconfig in /XXX/nuttx-apps.git/examples/mcuboot
mkkconfig in /XXX/nuttx-apps.git/examples/module
mkkconfig in /XXX/nuttx-apps.git/examples/rust
mkkconfig in /XXX/nuttx-apps.git/examples/sotest
mkkconfig in /XXX/nuttx-apps.git/examples
mkkconfig in /XXX/nuttx-apps.git/fsutils
mkkconfig in /XXX/nuttx-apps.git/games
mkkconfig in /XXX/nuttx-apps.git/graphics
mkkconfig in /XXX/nuttx-apps.git/industry
mkkconfig in /XXX/nuttx-apps.git/inertial
mkkconfig in /XXX/nuttx-apps.git/interpreters/luamodules
mkkconfig in /XXX/nuttx-apps.git/interpreters
mkkconfig in /XXX/nuttx-apps.git/logging
mkkconfig in /XXX/nuttx-apps.git/lte
mkkconfig in /XXX/nuttx-apps.git/math
mkkconfig in /XXX/nuttx-apps.git/mlearning
mkkconfig in /XXX/nuttx-apps.git/netutils
mkkconfig in /XXX/nuttx-apps.git/sdr
mkkconfig in /XXX/nuttx-apps.git/system
mkkconfig in /XXX/nuttx-apps.git/testing/arch
mkkconfig in /XXX/nuttx-apps.git/testing/cxx
mkkconfig in /XXX/nuttx-apps.git/testing/drivers
mkkconfig in /XXX/nuttx-apps.git/testing/fs
mkkconfig in /XXX/nuttx-apps.git/testing/libc
mkkconfig in /XXX/nuttx-apps.git/testing/mm
mkkconfig in /XXX/nuttx-apps.git/testing/sched
mkkconfig in /XXX/nuttx-apps.git/testing
mkkconfig in /XXX/nuttx-apps.git/videoutils
mkkconfig in /XXX/nuttx-apps.git/wireless/bluetooth
mkkconfig in /XXX/nuttx-apps.git/wireless/ieee802154
mkkconfig in /XXX/nuttx-apps.git/wireless
mkkconfig in /XXX/nuttx-apps.git
#
# configuration written to .config
#

% gmake -j8
Create version.h
Cloning Espressif HAL for 3rd Party Platforms
Clone: chip/esp-hal-3rdparty LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
Register: nsh
Register: sh
Register: bt
Espressif HAL for 3rd Party Platforms: a461ca0750d1a3deca6b10a283064dbcd2b76fb1
Espressif HAL for 3rd Party Platforms: initializing submodules...
Applying patches...
CPP:  /XXX/nuttx.git/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld-> /XXX/nuttx.git/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld.tmpLD: nuttx
Memory region         Used Size  Region Size  %age Used
             ROM:      406628 B    4194272 B      9.69%
     iram0_0_seg:       95772 B       168 KB     55.67%
     irom0_0_seg:      275556 B    3342304 B      8.24%
     dram0_0_seg:      101968 B     115200 B     88.51%
     drom0_0_seg:       90064 B    4194272 B      2.15%
    rtc_iram_seg:          0 GB         8 KB      0.00%
    rtc_slow_seg:          0 GB         4 KB      0.00%
      extmem_seg:          0 GB         4 MB      0.00%
CP: nuttx.hex
MKIMAGE: ESP32 binary
esptool.py -c esp32 elf2image --ram-only-header -fs 4MB -fm dio -ff "40m" -o nuttx.bin nuttx
esptool.py v4.8.1
Creating esp32 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Merged 1 ELF section
Successfully created esp32 image.
Generated: nuttx.bin
```

```
% ./tools/configure.sh -B nucleo-wb55rg:ble
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
CP: arch/dummy/Kconfig to /XXX/nuttx.git/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /XXX/nuttx.git/boards/dummy/dummy_kconfig
LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /XXX/nuttx.git/boards/arm/stm32wb/nucleo-wb55rg/include
LN: drivers/platform to /XXX/nuttx.git/drivers/dummy
LN: include/arch/chip to /XXX/nuttx.git/arch/arm/include/stm32wb
LN: arch/arm/src/chip to /XXX/nuttx.git/arch/arm/src/stm32wb
LN: arch/arm/src/board to /XXX/nuttx.git/boards/arm/stm32wb/nucleo-wb55rg/src
mkkconfig in /XXX/nuttx-apps.git/audioutils
mkkconfig in /XXX/nuttx-apps.git/benchmarks
mkkconfig in /XXX/nuttx-apps.git/boot
mkkconfig in /XXX/nuttx-apps.git/canutils
mkkconfig in /XXX/nuttx-apps.git/crypto
mkkconfig in /XXX/nuttx-apps.git/database
mkkconfig in /XXX/nuttx-apps.git/examples/mcuboot
mkkconfig in /XXX/nuttx-apps.git/examples/module
mkkconfig in /XXX/nuttx-apps.git/examples/rust
mkkconfig in /XXX/nuttx-apps.git/examples/sotest
mkkconfig in /XXX/nuttx-apps.git/examples
mkkconfig in /XXX/nuttx-apps.git/fsutils
mkkconfig in /XXX/nuttx-apps.git/games
mkkconfig in /XXX/nuttx-apps.git/graphics
mkkconfig in /XXX/nuttx-apps.git/industry
mkkconfig in /XXX/nuttx-apps.git/inertial
mkkconfig in /XXX/nuttx-apps.git/interpreters/luamodules
mkkconfig in /XXX/nuttx-apps.git/interpreters
mkkconfig in /XXX/nuttx-apps.git/logging
mkkconfig in /XXX/nuttx-apps.git/lte
mkkconfig in /XXX/nuttx-apps.git/math
mkkconfig in /XXX/nuttx-apps.git/mlearning
mkkconfig in /XXX/nuttx-apps.git/netutils
mkkconfig in /XXX/nuttx-apps.git/sdr
mkkconfig in /XXX/nuttx-apps.git/system
mkkconfig in /XXX/nuttx-apps.git/testing/arch
mkkconfig in /XXX/nuttx-apps.git/testing/cxx
mkkconfig in /XXX/nuttx-apps.git/testing/drivers
mkkconfig in /XXX/nuttx-apps.git/testing/fs
mkkconfig in /XXX/nuttx-apps.git/testing/libc
mkkconfig in /XXX/nuttx-apps.git/testing/mm
mkkconfig in /XXX/nuttx-apps.git/testing/sched
mkkconfig in /XXX/nuttx-apps.git/testing
mkkconfig in /XXX/nuttx-apps.git/videoutils
mkkconfig in /XXX/nuttx-apps.git/wireless/bluetooth
mkkconfig in /XXX/nuttx-apps.git/wireless/ieee802154
mkkconfig in /XXX/nuttx-apps.git/wireless
mkkconfig in /XXX/nuttx-apps.git
#
# configuration written to .config
#

% gmake -j8
Create version.h
LN: platform/board to /XXX/nuttx-apps.git/platform/dummy
Register: nsh
Register: sh
Register: ostest
Register: bt
chip/stm32wb_gpio.c:44:11: note: '#pragma message: CONFIG_STM32WB_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32WB_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      298692 B       512 KB     56.97%
           sram1:       18160 B       192 KB      9.24%
          sram2a:           0 B        32 KB      0.00%
          sram2b:           0 B        32 KB      0.00%
CP: nuttx.hex
CP: nuttx.bin

```
