### PR TITLE
drivers/ioexpander/icjx: add option to set filters during initialization

### DIFF
--- a/drivers/ioexpander/icjx.c
+++ b/drivers/ioexpander/icjx.c
@@ -1084,31 +1084,47 @@ FAR struct ioexpander_dev_s *icjx_initialize(FAR struct spi_dev_s *spi,
   ret = icjx_write(priv, ICJX_CTRL_WORD_2_A, regval, ICJX_NOB1);
   if (ret < 0)
     {
-      gpioerr("ERROR: Could write to ICJX_CTRL_WORD_2_A: %d!\n", ret);
+      gpioerr("ERROR: Couldn't write to ICJX_CTRL_WORD_2_A: %d!\n", ret);
       goto err;
     }
 
   ret = icjx_write(priv, ICJX_CTRL_WORD_2_B, regval, ICJX_NOB1);
   if (ret < 0)
     {
-      gpioerr("ERROR: Could write to ICJX_CTRL_WORD_2_B: %d!\n", ret);
+      gpioerr("ERROR: Couldn't write to ICJX_CTRL_WORD_2_B: %d!\n", ret);
       goto err;
     }
 
   /* Bypass filters as those are not yet supported. */
 
-  regval = ICJX_CTRL_WORD_1_BYP0 | ICJX_CTRL_WORD_1_BYP1;
+  if (config->filters != ICJX_CTRL_WORD_FILTER_DISABLED)
+    {
+      regval = ICJX_CTRL_WORD_3_ICLK;
+    }
+  else
+    {
+      regval = ICJX_CTRL_WORD_3_DIS;
+    }
+
+  ret = icjx_write(priv, ICJX_CTRL_WORD_3_B, regval, ICJX_NOB1);
+  if (ret < 0)
+    {
+      gpioerr("ERROR: Couldn't write to ICJX_CTRL_WORD_3_B: %d!\n", ret);
+      goto err;
+    }
+
+  regval = (config->filters << 4) | config->filters;
   ret = icjx_write(priv, ICJX_CTRL_WORD_1_A, regval, ICJX_NOB1);
   if (ret < 0)
     {
-      gpioerr("ERROR: Could write to ICJX_CTRL_WORD_1_A: %d!\n", ret);
+      gpioerr("ERROR: Couldn't write to ICJX_CTRL_WORD_1_A: %d!\n", ret);
       goto err;
     }
 
   ret = icjx_write(priv, ICJX_CTRL_WORD_1_B, regval, ICJX_NOB1);
   if (ret < 0)
     {
-      gpioerr("ERROR: Could write to ICJX_CTRL_WORD_1_B: %d!\n", ret);
+      gpioerr("ERROR: Couldn't write to ICJX_CTRL_WORD_1_B: %d!\n", ret);
       goto err;
     }
 

--- a/drivers/ioexpander/icjx.h
+++ b/drivers/ioexpander/icjx.h
@@ -100,6 +100,11 @@
 #define ICJX_CTRL_WORD_2_NIOL   (1 << 3)
 #define ICJX_CTRL_WORD_2_NIOH   (1 << 7)
 
+/* Control Word 3 */
+
+#define ICJX_CTRL_WORD_3_ICLK   (1 << 2)
+#define ICJX_CTRL_WORD_3_DIS    (1 << 3)
+
 /* Control Word 4 */
 
 #define ICJX_CTRL_WORD_4_EOI    (1 << 7)

--- a/include/nuttx/ioexpander/icjx.h
+++ b/include/nuttx/ioexpander/icjx.h
@@ -42,6 +42,12 @@
 #define ICJX_CTRL_WORD_PULLUP_600U    6   /* 600 uA pull up */
 #define ICJX_CTRL_WORD_PULLUP_2M      7   /* 2 mA pull up*/
 
+#define ICJX_CTRL_WORD_FILTER_1 0         /* 14.5 * 1/CLK */
+#define ICJX_CTRL_WORD_FILTER_2 1         /* 896.5 * 1/CLK */
+#define ICJX_CTRL_WORD_FILTER_3 2         /* 3584.5 * 1/CLK */
+#define ICJX_CTRL_WORD_FILTER_4 3         /* 7168.5 * 1/CLK */
+#define ICJX_CTRL_WORD_FILTER_DISABLED 8  /* Filters are bypassed */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -65,6 +71,9 @@ struct icjx_config_s
   uint8_t verification; /* True if data verification on MISO line is used */
   uint8_t current_src;  /* Current sources for pin nibbles (pull up,
                          * pull down) - see Control Word 2 register
+                         */
+  uint8_t filters;      /* Filters configuration for pin nibbles - see
+                         * Control Word 1 register.
                          */
   uint8_t addr;         /* Device address (set by A(1:0) pins) */
   uint8_t mode;         /* SPI mode */


### PR DESCRIPTION
## Summary
This adds `filters` field to `icjx_config_s` structure that is passed as an argument in `icjx_initialize` function. This field allows to configure I/O filters (control world 1 and 3) with three possible filters or disable them at all.

The filter configuration is currently only configurable during the initialization, not at run time (the same as current source).

## Impact

It is now possible to set up filtering on icjx I/Os. This has no impact on current implementations in BSP layer.

## Testing
Tested on SAMv7 custom board with icjx expander.
