### PR TITLE
Fix problematic spelling issues

### DIFF
--- a/arch/arm/include/kinetis/chip.h
+++ b/arch/arm/include/kinetis/chip.h
@@ -1302,8 +1302,8 @@
 #  define KINETIS_NUSBDEV         1            /* One USB device controller */
 #  define KINETIS_NSDHC           1            /* SD host controller */
 #  define KINETIS_NI2C            3            /* Three I2C modules */
-#  define KINETIS_NUART           6            /* Six UART modues */
-#  define KINETIS_NSPI            3             Three SPI modules
+#  define KINETIS_NUART           6            /* Six UART modules */
+#  define KINETIS_NSPI            3            /* Three SPI modules */
 #  define KINETIS_NCAN            1            /* One CAN controllers */
 #  define KINETIS_NI2S            1            /* One I2S modules */
 #  define KINETIS_NSLCD           1            /* One segment LCD interface (up to 36x8/40x4) */
@@ -1341,8 +1341,8 @@
 #  define KINETIS_NUSBDEV         1            /* One USB device controller */
 #  define KINETIS_NSDHC           1            /* SD host controller */
 #  define KINETIS_NI2C            3            /* Three I2C modules */
-#  define KINETIS_NUART           6            /* Six UART modues */
-#  define KINETIS_NSPI            3             Three SPI modules
+#  define KINETIS_NUART           6            /* Six UART modules */
+#  define KINETIS_NSPI            3            /* Three SPI modules */
 #  define KINETIS_NCAN            1            /* One CAN controllers */
 #  define KINETIS_NI2S            1            /* One I2S modules */
 #  define KINETIS_NSLCD           1            /* One segment LCD interface (up to 36x8/40x4) */

--- a/arch/arm/src/stm32h7/stm32_rptun.c
+++ b/arch/arm/src/stm32h7/stm32_rptun.c
@@ -49,7 +49,7 @@
 #    error CONFIG_OPENAMP_CACHE must be set
 #  endif
 #  if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARM_MPU)
-#    erro CONFIG_ARM_MPU must be enabled
+#    error CONFIG_ARM_MPU must be enabled
 #  endif
 #endif
 

--- a/libs/libc/locale/lib_langinfo.c
+++ b/libs/libc/locale/lib_langinfo.c
@@ -118,7 +118,7 @@ FAR char *nl_langinfo(nl_item item)
       case MON_1:
         return "January";
       case MON_2:
-        return "Feburary";
+        return "February";
       case MON_3:
         return "March";
       case MON_4:

--- a/tools/simwifi/udhcpc.script
+++ b/tools/simwifi/udhcpc.script
@@ -39,7 +39,7 @@ case $1 in
         [ ".$subnet" = .255.255.255.255 ] \
             && onlink=onlink || onlink=
         busybox ip -4 route add default via $router dev $interface $onlink
-        log info "udhcpc add router $router on $interfac"
+        log info "udhcpc add router $router on $interface"
     fi
 
     DEF_NS="nameserver 8.8.8.8"


### PR DESCRIPTION
## Summary

The introduction of [codespell](https://github.com/codespell-project/codespell/) led me to a few minor issues hidden in the nuttx code base.

This changeset fixes these fairly obvious issues.

## Impact

* one compile error message now works as intended
* a define for the the kinetis platform is valid now
* one udhcpc log message contains the previously missing network interface name
* the spelling of "February" (as returned by `nl_langinfo`) is correct now

## Testing

All of the above issues were well hidden edge cases. They are probably quite hard to trigger.

Since all of them are easy to spot and extremly trivial, I did not test anything here.