### PR TITLE
net/tcp/tcp_conn.c: optimize the port conflict detection rules for tcp_listener()

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -143,7 +143,8 @@ static FAR struct tcp_conn_s *
 #endif /* CONFIG_NET_IPv6 */
             {
               if (net_ipv4addr_cmp(conn->u.ipv4.laddr, ipaddr->ipv4) ||
-                  net_ipv4addr_cmp(conn->u.ipv4.laddr, INADDR_ANY))
+                  net_ipv4addr_cmp(conn->u.ipv4.laddr, INADDR_ANY) ||
+                  net_ipv4addr_cmp(ipaddr->ipv4, INADDR_ANY))
                 {
                   /* The port number is in use, return the connection */
 
@@ -158,7 +159,8 @@ static FAR struct tcp_conn_s *
 #endif /* CONFIG_NET_IPv4 */
             {
               if (net_ipv6addr_cmp(conn->u.ipv6.laddr, ipaddr->ipv6) ||
-                  net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
+                  net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr) ||
+                  net_ipv6addr_cmp(ipaddr->ipv6, g_ipv6_unspecaddr))
                 {
                   /* The port number is in use, return the connection */
 


### PR DESCRIPTION
## Summary
net/tcp/tcp_conn.c: optimize the port conflict detection rules for tcp_listener().
Fixed potential conflict between implicit binding and port conflict detection.
Implicit binding automatically allocates an interface address during connection,but port conflict detection occurs before binding/connecting. This can cause issues when creating multiple TCP connections in succession. If the first connection uses a random port via implicit binding, subsequent connections might reuse the same port under current filtering rules, leading to connect() failures.

## Impact

New Feature/Change: Issue fix (no new feature).
User Impact: optimize the port conflict detection rules for tcp_listener().
Build Impact:No new Kconfig options or build system changes.
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing

Scenario simulation:
```
// Connection A:
socket();
connect("192.168.1.100:8080"); // Implicitly binds to 192.168.1.100:random port
// Connection B:
socket();
connect("192.168.1.100:8080"); // Under current filtering rules, port conflict detection is ineffective, may randomly assign A's port
```


