### PR TITLE
fs/dup3: If "newfd" is open, close it gracefully to prevent panic

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -462,6 +462,7 @@ struct file
   int               f_oflags;   /* Open mode flags */
 #ifdef CONFIG_FS_REFCOUNT
   atomic_t          f_refs;     /* Reference count */
+  sem_t             f_closem;   /* Free: file is fully closed */
 #endif
   off_t             f_pos;      /* File position */
   FAR struct inode *f_inode;    /* Driver or file system interface */


### PR DESCRIPTION
## Summary

There are two race conditions present in the current implementation:

1. File is partially open / getting closed and dup2/3 is called
- This condition arises when one thread opens and a second thread duplicates a fixed file descriptor number that happens to collide with the file being opened.
2. File I/O is active but someone calls close / dup2/3 on the descriptor.
- This condition occurs when one thread writes and another calls close or dup2/3 on an open descriptor. If the write operation is not finished before closing the file, it will violate the NuttX f_refs counter which protects the file I/O from getting its file struct wiped from under its feet.

Fix these extremely rare race conditions by:
1. Returning an error (-EBUSY) to the user
2. Waiting for the file I/O to finish before closing and re-using the descriptor "newfd"

This would not be an issue if only the userspace would panic due to totally nonsensical use of dup2/3, but in our case the kernel will crash as the file description behind newfd changes unexpectedly -> when the device tries to access the file description it cannot find its inode nor its private data.

## Impact

Attempt to fix dup2() and dup3() system calls. Currently they have a race condition that causes the kernel to crash.
No impact to other APIs, documentation, user etc.

## Testing

MPFS target with BUILD_KERNEL and several processes / threads using dup2, write. Before this patch we get random crashes net_local and socket APIs due to disappearing file descriptors. With this patch we no longer crash.

rv-virt:ksmp64 ostest
rv-virt:knsh64 ostest

 


