### PR TITLE
sched/wdog: watchdog timer improvements.

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -571,7 +571,7 @@ int clock_isleapyear(int year);
  *
  ****************************************************************************/
 
-int clock_daysbeforemonth(int month, bool leapyear);
+int clock_daysbeforemonth(int month, bool leap_year);
 
 /****************************************************************************
  * Name:  clock_dayoftheweek

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -101,25 +101,25 @@
 
 /* Timing constants *********************************************************/
 
-#define NSEC_PER_SEC          1000000000L /* Seconds */
-#define USEC_PER_SEC             1000000L
-#define MSEC_PER_SEC                1000L
+#define NSEC_PER_SEC          1000000000UL /* Seconds */
+#define USEC_PER_SEC             1000000UL
+#define MSEC_PER_SEC                1000UL
 #define DSEC_PER_SEC                  10
 #define HSEC_PER_SEC                   2
 
-#define NSEC_PER_HSEC          500000000L /* Half seconds */
-#define USEC_PER_HSEC             500000L
+#define NSEC_PER_HSEC          500000000UL /* Half seconds */
+#define USEC_PER_HSEC             500000UL
 #define MSEC_PER_HSEC                500
 #define DSEC_PER_HSEC                  5
 
-#define NSEC_PER_DSEC          100000000L /* Deciseconds */
-#define USEC_PER_DSEC             100000L
+#define NSEC_PER_DSEC          100000000UL /* Deciseconds */
+#define USEC_PER_DSEC             100000UL
 #define MSEC_PER_DSEC                100
 
-#define NSEC_PER_MSEC            1000000L /* Milliseconds */
-#define USEC_PER_MSEC               1000L
+#define NSEC_PER_MSEC            1000000UL /* Milliseconds */
+#define USEC_PER_MSEC               1000UL
 
-#define NSEC_PER_USEC               1000L /* Microseconds */
+#define NSEC_PER_USEC               1000UL /* Microseconds */
 
 #define SEC_PER_MIN                   60
 #define NSEC_PER_MIN           (NSEC_PER_SEC * SEC_PER_MIN)
@@ -351,7 +351,7 @@ EXTERN volatile clock_t g_system_ticks;
   while (0)
 
 #define clock_time2ticks(ts) \
-  ((clock_t)(ts)->tv_sec * TICK_PER_SEC + NSEC2TICK((ts)->tv_nsec))
+  ((clock_t)(ts)->tv_sec * TICK_PER_SEC + NSEC2TICK((uint32_t)(ts)->tv_nsec))
 
 #define clock_usec2time(ts, usec) \
   do \
@@ -364,7 +364,8 @@ EXTERN volatile clock_t g_system_ticks;
   while (0)
 
 #define clock_time2usec(ts) \
-  ((uint64_t)(ts)->tv_sec * USEC_PER_SEC + div_const((ts)->tv_nsec, NSEC_PER_USEC))
+  ((uint64_t)(ts)->tv_sec * USEC_PER_SEC + \
+   div_const((uint32_t)(ts)->tv_nsec, NSEC_PER_USEC))
 
 #define clock_nsec2time(ts, nsec) \
   do \
@@ -377,7 +378,7 @@ EXTERN volatile clock_t g_system_ticks;
   while (0)
 
 #define clock_time2nsec(ts) \
