### PR TITLE
arch/arm/rp23xx: Fix PWM registers access

### DIFF
--- a/arch/arm/src/rp23xx/hardware/rp23xx_pwm.h
+++ b/arch/arm/src/rp23xx/hardware/rp23xx_pwm.h
@@ -35,11 +35,11 @@
 
 /* Register offsets *********************************************************/
 
-#define RP23XX_PWM_CSR_OFFSET(n)  (0x000000 + (n) * 14) /* PWM control and status register */
-#define RP23XX_PWM_DIV_OFFSET(n)  (0x000004 + (n) * 14) /* PWM clock divisor register */
-#define RP23XX_PWM_CTR_OFFSET(n)  (0x000008 + (n) * 14) /* PWM counter register */
-#define RP23XX_PWM_CC_OFFSET(n)   (0x00000c + (n) * 14) /* PWM compare register */
-#define RP23XX_PWM_TOP_OFFSET(n)  (0x000010 + (n) * 14) /* PWM wrap value register */
+#define RP23XX_PWM_CSR_OFFSET(n)  (0x000000 + (n) * 20) /* PWM control and status register */
+#define RP23XX_PWM_DIV_OFFSET(n)  (0x000004 + (n) * 20) /* PWM clock divisor register */
+#define RP23XX_PWM_CTR_OFFSET(n)  (0x000008 + (n) * 20) /* PWM counter register */
+#define RP23XX_PWM_CC_OFFSET(n)   (0x00000c + (n) * 20) /* PWM compare register */
+#define RP23XX_PWM_TOP_OFFSET(n)  (0x000010 + (n) * 20) /* PWM wrap value register */
 #define RP23XX_PWM_EN_OFFSET     0x0000f0               /* PWM enable register */
 #define RP23XX_PWM_INTR_OFFSET    0x0000f4              /* PWM raw interrupt register */
 #define RP23XX_PWM_IRQ0_INTE_OFFSET    0x0000f8         /* PWM interrupt enable register */

--- a/arch/arm/src/rp23xx/rp23xx_pwm.c
+++ b/arch/arm/src/rp23xx/rp23xx_pwm.c
@@ -572,7 +572,7 @@ static inline void set_enabled(struct rp23xx_pwm_lowerhalf_s  * priv)
 {
   irqstate_t flags = enter_critical_section();
 
-  modreg32(1 << priv->num, 1 << priv->num,  RP23XX_PWM_ENA);
+  modreg32(1 << priv->num, 1 << priv->num,  RP23XX_PWM_EN);
 
   leave_critical_section(flags);
 }
@@ -592,7 +592,7 @@ static inline void clear_enabled(struct rp23xx_pwm_lowerhalf_s  * priv)
 {
   irqstate_t flags = enter_critical_section();
 
-  modreg32(0, 1 << priv->num, RP23XX_PWM_ENA);
+  modreg32(0, 1 << priv->num, RP23XX_PWM_EN);
 
   leave_critical_section(flags);
 }


### PR DESCRIPTION
Fix offset alignment and correct the PWM enable register name

## Summary

Current PWM on rp23xx implementation is broken this pull fixes this.

## Impact

Working PWM

## Testing

Tested on pico2 with single channel and multichannel (2) setup via pwm app.

