### PR TITLE
fs/procfs: Improve subdirectory recognition

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -740,7 +740,8 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
           /* Test for a sub-string match (e.g. "ls /proc/fs") */
 
           else if (strncmp(g_procfs_entries[x].pathpattern, relpath,
-                           len) == 0)
+                           len) == 0 &&
+                   g_procfs_entries[x].pathpattern[len] == '/')
             {
               FAR struct procfs_level1_s *level1;
 
@@ -1166,7 +1167,8 @@ static int procfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
           /* Test for an internal subdirectory stat */
 
           else if (strncmp(g_procfs_entries[x].pathpattern, relpath,
-                           len) == 0)
+                           len) == 0 &&
+                   g_procfs_entries[x].pathpattern[len] == '/')
             {
               /* It's an internal subdirectory */
 


### PR DESCRIPTION
This patch fixes https://github.com/apache/nuttx/issues/16237, where cd'ing to a non-directory prefix of a procfs entry would succeed.

I've read the contributing guidelines, and I think I'm short a mandatory build log; the problem is that there other (minor) issues that prevent building nuttx for my board out of the box. Advice welcome here!

I did run `checkpatch.sh`.

## Summary

As described in #16237 , the current procfs implementation allows nonsensical chdir operations to succeed. For example, if `/proc/thermal` exists but `/proc/t` doesn't, `cd /proc/t` will succeed and indicate that there is a `ermal` subdirectory.

This is confusing and may potentially cause other bugs.

This minimal fix simply adds two extra conditions in places where we think we recognized a directory prefix, ensuring that we're actually at a directory boundary (a '/').

## Impact

The intended impact is minimal: chdir will fail in cases where it should have failed before, and we can no longer reach the buggy state of believing we're in a nonexistent directory in `/proc`.

## Testing

Testing this was a bit hard as the current nuttx tree did not build out of the box for me and required other changes. I'd appreciate guidance on how to test further if that's helpful!