### PR TITLE
sched/signal: Fix signal delivered to a wrong thread

### DIFF
--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -109,7 +109,7 @@ static int group_signal_handler(pid_t pid, FAR void *arg)
        * receive the signal.
        */
 
-      ret = nxsig_tcbdispatch(tcb, info->siginfo);
+      ret = nxsig_tcbdispatch(tcb, info->siginfo, true);
       if (ret < 0)
         {
           return ret;
@@ -150,7 +150,7 @@ static int group_signal_handler(pid_t pid, FAR void *arg)
            * blocking the signal will receive the signal.
            */
 
-          ret = nxsig_tcbdispatch(tcb, info->siginfo);
+          ret = nxsig_tcbdispatch(tcb, info->siginfo, true);
           if (ret < 0)
             {
               return ret;
@@ -257,7 +257,7 @@ int group_signal(FAR struct task_group_s *group, FAR siginfo_t *siginfo)
 
       /* Now deliver the signal to the selected group member */
 
-      ret = nxsig_tcbdispatch(tcb, siginfo);
+      ret = nxsig_tcbdispatch(tcb, siginfo, true);
     }
 
 errout:

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -498,7 +498,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
               wd_cancel(&stcb->waitdog);
             }
 
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_waitingforsignal());
 
@@ -560,7 +560,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
               wd_cancel(&stcb->waitdog);
             }
 
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_waitingforsignal());
 
@@ -620,7 +620,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
 #ifdef HAVE_GROUP_MEMBERS
           group_continue(stcb);
 #else
-          /* Remove the task from waitting list */
+          /* Remove the task from waiting list */
 
           dq_rem((FAR dq_entry_t *)stcb, list_stoppedtasks());
 

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -332,7 +332,8 @@ static void nxsig_dispatch_kernel_action(FAR struct tcb_s *stcb,
  ****************************************************************************/
 
 static FAR sigpendq_t *nxsig_add_pendingsignal(FAR struct tcb_s *stcb,
-                                               FAR siginfo_t *info)
+                                               FAR siginfo_t *info,
+                                               bool group_dispatch)
 {
   FAR struct task_group_s *group;
   FAR sigpendq_t *sigpend;
@@ -362,6 +363,12 @@ static FAR sigpendq_t *nxsig_add_pendingsignal(FAR struct tcb_s *stcb,
           /* Put the signal information into the allocated structure */
 
           memcpy(&sigpend->info, info, sizeof(siginfo_t));
+
+          /* Mark the tcb which need to receive the signal. If any
+           * thread in the group may receive it, set it to NULL
+           */
+
+          sigpend->tcb = group_dispatch ? NULL : stcb;
 
           /* Add the structure to the group pending signal list */
 
@@ -400,7 +407,8 @@ static FAR sigpendq_t *nxsig_add_pendingsignal(FAR struct tcb_s *stcb,
  *
  ****************************************************************************/
 
-int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
+int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
+                      bool group_dispatch)
 {
   FAR struct tcb_s *rtcb = this_task();
   irqstate_t flags;
@@ -508,7 +516,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
 
           if (masked == 0)
             {
-              sigpend = nxsig_add_pendingsignal(stcb, info);
+              sigpend = nxsig_add_pendingsignal(stcb, info, group_dispatch);
             }
 #endif
         }
@@ -519,7 +527,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
 
       else
         {
-          sigpend = nxsig_add_pendingsignal(stcb, info);
+          sigpend = nxsig_add_pendingsignal(stcb, info, group_dispatch);
         }
     }
 
@@ -716,7 +724,7 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
 
           if (stcb != NULL && group == this_task()->group)
             {
-              return nxsig_tcbdispatch(stcb, info);
+              return nxsig_tcbdispatch(stcb, info, false);
             }
         }
       else
@@ -742,7 +750,7 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
       return -ESRCH;
     }
 
-  return nxsig_tcbdispatch(stcb, info);
+  return nxsig_tcbdispatch(stcb, info, false);
 
 #endif
 }

--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -86,10 +86,13 @@ sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
 
   if (stcb == NULL)
     {
-      stcb = this_task();
+      group = this_task()->group;
+    }
+  else
+    {
+      group = stcb->group;
     }
 
-  group = stcb->group;
   DEBUGASSERT(group);
 
   sigemptyset(&sigpendset);
