### PR TITLE
nuttx/msgq: add kernel message queue support

### DIFF
--- a/include/nuttx/msgq.h
+++ b/include/nuttx/msgq.h
@@ -1,0 +1,315 @@
+/****************************************************************************
+ * include/nuttx/msgq.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef ___INCLUDE_NUTTX_MSGQ_H
+#define ___INCLUDE_NUTTX_MSGQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/irq.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/circbuf.h>
+#include <nuttx/spinlock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: NXMSGQ_INITIALIZER
+ *
+ * Description:
+ *   Statically define and initialize a message queue.
+ *
+ *   The message queue's ring buffer contains space for max_msgs messages,
+ *   each of which is msg_size bytes long.
+ *
+ * Input Parameters:
+ *   buffer   - Ring buffer of Message Queue
+ *   msg_size - Message size (in bytes).
+ *   max_msgs - Maximum number of messages that can be queued.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+#  define NXMSGQ_INITIALIZER(buffer, msg_size, max_msgs) \
+    { \
+      CIRCBUF_INITIALIZER(buffer, msg_size * max_msgs), \
+      msg_size, \
+      NXSEM_INITIALIZER(0, 0), \
+      NXSEM_INITIALIZER(0, 0), \
+      false, \
+      SP_UNLOCKED, \
+    }
+#else
+#  define NXMSGQ_INITIALIZER(buffer, msg_size, max_msgs) \
+    { \
+      CIRCBUF_INITIALIZER(buffer, msg_size * max_msgs), \
+      msg_size, \
+      NXSEM_INITIALIZER(0, 0), \
+      NXSEM_INITIALIZER(0, 0), \
+      false, \
+    }
+#endif
+
+/****************************************************************************
+ * Public Type Declarations
+ ****************************************************************************/
+
+/* This structure defines a kernel message queue */
+
+typedef struct nxmsgq
+{
+  struct circbuf_s cbuf;
+  int              msg_size;
+  sem_t            txsem;
+  sem_t            rxsem;
+  bool             alloc;
+#ifdef CONFIG_SMP
+  spinlock_t       lock;
+#endif
+} nxmsgq_t;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: nxmsgq_init
+ *
+ * Description:
+ *   Initialize a message queue with static ring buffer
+ *
+ *   This routine initializes a message queue object, prior to its first use.
+ *
+ *   The message queue's ring buffer must contain space for max_msgs
+ *   messages, each of which is msg_size bytes long. Alignment of the
+ *   message queue's ring buffer is not necessary.
+ *
+ * Input Parameters:
+ *   msgq     - Address of the message queue.
+ *   buffer   - Pointer to ring buffer that holds queued messages.
+ *   msg_size - Message size (in bytes).
+ *   max_msgs - Maximum number of messages that can be queued.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void nxmsgq_init(FAR nxmsgq_t *msgq, FAR void *buffer,
+                 size_t msg_size, uint32_t max_msgs);
+
+/****************************************************************************
+ * Name: nxmsgq_create
+ *
+ * Description:
+ *   Create a message queue.
+ *
+ *   This routine initializes a message queue object, prior to its first use,
+ *   allocating its internal ring buffer from the calling thread's resource
+ *   pool.
+ *
+ *   Memory allocated for the ring buffer can be released by calling
+ *   nxmsgq_destroy()
+ *
+ * Input Parameters:
+ *   msg_size - Message size (in bytes).
+ *   max_msgs - Maximum number of messages that can be queued.
+ *
+ * Returned Value:
+ *   NULL if there was insufficient memory to create nxmsgq.
+ *
+ ****************************************************************************/
+
+FAR nxmsgq_t *nxmsgq_create(size_t msg_size, uint32_t max_msgs);
+
+/****************************************************************************
+ * Name: nxmsgq_destroy
+ *
+ * Description:
+ *   Destroy Message Queue
+ *
+ * Input Parameters:
+ *   msgq - message queue to cleanup
+ *
+ ****************************************************************************/
+
+void nxmsgq_destroy(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_used
+ *
+ * Description:
+ *   Get the number of messages in a message queue.
+ *
+ *   This routine returns the number of messages in a message queue's
+ *   ring buffer.
+ *
+ * Returned Value:
+ *   return Number of ring buffer entries.
+ *
+ ****************************************************************************/
+
+int nxmsgq_used(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_used
+ *
+ * Description:
+ *   Get the amount of free space in a message queue.
+ *
+ *   This routine returns the number of unused entries in a message queue's
+ *   ring buffer.
+ *
+ * Returned Value:
+ *   return Number of unused ring buffer entries.
+ *
+ ****************************************************************************/
+
+int nxmsgq_space(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_is_empty
+ *
+ * Description:
+ *   Return true if the ring buffer is empty.
+ *
+ ****************************************************************************/
+
+bool nxmsgq_is_empty(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_is_full
+ *
+ * Description:
+ *   Return true if the ring buffer is full.
+ *
+ ****************************************************************************/
+
+bool nxmsgq_is_full(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_purge
+ *
+ * Description:
+ *   Purge a message queue.
+ *
+ *   This routine discards all unreceived messages in a message queue's ring
+ *   buffer.
+ *
+ ****************************************************************************/
+
+void nxmsgq_purge(FAR nxmsgq_t *msgq);
+
+/****************************************************************************
+ * Name: nxmsgq_ticksend / nxmsgq_send / nxmsgq_trysend
+ *
+ * Description:
+ *   Send a message to a message queue
+ *
+ *   This routine sends a message to message queue.
+ *
+ *   The message content is copied from buffer into msgq and the buffer
+ *   pointer is not retained, so the message content will not be modified
+ *   by this function.
+ *
+ * Input Parameters:
+ *   msgq     - Address of the message queue.
+ *   data     - Pointer to the message.
+ *   timeout  - Waiting period to add the message
+ *
+ * Returned Value:
+ *   0        - Message sent.
+ *   -EAGAIN  - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+int nxmsgq_ticksend(FAR nxmsgq_t *msgq,
+                    FAR const void *buffer, uint32_t delay);
+int nxmsgq_send(FAR nxmsgq_t *msgq, FAR const void *buffer);
+int nxmsgq_trysend(FAR nxmsgq_t *msgq, FAR const void *buffer);
+
+/****************************************************************************
+ * Name: nxmsgq_tickrecv / nxmsgq_tryrecv / nxmsgq_recv
+ *
+ * Description:
+ *   Receive a message from a message queue
+ *
+ *   This routine receives a message from message queue in a "first in,
+ *   first out" manner.
+ *
+ * Input Parameters:
+ *   msgq    - Address of the message queue.
+ *   buffer  - Address of area to hold the received message.
+ *   timeout - Waiting period to receive the message,
+ *
+ * Returned Value:
+ *   0       - Message received.
+ *   -EAGAIN - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+int nxmsgq_tickrecv(FAR nxmsgq_t *msgq, FAR void *buffer, uint32_t delay);
+int nxmsgq_tryrecv(FAR nxmsgq_t *msgq, FAR void *buffer);
+int nxmsgq_recv(FAR nxmsgq_t *msgq, FAR void *buffer);
+
+/****************************************************************************
+ * Name: nxmsgq_tickpeek / nxmsgq_trypeek / nxmsgq_peek
+ *
+ * Description:
+ *   Peek/read a message from a message queue.
+ *
+ *   This routine reads a message from message queue in a "first in,
+ *   first out" manner and leaves the message in the queue.
+ *
+ * Input Parameters:
+ *   msgq    - Address of the message queue.
+ *   buffer  - Address of area to hold the received message.
+ *   timeout - Waiting period to receive the message,
+ *
+ * Returned Value:
+ *   0       - Message read.
+ *   -EAGAIN - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+int nxmsgq_tickpeek(FAR nxmsgq_t *msgq, FAR void *buffer, uint32_t delay);
+int nxmsgq_trypeek(FAR nxmsgq_t *msgq, FAR void *buffer);
+int nxmsgq_peek(FAR nxmsgq_t *msgq, FAR void *buffer);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___INCLUDE_NUTTX_MSGQ_H */

--- a/sched/mqueue/Make.defs
+++ b/sched/mqueue/Make.defs
@@ -39,6 +39,8 @@ CSRCS += msgctl.c msgget.c msginternal.c msgrcv.c msgsnd.c
 
 endif
 
+CSRCS += msgq.c
+
 # Include mqueue build support
 
 DEPPATH += --dep-path mqueue

--- a/sched/mqueue/msgq.c
+++ b/sched/mqueue/msgq.c
@@ -1,0 +1,494 @@
+/****************************************************************************
+ * sched/mqueue/msgq.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/irq.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/circbuf.h>
+#include <nuttx/spinlock.h>
+
+#include <nuttx/msgq.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static inline_function irqstate_t nxmsgq_lock(FAR nxmsgq_t *msgq)
+{
+#ifdef CONFIG_SMP
+  return spin_lock_irqsave(&msgq->lock);
+#else
+  UNUSED(msgq);
+  return enter_critical_section();
+#endif
+}
+
+static inline_function void nxmsgq_unlock(FAR nxmsgq_t *msgq,
+                                          irqstate_t flags)
+{
+#ifdef CONFIG_SMP
+  spin_unlock_irqrestore(&msgq->lock, flags);
+#else
+  UNUSED(msgq);
+  leave_critical_section(flags);
+#endif
+}
+
+static inline_function int nxmsgq_post(FAR sem_t *sem)
+{
+  int semcount;
+
+  nxsem_get_value(sem, &semcount);
+  if (semcount < 1)
+    {
+      return nxsem_post(sem);
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxmsgq_init
+ *
+ * Description:
+ *   Initialize a message queue with static ring buffer
+ *
+ *   This routine initializes a message queue object, prior to its first use.
+ *
+ *   The message queue's ring buffer must contain space for max_msgs
+ *   messages, each of which is msg_size bytes long. Alignment of the
+ *   message queue's ring buffer is not necessary.
+ *
+ * Input Parameters:
+ *   msgq     - Address of the message queue.
+ *   buffer   - Pointer to ring buffer that holds queued messages.
+ *   msg_size - Message size (in bytes).
+ *   max_msgs - Maximum number of messages that can be queued.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void nxmsgq_init(FAR nxmsgq_t *msgq, FAR void *buffer, size_t msg_size,
+                 uint32_t max_msgs)
+{
+  circbuf_init(&msgq->cbuf, buffer, msg_size * max_msgs);
+
+  nxsem_init(&msgq->txsem, 0, 0);
+  nxsem_init(&msgq->rxsem, 0, 0);
+
+#ifdef CONFIG_SMP
+  spin_lock_init(&msgq->lock);
+#endif
+
+  msgq->msg_size = msg_size;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_create
+ *
+ * Description:
+ *   Create a message queue.
+ *
+ *   This routine initializes a message queue object, prior to its first use,
+ *   allocating its internal ring buffer from the calling thread's resource
+ *   pool.
+ *
+ *   Memory allocated for the ring buffer can be released by calling
+ *   nxmsgq_destroy()
+ *
+ * Input Parameters:
+ *   msg_size - Message size (in bytes).
+ *   max_msgs - Maximum number of messages that can be queued.
+ *
+ * Returned Value:
+ *   NULL if there was insufficient memory to create nxmsgq.
+ *
+ ****************************************************************************/
+
+FAR nxmsgq_t *nxmsgq_create(size_t msg_size, uint32_t max_msgs)
+{
+  FAR nxmsgq_t *msgq;
+
+  msgq = kmm_zalloc(sizeof(*msgq) + msg_size * max_msgs);
+  if (msgq == NULL)
+    {
+      return NULL;
+    }
+
+  msgq->alloc = true;
+
+  nxmsgq_init(msgq, msgq + 1, msg_size, max_msgs);
+
+  return msgq;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_destroy
+ *
+ * Description:
+ *   Destroy Message Queue
+ *
+ * Input Parameters:
+ *   msgq - message queue to cleanup
+ *
+ ****************************************************************************/
+
+void nxmsgq_destroy(FAR nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+
+  flags = nxmsgq_lock(msgq);
+
+  nxsem_destroy(&msgq->txsem);
+  nxsem_destroy(&msgq->rxsem);
+
+  circbuf_uninit(&msgq->cbuf);
+
+  if (msgq->alloc)
+    {
+      kmm_free(msgq);
+    }
+
+  nxmsgq_unlock(msgq, flags);
+}
+
+/****************************************************************************
+ * Name: nxmsgq_used
+ *
+ * Description:
+ *   Get the number of messages in a message queue.
+ *
+ *   This routine returns the number of messages in a message queue's
+ *   ring buffer.
+ *
+ * Returned Value:
+ *   return Number of ring buffer entries.
+ *
+ ****************************************************************************/
+
+int nxmsgq_used(FAR nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+  int num;
+
+  flags = nxmsgq_lock(msgq);
+
+  num = circbuf_used(&msgq->cbuf) / msgq->msg_size;
+
+  nxmsgq_unlock(msgq, flags);
+
+  return num;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_used
+ *
+ * Description:
+ *   Get the amount of free space in a message queue.
+ *
+ *   This routine returns the number of unused entries in a message queue's
+ *   ring buffer.
+ *
+ * Returned Value:
+ *   return Number of unused ring buffer entries.
+ *
+ ****************************************************************************/
+
+int nxmsgq_space(FAR nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+  int num;
+
+  flags = nxmsgq_lock(msgq);
+
+  num = circbuf_space(&msgq->cbuf) / msgq->msg_size;
+
+  nxmsgq_unlock(msgq, flags);
+
+  return num;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_is_empty
+ *
+ * Description:
+ *   Return true if the ring buffer is empty.
+ *
+ ****************************************************************************/
+
+bool nxmsgq_is_empty(FAR nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+  bool empty;
+
+  flags = nxmsgq_lock(msgq);
+
+  empty = circbuf_is_empty(&msgq->cbuf);
+
+  nxmsgq_unlock(msgq, flags);
+
+  return empty;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_is_full
+ *
+ * Description:
+ *   Return true if the ring buffer is full.
+ *
+ ****************************************************************************/
+
+bool nxmsgq_is_full(FAR nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+  bool full;
+
+  flags = nxmsgq_lock(msgq);
+
+  full = circbuf_is_full(&msgq->cbuf);
+
+  nxmsgq_unlock(msgq, flags);
+
+  return full;
+}
+
+/****************************************************************************
+ * Name: nxmsgq_purge
+ *
+ * Description:
+ *   Purge a message queue.
+ *
+ *   This routine discards all unreceived messages in a message queue's ring
+ *   buffer.
+ *
+ ****************************************************************************/
+
+void nxmsgq_purge(nxmsgq_t *msgq)
+{
+  irqstate_t flags;
+
+  flags = nxmsgq_lock(msgq);
+
+  circbuf_reset(&msgq->cbuf);
+
+  nxmsgq_unlock(msgq, flags);
+}
+
+/****************************************************************************
+ * Name: nxmsgq_ticksend / nxmsgq_send / nxmsgq_trysend
+ *
+ * Description:
+ *   Send a message to a message queue
+ *
+ *   This routine sends a message to message queue.
+ *
+ *   The message content is copied from buffer into msgq and the buffer
+ *   pointer is not retained, so the message content will not be modified
+ *   by this function.
+ *
+ * Input Parameters:
+ *   msgq     - Address of the message queue.
+ *   data     - Pointer to the message.
+ *   timeout  - Waiting period to add the message
+ *
+ * Returned Value:
+ *   0        - Message sent.
+ *   -EAGAIN  - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+int nxmsgq_ticksend(FAR nxmsgq_t *msgq, FAR const void *buffer,
+                    uint32_t delay)
+{
+  irqstate_t flags;
+  int ret = 0;
+
+  flags = nxmsgq_lock(msgq);
+
+  while (circbuf_space(&msgq->cbuf) < msgq->msg_size)
+    {
+      if (delay == 0)
+        {
+          ret = -EAGAIN;
+          goto bail;
+        }
+
+      nxmsgq_unlock(msgq, flags);
+
+      ret = nxsem_tickwait_uninterruptible(&msgq->txsem, delay);
+
+      flags = nxmsgq_lock(msgq);
+      if (ret < 0)
+        {
+          goto bail;
+        }
+    }
+
+  circbuf_write(&msgq->cbuf, buffer, msgq->msg_size);
+
+  nxmsgq_post(&msgq->rxsem);
+
+bail:
+  nxmsgq_unlock(msgq, flags);
+
+  return ret;
+}
+
+int nxmsgq_send(FAR nxmsgq_t *msgq, FAR const void *buffer)
+{
+  return nxmsgq_ticksend(msgq, buffer, UINT32_MAX);
+}
+
+int nxmsgq_trysend(FAR nxmsgq_t *msgq, FAR const void *buffer)
+{
+  return nxmsgq_ticksend(msgq, buffer, 0);
+}
+
+/****************************************************************************
+ * Name: nxmsgq_tickrecv / nxmsgq_tryrecv / nxmsgq_recv
+ *
+ * Description:
+ *   Receive a message from a message queue
+ *
+ *   This routine receives a message from message queue in a "first in,
+ *   first out" manner.
+ *
+ * Input Parameters:
+ *   msgq    - Address of the message queue.
+ *   buffer  - Address of area to hold the received message.
+ *   timeout - Waiting period to receive the message,
+ *
+ * Returned Value:
+ *   0       - Message received.
+ *   -EAGAIN - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+static int nxmsgq_recv_internal(FAR nxmsgq_t *msgq, FAR void *buffer,
+                                uint32_t delay, bool peek)
+{
+  irqstate_t flags;
+  int ret;
+
+again:
+  flags = nxmsgq_lock(msgq);
+
+  if (circbuf_used(&msgq->cbuf) >= msgq->msg_size)
+    {
+      if (!peek)
+        {
+          circbuf_read(&msgq->cbuf, buffer, msgq->msg_size);
+        }
+      else
+        {
+          circbuf_peek(&msgq->cbuf, buffer, msgq->msg_size);
+        }
+
+      nxmsgq_post(&msgq->txsem);
+
+      nxmsgq_unlock(msgq, flags);
+
+      return 0;
+    }
+
+  nxmsgq_unlock(msgq, flags);
+
+  if (delay == 0)
+    {
+      return -ETIMEDOUT;
+    }
+  else if (delay == UINT32_MAX)
+    {
+      ret = nxsem_wait_uninterruptible(&msgq->rxsem);
+    }
+  else
+    {
+      ret = nxsem_tickwait_uninterruptible(&msgq->rxsem, delay);
+    }
+
+  if (ret == 0)
+    {
+      goto again;
+    }
+
+  return ret;
+}
+
+int nxmsgq_tickrecv(FAR nxmsgq_t *msgq, FAR void *buffer, uint32_t delay)
+{
+  return nxmsgq_recv_internal(msgq, buffer, delay, false);
+}
+
+int nxmsgq_tryrecv(FAR nxmsgq_t *msgq, FAR void *buffer)
+{
+  return nxmsgq_recv_internal(msgq, buffer, 0, false);
+}
+
+int nxmsgq_recv(FAR nxmsgq_t *msgq, FAR void *buffer)
+{
+  return nxmsgq_recv_internal(msgq, buffer, UINT32_MAX, false);
+}
+
+/****************************************************************************
+ * Name: nxmsgq_tickpeek / nxmsgq_trypeek / nxmsgq_peek
+ *
+ * Description:
+ *   Peek/read a message from a message queue.
+ *
+ *   This routine reads a message from message queue in a "first in,
+ *   first out" manner and leaves the message in the queue.
+ *
+ * Input Parameters:
+ *   msgq    - Address of the message queue.
+ *   buffer  - Address of area to hold the received message.
+ *   timeout - Waiting period to receive the message,
+ *
+ * Returned Value:
+ *   0       - Message read.
+ *   -EAGAIN - Waiting period timed out.
+ *
+ ****************************************************************************/
+
+int nxmsgq_tickpeek(FAR nxmsgq_t *msgq, FAR void *buffer, uint32_t delay)
+{
+  return nxmsgq_recv_internal(msgq, buffer, delay, true);
+}
+
+int nxmsgq_trypeek(FAR nxmsgq_t *msgq, FAR void *buffer)
+{
+  return nxmsgq_recv_internal(msgq, buffer, 0, true);
+}
+
+int nxmsgq_peek(FAR nxmsgq_t *msgq, FAR void *buffer)
+{
+  return nxmsgq_recv_internal(msgq, buffer, UINT32_MAX, true);
+}


### PR DESCRIPTION

## Summary

nuttx/msgq: add kernel message queue support

Currently NuttX have 2 message queue implementations:

1. Posix Message Queue    (mq_close/mq_getattr/mq_getsetattr/mq_notify/mq_open/mq_overview/mq_receive/mq_send/mq_setattr/mq_timedreceive/mq_timedsend/mq_unlink)
2. System V Message Queue (msgctl/msgget/msggrep/msginit/msgmerge/msgop/msgrcv/msgsnd)

Posix/SysteV message queues meet the standard implementation, But there are various limitations for kernel developer:

1. Depends on the file system, and message sending and receiving require file descriptors as handles, resulting in additional resource overhead and performance degradation
2. Do not support static memory pool configuration, and use global shared memory pools, which will cause more uncertainty in some use case.
3. Cannot support additional capabilities(such as "message peek")

So in this PR, we are planing to introduce the "nxmsgq" implementation to simplify the development in kernel space:
(Compare with of Zephyr and FreeRTOS interfaces)

```
------------------------------------------------------------------------------
|      NuttX          |         Zephyr          |       FreeRTOS             |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_init       |       k_msgq_init       |      xQueueCreateStatic    |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_create     |    k_msgq_alloc_init    |      xQueueCreate          |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_destroy    |    k_msgq_cleanup       |      vQueueDelete          |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_used       |    k_msgq_num_used_get  |   uxQueueMessagesWaiting   |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_space      |    k_msgq_num_free_get  |   uxQueueSpacesAvailable   |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_purge      |     k_msgq_purge        |                            |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_ticksend   |     k_msgq_put          |       xQueueSend           |
|   nxmsgq_trysend    |                         |      xQueueSendFromISR     |
|   nxmsgq_send       |                         |       xQueueSend           |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_tickrecv   |     k_msgq_get          |      xQueueReceive         |
|   nxmsgq_tryrecv    |                         |    xQueueReceiveFromISR    |
|   nxmsgq_recv       |                         |       xQueueReceive        |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_tickpeek   |     k_msgq_peek         |       xQueuePeek           |
|   nxmsgq_trypeek    |                         |       xQueuePeekFromISR    |
|   nxmsgq_peek       |                         |       xQueuePeek           |
|---------------------|-------------------------|----------------------------|
|   nxmsgq_is_empty   |                         |                            |
|   nxmsgq_is_full    |                         |                            |
------------------------------------------------------------------------------
```

```
Posix  Open Test(mq)     : loop: 1001:spending 0.13305000s
Kernel Open Test(nxmsgq) : loop: 1001:spending 0.6345000s (-52%)

Posix  Recv Test(mq)     : loop: 1001:spending 0.7884000s
Kernel Recv Test(nxmsgq) : loop: 1001:spending 0.6837000s (-13%)
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh,  Cortex-M55, test code as below

```

#include <nuttx/config.h>
#include <stdio.h>

#include <fcntl.h>   
#include <sys/stat.h>
#include <mqueue.h>
#include <nuttx/msgq.h>
#include <nuttx/irq.h>
#include <errno.h>

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

static void timespec_sub(struct timespec *dest,                            
                         struct timespec *ts1,                             
                         struct timespec *ts2)                             
{                                                                          
  dest->tv_sec = ts1->tv_sec - ts2->tv_sec;                                
  dest->tv_nsec = ts1->tv_nsec - ts2->tv_nsec;                             
                                                                           
  if (dest->tv_nsec < 0)                                                   
    {                                                                      
      dest->tv_nsec += 1000000000;                                         
      dest->tv_sec -= 1;                                                   
    }                                                                      
}       

void mq_open_test(void)
{
  struct timespec result;                                                  
  struct timespec start;                                                   
  struct timespec end;     
  nxmsgq_t *msg;
  mqd_t mq;

  irqstate_t flags;
  int loop = 0;
  

  /* Posix Message Queue Test */

  flags = enter_critical_section();
  clock_gettime(CLOCK_MONOTONIC, &start);
  while (loop++ < 1000)
    {
      mq = mq_open("test", O_RDWR | O_CREAT, 0644, NULL);
      if (mq < 0) {
        printf("mq_open fail: %d\n", mq);
        break;
      }

      mq_close(mq);
    }
  clock_gettime(CLOCK_MONOTONIC, &end);
  leave_critical_section(flags);

  timespec_sub(&result, &end, &start);
  printf("Posix  Open Test : loop: %d:spending %lld.%lds\n", loop, result.tv_sec, result.tv_nsec);

  /* Kernel Message Queue Test */

  loop = 0;

  flags = enter_critical_section();
  clock_gettime(CLOCK_MONOTONIC, &start);
  while (loop++ < 1000)
    {
      msg = nxmsgq_create(64, 8);
      if (msg == NULL) {
        printf("nxmsgq_create fail: %p\n", msg);
        break;
      }

      nxmsgq_destroy(msg);
    }
  clock_gettime(CLOCK_MONOTONIC, &end);
  leave_critical_section(flags);

  timespec_sub(&result, &end, &start);

  printf("Kernel Open Test : loop: %d:spending %lld.%lds\n", loop, result.tv_sec, result.tv_nsec);
}

mqd_t     g_mq;
nxmsgq_t *g_msg;

void *message_thread(void *arg)
{
  struct timespec result;                                                  
  struct timespec start;                                                   
  struct timespec end;     
  irqstate_t flags;
  char tmp[64];
  int loop = 0;
  int ret;
  unsigned int prio;

  /* Posix Message Queue Test */

  flags = enter_critical_section();
  clock_gettime(CLOCK_MONOTONIC, &start);
  while (loop++ < 1000)
    {
      ret = mq_receive(g_mq, tmp, 64, &prio);
      if (ret < 0)
        {
          printf("mq_receive fail: %d, loop: %d, errno: %d\n", ret, loop, errno);
          return NULL;
        }
    }
  clock_gettime(CLOCK_MONOTONIC, &end);
  leave_critical_section(flags);

  timespec_sub(&result, &end, &start);
  printf("Posix  Recv Test : loop: %d:spending %lld.%lds\n", loop, result.tv_sec, result.tv_nsec);

  /* Kernel Message Queue Test */

  loop = 0;

  flags = enter_critical_section();
  clock_gettime(CLOCK_MONOTONIC, &start);
  while (loop++ < 1000)
    {
      ret = nxmsgq_recv(g_msg, tmp);
      if (ret < 0)
        {
          printf("nxmsgq_recv fail: %d, loop: %d\n", ret, loop);
          return NULL;
        }
    }
  clock_gettime(CLOCK_MONOTONIC, &end);
  leave_critical_section(flags);

  timespec_sub(&result, &end, &start);
  printf("Kernel Recv Test : loop: %d:spending %lld.%lds\n", loop, result.tv_sec, result.tv_nsec);

  return NULL;
}


void mq_sendrecv_test(void)
{
  struct sched_param sparam;
  pthread_attr_t tattr;
  pthread_t pid;
  char tmp[64];
  int loop = 0;
  int ret;

  g_mq = mq_open("test", O_RDWR | O_CREAT, 0644, NULL);
  if (g_mq < 0)
    {
      printf("mq_open fail: %d\n", g_mq);
      return;
    }

  g_msg = nxmsgq_create(64, 8);
  if (g_msg < 0)
    {
      printf("nxmsgq_create fail: %p\n", g_msg);
      return;
    }

  pthread_attr_init(&tattr);
  sparam.sched_priority = 200;
  pthread_attr_setschedparam(&tattr, &sparam);

  pthread_create(&pid, &tattr, message_thread, NULL);

  while (loop++ < 1000)
    {
      ret = mq_send(g_mq, tmp, 64, 0);
      if (ret < 0)
        {
          printf("mq_send fail: %d\n", ret);
          return;
        }
    }

  loop = 0;
  while (loop++ < 1000)
    {
      ret = nxmsgq_send(g_msg, tmp);
      if (ret < 0)
        {
          printf("nxmsgq_send fail: %d\n", ret);
          return;
        }
    }

}

int main(int argc, FAR char *argv[])
{
  mq_open_test();
  mq_sendrecv_test();
  return 0;
}
```
