### PR TITLE
Cmake: Implement CMake build of Tiva arch

### DIFF
--- a/arch/arm/src/tiva/CMakeLists.txt
+++ b/arch/arm/src/tiva/CMakeLists.txt
@@ -20,123 +20,14 @@
 #
 # ##############################################################################
 
+# Paths to source files
+
+add_subdirectory(common)
+
 if(CONFIG_ARCH_CHIP_LM)
-  set(ARCH_CHIP lm)
+  add_subdirectory(lm)
 elseif(CONFIG_ARCH_CHIP_TM4C)
-  set(ARCH_CHIP tm4c)
-elseif(CONFIG_ARCH_CHIP_CC13X0)
-  set(ARCH_CHIP cc13xx)
-elseif(CONFIG_ARCH_CHIP_CC13X2)
-  set(ARCH_CHIP cc13xx)
+  add_subdirectory(tm4c)
+elseif((CONFIG_ARCH_CHIP_CC13X0) OR (CONFIG_ARCH_CHIP_CC13X2))
+  add_subdirectory(cc13xx)
 endif()
-
-set(SRCS)
-
-if(NOT CONFIG_ARCH_IDLE_CUSTOM)
-  list(APPEND SRCS tiva_idle.c)
-endif()
-
-list(APPEND SRCS tiva_allocateheap.c tiva_irq.c tiva_lowputc.c tiva_serial.c)
-list(APPEND SRCS tiva_ssi.c)
-
-if(CONFIG_ARCH_CHIP_LM3S)
-  list(APPEND SRCS lmxx_tm4c_start.c lm3s_gpio.c lmxx_tm4c_gpioirq.c)
-  list(APPEND SRCS lm4xx_tm3c_sysctrl.c)
-elseif(CONFIG_ARCH_CHIP_LM4F)
-  list(APPEND SRCS lmxx_tm4c_start.c lm4f_gpio.c lmxx_tm4c_gpioirq.c)
-  list(APPEND SRCS lm4xx_tm3c_sysctrl.c)
-elseif(CONFIG_ARCH_CHIP_TM4C)
-  list(APPEND SRCS lmxx_tm4c_start.c tm4c_gpio.c lmxx_tm4c_gpioirq.c)
-  if(CONFIG_ARCH_CHIP_TM4C129)
-    list(APPEND SRCS tm4c129_sysctrl.c)
-  else()
-    list(APPEND SRCS lm4xx_tm3c_sysctrl.c)
-  endif()
-
-elseif(CONFIG_ARCH_CHIP_CC13X0)
-  list(APPEND SRCS cc13xx_start.c cc13xx_prcm.c cc13xx_chipinfo.c cc13xx_gpio.c)
-  list(APPEND SRCS cc13xx_gpioirq.c cc13xx_enableclks.c cc13xx_enablepwr.c)
-  list(APPEND SRCS cc13x0_trim.c cc13x0_rom.c)
-elseif(CONFIG_ARCH_CHIP_CC13X2)
-  list(APPEND SRCS cc13xx_start.c cc13xx_prcm.c cc13xx_chipinfo.c cc13xx_gpio.c)
-  list(APPEND SRCS cc13xx_gpioirq.c cc13xx_enableclks.c cc13xx_enablepwr.c)
-  list(APPEND SRCS cc13x2_aux_sysif.c)
-  if(CONFIG_ARCH_CHIP_CC13XX_V1)
-    list(APPEND SRCS cc13x2_v1_trim.c cc13x2_cc26x2_v1_rom.c)
-  else()
-    list(APPEND SRCS cc13x2_v2_trim.c)
-  endif()
-endif()
-
-if(CONFIG_DEBUG_GPIO_INFO)
-  list(APPEND SRCS tiva_dumpgpio.c)
-endif()
-
-if(NOT CONFIG_SCHED_TICKLESS)
-  list(APPEND SRCS tiva_timerisr.c)
-endif()
-
-if(CONFIG_BUILD_PROTECTED)
-  list(APPEND SRCS tiva_userspace.c tiva_mpuinit.c)
-endif()
-
-if(CONFIG_TIVA_I2C)
-  list(APPEND SRCS tiva_i2c.c)
-endif()
-
-if(CONFIG_TIVA_PWM)
-  list(APPEND SRCS tiva_pwm.c)
-endif()
-
-if(CONFIG_TIVA_QEI)
-  list(APPEND SRCS tiva_qencoder.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tiva_timerlib.c)
-  if(CONFIG_TIVA_TIMER32_PERIODIC)
-    list(APPEND SRCS tiva_timerlow32.c)
-  endif()
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tiva_adclow.c)
-  list(APPEND SRCS tiva_adclib.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tiva_can.c)
-endif()
-
-if(CONFIG_TIVA_ETHERNET)
-  if(CONFIG_ARCH_CHIP_LM3S)
-    list(APPEND SRCS lm3s_ethernet.c)
-  endif()
-  if(CONFIG_ARCH_CHIP_TM4C)
-    list(APPEND SRCS tm4c_ethernet.c)
-  endif()
-endif()
-
-if(CONFIG_TIVA_FLASH)
-  list(APPEND SRCS tiva_flash.c)
-endif()
-
-if(CONFIG_TIVA_EEPROM)
-  list(APPEND SRCS tiva_eeprom.c)
-endif()
-
-if(CONFIG_TIVA_HCIUART)
-  list(APPEND SRCS tiva_hciuart.c)
-endif()
-
-set(COMMON_SRCS)
-
-foreach(src ${SRCS})
-  if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/common/${src})
-    list(APPEND COMMON_SRCS common/${src})
-  else()
-    list(APPEND COMMON_SRCS ${ARCH_CHIP}/${src})
-  endif()
-endforeach()
-
-target_sources(arch PRIVATE ${COMMON_SRCS})