@@ -98,7 +101,10 @@ sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
   for (sigpend = (FAR sigpendq_t *)group->tg_sigpendingq.head;
        (sigpend); sigpend = sigpend->flink)
     {
-      nxsig_addset(&sigpendset, sigpend->info.si_signo);
+      if (stcb == NULL || sigpend->tcb == NULL || stcb == sigpend->tcb)
+        {
+          nxsig_addset(&sigpendset, sigpend->info.si_signo);
+        }
     }
 
   leave_critical_section(flags);

--- a/sched/signal/sig_removependingsignal.c
+++ b/sched/signal/sig_removependingsignal.c
@@ -63,9 +63,14 @@ FAR sigpendq_t *nxsig_remove_pendingsignal(FAR struct tcb_s *stcb, int signo)
 
   flags = enter_critical_section();
 
+  /* If stcb == NULL, the signal is for whole group. Otherwise only
+   * remove the one which is to be delivered to the stcb
+   */
+
   for (prevsig = NULL,
        currsig = (FAR sigpendq_t *)group->tg_sigpendingq.head;
-       (currsig && currsig->info.si_signo != signo);
+       currsig && (currsig->info.si_signo != signo ||
+                   (currsig->tcb != NULL && currsig->tcb != stcb));
        prevsig = currsig, currsig = currsig->flink);
 
   if (currsig)

--- a/sched/signal/sig_tgkill.c
+++ b/sched/signal/sig_tgkill.c
@@ -78,7 +78,6 @@ int nxsig_tgkill(pid_t pid, pid_t tid, int signo)
 #ifdef CONFIG_SCHED_HAVE_PARENT
   FAR struct tcb_s *rtcb = this_task();
 #endif
-  FAR struct tcb_s *stcb;
   siginfo_t info;
   int ret;
 
@@ -101,27 +100,7 @@ int nxsig_tgkill(pid_t pid, pid_t tid, int signo)
   info.si_status          = OK;
 #endif
 
-  /* Get the TCB associated with the thread */
-
-  stcb = nxsched_get_tcb(tid);
-  if (!stcb)
-    {
-      ret = -ESRCH;
-      goto errout;
-    }
-
-  /* Dispatch the signal to thread, bypassing normal task group thread
-   * dispatch rules.
-   */
-
-  ret = nxsig_tcbdispatch(stcb, &info);
-
-  if (ret < 0)
-    {
-      goto errout;
-    }
-
-  return OK;
+  ret = nxsig_dispatch(tid, &info, pid == (pid_t)-1);
 
 errout:
   return ret;

--- a/sched/signal/sig_unmaskpendingsignal.c
+++ b/sched/signal/sig_unmaskpendingsignal.c
@@ -104,7 +104,8 @@ bool nxsig_unmask_pendingsignal(void)
                * other than this thread.
                */
 
-              nxsig_tcbdispatch(rtcb, &pendingsig->info);
+              nxsig_tcbdispatch(rtcb, &pendingsig->info,
+                                pendingsig->tcb == NULL);
 
               /* Then remove it from the pending signal list */
 

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -80,6 +80,7 @@ typedef struct sigactq  sigactq_t;
 struct sigpendq
 {
   FAR struct sigpendq *flink;    /* Forward link */
+  FAR struct tcb_s *tcb;         /* TCB of thread to deliver to */
   siginfo_t info;                /* Signal information */
   uint8_t   type;                /* (Used to manage allocations) */
 };
@@ -168,7 +169,8 @@ int                nxsig_default_initialize(FAR struct tcb_s *tcb);
 /* sig_dispatch.c */
 
 int                nxsig_tcbdispatch(FAR struct tcb_s *stcb,
-                                     FAR siginfo_t *info);
+                                     FAR siginfo_t *info,
+                                     bool group_dispatch);
 int                nxsig_dispatch(pid_t pid, FAR siginfo_t *info,
                                   bool thread);
 


### PR DESCRIPTION
## Summary

When using pthread_kill, the signal should be delivered to the specified thread. Current implementation, however, may add the signal to the groups pending list, if the signal is masked at the time of dispatch. From the group's pending list it can be delivered to any thread of the group, which is wrong.

Fix this by adding a new field "FAR struct tcb_s *tcb" to "struct sigpendq", marking if the signal needs to be delivered to a specific thread. Use NULL for the value if delivery to any thread in the group is ok.

## Impact

This fixes operation of pthread_kill

## Testing

Tested with ostest in qemu on a real HW (MPFS, risc-v 64-bit, smp 4 cores) and in rv-virt:smp with the patch https://github.com/apache/nuttx-apps/pull/3070. The ostest fails after a few rounds without this patch, and passes with this one.
