### PR TITLE
Corrected configure.sh call in customboards.rst

### DIFF
--- a/Documentation/guides/customboards.rst
+++ b/Documentation/guides/customboards.rst
@@ -46,7 +46,7 @@ To build the custom board, the syntax is slightly different to in-tree boards an
 
     .. code-block:: console
 
-      $ .tools/configure -l ../CustomBoards/MyCustomBoardName/configs/MyCustomConfig
+      $ ./tools/configure.sh -l ../CustomBoards/MyCustomBoardName/configs/MyCustomConfig
       Copy files
       Select CONFIG_HOST_LINUX=y
       Refreshing...


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR updates the minor remark in the documentation for the custom board porting process.

## Impact

documentation

## Testing

I've tried to port NuttX for custom-based board on STM32H743 and faced that the doc seems to be outdated

