### PR TITLE
sched/wqueue: Fix wd_cancel_sync and improve work_queue performance.

### DIFF
--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -90,16 +90,6 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
   work->arg    = arg;             /* Callback argument */
   work->qtime  = clock() + delay; /* Delay until work performed */
 
-  /* delay+1 is to prevent the insufficient sleep time if we are
-   * currently near the boundary to the next tick.
-   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
-   * |           ^ Here we get the current tick
-   * In this case we delay 1 tick, timer will be triggered at
-   * current_tick + 1, which is not enough for at least 1 tick.
-   */
-
-  work->qtime += 1;
-
   /* Insert the work into the wait queue sorted by the expired time. */
 
   head = list_first_entry(&wqueue->q, struct work_s, node);


### PR DESCRIPTION
## Summary

This commit fixed work_cancel_sync at a very rare boundary case. When a worker thread re-enqueues the work data structure during the execution of work, the user thread cannot directly dequeue the work in `work_cancel_sync`. Instead, it should wait until all workers' references to the work data structure have been eliminated after dequeuing.

Besides, this commit improve the performance of the work_queue by reducing unnecessary timer setting.

## Impact

This modification mainly affects modules that use workqueue, and may affect the timing of workqueue execution and workqueue cancel semantics.

## Testing

Tested on `esp32s3`, `sim` and `qemu/x86_64`.

Issues mentioned in `https://github.com/apache/nuttx/issues/16337` should be fixed.
