### PR TITLE
boards/arm/tiva/tm4c123g-launchpad: add CMakeLists.txt

### DIFF
--- a/boards/arm/tiva/tm4c123g-launchpad/CMakeLists.txt
+++ b/boards/arm/tiva/tm4c123g-launchpad/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/tiva/tm4c123g-launchpad/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+++ b/boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+# ##############################################################################
+# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS tm4c_boot.c tm4c_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS tm4c_autoleds.c)
+else()
+  list(APPEND SRCS tm4c_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS tm4c_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS tm4c_appinit.c)
+endif()
+
+if(CONFIG_TIVA_ADC)
+  list(APPEND SRCS tm4c_adc.c)
+endif()
+
+if(CONFIG_TIVA_AT24)
+  list(APPEND SRCS tm4c_at24.c)
+endif()
+
+if(CONFIG_TIVA_CAN)
+  list(APPEND SRCS tm4c_can.c)
+  if(CONFIG_TIVA_MCP2515)
+    list(APPEND SRCS tm4c_mcp2515.c)
+  endif()
+endif()
+
+if(CONFIG_TIVA_SSI)
+  list(APPEND SRCS tm4c_ssi.c)
+endif()
+
+if(CONFIG_TIVA_TIMER)
+  list(APPEND SRCS tm4c_timer.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")


### PR DESCRIPTION
## Summary

This commit introduces CMake build support for the TI TM4C123G LaunchPad development board within the NuttX RTOS. It achieves this by adding a CMakeLists.txt file to the boards/arm/tiva/tm4c123g-launchpad & boards/arm/tiva/tm4c123g-launchpad directory. This new file does not introduce CMake support from scratch but rather integrates the existing CMake configurations already present in the arch folders. The primary purpose is to enable building NuttX for this specific board using the CMake build system.

## Impact

This change primarily affects the build process for the tm4c123g-launchpad board. Developers who prefer or need to use CMake for their NuttX builds will now have this option for this specific target. It does not remove the existing build system but provides an alternative. This change should not directly impact existing users who continue to use the traditional make build.

## Testing

To verify this change, the following steps were taken:

* **Host OS:** WSL2 Ubuntu 24.04
* **CPU:** Intel Core i5 10th Gen (Hexacore)
* **Target:** `tm4c123g-launchpad`

* **Verification Steps:**
    1.  Navigated to the root NuttX directory: `nuttxspace/nuttx`.
    2.  Executed the CMake command to configure the build. The exact command used was likely similar to: ` cmake -B build -DBOARD_CONFIG=tm4c123g-launchpad:nsh  -GNinja `. **Please adjust this command to reflect your exact configuration.**
    3. Flashed and run diffrent programs many times without any errors
    5.  Verified that the entire NuttX build process completed successfully the `tm4c123g-launchpad` configuration.


