### PR TITLE
Added a small usability improve for Unix.ml savedefconfig

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -768,6 +768,7 @@ savedefconfig: apps_preconfig
 	$(Q) rm -f warning.tmp
 	$(Q) rm -f defconfig.tmp
 	$(Q) rm -f sortedconfig.tmp
+	$(info "The defconfig was generated successfully at $(PWD)/defconfig .If you're building out-of-tree configuration, then don't forget to copy it into your defconfig original location")
 
 # export
 #


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

I've found that while working on the custom board initial platform bringup it's a kind of:
- make menuconfig
-make savedefconfig
-git add
-git commit flow
When the board is configured to be out-of-tree, then it's possible to simply forget where the defconfig is stored/how to navigate into it.

## Impact

Buildsystem

## Testing

Just a simple make savedefconfig is enough:
```log
"The defconfig was generated successfully at /workspaces/rtos_labs/nuttxspace/nuttx/defconfig .If you're building out-of-tree configuration, then copy it to your configuration defconfig"
```


