### PR TITLE
boards/[xtensa|risc-v]/esp32[|s2|s3|c3|c6|h2]: Update flash mappings for MCUboot

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -209,7 +209,13 @@ GND          Ground
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32c3-builtin.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32c3-builtin.cfg -c 'init; reset halt; esp appimage_offset 0x0'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x0`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 If you want to debug with an external JTAG adapter it can
 be connected as follows:

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -200,7 +200,13 @@ USB-to-JTAG adapter.
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32c6-builtin.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32c3-builtin.cfg -c 'init; reset halt; esp appimage_offset 0x0'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x0`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 If you want to debug with an external JTAG adapter it can
 be connected as follows:

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -201,7 +201,13 @@ USB-to-JTAG adapter.
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32h2-builtin.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32c3-builtin.cfg -c 'init; reset halt; esp appimage_offset 0x0'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x0`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 If you want to debug with an external JTAG adapter it can
 be connected as follows:

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -241,7 +241,13 @@ described for the :ref:`ESP32-DevKitC <platforms/xtensa/esp32/boards/esp32-devki
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32-wrover-kit-1.8v.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32-wrover-kit-3.3v.cfg -c 'init; reset halt; esp appimage_offset 0x1000'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x1000`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESP32_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 Once OpenOCD is running, you can use GDB to connect to it and debug your application::
 

--- a/Documentation/platforms/xtensa/esp32s2/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/index.rst
@@ -231,7 +231,13 @@ directly to the ESP32-S2 JTAG pins.
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32s2-kaluga-1.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32s2-kaluga-1.cfg -c 'init; reset halt; esp appimage_offset 0x1000'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x1000`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 Once OpenOCD is running, you can use GDB to connect to it and debug your application::
 

