### PR TITLE
arch/arm64/imx9: Support for AHAB authentication + ROMAPI

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -32,6 +32,7 @@ ignore-words-list =
   hart,
   hsi,
   iif,
+  infor,
   inport,
   lod,
   mot,

--- a/arch/arm64/include/imx9/imx9_ahab.h
+++ b/arch/arm64/include/imx9/imx9_ahab.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/arm64/include/imx9/imx9_ahab.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H
+#define __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <imx_container.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ahab_auth_release
+ *
+ * Description:
+ *   Release the current container used by ELE for AHAB.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int ahab_auth_release(void);
+
+/****************************************************************************
+ * Name: ahab_read_auth_image
+ *
+ * Description:
+ *   Copy to RAM, then authenticate the image_index image of the container.
+ *
+ * Input Parameters:
+ *   container - Pointer to a copy of the AHAB container header in RAM.
+ *   image_index - The index of the image in the current container.
+ *   container_offset - Offset of the container in the boot device.
+ *
+ * Returned Value:
+ *   NULL pointer for failure, otherwise a pointer to the beginning of the
+ *   authenticated, image's header.
+ *
+ ****************************************************************************/
+
+struct boot_img_hdr *ahab_read_auth_image(struct container_hdr *container,
+                                          int image_index,
+                                          unsigned long container_offset);
+
+#endif /* __ARCH_ARM64_INCLUDE_IMX9_IMX9_AHAB_H */

