### PR TITLE
net: use bps units for bitrate in SocketCAN interfaces.

### DIFF
--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -1549,11 +1549,11 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
           if (priv->canfd_capable)
             {
-              req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+              req->data_bitrate = priv->data_timing.bitrate;
               req->data_samplep = priv->data_timing.samplep;
             }
           else
@@ -1572,7 +1572,7 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
           struct flexcan_timeseg arbi_timing;
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
 
           if (imx9_bitratetotimeseg(&arbi_timing, 10, 0))
@@ -1586,7 +1586,7 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
 
           if (priv->canfd_capable)
           {
-            data_timing.bitrate = req->data_bitrate * 1000;
+            data_timing.bitrate = req->data_bitrate;
             data_timing.samplep = req->data_samplep;
 
             if (ret == OK && imx9_bitratetotimeseg(&data_timing, 10, 1))

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1517,11 +1517,11 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
           if (priv->canfd_capable)
             {
-              req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+              req->data_bitrate = priv->data_timing.bitrate;
               req->data_samplep = priv->data_timing.samplep;
             }
           else
@@ -1540,7 +1540,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
           struct flexcan_timeseg arbi_timing;
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
 
           if (imxrt_bitratetotimeseg(&arbi_timing, 10, 0))
@@ -1554,7 +1554,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 
           if (priv->canfd_capable)
           {
-            data_timing.bitrate = req->data_bitrate * 1000;
+            data_timing.bitrate = req->data_bitrate;
             data_timing.samplep = req->data_samplep;
 
             if (ret == OK && imxrt_bitratetotimeseg(&data_timing, 10, 1))

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1485,10 +1485,10 @@ static int kinetis_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
 #ifdef CONFIG_NET_CAN_CANFD
-          req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+          req->data_bitrate = priv->data_timing.bitrate;
           req->data_samplep = priv->data_timing.samplep;
 #else
           req->data_bitrate = 0;
@@ -1504,7 +1504,7 @@ static int kinetis_ioctl(struct net_driver_s *dev, int cmd,
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
           struct flexcan_timeseg arbi_timing;
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
 
           if (kinetis_bitratetotimeseg(&arbi_timing, 10, 0))
@@ -1518,7 +1518,7 @@ static int kinetis_ioctl(struct net_driver_s *dev, int cmd,
 
 #ifdef CONFIG_NET_CAN_CANFD
           struct flexcan_timeseg data_timing;
-          data_timing.bitrate = req->data_bitrate * 1000;
+          data_timing.bitrate = req->data_bitrate;
           data_timing.samplep = req->data_samplep;
 
           if (ret == OK && kinetis_bitratetotimeseg(&data_timing, 10, 1))

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1468,10 +1468,10 @@ static int s32k1xx_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
 #ifdef CONFIG_NET_CAN_CANFD
-          req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+          req->data_bitrate = priv->data_timing.bitrate;
           req->data_samplep = priv->data_timing.samplep;
 #else
           req->data_bitrate = 0;
@@ -1487,7 +1487,7 @@ static int s32k1xx_ioctl(struct net_driver_s *dev, int cmd,
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
           struct flexcan_timeseg arbi_timing;
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
 
           if (s32k1xx_bitratetotimeseg(&arbi_timing, 10, 0))
@@ -1501,7 +1501,7 @@ static int s32k1xx_ioctl(struct net_driver_s *dev, int cmd,
 
 #ifdef CONFIG_NET_CAN_CANFD
           struct flexcan_timeseg data_timing;
-          data_timing.bitrate = req->data_bitrate * 1000;
+          data_timing.bitrate = req->data_bitrate;
           data_timing.samplep = req->data_samplep;
 
           if (ret == OK && s32k1xx_bitratetotimeseg(&data_timing, 10, 1))

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -1657,10 +1657,10 @@ static int s32k3xx_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
 #ifdef CONFIG_NET_CAN_CANFD
-          req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+          req->data_bitrate = priv->data_timing.bitrate;
           req->data_samplep = priv->data_timing.samplep;
 #else
           req->data_bitrate = 0;
@@ -1676,7 +1676,7 @@ static int s32k3xx_ioctl(struct net_driver_s *dev, int cmd,
               (struct can_ioctl_data_s *)((uintptr_t)arg);
 
           struct flexcan_timeseg arbi_timing;
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
 
           if (s32k3xx_bitratetotimeseg(&arbi_timing, 10, 0,
@@ -1691,7 +1691,7 @@ static int s32k3xx_ioctl(struct net_driver_s *dev, int cmd,
 
 #ifdef CONFIG_NET_CAN_CANFD
           struct flexcan_timeseg data_timing;
-          data_timing.bitrate = req->data_bitrate * 1000;
+          data_timing.bitrate = req->data_bitrate;
           data_timing.samplep = req->data_samplep;
 
           if (ret == OK && s32k3xx_bitratetotimeseg(&data_timing, 10, 1,

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -1951,9 +1951,9 @@ static int fdcan_netdev_ioctl(struct net_driver_s *dev, int cmd,
         {
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
 #ifdef CONFIG_NET_CAN_CANFD
-          req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+          req->data_bitrate = priv->data_timing.bitrate;
 #else
           req->data_bitrate = 0;
 #endif
@@ -1968,9 +1968,9 @@ static int fdcan_netdev_ioctl(struct net_driver_s *dev, int cmd,
 
           /* Apply the new timings (interface is guaranteed to be down) */
 
-          priv->arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          priv->arbi_timing.bitrate = req->arbi_bitrate;
 #ifdef CONFIG_NET_CAN_CANFD
-          priv->data_timing.bitrate = req->data_bitrate * 1000;
+          priv->data_timing.bitrate = req->data_bitrate;
 #endif
         }
         break;

--- a/arch/arm64/src/imx9/imx9_flexcan.c
+++ b/arch/arm64/src/imx9/imx9_flexcan.c
@@ -1597,11 +1597,11 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
           struct imx9_driver_s *priv = (struct imx9_driver_s *)dev;
           struct can_ioctl_data_s *req =
               (struct can_ioctl_data_s *)((uintptr_t)arg);
-          req->arbi_bitrate = priv->arbi_timing.bitrate / 1000; /* kbit/s */
+          req->arbi_bitrate = priv->arbi_timing.bitrate;
           req->arbi_samplep = priv->arbi_timing.samplep;
           if (priv->canfd_capable)
             {
-              req->data_bitrate = priv->data_timing.bitrate / 1000; /* kbit/s */
+              req->data_bitrate = priv->data_timing.bitrate;
               req->data_samplep = priv->data_timing.samplep;
             }
           else
@@ -1622,12 +1622,12 @@ static int imx9_ioctl(struct net_driver_s *dev, int cmd,
           struct flexcan_timeseg arbi_timing;
           struct flexcan_timeseg data_timing;
 
-          arbi_timing.bitrate = req->arbi_bitrate * 1000;
+          arbi_timing.bitrate = req->arbi_bitrate;
           arbi_timing.samplep = req->arbi_samplep;
           ret = imx9_bitratetotimeseg(priv, &arbi_timing, false);
           if (ret == OK && priv->canfd_capable)
             {
-              data_timing.bitrate = req->data_bitrate * 1000;
+              data_timing.bitrate = req->data_bitrate;
               data_timing.samplep = req->data_samplep;
               ret = imx9_bitratetotimeseg(priv, &data_timing, true);
             }

--- a/include/net/if.h
+++ b/include/net/if.h
@@ -178,9 +178,9 @@ struct mii_ioctl_data_s
 
 struct can_ioctl_data_s
 {
-  uint16_t arbi_bitrate; /* Classic CAN / Arbitration phase bitrate kbit/s */
+  uint32_t arbi_bitrate; /* Classic CAN / Arbitration phase bitrate bit/s */
   uint16_t arbi_samplep; /* Classic CAN / Arbitration phase input % */
-  uint16_t data_bitrate; /* Data phase bitrate kbit/s */
+  uint32_t data_bitrate; /* Data phase bitrate bit/s */
   uint16_t data_samplep; /* Data phase sample point % */
 };
 


### PR DESCRIPTION
## Summary

This makes SocketCAN bitrate units compatible with what Linux uses (bps instead of previous kbps) and allows representing usual Single Wire Can (SAE J2411) usual bitrates of 33333 and 83333 bps.

## Impact

All calls to bitrate-related ioctl need to be updated. I have updated all affected drivers in this PR, and made a separate PR to update tools (https://github.com/apache/nuttx-apps/pull/3061)

* Is new feature added? NO Is existing feature changed? YES
* Impact on build: NO
* Impact on hardware: NO. The setting programmed on the HW is unaffected, only how this is represented on user space does.
* Impact on documentation: YES, but minimal. The affected IOCTLs are Nuttx-specific, and the data stuctures providing the info (and thus determining the units) were only described on header files, which the patch updates (including such comments)
* Impact on security: NO
* Impact on compatibility: YES, this makes the units used for bitrate in SocketCAN bps, which are the same units used by Linux to perform the same operation using netlink.

## Testing

Tested using slcan to check bitrate is properly set (CAN message still arrive properly) after this change.
