### PR TITLE
sched/signal: signal dispatch cleanups

### DIFF
--- a/sched/signal/sig_allocpendingsigaction.c
+++ b/sched/signal/sig_allocpendingsigaction.c
@@ -80,22 +80,6 @@ FAR sigq_t *nxsig_alloc_pendingsigaction(void)
       flags = enter_critical_section();
       sigq = (FAR sigq_t *)sq_remfirst(&g_sigpendingaction);
       leave_critical_section(flags);
-
-      /* Check if we got one. */
-
-      if (!sigq)
-        {
-          /* No...Try the resource pool */
-
-          sigq = kmm_malloc(sizeof(sigq_t));
-
-          /* Check if we got an allocated message */
-
-          if (sigq)
-            {
-              sigq->type = SIG_ALLOC_DYN;
-            }
-        }
     }
 
   return sigq;

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -542,7 +542,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
               wd_cancel(&stcb->waitdog);
             }
 
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_waitingforsignal());
 
@@ -604,7 +604,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
               wd_cancel(&stcb->waitdog);
             }
 
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_waitingforsignal());
 
@@ -664,7 +664,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
 #ifdef HAVE_GROUP_MEMBERS
           group_continue(stcb);
 #else
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_stoppedtasks());
 


### PR DESCRIPTION
## Summary

The critical section scope was widened before to avoid race conditions between signal dispatch and signal delivery,
which were especially harmful for SMP systems (but exist also for single CPU).

This PR makes the scope a bit smaller by removing thigs which don't need to be inside the critical section, to more
appropriate places.

The nxsig_find_action can be done before entering the protected section, and the found action can be just passed in.

The memory allocations which are done as a backup if one runs out of preallocated pending structures can be done
beforehand, and the dynamically allocated structures simply injected into the free structure lists. This has the downside
that it may leave a dynamically allocated pending structure in the free list for some period of time, in case it is not needed after all. But this is not an issue, it is freed eventually in case it gets used.

## Impact

This is unlikely to have any impact in testing, since typically the preallocated pending structures never run out. But this makes the critical section a bit smaller again by re-structuring things which are not needed to be in the critical section outside.

In the case of really running out of pre-allocated pending structures, this removes a rare, but potential race condition between dispatch and delivery, if the dispatch leaves critical section in the middle of the logic by sleeping on heap mutex.

## Testing

Tested on qemu rv-virt:smp, and on real HW (MPFS). The memory allocation has been tested by hacking the "NUM_PENDING_ACTIONS" and "NUM_SIGNALS_PENDING" to 1 and to 0, to force allocations, and tested with ostest.