--- a/arch/arm/src/tiva/cc13xx/CMakeLists.txt
+++ b/arch/arm/src/tiva/cc13xx/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+# arch/arm/src/tiva/cc13xx/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,43 +20,41 @@
 #
 # ##############################################################################
 
-set(SRCS tm4c_boot.c tm4c_bringup.c tm4c_ssi.c)
+if((CONFIG_ARCH_CHIP_CC13X0) OR (CONFIG_ARCH_CHIP_CC13X2))
+  set(SRCS)
 
-if(CONFIG_ARCH_LEDS)
-  list(APPEND SRCS tm4c_autoleds.c)
-endif()
-
-if(CONFIG_BOARDCTL)
-  list(APPEND SRCS tm4c_appinit.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tm4c_timer.c)
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tm4c_adc.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tm4c_can.c)
-endif()
-
-if(CONFIG_CAN_MCP2515)
-  list(APPEND SRCS tm4c_mcp2515.c)
-endif()
-
-if(CONFIG_MTD_AT24XX)
-  if(CONFIG_TIVA_I2C0)
-    list(APPEND SRCS tm4c_at24.c)
+  if(CONFIG_ARCH_CHIP_CC13X0)
+    list(
+      APPEND
+      SRCS
+      cc13xx_start.c
+      cc13xx_prcm.c
+      cc13xx_chipinfo.c
+      cc13xx_gpio.c
+      cc13xx_gpioirq.c
+      cc13xx_enableclks.c
+      cc13xx_enablepwr.c
+      cc13x0_trim.c
+      cc13x0_rom.c)
+  elseif(CONFIG_ARCH_CHIP_CC13X2)
+    list(
+      APPEND
+      SRCS
+      cc13xx_start.c
+      cc13xx_prcm.c
+      cc13xx_chipinfo.c
+      cc13xx_gpio.c
+      cc13xx_gpioirq.c
+      cc13xx_enableclks.c
+      cc13xx_enablepwr.c
+      cc13x2_aux_sysif.c)
+    if(CONFIG_ARCH_CHIP_CC13XX_V1)
+      list(APPEND SRCS cc13x2_v1_trim.c cc13x2_cc26x2_v1_rom.c)
+    else()
+      list(APPEND SRCS cc13x2_v2_trim.c)
+    endif()
   endif()
