### PR TITLE
sched: Fix typo on queue.h

### DIFF
--- a/sched/sched/queue.h
+++ b/sched/sched/queue.h
@@ -63,12 +63,12 @@
     } \
   while (0)
 
-#define dq_insert_mid(pre, mid, next) \
+#define dq_insert_mid(prev, mid, next) \
   do \
     { \
       mid->flink = next; \
       mid->blink = prev; \
-      pre->flink = mid; \
+      prev->flink = mid; \
       next->blink = mid; \
     } \
   while (0)


### PR DESCRIPTION
## Summary

This typo was in the dq_insert_mid() macro introduced in the https://github.com/apache/nuttx/pull/13616

This issue was found by Serg Podtynnyi <serg@podtynnyi.com>


## Impact

Fix

## Testing

Build
