### PR TITLE
fix misspelled names in locally scoped code

### DIFF
--- a/arch/arm/src/mx8mp/mx8mp_ecspi.c
+++ b/arch/arm/src/mx8mp/mx8mp_ecspi.c
@@ -639,19 +639,19 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       size = size * 2;
     }
 
-  int transfered = 0;
-  while (transfered < size)
+  int transferred = 0;
+  while (transferred < size)
     {
       int ret = mx8mp_spi_transfer(priv,
-                                  (const uint8_t *)txbuffer + transfered,
-                                        (uint8_t *)rxbuffer + transfered,
-                                    size - transfered);
+                                  (const uint8_t *)txbuffer + transferred,
+                                        (uint8_t *)rxbuffer + transferred,
+                                    size - transferred);
       if (ret < 0)
         {
           break;
         }
 
-      transfered += ret;
+      transferred += ret;
     }
 }
 

--- a/arch/arm/src/samv7/sam_1wire.c
+++ b/arch/arm/src/samv7/sam_1wire.c
@@ -594,7 +594,7 @@ static int sam_process(struct sam_1wire_s *priv,
                        const struct sam_1wire_msg_s *msgs, int count)
 {
   irqstate_t irqs;
-  uint8_t indx;
+  uint8_t index;
   int ret;
 
   /* Lock out other clients */
@@ -607,9 +607,9 @@ static int sam_process(struct sam_1wire_s *priv,
 
   priv->result = ERROR;
 
-  for (indx = 0; indx < count; indx++)
+  for (index = 0; index < count; index++)
     {
-      switch (msgs[indx].task)
+      switch (msgs[index].task)
         {
         case ONEWIRETASK_NONE:
           priv->result = OK;
@@ -624,7 +624,7 @@ static int sam_process(struct sam_1wire_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           sam_send(priv, RESET_TX);
           leave_critical_section(irqs);
 
@@ -643,7 +643,7 @@ static int sam_process(struct sam_1wire_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           sam_send(priv, (*priv->byte & (1 << priv->bit)) ?
@@ -665,7 +665,7 @@ static int sam_process(struct sam_1wire_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           sam_send(priv, READ_TX);

--- a/arch/arm/src/stm32/stm32_1wire.c
+++ b/arch/arm/src/stm32/stm32_1wire.c
@@ -729,7 +729,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
                                int count)
 {
   irqstate_t irqs;
-  int indx;
+  int index;
   int ret;
 
   /* Lock out other clients */
@@ -742,9 +742,9 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
 
   priv->result = ERROR;
 
-  for (indx = 0; indx < count; indx++)
+  for (index = 0; index < count; index++)
     {
-      switch (msgs[indx].task)
+      switch (msgs[index].task)
         {
         case ONEWIRETASK_NONE:
           priv->result = OK;
@@ -760,7 +760,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           stm32_1wire_send(priv, RESET_TX);
           leave_critical_section(irqs);
 
@@ -780,7 +780,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           stm32_1wire_send(priv, (*priv->byte & (1 << priv->bit)) ?
@@ -803,7 +803,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           stm32_1wire_send(priv, READ_TX);

--- a/arch/arm/src/stm32l4/stm32l4_1wire.c
+++ b/arch/arm/src/stm32l4/stm32l4_1wire.c
@@ -643,7 +643,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
                                int count)
 {
   irqstate_t irqs;
-  int indx;
+  int index;
   int ret;
 
   /* Lock out other clients */
@@ -656,9 +656,9 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
 
   priv->result = ERROR;
 
-  for (indx = 0; indx < count; indx++)
+  for (index = 0; index < count; index++)
     {
-      switch (msgs[indx].task)
+      switch (msgs[index].task)
         {
         case ONEWIRETASK_NONE:
           priv->result = OK;
@@ -674,7 +674,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           stm32_1wire_send(priv, RESET_TX);
           leave_critical_section(irqs);
 
@@ -694,7 +694,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           stm32_1wire_send(priv, (*priv->byte & (1 << priv->bit)) ?
@@ -717,7 +717,7 @@ static int stm32_1wire_process(struct stm32_1wire_priv_s *priv,
           /* Atomic */
 
           irqs = enter_critical_section();
-          priv->msgs = &msgs[indx];
+          priv->msgs = &msgs[index];
           priv->byte = priv->msgs->buffer;
           priv->bit = 0;
           stm32_1wire_send(priv, READ_TX);

--- a/arch/arm/src/tlsr82/tlsr82_adc.c
+++ b/arch/arm/src/tlsr82/tlsr82_adc.c
@@ -1172,14 +1172,14 @@ static void adc_shutdown(struct adc_dev_s *dev)
  *
  ****************************************************************************/
 
-int tlsr82_adc_init(const char *devpath, int miror)
+int tlsr82_adc_init(const char *devpath, int minor)
 {
   int ret = OK;
   struct adc_dev_s *dev;
 
-  ainfo("ADC channel: %" PRIu8 "\n", miror);
+  ainfo("ADC channel: %" PRIu8 "\n", minor);
 
-  switch (miror)
+  switch (minor)
     {
 #ifdef CONFIG_TLSR82_ADC_CHAN0
       case ADC_CHAN_0:

--- a/arch/arm/src/tlsr82/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/tlsr82_adc.h
@@ -62,6 +62,6 @@
  * Name: tlsr82_adc_init
  ****************************************************************************/
 
-int tlsr82_adc_init(const char *devpath, int miror);
+int tlsr82_adc_init(const char *devpath, int minor);
 
 #endif /* __ARCH_ARM_SRC_TLSR82_TLSR82_ADC_H */

--- a/arch/arm/src/tlsr82/tlsr82_pwm.c
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.c
@@ -767,7 +767,7 @@ static int pwm_ioctl(struct pwm_lowerhalf_s *dev, int cmd,
  *
  ****************************************************************************/
 
-int tlsr82_pwminitialize(const char *devpath, int miror)
+int tlsr82_pwminitialize(const char *devpath, int minor)
 {
   struct tlsr82_pwmtimer_s *lower;
   int ret = OK;
@@ -798,9 +798,9 @@ int tlsr82_pwminitialize(const char *devpath, int miror)
       up_enable_irq(NR_SW_PWM_IRQ);
     }
 
-  pwminfo("PWM%u\n", miror);
+  pwminfo("PWM%u\n", minor);
 
-  switch (miror)
+  switch (minor)
     {
 #ifdef CONFIG_TLSR82_PWM0
       case 0:

--- a/arch/arm/src/tlsr82/tlsr82_pwm.h
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.h
@@ -75,7 +75,7 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-int tlsr82_pwminitialize(const char *devpath, int miror);
+int tlsr82_pwminitialize(const char *devpath, int minor);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/xtensa/src/esp32/esp32_himem_chardev.c
+++ b/arch/xtensa/src/esp32/esp32_himem_chardev.c
@@ -361,7 +361,7 @@ int himem_chardev_register(char *name, size_t size)
 int himem_chardev_unregister(char *name)
 {
   int ret = 0;
-  int successed = 0;
+  int success = 0;
   struct himem_chardev_s *dev;
   struct himem_chardev_s *tmp;
   nxmutex_lock(&lock);
@@ -379,7 +379,7 @@ int himem_chardev_unregister(char *name)
               if (ret != 0)
                 {
                   merr("Failed to unmap himem.\n");
-                  successed = -1;
+                  success = -1;
                 }
 
               g_ram_offset = HIMEM_UNMAPPED;
@@ -390,20 +390,20 @@ int himem_chardev_unregister(char *name)
           if (ret != 0)
             {
               merr("Failed to free himem.\n");
-              successed = -1;
+              success = -1;
             }
 
           ret = unregister_driver(dev->name);
           if (ret != 0)
             {
               merr("Failed to unregister driver. dev=%s\n", dev->name);
-              successed = -1;
+              success = -1;
             }
 
           list_delete(&dev->node);
           kmm_free(dev);
           nxmutex_unlock(&lock);
-          return successed;
+          return success;
         }
     }
 

--- a/drivers/modem/alt1250/altmdm.c
+++ b/drivers/modem/alt1250/altmdm.c
@@ -95,7 +95,7 @@ typedef enum altmdm_state_e
   ALTMDM_STATE_SETSUSTIMER,      /* Start TX suspend timer state */
   ALTMDM_STATE_SETSUSTIMERSLEEP, /* Start TX suspend timer when sleep
                                   * state */
-  ALTMDM_STATE_DESTORY,          /* State to be destroyed */
+  ALTMDM_STATE_DESTROY,          /* State to be destroyed */
 } altmdm_state_t;
 
 typedef enum version_phase_e
@@ -261,7 +261,7 @@ static const struct state_func_s g_state_func[] =
   TABLE_CONTENT(DELAYNEXT,        common,      delaynext, delaynext),
   TABLE_CONTENT(SETSUSTIMER,      common,      common,    setsustimer),
   TABLE_CONTENT(SETSUSTIMERSLEEP, common,      common,    setsustimersleep),
-  TABLE_CONTENT(DESTORY,          destroy,     common,    common),
+  TABLE_CONTENT(DESTROY,          destroy,     common,    common),
 };
 
 static struct altmdm_dev_s g_altmdm_dev;
@@ -483,7 +483,7 @@ static altmdm_state_t process_state_poweroff(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & (EVENT_POWERON | EVENT_SUSPEND | EVENT_RESUME))
     {
@@ -546,7 +546,7 @@ static altmdm_state_t process_state_sleep(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -610,7 +610,7 @@ static altmdm_state_t process_state_sleepwotx(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -685,7 +685,7 @@ static altmdm_state_t process_state_idle4rst(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -746,7 +746,7 @@ static altmdm_state_t process_state_idlewto(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -814,7 +814,7 @@ static altmdm_state_t process_state_idlewoto(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -874,7 +874,7 @@ static altmdm_state_t process_state_idlewotx(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -1026,7 +1026,7 @@ static altmdm_state_t process_state_hdrsreq(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -1133,7 +1133,7 @@ static altmdm_state_t process_state_bodysreq(uint32_t event,
   if (event & EVENT_DESTROY)
     {
       altmdm_event_clear(&g_altmdm_dev.event, EVENT_DESTROY);
-      state = ALTMDM_STATE_DESTORY;
+      state = ALTMDM_STATE_DESTROY;
     }
   else if (event & EVENT_POWEROFF)
     {
@@ -1481,7 +1481,7 @@ static altmdm_state_t process_state_setsustimersleep(uint32_t event,
 }
 
 /****************************************************************************
- * DESTORY state
+ * DESTROY state
  ****************************************************************************/
 
 static int next_state_destroy(altmdm_state_t state)
@@ -1589,7 +1589,7 @@ int altmdm_poweron(void)
   /* Is in POWERON state? */
 
   if ((g_altmdm_dev.current_state != ALTMDM_STATE_POWEROFF) &&
-      (g_altmdm_dev.current_state != ALTMDM_STATE_DESTORY))
+      (g_altmdm_dev.current_state != ALTMDM_STATE_DESTROY))
     {
       if (!(evt & EVENT_POWEROFF))
         {
@@ -1633,7 +1633,7 @@ int altmdm_poweroff(void)
   /* Is in POWEROFF state? */
 
   if ((g_altmdm_dev.current_state == ALTMDM_STATE_POWEROFF) ||
-      (g_altmdm_dev.current_state == ALTMDM_STATE_DESTORY))
+      (g_altmdm_dev.current_state == ALTMDM_STATE_DESTROY))
     {
       if (!(evt & EVENT_POWERON))
         {

--- a/drivers/usbhost/usbhost_bthci.c
+++ b/drivers/usbhost/usbhost_bthci.c
@@ -683,7 +683,7 @@ static inline int usbhci_cfgdesc(FAR struct usbhost_state_s *priv,
 
 static int usbhost_ctrl_cmd(FAR struct usbhost_state_s *priv,
                             uint8_t type, uint8_t req, uint16_t value,
-                            uint16_t indx, FAR uint8_t *payload,
+                            uint16_t index, FAR uint8_t *payload,
                             uint16_t len)
 {
   FAR struct usbhost_hubport_s *hport;
@@ -697,7 +697,7 @@ static int usbhost_ctrl_cmd(FAR struct usbhost_state_s *priv,
   ctrlreq->req  = req;
 
   usbhost_putle16(ctrlreq->value, value);
-  usbhost_putle16(ctrlreq->index, indx);
+  usbhost_putle16(ctrlreq->index, index);
   usbhost_putle16(ctrlreq->len,   len);
 
   if (type & USB_REQ_DIR_IN)

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -571,7 +571,7 @@ int clock_isleapyear(int year);
  *
  ****************************************************************************/
 
-int clock_daysbeforemonth(int month, bool leapyear);
+int clock_daysbeforemonth(int month, bool leap_year);
 
 /****************************************************************************
  * Name:  clock_dayoftheweek

--- a/include/string.h
+++ b/include/string.h
@@ -77,7 +77,7 @@ int        strncmp(FAR const char *, FAR const char *, size_t);
 int        strcoll(FAR const char *, FAR const char *s2);
 FAR char  *strcpy(FAR char *dest, FAR const char *src);
 FAR char  *stpcpy(FAR char *dest, FAR const char *src);
-size_t     strlcpy(FAR char *dst, FAR const char *src, size_t siz);
+size_t     strlcpy(FAR char *dst, FAR const char *src, size_t size);
 FAR char  *strncpy(FAR char *, FAR const char *, size_t);
 FAR char  *stpncpy(FAR char *, FAR const char *, size_t);
 FAR char  *strpbrk(FAR const char *, FAR const char *);
@@ -166,10 +166,10 @@ fortify_function(stpncpy) FAR char *stpncpy(FAR char *dest,
 
 fortify_function(strlcpy) size_t strlcpy(FAR char *dst,
                                          FAR const char *src,
-                                         size_t siz)
+                                         size_t size)
 {
-  fortify_assert(siz <= fortify_size(dst, 0));
-  return __real_strlcpy(dst, src, siz);
+  fortify_assert(size <= fortify_size(dst, 0));
+  return __real_strlcpy(dst, src, size);
 }
 
 fortify_function(strncpy) FAR char *strncpy(FAR char *dest,

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -274,10 +274,10 @@ fortify_function(wcscpy) FAR wchar_t *wcscpy(FAR wchar_t *dst,
 
 fortify_function(wcslcpy) size_t wcslcpy(FAR wchar_t *dst,
                                          FAR const wchar_t *src,
-                                         size_t siz)
+                                         size_t size)
 {
-  fortify_assert(siz <= fortify_size(dst, 0) / sizeof(wchar_t));
-  return __real_wcslcpy(dst, src, siz);
+  fortify_assert(size <= fortify_size(dst, 0) / sizeof(wchar_t));
+  return __real_wcslcpy(dst, src, size);
 }
 
 fortify_function(wcscat) FAR wchar_t *wcscat(FAR wchar_t *dst,
@@ -290,26 +290,26 @@ fortify_function(wcscat) FAR wchar_t *wcscat(FAR wchar_t *dst,
 
 fortify_function(wcsncat) FAR wchar_t *wcsncat(FAR wchar_t *dst,
                                                FAR const wchar_t *src,
-                                               size_t siz)
+                                               size_t size)
 {
-  fortify_assert(siz <= fortify_size(dst, 0) / sizeof(wchar_t));
-  return __real_wcsncat(dst, src, siz);
+  fortify_assert(size <= fortify_size(dst, 0) / sizeof(wchar_t));
+  return __real_wcsncat(dst, src, size);
 }
 
 fortify_function(wcslcat) size_t wcslcat(FAR wchar_t *dst,
                                          FAR const wchar_t *src,
-                                         size_t siz)
+                                         size_t size)
 {
-  fortify_assert(siz <= fortify_size(dst, 0) / sizeof(wchar_t));
-  return __real_wcslcat(dst, src, siz);
+  fortify_assert(size <= fortify_size(dst, 0) / sizeof(wchar_t));
+  return __real_wcslcat(dst, src, size);
 }
 
 fortify_function(wcsncpy) FAR wchar_t *wcsncpy(FAR wchar_t *dst,
                                                FAR const wchar_t *src,
-                                               size_t siz)
+                                               size_t size)
 {
-  fortify_assert(siz <= fortify_size(dst, 0) / sizeof(wchar_t));
-  return __real_wcsncpy(dst, src, siz);
+  fortify_assert(size <= fortify_size(dst, 0) / sizeof(wchar_t));
+  return __real_wcsncpy(dst, src, size);
 }
 
 fortify_function(wcsnrtombs) size_t wcsnrtombs(FAR char *dst,

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -153,15 +153,15 @@ static ssize_t blkoutstream_puts(FAR struct lib_sostream_s *self,
 
       if (offset > 0)
         {
-          size_t copyin = offset + remain > sectorsize ?
-                          sectorsize - offset : remain;
+          size_t copying = offset + remain > sectorsize ?
+                           sectorsize - offset : remain;
 
-          memcpy(stream->cache + offset, ptr, copyin);
+          memcpy(stream->cache + offset, ptr, copying);
 
-          ptr        += copyin;
-          offset     += copyin;
-          self->nput += copyin;
-          remain     -= copyin;
+          ptr        += copying;
+          offset     += copying;
+          self->nput += copying;
+          remain     -= copying;
 
           if (offset == sectorsize)
             {
@@ -189,7 +189,7 @@ static ssize_t blkoutstream_puts(FAR struct lib_sostream_s *self,
       else
         {
           size_t nsector = remain / sectorsize;
-          size_t copyin = nsector * sectorsize;
+          size_t copying = nsector * sectorsize;
 
           ret = inode->u.i_bops->write(inode, ptr, sector, nsector);
           if (ret < 0)
@@ -197,9 +197,9 @@ static ssize_t blkoutstream_puts(FAR struct lib_sostream_s *self,
               return ret;
             }
 
-          ptr        += copyin;
-          self->nput += copyin;
-          remain     -= copyin;
+          ptr        += copying;
+          self->nput += copying;
+          remain     -= copying;
         }
     }
 

--- a/libs/libc/stream/lib_lzfcompress.c
+++ b/libs/libc/stream/lib_lzfcompress.c
@@ -72,21 +72,21 @@ static ssize_t lzfoutstream_puts(FAR struct lib_outstream_s *self,
   FAR struct lzf_header_s *header;
   FAR const char *ptr = buf;
   size_t total = len;
-  size_t copyin;
+  size_t copying;
   size_t outlen;
   ssize_t ret;
 
   while (total > 0)
     {
-      copyin = stream->offset + total > LZF_STREAM_BLOCKSIZE ?
-               LZF_STREAM_BLOCKSIZE - stream->offset : total;
+      copying = stream->offset + total > LZF_STREAM_BLOCKSIZE ?
+                LZF_STREAM_BLOCKSIZE - stream->offset : total;
 
-      memcpy(stream->in + stream->offset, ptr, copyin);
+      memcpy(stream->in + stream->offset, ptr, copying);
 
-      ptr            += copyin;
-      stream->offset += copyin;
-      self->nput     += copyin;
-      total          -= copyin;
+      ptr            += copying;
+      stream->offset += copying;
+      self->nput     += copying;
+      total          -= copying;
 
       if (stream->offset == LZF_STREAM_BLOCKSIZE)
         {

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -101,15 +101,15 @@ static ssize_t mtdoutstream_puts(FAR struct lib_sostream_s *self,
 
       if (offset > 0)
         {
-          size_t copyin = offset + remain > erasesize ?
-                          erasesize - offset : remain;
+          size_t copying = offset + remain > erasesize ?
+                           erasesize - offset : remain;
 
-          memcpy(stream->cache + offset, ptr, copyin);
+          memcpy(stream->cache + offset, ptr, copying);
 
-          ptr        += copyin;
-          offset     += copyin;
-          self->nput += copyin;
-          remain     -= copyin;
+          ptr        += copying;
+          offset     += copying;
+          self->nput += copying;
+          remain     -= copying;
 
           if (offset == erasesize)
             {
@@ -143,7 +143,7 @@ static ssize_t mtdoutstream_puts(FAR struct lib_sostream_s *self,
       else
         {
           size_t nblock = remain / erasesize;
-          size_t copyin = nblock * erasesize;
+          size_t copying = nblock * erasesize;
 
           ret = MTD_ERASE(i_mtd, sblock, nblock);
           if (ret < 0)
@@ -158,9 +158,9 @@ static ssize_t mtdoutstream_puts(FAR struct lib_sostream_s *self,
               return ret;
             }
 
-          ptr        += copyin;
-          self->nput += copyin;
-          remain     -= copyin;
+          ptr        += copying;
+          self->nput += copying;
+          remain     -= copying;
         }
     }
 

--- a/libs/libc/time/lib_daysbeforemonth.c
+++ b/libs/libc/time/lib_daysbeforemonth.c
@@ -52,19 +52,19 @@ static const uint16_t g_daysbeforemonth[13] =
  *    month.
  *
  * Input Parameters:
- *    month    - The month in the form of tm_mon, that is a range of 0-11.
- *    leapyear - True if leap year and there are 29 days in February.
- *               NOTE the month=1 is February.
+ *    month     - The month in the form of tm_mon, that is a range of 0-11.
+ *    leap_year - True if leap year and there are 29 days in February.
+ *                NOTE the month=1 is February.
  *
  * Returned Value:
  *    The number of days that occurred before the month
  *
  ****************************************************************************/
 
-int clock_daysbeforemonth(int month, bool leapyear)
+int clock_daysbeforemonth(int month, bool leap_year)
 {
   int retval = g_daysbeforemonth[month];
-  if (month >= 2 && leapyear)
+  if (month >= 2 && leap_year)
     {
       retval++;
     }

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -155,7 +155,7 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
   int  min;
   int  max;
   int  tmp;
-  bool leapyear;
+  bool leap_year;
 
   /* There is one leap year every four years, so we can get close with the
    * following:
@@ -170,11 +170,11 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
    * Is this year a leap year? (we'll need this later too)
    */
 
-  leapyear = clock_isleapyear(value + EPOCH_YEAR);
+  leap_year = clock_isleapyear(value + EPOCH_YEAR);
 
   /* Get the number of days in the year */
 
-  tmp = (leapyear ? DAYSPERLYEAR : DAYSPERNYEAR);
+  tmp = (leap_year ? DAYSPERLYEAR : DAYSPERNYEAR);
 
   /* Do we have that many days left to account for? */
 
@@ -187,15 +187,15 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
 
       /* Is the next year a leap year? */
 
-      leapyear = clock_isleapyear(value + EPOCH_YEAR);
+      leap_year = clock_isleapyear(value + EPOCH_YEAR);
 
       /* Get the number of days in the next year */
 
-      tmp = (leapyear ? DAYSPERLYEAR : DAYSPERNYEAR);
+      tmp = (leap_year ? DAYSPERLYEAR : DAYSPERNYEAR);
     }
 
   /* At this point, 'value' has the years since 1970 and 'days' has number
-   * of days into that year.  'leapyear' is true if the year in 'value' is
+   * of days into that year.  'leap_year' is true if the year in 'value' is
    * a leap year.
    */
 
@@ -216,7 +216,7 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
        * month following the midpoint.
        */
 
-      tmp = clock_daysbeforemonth(value + 1, leapyear);
+      tmp = clock_daysbeforemonth(value + 1, leap_year);
 
       /* Does the number of days before this month that equal or exceed the
        * number of days we have remaining?
@@ -228,7 +228,7 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
            * midpoint, 'value'.  Could it be the midpoint?
            */
 
-          tmp = clock_daysbeforemonth(value, leapyear);
+          tmp = clock_daysbeforemonth(value, leap_year);
           if (tmp > days)
             {
               /* No... The one we want is somewhere between min and value-1 */
@@ -261,7 +261,7 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
    * the selected month
    */
 
-  days -= clock_daysbeforemonth(value, leapyear);
+  days -= clock_daysbeforemonth(value, leap_year);
 
   /* At this point, value has the month into this year (zero based) and days
    * has number of days into this month (zero based)

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -1389,7 +1389,7 @@ static int_fast32_t transtime(int year,
                               FAR const struct rule_s *rulep,
                               int_fast32_t offset)
 {
-  int leapyear;
+  int leap_year;
   int_fast32_t value;
   int i;
   int d;
@@ -1400,7 +1400,7 @@ static int_fast32_t transtime(int year,
   int dow;
 
   value = 0;
-  leapyear = isleap(year);
+  leap_year = isleap(year);
   switch (rulep->r_type)
     {
     case JULIAN_DAY:
@@ -1413,7 +1413,7 @@ static int_fast32_t transtime(int year,
        */
 
       value = (rulep->r_day - 1) * SECSPERDAY;
-      if (leapyear && rulep->r_day >= 60)
+      if (leap_year && rulep->r_day >= 60)
         {
           value += SECSPERDAY;
         }
@@ -1461,7 +1461,7 @@ static int_fast32_t transtime(int year,
 
       for (i = 1; i < rulep->r_week; ++i)
         {
-          if (d + DAYSPERWEEK >= g_mon_lengths[leapyear][rulep->r_mon - 1])
+          if (d + DAYSPERWEEK >= g_mon_lengths[leap_year][rulep->r_mon - 1])
             {
               break;
             }
@@ -1474,7 +1474,7 @@ static int_fast32_t transtime(int year,
       value = d * SECSPERDAY;
       for (i = 0; i < rulep->r_mon - 1; ++i)
         {
-          value += g_mon_lengths[leapyear][i] * SECSPERDAY;
+          value += g_mon_lengths[leap_year][i] * SECSPERDAY;
         }
       break;
     }

--- a/libs/libc/time/lib_timegm.c
+++ b/libs/libc/time/lib_timegm.c
@@ -82,7 +82,7 @@ static void adjust(FAR int *tenx, FAR int *x, int base)
 
 static void normalize(FAR struct tm *tm)
 {
-  bool leapyear = false;
+  bool leap_year = false;
   int year;
 
   for (; ; )
@@ -97,7 +97,7 @@ static void normalize(FAR struct tm *tm)
 
       /* Is this a leap year? */
 
-      leapyear = clock_isleapyear(year);
+      leap_year = clock_isleapyear(year);
 
       /* Adjust mday field */
 
@@ -106,11 +106,11 @@ static void normalize(FAR struct tm *tm)
           tm->tm_mon--;
           if (tm->tm_mon < 0)
             {
-              tm->tm_mday += g_mon_lengths[leapyear][TM_DECEMBER];
+              tm->tm_mday += g_mon_lengths[leap_year][TM_DECEMBER];
               break;
             }
 
-          tm->tm_mday += g_mon_lengths[leapyear][tm->tm_mon];
+          tm->tm_mday += g_mon_lengths[leap_year][tm->tm_mon];
         }
 
       if (tm->tm_mon < 0)
@@ -118,9 +118,9 @@ static void normalize(FAR struct tm *tm)
           continue;
         }
 
-      while (tm->tm_mday > g_mon_lengths[leapyear][tm->tm_mon])
+      while (tm->tm_mday > g_mon_lengths[leap_year][tm->tm_mon])
         {
-          tm->tm_mday -= g_mon_lengths[leapyear][tm->tm_mon];
+          tm->tm_mday -= g_mon_lengths[leap_year][tm->tm_mon];
           tm->tm_mon++;
           if (tm->tm_mon > (MONSPERYEAR - 1))
             {
@@ -164,13 +164,13 @@ static void normalize(FAR struct tm *tm)
           tm->tm_hour -= HOURSPERDAY;
           tm->tm_mday++;
 
-          if (tm->tm_mday > g_mon_lengths[leapyear][tm->tm_mon])
+          if (tm->tm_mday > g_mon_lengths[leap_year][tm->tm_mon])
             {
               break;
             }
         }
 
-      if (tm->tm_mday > g_mon_lengths[leapyear][tm->tm_mon])
+      if (tm->tm_mday > g_mon_lengths[leap_year][tm->tm_mon])
         {
           continue;
         }
@@ -185,7 +185,7 @@ static void normalize(FAR struct tm *tm)
   /* Determine the day of the year; -1 because the mday is 1-indexed */
 
   tm->tm_yday = tm->tm_mday - 1 + clock_daysbeforemonth(tm->tm_mon,
-                                                        leapyear);
+                                                        leap_year);
 
   /* Finally calculate the weekday */
 

--- a/libs/libc/wchar/lib_wcslcat.c
+++ b/libs/libc/wchar/lib_wcslcat.c
@@ -42,27 +42,27 @@
  * Name:  wcslcat
  *
  * Description:
- *     Appends src to string dst of size siz (unlike wcsncat, siz is the
- *     full size of dst, not space left).  At most siz-1 characters
- *     will be copied.  Always NUL terminates (unless siz == 0).
- *     Returns wcslen(initial dst) + wcslen(src); if retval >= siz,
+ *     Appends src to string dst of size "size" (unlike wcsncat, "size"
+ *     is the full size of dst, no space left).  At most size-1 characters
+ *     will be copied.  Always NUL terminates (unless size == 0).
+ *     Returns wcslen(initial dst) + wcslen(src); if retval >= size,
  *     truncation occurred.
  *
  * Input Parameters:
- *   dst - the dest wchar string that contains the concatenated string
- *   src - the source wchar string that we need to concatenate
- *   siz - the max length that can be written to the end of the dst string
+ *   dst  - the dest wchar string that contains the concatenated string
+ *   src  - the source wchar string that we need to concatenate
+ *   size - the max length that can be written to the end of the dst string
  *
  * Returned Value:
  *   The total length of the wchar string that concatenated
  *
  ****************************************************************************/
 
-size_t wcslcat(FAR wchar_t *dst, FAR const wchar_t *src, size_t siz)
+size_t wcslcat(FAR wchar_t *dst, FAR const wchar_t *src, size_t size)
 {
   FAR wchar_t *d = dst;
   FAR const wchar_t *s = src;
-  size_t n = siz;
+  size_t n = size;
   size_t dlen;
 
   /* Find the end of dst and adjust bytes left but don't go past end */
@@ -73,7 +73,7 @@ size_t wcslcat(FAR wchar_t *dst, FAR const wchar_t *src, size_t siz)
     }
 
   dlen = d - dst;
-  n = siz - dlen;
+  n = size - dlen;
 
   if (n == 0)
     {

--- a/libs/libc/wchar/lib_wcslcpy.c
+++ b/libs/libc/wchar/lib_wcslcpy.c
@@ -47,17 +47,17 @@
  * Name: wcslen
  *
  * Description:
- *   Copy src to string dst of size siz.  At most siz-1 characters
- *   will be copied.  Always NUL terminates (unless siz == 0).
- *   Returns wcslen(src); if retval >= siz, truncation occurred.
+ *   Copy src to string dst of size "size".  At most size-1 characters
+ *   will be copied.  Always NUL terminates (unless size == 0).
+ *   Returns wcslen(src); if retval >= size, truncation occurred.
  *
  ****************************************************************************/
 
-size_t wcslcpy(FAR wchar_t *dst, FAR const wchar_t *src, size_t siz)
+size_t wcslcpy(FAR wchar_t *dst, FAR const wchar_t *src, size_t size)
 {
   FAR wchar_t *d = dst;
   FAR const wchar_t *s = src;
-  size_t n = siz;
+  size_t n = size;
 
   /* Copy as many bytes as will fit */
 
@@ -77,7 +77,7 @@ size_t wcslcpy(FAR wchar_t *dst, FAR const wchar_t *src, size_t siz)
 
   if (n == 0)
     {
-      if (siz != 0)
+      if (size != 0)
         {
           *d = '\0';            /* NUL-terminate dst */
         }

--- a/libs/libdsp/lib_pmsm_model.c
+++ b/libs/libdsp/lib_pmsm_model.c
@@ -232,14 +232,14 @@ int pmsm_model_elec(FAR struct pmsm_model_f32_s *model,
 
 int pmsm_model_mech(FAR struct pmsm_model_f32_s *model, float load)
 {
-  float angle = 0.0f;
-  float dir   = 0.0f;
-  float te    = 0.0f;
-  float tmp1  = 0.0f;
-  float tmp2  = 0.0f;
-  float tmp3  = 0.0f;
-  float tmp4  = 0.0f;
-  float tmp5  = 0.0f;
+  float angle  = 0.0f;
+  float dir    = 0.0f;
+  float torque = 0.0f;
+  float tmp1   = 0.0f;
+  float tmp2   = 0.0f;
+  float tmp3   = 0.0f;
+  float tmp4   = 0.0f;
+  float tmp5   = 0.0f;
 
   DEBUGASSERT(model);
 
@@ -251,11 +251,11 @@ int pmsm_model_mech(FAR struct pmsm_model_f32_s *model, float load)
   tmp4 = 1.5f * model->phy.motor.p;
   tmp5 = tmp4 * model->state.i_dq.q;
 
-  te =  tmp5 * tmp3;
+  torque =  tmp5 * tmp3;
 
   /* Get new mechanical velocity */
 
-  tmp1 = te - load;
+  tmp1 = torque - load;
   tmp2 = model->per * tmp1 ;
   tmp3 = tmp2 * model->phy.one_by_iner;
 

--- a/libs/libdsp/lib_pmsm_model_b16.c
+++ b/libs/libdsp/lib_pmsm_model_b16.c
@@ -145,14 +145,14 @@ int pmsm_model_elec_b16(FAR struct pmsm_model_b16_s *model,
 
 int pmsm_model_mech_b16(FAR struct pmsm_model_b16_s *model, b16_t load)
 {
-  b16_t angle = 0;
-  b16_t dir   = 0;
-  b16_t te    = 0;
-  b16_t tmp1  = 0;
-  b16_t tmp2  = 0;
-  b16_t tmp3  = 0;
-  b16_t tmp4  = 0;
-  b16_t tmp5  = 0;
+  b16_t angle  = 0;
+  b16_t dir    = 0;
+  b16_t torque = 0;
+  b16_t tmp1   = 0;
+  b16_t tmp2   = 0;
+  b16_t tmp3   = 0;
+  b16_t tmp4   = 0;
+  b16_t tmp5   = 0;
 
   DEBUGASSERT(model);
 
@@ -164,11 +164,11 @@ int pmsm_model_mech_b16(FAR struct pmsm_model_b16_s *model, b16_t load)
   tmp4 = b16mulb16((b16ONE + b16HALF), itob16(model->phy.motor.p));
   tmp5 = b16mulb16(tmp4, model->state.i_dq.q);
 
-  te = b16mulb16(tmp5, tmp3);
+  torque = b16mulb16(tmp5, tmp3);
 
   /* Get new mechanical velocity */
 
-  tmp1 = te - load;
+  tmp1 = torque - load;
   tmp2 = b16mulb16(model->per, tmp1);
   tmp3 = b16mulb16(tmp2, model->phy.one_by_iner);
 

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -253,7 +253,7 @@ void mm_memdump(FAR struct mm_heap_s *heap,
         }
       else
         {
-          name = "Unkown";
+          name = "Unknown";
           tcb  = nxsched_get_tcb(pid);
         }
 

--- a/mm/tlsf/mm_tlsf.c
+++ b/mm/tlsf/mm_tlsf.c
@@ -1230,7 +1230,7 @@ void mm_memdump(FAR struct mm_heap_s *heap,
         }
       else
         {
-          name = "Unkown";
+          name = "Unknown";
           tcb  = nxsched_get_tcb(pid);
         }
 

--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -61,7 +61,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
                     unsigned int target_offset)
 {
   FAR struct iob_s *iob;
-  unsigned int copyin;
+  unsigned int copying;
   unsigned int remain;
   int ret;
 
@@ -122,18 +122,18 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
           iob = iob->io_flink;
         }
 
-      copyin = CONFIG_IOB_BUFSIZE -
-               (iob->io_len + iob->io_offset);
-      if (copyin > remain)
+      copying = CONFIG_IOB_BUFSIZE -
+                (iob->io_len + iob->io_offset);
+      if (copying > remain)
         {
-          copyin = remain;
+          copying = remain;
         }
 
-      if (copyin > 0)
+      if (copying > 0)
         {
           ret = file_read(file, iob->io_data +
                           (iob->io_len + iob->io_offset),
-                          copyin);
+                          copying);
           if (ret < 0)
             {
               goto errout;

--- a/tools/cxd56/clefia.c
+++ b/tools/cxd56/clefia.c
@@ -491,18 +491,18 @@ int clefiakeyset(unsigned char *rk, const unsigned char *skey)
 void clefiaencrypt(unsigned char *ct, const unsigned char *pt,
                    const unsigned char *rk, const int r)
 {
-  unsigned char rin[16];
-  unsigned char  rout[16];
+  unsigned char r_in[16];
+  unsigned char  r_out[16];
 
-  bytecpy(rin, pt, 16);
+  bytecpy(r_in, pt, 16);
 
-  bytexor(rin + 4, rin + 4, rk + 0, 4); /* initial key whitening */
-  bytexor(rin + 12, rin + 12, rk + 4, 4);
+  bytexor(r_in + 4, r_in + 4, rk + 0, 4); /* initial key whitening */
+  bytexor(r_in + 12, r_in + 12, rk + 4, 4);
   rk += 8;
 
-  clefiagfn4(rout, rin, rk, r); /* GFN_{4,r} */
+  clefiagfn4(r_out, r_in, rk, r); /* GFN_{4,r} */
 
-  bytecpy(ct, rout, 16);
+  bytecpy(ct, r_out, 16);
   bytexor(ct + 4, ct + 4, rk + r * 8 + 0, 4);   /* final key whitening */
   bytexor(ct + 12, ct + 12, rk + r * 8 + 4, 4);
 }

--- a/tools/flash_writer.py
+++ b/tools/flash_writer.py
@@ -345,15 +345,15 @@ class TelnetDev:
         pass
 
     def set_file_size(self, filesize):
-        self.bytes_transfered = 0
+        self.bytes_transferred = 0
         self.filesize = filesize
         self.count = 0
 
     def show_progress(self, sendsize):
         if PRINT_RAW_COMMAND:
             if self.count < MAX_DOT_COUNT:
-                self.bytes_transfered = self.bytes_transfered + sendsize
-                cur_count = int(self.bytes_transfered * MAX_DOT_COUNT / self.filesize)
+                self.bytes_transferred = self.bytes_transferred + sendsize
+                cur_count = int(self.bytes_transferred * MAX_DOT_COUNT / self.filesize)
                 if MAX_DOT_COUNT < cur_count:
                     cur_count = MAX_DOT_COUNT
                 for idx in range(cur_count - self.count):
@@ -431,15 +431,15 @@ class SerialDev:
         self.serial.setDTR(False)
 
     def set_file_size(self, filesize):
-        self.bytes_transfered = 0
+        self.bytes_transferred = 0
         self.filesize = filesize
         self.count = 0
 
     def show_progress(self, sendsize):
         if PRINT_RAW_COMMAND:
             if self.count < MAX_DOT_COUNT:
-                self.bytes_transfered = self.bytes_transfered + sendsize
-                cur_count = int(self.bytes_transfered * MAX_DOT_COUNT / self.filesize)
+                self.bytes_transferred = self.bytes_transferred + sendsize
+                cur_count = int(self.bytes_transferred * MAX_DOT_COUNT / self.filesize)
                 if MAX_DOT_COUNT < cur_count:
                     cur_count = MAX_DOT_COUNT
                 for idx in range(cur_count - self.count):

--- a/tools/pynuttx/nxgdb/utils.py
+++ b/tools/pynuttx/nxgdb/utils.py
@@ -352,10 +352,10 @@ def parse_and_eval(expression: str, global_context: bool = False):
     return Value(gdb_value)
 
 
-def gdb_eval_or_none(expresssion):
+def gdb_eval_or_none(expression):
     """Evaluate an expression and return None if it fails"""
     try:
-        return parse_and_eval(expresssion)
+        return parse_and_eval(expression)
     except gdb.error:
         return None
 

--- a/tools/stm32_pinmap_tool.py
+++ b/tools/stm32_pinmap_tool.py
@@ -446,7 +446,7 @@ def parse_conditional(lines, conditions):
     return defines
 
 
-def formmatter(args):
+def formatter(args):
     # if pinmap passed is a legacy pinmap. Just generate a report
     report_only = args.report is not False
 
@@ -566,7 +566,7 @@ def main():
             "Python 2 is not supported. Please try again using Python 3."
         )
     args = parse_args()
-    formmatter(args)
+    formatter(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

[Codespell](https://github.com/codespell-project/codespell/) discovered a few typos in variable or function names.

These misspelled words are used in strictly local scopes. Renaming these should not cause any problems.

## Impact

* Changing the name of a local variable within a function should not cause issues.
* One python function name was changed. But this function was only used in self-contained script (not a library module).
* One item name in an X macro was changed. But this X macro was used only in a module (not visible via the corresponding header file).


## Testing

No testing was conducted.