-  ((uint64_t)(ts)->tv_sec * NSEC_PER_SEC + (ts)->tv_nsec)
+  ((uint64_t)(ts)->tv_sec * NSEC_PER_SEC + (uint64_t)(ts)->tv_nsec)
 
 /****************************************************************************
  * Name:  clock_timespec_add

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -353,6 +353,10 @@ EXTERN volatile clock_t g_system_ticks;
 #define clock_time2ticks(ts) \
   ((clock_t)(ts)->tv_sec * TICK_PER_SEC + NSEC2TICK((uint32_t)(ts)->tv_nsec))
 
+#define clock_time2ticks_floor(ts) \
+  ((clock_t)(ts)->tv_sec * TICK_PER_SEC + \
+   div_const((uint32_t)(ts)->tv_nsec, NSEC_PER_TICK))
+
 #define clock_usec2time(ts, usec) \
   do \
     { \

--- a/include/nuttx/timers/oneshot.h
+++ b/include/nuttx/timers/oneshot.h
@@ -395,7 +395,7 @@ int oneshot_tick_current(FAR struct oneshot_lowerhalf_s *lower,
     }
 
   ret = lower->ops->current(lower, &ts);
-  *ticks = clock_time2ticks(&ts);
+  *ticks = clock_time2ticks_floor(&ts);
 
   return ret;
 }

--- a/libs/libc/time/lib_daysbeforemonth.c
+++ b/libs/libc/time/lib_daysbeforemonth.c
@@ -52,19 +52,19 @@ static const uint16_t g_daysbeforemonth[13] =
  *    month.
  *
  * Input Parameters:
- *    month    - The month in the form of tm_mon, that is a range of 0-11.
- *    leapyear - True if leap year and there are 29 days in February.
- *               NOTE the month=1 is February.
+ *    month     - The month in the form of tm_mon, that is a range of 0-11.
+ *    leap_year - True if leap year and there are 29 days in February.
+ *                NOTE the month=1 is February.
  *
  * Returned Value:
  *    The number of days that occurred before the month
  *
  ****************************************************************************/
 
-int clock_daysbeforemonth(int month, bool leapyear)
+int clock_daysbeforemonth(int month, bool leap_year)
 {
   int retval = g_daysbeforemonth[month];
-  if (month >= 2 && leapyear)
+  if (month >= 2 && leap_year)
     {
       retval++;
     }

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -150,6 +150,16 @@ config USEC_PER_TICK
 		This value should never be less than the underlying resolution of
 		the timer.  Error may ensue.
 
+config TIMER_ADJUST_USEC
+	int "System timer tick adjustment (microseconds)"
+	default 0
+	---help---
+		This value is added to the absolute tick set to the system timer.
+		This is used to compensate for interrupt latency in real-time
+		systems where the event required to be triggered on exact time.
+		The default value of 0 means that no adjustment is made. E.g.
+		5 means for each timer being set will be fired 5 microseconds earlier.
+
 if !SCHED_TICKLESS
 
 config SYSTEMTICK_EXTCLK

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1179,7 +1179,7 @@ config SCHED_PROFILE_TICKSPERSEC
 	int "Profile sampling rate"
 	default 1000
 	---help---
-		This is the frequency at which the profil functon will sample the
+		This is the frequency at which the profil function will sample the
 		running program. The default is 1000Hz.
 
 menuconfig SCHED_INSTRUMENTATION
@@ -2000,11 +2000,11 @@ config SCHED_EVENTS
 		events to event objects.
 
 config ASSERT_PAUSE_CPU_TIMEOUT
-	int "Timeout in milisecond to pause another CPU when assert"
+	int "Timeout in millisecond to pause another CPU when assert"
 	default 2000
 	depends on SMP
 	---help---
-		Timeout in milisecond to pause another CPU when assert. Only available
+		Timeout in millisecond to pause another CPU when assert. Only available
 		when SMP is enabled.
 		Enable to support perf events.
 

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -84,7 +84,7 @@ clock_t clock_systime_ticks(void)
     };
 
   clock_systime_timespec(&ts);
-  return clock_time2ticks(&ts);
+  return clock_time2ticks_floor(&ts);
 #elif defined(CONFIG_ALARM_ARCH) || \
       defined(CONFIG_TIMER_ARCH) || \
       defined(CONFIG_SCHED_TICKLESS)

--- a/sched/group/group_continue.c
+++ b/sched/group/group_continue.c
@@ -67,7 +67,7 @@ static int group_continue_handler(pid_t pid, FAR void *arg)
   rtcb = nxsched_get_tcb(pid);
   if (rtcb != NULL)
     {
-      /* Remove the task from waitting list */
+      /* Remove the task from waiting list */
 
       nxsched_remove_blocked(rtcb);
 

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -130,7 +130,7 @@ int up_timer_gettick(FAR clock_t *ticks)
   struct timespec ts;
   int ret;
   ret = up_timer_gettime(&ts);
-  *ticks = clock_time2ticks(&ts);
+  *ticks = clock_time2ticks_floor(&ts);
   return ret;
 }
 #endif
@@ -149,7 +149,7 @@ int up_alarm_tick_cancel(FAR clock_t *ticks)
   struct timespec ts;
   int ret;
   ret = up_alarm_cancel(&ts);
