### PR TITLE
boards/esp32s3: fix rtc segment on linker script

### DIFF
--- a/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld
@@ -719,14 +719,14 @@ SECTIONS
      */
 
     . = SIZEOF(.rtc.text);
-  } >rtc_data_seg
+  } >rtc_slow_seg
 
   /* RTC BSS section. */
 
   .rtc.bss (NOLOAD) :
   {
     *(.rtc.bss)
-  } >rtc_data_seg
+  } >rtc_slow_seg
 
   .rtc.data :
   {
@@ -738,7 +738,7 @@ SECTIONS
    /* Whatever is left from the RTC memory is used as a special heap. */
 
     . = ALIGN (4);
-  } >rtc_data_seg AT>ROM
+  } >rtc_slow_seg AT>ROM
 
   .rtc.heap : ALIGN(4)
   {


### PR DESCRIPTION
Modify rtc_data_seg to rtc_slow_seg to fix RTC problems. The proper location for those is in RTC slow memory.

## Summary

This PR essentially fix the issue of using MCUBoot + RTC defconfig on the ESP32S3.

## Impact

Impact on user: Allows use of MCUBoot + RTC defconfig.

Impact on build: No.

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

### Building
Use this defconfig which has MCUBoot and RTC enabled:

```
CONFIG_ARCH="xtensa"
CONFIG_ARCH_BOARD="esp32s3-devkit"
CONFIG_ARCH_BOARD_COMMON=y
CONFIG_ARCH_BOARD_ESP32S3_DEVKIT=y
CONFIG_ARCH_CHIP="esp32s3"
CONFIG_ARCH_CHIP_ESP32S3=y
CONFIG_ARCH_CHIP_ESP32S3WROOM1N4=y
CONFIG_ARCH_INTERRUPTSTACK=2048
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARCH_XTENSA=y
CONFIG_BOARDCTL_RESET=y
CONFIG_BOARD_LOOPSPERMSEC=16717
CONFIG_BUILTIN=y
CONFIG_ESP32S3_APP_FORMAT_MCUBOOT=y
CONFIG_ESP32S3_RT_TIMER=y
CONFIG_ESP32S3_SPIFLASH=y
CONFIG_ESP32S3_UART0=y
CONFIG_EXAMPLES_ALARM=y
CONFIG_FS_PROCFS=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_IDLETHREAD_STACKSIZE=3072
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_INIT_STACKSIZE=3072
CONFIG_INTELHEX_BINARY=y
CONFIG_MM_REGIONS=3
CONFIG_NSH_ARCHINIT=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_RAM_SIZE=114688
CONFIG_RAM_START=0x20000000
CONFIG_RR_INTERVAL=200
CONFIG_RTC=y
CONFIG_RTC_ALARM=y
CONFIG_RTC_DRIVER=y
CONFIG_RTC_NALARMS=2
CONFIG_SCHED_WAITPID=y
CONFIG_START_DAY=6
CONFIG_START_MONTH=12
CONFIG_START_YEAR=2011
CONFIG_SYSLOG_BUFFER=y
CONFIG_SYSTEM_NSH=y
CONFIG_UART0_SERIAL_CONSOLE=y
```

### Running

Open the serial port and reboot the board.

### Results

Before the fix we had an error on RTC_RAM region, which should be 0x5000_0000.
```
[esp32s3] [INF] *** Booting MCUboot build v2.2.0-rc1 ***
[esp32s3] [INF] [boot] chip revision: v0.1
[esp32s3] [INF] [boot.esp32s3] Boot SPI Speed : 40MHz
[esp32s3] [INF] [boot.esp32s3] SPI Mode       : DIO
[esp32s3] [INF] [boot.esp32s3] SPI Flash Size : 8MB
[esp32s3] [INF] [boot] Enabling RNG early entropy source...
[esp32s3] [INF] Primary image: magic=good, swap_type=0x1, copy_done=0x3, image_ok=0x1
[esp32s3] [INF] Scratch: magic=unset, swap_type=0x1, copy_done=0x3, image_ok=0x3
[esp32s3] [INF] Boot source: primary slot
[esp32s3] [INF] Image index: 0, Swap type: none
[esp32s3] [INF] Disabling RNG early entropy source...
[esp32s3] [INF] br_image_off = 0x10000
[esp32s3] [INF] ih_hdr_size = 0x20
[esp32s3] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32s3] [ERR] RTC_RAM region in load header is not valid. Aborting 0x600fe000
```

Now: boots normally.
```
[...]
[esp32s3] [INF] Loading image 0 - slot 0 from flash, area id: 1
[esp32s3] [INF] DRAM segment: start=0x138b4, size=0xe4c, vaddr=0x3fc8a1e0
[esp32s3] [INF] IRAM segment: start=0x10080, size=0x3834, vaddr=0x40374000
[esp32s3] [INF] start=0x40374cb8
IROM segment aligned lma 0x00020000 vma 0x42000000 len 0x013537 (79159)
DROM segment aligned lma 0x00040000 vma 0x3c040000 len 0x002c74 (11380)

NuttShell (NSH) NuttX-10.4.0
nsh> 
```