### PR TITLE
boards/[risc-v|xtensa]/esp32[|c3|c6|h2|s3]: set coexiram sections

### DIFF
--- a/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
+++ b/boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld
@@ -118,6 +118,8 @@ SECTIONS
     *(.iram1)
     *(.iram1.*)
 
+    *libcoexist.a:(.coexiram .coexiram.*)
+
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)

--- a/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
+++ b/boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld
@@ -118,6 +118,8 @@ SECTIONS
     *(.iram1)
     *(.iram1.*)
 
+    *libcoexist.a:(.coexiram .coexiram.*)
+
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)

--- a/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
+++ b/boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld
@@ -118,6 +118,8 @@ SECTIONS
     *(.iram1)
     *(.iram1.*)
 
+    *libcoexist.a:(.coexiram .coexiram.*)
+
     *libsched.a:irq_dispatch.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_lock.*(.text .text.* .literal .literal.*)
     *libsched.a:sched_unlock.*(.text .text.* .literal .literal.*)

--- a/boards/xtensa/esp32/common/scripts/esp32_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/esp32_sections.ld
@@ -153,6 +153,7 @@ SECTIONS
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
     esp32_start.*(.literal .text .literal.* .text.*)
+    *libcoexist.a:(.coexiram .coexiram.*)
     *libphy.a:(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
     *libpp.a:(.literal .text .literal.* .text.*)

--- a/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
@@ -158,7 +158,7 @@ SECTIONS
     *(.iram1 .iram1.*)
     esp32s3_start.*(.literal .text .literal.* .text.*)
     esp32s3_region.*(.literal .text .literal.* .text.*)
-
+    *libcoexist.a:(.coexiram .coexiram.*)
     *libarch.a:*esp_loader.*(.literal .text .literal.* .text.*)
     *libarch.a:esp32s3_cpuindex.*(.literal .text .literal.* .text.*)
     *libarch.a:esp32s3_irq.*(.literal .text .literal.* .text.*)


### PR DESCRIPTION
## Summary

* boards/[risc-v|xtensa]/esp32[|c3|c6|h2|s3]: set coexiram sections

This PR sets the coexiram (from libcoexist.a) sections on IRAM.

Before this patch, no other rules matched such sections and the sections could be placed outside markers that denote the end of the text sections, causing unexpected errors.

## Impact

Impact on user: YES. Avoid unexpected errors when BLE + Wi-Fi are enabled.

Impact on build: NO.

Impact on hardware: YES. Affect devices with coexistence (Wi-Fi, Bluetooth, or 802.15.4): ESP32, ESP32-C3, ESP32-C6, ESP32-H2 and ESP32-S3.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Build the `blewifi` defconfig before and after applying the patch, checking where `.coexiram` setions are being placed on `nuttx.map`. Taking `esp32-devkitc:blewifi` as an example:

### Building

```
make -j distclean && ./tools/configure.sh esp32-devkitc:blewifi && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_PORT=/dev/ttyUSB1 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

```
minicom -D /dev/ttyUSB1
```

Check if the device boots properly.

### Results

Check - on `nuttx.map` - for the `.coexiram` sections before and after applying this patch: 

#### Before 

```
                0x0000000040177e9c                _text_end = ABSOLUTE (.)
                0x0000000040177e9c                _etext = .

.coexiram.8     0x0000000040177e9c       0x15 load address 0x00000000000d7e9c
 .coexiram.8    0x0000000040177e9c       0x15 /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace_alfa/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_coex/lib/esp32/libcoexist.a(coexist_api.o)
                0x0000000040177ea0                coex_wifi_release
```

Please note that `.coexiram.8` is being placed after `_text_end` and `_etext` markers.

#### After

```
.iram0.text     0x0000000040080400    0x2657c load address 0x0000000000000420
                0x0000000040080400                _iram_text_start = ABSOLUTE (.)

 .coexiram.8    0x000000004008c080       0x11 /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace_alfa/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_coex/lib/esp32/libcoexist.a(coexist_api.o)
                                         0x15 (size before relaxing)
                0x000000004008c080                coex_wifi_release

 *fill*         0x00000000400a696b       0x11 
                0x00000000400a697c                _iram_text_end = ABSOLUTE (.)
```

Now, `.coexiram.8` is within IRAM start/end markers (