### PR TITLE
Fixed empty line handling process_config.sh

### DIFF
--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -56,9 +56,15 @@ process_file() {
                 exit 1
             fi
         else
-            local key_config="$(echo "$line" | cut -d= -f1)="
-            sed -i.backup "/$key_config/d" $output_file
-            echo "$line" >> $output_file
+            if [[ -n "$line" ]]; then
+                local key_config="$(echo "$line" | cut -d= -f1)="
+                sed -i.backup "/^$key_config/d" "$output_file"
+                echo "$line" >> "$output_file"
+
+                echo "Appended $line to $output_file"
+            else
+                echo "The empty line from defconfig was skipped from adding to $output_file"
+            fi
         fi
     done < "$input_file"
 }


### PR DESCRIPTION
This commit fixed empty line handling in the config file for being able to used KConfig-based defconfigs with the empty lines in them

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

While trying to port NuttX to the custom board I've faced with the issue which resulted into the deeper debugging of the buildsystem internals in the NuttX. Essentially, the issue was that for some reason I was not able to configure the build for the board from scratch. At the same time, it was possible to used existing defconfigs for WeAct STM32H743 board. So that, I've decided to figure out what's the difference between the configurations, since initially everything was copied more or less identical to the board in the repo.

I managed to trace the execution of the process_config.sh and figure out, that it seems that in a case of executing echo with the empty line the content of the whole .config disapears.

The configuration file which I was playing with:
```
#
# This file is autogenerated: And created with custom comments..
#
# You can use "make menuconfig" to make any modifications to the installed .config file.
# You can then do "make savedefconfig" to generate a new defconfig file that includes your
# modifications.
#
# CONFIG_NSH_DISABLE_IFCONFIG is not set
# CONFIG_NSH_DISABLE_PS is not set
# CONFIG_STANDARD_SERIAL is not set
# CONFIG_STM32H7_USE_LEGACY_PINMAP is not set
CONFIG_ARCH="arm"
CONFIG_ARCH_BOARD_CUSTOM=y
CONFIG_ARCH_BOARD_CUSTOM_DIR="../../we-act-board-bringup/boards/arm/stm32h7/weact-stm32h743custom"
CONFIG_ARCH_BOARD_CUSTOM_NAME="weact-stm32h743custom"
CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH=y

CONFIG_ARCH_HAVE_LEDS=y
CONFIG_ARCH_HAVE_BUTTONS=y
CONFIG_ARCH_HAVE_IRQBUTTONS=y

CONFIG_ARCH_CHIP_STM32H7=y
CONFIG_ARCH_CHIP_STM32H7_CORTEXM7=y
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARMV7M_DCACHE=y
CONFIG_ARMV7M_DCACHE_WRITETHROUGH=y
CONFIG_ARMV7M_DTCM=y
CONFIG_ARMV7M_ICACHE=y
CONFIG_BOARD_LOOPSPERMSEC=43103
CONFIG_BUILTIN=y
CONFIG_DEBUG_SYMBOLS=y
CONFIG_EXPERIMENTAL=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_INTELHEX_BINARY=y
CONFIG_LINE_MAX=64
CONFIG_MM_REGIONS=4
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_RAM_SIZE=245760
CONFIG_RAM_START=0x20010000
CONFIG_RAW_BINARY=y
CONFIG_RR_INTERVAL=200
CONFIG_SCHED_WAITPID=y
CONFIG_SPI=y
CONFIG_START_DAY=11
CONFIG_START_MONTH=5
CONFIG_START_YEAR=2024
CONFIG_STM32H7_USART1=y
CONFIG_SYSTEM_NSH=y
CONFIG_TASK_NAME_SIZE=0
CONFIG_USART1_SERIAL_CONSOLE=y
```
## Impact

Build process.

## Testing
The following adjustment for the build script was made for being able to trace its execution:

```log
local key_config="$(echo "$line" | cut -d= -f1)="
sed -i.backup "/$key_config/d" $output_file
echo "$line" >> $output_file
echo "Appended $line to $output_file"

echo "CONTENT OF OUTPUT FILE BEGIN"
cat $output_file
echo "CONTENT OF OUTPUT FILE END"
```

Log without the fix:
https://pastebin.com/YEh17R0i
It's observable that the CONFIG_ARCH="arm" dissapears with all of the previous added lines(log line 206 and further, empty line was added, then there is no CONFIG_ARCH="arm" in the logs

Log with the fix:
https://pastebin.com/STxQfA8f

It's observable that even if the empty lines are not preserved in the result .config file, all of the config options are in-place, so the config is correctly parsed:


Btw, I'm not sure that it's the correct fix and how many places can be affected by this issue with empty lines proper handling. From my experience with buildroot, it's possible to have empty lines in the configuration file. So that, if this issue can affect multiple places, then it's worthwhile to simply warn user about the empty lines in the configuration file and break the compilation process.

If the strategy is to exit and warn the user about the potential issues with defconfig, then the fix should be like that:

```sh
 if [[ -n "$line" ]]; then
         local key_config="$(echo "$line" | cut -d= -f1)="
         sed -i.backup "/^$key_config/d" "$output_file"
         echo "$line" >> "$output_file"

         echo "Appended $line to $output_file"
else
      echo "The empty line was detected in the $input_file!"
      exit 1
fi
```

Further investigation shows, that without this fix the configuration of  NuttX fails with the known issue which was discussed 5 years ago
https://github.com/apache/nuttx/issues/2206

The same behaviour with the empty arch passing happens when defconfig for the out-of-tree board has empty lines 😄 
```shell
vscode ➜ /workspaces/rtos_labs/nuttxspace/nuttx (master) $ ./tools/configure.sh -l ../../we-act-board-bringup/boards/arm/stm32h7/weact-stm32h743custom/configs/nsh
  Copy files
Calling config processing  with process_config.sh with /workspaces/rtos_labs/nuttxspace/nuttx/tools/../../../we-act-board-bringup/boards/arm/stm32h7/weact-stm32h743custom/configs/nsh
Calling sethost.sh
  Select CONFIG_HOST_LINUX=y
  Select CONFIG_HOST_ARM64=y
  Refreshing...
CP: arch/dummy/Kconfig to /workspaces/rtos_labs/nuttxspace/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /workspaces/rtos_labs/nuttxspace/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /workspaces/rtos_labs/nuttxspace/apps/platform/
LN: include/arch to arch//include
No directory at /workspaces/rtos_labs/nuttxspace/nuttx/arch//include
make[1]: *** [tools/Unix.mk:286: include/arch] Error 1
make: *** [tools/Unix.mk:725: olddefconfig] Error 2
ERROR: failed to refresh
```
           
