### PR TITLE
arch/risc-v: Add RS485 support for esp32[-c3|-c6|h2]

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1090,7 +1090,7 @@ config ESPRESSIF_WIFI_RX_BA_WIN
 		Set the size of WiFi Block Ack RX window. Generally a bigger value means higher throughput and better
 		compatibility but more memory. Most of time we should NOT change the default value unless special
 		reason, e.g. test the maximum UDP RX throughput with iperf etc. For iperf test in shieldbox, the
-		recommended value is 9~12. If PSRAM is used and WiFi memory is prefered to allocat in PSRAM first,
+		recommended value is 9~12. If PSRAM is used and WiFi memory is preferred to allocate in PSRAM first,
 		the default and minimum value should be 16 to achieve better throughput and compatibility with both
 		stations and APs.
 
@@ -1193,6 +1193,31 @@ menu "UART Configuration"
 
 if ESPRESSIF_UART0
 
+config ESPRESSIF_UART0_RS485
+	bool "RS-485 on UART0"
+	default n
+	---help---
+		Enable RS-485 interface on UART0. Your board config will have to
+		provide GPIO_UART0_RS485_DIR pin definition.
+
+config ESPRESSIF_UART0_RS485_DIR_PIN
+	int "UART0 RS-485 DIR pin"
+	default 10
+	range 0 46
+	depends on ESPRESSIF_UART0_RS485
+	---help---
+		DIR pin for RS-485 on UART0. This pin will control the RS485 enable
+		TX of the RS485 transceiver.
+
+config ESPRESSIF_UART0_RS485_DIR_POLARITY
+	int "UART0 RS-485 DIR pin polarity"
+	default 1
+	range 0 1
+	depends on ESPRESSIF_UART0_RS485
+	---help---
+		Polarity of DIR pin for RS-485 on UART0. Set to state on DIR pin which
+		enables TX (0 - low / nTXEN, 1 - high / TXEN).
+
 config ESPRESSIF_UART0_TXPIN
 	int "UART0 TX Pin"
 	default 21 if ESPRESSIF_ESP32C3
@@ -1234,6 +1259,31 @@ config ESPRESSIF_UART0_CTSPIN
 endif # ESPRESSIF_UART0
 
 if ESPRESSIF_UART1
+
+config ESPRESSIF_UART1_RS485
+	bool "RS-485 on UART1"
+	default n
+	---help---
+		Enable RS-485 interface on UART1. Your board config will have to
+		provide GPIO_UART1_RS485_DIR pin definition.
+
+config ESPRESSIF_UART1_RS485_DIR_PIN
+	int "UART1 RS-485 DIR pin"
+	default 4
+	range 0 46
+	depends on ESPRESSIF_UART1_RS485
+	---help---
+		DIR pin for RS-485 on UART1. This pin will control the RS485 enable
+		TX of the RS485 transceiver.
+
+config ESPRESSIF_UART1_RS485_DIR_POLARITY
+	int "UART1 RS-485 DIR pin polarity"
+	default 1
+	range 0 1
+	depends on ESPRESSIF_UART1_RS485
+	---help---
+		Polarity of DIR pin for RS-485 on UART1. Set to state on DIR pin which
+		enables TX (0 - low / nTXEN, 1 - high / TXEN).
 
 config ESPRESSIF_UART1_TXPIN
 	int "UART1 TX Pin"

--- a/arch/risc-v/src/common/espressif/esp_config.h
+++ b/arch/risc-v/src/common/espressif/esp_config.h
@@ -44,6 +44,13 @@
 #  define HAVE_UART_DEVICE 1 /* Flag to indicate a UART has been selected */
 #endif
 
+/* Is RS-485 used? */
+
+#if defined(CONFIG_ESPRESSIF_UART0_RS485) || \
+    defined(CONFIG_ESPRESSIF_UART1_RS485)
+#  define HAVE_RS485 1
+#endif
+
 /* Serial Console ***********************************************************/
 
 /* Is there a serial console?  There should be no more than one defined.  It

--- a/arch/risc-v/src/common/espressif/esp_lowputc.c
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.c
@@ -102,6 +102,14 @@ struct esp_uart_s g_uart0_config =
   .oflow  = false,   /* output flow control (CTS) disabled */
 #endif
 #endif
+#ifdef CONFIG_ESPRESSIF_UART0_RS485
+  .rs485_dir_gpio = CONFIG_ESPRESSIF_UART0_RS485_DIR_PIN,
+#if (CONFIG_ESPRESSIF_UART0_RS485_DIR_POLARITY == 0)
+  .rs485_dir_polarity = false,
+#else
+  .rs485_dir_polarity = true,
+#endif
+#endif
   .hal = &g_uart0_hal,
   .lock = SP_UNLOCKED
 };