--- a/arch/arm64/include/imx9/imx9_romapi.h
+++ b/arch/arm64/include/imx9/imx9_romapi.h
@@ -1,0 +1,153 @@
+/****************************************************************************
+ * arch/arm64/include/imx9/imx9_romapi.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H
+#define __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* infor_type values for imx9_rom_api_query_boot_infor(). */
+
+#define QUERY_ROM_VER    1
+#define QUERY_BOOT_DEV   2
+#define QUERY_PAGE_SZ    3
+#define QUERY_IVT_OFF    4
+#define QUERY_BOOT_STAGE 5
+#define QUERY_IMG_OFF    6
+
+/* Native return values from ROM API. */
+
+#define  ROMAPI_INVALID_PARA         1
+#define  ROMAPI_READ_FAILURE         2
+#define  ROMAPI_DEVICE_NOT_READY     3
+#define  ROMAPI_OUT_OF_DEVICE_MEMORY 4
+#define  ROMAPI_OK                   0xf0
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Boot device types returned by ROM API (i.MX93). */
+
+enum imx9_romapi_bootdev_e
+{
+  BOOTDEV_SD           = 1,
+  BOOTDEV_MMC          = 2,
+  BOOTDEV_NAND         = 3,
+  BOOTDEV_FLEXSPI_NOR  = 4,
+  BOOTDEV_SPI_NOR      = 6,
+  BOOTDEV_FLEXSPI_NAND = 8,
+  BOOTDEV_USB          = 0xe,
+  BOOTDEV_MEM_DEV      = 0xf,
+  BOOTDEV_INVALID      = 0xff
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_romapi_load_image
+ *
+ * Description:
+ *   Use the i.MX9 ROM API, to copy data from the boot device to memory.
+ *
+ * Input Parameters:
+ *   dest - Copy destination.
+ *   offset - Offset from boot device to copy from.
+ *   size - Size in bytes to copy.
+ *
+ * Returned Value:
+ *   ROMAPI_OK - Success.
+ *   ROMAPI_INVALID_PARA - Invalid parameters.
+ *   ROMAPI_READ_FAILURE - Low level device read failure.
+ *   ROMAPI_DEVICE_NOT_READY - The device isn't initialized or is invalid.
+ *   ROMAPI_OUT_OF_DEVICE_MEMORY - Attempted to read data outside of the
+ *   boot device's memory.
+ *
+ ****************************************************************************/
+
+uint32_t imx9_romapi_load_image(uint8_t *dest, uint32_t offset,
+                                uint32_t size);
+
+/****************************************************************************
+ * Name: imx9_romapi_query_boot_infor
+ *
+ * Description:
+ *   Query information from the ROM API.
+ *
+ * Input Parameters:
+ *   infor_type - Type of information to query.
+ *   infor -  Points to the word to save the queried information.
+ *
+ * Returned Value:
+ *   ROMAPI_OK - Success.
+ *   ROMAPI_INVALID_PARA - Invalid parameters.
+ *
+ ****************************************************************************/
+
+uint32_t imx9_romapi_query_boot_infor(uint32_t infor_type, uint32_t *infor);
+
+/****************************************************************************
+ * Name: imx9_romapi_get_boot_device
+ *
+ * Description:
+ *   Get the boot device type.
+ *
+ * Returned Value:
+ *   The device type.
+ *
+ ****************************************************************************/
+
+enum imx9_romapi_bootdev_e imx9_romapi_get_boot_device(void);
+
+/****************************************************************************
+ * Name: imx9_romapi_get_seq_cntr_base
+ *
+ * Description:
+ *   Get the offset in bytes from the boot device of the cntr_idx container.
+ *   The containers are assumed to be sequential in the boot device's
+ *   memory.
+ *
+ * Input Parameters:
+ *   image_offset - Image offset of the first container in the boot device.
+ *   pagesize - Pagesize of the boot device.
+ *   cntr_idx - Index of the container.
+ *
+ * Returned Value:
+ *   The offset from the boot device in bytes of the cntr_idx container.
+ *   -1 is returned in case of error.
+ *
+ ****************************************************************************/
+
+int64_t imx9_romapi_get_seq_cntr_base(uint32_t image_offset,
+                                      uint32_t pagesize,
+                                      uint8_t cntr_idx);
+#endif /* __ARCH_ARM64_INCLUDE_IMX9_IMX9_ROMAPI_H */

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -100,6 +100,13 @@ ifeq ($(CONFIG_MM_KASAN_DISABLE_WRITES_CHECK),y)
   ARCHOPTIMIZATION += --param asan-instrument-writes=0
 endif
 
+# If we don't use MMU, all memory is treated as device memory and can't handle
+# alignment faults. Some compiler builtins like memset() can introduce
+# alignment faults. We need to disable them in that case.
+ifneq ($(CONFIG_ARCH_USE_MMU),y)
+  ARCHOPTIMIZATION += -fno-builtin
+endif
+
 # Instrumentation options
 
 ifeq ($(CONFIG_ARCH_INSTRUMENT_ALL),y)

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -195,6 +195,10 @@ if(CONFIG_DEBUG_SYMBOLS)
   add_compile_options(${CONFIG_DEBUG_SYMBOLS_LEVEL})
 endif()
 
+if(NOT CONFIG_ARCH_USE_MMU)
+  add_compile_options(-fno-builtin)
+endif()
+
 if(CONFIG_ARCH_TOOLCHAIN_GNU AND NOT CONFIG_ARCH_TOOLCHAIN_CLANG)
   if(NOT GCCVER)
     execute_process(COMMAND ${CMAKE_C_COMPILER} --version

--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -64,8 +64,8 @@ config IMX9_HAVE_ATF_FIRMWARE
 	select ARM64_HAVE_PSCI
 	---help---
 		Configure this n if using Nuttx bootloader that does not
-		implemet EL3 services, by default this is y when using uboot as
-		a booloader
+		implement EL3 services, by default this is y when using uboot as
+		a bootloader
 
 config IMX9_BOOTLOADER
 	bool "Bootloader"
@@ -839,7 +839,7 @@ config IMX9_LPI2C_DMA_MAXMSG
 	default 8
 	depends on IMX9_LPI2C_DMA
 	---help---
-		This option set the mumber of mesg that can be in a transfer.
+		This option set the number of mesg that can be in a transfer.
 		It is used to allocate space for the 16 bit LPI2C commands
 		that will be DMA-ed to the LPI2C device.
 

--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -91,6 +91,30 @@ config IMX9_DDR_TRAINING
 	---help---
 		Perform DDR training to prepare the external memory for use.
 
+config IMX9_ROMAPI
+	bool "ROM API functionality"
+	depends on IMX9_BOOTLOADER
+	default n
+	---help---
+		Enable wrappers that call the on‑chip ROM API for image download
+		and boot‑information queries. Required for AHAB secure boot
+		unless an alternative generic device loader is supplied.
+
+config IMX9_AHAB_BOOT
+	bool "Support i.MX9 AHAB features"
+	depends on IMX9_BOOTLOADER
+	select IMX9_ROMAPI  # AHAB needs a loader; ROMAPI is the default
+	default n
+	---help---
+		Enable AHAB functionality
+
+config IMX_AHAB_CNTR_ADDR
+	hex "Load address of the AHAB container in RAM"
+	depends on IMX9_AHAB_BOOT
+	default 0x80000000
+	---help---
+		Physical address where the AHAB container header is loaded into memory.
+
 menu "i.MX9 Peripheral Selection"
 
 config IMX9_EDMA

--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -89,6 +89,14 @@ ifeq ($(CONFIG_IMX9_BOOTLOADER), y)
   CHIP_CSRCS += imx9_ele.c
 endif
 
+ifeq ($(CONFIG_IMX9_ROMAPI), y)
+  CHIP_CSRCS += imx9_romapi.c
+endif
+
+ifeq ($(CONFIG_IMX9_AHAB_BOOT), y)
+  CHIP_CSRCS += imx9_ahab.c
+endif
+
 ifeq ($(CONFIG_IMX9_DDR_TRAINING),y)
   CHIP_CSRCS += $(DDR_CSRCS)
 endif

--- a/arch/arm64/src/imx9/hardware/imx9_ele.h
+++ b/arch/arm64/src/imx9/hardware/imx9_ele.h
@@ -33,16 +33,19 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ELE_MAX_MSG             255U
-#define AHAB_VERSION            0x6
-#define AHAB_CMD_TAG            0x17
-#define AHAB_RESP_TAG           0xe1
-#define ELE_RELEASE_RDC_REQ     0xc4
-#define ELE_READ_FUSE_REQ       0x97
-#define ELE_GET_EVENTS          0xa2
-#define ELE_DERIVE_KEY_REQ      0xa9
-#define ELE_FWD_LIFECYCLE_UP    0x95
-#define ELE_OK                  0xd6
+#define ELE_MAX_MSG               255U
+#define AHAB_VERSION              0x6
+#define AHAB_CMD_TAG              0x17
+#define AHAB_RESP_TAG             0xe1
+#define ELE_RELEASE_RDC_REQ       0xc4
+#define ELE_READ_FUSE_REQ         0x97
+#define ELE_GET_EVENTS_REQ        0xa2
+#define ELE_DERIVE_KEY_REQ        0xa9
+#define ELE_FWD_LIFECYCLE_UP_REQ  0x95
+#define ELE_OEM_CNTN_AUTH_REQ     0x87
+#define ELE_VERIFY_IMAGE_REQ      0x88
+#define ELE_RELEASE_CONTAINER_REQ 0x89
+#define ELE_OK                    0xd6
 
 #define ELE_MU_TCR (IMX9_S3MUA_BASE + 0x120)
 #define ELE_MU_TSR (IMX9_S3MUA_BASE + 0x124)

--- a/arch/arm64/src/imx9/imx9_ahab.c
+++ b/arch/arm64/src/imx9/imx9_ahab.c
@@ -1,0 +1,120 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_ahab.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <debug.h>
+#include <stdio.h>
+#include <nuttx/nuttx.h>
+#include <nuttx/arch.h>
+#include "imx9_ele.h"
+#include <arch/imx9/imx9_romapi.h>
+#include <arch/imx9/imx9_ahab.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+struct boot_img_hdr *ahab_read_auth_image(struct container_hdr *container,
+                                          int image_index,
+                                          unsigned long container_offset)
+{
+  struct boot_img_hdr *images;
+  unsigned long offset;
+  unsigned long size;
+
+  _info("Image index is %d number of container images are %hhu\n",
+        image_index, container->num_images);
+  if (image_index > container->num_images)
+    {
+      _info("[%s]: Invalid image number\n", __func__);
+      return NULL;
+    }
+
+  images = (struct boot_img_hdr *)((uint8_t *)container +
+           sizeof(struct container_hdr));
+
+  uint32_t ret;
+  uint32_t pagesize;
+  ret = imx9_romapi_query_boot_infor(QUERY_PAGE_SZ, &pagesize);
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Failed to query pagesize\n", __func__);
+      return NULL;
+    }
+
+  if (!IS_ALIGNED(images[image_index].offset, pagesize))
+    {
+      _err("[%s]: image%d offset not aligned to %u\n", __func__,
+           image_index, pagesize);
+      return NULL;
+    }
+
+  size = ALIGN_UP(images[image_index].size, pagesize);
+
+  offset = images[image_index].offset + container_offset;
+
+  _info("[%s]: container: %p offset: %lu size: %lu\n", __func__,
+        container, offset, size);
+
+  imx9_romapi_load_image((uint8_t *)images[image_index].dst, offset,
+                          size);
+
+  /* Flush the cache so ELE can read from RAM the updated values. */
+
+  up_flush_dcache((unsigned long)images[image_index].dst,
+                  images[image_index].dst + size);
+
+  uint32_t respo;
+  if (imx9_ele_verify_image(image_index, &respo))
+    {
+      _err("[%s]: Failed with response %x\n", __func__, respo);
+      return NULL;
+    }
+  else
+    {
+      _info("[%s]: Image successfully verified.", __func__);
+    }
+
+  return &images[image_index];
+}
+
+int ahab_auth_release(void)
+{
+  int err;
+  uint32_t resp;
+
+  err = imx9_ele_release_container(&resp);
+  if (err)
+    {
+      _err("[%s]: ELE error 0x%x\n", __func__, resp);
+    }
+  else
+    {
+      _info("[%s]: Container successfully released\n", __func__);
+    }
+
+  return err;
+}

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -142,9 +142,11 @@ void arm64_chip_boot(void)
 #endif
 #endif
 
