### PR TITLE
arch/arm/rp23xx: fix linker scripts 100% RAM usage bug

### DIFF
--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
@@ -256,11 +256,11 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_default.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_default.ld
@@ -269,11 +269,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+    /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_no_flash.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_no_flash.ld
@@ -215,11 +215,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+    /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {


### PR DESCRIPTION
## Summary
Compiling with --print-memory-usage always shows 100% RAM
Upstream bug https://github.com/raspberrypi/pico-sdk/issues/1871

## Before
```
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           FLASH:      414516 B         4 MB      9.88%
             RAM:        512 KB       512 KB    100.00%
       SCRATCH_X:           0 B         4 KB      0.00%
       SCRATCH_Y:           0 B         4 KB      0.00%
CP: nuttx.asm
Generating: nuttx.uf2
Done.
```

## After

```
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           FLASH:      414516 B         4 MB      9.88%
             RAM:       39152 B       512 KB      7.47%
       SCRATCH_X:           0 B         4 KB      0.00%
       SCRATCH_Y:           0 B         4 KB      0.00%
CP: nuttx.asm
Generating: nuttx.uf2
Done.
```

