### PR TITLE
Documentation: Fix bad practice instructions

### DIFF
--- a/Documentation/platforms/sim/network_linux.rst
+++ b/Documentation/platforms/sim/network_linux.rst
@@ -44,7 +44,7 @@ To compile:
 
 .. code-block:: bash
 
-    $ cp boards/sim/sim/sim/configs/tcpblaster/defconfig .config
+    $ ./tools/configure.sh sim:tcpblaster
     $ make menuconfig  # optional, to adjust configuration
     $ make clean; make
 


### PR DESCRIPTION
## Summary

It is not recommend to just copy defconfig to .config instead of running ./tools/configure.sh. The configure script will do more than just copying the defconfig, it will create backup config, it will check if apps/ dir exists, etc.

## Impact

End users will void mistakes

## Testing

DOC


