### PR TITLE
boards/xtensa/esp32[|s2|s3]: Fix unknown disassembling instructions

### DIFF
--- a/boards/xtensa/esp32/common/scripts/esp32_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/esp32_sections.ld
@@ -460,6 +460,26 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT>ROM
 
+  /* This section will be used by the debugger and disassembler to get more
+   * information about raw data present in the code.
+   * Indeed, it may be required to add some padding at some points in the
+   * code in order to align a branch/jump destination on a particular bound.
+   * Padding these instructions will generate null bytes that shall be
+   * interpreted as data, and not code by the debugger or disassembler.
+   * This section will only be present in the ELF file, not in the final
+   * binary.
+   */
+
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop .gnu.linkonce.prop.*))
+  }
+
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit .gnu.linkonce.p.*))
+  }
+
   _image_drom_vma = ADDR(.flash.rodata);
   _image_drom_lma = LOADADDR(.flash.rodata);
   _image_drom_size = LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - _image_drom_lma;

--- a/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
+++ b/boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld
@@ -382,6 +382,28 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT>ROM
 
+
+
+  /* This section will be used by the debugger and disassembler to get more
+   * information about raw data present in the code.
+   * Indeed, it may be required to add some padding at some points in the
+   * code in order to align a branch/jump destination on a particular bound.
+   * Padding these instructions will generate null bytes that shall be
+   * interpreted as data, and not code by the debugger or disassembler.
+   * This section will only be present in the ELF file, not in the final
+   * binary.
+   */
+
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop .gnu.linkonce.prop.*))
+  }
+
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit .gnu.linkonce.p.*))
+  }
+
   _image_drom_vma = ADDR(.flash.rodata);
   _image_drom_lma = LOADADDR(.flash.rodata);
   _image_drom_size = LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) - _image_drom_lma;

--- a/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
@@ -495,6 +495,26 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg AT>ROM
 
+  /* This section will be used by the debugger and disassembler to get more
+   * information about raw data present in the code.
+   * Indeed, it may be required to add some padding at some points in the
+   * code in order to align a branch/jump destination on a particular bound.
+   * Padding these instructions will generate null bytes that shall be
+   * interpreted as data, and not code by the debugger or disassembler.
+   * This section will only be present in the ELF file, not in the final
+   * binary.
+   */
+
+  .xt.prop 0 :
+  {
+    KEEP (*(.xt.prop .gnu.linkonce.prop.*))
+  }
+
+  .xt.lit 0 :
+  {
+    KEEP (*(.xt.lit .gnu.linkonce.p.*))
+  }
+
   /* The alignment of the ".flash.text" output section is forced to
    * 0x00010000 (64KB) to ensure that it will be allocated at the beginning
    * of the next available Flash block.


### PR DESCRIPTION
## Summary

* boards/xtensa/esp32[|s2|s3]: Fix unknown disassembling instructions

This PR adds sections used by the debugger and disassembler to get more information about raw data present in the code.

## Impact

Impact on user: YES. It fixes the issue https://github.com/apache/nuttx/issues/16235 and enables proper debugging of the generated code.

Impact on build: NO.

Impact on hardware: YES. It impacts all Xtensa-based Espressif SoCs (ESP32, ESP32-S2 and ESP32-S3)

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Testing it like it was reported at https://github.com/apache/nuttx/issues/16235, comparing the disassembler's result before and after applying this patch. Taking ESP32-S3 as an example:

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:nsh && make -j$(nproc) && xtensa-esp32s3-elf-objdump -D nuttx  > objdump.flat
```

### Running

Just run the NSH to check if it's booting successfully:
```
picocom -b 115200 /dev/ttyUSB0
```

### Results

Compare `objdump.flat`'s `cmd_uname` before and after applying the patch:

#### Before

```
42019db4 <cmd_uname>:
42019db4:	02e136        	entry	a1, 0x170
42019db7:	060c      	movi.n	a6, 0
42019db9:	506132        	s32i	a3, a1, 0x140
42019dbc:	025d      	mov.n	a5, a2
42019dbe:	063d      	mov.n	a3, a6
42019dc0:	001306        	j	42019e10 <cmd_uname+0x5c>
42019dc3:	c22200        	quou	a2, a2, a0
42019dc6:	27571c9f 	ee.vmulas.s8.accx.ld.ip.qup	q6, a9, 0x1c0, q4, q2, q5, q7
42019dca:	713037        	bltu	a0, a3, 42019e3f <cmd_uname+0x8b>
42019dcd:	2270da7f 	ee.vmulas.s8.accx.ld.ip.qup	q4, a7, 160, q7, q2, q7, q0
42019dd1:	0228a0        	andb	b2, b8, b10
```

#### After

```
42019db4 <cmd_uname>:
42019db4:	02e136        	entry	a1, 0x170
42019db7:	060c      	movi.n	a6, 0
42019db9:	506132        	s32i	a3, a1, 0x140
42019dbc:	025d      	mov.n	a5, a2
42019dbe:	063d      	mov.n	a3, a6
42019dc0:	001306        	j	42019e10 <cmd_uname+0x5c>
42019dc3:	00          	.byte 00
42019dc4:	9fc222        	addi	a2, a2, -97
42019dc7:	571c      	movi.n	a7, 21
42019dc9:	303727        	bltu	a7, a2, 42019dfd <cmd_uname+0x49>
42019dcc:	da7f71        	l32r	a7, 420107c8 <_image_irom_vma+0x7c8> (3c041408 <g_type+0x21>)
42019dcf:	a02270        	addx4	a2, a2, a7
42019dd2:	0228      	l32i.n	a2, a2, 0
42019dd4:	0002a0        	jx	a2
42019dd7:	120c      	movi.n	a2, 1
42019dd9:	000686        	j	42019df7 <cmd_uname+0x43>
42019ddc:	420c      	movi.n	a2, 4
42019dde:	000546        	j	42019df7 <cmd_uname+0x43>
42019de1:	820c      	movi.n	a2, 8
42019de3:	000406        	j	42019df7 <cmd_uname+0x43>
```