### PR TITLE
{bp-16177} arch/mpfs/usb: Align usb_ctrlreq_s properly to 32-bit boundary

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_usb.h
@@ -448,6 +448,7 @@ struct mpfs_usbdev_s
 
   /* USB-specific fields */
 
+  aligned_data(4)
   struct usb_ctrlreq_s ctrl;          /* Last EP0 request */
   uint8_t              devstate;      /* State of the device (see enum mpfs_devstate_e) */
   uint8_t              prevstate;     /* Previous state of the device before SUSPEND */


### PR DESCRIPTION
## Summary

The alignment of the ctrlreq was correct by luck, and was broken when the spinlock was added to the structure. In non-smp configurations spinlock_t is currently 8-bits, causing wrong alignment of the ctrlreq structure.

## Impact

RELEASE

## Testing

CI
