### PR TITLE
libc/backtrace: Fix compilation error when set LIBC_BACKTRACE_BUFFSIZE

### DIFF
--- a/libs/libc/misc/lib_backtrace.c
+++ b/libs/libc/misc/lib_backtrace.c
@@ -267,14 +267,14 @@ int backtrace_record(int skip)
 
       entry = &bp->pool[index];
       entry->count++;
-      spin_unlock_irqrestore(&pool->lock, flags);
+      spin_unlock_irqrestore(&bp->lock, flags);
       return index;
     }
 
   index = backtrace_alloc(bp);
   if (index < 0)
     {
-      spin_unlock_irqrestore(&pool->lock, flags);
+      spin_unlock_irqrestore(&bp->lock, flags);
       return index;
     }
 
@@ -289,7 +289,7 @@ int backtrace_record(int skip)
 
   entry->next = bp->bucket[slot];
   bp->bucket[slot] = index;
-  spin_unlock_irqrestore(&pool->lock, flags);
+  spin_unlock_irqrestore(&bp->lock, flags);
   return index;
 }
 
@@ -323,7 +323,7 @@ int backtrace_remove(int index)
   if (entry->count > 1)
     {
       entry->count--;
-      spin_unlock_irqrestore(&pool->lock, flags);
+      spin_unlock_irqrestore(&bp->lock, flags);
       return OK;
     }
 
@@ -367,7 +367,7 @@ int backtrace_remove(int index)
     }
 
   backtrace_free(bp, index);
-  spin_unlock_irqrestore(&pool->lock, flags);
+  spin_unlock_irqrestore(&bp->lock, flags);
   return OK;
 }
 


### PR DESCRIPTION
Fix the compilation error of `lib_backtrace.c` when setting `CONFIG_LIBC_BACKTRACE_BUFFSIZE`.

## Summary

Hello, I was trying to configure `CONFIG_LIBC_BACKTRACE_BUFFSIZE` when using `backtrace`, but a compilation error warning was triggered. After checking the source code, I found that in `lib_backtrace.c`, the lock is acquired using `flags = spin_lock_irqsave(&bp->lock);`, but when releasing the lock, `spin_unlock_irqrestore(&pool->lock, flags);` is used. I couldn't find any local or global variables related to `pool`. After changing `pool` to `bp`, the compilation error warning disappeared and the compilation was successful.

## Impact

When `CONFIG_LIBC_BACKTRACE_BUFFSIZE` is set, there is no compilation error warning, and the compilation can be successfully completed. This may impact to all architectures.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): OS: Linux:5.15.167.4-microsoft-standard-WSL2, CPU: AMD x86_64, compiler: gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)
  * Target(s): arch: sim:nsh

  step
  ```
  make distclean
  ./tools/configure.sh sim:nsh
  make menuconfig
  # Library Routines ‣ The size of backtrace record buffer ‣ 128
  make -j16
  ```

  `.config`:
  ```
  ...
  CONFIG_LIBC_BACKTRACE_BUFFSIZE=128
  CONFIG_LIBC_BACKTRACE_DEPTH=8
  CONFIG_LIBC_MUTEX_BACKTRACE=0
  # CONFIG_LIBC_HEX2BIN is not set
  CONFIG_BUILTIN=y
  ...
  ```

  Testing logs before change:

  ```
CP:  /home/rong/git/nuttx-rongbc/nuttx/include/nuttx/config.h
CP:  /home/rong/git/nuttx-rongbc/nuttx/include/nuttx/fs/hostfs.h
In file included from misc/lib_backtrace.c:33:
misc/lib_backtrace.c: In function ‘backtrace_record’:
misc/lib_backtrace.c:270:31: error: ‘pool’ undeclared (first use in this function); did you mean ‘bool’?
  270 |       spin_unlock_irqrestore(&pool->lock, flags);
      |                               ^~~~
misc/lib_backtrace.c:270:31: note: each undeclared identifier is reported only once for each function it appears in
CC:  signal/sig_initialize.c misc/lib_backtrace.c: In function ‘backtrace_remove’:
misc/lib_backtrace.c:326:31: error: ‘pool’ undeclared (first use in this function); did you mean ‘bool’?
  326 |       spin_unlock_irqrestore(&pool->lock, flags);
      |                               ^~~~
CC:  signal/sig_action.c make[1]: *** [Makefile:156: bin/lib_backtrace.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [tools/LibTargets.mk:196: libs/libc/libc.a] Error 2
make: *** Waiting for unfinished jobs....
  ```

  Testing logs after change:

  ```
$ make -j16
Create version.h
LD:  nuttx
Pac SIM with dynamic libs..
'/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
  ```


