### PR TITLE
stm32h7: enable Ethernet for STM32H7X7XX

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
@@ -35,7 +35,8 @@
 
 #if defined(CONFIG_STM32H7_STM32H7X3XX) || \
     defined(CONFIG_STM32H7_STM32H7B3XX) || \
-    defined(CONFIG_STM32H7_STM32H7X5XX)
+    defined(CONFIG_STM32H7_STM32H7X5XX) || \
+    defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

This adds Ethernet support for the STM32H7X7. This was missing.

## Impact

Makes it work for me, not sure.

## Testing

Tested downstream in PX4.


