### PR TITLE
arch/arm/rp23xx: add missing fpu init for smp cores

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_cpustart.c
+++ b/arch/arm/src/rp23xx/rp23xx_cpustart.c
@@ -144,6 +144,8 @@ static void core1_boot(void)
   arm_initialize_stack();
 #endif
 
+  arm_fpuconfig();
+
   fifo_drain();
 
   /* Setup NVIC */


### PR DESCRIPTION
## Summary

On SMP systems we should enable FPU on each core

FPU extenstion support must be enabled on each core as stated on 4.6.5 arm m33 devices generic user guide.