@@ -146,6 +154,14 @@ struct esp_uart_s g_uart1_config =
   .oflow  = true,    /* output flow control (CTS) enabled */
 #else
   .oflow  = false,   /* output flow control (CTS) disabled */
+#endif
+#endif
+#ifdef CONFIG_ESPRESSIF_UART1_RS485
+  .rs485_dir_gpio = CONFIG_ESPRESSIF_UART1_RS485_DIR_PIN,
+#if (CONFIG_ESPRESSIF_UART1_RS485_DIR_POLARITY == 0)
+  .rs485_dir_polarity = false,
+#else
+  .rs485_dir_polarity = true,
 #endif
 #endif
   .hal = &g_uart1_hal,
@@ -287,6 +303,15 @@ void esp_lowputc_config_pins(const struct esp_uart_s *priv)
     {
       esp_configgpio(priv->ctspin, INPUT | PULLUP);
       esp_gpio_matrix_in(priv->ctspin, priv->ctssig, 0);
+    }
+#endif
+
+#ifdef HAVE_RS485
+  if (priv->rs485_dir_gpio != 0)
+    {
+      esp_configgpio(priv->rs485_dir_gpio, OUTPUT);
+      esp_gpio_matrix_out(priv->rs485_dir_gpio, SIG_GPIO_OUT_IDX, 0, 0);
+      esp_gpiowrite(priv->rs485_dir_gpio, !priv->rs485_dir_polarity);
     }
 #endif
 }

--- a/arch/risc-v/src/common/espressif/esp_lowputc.h
+++ b/arch/risc-v/src/common/espressif/esp_lowputc.h
@@ -76,6 +76,10 @@ struct esp_uart_s
   uint8_t             ctssig;    /* CTS signal */
   bool                oflow;     /* Output flow control (CTS) enabled */
 #endif
+#ifdef HAVE_RS485
+  uint8_t  rs485_dir_gpio;     /* UART RS-485 DIR GPIO pin cfg */
+  bool     rs485_dir_polarity; /* UART RS-485 DIR TXEN polarity */
+#endif
   uart_hal_context_t *hal;       /* HAL context */
   spinlock_t          lock;      /* Spinlock */
 };


### PR DESCRIPTION
## Summary

Add missing RS485 support for Risc-V based Espressif devices 

* arch/risc-v/espressif: Fix Serial IFLOW build issue

Serial IFLOW build error fixed for risc-v based Espressif devices

* arch/risc-v/espressif: Add RS485 support for esp32[c3|c6|h2]

Add RS485 support for Risc-V based Espressif devices

## Impact

Impact on user: No, missing feature added

Impact on build: Current builds works fine, new option added for new feature

Impact on hardware: Serial peripheral got affected, new feature added

Impact on documentation: No

Impact on security: No

Impact on compatibility: No, it is compatible between older defconfigs

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building

This command used to build:

```
./tools/configure.sh esp32c6-devkitc:nsh && kconfig-tweak -e CONFIG_ESPRESSIF_UART1 && kconfig-tweak -e CONFIG_ESPRESSIF_UART1_RS485 && kconfig-tweak -e CONFIG_EXAMPLES_SERIALRX && kconfig-tweak -e CONFIG_EXAMPLES_SERIALRX_PRINTSTR && kconfig-tweak -e DEBUG_SYMBOLS && make olddefconfig && make flash ESPTOOL_BINDIR=./ ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom
```

### Connection list

2 MAX485 adapter used

##### Transmitter Side:

| ESP Device (esp32c3, esp32c6, esp32h2) | MAX485 Adapter |
|----------------------------------------|----------------|
| GPIO8                                  | DI             |
| GPIO9                                  | RO             |
| GPIO4                                  | DE             |
| GPIO4                                  | RE             |


#### Reciever Side

| ESP Device (esp32c3, esp32c6, esp32h2) | MAX485 Adapter |
|----------------------------------------|----------------|
| GPIO8                                  | DI             |
| GPIO9                                  | RO             |
| GPIO4                                  | DE             |
| GPIO4                                  | RE             |


### MAX485 Adapter Connections

| MAX485 Adapter | MAX485 Adapter |
|----------------|----------------|
| A              | A              |
| B              | B              |

Overall connection looks like this:

ESP-Device -- MAX485 Adapter -- MAX485 Adapter -- Logic Analyzer/ESP-Device

### Running

Transmitter - Reciever test:

`echo 1 > /dev/ttyS1` command used to send data and we can see "1\n" output on logic analyzer and other ESP-Device