+#ifdef CONFIG_ARCH_USE_MMU
   /* MAP IO and DRAM, enable MMU. */
 
   arm64_mmu_init(true);
+#endif
 
   /* Do UART early initialization & pin muxing */
 

--- a/arch/arm64/src/imx9/imx9_ele.c
+++ b/arch/arm64/src/imx9/imx9_ele.c
@@ -267,7 +267,7 @@ int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size)
   msg.header.version = AHAB_VERSION;
   msg.header.tag = AHAB_CMD_TAG;
   msg.header.size = 1;
-  msg.header.command = ELE_GET_EVENTS;
+  msg.header.command = ELE_GET_EVENTS_REQ;
 
   imx9_ele_sendmsg(&msg);
   imx9_ele_receivemsg(&msg);
@@ -298,7 +298,7 @@ int imx9_ele_close_device(void)
   msg.header.version = AHAB_VERSION;
   msg.header.tag = AHAB_CMD_TAG;
   msg.header.size = 2;
-  msg.header.command = ELE_FWD_LIFECYCLE_UP;
+  msg.header.command = ELE_FWD_LIFECYCLE_UP_REQ;
   msg.data[0] = 0x08;
 
   imx9_ele_sendmsg(&msg);
@@ -317,3 +317,73 @@ uint32_t imx9_ele_get_lifecycle(void)
   return (getreg32(FSB_LC_REG) & 0x3ff);
 }
 
