### PR TITLE
arch/esp32_partition.c:  fix the incorrect boot sequence when switching from Factory to OTA_1

### DIFF
--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -333,7 +333,7 @@ static int ota_set_bootseq(struct mtd_dev_priv *dev, int num)
           }
         else if (ret == OTA_IMG_BOOT_FACTORY)
           {
-            next_seq = 1;
+            next_seq = (uint32_t)num;
           }
         else
           {


### PR DESCRIPTION
## Summary
arch/esp32_partition.c:
- There are six possible sequence arrangements for switching the boot sequence of the three partitions (factory/ota_0/ota_1) through the ota_set_bootseq() and ota_get_bootseq() interfaces. However, it has been discovered that after executing the switch from factory to ota_1, the result read by ota_get_bootseq() is ota_0.

- The current solution is to directly use the target partition's number (num) as next_seq to ensure the correct increment logic of seq. Ensure the formula:(seq-1) % OTA_DATA_NUM + OTA_IMG_BOOT_OTA_0 correctly maps to ota_0 or ota_1

## Impact
New Feature/Change: Issue fix (no new feature).
User Impact: when exist three OTA partitions (factory/ota_0/ota_1).
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: Only ESP32; other architectures unaffected.
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
Verify the ESP32 OTA boot sequence using the relevant interfaces: ota_get_bootseq() and ota_set_bootseq().

Testing before fix:
```
I (521) boot: Loaded app from partition at offset 0x20000
I (521) boot: Disabling RNG early entropy source...
A__esp32_start: ESP32 chip revision is v3.0
NuttShell (NSH) 
nsh> tc_ota_test -s TC_OTA_SET_BOOTSEQ_OTA_1_TEST
.....
nsh> tc_ota_test -s TC_OTA_GET_BOOTSEQ_TEST
INFO: Running image from /dev/esp/partition/ota_0  ret=1
```

Testing after fix:
```
I (521) boot: Loaded app from partition at offset 0x20000
I (521) boot: Disabling RNG early entropy source...
A__esp32_start: ESP32 chip revision is v3.0
NuttShell (NSH)
nsh> tc_ota_test -s TC_OTA_SET_BOOTSEQ_OTA_1_TEST
.....
nsh> tc_ota_test -s TC_OTA_GET_BOOTSEQ_TEST
INFO: Running image from /dev/esp/partition/ota_1  ret=2
```
