### PR TITLE
boards/stm32h5/nucleo-h563zi: Add USART2 board defines.

### DIFF
--- a/boards/arm/stm32h5/nucleo-h563zi/include/board.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/include/board.h
@@ -251,16 +251,6 @@
 #define STM32_RCC_CCIPR5_ADCDACSEL RCC_CCIPR5_ADCDACSEL_PLL2RCK
 #define STM32_ADC_CLK_FREQUENCY    STM32_PLL2R_FREQUENCY
 
-#define GPIO_ADC1_IN3   (GPIO_ADC1_IN3_0)
-#define GPIO_ADC1_IN10  (GPIO_ADC1_IN10_0)
-
-/* USART3: Connected to Arduino connector D0/D1 (or to STLink VCP if solder
- * bridges SB123 to SB130 are re-worked accordingly).
- */
-
-#define GPIO_USART3_RX   GPIO_USART3_RX_4    /* PD9 */
-#define GPIO_USART3_TX   GPIO_USART3_TX_4    /* PD8 */
-
 /* LED definitions **********************************************************/
 
 /* The Nucleo board has numerous LEDs but only three, LD1 a Green LED,
@@ -324,6 +314,26 @@
 #define BUTTON_USER        0
 #define NUM_BUTTONS        1
 #define BUTTON_USER_BIT    (1 << BUTTON_USER)
+
+/* Alternate function pin selections ****************************************/
+
+/* ADC */
+
+#define GPIO_ADC1_IN3   (GPIO_ADC1_IN3_0)
+#define GPIO_ADC1_IN10  (GPIO_ADC1_IN10_0)
+
+/* USART3 (Nucleo Virtual Console): Default board solder bridge configuration
+ * has USART3 going to the on board ST-Link to provide a VCP. Refer to
+ * STMicro user manual [UM3115] for more info on solder bridge configuration.
+ */
+
+#define GPIO_USART3_RX   GPIO_USART3_RX_4    /* PD9 */
+#define GPIO_USART3_TX   GPIO_USART3_TX_4    /* PD8 */
+
+/* USART2 */
+
+#define GPIO_USART2_RX   GPIO_USART2_RX_2    /* PD6 */
+#define GPIO_USART2_TX   GPIO_USART2_TX_2    /* PD5 */
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION
This adds the ability to use USART2 as a console if wanting to use a console without going through the ST-Link VCOM port. This required when using an external debugger or trace with this board.

## Summary

The Nucleo H563ZI development board supports using an external debugger or trace over the onboard MIPI20 connector (CN5) when a jumper is applied to JP1. However, this removes RX from onboard ST-Link VCOM port. This change allows configuring USART2 as the serial console to allow full serial console connection when using an external debugger.

Also organized a couple of defines in `board.h` to align with their location in other STM32 board files.

## Impact

Makes Nucleo H563ZI board support compatible with external debuggers while maintaining serial console.

## Testing

- Host: Ubuntu 24.04 Docker container on Ubuntu 24.04 host (WSL2)
- Compiler: `arm-none-eabi-gcc (Arm GNU Toolchain 13.3.Rel1 (Build arm-13.24)) 13.3.1 20240614`
- Configuration: `nucleo-h563zi:nsh` with modifications:
  - Enable `USART2` in peripheral selection
  - Switch serial console to `USART2_SERIAL_CONSOLE`

NSH was confirmed to run over USART2.

This is the result of `make savedefconfig` including the tweaks to enable USART2 console:
```
#
# This file is autogenerated: PLEASE DO NOT EDIT IT.
#
# You can use "make menuconfig" to make any modifications to the installed .config file.
# You can then do "make savedefconfig" to generate a new defconfig file that includes your
# modifications.
#
# CONFIG_NSH_ARGCAT is not set
# CONFIG_STANDARD_SERIAL is not set
CONFIG_ARCH="arm"
CONFIG_ARCH_BOARD="nucleo-h563zi"
CONFIG_ARCH_BOARD_NUCLEO_H563ZI=y
CONFIG_ARCH_BUTTONS=y
CONFIG_ARCH_CHIP="stm32h5"
CONFIG_ARCH_CHIP_STM32H563ZI=y
CONFIG_ARCH_CHIP_STM32H5=y
CONFIG_ARCH_INTERRUPTSTACK=2048
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARMV8M_STACKCHECK=y
CONFIG_BOARD_LOOPSPERMSEC=9251
CONFIG_BUILTIN=y
CONFIG_DEBUG_ASSERTIONS=y
CONFIG_DEBUG_FEATURES=y
CONFIG_DEBUG_SYMBOLS=y
CONFIG_FS_PROCFS=y
CONFIG_FS_PROCFS_REGISTER=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_IDLETHREAD_STACKSIZE=2048
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_LINE_MAX=64
CONFIG_NSH_ARCHINIT=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_DISABLE_IFUPDOWN=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_RAM_SIZE=655360
CONFIG_RAM_START=0x20000000
CONFIG_RAW_BINARY=y
CONFIG_READLINE_CMD_HISTORY=y
CONFIG_READLINE_TABCOMPLETION=y
CONFIG_RR_INTERVAL=200
CONFIG_SCHED_WAITPID=y
CONFIG_STACK_COLORATION=y
CONFIG_STM32H5_USART2=y
CONFIG_STM32H5_USART3=y
CONFIG_SYSTEM_NSH=y
CONFIG_TASK_NAME_SIZE=0
CONFIG_USART2_SERIAL_CONSOLE=y
```