-  *ticks = clock_time2ticks(&ts);
+  *ticks = clock_time2ticks_floor(&ts);
   return ret;
 }
 #  else
@@ -165,7 +165,7 @@ int up_timer_tick_cancel(FAR clock_t *ticks)
   struct timespec ts;
   int ret;
   ret = up_timer_cancel(&ts);
-  *ticks = clock_time2ticks(&ts);
+  *ticks = clock_time2ticks_floor(&ts);
   return ret;
 }
 #  endif
@@ -494,7 +494,7 @@ void nxsched_alarm_expiration(FAR const struct timespec *ts)
 
   DEBUGASSERT(ts);
 
-  ticks = clock_time2ticks(ts);
+  ticks = clock_time2ticks_floor(ts);
   nxsched_alarm_tick_expiration(ticks);
 }
 #endif

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -410,7 +410,7 @@ static clock_t nxsched_timer_start(clock_t ticks, clock_t interval)
       /* Normally, timer event cannot triggered on exact time
        * due to the existence of interrupt latency.
        * Assuming that the interrupt latency is distributed within
-       * [Best-Case Execution Time, Worst-Case Excution Time],
+       * [Best-Case Execution Time, Worst-Case Execution Time],
        * we can set the timer adjustment value to the BCET to
        * reduce the latency.
        * After the adjustment, the timer interrupt latency will be

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -150,7 +150,7 @@ out:
 
 int nxsem_tickwait_uninterruptible(FAR sem_t *sem, uint32_t delay)
 {
-  clock_t end = clock_systime_ticks() + delay + 1;
+  clock_t end = clock_delay2abstick(delay);
   int ret;
 
   for (; ; )

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -304,7 +304,15 @@ int nxsig_clockwait(int clockid, int flags,
 
       if ((flags & TIMER_ABSTIME) == 0)
         {
-          expect = clock_systime_ticks() + clock_time2ticks(rqtp);
+          /* delay+1 is to prevent the insufficient sleep time if we are
+           * currently near the boundary to the next tick.
+           * | current_tick | current_tick + 1 | current_tick + 2 | .... |
+           * |           ^ Here we get the current tick
+           * In this case we delay 1 tick, timer will be triggered at
+           * current_tick + 1, which is not enough for at least 1 tick.
+           */
+
+          expect = clock_systime_ticks() + clock_time2ticks(rqtp) + 1;
           wd_start_abstick(&rtcb->waitdog, expect,
                            nxsig_timeout, (uintptr_t)rtcb);
         }

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -113,7 +113,7 @@ static void nxsig_timeout(wdparm_t arg)
 #endif
         }
 
-      /* Remove the task from waitting list */
+      /* Remove the task from waiting list */
 
       dq_rem((FAR dq_entry_t *)wtcb, list_waitingforsignal());
 
@@ -183,7 +183,7 @@ void nxsig_wait_irq(FAR struct tcb_s *wtcb, int errcode)
 #endif
         }
 
