### PR TITLE
arch/arm/rp23xx: update USB PLL/VCO/FBDIV

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_clock.c
+++ b/arch/arm/src/rp23xx/rp23xx_clock.c
@@ -231,8 +231,8 @@ void clocks_init(void)
 
   /* Configure PLLs
    *                   REF     FBDIV VCO     POSTDIV
-   * PLL SYS: 12 / 1 = 12MHz * 125 = 1500MHZ / 5 / 2 = 150MHz
-   * PLL USB: 12 / 1 = 12MHz * 40  = 480 MHz / 5 / 2 =  48MHz
+   * PLL SYS: 12 / 1 = 12MHz * 125 = 1500MHz / 5 / 2 = 150MHz
+   * PLL USB: 12 / 1 = 12MHz * 100 = 1200MHz / 5 / 5 =  48MHz
    */
 
   setbits_reg32(RP23XX_RESETS_RESET_PLL_SYS | RP23XX_RESETS_RESET_PLL_USB,
@@ -244,7 +244,7 @@ void clocks_init(void)
     ;
 
   rp23xx_pll_init(RP23XX_PLL_SYS_BASE, 1, 1500 * MHZ, 5, 2);
-  rp23xx_pll_init(RP23XX_PLL_USB_BASE, 1, 480 * MHZ, 5, 2);
+  rp23xx_pll_init(RP23XX_PLL_USB_BASE, 1, 1200 * MHZ, 5, 5);
 
   /* Configure clocks */
 

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -2097,6 +2097,9 @@ int usbdev_register(struct usbdevclass_driver_s *driver)
 
   g_usbdev.usbdev.speed = USB_SPEED_FULL;
 
+  modreg32(0, RP23XX_USBCTRL_REGS_MAIN_CTRL_PHY_ISO,
+    RP23XX_USBCTRL_REGS_MAIN_CTRL);
+
   putreg32(RP23XX_USBCTRL_REGS_MAIN_CTRL_CONTROLLER_EN,
            RP23XX_USBCTRL_REGS_MAIN_CTRL);
 


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/6cf356ee-9b29-4160-9f15-d44465eaf013)

RP2350 datasheet and upstream pico-sdk suggests higher VCO freq to
better output stability.
Increase the VCO and update PLL divs according to specs and calculation.
Higher VCO freq is more stable, lower VCO freq is more power friendly.
Also it's possible to use 120/6/5 with VCO 1440MHz for USB PLL to even
higher output stability.
USB setup changes from rp2040
Must clear the MAIN_CTRL.PHY_ISO bit at startup and after power down
events.

## Impact

More stable USB operations

## Testing

```
[280432.642035] usb 1-1: new full-speed USB device number 118 using xhci_hcd
[280432.792214] usb 1-1: New USB device found, idVendor=0525, idProduct=a4a7, bcdDevice= 1.01
[280432.792240] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[280432.792243] usb 1-1: Product: CDC/ACM Serial
[280432.792246] usb 1-1: Manufacturer: NuttX
[280432.792251] usb 1-1: SerialNumber: 0
[280432.838272] cdc_acm 1-1:1.0: ttyACM2: USB ACM device
```
```
---- Opened the serial port /dev/ttyACM2 ----

NuttShell (NSH) NuttX-12.9.0
nsh> ls /dev/
/dev:
 console
 null
 ttyACM0
 zero
```
