### PR TITLE
risc-v/k230: update documents

### DIFF
--- a/Documentation/platforms/risc-v/k230/boards/canmv230/index.rst
+++ b/Documentation/platforms/risc-v/k230/boards/canmv230/index.rst
@@ -104,7 +104,7 @@ With export package, we can then build the apps and ROMFS:
    $ cd apps
    $ # import the nuttx-export-*.gz package from kernel
    $ tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.gz
-   $ make import)  # build the apps
+   $ make import  # build the apps
    $ # generate ROMFS image for contents in apps/bin folder
    $ tools/mkromfsimg.sh ../nuttx/arch/risc-v/src/board/romfs_boot.c
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

fix typo
remove a `)` that should not be here

## Impact

the documentation only

## Testing

The origin command causes an error `bash: syntax error near unexpected token ')'`, and this PR fixed this problem


