### PR TITLE
arch/arm/sama5: Add support for reset reason logging

### DIFF
--- a/arch/arm/src/sama5/sam_systemreset.h
+++ b/arch/arm/src/sama5/sam_systemreset.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/sama5/sam_systemreset.c
+ * arch/arm/src/sama5/sam_systemreset.h
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -20,27 +20,27 @@
  *
  ****************************************************************************/
 
+#ifndef __ARCH_ARM_SRC_SAMA5_SAM_SYSTEMRESET_H
+#define __ARCH_ARM_SRC_SAMA5_SAM_SYSTEMRESET_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
 #include <stdint.h>
-#include <assert.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/sama5/chip.h>
-
-#include "arm_internal.h"
-#include "hardware/sam_rstc.h"
-#include "sam_systemreset.h"
-
-#ifdef CONFIG_SAMA5_SYSTEMRESET
 
 /****************************************************************************
- * Public Functions
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SAMA5_RESET_PWRUP       1
+#define SAMA5_RESET_BACKUP      2
+#define SAMA5_RESET_WDOG        3
+#define SAMA5_RESET_SWRST       4
+#define SAMA5_RESET_NRST        5
+
+/****************************************************************************
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
@@ -59,73 +59,6 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_BOARDCTL_RESET_CAUSE
-int sam_get_reset_cause(void)
-{
-  int ret;
-  uint32_t rstsr;
+int sam_get_reset_cause(void);
 
-  rstsr = getreg32(SAM_RSTC_SR);
-  switch (rstsr & RSTC_SR_RSTTYP_MASK)
-    {
-      case RSTC_SR_RSTTYP_PWRUP:
-        ret = SAMA5_RESET_PWRUP;
-        break;
-      case RSTC_SR_RSTTYP_BACKUP:
-        ret =  SAMA5_RESET_BACKUP;
-        break;
-      case RSTC_SR_RSTTYP_WDOG:
-        ret =  SAMA5_RESET_WDOG;
-        break;
-      case RSTC_SR_RSTTYP_SWRST:
-        ret =  SAMA5_RESET_SWRST;
-        break;
-      case RSTC_SR_RSTTYP_NRST:
-        ret = SAMA5_RESET_NRST;
-        break;
-      default:
-        ret = -1;
-        break;
-    }
-
-  return ret;
-}
-#endif
-
-/****************************************************************************
- * Name: up_systemreset
- *
- * Description:
- *   Internal reset logic.
- *
- ****************************************************************************/
-
-void up_systemreset(void)
-{
-  uint32_t rstcr;
-#if defined(CONFIG_SAMA5_EXTRESET_ERST) && CONFIG_SAMA5_EXTRESET_ERST != 0
-  uint32_t rstmr;
-#endif
-
-  rstcr  = (RSTC_CR_PROCRST | RSTC_CR_KEY);
-
-#if defined(CONFIG_ARCH_CHIP_SAMA5D3)
-  rstcr  |= RSTC_CR_PERRST;
-#endif
-
-#if defined(CONFIG_SAMA5_EXTRESET_ERST) && CONFIG_SAMA5_EXTRESET_ERST != 0
-  rstcr |= RSTC_CR_EXTRST;
-
-  rstmr  = getreg32(SAM_RSTC_MR);
-  rstmr &= ~RSTC_MR_ERSTL_MASK;
-  rstmr &= RSTC_MR_ERSTL(CONFIG_SAMA5_EXTRESET_ERST - 1) | RSTC_MR_KEY;
-  putreg32(rstmr, SAM_RSTC_MR);
-#endif
-
-  putreg32(rstcr, SAM_RSTC_CR);
-
-  /* Wait for the reset */
-
-  for (; ; );
-}
-#endif /* CONFIG_SAMA5_SYSTEMRESET */
+#endif /* __ARCH_ARM_SRC_SAMA5_SAM_SYSTEMRESET_H */


### PR DESCRIPTION
## Summary

This adds the function `sam_get_reset_cause` to arch/arm/src/sama5 to allow a board to determine the reason for a reset. This is useful in NXboot, for example.

The function, in keeping with other ARM devices, reads the reset status register to determine the cause,

## Impact

This only applies to ARM:SAMA5

This function has not existed for this arch until now, so there will be no impact to existing software.

No writes to any registers are made so system behaviour will not be affected.

## Testing

This has been tested on my custom board, using a SAMA5D27C-D1G, in combination with NXboot. Power, manual, and I can confirm that software resets are correctly determined and reported.

It should apply to SAMA5D3 and SAMA5D4 family processors, and work, but I have no boards with these processors. However a check of the relevant family datasheets shows the status register to be the same for all 3 SAMA5 families.