+int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 3;
+  msg.header.command = ELE_OEM_CNTN_AUTH_REQ;
+  msg.data[0] = upper_32_bits(ctnr_addr);
+  msg.data[1] = lower_32_bits(ctnr_addr);
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_release_container(uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 1;
+  msg.header.command = ELE_RELEASE_CONTAINER_REQ;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}
+
+int imx9_ele_verify_image(uint32_t img_id, uint32_t *response)
+{
+  msg.header.version = AHAB_VERSION;
+  msg.header.tag = AHAB_CMD_TAG;
+  msg.header.size = 2;
+  msg.header.command = ELE_VERIFY_IMAGE_REQ;
+  msg.data[0] = 1 << img_id;
+
+  imx9_ele_sendmsg(&msg);
+  imx9_ele_receivemsg(&msg);
+
+  if (response)
+    {
+      *response = msg.data[0];
+    }
+
+  if ((msg.data[0] & 0xff) == ELE_OK)
+    {
+      return 0;
+    }
+
+  return -EIO;
+}

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -126,7 +126,7 @@ int imx9_ele_get_key(uint8_t *key, size_t key_size,
  *   buffer_size   -  Event buffer size
  *
  * Returned Value:
- *  Zero (OK) is returned if no envents success. A negated errno value
+ *  Zero (OK) is returned if no events success. A negated errno value
  *  is returned on failure. Positive value is number of events read.
  *
  ****************************************************************************/
@@ -143,7 +143,7 @@ int imx9_ele_get_events(uint32_t *buffer, size_t buffer_size);
  *   OEM close state. This operation is irreversible.
  *
  * Returned Value:
- *  Zero (OK) is returned if no envents success. A negated errno value
+ *  Zero (OK) is returned if no events success. A negated errno value
  *  is returned on failure.
  *
  ****************************************************************************/

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -163,4 +163,60 @@ int imx9_ele_close_device(void);
 
 uint32_t imx9_ele_get_lifecycle(void);
 
+/****************************************************************************
+ * Name: imx9_ele_auth_oem_ctnr
+ *
+ * Description:
+ *   Authenticate container header.
+ *
+ * Input Parameters:
+ *   ctnr_addr - Address of the container header.
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_auth_oem_ctnr(unsigned long ctnr_addr, uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_release_container
+ *
+ * Description:
+ *   Release the container from the ELE, used after imx9_ele_auth_oem_ctnr().
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_release_container(uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_verify_image
+ *
+ * Description:
+ *   Verify the specified image, for the current container.
+ *
+ * Input Parameters:
+ *   img_id - The id of the image in the context of the current container.
+ *
+ * Output Parameters:
+ *   response - ELE response, can be used for debugging.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_verify_image(uint32_t img_id, uint32_t *response);
 #endif /* __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H */

--- a/arch/arm64/src/imx9/imx9_romapi.c
+++ b/arch/arm64/src/imx9/imx9_romapi.c
@@ -1,0 +1,171 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx9_romapi.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <arch/imx9/imx9_romapi.h>
+#include <nuttx/nuttx.h>
+#include <imx_container.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* i.MX9 ROM API structure. */
+
+struct romapi_s
+{
+  uint16_t ver;
+  uint16_t tag;
+  uint32_t reserved1;
+  uint32_t (*load_image)(uint8_t *dest, uint32_t offset, uint32_t size,
+                         uint32_t xor);
+  uint32_t (*query_boot_infor)(uint32_t infor_type, uint32_t *infor,
+                               uint32_t xor);
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Physical address of the ROM api. */
+
+static struct romapi_s *imx9_romapi_s = (struct romapi_s *)0x1980;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+uint32_t imx9_romapi_load_image(uint8_t *dest, uint32_t offset,
+                                uint32_t size)
+{
+  uint32_t xor;
+  uint32_t ret;
+
+  xor = (uintptr_t)dest ^ offset ^ size;
+  ret = imx9_romapi_s->load_image(dest, offset, size, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Couldn't download image.", __func__);
+    }
+
+  return ret;
+}
+
+uint32_t imx9_romapi_query_boot_infor(uint32_t infor_type, uint32_t *infor)
+{
+  uint32_t ret;
+  uint32_t xor;
+
+  xor = infor_type ^ (uintptr_t)infor;
+  ret = imx9_romapi_s->query_boot_infor(infor_type, infor, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      _err("[%s]: Couldn't query boot info.", __func__);
+    }
+
+  return ret;
+}
+
+enum imx9_romapi_bootdev_e imx9_romapi_get_boot_device(void)
+{
+  int ret;
+  uint32_t boot;
+  enum imx9_romapi_bootdev_e boot_type;
+  uint32_t xor = (uintptr_t)&boot ^ QUERY_BOOT_DEV;
+
+  ret = imx9_romapi_s->query_boot_infor(QUERY_BOOT_DEV, &boot, xor);
+
+  if (ret != ROMAPI_OK)
+    {
+      return BOOTDEV_INVALID;
+    }
+
+  boot_type = boot >> 16;
+
+  switch (boot_type)
+    {
+      case BOOTDEV_SD:
+        break;
+      case BOOTDEV_MMC:
+        break;
+      case BOOTDEV_NAND:
+        break;
+      case BOOTDEV_FLEXSPI_NOR:
+        break;
+      case BOOTDEV_SPI_NOR:
+        break;
+      case BOOTDEV_FLEXSPI_NAND:
+        break;
+      case BOOTDEV_USB:
+        break;
+      case BOOTDEV_MEM_DEV:
+        break;
+      default:
+        _err("[%s]: Invalid boot device.\n", __func__);
+        boot_type = BOOTDEV_INVALID;
+        break;
+    }
+
+  return boot_type;
+}
+
+int64_t imx9_romapi_get_seq_cntr_base(uint32_t image_offset,
+                                      uint32_t pagesize,
+                                      uint8_t cntr_idx)
+{
+  uint32_t size;
+  uint32_t ret;
+  uint16_t cntr_size;
+  struct container_hdr *hdr;
+
+  size = ALIGN_UP(sizeof(struct container_hdr), pagesize);
+  hdr = (struct container_hdr *)(CONFIG_IMX_AHAB_CNTR_ADDR);
+
+  if (CONTAINER_HDR_ALIGNMENT % pagesize != 0)
+    {
+      _err("[%s]: Unsupported pagesize.\n", __func__);
+      return -1;
+    }
+
+  for (uint8_t i = 0; i < cntr_idx; i++)
+    {
+      ret = imx9_romapi_load_image((uint8_t *)CONFIG_IMX_AHAB_CNTR_ADDR,
+                                       image_offset, size);
+      if (ret != ROMAPI_OK)
+        {
+          _err("[%s]: Failure at iteration %hhu\n", __func__, i);
+          return -1;
+        }
+
+      cntr_size = hdr->length_lsb + (hdr->length_msb << 8);
+      image_offset = ALIGN_UP((cntr_size + image_offset),
+                              CONTAINER_HDR_ALIGNMENT);
+    }
+
+  return image_offset;
+}

--- a/include/imx_container.h
+++ b/include/imx_container.h
@@ -1,0 +1,129 @@
+/****************************************************************************
+ * include/imx_container.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_IMX_CONTAINER_H
+#define __INCLUDE_IMX_CONTAINER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IV_MAX_LEN                 32
+#define HASH_MAX_LEN               64
+
+#define CONTAINER_HDR_ALIGNMENT    0x400
+#define CONTAINER_HDR_EMMC_OFFSET  0
+#define CONTAINER_HDR_MMCSD_OFFSET SZ_32K
+#define CONTAINER_HDR_QSPI_OFFSET  SZ_4K
+#define CONTAINER_HDR_NAND_OFFSET  SZ_128M
+
+#define CONTAINER_HDR_TAG          0x87
+#define CONTAINER_HDR_VERSION      0
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* i.MX AHAB container header. */
+
+begin_packed_struct struct container_hdr
+{
+  uint8_t  version;
+  uint8_t  length_lsb;
+  uint8_t  length_msb;
+  uint8_t  tag;
+  uint32_t flags;
+  uint16_t sw_version;
+  uint8_t  fuse_version;
+  uint8_t  num_images;
+  uint16_t sig_blk_offset;
+  uint16_t reserved;
+} end_packed_struct;
+
+/* i.MX AHAB container, image header. */
+
+begin_packed_struct struct boot_img_hdr
+{
+  uint32_t offset;
+  uint32_t size;
+  uint64_t dst;
+  uint64_t entry;
+  uint32_t hab_flags;
+  uint32_t meta;
+  uint8_t  hash[HASH_MAX_LEN];
+  uint8_t  iv[IV_MAX_LEN];
+} end_packed_struct;
+
+/* i.MX AHAB container, signature block header. */
+
+begin_packed_struct struct signature_block_hdr
+{
+  uint8_t  version;
+  uint8_t  length_lsb;
+  uint8_t  length_msb;
+  uint8_t  tag;
+  uint16_t srk_table_offset;
+  uint16_t cert_offset;
+  uint16_t blob_offset;
+  uint16_t signature_offset;
+  uint32_t reserved;
+} end_packed_struct;
+
+/* Header used for the generation of an encrypted key blob from ELE. */
+
+begin_packed_struct struct generate_key_blob_hdr
+{
+  uint8_t version;
+  uint8_t length_lsb;
+  uint8_t length_msb;
+  uint8_t tag;
+  uint8_t flags;
+  uint8_t size;
+  uint8_t algorithm;
+  uint8_t mode;
+} end_packed_struct;
+
+/****************************************************************************
+ * Name: imx_valid_container_hdr
+ *
+ * Description:
+ *   Simple validation of the container header.
+ *
+ * Returned Value:
+ *   true for Success, otherwise false
+ *
+ ****************************************************************************/
+
+static inline bool imx_valid_container_hdr(struct container_hdr *container)
+{
+    return container->tag == CONTAINER_HDR_TAG &&
+           container->version == CONTAINER_HDR_VERSION;
+}
+#endif /* __INCLUDE_IMX_CONTAINER_H */


### PR DESCRIPTION
## Summary

This PR extends the i.MX9 ELE API with commands required for AHAB authentication. A new file, `imx9_ahab.c`, encapsulates the AHAB-specific image authentication logic, building on top of the lower-level ELE API.

In addition, `imx9_romapi.c` introduces support for the i.MX ROM API to enable boot device–agnostic image loading. This allows BL2 to load container headers from the boot device and authenticate them using the new AHAB and ELE infrastructure. **For now the ROM API is required by AHAB boot to load the images from the boot device.**

Finally, this PR adds an option to disable MMU support for i.MX9 builds. Disabling the MMU is appropriate in BL2/SPL stages, where TF-A will reinitialize the MMU in EL3, rendering early setup redundant. Omitting the MMU also reduces memory usage by ~50 KB in some cases, depending on the size of the translation tables.


## Impact
There is no impact on existing builds since the new functionality is guarded by `CONFIG_IMX9_ROMAPI` and `IMX9_AHAB_BOOT`. The modification on imx9_ele.[ch] simply extends the current functionality.

The MMU disablement however, requires usage of `CONFIG_ARCH_USE_MMU=y` which is sometimes mistaken with `CONFIG_ARCH_HAVE_MMU`. imx9 builds that don't use `CONFIG_ARCH_USE_MMU=y ` will now run with the MMU disabled.
Imx9 builds with `CONFIG_ARCH_USE_MMU=y`  will not be affected.


## Testing
### Hardware:
Custom i.MX93 board booting from FLEXSPI NOR. (Other boot devices, like NAND were not tested).

### Software:
Various tests have been done using several images of TF-A (Bl31), optee(BL32), BL33.
For the tests `tools/imx9/Config.mk` was modified to generate a multi-image container, i.e:
`
	$(Q) tools$(DELIM)imx9$(DELIM)mkimage_imx9$(HOSTEXEEXT) -soc IMX9 -dev flexspi -append $(BASE_PATH)$(AHAB)$(DELIM)mx93a1-ahab-container.img -c -ap nuttx.bin a55 0x2049a000 -c -ap ../../imx-atf/build/imx93/debug/bl31.bin a55 0x204e0000 -ap ../../imx-optee-os/build.imx-mx93evk/core/tee-raw.bin a55 0x96000000 -ap bl33_image a55 0x80200000 -out flash.bin`

The functionality provided by the PR still needs a bootloader implementation that uses them, the following logs are from my custom bootloader.

Sample logs:

```
[BL2/SPL terminal output]
image offset 0x1000, pagesize 0x1, ivt offset 0x0
ATF cntr image header is valid!

Image index is 0 number of container images are 3
[read_auth_image]: container: 0x80000000 offset: 284672 size: 61440
[read_auth_image]: Image succesfully verified.

Image index is 1 number of container images are 3
[read_auth_image]: container: 0x80000000 offset: 346112 size: 585728
[read_auth_image]: Image succesfully verified.

Image index is 2 number of container images are 3
[read_auth_image]: container: 0x80000000 offset: 931840 size: 267264
[read_auth_image]: Image succesfully verified.
[ahab_auth_release]: Container sucessfully released
jumping 204e0000...

[BL31/ IMX-ATF]
NOTICE:  TRDC init done
NOTICE:  BL31: v2.10.0	(debug):android-15.0.0_1.2.0-dirty
NOTICE:  BL31: Built : 15:03:23, May  6 2025
INFO:    GICv3 without legacy support detected.
INFO:    ARM GICv3 driver initialized in EL3
INFO:    Maximum SPI INTID supported: 991
INFO:    BL31: Initializing runtime services
WARNING: BL31: cortex_a55: CPU workaround for erratum 1530923 was missing!
INFO:    BL31: Initializing BL32
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x80200000
[BL32/optee logs were disabled]

[BL33 Logs/PX4]
[boot] Rev 0x0 : Ver 0x1 SalukiNXP93001000
Initializing SDIO slot 0
Bind SDIO to the MMC/SD driver, minor=0
ERROR: Failed to mount procfs at /proc: -1
gimbal [0:100]
gps [0:100]
hott_sensors [0:100]
hott_telemetry [0:100]
airspeed_selector [0:100]
cdcacm [0:100]
commander [0:100]
control_allocator [0:100]
dataman [0:100]
send_event [0:100]
flight_mode_manager [0:100]
gyro_calibration [0:100]
land_detector [0:100]
landing_target_estimator [0:100]
local_position_estimator [0:100]
logger [0:100]
mavlink [0:100]
mc_hover_thrust_estimator [0:100]
mc_pos_control [0:100]
navigator [0:100]
rc_update [0:100]
[...]

```



