### PR TITLE
wireless/ieee802154: Replace direct access to semaphore value with nx…

### DIFF
--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -2018,7 +2018,9 @@ static void mac802154_rxbeaconframe(FAR struct ieee802154_privmac_s *priv,
                     }
                   else if (priv->curr_op == MAC802154_OP_NONE)
                     {
-                      DEBUGASSERT(priv->opsem.semcount == 1);
+                      int sval;
+                      DEBUGASSERT(nxsem_get_value(&priv->opsem, &sval) == 0
+                                  && sval == 1);
                       nxsem_wait_uninterruptible(&priv->opsem);
                       priv->curr_op = MAC802154_OP_AUTOEXTRACT;
                       priv->curr_cmd = IEEE802154_CMD_DATA_REQ;


### PR DESCRIPTION

## Summary

Correct the debugassert line in wireless/ieee802154. Code should not access semaphore internals directly, but use the defined interface for that.

## Impact

No functional impact, cleanup of a single debugassert line. The direct access to semaphore internals block CI on https://github.com/apache/nuttx/pull/16194

## Testing

Tested that the code compiles
