### PR TITLE
arch/arm/stm32h5: Add USART6 serial driver config.

### DIFF
--- a/arch/arm/src/stm32h5/Kconfig
+++ b/arch/arm/src/stm32h5/Kconfig
@@ -4264,6 +4264,18 @@ config UART5_RS485_DIR_POLARITY
 
 endif # UART5_SERIALDRIVER
 
+choice
+	prompt "USART6 Driver Configuration"
+	default STM32H5_USART6_SERIALDRIVER
+	depends on STM32H5_USART6
+
+config STM32H5_USART6_SERIALDRIVER
+	bool "Standard serial driver"
+	select USART6_SERIALDRIVER
+	select STM32H5_SERIALDRIVER
+
+endchoice # USART6 Driver Configuration
+
 if USART6_SERIALDRIVER
 
 config USART6_RS485

--- a/arch/arm/src/stm32h5/stm32_uart.h
+++ b/arch/arm/src/stm32h5/stm32_uart.h
@@ -514,9 +514,9 @@
 #if defined(CONFIG_LPUART1_RS485) || defined(CONFIG_USART1_RS485) || \
     defined(CONFIG_USART2_RS485)  || defined(CONFIG_USART3_RS485) || \
     defined(CONFIG_UART4_RS485)   || defined(CONFIG_UART5_RS485)  || \
-    defined(CONFIG_USART6_RS485)   || defined(CONFIG_UART7_RS485) || \
+    defined(CONFIG_USART6_RS485)  || defined(CONFIG_UART7_RS485) || \
     defined(CONFIG_UART8_RS485)   || defined(CONFIG_UART9_RS485) || \
-    defined(CONFIG_USART10_RS485)  || defined(CONFIG_USART11_RS485) || \
+    defined(CONFIG_USART10_RS485) || defined(CONFIG_USART11_RS485) || \
     defined(CONFIG_UART12_RS485)
 #  define HAVE_RS485 1
 #endif


### PR DESCRIPTION
Original code by @ArrestedLightning https://github.com/ArrestedLightning/nuttx/tree/h5_uart_driver_config

## Summary

This adds USART6 Kconfig options that were missed in the original PR. 

## Impact

Allows selecting USART6 on the H5 architecture. 

## Testing

Board: Custom board.
Chip: STM32H563ZI