-      /* Remove the task from waitting list */
+      /* Remove the task from waiting list */
 
       dq_rem((FAR dq_entry_t *)wtcb, list_waitingforsignal());
 

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -304,15 +304,7 @@ int nxsig_clockwait(int clockid, int flags,
 
       if ((flags & TIMER_ABSTIME) == 0)
         {
-          /* delay+1 is to prevent the insufficient sleep time if we are
-           * currently near the boundary to the next tick.
-           * | current_tick | current_tick + 1 | current_tick + 2 | .... |
-           * |           ^ Here we get the current tick
-           * In this case we delay 1 tick, timer will be triggered at
-           * current_tick + 1, which is not enough for at least 1 tick.
-           */
-
-          expect = clock_systime_ticks() + clock_time2ticks(rqtp) + 1;
+          expect = clock_delay2abstick(clock_time2ticks(rqtp));
           wd_start_abstick(&rtcb->waitdog, expect,
                            nxsig_timeout, (uintptr_t)rtcb);
         }

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -328,7 +328,16 @@ int timer_settime(timer_t timerid, int flags,
        */
 
       delay = clock_time2ticks(&value->it_value);
-      timer->pt_expected = clock_systime_ticks() + delay;
+
+      /* delay+1 is to prevent the insufficient sleep time if we are
+       * currently near the boundary to the next tick.
+       * | current_tick | current_tick + 1 | current_tick + 2 | .... |
+       * |           ^ Here we get the current tick
+       * In this case we delay 1 tick, timer will be triggered at
+       * current_tick + 1, which is not enough for at least 1 tick.
+       */
+
+      timer->pt_expected = clock_systime_ticks() + delay + 1;
     }
 
   /* Then start the watchdog */

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -316,9 +316,7 @@ int timer_settime(timer_t timerid, int flags,
     {
       /* Calculate a delay corresponding to the absolute time in 'value' */
 
-      clock_abstime2ticks(timer->pt_clock, &value->it_value,
-                          &timer->pt_expected);
-      timer->pt_expected += clock_systime_ticks();
+      clock_abstime2ticks(timer->pt_clock, &value->it_value, &delay);
     }
   else
     {
@@ -328,18 +326,9 @@ int timer_settime(timer_t timerid, int flags,
        */
 
       delay = clock_time2ticks(&value->it_value);
-      timer->pt_expected = clock_systime_ticks() + delay;
     }
 
-  /* This is to prevent the insufficient sleep time if we are
-   * currently near the boundary to the next tick.
-   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
-   * |           ^ Here we get the current tick
-   * In this case we delay 1 tick, timer will be triggered at
-   * current_tick + 1, which is not enough for at least 1 tick.
-   */
-
-  timer->pt_expected += 1;
+  timer->pt_expected = clock_delay2abstick(delay);
 
   /* Then start the watchdog */
 

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -331,7 +331,7 @@ int timer_settime(timer_t timerid, int flags,
       timer->pt_expected = clock_systime_ticks() + delay;
     }
 
-  /* delay+1 is to prevent the insufficient sleep time if we are
+  /* This is to prevent the insufficient sleep time if we are
    * currently near the boundary to the next tick.
    * | current_tick | current_tick + 1 | current_tick + 2 | .... |
    * |           ^ Here we get the current tick

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -328,17 +328,18 @@ int timer_settime(timer_t timerid, int flags,
        */
 
       delay = clock_time2ticks(&value->it_value);
-
-      /* delay+1 is to prevent the insufficient sleep time if we are
-       * currently near the boundary to the next tick.
-       * | current_tick | current_tick + 1 | current_tick + 2 | .... |
-       * |           ^ Here we get the current tick
-       * In this case we delay 1 tick, timer will be triggered at
-       * current_tick + 1, which is not enough for at least 1 tick.
-       */
-
-      timer->pt_expected = clock_systime_ticks() + delay + 1;
+      timer->pt_expected = clock_systime_ticks() + delay;
     }
+
+  /* delay+1 is to prevent the insufficient sleep time if we are
+   * currently near the boundary to the next tick.
+   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
+   * |           ^ Here we get the current tick
+   * In this case we delay 1 tick, timer will be triggered at
+   * current_tick + 1, which is not enough for at least 1 tick.
+   */
+
+  timer->pt_expected += 1;
 
   /* Then start the watchdog */
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -119,14 +119,10 @@ static void wdentry_period(wdparm_t arg)
 
   wdperiod->func(wdperiod->wdog.arg);
 
-  /* Since we set `ticks++` at `wd_start_abstick`,
-   * we need to use `expired - 1` here to avoid time drift.
-   */
-
   if (wdperiod->period != 0)
     {
       wd_start_abstick(&wdperiod->wdog,
-                       wdperiod->wdog.expired + wdperiod->period - 1,
+                       wdperiod->wdog.expired + wdperiod->period,
                        wdentry_period, wdperiod->wdog.arg);
     }
 }
@@ -323,23 +319,6 @@ int wd_start_abstick(FAR struct wdog_s *wdog, clock_t ticks,
       return -EINVAL;
     }
 
-  /* Calculate ticks+1, forcing the delay into a range that we can handle.
-   *
-   * NOTE that one is added to the delay.  This is correct and must not be
-   * changed:  The contract for the use wdog_start is that the wdog will
-   * delay FOR AT LEAST as long as requested, but may delay longer due to
-   * variety of factors.  The wdog logic has no knowledge of the the phase
-   * of the system timer when it is started:  The next timer interrupt may
-   * occur immediately or may be delayed for almost a full cycle. In order
-   * to meet the contract requirement, the requested time is also always
-   * incremented by one so that the delay is always at least as long as
-   * requested.
-   *
-   * There is extensive documentation about this time issue elsewhere.
-   */
-
-  ticks++;
-
   /* NOTE:  There is a race condition here... the caller may receive
    * the watchdog between the time that wd_start_abstick is called and
    * the critical section is established.
@@ -436,6 +415,23 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
     {
       return -EINVAL;
     }
+
+  /* Calculate delay+1, forcing the delay into a range that we can handle.
+   *
+   * NOTE that one is added to the delay.  This is correct and must not be
+   * changed:  The contract for the use wdog_start is that the wdog will
+   * delay FOR AT LEAST as long as requested, but may delay longer due to
+   * variety of factors.  The wdog logic has no knowledge of the the phase
+   * of the system timer when it is started:  The next timer interrupt may
+   * occur immediately or may be delayed for almost a full cycle. In order
+   * to meet the contract requirement, the requested time is also always
+   * incremented by one so that the delay is always at least as long as
+   * requested.
+   *
+   * There is extensive documentation about this time issue elsewhere.
+   */
+
+  delay++;
 
   return wd_start_abstick(wdog, clock_systime_ticks() + delay,
                           wdentry, arg);

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -431,9 +431,7 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
    * There is extensive documentation about this time issue elsewhere.
    */
 
-  delay++;
-
-  return wd_start_abstick(wdog, clock_systime_ticks() + delay,
+  return wd_start_abstick(wdog, clock_systime_ticks() + delay + 1,
                           wdentry, arg);
 }
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -416,23 +416,7 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
       return -EINVAL;
     }
 
