### PR TITLE
espressif: Add variable to override MCUboot version and URL

### DIFF
--- a/arch/risc-v/src/common/espressif/Bootloader.mk
+++ b/arch/risc-v/src/common/espressif/Bootloader.mk
@@ -35,8 +35,14 @@ BOOTLOADER_CONFIG    = $(BOOTLOADER_SRCDIR)/bootloader.conf
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_SRCDIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
-MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
 MCUBOOT_TOOLCHAIN  = $(TOOLSDIR)/mcuboot_toolchain_espressif.cmake
+ifndef MCUBOOT_VERSION
+	MCUBOOT_VERSION = $(CONFIG_ESPRESSIF_MCUBOOT_VERSION)
+endif
+
+ifndef MCUBOOT_URL
+	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
 
 # Helpers for creating the configuration file
 
@@ -92,7 +98,7 @@ BOOTLOADER_BIN = $(TOPDIR)/mcuboot-$(CHIP_SERIES).bin
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_SRCDIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
-	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESPRESSIF_MCUBOOT_VERSION)
+	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)

--- a/arch/xtensa/src/esp32/Bootloader.mk
+++ b/arch/xtensa/src/esp32/Bootloader.mk
@@ -35,8 +35,14 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
-MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
 MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32/mcuboot_toolchain_esp32.cmake
+ifndef MCUBOOT_VERSION
+	MCUBOOT_VERSION = $(CONFIG_ESP32_MCUBOOT_VERSION)
+endif
+
+ifndef MCUBOOT_URL
+	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
 
 # Helpers for creating the configuration file
 
@@ -128,7 +134,7 @@ BOOTLOADER_SIGNED_BIN = $(TOPDIR)/mcuboot-esp32.signed.bin
 $(MCUBOOT_SRCDIR):
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
-	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESP32_MCUBOOT_VERSION)
+	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)

--- a/arch/xtensa/src/esp32s2/Bootloader.mk
+++ b/arch/xtensa/src/esp32s2/Bootloader.mk
@@ -35,8 +35,14 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
-MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
 MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
+ifndef MCUBOOT_VERSION
+	MCUBOOT_VERSION = $(CONFIG_ESP32S2_MCUBOOT_VERSION)
+endif
+
+ifndef MCUBOOT_URL
+	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
 
 $(BOOTLOADER_DIR):
 	$(Q) mkdir -p $(BOOTLOADER_DIR) &>/dev/null
@@ -121,7 +127,7 @@ BOOTLOADER_SIGNED_BIN = $(TOPDIR)/mcuboot-esp32s2.signed.bin
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_DIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
-	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESP32S2_MCUBOOT_VERSION)
+	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)

--- a/arch/xtensa/src/esp32s3/Bootloader.mk
+++ b/arch/xtensa/src/esp32s3/Bootloader.mk
@@ -35,8 +35,14 @@ BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
-MCUBOOT_URL        = https://github.com/mcu-tools/mcuboot
 MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
+ifndef MCUBOOT_VERSION
+	MCUBOOT_VERSION = $(CONFIG_ESP32S3_MCUBOOT_VERSION)
+endif
+
+ifndef MCUBOOT_URL
+	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
 
 $(BOOTLOADER_DIR):
 	$(Q) mkdir -p $(BOOTLOADER_DIR) &>/dev/null
@@ -98,7 +104,7 @@ BOOTLOADER_BIN        = $(TOPDIR)/mcuboot-esp32s3.bin
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_DIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
-	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(CONFIG_ESP32S3_MCUBOOT_VERSION)
+	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
 $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)


### PR DESCRIPTION
## Summary

* espressif: Add variable to override MCUboot version and URL

The version and the git repository of Espressif's MCUboot port can be changed by setting the `MCUBOOT_VERSION` and `MCUBOOT_URL` environment variables before running the `make bootloader` command.

## Impact

Impact on user: NO.

Impact on build: YES. If the environment variables `MCUBOOT_VERSION` and `MCUBOOT_URL` are set, use them instead of the default values.

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

This can be tested by setting it to other values and checking the folder where MCUboot is cloned. For ESP32-S3, for instance, the default values for `MCUBOOT_VERSION` and `MCUBOOT_URL` are defined by, respectively, by `CONFIG_ESP32S3_MCUBOOT_VERSION` (which currently is set to `20f98e0a975c24864872e0df5701eb1082e9c957`) and `https://github.com/mcu-tools/mcuboot`.

### Building

In this test, set another version and clone it from another repository (a fork, for instance):

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:mcuboot_nsh && MCUBOOT_VERSION="f6e8e88aa693c376a7e71d44aa04bc9908f0e74e" MCUBOOT_URL="https://github.com/tmedicci/mcuboot" make bootloader
```

### Running

Wait for the bootloader to be built...

### Results

Check the `nuttx/arch/xtensa/src/chip/bootloader/mcuboot` folder:

#### The version
```
$ git --no-pager show
commit f6e8e88aa693c376a7e71d44aa04bc9908f0e74e (HEAD, origin/main, origin/HEAD, main)
```

#### The git repository
```
git remote -v
origin	https://github.com/tmedicci/mcuboot (fetch)
origin	https://github.com/tmedicci/mcuboot (push)
```

Both the git repository and the version retrieved correspond to the overridden values.