### PR TITLE
rp2040/gpio: Fix debug assertion for interrupts.

### DIFF
--- a/arch/arm/src/rp2040/rp2040_gpio.c
+++ b/arch/arm/src/rp2040/rp2040_gpio.c
@@ -302,7 +302,7 @@ int rp2040_gpio_irq_attach(uint32_t gpio, uint32_t intrmode,
     }
 
   DEBUGASSERT(gpio < RP2040_GPIO_NUM);
-  DEBUGASSERT(intrmode <= RP2040_GPIO_INTR_EDGE_HIGH);
+  DEBUGASSERT(intrmode <= 0xf);
 
   /* Save handler information */
 


### PR DESCRIPTION
## Summary

The previous interrupt implementation allowed only one single interrupt mode to be selected. The debug assertion is now updated to allow the entire range of possible interrupt combinations (a 4-bit field), up to 0xf.

## Impact

The `DEBUGASSERT` will no longer fail for users who are making use of the multiple interrupt mode selection.

This affects all RP2040 boards where code is using more than one interrupt type (no such code exists in the kernel or apps yet, only for users). No other systems affected.

## Testing

Successful build locally, verified that the assertion no longer fails when `DEBUGASSERT` is enabled on a W5500-EVB Pico.

```console
$ ./tools/configure.sh w5500-evb-pico:usbnsh
$ make menuconfig
# Enable debug features and CONFIG_DEBUG_ASSERTIONS
# Enable CONFIG_DEV_GPIO and CONFIG_EXAMPLES_GPIO
$ make -j
/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: warning: rp2040_boot_stage2.elf has a LOAD segment with RWX permissions
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        244 KB         2 MB     11.91%
            sram:       24120 B       264 KB      8.92%
Generating: nuttx.uf2
Done.
```

Previous behaviour: program would crash at the assert statement
Current behaviour: assertion passes