### PR TITLE
Support ethernet without MDIO & MDC lines

### DIFF
--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -3604,9 +3604,10 @@ static inline void stm32_ethgpioconfig(struct stm32_ethmac_s *priv)
 #if defined(CONFIG_STM32H5_MII) || defined(CONFIG_STM32H5_RMII)
 
   /* MDC and MDIO are common to both modes */
-
+# ifndef CONFIG_STM32H5_NO_PHY
   stm32_configgpio(GPIO_ETH_MDC);
   stm32_configgpio(GPIO_ETH_MDIO);
+# endif
 
   /* Set up the MII interface */
 

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -3699,9 +3699,10 @@ static inline void stm32_ethgpioconfig(struct stm32_ethmac_s *priv)
 #if defined(CONFIG_STM32H7_MII) || defined(CONFIG_STM32H7_RMII)
 
   /* MDC and MDIO are common to both modes */
-
+# ifndef CONFIG_STM32H7_NO_PHY
   stm32_configgpio(GPIO_ETH_MDC);
   stm32_configgpio(GPIO_ETH_MDIO);
+# endif
 
   /* Set up the MII interface */
 


### PR DESCRIPTION
## Summary

Closes #16213 

We have a board with an STM32H7 connected to an IC switch through RMII. This IC switch is also connected to an embedded Linux soc and the MDIO and MDC lines are connected to that SOC for configuration.

However the code in NuttX expects the MDIO / MDC lines and configures them unconditionally. When we comment out the lines while having the `CONFIG_STM32H7_NO_PHY` set it works for us.

## Impact
As far as I can tell, the MDIO and MDC lines should not be used when the option `CONFIG_STM32H7_NO_PHY`  is set ? Not configuring the pins should therefore be the expected behavior.

The changes are limited to STM32H7 and H5 because they are the only targets that I found that define a `NO_PHY` option.

## Testing

Tested by commenting out the two lines on a custom board with an STM32H7 running PX4 which is running on top of Nuttx. The STM32 is connected to an IC switch over RMII and the IC switch is configured from a second SOC running Linux. The Linux driver configures the IC switch.

Before the changes this setup didn't work, with the changes it works.


