### PR TITLE
wqueue: improve the robustness of the work

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -72,12 +72,7 @@ struct wdlist_node
   FAR struct wdlist_node *next;
 };
 
-/* This is the internal representation of the watchdog timer structure.
- * Notice !!!
- * Carefully with the struct wdog_s order, you may not directly modify
- * this. This struct will combine in struct work_s in union type, and,
- * wqueue will modify/check this struct in kwork work_qcancel().
- */
+/* Support a doubly linked list of watchdog timers */
 
 struct wdog_s
 {

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -249,16 +249,10 @@ typedef CODE void (*worker_t)(FAR void *arg);
 
 struct work_s
 {
-  union
-  {
-    struct
-    {
-      struct dq_entry_s dq;      /* Implements a double linked list */
-      clock_t qtime;             /* Time work queued */
-    } s;
-    struct wdog_s timer;         /* Delay expiry timer */
-    struct wdog_period_s ptimer; /* Period expiry timer */
-  } u;
+  struct dq_entry_s dq;          /* Implements a double linked list */
+  clock_t qtime;                 /* Time work queued */
+  struct wdog_s timer;           /* Delay expiry timer */
+  struct wdog_period_s ptimer;   /* Period expiry timer */
   worker_t  worker;              /* Work callback */
   FAR void *arg;                 /* Callback argument */
   FAR struct kwork_wqueue_s *wq; /* Work queue */
@@ -561,9 +555,9 @@ int work_cancel_sync_wq(FAR struct kwork_wqueue_s *wqueue,
  ****************************************************************************/
 
 #ifdef __KERNEL__
-#  define work_timeleft(work) wd_gettime(&((work)->u.timer))
+#  define work_timeleft(work) wd_gettime(&((work)->timer))
 #else
-#  define work_timeleft(work) ((sclock_t)((work)->u.s.qtime - clock()))
+#  define work_timeleft(work) ((sclock_t)((work)->qtime - clock()))
 #endif
 
 /****************************************************************************

--- a/libs/libc/wqueue/work_cancel.c
+++ b/libs/libc/wqueue/work_cancel.c
@@ -89,7 +89,7 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
        */
 
       curr = wqueue->q.head;
-      while (curr && curr != &work->u.s.dq)
+      while (curr && curr != &work->dq)
         {
           prev = curr;
           curr = curr->flink;

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -87,9 +87,9 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
   /* Initialize the work structure */
 
-  work->worker = worker;             /* Work callback. non-NULL means queued */
-  work->arg    = arg;                /* Callback argument */
-  work->u.s.qtime = clock() + delay; /* Delay until work performed */
+  work->worker  = worker;           /* Work callback. non-NULL means queued */
+  work->arg     = arg;              /* Callback argument */
+  work->s.qtime = clock() + delay;  /* Delay until work performed */
 
   /* Do the easy case first -- when the work queue is empty. */
 
@@ -97,7 +97,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
     {
       /* Add the watchdog to the head == tail of the queue. */
 
-      dq_addfirst(&work->u.s.dq, &wqueue->q);
+      dq_addfirst(&work->s.dq, &wqueue->q);
       nxsem_post(&wqueue->wake);
     }
 
@@ -111,7 +111,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
       do
         {
-          delta = work->u.s.qtime - ((FAR struct work_s *)curr)->u.s.qtime;
+          delta = work->s.qtime - ((FAR struct work_s *)curr)->qtime;
           if (delta < 0)
             {
               break;
@@ -128,7 +128,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog at the head of the list */
 
-          dq_addfirst(&work->u.s.dq, &wqueue->q);
+          dq_addfirst(&work->dq, &wqueue->q);
           nxsem_get_value(&wqueue->wake, &semcount);
           if (semcount < 1)
             {
@@ -139,7 +139,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog in mid- or end-of-queue */
 
-          dq_addafter(prev, &work->u.s.dq, &wqueue->q);
+          dq_addafter(prev, &work->dq, &wqueue->q);
         }
     }
 

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -125,7 +125,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
        * zero will always execute immediately.
        */
 
-      elapsed = clock() - work->u.s.qtime;
+      elapsed = clock() - work->qtime;
 
       /* Is this delay work ready? */
 
@@ -180,7 +180,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
         }
       else
         {
-          next = work->u.s.qtime - clock();
+          next = work->qtime - clock();
           break;
         }
     }

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -66,7 +66,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
        */
 
       work->worker = NULL;
-      wd_cancel(&work->u.timer);
+      wd_cancel(&work->timer);
       if (dq_inqueue((FAR dq_entry_t *)work, &wqueue->q))
         {
           dq_rem((FAR dq_entry_t *)work, &wqueue->q);

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -164,7 +164,7 @@ int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
        */
 
       work->worker = NULL;
-      wd_cancel(&work->u.timer);
+      wd_cancel(&work->timer);
       if (dq_inqueue((FAR dq_entry_t *)work, &wqueue->q))
         {
           dq_rem((FAR dq_entry_t *)work, &wqueue->q);
@@ -190,12 +190,12 @@ int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
     }
   else if (period == 0)
     {
-      ret = wd_start(&work->u.timer, delay,
+      ret = wd_start(&work->timer, delay,
                      work_timer_expiry, (wdparm_t)work);
     }
   else
     {
-      ret = wd_start_period(&work->u.ptimer, delay, period,
+      ret = wd_start_period(&work->ptimer, delay, period,
                             work_timer_expiry, (wdparm_t)work);
     }
 


### PR DESCRIPTION
## Summary

struct work_s
{
  union
  {
    struct
    {
      struct dq_entry_s dq;      /* Implements a double linked list */
      clock_t qtime;             /* Time work queued */
    } s;
    struct wdog_s timer;         /* Delay expiry timer */
    struct wdog_period_s ptimer; /* Period expiry timer */
  } u;
  worker_t  worker;              /* Work callback */
  FAR void *arg;                 /* Callback argument */
  FAR struct kwork_wqueue_s *wq; /* Work queue */
};

work_cancel() should determine whether the current work is in the timer or has already entered the queue.
This judgment is indispensable because the structure is a union. Whether it is interpreted as a timer or as a dq needs to be determined.

But this judgment seriously depends on the order of struct wdog_s and struct dq_entry_s, once someone change the order of any, there is a bug. So we decide remove the union, to improve the robustness.

## Impact

For the work_s structure size will grow bigger, then we will provide a another optimization patch
https://github.com/apache/nuttx/pull/16231


## Testing

Ostest in sim:nsh


