### PR TITLE
arch/arm/src/stm32h7: unassigned ret variable in SIOCSCANBITRATE.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -1972,6 +1972,7 @@ static int fdcan_netdev_ioctl(struct net_driver_s *dev, int cmd,
 #ifdef CONFIG_NET_CAN_CANFD
           priv->data_timing.bitrate = req->data_bitrate * 1000;
 #endif
+          ret = OK;
         }
         break;
 #endif /* CONFIG_NETDEV_CAN_BITRATE_IOCTL */


### PR DESCRIPTION
## Summary

This problem was introduced in https://github.com/apache/nuttx/pull/16199

In that PR, the assignment of "ret" variable was removed so now this variable might be used in uninitialized status when ioctl(...SIOCSCANBITRATE...) is called.

## Impact

ioctl calls for CAN interfaces on stm32h7 can return as failed when they effectively succeeded.

## Testing

The error was found due to a compiler warning after the previous PR was already merged.