### PR TITLE
{bp-16173} arch/risc-v: PANIC() on system call crash

### DIFF
--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -103,7 +103,8 @@ int riscv_exception(int mcause, void *regs, void *args)
          cause, READ_CSR(CSR_EPC), READ_CSR(CSR_TVAL));
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+  if (((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) &&
+      ((tcb->flags & TCB_FLAG_SYSCALL) == false))
     {
       _alert("Segmentation fault in PID %d: %s\n",
              tcb->pid, get_task_name(tcb));


### PR DESCRIPTION
## Summary

If a process causes a fatal error when it's running a system call, the whole system should crash as the crash originated from the kernel.

Do this by running the PANIC() branch, if task is in syscall.

## Impact

RELEASE

## Testing

CI
