### PR TITLE
drivers/sensors/lis2mdl: Fix SYSLOG call.

### DIFF
--- a/drivers/sensors/lis2mdl_uorb.c
+++ b/drivers/sensors/lis2mdl_uorb.c
@@ -1140,7 +1140,7 @@ static int lis2mdl_control(FAR struct sensor_lowerhalf_s *lower,
 
     default:
       err = -EINVAL;
-      snerr("Unknown command for LIS2MDL: lu\n", cmd);
+      snerr("Unknown command for LIS2MDL: %d\n", cmd);
       break;
     }
 


### PR DESCRIPTION
## Summary

This call to syslog was missing the '%' in its format string, and also was using the wrong format string (lu instead of d) to print the `cmd` argument. It is corrected and the compiler warning resolved.

## Impact

Syslog call will now work correctly and the build output has one less error.

## Testing

Built locally.

Before, the compiler output included:

```console
sensors/lis2mdl_uorb.c: In function 'lis2mdl_control':
sensors/lis2mdl_uorb.c:1143:13: warning: too many arguments for format [-Wformat-extra-args]
 1143 |       snerr("Unknown command for LIS2MDL: lu\n", cmd);
```

Now there is no warning.