### PR TITLE
[BREAKING] setlogmask: fix setlogmask behavior according to POSIX standard

### DIFF
--- a/include/syslog.h
+++ b/include/syslog.h
@@ -232,10 +232,6 @@ void vsyslog(int priority, FAR const IPTR char *fmt, va_list ap)
  *   to a priority p is LOG_MASK(p); LOG_UPTO(p) provides the mask of all
  *   priorities in the above list up to and including p.
  *
- *   Per OpenGroup.org "If the maskpri argument is 0, the current log mask
- *   is not modified."  In this implementation, the value zero is permitted
- *   in order to disable all syslog levels.
- *
  *   NOTE:  setlogmask is not a thread-safe, re-entrant function.  Concurrent
  *   use of setlogmask() will have undefined behavior.
  *

--- a/libs/libc/syslog/lib_setlogmask.c
+++ b/libs/libc/syslog/lib_setlogmask.c
@@ -55,10 +55,6 @@ uint8_t g_syslog_mask = CONFIG_SYSLOG_DEFAULT_MASK;
  *   to a priority p is LOG_MASK(p); LOG_UPTO(p) provides the mask of all
  *   priorities in the above list up to and including p.
  *
- *   Per OpenGroup.org "If the maskpri argument is 0, the current log mask
- *   is not modified."  In this implementation, the value zero is permitted
- *   in order to disable all syslog levels.
- *
  *   NOTE:  setlogmask is not a thread-safe, re-entrant function.  Concurrent
  *   use of setlogmask() will have undefined behavior.
  *
@@ -80,8 +76,13 @@ int setlogmask(int mask)
 {
   uint8_t oldmask;
 
-  oldmask       = g_syslog_mask;
-  g_syslog_mask = (uint8_t)mask;
+  oldmask = g_syslog_mask;
+  if (mask != 0)
+    {
+      /* If the mask argument is 0, the current logmask is not modified. */
+
+      g_syslog_mask = (uint8_t)mask;
+    }
 
   return oldmask;
 }


### PR DESCRIPTION
## Summary
[POSIX states ](https://pubs.opengroup.org/onlinepubs/009695399/functions/setlogmask.html)

> "If the maskpri argument is 0, the current log mask is not modified." 

The current implementation of `setlogmask` function in NuttX doesn't respect this and thus is in a clear violation with a strict POSIX compliance rule in The Inviolable Principles of NuttX. The current implementation doesn't allow to simply obtain the current logging level without changing it and also breaks the application's compatibility with other POSIX systems.

This commit therefore changes the behavior to the expected one. Passing argument 0 doesn't change the current log mask, but just returns the old one.

## Impact
This is a breaking change as it changes the behavior of `setlogmask` function call. However, the current implementation is wrong and in a violation with POSIX standard, therefore this should be changed. If there are applications that uses 0 argument to disable logging, then these would have to be fixed to behave in compliance with POSIX standard.

The updated implementation should be the same as in Linux and other POSIX compliant systems.


