### PR TITLE
tools/ci/testlist/sim-01.dat: skip build sim:can for macOS

### DIFF
--- a/tools/ci/testlist/sim-01.dat
+++ b/tools/ci/testlist/sim-01.dat
@@ -7,6 +7,9 @@
 # clang doesn't -fsanitize=kernel-address
 -Darwin,sim:citest
 
+# macOS can compilation is not currently supported
+-Darwin,sim:can
+
 # Boards build by CMake
 CMake,sim:alsa
 CMake,sim:bluetooth


### PR DESCRIPTION
## Summary

macOS sim:can compilation is not currently supported.

#16285 is used socketcan package an implementation of the CAN (Controller Area Network) protocols for Linux.

[SocketCAN - Controller Area Network](https://www.kernel.org/doc/html/latest/networking/can.html)
 [Linux-CAN / SocketCAN ](https://github.com/linux-can/can-utils)

macOS (sim-01) in NuttX mirror is broken
https://github.com/NuttX/nuttx/actions/runs/14874088222/job/41768036360#step:7:1511

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub macOS (sim-01) 

[macOS13 (sim-01)](https://github.com/simbit18/nuttx_test_pr/actions/runs/14881621718/job/41790928553#logs)



