### PR TITLE
sched/wqueue: Refactor delayed and periodic workqueue.

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -72,12 +72,7 @@ struct wdlist_node
   FAR struct wdlist_node *next;
 };
 
-/* This is the internal representation of the watchdog timer structure.
- * Notice !!!
- * Carefully with the struct wdog_s order, you may not directly modify
- * this. This struct will combine in struct work_s in union type, and,
- * wqueue will modify/check this struct in kwork work_qcancel().
- */
+/* Support a doubly linked list of watchdog timers */
 
 struct wdog_s
 {
@@ -87,7 +82,7 @@ struct wdog_s
 #ifdef CONFIG_PIC
   FAR void          *picbase;    /* PIC base address */
 #endif
-  clock_t            expired;    /* Timer associated with the absoulute time */
+  clock_t            expired;    /* Timer associated with the absolute time */
 };
 
 struct wdog_period_s
@@ -168,7 +163,7 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
  *
  * Input Parameters:
  *   wdog     - Watchdog ID
- *   ticks    - Absoulute time in clock ticks
+ *   ticks    - Absolute time in clock ticks
  *   wdentry  - Function to call on timeout
  *   arg      - Parameter to pass to wdentry.
  *

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -249,16 +249,11 @@ typedef CODE void (*worker_t)(FAR void *arg);
 
 struct work_s
 {
-  struct list_node node;         /* Implements a double linked list */
-  clock_t qtime;                 /* Time work queued */
-  union
-  {
-    struct wdog_s timer;         /* Delay expiry timer */
-    struct wdog_period_s ptimer; /* Period expiry timer */
-  } u;
-  worker_t  worker;              /* Work callback */
-  FAR void *arg;                 /* Callback argument */
-  FAR struct kwork_wqueue_s *wq; /* Work queue */
+  struct list_node node;   /* Implements a double linked list */
+  clock_t          qtime;  /* Time work queued */
+  clock_t          period; /* Periodical delay ticks */
+  worker_t         worker; /* Work callback */
+  FAR void        *arg;    /* Callback argument */
 };
 
 /* This is an enumeration of the various events that may be

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -33,7 +33,7 @@
 #include <stdint.h>
 
 #include <nuttx/clock.h>
-#include <nuttx/queue.h>
+#include <nuttx/list.h>
 #include <nuttx/wdog.h>
 
 /****************************************************************************
@@ -249,7 +249,7 @@ typedef CODE void (*worker_t)(FAR void *arg);
 
 struct work_s
 {
-  struct dq_entry_s dq;          /* Implements a double linked list */
+  struct list_node node;         /* Implements a double linked list */
   clock_t qtime;                 /* Time work queued */
   union
   {

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -249,13 +249,10 @@ typedef CODE void (*worker_t)(FAR void *arg);
 
 struct work_s
 {
+  struct dq_entry_s dq;          /* Implements a double linked list */
+  clock_t qtime;                 /* Time work queued */
   union
   {
-    struct
-    {
-      struct dq_entry_s dq;      /* Implements a double linked list */
-      clock_t qtime;             /* Time work queued */
-    } s;
     struct wdog_s timer;         /* Delay expiry timer */
     struct wdog_period_s ptimer; /* Period expiry timer */
   } u;
@@ -560,11 +557,7 @@ int work_cancel_sync_wq(FAR struct kwork_wqueue_s *wqueue,
  *
  ****************************************************************************/
 
-#ifdef __KERNEL__
-#  define work_timeleft(work) wd_gettime(&((work)->u.timer))
-#else
-#  define work_timeleft(work) ((sclock_t)((work)->u.s.qtime - clock()))
-#endif
+#define work_timeleft(work) ((sclock_t)((work)->qtime - clock()))
 
 /****************************************************************************
  * Name: lpwork_boostpriority

--- a/libs/libc/wqueue/work_cancel.c
+++ b/libs/libc/wqueue/work_cancel.c
@@ -65,8 +65,6 @@
 static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
                         FAR struct work_s *work)
 {
-  FAR dq_entry_t *prev = NULL;
-  FAR dq_entry_t *curr;
   int ret = -ENOENT;
   int semcount;
 
@@ -83,37 +81,16 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
 
   if (work->worker != NULL)
     {
-      /* Search the work activelist for the target work. We can't
-       * use dq_rem to do this because there are additional operations that
-       * need to be done.
-       */
-
-      curr = wqueue->q.head;
-      while (curr && curr != &work->dq)
-        {
-          prev = curr;
-          curr = curr->flink;
-        }
-
-      /* Check if the work was found in the list.  If not, then an OS
-       * error has occurred because the work is marked active!
-       */
-
-      DEBUGASSERT(curr);
+      bool is_head = list_is_head(&wqueue->q, &work->node);
 
       /* Now, remove the work from the work queue */
 
-      if (prev)
-        {
-          /* Remove the work from mid- or end-of-queue */
+      list_delete(&work->node);
 
-          dq_remafter(prev, &wqueue->q);
-        }
-      else
+      if (is_head)
         {
           /* Remove the work at the head of the queue */
 
-          dq_remfirst(&wqueue->q);
           nxsem_get_value(&wqueue->wake, &semcount);
           if (semcount < 1)
             {

--- a/libs/libc/wqueue/work_cancel.c
+++ b/libs/libc/wqueue/work_cancel.c
@@ -89,7 +89,7 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
        */
 
       curr = wqueue->q.head;
-      while (curr && curr != &work->u.s.dq)
+      while (curr && curr != &work->dq)
         {
           prev = curr;
           curr = curr->flink;

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -89,6 +89,16 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
   work->arg    = arg;             /* Callback argument */
   work->qtime  = clock() + delay; /* Delay until work performed */
 
+  /* delay+1 is to prevent the insufficient sleep time if we are
+   * currently near the boundary to the next tick.
+   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
+   * |           ^ Here we get the current tick
+   * In this case we delay 1 tick, timer will be triggered at
+   * current_tick + 1, which is not enough for at least 1 tick.
+   */
+
+  work->qtime += 1;
+
   /* Insert the work into the wait queue sorted by the expired time. */
 
   list_for_every_entry(&wqueue->q, curr, struct work_s, node)

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -77,6 +77,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
                        FAR void *arg, clock_t delay)
 {
   FAR struct work_s *curr;
+  FAR struct work_s *head;
   int semcount;
 
   /* Get exclusive access to the work queue */
@@ -101,6 +102,8 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
   /* Insert the work into the wait queue sorted by the expired time. */
 
+  head = list_first_entry(&wqueue->q, struct work_s, node);
+
   list_for_every_entry(&wqueue->q, curr, struct work_s, node)
     {
       if (!clock_compare(curr->qtime, work->qtime))
@@ -122,7 +125,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
    * We should wake up the worker thread.
    */
 
-  if (list_is_head(&wqueue->q, &work->node))
+  if (curr == head)
     {
       nxsem_get_value(&wqueue->wake, &semcount);
       if (semcount < 1)

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -87,9 +87,9 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
   /* Initialize the work structure */
 
-  work->worker = worker;             /* Work callback. non-NULL means queued */
-  work->arg    = arg;                /* Callback argument */
-  work->u.s.qtime = clock() + delay; /* Delay until work performed */
+  work->worker = worker;          /* Work callback. non-NULL means queued */
+  work->arg    = arg;             /* Callback argument */
+  work->qtime  = clock() + delay; /* Delay until work performed */
 
   /* Do the easy case first -- when the work queue is empty. */
 
@@ -97,7 +97,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
     {
       /* Add the watchdog to the head == tail of the queue. */
 
-      dq_addfirst(&work->u.s.dq, &wqueue->q);
+      dq_addfirst(&work->dq, &wqueue->q);
       nxsem_post(&wqueue->wake);
     }
 
@@ -111,7 +111,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
       do
         {
-          delta = work->u.s.qtime - ((FAR struct work_s *)curr)->u.s.qtime;
+          delta = work->qtime - ((FAR struct work_s *)curr)->qtime;
           if (delta < 0)
             {
               break;
@@ -128,7 +128,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog at the head of the list */
 
-          dq_addfirst(&work->u.s.dq, &wqueue->q);
+          dq_addfirst(&work->dq, &wqueue->q);
           nxsem_get_value(&wqueue->wake, &semcount);
           if (semcount < 1)
             {
@@ -139,7 +139,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog in mid- or end-of-queue */
 
-          dq_addafter(prev, &work->u.s.dq, &wqueue->q);
+          dq_addafter(prev, &work->dq, &wqueue->q);
         }
     }
 

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -94,7 +94,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
   FAR struct work_s *work;
   worker_t worker;
   FAR void *arg;
-  sclock_t elapsed;
+  clock_t tick;
   clock_t next;
   int ret;
 
@@ -126,18 +126,18 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
        * zero will always execute immediately.
        */
 
-      elapsed = clock() - work->qtime;
+      tick = clock();
 
       /* Is this delay work ready? */
 
-      if (elapsed >= 0)
+      if (clock_compare(work->qtime, tick))
         {
           /* Remove the ready-to-execute work from the list */
 
           list_delete(&work->node);
 
           /* Extract the work description from the entry (in case the work
-           * instance by the re-used after it has been de-queued).
+           * instance by the reused after it has been de-queued).
            */
 
           worker = work->worker;

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -125,7 +125,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
        * zero will always execute immediately.
        */
 
-      elapsed = clock() - work->u.s.qtime;
+      elapsed = clock() - work->qtime;
 
       /* Is this delay work ready? */
 
@@ -180,7 +180,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
         }
       else
         {
-          next = work->u.s.qtime - clock();
+          next = work->qtime - clock();
           break;
         }
     }

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -34,7 +34,7 @@
 #include <assert.h>
 
 #include <nuttx/clock.h>
-#include <nuttx/queue.h>
+#include <nuttx/list.h>
 #include <nuttx/wqueue.h>
 
 #include "wqueue/wqueue.h"
@@ -63,7 +63,7 @@
 
 struct usr_wqueue_s g_usrwork =
 {
-  {NULL, NULL},
+  LIST_INITIAL_VALUE(g_usrwork.q),
   NXMUTEX_INITIALIZER,
   SEM_INITIALIZER(0),
 };
@@ -91,7 +91,7 @@ struct usr_wqueue_s g_usrwork =
 
 static void work_process(FAR struct usr_wqueue_s *wqueue)
 {
-  volatile FAR struct work_s *work;
+  FAR struct work_s *work;
   worker_t worker;
   FAR void *arg;
   sclock_t elapsed;
@@ -116,9 +116,10 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
    * so ourselves, and (2) there will be no changes to the work queue
    */
 
-  work = (FAR struct work_s *)wqueue->q.head;
-  while (work)
+  while (!list_is_empty(&wqueue->q))
     {
+      work = list_first_entry(&wqueue->q, struct work_s, node);
+
       /* Is this work ready? It is ready if there is no delay or if
        * the delay has elapsed.  is the time that the work was added
        * to the work queue. Therefore a delay of equal or less than
@@ -133,7 +134,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
         {
           /* Remove the ready-to-execute work from the list */
 
-          dq_remfirst(&wqueue->q);
+          list_delete(&work->node);
 
           /* Extract the work description from the entry (in case the work
            * instance by the re-used after it has been de-queued).
@@ -175,8 +176,6 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
                   return;
                 }
             }
-
-          work = (FAR struct work_s *)wqueue->q.head;
         }
       else
         {
@@ -287,7 +286,7 @@ int work_usrstart(void)
 
   /* Initialize the work queue */
 
-  dq_init(&g_usrwork.q);
+  list_initialize(&g_usrwork.q);
 
 #ifdef CONFIG_BUILD_PROTECTED
 

--- a/libs/libc/wqueue/wqueue.h
+++ b/libs/libc/wqueue/wqueue.h
@@ -33,6 +33,7 @@
 
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/list.h>
 #include <nuttx/wqueue.h>
 
 #if defined(CONFIG_LIBC_USRWORK) && !defined(__KERNEL__)
@@ -49,9 +50,9 @@
 
 struct usr_wqueue_s
 {
-  struct dq_queue_s q;      /* The queue of pending work */
-  mutex_t           lock;   /* exclusive access to user-mode work queue */
-  sem_t             wake;   /* The wake-up semaphore of the  usrthread */
+  struct list_node q;    /* The queue of pending work */
+  mutex_t          lock; /* exclusive access to user-mode work queue */
+  sem_t            wake; /* The wake-up semaphore of the  usrthread */
 };
 
 /****************************************************************************

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -31,7 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/queue.h>
+#include <nuttx/list.h>
 #include <nuttx/wqueue.h>
 
 #include "wqueue/wqueue.h"
@@ -67,10 +67,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
 
       work->worker = NULL;
       wd_cancel(&work->u.timer);
-      if (dq_inqueue((FAR dq_entry_t *)work, &wqueue->q))
-        {
-          dq_rem((FAR dq_entry_t *)work, &wqueue->q);
-        }
+      list_delete(&work->node);
 
       ret = OK;
     }

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -46,7 +46,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
                         FAR struct work_s *work)
 {
   irqstate_t flags;
-  int ret = -ENOENT;
+  int        ret = OK;
 
   if (wqueue == NULL || work == NULL)
     {
@@ -59,17 +59,37 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
    */
 
   flags = spin_lock_irqsave(&wqueue->lock);
-  if (work->worker != NULL)
+
+  /* Check whether we own the work structure. */
+
+  if (!work_available(work))
     {
-      /* Remove the entry from the work queue and make sure that it is
-       * marked as available (i.e., the worker field is nullified).
-       */
+      bool is_head = list_is_head(&wqueue->pending, &work->node);
+
+      /* Seize the ownership from the work thread. */
 
       work->worker = NULL;
-      wd_cancel(&work->u.timer);
+
       list_delete(&work->node);
 
-      ret = OK;
+      /* If the head of the pending queue has changed, we should reset
+       * the wqueue timer.
+       */
+
+      if (is_head)
+        {
+          if (!list_is_empty(&wqueue->pending))
+            {
+              work = list_first_entry(&wqueue->pending, struct work_s, node);
+
+              ret = wd_start_abstick(&wqueue->timer, work->qtime,
+                                     work_timer_expired, (wdparm_t)wqueue);
+            }
+          else
+            {
+              wd_cancel(&wqueue->timer);
+            }
+        }
     }
   else if (!up_interrupt_context() && !sched_idletask() && sync)
     {

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -41,67 +41,6 @@
 #ifdef CONFIG_SCHED_WORKQUEUE
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define queue_work(wqueue, work) \
-  do \
-    { \
-      list_add_tail(&(wqueue)->q, &(work)->node); \
-      if ((wqueue)->wait_count > 0) /* There are threads waiting for sem. */ \
-        { \
-          (wqueue)->wait_count--; \
-          nxsem_post(&(wqueue)->sem); \
-        } \
-    } \
-  while (0)
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: work_timer_expiry
- ****************************************************************************/
-
-static void work_timer_expiry(wdparm_t arg)
-{
-  FAR struct work_s *work = (FAR struct work_s *)arg;
-
-  irqstate_t flags = spin_lock_irqsave(&work->wq->lock);
-  sched_lock();
-
-  /* We have being canceled */
-
-  if (work->worker != NULL)
-    {
-      queue_work(work->wq, work);
-    }
-
-  spin_unlock_irqrestore(&work->wq->lock, flags);
-  sched_unlock();
-}
-
-static bool work_is_canceling(FAR struct kworker_s *kworkers, int nthreads,
-                              FAR struct work_s *work)
-{
-  int wndx;
-
-  for (wndx = 0; wndx < nthreads; wndx++)
-    {
-      if (kworkers[wndx].work == work)
-        {
-          if (kworkers[wndx].wait_count > 0)
-            {
-              return true;
-            }
-        }
-    }
-
-  return false;
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -141,65 +80,67 @@ int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
                          FAR void *arg, clock_t delay, clock_t period)
 {
   irqstate_t flags;
-  int ret = OK;
+  clock_t    expected;
+  bool wake = false;
+  int  ret  = OK;
 
   if (wqueue == NULL || work == NULL || worker == NULL)
     {
       return -EINVAL;
     }
 
+  /* Ensure the work has been canceled. */
+
+  work_cancel_wq(wqueue, work);
+
+  /* delay+1 is to prevent the insufficient sleep time if we are
+   * currently near the boundary to the next tick.
+   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
+   * |           ^ Here we get the current tick
+   * In this case we delay 1 tick, timer will be triggered at
+   * current_tick + 1, which is not enough for at least 1 tick.
+   */
+
+  expected = clock_systime_ticks() + delay + 1;
+
   /* Interrupts are disabled so that this logic can be called from with
    * task logic or from interrupt handling logic.
    */
 
   flags = spin_lock_irqsave(&wqueue->lock);
-  sched_lock();
-
-  /* Remove the entry from the timer and work queue. */
-
-  if (work->worker != NULL)
-    {
-      /* Remove the entry from the work queue and make sure that it is
-       * marked as available (i.e., the worker field is nullified).
-       */
-
-      work->worker = NULL;
-      wd_cancel(&work->u.timer);
-
-      list_delete(&work->node);
-    }
-
-  if (work_is_canceling(wqueue->worker, wqueue->nthreads, work))
-    {
-      goto out;
-    }
 
   /* Initialize the work structure. */
 
-  work->worker = worker;           /* Work callback. non-NULL means queued */
-  work->arg    = arg;              /* Callback argument */
-  work->wq     = wqueue;           /* Work queue */
+  work->worker = worker;   /* Work callback. non-NULL means queued */
+  work->arg    = arg;      /* Callback argument */
+  work->qtime  = expected; /* Expected time */
+  work->period = period;   /* Periodical delay */
 
-  /* Queue the new work */
+  /* Insert to the pending list of the wqueue. */
 
-  if (!delay)
+  if (delay)
     {
-      queue_work(wqueue, work);
-    }
-  else if (period == 0)
-    {
-      ret = wd_start(&work->u.timer, delay,
-                     work_timer_expiry, (wdparm_t)work);
+      if (work_insert_pending(wqueue, work))
+        {
+          /* Start the timer if the work is the earliest expired work. */
+
+          ret = wd_start_abstick(&wqueue->timer, work->qtime,
+                                 work_timer_expired, (wdparm_t)wqueue);
+        }
     }
   else
     {
-      ret = wd_start_period(&work->u.ptimer, delay, period,
-                            work_timer_expiry, (wdparm_t)work);
+      list_add_tail(&wqueue->expired, &work->node);
+      wake = true;
     }
 
-out:
   spin_unlock_irqrestore(&wqueue->lock, flags);
-  sched_unlock();
+
+  if (wake)
+    {
+      nxsem_post(&wqueue->sem);
+    }
+
   return ret;
 }
 

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -83,11 +83,14 @@
 
 struct hp_wqueue_s g_hpwork =
 {
-  LIST_INITIAL_VALUE(g_hpwork.q),
-  SEM_INITIALIZER(0),
-  SEM_INITIALIZER(0),
-  SP_UNLOCKED,
-  CONFIG_SCHED_HPNTHREADS,
+  {
+    LIST_INITIAL_VALUE(g_hpwork.wq.expired),
+    LIST_INITIAL_VALUE(g_hpwork.wq.pending),
+    SEM_INITIALIZER(0),
+    SEM_INITIALIZER(0),
+    SP_UNLOCKED,
+    CONFIG_SCHED_HPNTHREADS,
+  }
 };
 
 #endif /* CONFIG_SCHED_HPWORK */
@@ -97,11 +100,14 @@ struct hp_wqueue_s g_hpwork =
 
 struct lp_wqueue_s g_lpwork =
 {
-  LIST_INITIAL_VALUE(g_lpwork.q),
-  SEM_INITIALIZER(0),
-  SEM_INITIALIZER(0),
-  SP_UNLOCKED,
-  CONFIG_SCHED_LPNTHREADS,
+  {
+    LIST_INITIAL_VALUE(g_lpwork.wq.expired),
+    LIST_INITIAL_VALUE(g_lpwork.wq.pending),
+    SEM_INITIALIZER(0),
+    SEM_INITIALIZER(0),
+    SP_UNLOCKED,
+    CONFIG_SCHED_LPNTHREADS,
+  }
 };
 
 #endif /* CONFIG_SCHED_LPWORK */
@@ -109,6 +115,51 @@ struct lp_wqueue_s g_lpwork =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static inline_function
+void work_dispatch(FAR struct kwork_wqueue_s *wq)
+{
+  FAR struct work_s *work;
+  FAR struct work_s *next;
+  unsigned int count = 0;
+  clock_t      ticks = clock_systime_ticks();
+
+  /* Wake up the worker thread once there is expired work.
+   * If some worker threads are busy, here the callback will
+   * wake up another waiting work thread.
+   *
+   * Becareful of the special case that the pending work
+   * has been canceled but the timer is expired.
+   * In this case we should not wake up any worker thread.
+   */
+
+  list_for_every_entry_safe(&wq->pending, work, next, struct work_s, node)
+    {
+      /* Check whether the work has expired. */
+
+      if (!clock_compare(work->qtime, ticks))
+        {
+          wd_start_abstick(&wq->timer, work->qtime,
+                           work_timer_expired, (wdparm_t)wq);
+          break;
+        }
+
+      /* Expired work will be moved to tail of the expired queue. */
+
+      list_delete(&work->node);
+      list_add_tail(&wq->expired, &work->node);
+
+      /* Note that the thread execution this function is also
+       * a worker thread, which has already been woken up by the timer.
+       * So only `count - 1` semaphore will be posted.
+       */
+
+      if (count++ > 0)
+        {
+          nxsem_post(&wq->sem);
+        }
+    }
+}
 
 /****************************************************************************
  * Name: work_thread
@@ -135,11 +186,11 @@ struct lp_wqueue_s g_lpwork =
 static int work_thread(int argc, FAR char *argv[])
 {
   FAR struct kwork_wqueue_s *wqueue;
-  FAR struct kworker_s *kworker;
-  FAR struct work_s *work;
-  worker_t worker;
-  irqstate_t flags;
-  FAR void *arg;
+  FAR struct kworker_s      *kworker;
+  FAR struct work_s         *work;
+  worker_t      worker;
+  irqstate_t    flags;
+  FAR void     *arg;
 
   /* Get the handle from argv */
 
@@ -148,33 +199,38 @@ static int work_thread(int argc, FAR char *argv[])
   kworker = (FAR struct kworker_s *)
             ((uintptr_t)strtoul(argv[2], NULL, 16));
 
-  flags = spin_lock_irqsave(&wqueue->lock);
-  sched_lock();
-
-  /* Loop forever */
+  /* Loop until wqueue->exit != 0.
+   * Since the only way to set wqueue->exit is to call work_queue_free(),
+   * there is no need for entering the critical section.
+   */
 
   while (!wqueue->exit)
     {
-      /* And check each entry in the work queue.  Since we have disabled
+      /* And check first entry in the work queue. Since we have disabled
        * interrupts we know:  (1) we will not be suspended unless we do
        * so ourselves, and (2) there will be no changes to the work queue
        */
 
-      /* Remove the ready-to-execute work from the list */
+      flags = spin_lock_irqsave(&wqueue->lock);
+      sched_lock();
 
-      while (!list_is_empty(&wqueue->q))
+      /* If the wqueue timer is expired and non-active, it indicates that
+       * there might be expired work in the pending queue.
+       */
+
+      if (!WDOG_ISACTIVE(&wqueue->timer))
         {
-          work = list_first_entry(&wqueue->q, struct work_s, node);
+          work_dispatch(wqueue);
+        }
+
+      if (!list_is_empty(&wqueue->expired))
+        {
+          work = list_first_entry(&wqueue->expired, struct work_s, node);
 
           list_delete(&work->node);
 
-          if (work->worker == NULL)
-            {
-              continue;
-            }
-
-          /* Extract the work description from the entry (in case the work
-           * instance will be re-used after it has been de-queued).
+          /* Extract the work description from the entry (in case the
+           * work instance will be reused after it has been de-queued).
            */
 
           worker = work->worker;
@@ -183,20 +239,41 @@ static int work_thread(int argc, FAR char *argv[])
 
           arg = work->arg;
 
-          /* Mark the work as no longer being queued */
+          /* Check whether the work is periodic. */
 
-          work->worker = NULL;
+          if (work->period != 0)
+            {
+              /* Calculate next expiration qtime. */
+
+              work->qtime += work->period;
+
+              /* Enqueue to the waiting queue */
+
+              if (work_insert_pending(wqueue, work))
+                {
+                  /* We should reset timer if the work is the earliest. */
+
+                  wd_start_abstick(&wqueue->timer, work->qtime,
+                                   work_timer_expired, (wdparm_t)wqueue);
+                }
+            }
+          else
+            {
+              /* Return the work structure ownership to the work owner. */
+
+              work->worker = NULL;
+            }
 
           /* Mark the thread busy */
 
           kworker->work = work;
 
+          spin_unlock_irqrestore(&wqueue->lock, flags);
+          sched_unlock();
+
           /* Do the work.  Re-enable interrupts while the work is being
            * performed... we don't have any idea how long this will take!
            */
-
-          spin_unlock_irqrestore(&wqueue->lock, flags);
-          sched_unlock();
 
           CALL_WORKER(worker, arg);
           flags = spin_lock_irqsave(&wqueue->lock);
@@ -215,22 +292,13 @@ static int work_thread(int argc, FAR char *argv[])
             }
         }
 
-      /* Then process queued work.  work_process will not return until: (1)
-       * there is no further work in the work queue, and (2) semaphore is
-       * posted.
-       */
-
-      wqueue->wait_count++;
       spin_unlock_irqrestore(&wqueue->lock, flags);
       sched_unlock();
 
-      nxsem_wait_uninterruptible(&wqueue->sem);
-      flags = spin_lock_irqsave(&wqueue->lock);
-      sched_lock();
-    }
+      /* Wait for the semaphore to be posted by the wqueue timer. */
 
-  spin_unlock_irqrestore(&wqueue->lock, flags);
-  sched_unlock();
+      nxsem_wait_uninterruptible(&wqueue->sem);
+    }
 
   nxsem_post(&wqueue->exsem);
   return OK;
@@ -304,6 +372,27 @@ static int work_thread_create(FAR const char *name, int priority,
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: work_timer_expired
+ *
+ * Description:
+ *   The wqueue timer callback.
+ *
+ * Input Parameters:
+ *   arg  - The work queue.
+ *
+ ****************************************************************************/
+
+void work_timer_expired(wdparm_t arg)
+{
+  /* The work time expired callback will wake up at least one worker thread
+   * to dispatch the expired work.
+   */
+
+  FAR struct kwork_wqueue_s *wq = (FAR struct kwork_wqueue_s *)arg;
+  nxsem_post(&wq->sem);
+}
+
+/****************************************************************************
  * Name: work_queue_create
  *
  * Description:
@@ -349,7 +438,9 @@ FAR struct kwork_wqueue_s *work_queue_create(FAR const char *name,
 
   /* Initialize the work queue structure */
 
-  list_initialize(&wqueue->q);
+  list_initialize(&wqueue->expired);
+  list_initialize(&wqueue->pending);
+  wqueue->timer.func = NULL;
   nxsem_init(&wqueue->sem, 0, 0);
   nxsem_init(&wqueue->exsem, 0, 0);
   wqueue->nthreads = nthreads;
@@ -391,6 +482,8 @@ int work_queue_free(FAR struct kwork_wqueue_s *wqueue)
     {
       return -EINVAL;
     }
+
+  wd_cancel(&wqueue->timer);
 
   /* Mark the work queue as exiting */
 

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -33,7 +33,7 @@
 #include <stdbool.h>
 
 #include <nuttx/clock.h>
-#include <nuttx/queue.h>
+#include <nuttx/list.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/spinlock.h>
 
@@ -66,7 +66,7 @@ struct kworker_s
 
 struct kwork_wqueue_s
 {
-  struct dq_queue_s q;         /* The queue of pending work */
+  struct list_node  q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
   spinlock_t        lock;      /* Spinlock */
@@ -83,7 +83,7 @@ struct kwork_wqueue_s
 #ifdef CONFIG_SCHED_HPWORK
 struct hp_wqueue_s
 {
-  struct dq_queue_s q;         /* The queue of pending work */
+  struct list_node  q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
   spinlock_t        lock;      /* Spinlock */
@@ -104,7 +104,7 @@ struct hp_wqueue_s
 #ifdef CONFIG_SCHED_LPWORK
 struct lp_wqueue_s
 {
-  struct dq_queue_s q;         /* The queue of pending work */
+  struct list_node  q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   sem_t             exsem;     /* Sync waiting for thread exit */
   spinlock_t        lock;      /* Spinlock */


### PR DESCRIPTION
## Summary

This commit refactors the delayed and the periodic workqueue, and changes the timer to be set in `work_thread`. The improvements of this change are as follows:
- Fix the memory reuse problem of the original periodic workqueue implementation.  https://github.com/apache/nuttx/pull/15937#issuecomment-2808973151
- By removing the `wdog_s` structure in the `work_s` structure, the memory overhead of each `work_s` structure is reduced by about 30 bytes.
- Set the timer for each workqueue instead of each work, which improves system performance.
- Simplified the workqueue cancel processing.

## Impact

This modification mainly affects modules that use workqueue, and may affect the timing of workqueue execution and workqueue cancel semantics.

## Testing

`wqueue_test` tested on QEMU/x86_64. Periodical workqueue can work now.


