### PR TITLE
arch/risc-v: save/restore fpu registers always when CONFIG_ARCH_LAZYFPU is off

### DIFF
--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -100,20 +100,18 @@ riscv_fpuconfig:
 
 riscv_savefpu:
 
+#ifdef CONFIG_ARCH_LAZYFPU
   REGLOAD    t0, REG_INT_CTX(a0)
   li         t1, MSTATUS_FS
   and        t2, t0, t1
   li         t1, MSTATUS_FS_DIRTY
-#ifdef CONFIG_ARCH_LAZYFPU
   bne        t2, t1, 1f
-#else
-  blt        t2, t1, 1f
-#endif
   li         t1, ~MSTATUS_FS
   and        t0, t0, t1
   li         t1, MSTATUS_FS_CLEAN
   or         t0, t0, t1
   REGSTORE   t0, REG_INT_CTX(a0)
+#endif
 
   riscv_savefpu a1
 
@@ -146,11 +144,13 @@ riscv_savefpu:
 
 riscv_restorefpu:
 
+#ifdef CONFIG_ARCH_LAZYFPU
   REGLOAD      t0, REG_INT_CTX(a0)
   li           t1, MSTATUS_FS
   and          t2, t0, t1
   li           t1, MSTATUS_FS_INIT
   ble          t2, t1, 1f
+#endif
 
   riscv_loadfpu a1
 


### PR DESCRIPTION

## Summary

To fix a fpu illegal instruction exception due to fcsr have invalid rounding-mode,  restore fcsr/f0~f31 with a random value from stack because fpu context is not save into stack when mstatus.fs is clean(not dirty).

The number of save/restore fpu context operations is not equal. In fact, CONFIG_ARCH_LAZYFPU is a performance optimization mechanism aimed at minimizing the saving and restoring of FPU registers. In some cases, it may only need to be saved once but must be restored multiple times. Therefore, this optimization mechanism dictates that saving cannot be done on the stack; it must be stored at a fixed location(e.g. task control block buffer), as the stack requires push/pop operations to be matched.

In case of that CONFIG_ARCH_LAZYFPU is off, save/restore FPU registers always into stack to avoid the above issues.

## Impact

risc-v cpus,  CONFIG_ARCH_FPU is on and CONFIG_ARCH_LAZYFPU is off

## Testing

qemu-rv, nsh64 project
ostest (include fpu test), 10times


