### PR TITLE
net/netdev: Change SIOCSCANBITRATE to require interface down.

### DIFF
--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -1601,15 +1601,13 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
               if (priv->canfd_capable)
               {
                 priv->data_timing = data_timing;
               }
-
-              imx9_ifup(dev);
             }
         }
         break;

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1569,15 +1569,13 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
               if (priv->canfd_capable)
               {
                 priv->data_timing = data_timing;
               }
-
-              imxrt_ifup(dev);
             }
         }
         break;

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1533,13 +1533,12 @@ static int kinetis_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
 #ifdef CONFIG_NET_CAN_CANFD
               priv->data_timing = data_timing;
 #endif
-              kinetis_ifup(dev);
             }
         }
         break;

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1516,13 +1516,12 @@ static int s32k1xx_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
 #ifdef CONFIG_NET_CAN_CANFD
               priv->data_timing = data_timing;
 #endif
-              s32k1xx_ifup(dev);
             }
         }
         break;

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -1707,13 +1707,12 @@ static int s32k3xx_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
 #ifdef CONFIG_NET_CAN_CANFD
               priv->data_timing = data_timing;
 #endif
-              s32k3xx_ifup(dev);
             }
         }
         break;

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -1966,19 +1966,12 @@ static int fdcan_netdev_ioctl(struct net_driver_s *dev, int cmd,
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
+          /* Apply the new timings (interface is guaranteed to be down) */
+
           priv->arbi_timing.bitrate = req->arbi_bitrate * 1000;
 #ifdef CONFIG_NET_CAN_CANFD
           priv->data_timing.bitrate = req->data_bitrate * 1000;
 #endif
-
-          /* Reset CAN controller and start with new timings */
-
-          ret = fdcan_initialize(priv);
-
-          if (ret == OK)
-            {
-              ret = fdcan_ifup(dev);
-            }
         }
         break;
 #endif /* CONFIG_NETDEV_CAN_BITRATE_IOCTL */

--- a/arch/arm64/src/imx9/imx9_flexcan.c
+++ b/arch/arm64/src/imx9/imx9_flexcan.c
@@ -1634,15 +1634,13 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
 
           if (ret == OK)
             {
-              /* Reset CAN controller and start with new timings */
+              /* Apply the new timings (interface is guaranteed to be down) */
 
               priv->arbi_timing = arbi_timing;
               if (priv->canfd_capable)
               {
                 priv->data_timing = data_timing;
               }
-
-              imx9_ifup(dev);
             }
         }
         break;

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1176,8 +1176,18 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
 #endif
 
 #if defined(CONFIG_NETDEV_IOCTL) && defined(CONFIG_NETDEV_CAN_BITRATE_IOCTL)
-      case SIOCGCANBITRATE:  /* Get bitrate from a CAN controller */
       case SIOCSCANBITRATE:  /* Set bitrate of a CAN controller */
+        if (dev->d_flags & IFF_UP)
+          {
+            /* Cannot set bitrate if the interface is up. */
+
+            ret = -EBUSY;
+            break;
+          }
+
+        /* If down, fall-through to common code in SIOCGCANBITRATE. */
+
+      case SIOCGCANBITRATE:  /* Get bitrate from a CAN controller */
         if (dev->d_ioctl)
           {
             FAR struct can_ioctl_data_s *can_bitrate_data =


### PR DESCRIPTION
## Summary

In Linux, CAN bitrate is set with netlink, not ioctl, and you need to
set a bitrate before bringing the interface up (make sense). In Nuttx,
you can begin the interface up (it uses a default bitrate) and then
you can change it. My guess is calling ifup at the end is precisely to
avoid requiring another ifdown/ifup cycle from app code.

SocketCAN is a Linux thing, so we should try to mimic the behaviour.
Implementing netlink would be overkill (and moreover, it is common in
Linux to use libsocketcan to abstract the netlink internals anyways)
but at least we should have similar semantics

## Impact

The change makes changing bitrate on an up interface fails. This is done on the portable, architecture-independent section of ioctl handling, so it affects all the drivers and makes the semantics clear.
Al existing SocketCAN drivers have also been updated.

Now the process for setting bitrate on an open interface is:

1. ifdown the interface is it's up
2. Call SIOCSCANBITRATE
3. ifup the interface.

This requires an update in apps/canutils/slcan. PR following.

## Testing

The change was tested on a custom platform using s32k148 uC, confirming changing the bitrate no longer brings the interface up.