### PR TITLE
boards/arm/stm32h7: Fix too small usbhost stack size

### DIFF
--- a/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_usb.c
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_usb.c
@@ -63,7 +63,7 @@
 #endif
 
 #ifndef CONFIG_LINUM_STM32H753BI_USBHOST_STACKSIZE
-#  define CONFIG_LINUM_STM32H753BI_USBHOST_STACKSIZE 1024
+#  define CONFIG_LINUM_STM32H753BI_USBHOST_STACKSIZE 2048
 #endif
 
 /****************************************************************************

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
@@ -63,7 +63,7 @@
 #endif
 
 #ifndef CONFIG_NUCLEOH743ZI_USBHOST_STACKSIZE
-#  define CONFIG_NUCLEOH743ZI_USBHOST_STACKSIZE 1024
+#  define CONFIG_NUCLEOH743ZI_USBHOST_STACKSIZE 2048
 #endif
 
 /****************************************************************************

--- a/boards/arm/stm32h7/openh743i/src/stm32_usb.c
+++ b/boards/arm/stm32h7/openh743i/src/stm32_usb.c
@@ -51,7 +51,7 @@
 #endif
 
 #define USBHOST_PRIO      (100)
-#define USBHOST_STACKSIZE (1024)
+#define USBHOST_STACKSIZE (2048)
 
 /****************************************************************************
  * Private Data

--- a/boards/arm/stm32h7/stm32h747i-disco/src/stm32_usb.c
+++ b/boards/arm/stm32h7/stm32h747i-disco/src/stm32_usb.c
@@ -63,7 +63,7 @@
 #endif
 
 #ifndef CONFIG_STM32H747XI_DISCO_USBHOST_STACKSIZE
-#  define CONFIG_STM32H747XI_DISCO_USBHOST_STACKSIZE 1024
+#  define CONFIG_STM32H747XI_DISCO_USBHOST_STACKSIZE 2048
 #endif
 
 /****************************************************************************

--- a/boards/arm/stm32h7/weact-stm32h743/src/stm32_usb.c
+++ b/boards/arm/stm32h7/weact-stm32h743/src/stm32_usb.c
@@ -63,7 +63,7 @@
 #endif
 
 #ifndef CONFIG_WEACT_STM32H743_USBHOST_STACKSIZE
-#  define CONFIG_WEACT_STM32H743_USBHOST_STACKSIZE 1024
+#  define CONFIG_WEACT_STM32H743_USBHOST_STACKSIZE 2048
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Changed usbhost stack sizes to 2048 for affected STM32H7 boards. This was previously causing stack overflows when usb is inserted.

## Summary

When USB host was enabled on STM32H7 boards, memory corruption happened due a stack overflow in the usbhost thread.
This was because the default stacksize was set to 1024. This is now 2048, which should be big enough.

This was discovered in issue https://github.com/apache/nuttx/issues/16256

It is also discovered that the **usbhost_stacksize** configuration is not added to board specific Kconfig while it should be. I decided to not add these in this commit because I am unable to test them all. It is a safer option to simply change all stacksizes to something safe initially.

## Impact

Impacts all STM32H7 hardware users (Except the boards were it was already 2048). They can now use usbhost without memory corruption.

_For the NuttX PR bot:
Does not impact documentation, build process, security or compatibility._

## Testing

Testing information is found in the issue mentioned before, but here is a screenshot of usbhost being a little bigger than 1kB after USB insertion, which was the previous default. Stacksize is now 4kB in this screenshot for testing. This proves that it was too big before. This was tested on the a nucleo-STM32H743zi usb configuration on custom (out of tree) STM32H753zi hardware. They are compatible.

![image](https://github.com/user-attachments/assets/4f5c6553-b1e8-466a-8349-503a4b783da8)

_For the NuttX PR bot:
OS: yes
CPU: yes
compiler: yes_
