### PR TITLE
arch/arm/stm32h5: Fix i2c compiler warnings.

### DIFF
--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -1363,6 +1363,7 @@ static void stm32_i2c_setclock(struct stm32_i2c_priv_s *priv,
           break;
 #endif
         default:
+          break;
         }
 
       /* Set i2c_ker_ck period ti2cclk in nanoseconds */
@@ -2470,6 +2471,7 @@ static int stm32_i2c_init(struct stm32_i2c_priv_s *priv)
       break;
 #endif
       default:
+        break;
     }
 
   /* Force a frequency update */


### PR DESCRIPTION
Add missing break statements to i2c driver to avoid complaints from compiler.

Original Author: @ArrestedLightning 
## Summary

This fixes a compiler warning, `error: label at end of compound statement`, that occurs due to the missing break statements in default cases in the i2c driver.

## Impact

Small bug fix. 

## Testing

Board: Custom board.
Chip: STM32H563ZI

