### PR TITLE
sched/queue: fix typo in dq_insert_mid macro

### DIFF
--- a/sched/sched/queue.h
+++ b/sched/sched/queue.h
@@ -63,12 +63,12 @@
     } \
   while (0)
 
-#define dq_insert_mid(pre, mid, next) \
+#define dq_insert_mid(prev, mid, next) \
   do \
     { \
       mid->flink = next; \
       mid->blink = prev; \
-      pre->flink = mid; \
+      prev->flink = mid; \
       next->blink = mid; \
     } \
   while (0)


### PR DESCRIPTION
## Summary

`pre` vs `prev` macro param mismatch 

## Impact

Was only used in `nxsched_process_delivered` and by coincidental match of variable `prev` already  defined in the scope  worked fine.