+
+  target_sources(arch PRIVATE ${SRCS})
+
 endif()
-
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS tm4c_buttons.c)
-endif()
-
-target_sources(board PRIVATE ${SRCS})
-
-set_property(GLOBAL PROPERTY LD_SCRIPT
-                             "${NUTTX_BOARD_DIR}/scripts/tm4c123g-launchpad.ld")

--- a/arch/arm/src/tiva/common/CMakeLists.txt
+++ b/arch/arm/src/tiva/common/CMakeLists.txt
@@ -1,0 +1,102 @@
+# ##############################################################################
+# arch/arm/src/tiva/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS tiva_idle.c)
+endif()
+
+list(
+  APPEND
+  SRCS
+  tiva_allocateheap.c
+  tiva_irq.c
+  tiva_lowputc.c
+  tiva_serial.c
+  tiva_ssi.c)
+
+if(CONFIG_ARCH_CHIP_LM3S)
+  list(APPEND SRCS lmxx_tm4c_start.c lmxx_tm4c_gpioirq.c lm4xx_tm3c_sysctrl.c)
+elseif(CONFIG_ARCH_CHIP_LM4F)
+  list(APPEND SRCS lmxx_tm4c_start.c lmxx_tm4c_gpioirq.c lm4xx_tm3c_sysctrl.c)
+elseif(CONFIG_ARCH_CHIP_TM4C)
+  list(APPEND SRCS lmxx_tm4c_start.c lmxx_tm4c_gpioirq.c)
+  if(NOT CONFIG_ARCH_CHIP_TM4C129)
+    list(APPEND SRCS lm4xx_tm3c_sysctrl.c)
+  endif()
+endif()
+
+if(CONFIG_DEBUG_GPIO_INFO)
+  list(APPEND SRCS tiva_dumpgpio.c)
+endif()
+
+if(NOT CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS tiva_timerisr.c)
+endif()
+
+if(CONFIG_BUILD_PROTECTED)
+  list(APPEND SRCS tiva_userspace.c tiva_mpuinit.c)
+endif()
+
+if(CONFIG_TIVA_I2C)
+  list(APPEND SRCS tiva_i2c.c)
+endif()
+
+if(CONFIG_TIVA_PWM)
+  list(APPEND SRCS tiva_pwm.c)
+endif()
+
+if(CONFIG_TIVA_QEI)
+  list(APPEND SRCS tiva_qencoder.c)
+endif()
+
+if(CONFIG_TIVA_TIMER)
+  list(APPEND SRCS tiva_timerlib.c)
+  if(CONFIG_TIVA_TIMER32_PERIODIC)
+    list(APPEND SRCS tiva_timerlow32.c)
+  endif()
+endif()
+
+if(CONFIG_TIVA_ADC)
+  list(APPEND SRCS tiva_adclow.c tiva_adclib.c)
+endif()
+
+if(CONFIG_TIVA_CHAR_DEV_CAN)
+  list(APPEND SRCS tiva_can.c)
+endif()
+
+if(CONFIG_TIVA_SOCKET_CAN)
+  list(APPEND SRCS tiva_sock_can.c)
+endif()
+
+if(CONFIG_TIVA_FLASH)
+  list(APPEND SRCS tiva_flash.c)
+endif()
+
+if(CONFIG_TIVA_EEPROM)
+  list(APPEND SRCS tiva_eeprom.c)
+endif()
+
+if(CONFIG_TIVA_HCIUART)
+  list(APPEND SRCS tiva_hciuart.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/tiva/lm/CMakeLists.txt
+++ b/arch/arm/src/tiva/lm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+# arch/arm/src/tiva/lm/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,43 +20,19 @@
 #
 # ##############################################################################
 
-set(SRCS tm4c_boot.c tm4c_bringup.c tm4c_ssi.c)
+if(CONFIG_ARCH_CHIP_LM)
+  set(SRCS)
 
-if(CONFIG_ARCH_LEDS)
-  list(APPEND SRCS tm4c_autoleds.c)
-endif()
-
-if(CONFIG_BOARDCTL)
-  list(APPEND SRCS tm4c_appinit.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tm4c_timer.c)
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tm4c_adc.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tm4c_can.c)
-endif()
-
-if(CONFIG_CAN_MCP2515)
-  list(APPEND SRCS tm4c_mcp2515.c)
-endif()
-
-if(CONFIG_MTD_AT24XX)
-  if(CONFIG_TIVA_I2C0)
-    list(APPEND SRCS tm4c_at24.c)
+  if(CONFIG_ARCH_CHIP_LM3S)
+    list(APPEND SRCS lm3s_gpio.c)
+  elseif(CONFIG_ARCH_CHIP_LM4F)
+    list(APPEND SRCS lm4f_gpio.c)
   endif()
