### PR TITLE
tools/process_config: remove unused unnecessary printing

### DIFF
--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -60,10 +60,6 @@ process_file() {
                 local key_config="$(echo "$line" | cut -d= -f1)="
                 sed -i.backup "/^$key_config/d" "$output_file"
                 echo "$line" >> "$output_file"
-
-                echo "Appended $line to $output_file"
-            else
-                echo "The empty line from defconfig was skipped from adding to $output_file"
             fi
         fi
     done < "$input_file"


### PR DESCRIPTION
## Summary

 tools/process_config: remove unused unnecessary printing

 Too much unnecessary printing that meaningless to non-builder developers

 Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

Restore the configure print as before

## Testing

```
nuttx$ ./tools/configure.sh  sim/nsh
  Copy files
Appended # to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # This file is autogenerated: PLEASE DO NOT EDIT IT. to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # You can use "make menuconfig" to make any modifications to the installed .config file. to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # You can then do "make savedefconfig" to generate a new defconfig file that includes your to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # modifications. to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended # CONFIG_NSH_CMDOPT_HEXDUMP is not set to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ARCH="sim" to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ARCH_BOARD="sim" to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ARCH_BOARD_SIM=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ARCH_CHIP="sim" to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ARCH_SIM=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_BOARDCTL_APP_SYMTAB=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_BOARDCTL_POWEROFF=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_BOARD_LOOPSPERMSEC=0 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_BOOT_RUNFROMEXTSRAM=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_BUILTIN=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_COVERAGE_ALL=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_COVERAGE_TOOLCHAIN=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEBUG_ASSERTIONS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEBUG_ASSERTIONS_EXPRESSION=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEBUG_FEATURES=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEBUG_SYMBOLS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEV_GPIO=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_DEV_LOOP=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ETC_FATDEVNO=2 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ETC_ROMFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_ETC_ROMFSDEVNO=1 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_EXAMPLES_GPIO=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_EXAMPLES_HELLO=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FAT_LCNAMES=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FAT_LFN=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_BINFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_FAT=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_HOSTFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_PROCFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_RAMMAP=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_FS_ROMFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_GPIO_LOWER_HALF=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_HAVE_CXXINITIALIZE=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_IDLETHREAD_STACKSIZE=4096 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_INIT_ENTRYPOINT="nsh_main" to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_IOEXPANDER=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_IOEXPANDER_DUMMY=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_ENVPATH=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_EXECFUNCS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_LOCALE=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_LOCALE_CATALOG=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_LOCALE_GETTEXT=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_MAX_EXITFUNS=1 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_LIBC_NUMBERED_ARGS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_NDEBUG=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_NSH_ARCHINIT=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_NSH_BUILTIN_APPS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_NSH_FILE_APPS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_NSH_READLINE=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_PATH_INITIAL="/bin" to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_PIPES=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_PSEUDOFS_ATTRIBUTES=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_PSEUDOFS_FILE=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_PSEUDOFS_SOFTLINKS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_READLINE_TABCOMPLETION=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SCHED_BACKTRACE=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SCHED_EVENTS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SCHED_HAVE_PARENT=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SCHED_WAITPID=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SIM_HOSTFS=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SIM_WALLTIME_SIGNAL=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_START_MONTH=6 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_START_YEAR=2008 to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SYSTEM_DUMPSTACK=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SYSTEM_GCOV=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_SYSTEM_NSH=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
Appended CONFIG_TESTING_OSTEST=y to /home/archer/code/nuttx/n1/nuttx/tools/../.config
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/archer/code/nuttx/n1/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/archer/code/nuttx/n1/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/archer/code/nuttx/n1/apps/platform/dummy
LN: include/arch to arch/sim/include
LN: include/arch/board to /home/archer/code/nuttx/n1/nuttx/boards/sim/sim/sim/include
LN: drivers/platform to /home/archer/code/nuttx/n1/nuttx/drivers/dummy
LN: include/arch/chip to /home/archer/code/nuttx/n1/nuttx/arch/sim/include/sim
LN: arch/sim/src/chip to /home/archer/code/nuttx/n1/nuttx/arch/sim/src/sim
LN: arch/sim/src/board to /home/archer/code/nuttx/n1/nuttx/boards/sim/sim/sim/src
Loaded configuration '.config'
Configuration saved to '.config'
```

after

```
nuttx$ ./tools/configure.sh  sim/nsh
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/archer/code/nuttx/n1/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/archer/code/nuttx/n1/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/archer/code/nuttx/n1/apps/platform/dummy
LN: include/arch to arch/sim/include
LN: include/arch/board to /home/archer/code/nuttx/n1/nuttx/boards/sim/sim/sim/include
LN: drivers/platform to /home/archer/code/nuttx/n1/nuttx/drivers/dummy
LN: include/arch/chip to /home/archer/code/nuttx/n1/nuttx/arch/sim/include/sim
LN: arch/sim/src/chip to /home/archer/code/nuttx/n1/nuttx/arch/sim/src/sim
LN: arch/sim/src/board to /home/archer/code/nuttx/n1/nuttx/boards/sim/sim/sim/src
Loaded configuration '.config'
Configuration saved to '.config'
```