--- a/Documentation/platforms/xtensa/esp32s3/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/index.rst
@@ -227,7 +227,13 @@ This is the case for the :ref:`ESP32-S3-DevKit <platforms/xtensa/esp32s3/boards/
 
 OpenOCD can then be used::
 
-  openocd -c 'set ESP_RTOS hwthread; set ESP_FLASH_SIZE 0' -f board/esp32s3-builtin.cfg
+  openocd -s <tcl_scripts_path> -c 'set ESP_RTOS hwthread' -f board/esp32s3-builtin.cfg -c 'init; reset halt; esp appimage_offset 0x0'
+
+.. note::
+  - ``appimage_offset`` should be set to ``0x0`` when ``Simple Boot`` is used. For MCUboot, this value should be set to
+    ``CONFIG_ESP32S3_OTA_PRIMARY_SLOT_OFFSET`` value (``0x10000`` by default).
+  - ``-s <tcl_scripts_path>`` defines the path to the OpenOCD scripts. Usually set to `tcl` if running openocd from its source directory.
+    It can be omitted if `openocd-esp32` were installed in the system with `sudo make install`.
 
 Once OpenOCD is running, you can use GDB to connect to it and debug your application::
 

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -170,7 +170,7 @@ config ESPRESSIF_BOOTLOADER_MCUBOOT
 config ESPRESSIF_MCUBOOT_VERSION
 	string "MCUboot version"
 	depends on ESPRESSIF_BOOTLOADER_MCUBOOT
-	default "12906fdeff4d46752fe3c7f211a7a2fbbc8b7318"
+	default "20f98e0a975c24864872e0df5701eb1082e9c957"
 
 choice ESPRESSIF_ESPTOOL_TARGET_SLOT
 	prompt "Target slot for image flashing"

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -2789,7 +2789,7 @@ endchoice
 config ESP32_MCUBOOT_VERSION
 	string "MCUboot version"
 	depends on ESP32_APP_FORMAT_MCUBOOT
-	default "b206b99b1555ca15f790a3287e57dc98ef3df2ac"
+	default "20f98e0a975c24864872e0df5701eb1082e9c957"
 
 config ESP32_APP_MCUBOOT_HEADER_SIZE
 	int "Application image header size (in bytes)"

--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -1403,7 +1403,7 @@ endchoice
 
 config ESP32S2_MCUBOOT_VERSION
 	string "MCUboot version"
-	default "b206b99b1555ca15f790a3287e57dc98ef3df2ac"
+	default "20f98e0a975c24864872e0df5701eb1082e9c957"
 	depends on ESP32S2_APP_FORMAT_MCUBOOT
 
 config ESP32S2_APP_MCUBOOT_HEADER_SIZE

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -2720,7 +2720,7 @@ endchoice
 
 config ESP32S3_MCUBOOT_VERSION
 	string "MCUboot version"
-	default "b206b99b1555ca15f790a3287e57dc98ef3df2ac"
+	default "20f98e0a975c24864872e0df5701eb1082e9c957"
 	depends on ESP32S3_APP_FORMAT_MCUBOOT
 
 config ESP32S3_APP_MCUBOOT_HEADER_SIZE

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_flat_memory.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_flat_memory.ld
@@ -73,7 +73,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 #elif defined (CONFIG_ESPRESSIF_SIMPLE_BOOT)

--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
@@ -31,6 +31,11 @@ SECTIONS
 #ifdef CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -58,6 +63,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif
 

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_flat_memory.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_flat_memory.ld
@@ -74,7 +74,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 #elif defined (CONFIG_ESPRESSIF_SIMPLE_BOOT)

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
@@ -31,6 +31,11 @@ SECTIONS
 #ifdef CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -58,6 +63,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif
 

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_flat_memory.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_flat_memory.ld
@@ -74,7 +74,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESPRESSIF_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 #elif defined (CONFIG_ESPRESSIF_SIMPLE_BOOT)

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
@@ -31,6 +31,11 @@ SECTIONS
 #ifdef CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -58,6 +63,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif
 

--- a/boards/xtensa/esp32/common/scripts/esp32_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/esp32_sections.ld
@@ -31,6 +31,11 @@ SECTIONS
 #ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -58,6 +63,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif
 

--- a/boards/xtensa/esp32/common/scripts/flat_memory.ld
+++ b/boards/xtensa/esp32/common/scripts/flat_memory.ld
@@ -59,7 +59,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESP32_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESP32_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 

--- a/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
@@ -31,6 +31,11 @@ SECTIONS
 #ifdef CONFIG_ESP32S2_APP_FORMAT_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -58,6 +63,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif
 

--- a/boards/xtensa/esp32s2/common/scripts/flat_memory.ld
+++ b/boards/xtensa/esp32s2/common/scripts/flat_memory.ld
@@ -71,7 +71,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 #elif defined (CONFIG_ESPRESSIF_SIMPLE_BOOT)

--- a/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
@@ -33,6 +33,11 @@ SECTIONS
 #ifdef CONFIG_ESP32S3_APP_FORMAT_MCUBOOT
   .metadata :
   {
+    /* The following metadata refers to the to MCUboot's struct
+     * esp_image_load_header defined at the following commit:
+     * https://github.com/mcu-tools/mcuboot/blob/cd22b693da426826e0255f8ee5b18d7360d9bc8f/boot/espressif/hal/include/esp_mcuboot_image.h
+     */
+
     /* Magic for load header */
 
     LONG(0xace637d3)
@@ -60,6 +65,46 @@ SECTIONS
     LONG(ADDR(.dram0.data))
     LONG(LOADADDR(.dram0.data))
     LONG(SIZEOF(.dram0.data))
+
+    /* RTC_IRAM metadata:
+     * - Destination address (VMA) for RTC_IRAM region
+     * - Flash offset (LMA) for start of RTC_IRAM region
+     * - Size of RTC_IRAM region
+     */
+
+    LONG(ADDR(.rtc.text))
+    LONG(LOADADDR(.rtc.text))
+    LONG(SIZEOF(.rtc.text))
+
+    /* RTC_DRAM metadata:
+     * - Destination address (VMA) for RTC_DRAM region
+     * - Flash offset (LMA) for start of RTC_DRAM region
+     * - Size of RTC_DRAM region
+     */
+
+    LONG(ADDR(.rtc.data))
+    LONG(LOADADDR(.rtc.data))
+    LONG(SIZEOF(.rtc.data))
+
+    /* IROM metadata:
+     * - Destination address (VMA) for IROM region
+     * - Flash offset (LMA) for start of IROM region
+     * - Size of IROM region
+     */
+
+    LONG(ADDR(.flash.text))
+    LONG(LOADADDR(.flash.text))
+    LONG(SIZEOF(.flash.text))
+
+    /* DROM metadata:
+     * - Destination address (VMA) for DROM region
+     * - Flash offset (LMA) for start of DROM region
+     * - Size of DROM region
+     */
+
+    LONG(ADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata))
+    LONG(LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - LOADADDR(.flash.rodata))
   } >metadata
 #endif /* CONFIG_ESP32S3_APP_FORMAT_MCUBOOT */
 

--- a/boards/xtensa/esp32s3/common/scripts/flat_memory.ld
+++ b/boards/xtensa/esp32s3/common/scripts/flat_memory.ld
@@ -95,7 +95,7 @@ MEMORY
    * signing of firmware image.
    */
 
-  metadata (RX) :        org = CONFIG_ESP32S3_APP_MCUBOOT_HEADER_SIZE, len = 0x20
+  metadata (RX) :        org = CONFIG_ESP32S3_APP_MCUBOOT_HEADER_SIZE, len = 0x60
   ROM (RX) :             org = ORIGIN(metadata) + LENGTH(metadata),
                          len = FLASH_SIZE - ORIGIN(ROM)
 #elif defined (CONFIG_ESPRESSIF_SIMPLE_BOOT)


### PR DESCRIPTION
## Summary

This PR adds new fields to the metadata section used by MCUBoot. The openocd-esp32 project requires these fields to properly map the flash segments and enable using SW breakpoints and flash through openocd-esp32.
MCUboot version was also updated and the corresponding documentation for each SoC too.

## Impact

Impact on user: YES. Now users can add SW-defined breakpoints (in addition to the already existing HW breakpoints)

Impact on build: NO.

Impact on hardware: YES. It enables it for all supported Espressif SoCS.

Impact on documentation: YES. The command used for `openocd-esp32` has changed. Documentation is provided for it.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Please, follow documentation for debugging each SoC. For ESP32-S3, for instance, the instructions are available [here](https://nuttx.apache.org/docs/latest/platforms/xtensa/esp32s3/index.html#debugging-with-openocd-and-gdb):

### Building

Following the instructions for ESP32-S3-DevKitC-1 board, build the firmware with `CONFIG_DEBUG_SYMBOLS=y`:

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:mcuboot_nsh && kconfig-tweak -e DEBUG_SYMBOLS && make olddefconfig && make bootloader && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

Open another terminal to run `openocd-esp32`:

```
openocd -s tcl -c 'set ESP_RTOS hwthread' -f board/esp32s3-builtin.cfg -c 'init; reset halt; esp appimage_offset 0x10000'
```

Then, create the `gdbinit` file with the following content:
```
target remote :3333
set remote hardware-watchpoint-limit 2
mon reset halt
flushregs
monitor reset halt
thb nsh_main
c
```

And, on another terminal, run GDB:
```
xtensa-esp32s3-elf-gdb -x ./gdbinit --tui nuttx
```

Insert breakpoints for the `ls`, `ps` and `help` NSH's commands on GDB:
```
b cmd_ls
b cmd_ps
b cmd_help
```

Finally, on NuttX's NSH terminal, type those commands and check the program being halted on GDB.

### Results

The device is expected to properly halt the program's execution when the software breakpoints are reached:

#### GDB log

```
Thread 1 "esp32s3.cpu0" hit Temporary breakpoint 1, nsh_main (argc=1107319712, argv=0x1) at nsh_main.c:54
+b cmd_ls
Breakpoint 2 at 0x42008b7c: file nsh_fscmds.c, line 1524.
Note: automatically using hardware breakpoints for read-only addresses.
+b cmd_ps
Breakpoint 3 at 0x42009df0: file nsh_proccmds.c, line 862.
+b cmd_help
Breakpoint 4 at 0x42007330: file nsh_command.c, line 998.
+c
Continuing.
[esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x42008B7C, debug_reason=00000001
Set GDB target to 'esp32s3.cpu0'
[esp32s3.cpu1] Target halted, PC=0x40043A3B, debug_reason=00000000

Thread 1 "esp32s3.cpu0" hit Breakpoint 2, cmd_ls (vtbl=0x3fc8c530, argc=1, argv=0x3fc8c1a0) at nsh_fscmds.c:1524
+c
Continuing.
[esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x42009DF0, debug_reason=00000001
Set GDB target to 'esp32s3.cpu0'
[esp32s3.cpu1] Target halted, PC=0x40043A3B, debug_reason=00000000

Thread 1 "esp32s3.cpu0" hit Breakpoint 3, cmd_ps (vtbl=0x3fc8c530, argc=1, argv=0x3fc8c1a0) at nsh_proccmds.c:862
+c
Continuing.
[esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x42007330, debug_reason=00000001
Set GDB target to 'esp32s3.cpu0'
[esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000

Thread 1 "esp32s3.cpu0" hit Breakpoint 4, cmd_help (vtbl=0x3fc8c530, argc=1, argv=0x3fc8c1a0) at nsh_command.c:998
+c
Continuing.
[esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
[esp32s3.cpu0] Target halted, PC=0x42013466, debug_reason=00000000
Set GDB target to 'esp32s3.cpu0'
[esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000

Thread 1 "esp32s3.cpu0" received signal SIGINT, Interrupt.
up_idle () at chip/esp32s3_idle.c:221
```

#### `openocd-esp32` log

```
Open On-Chip Debugger v0.12.0-esp32-20241016-315-gab6be67b (2025-04-10-17:18)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hwthread
Info : only one transport option; autoselecting 'jtag'
Info : esp_usb_jtag: VID set to 0x303a and PID to 0x1001
Info : esp_usb_jtag: capabilities descriptor set to 0x2000
Info : [(null)] Hardware thread awareness created
Info : [(null)] Hardware thread awareness created
Info : esp_usb_jtag: serial (7C:DF:A1:E7:27:5C)
Info : esp_usb_jtag: Device found. Base speed 40000KHz, div range 1 to 255
Info : clock speed 40000 kHz
Info : JTAG tap: esp32s3.tap0 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : JTAG tap: esp32s3.tap1 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : [esp32s3.cpu0] Examination succeed
Info : [esp32s3.cpu1] Examination succeed
Info : [esp32s3.cpu0] starting gdb server on 3333
Info : Listening on port 3333 for gdb connections
Info : JTAG tap: esp32s3.tap0 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : JTAG tap: esp32s3.tap1 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : [esp32s3.cpu0] requesting target halt and executing a soft reset
Info : [esp32s3.cpu0] Debug controller was reset.
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x42013466, debug_reason=00000000
Info : Set GDB target to 'esp32s3.cpu0'
Info : [esp32s3.cpu1] Debug controller was reset.
Info : [esp32s3.cpu1] Core was reset.
Info : [esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000
Info : [esp32s3.cpu1] Reset cause (1) - (Power on reset)
Info : [esp32s3.cpu0] Debug controller was reset.
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x500000EF, debug_reason=00000000
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Debug controller was reset.
Info : [esp32s3.cpu1] Core was reset.
Info : [esp32s3.cpu1] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Using flash bank 'esp32s3.cpu0.irom' size 80 KB
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Using flash bank 'esp32s3.cpu0.drom' size 12 KB
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Auto-detected flash bank 'esp32s3.cpu0.flash' size 8192 KB
Info : Using flash bank 'esp32s3.cpu0.flash' size 8192 KB
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Using flash bank 'esp32s3.cpu1.irom' size 80 KB
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Using flash bank 'esp32s3.cpu1.drom' size 12 KB
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCA2, debug_reason=00000001
Info : Flash mapping 0: 0x40000 -> 0x3c040000, 10 KB
Info : Flash mapping 1: 0x20000 -> 0x42000000, 79 KB
Info : Auto-detected flash bank 'esp32s3.cpu1.flash' size 8192 KB
Info : Using flash bank 'esp32s3.cpu1.flash' size 8192 KB
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : accepting 'gdb' connection on tcp/3333
Info : New GDB Connection: 1, Target esp32s3.cpu0, state: halted
Warn : Prefer GDB command "target extended-remote :3333" instead of "target remote :3333"
Info : JTAG tap: esp32s3.tap0 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : JTAG tap: esp32s3.tap1 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : [esp32s3.cpu0] requesting target halt and executing a soft reset
Info : [esp32s3.cpu0] Debug controller was reset.
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x500000EF, debug_reason=00000000
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Debug controller was reset.
Info : [esp32s3.cpu1] Core was reset.
Info : [esp32s3.cpu1] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : JTAG tap: esp32s3.tap0 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : JTAG tap: esp32s3.tap1 tap/device found: 0x120034e5 (mfg: 0x272 (Tensilica), part: 0x2003, ver: 0x1)
Info : [esp32s3.cpu0] requesting target halt and executing a soft reset
Info : [esp32s3.cpu0] Debug controller was reset.
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x500000EF, debug_reason=00000000
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Core was reset.
Info : [esp32s3.cpu0] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Debug controller was reset.
Info : [esp32s3.cpu1] Core was reset.
Info : [esp32s3.cpu1] Target halted, PC=0x40000400, debug_reason=00000000
Info : [esp32s3.cpu1] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Reset cause (3) - (Software core reset)
Info : [esp32s3.cpu0] Target halted, PC=0x42005BA0, debug_reason=00000001
Info : Set GDB target to 'esp32s3.cpu0'
Info : [esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x42007330, debug_reason=00000001
Info : Set GDB target to 'esp32s3.cpu0'
Info : [esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x42008B7C, debug_reason=00000001
Info : Set GDB target to 'esp32s3.cpu0'
Info : [esp32s3.cpu1] Target halted, PC=0x40043A3E, debug_reason=00000000
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x42009DF0, debug_reason=00000001
Info : Set GDB target to 'esp32s3.cpu0'
Info : [esp32s3.cpu1] Target halted, PC=0x40043A40, debug_reason=00000000
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCB6, debug_reason=00000001
Info : [esp32s3.cpu0] Target halted, PC=0x4038CCF6, debug_reason=00000001
```

Note that the "Flash mappings" are being correctly evaluated at the beginning of the logs.