### PR TITLE
boards/xtensa/esp32: Fix the SPI Flash MTD block device number

### DIFF
--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -429,7 +429,11 @@ static int init_storage_partition(void)
       return ret;
     }
 
+#ifdef CONFIG_ESP32_HAVE_OTA_PARTITION
+  ret = ftl_initialize(nitems(g_ota_partition_table), mtd);
+#else
   ret = ftl_initialize(0, mtd);
+#endif
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",


### PR DESCRIPTION
## Summary

* boards/xtensa/esp32: Fix the SPI Flash MTD block device number

This PR fixes the SPI flash MTD block device number if OTA's partitions are present. In this case, the OTA partitions are registered first and the corresponding MTD block device drivers are assigned with the numbers corresponding to those partitions. Then, the additional SPI flash partition should consider that when registering its own corresponding MTD block device driver.

## Impact

Impact on user: YES. Register the SPI flash partition successfully.

Impact on build: NO.

Impact on hardware: YES. Impacts ESP32 SPI flash device driver registration.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Before applying this patch, `esp32-devkitc:mcuboot_slot_confirm` defconfig failed to mount the SPI flash partition. By applying this patch, the error is gone and the MTD block device driver is properly mounted.

### Building

```
make -j distclean && ./tools/configure.sh esp32-devkitc:mcuboot_slot_confirm && kconfig-tweak -e DEBUG_FEATURES && make olddefconfig && make bootloader && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_PORT=/dev/ttyUSB1 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

```
picocom -b 115200 /dev/ttyUSB1
```

### Results

Compare before/after boot log: an error message appeared when trying to mount the SPI flash MTD block device driver. After applying this patch, the error message is gone and the device driver is mounted at `/dev/mtdblock3`.

#### Before

```
[esp32] [INF] *** Booting MCUboot build v1.10.0-131-gb206b99b ***
[esp32] [INF] [boot] chip revision: v3.0
[esp32] [INF] [boot.esp32] SPI Speed      : 40MHz
[esp32] [INF] [boot.esp32] SPI Mode       : DIO
[esp32] [INF] [boot.esp32] SPI Flash Size : 4MB
[esp32] [INF] [boot] Enabling RNG early entropy source...
[esp32] [INF] Primary image: magic=good, swap_type=0x2, copy_done=0x1, image_ok=0x1
[esp32] [INF] Scratch: magic=bad, swap_type=0x1, copy_done=0x2, image_ok=0x2
[esp32] [INF] Boot source: none
[esp32] [INF] Image index: 0, Swap type: none
[esp32] [INF] Disabling RNG early entropy source...
[esp32] [INF] br_image_off = 0x10000
[esp32] [INF] ih_hdr_size = 0x20
[esp32] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32] [INF] DRAM segment: start=0x2d63c, size=0x2b54, vaddr=0x3ffbb980
[esp32] [INF] IRAM segment: start=0x10040, size=0x1d5fc, vaddr=0x40080000
[esp32] [INF] start=0x40085008
IROM segment aligned lma 0x00060000 vma 0x400d0000 len 0x06f884 (456836)
DROM segment aligned lma 0x00040000 vma 0x3f410000 len 0x01841c (99356)
A__esp32_start: ESP32 chip revision is v3.0
BERROR: Failed to initialize the FTL layer: -17
ERROR: Failed to initialize SPI Flash
I (471) phy_init: phy_version 4830,54550f7,Jun 20 2024,14:22:08

NuttShell (NSH) NuttX-10.4.0
Welcome to MCUboot support on NuttX!
nsh> 
```

#### After

```
[esp32] [INF] *** Booting MCUboot build v1.10.0-131-gb206b99b ***
[esp32] [INF] [boot] chip revision: v3.0
[esp32] [INF] [boot.esp32] SPI Speed      : 40MHz
[esp32] [INF] [boot.esp32] SPI Mode       : DIO
[esp32] [INF] [boot.esp32] SPI Flash Size : 4MB
[esp32] [INF] [boot] Enabling RNG early entropy source...
[esp32] [INF] Primary image: magic=good, swap_type=0x2, copy_done=0x1, image_ok=0x3
[esp32] [INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[esp32] [INF] Boot source: none
[esp32] [INF] Image index: 0, Swap type: test
[esp32] [INF] Starting swap using scratch algorithm.
[esp32] [INF] Disabling RNG early entropy source...
[esp32] [INF] br_image_off = 0x10000
[esp32] [INF] ih_hdr_size = 0x20
[esp32] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32] [INF] DRAM segment: start=0x133f4, size=0x7e4, vaddr=0x3ffb1f80
[esp32] [INF] IRAM segment: start=0x10040, size=0x33b4, vaddr=0x40080000
[esp32] [INF] start=0x40081e70
IROM segment aligned lma 0x00030000 vma 0x400d0000 len 0x013498 (79000)
DROM segment aligned lma 0x00020000 vma 0x3f410000 len 0x003038 (12344)
A__esp32_start: ESP32 chip revision is v3.0
B
NuttShell (NSH) NuttX-10.4.0
Firmware OTA update successfully finished!
nsh> ls /dev/
/dev:
 console
 esp32flash
 mtdblock0
 mtdblock1
 mtdblock2
 mtdblock3
 null
 ota0
 ota1
 otascratch
 ttyS0
 zero
nsh>
```