-  /* Calculate delay+1, forcing the delay into a range that we can handle.
-   *
-   * NOTE that one is added to the delay.  This is correct and must not be
-   * changed:  The contract for the use wdog_start is that the wdog will
-   * delay FOR AT LEAST as long as requested, but may delay longer due to
-   * variety of factors.  The wdog logic has no knowledge of the the phase
-   * of the system timer when it is started:  The next timer interrupt may
-   * occur immediately or may be delayed for almost a full cycle. In order
-   * to meet the contract requirement, the requested time is also always
-   * incremented by one so that the delay is always at least as long as
-   * requested.
-   *
-   * There is extensive documentation about this time issue elsewhere.
-   */
-
-  return wd_start_abstick(wdog, clock_systime_ticks() + delay + 1,
-                          wdentry, arg);
+  return wd_start_abstick(wdog, clock_delay2abstick(delay), wdentry, arg);
 }
 
 /****************************************************************************

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -88,15 +88,7 @@ int work_queue_period_wq(FAR struct kwork_wqueue_s *wqueue,
       return -EINVAL;
     }
 
-  /* delay+1 is to prevent the insufficient sleep time if we are
-   * currently near the boundary to the next tick.
-   * | current_tick | current_tick + 1 | current_tick + 2 | .... |
-   * |           ^ Here we get the current tick
-   * In this case we delay 1 tick, timer will be triggered at
-   * current_tick + 1, which is not enough for at least 1 tick.
-   */
-
-  expected = clock_systime_ticks() + delay + 1;
+  expected = clock_delay2abstick(delay);
 
   /* Interrupts are disabled so that this logic can be called from with
    * task logic or from interrupt handling logic.


### PR DESCRIPTION
## Summary

- 1. Simplified the `nxsched_timer_process` function to enhance readability and maintainability.
- 2. Improved absolute timer accuracy by moving the `tick++` operation to the relative watchdog timer, removing unnecessary tick increments for absolute timers.
- 3. Added `CONFIG_TIMER_ADJUST_USEC` to support time compensation for watchdog timers, reducing interrupt latency by setting the timer adjustment value to the Best-Case Execution Time (BCET).

## Impact

- 1. Improves code maintainability and readability without functional changes.
- 2. Improves the accuracy of absolute timers by optimizing the tick increment process.
- 3. Enhances timer precision by compensating for interrupt latency.

## Testing

Tested on `QEMU/x86_64` and `sim`.
