### PR TITLE
arch/arm/rp23xx: fix not restart after TX error

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_i2c.c
+++ b/arch/arm/src/rp23xx/rp23xx_i2c.c
@@ -590,6 +590,7 @@ static int rp23xx_i2c_transfer(struct i2c_master_s *dev,
       if (priv->error != OK)
         {
           ret = priv->error;
+          wostop = 0;
           break;
         }
 
@@ -829,7 +830,8 @@ static void rp23xx_i2c_init(struct rp23xx_i2cdev_s *priv)
   i2c_reg_write(priv, RP23XX_I2C_IC_SDA_HOLD_OFFSET, 1);
 
   i2c_reg_write(priv, RP23XX_I2C_IC_CON_OFFSET,
-                (RP23XX_I2C_IC_CON_IC_SLAVE_DISABLE |
+                (RP23XX_I2C_IC_CON_IC_RESTART_EN |
+                 RP23XX_I2C_IC_CON_IC_SLAVE_DISABLE |
                  RP23XX_I2C_IC_CON_MASTER_MODE |
                  RP23XX_I2C_IC_CON_TX_EMPTY_CTRL));
 }


### PR DESCRIPTION
## Summary

Fix a bug that I2C driver can not transfer after TX abort error. It caused by remaining NO_STOP flag status.
same as done in commit 0df0a10 for cxd56xx

## Impact

Working i2c transfer after TX abort error.

## Testing

Tested with custom i2c slave device causing this issues. (15-minutes i2c poll test)


