### PR TITLE
github: master branch protection tune.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,15 +19,16 @@ github:
   protected_branches:
     master:
       required_status_checks:
-        strict: true
-        contexts:
-          - Check
-          - Lint
-          - Build
+        strict: false
+# Contexts cause hanging CI etc disable for now.
+#        contexts:
+#          - Check
+#          - Lint
+#          - Build
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_last_push_approval: true
         required_approving_review_count: 2
       required_linear_history: true
-      required_signatures: true
+      required_signatures: false
       required_conversation_resolution: true


### PR DESCRIPTION
## Summary

* Strict master branch protection requires all PR to be in sync with latest master even if changes are not related and there are no conflicts.
* Because we have lots of daily merges this blocks most of the PRs as they are forced to be rebased on top of current master.
* This also causes unnecessary automatic CI rebuild of each rebase.
* Therefore we are setting strict status checks setting to false.
* required_signatures in github means not only `git commit -s` but also
  cryptographic signature which is not required by us, seeting false.
* Disable "contexts" checks enforcement, that cause CI problems, mark TODO.
* This tunes parameters introduced in https://github.com/apache/nuttx/pull/16324.

References:
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file
https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

## Impact

* PR no longer enforced to rebase each time after master is updated.
* Saving precious CI resources after each rebase of PR.
* No cryptographic signatures of commits are enforced.

## Testing

This GitHub repository settings update turned out to be necessary after introduction of https://github.com/apache/nuttx/pull/16324.