+
+  if((CONFIG_TIVA_ETHERNET) AND (CONFIG_ARCH_CHIP_LM3S))
+    list(APPEND SRCS lm3s_ethernet.c)
+  endif()
+
+  target_sources(arch PRIVATE ${SRCS})
+
 endif()
-
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS tm4c_buttons.c)
-endif()
-
-target_sources(board PRIVATE ${SRCS})
-
-set_property(GLOBAL PROPERTY LD_SCRIPT
-                             "${NUTTX_BOARD_DIR}/scripts/tm4c123g-launchpad.ld")

--- a/arch/arm/src/tiva/tm4c/CMakeLists.txt
+++ b/arch/arm/src/tiva/tm4c/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+# arch/arm/src/tiva/tm4c/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,43 +20,19 @@
 #
 # ##############################################################################
 
-set(SRCS tm4c_boot.c tm4c_bringup.c tm4c_ssi.c)
+if(CONFIG_ARCH_CHIP_TM4C)
+  set(SRCS)
 
-if(CONFIG_ARCH_LEDS)
-  list(APPEND SRCS tm4c_autoleds.c)
-endif()
+  list(APPEND SRCS tm4c_gpio.c)
 
-if(CONFIG_BOARDCTL)
-  list(APPEND SRCS tm4c_appinit.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tm4c_timer.c)
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tm4c_adc.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tm4c_can.c)
-endif()
-
-if(CONFIG_CAN_MCP2515)
-  list(APPEND SRCS tm4c_mcp2515.c)
-endif()
-
-if(CONFIG_MTD_AT24XX)
-  if(CONFIG_TIVA_I2C0)
-    list(APPEND SRCS tm4c_at24.c)
+  if(CONFIG_ARCH_CHIP_TM4C129)
+    list(APPEND SRCS tm4c129_sysctrl.c)
   endif()
+
+  if(CONFIG_TIVA_ETHERNET)
+    list(APPEND SRCS tm4c_ethernet.c)
+  endif()
+
+  target_sources(arch PRIVATE ${SRCS})
+
 endif()
-
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS tm4c_buttons.c)
-endif()
-
-target_sources(board PRIVATE ${SRCS})
-
-set_property(GLOBAL PROPERTY LD_SCRIPT
-                             "${NUTTX_BOARD_DIR}/scripts/tm4c123g-launchpad.ld")

--- a/boards/arm/tiva/tm4c1294-launchpad/CMakeLists.txt
+++ b/boards/arm/tiva/tm4c1294-launchpad/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+# boards/arm/tiva/tm4c1294-launchpad/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,43 +20,4 @@
 #
 # ##############################################################################
 
-set(SRCS tm4c_boot.c tm4c_bringup.c tm4c_ssi.c)
-
-if(CONFIG_ARCH_LEDS)
-  list(APPEND SRCS tm4c_autoleds.c)
-endif()
-
-if(CONFIG_BOARDCTL)
-  list(APPEND SRCS tm4c_appinit.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tm4c_timer.c)
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tm4c_adc.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tm4c_can.c)
-endif()
-
-if(CONFIG_CAN_MCP2515)
-  list(APPEND SRCS tm4c_mcp2515.c)
-endif()
-
-if(CONFIG_MTD_AT24XX)
-  if(CONFIG_TIVA_I2C0)
-    list(APPEND SRCS tm4c_at24.c)
-  endif()
-endif()
-
-if(CONFIG_ARCH_BUTTONS)
-  list(APPEND SRCS tm4c_buttons.c)
-endif()
-
-target_sources(board PRIVATE ${SRCS})
-
-set_property(GLOBAL PROPERTY LD_SCRIPT
-                             "${NUTTX_BOARD_DIR}/scripts/tm4c123g-launchpad.ld")
+add_subdirectory(src)

