### PR TITLE
boards/Kconfig &&  drivers/serial/Kconfig Add depends on

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -5098,6 +5098,7 @@ config BOARDCTL_ROMDISK
 config BOARDCTL_APP_SYMTAB
 	bool "Enable application symbol table interfaces"
 	default n
+	depends on LIBC_EXECFUNCS
 	---help---
 		Enables support for the BOARDIOC_APP_SYMTAB boardctl() command.
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -264,6 +264,7 @@ config SERIAL_TERMIOS
 
 config TTY_LAUNCH
 	bool "Enable feature TTY launch program"
+	depends on SCHED_HPWORK
 	default n
 	---help---
 		If select this, then user can launch a program with a special input.


### PR DESCRIPTION
## Summary
We should add these depends to avoid compilation or functional errors

boards/boardctl.c：

```
#ifdef CONFIG_BOARDCTL_APP_SYMTAB
      /* CMD:           BOARDIOC_APP_SYMTAB
       * DESCRIPTION:   Select the application symbol table.  This symbol
       *                table provides the symbol definitions exported to
       *                application code from application space.
       * ARG:           A pointer to an instance of struct boardioc_symtab_s
       * CONFIGURATION: CONFIG_BOARDCTL_APP_SYMTAB
       * DEPENDENCIES:  None
       */

      case BOARDIOC_APP_SYMTAB:
        {
          FAR const struct boardioc_symtab_s *symdesc =
            (FAR const struct boardioc_symtab_s *)arg;

         DEBUGASSERT(symdesc != NULL);
         exec_setsymtab(symdesc->symtab, symdesc->nsymbols);
        }
        break;
#endif
```
drivers/serial/serial.c：

```
#ifdef CONFIG_TTY_LAUNCH_ENTRY
      task_spawn(CONFIG_TTY_LAUNCH_ENTRYNAME,
                 CONFIG_TTY_LAUNCH_ENTRYPOINT,
                 NULL, &attr, argv, NULL);
#else
      exec_spawn(CONFIG_TTY_LAUNCH_FILEPATH,
                 argv, NULL, NULL, 0, NULL, &attr);
#endif
```


## Impact

None
## Testing

CI
