### PR TITLE
wireless/lpwan/rn2xx3: Fix invalid sync word bug.

### DIFF
--- a/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
+++ b/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
@@ -1165,7 +1165,7 @@ static int rn2xx3_setsync(FAR struct rn2xx3_dev_s *priv, uint64_t sync)
 
   /* Write actual parameter and end command */
 
-  length = snprintf(syncstr, sizeof(syncstr), "%016llX\r\n", sync);
+  length = snprintf(syncstr, sizeof(syncstr), "%llX\r\n", sync);
   length = file_write(&priv->uart, syncstr, length);
   if (length < 0)
     {


### PR DESCRIPTION
## Summary

This commit resolves issue #16009, where a sync word of less than 64 bytes was printed as 0-padded hex. 0-padding is invalid for the RN2xx3 modules, so now it has been removed.

Closes #16009.

## Impact

Now users can successfully set the sync word of the RN2xx3 modules without receiving `EINVAL`.

## Testing

Builds successfully on local build. Tested on custom STM32H743 board and can successfully set the sync word.