--- a/boards/arm/tiva/tm4c1294-launchpad/src/CMakeLists.txt
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# boards/arm/tiva/tm4c123g-launchpad/src/CMakeLists.txt
+# boards/arm/tiva/tm4c1294-launchpad/src/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,43 +20,44 @@
 #
 # ##############################################################################
 
-set(SRCS tm4c_boot.c tm4c_bringup.c tm4c_ssi.c)
+set(SRCS tm4c_boot.c tm4c_bringup.c)
 
 if(CONFIG_ARCH_LEDS)
   list(APPEND SRCS tm4c_autoleds.c)
-endif()
-
-if(CONFIG_BOARDCTL)
-  list(APPEND SRCS tm4c_appinit.c)
-endif()
-
-if(CONFIG_TIVA_TIMER)
-  list(APPEND SRCS tm4c_timer.c)
-endif()
-
-if(CONFIG_TIVA_ADC)
-  list(APPEND SRCS tm4c_adc.c)
-endif()
-
-if(CONFIG_TIVA_CAN)
-  list(APPEND SRCS tm4c_can.c)
-endif()
-
-if(CONFIG_CAN_MCP2515)
-  list(APPEND SRCS tm4c_mcp2515.c)
-endif()
-
-if(CONFIG_MTD_AT24XX)
-  if(CONFIG_TIVA_I2C0)
-    list(APPEND SRCS tm4c_at24.c)
-  endif()
+else()
+  list(APPEND SRCS tm4c_userleds.c)
 endif()
 
 if(CONFIG_ARCH_BUTTONS)
   list(APPEND SRCS tm4c_buttons.c)
 endif()
 
+if(CONFIG_TIVA_ETHERNET)
+  list(APPEND SRCS tm4c_ethernet.c)
+endif()
+
+if(CONFIG_TIVA_CAN)
+  list(APPEND SRCS tm4c_can.c)
+endif()
+
+if(CONFIG_DK_TM4C129X_TIMER)
+  list(APPEND SRCS tm4c_timer.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS tm4c_appinit.c)
+endif()
+
+if(CONFIG_TIVA_HCIUART)
+  if(CONFIG_BLUETOOTH_UART)
+    list(APPEND SRCS tm4c_hciuart.c)
+  endif()
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS tm4c_reset.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})
 
-set_property(GLOBAL PROPERTY LD_SCRIPT
-                             "${NUTTX_BOARD_DIR}/scripts/tm4c123g-launchpad.ld")
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")


### PR DESCRIPTION
## Summary

added TI/Stellaris Tiva

CMake added **tm4c1294-launchpad** and **tm4c123g-launchpad board**.

this implementation #16195 is incorrect and broken.

## Impact

Impact on user: This PR adds **tm4c1294-launchpad and tm4c123g-launchpad board** with CMake build

Impact on build: This PR Implement CMake build of Tiva arch

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
Locally and on GitHub

Locally
```
D:\nuttx>cmake -B build -DBOARD_CONFIG=tm4c1294-launchpad:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  tm4c1294-launchpad
--   Config: nsh
--   Appdir: D:/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (9.5s)
-- Generating done (2.1s)
-- Build files have been written to: D:/nuttx/build

D:\nuttx>cmake --build build
[1447/1448] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      139172 B         1 MB     13.27%
            sram:       29384 B       256 KB     11.21%
[1448/1448] Generating nuttx.bin

```

GitHub

**tm4c1294-launchpad:nsh**
https://github.com/simbit18/nuttx_test_pr/actions/runs/14536972193/job/40787247827#logs
