### PR TITLE
CI: enable codespell

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -1,0 +1,14 @@
+/* Bit fields for LESENSE CURCH */
+  CURCH,
+  Linix,
+Linix 45ZWN24-40           2  0.5 Ohm    0.400 mH  2.34A   24V
+* Linix 45ZWN24-40 (PMSM motor dedicated for NXP FRDM-MC-LVMTR kit)
+          DUE SCHEM. PIN MAPPING    SAM3X       DUE SCHEM. BOARD LABEL
+  SCHEM,
+               * ADDR -> BTC & TBE - Send one more byte
+  TBE,
+      /* All even touch pads have the same position for the THN bits.
+      /* All odd touch pads have the same position for the THN bits.
+  THN,
+#  define AES_ISR_URAT_WORRDACC      (5 << AES_ISR_URAT_SHIFT) /* WRONLY register read access */
+  WRONLY,

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,49 @@
+[codespell]
+
+# Add complete lines to be ignored to this file.
+# Example for ignoring all current occurrences of (verifiably correct) word usage:
+#   grep -hirw "emac" | sort | uniq >>.codespell-ignore-lines
+exclude-file = .codespell-ignore-lines
+
+# Ignore complete files (e.g. legal text or other immutable material).
+skip =
+  LICENSE,
+
+# Ignore seemingly misspelled words.
+#   lowercase: case insensitive
+#   uppercase: case sensitive
+# (see https://github.com/codespell-project/codespell/issues/3638)
+# This setting should be used only for frequently used words.
+# Exotic word occurrences should be filtered with the "exclude-file" setting instead.
+ignore-words-list =
+  ACI,
+  AFE,
+  afile,
+  ALS,
+  AMEBA,
+  ARCHTYPE,
+  DAA,
+  dout,
+  emac,
+  eeeprom,
+  extint,
+  filp,
+  FRAM,
+  hart,
+  hsi,
+  iif,
+  inport,
+  lod,
+  mot,
+  NWE,
+  OEN,
+  PRES,
+  REGONS,
+  SAIs,
+  SER,
+  synopsys,
+  TE,
+  TIMOUT,
+  tolen,
+  UE,
+  WRON,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,9 +41,9 @@ jobs:
           echo "::add-matcher::nuttx/.github/nxstyle.json"
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install cmake-format black isort flake8
+          pip install codespell cmake-format black isort flake8
           cd nuttx
           commits="${{ github.event.pull_request.base.sha }}..HEAD"
           git log --oneline $commits
-          echo "../nuttx/tools/checkpatch.sh -u -m -g $commits"
-          ../nuttx/tools/checkpatch.sh -u -m -g $commits
+          echo "../nuttx/tools/checkpatch.sh -c -u -m -g $commits"
+          ../nuttx/tools/checkpatch.sh -c -u -m -g $commits

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
     -   id: nxstyle
         name: nxstyle
         language: script
-        entry: ./tools/checkpatch.sh -f
+        entry: ./tools/checkpatch.sh -c -f


### PR DESCRIPTION
## Summary

These commits add a `.codespellrc` configuration file with suitable defaults and comments for all relevant use-cases in nuttx.

Additionally the github workflow "check" is extended to run the codespell check on changed files.
The log message of the check refers to the `.codespellrc` file in order to help people skip valid false positives.

At the moment, 1990 out of 25838 files in the `nuttx` repository are reported by codespell as containing errors. I already prepared two pull requests, which will reduce the number of reported files to 630. In case I can keep the mood up, I may grind this number down to zero in the next days.


## Impact

### CI
CI tests will start to fail, if a file contains a spelling problem (as detected by codespell).

In case of a problem the PR submitter will:
1. Notice the failed CI workflow "check".
1. Take a look at that CI job log.
1. In case of a real spelling mistake:
    1. Fix the issue and update the PR.
1. In case of a misdetected spelling issue:
    1. Notice the reference to the file `.codespellrc` in the CI log.
    1. Take a look at the file `.codespellrc` and hopefully understands easily, which approach would be suitable for this issue (exclude the word, line or file).

### pre-commit

The `pre-commit` check displays spelling problems in changed files.
The configuration file (`.codespellrc`) is mentioned. 

## Testing

### CI
I did not test the CI workflow for now. This PR will be the first example.

### pre-commit
The pre-commit hook now detects spelling problems in changed files:
```
$ git diff HEAD~..HEAD
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 0402b282d3..065b3494b8 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# foo
 # ##############################################################################
 # CMakeLists.txt
 #
$ pre-commit run --from HEAD~ --to HEAD
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for added large files..............................................Passed
cmake-format.............................................................Passed
nxstyle..................................................................Failed
- hook id: nxstyle
- exit code: 1

Used config files:
    1: .codespellrc
CMakeLists.txt:162: inital ==> initial
CMakeLists.txt:271: platfrom ==> platform
CMakeLists.txt:318: Unsupport ==> Unsupported
CMakeLists.txt:385: extenstion ==> extension
```