### PR TITLE
arch/sim/sim_oneshot: Calculate next oneshot time in ticks instead of…

### DIFF
--- a/arch/sim/src/sim/sim_oneshot.c
+++ b/arch/sim/src/sim/sim_oneshot.c
@@ -137,7 +137,7 @@ static inline void sim_reset_alarm(struct timespec *alarm)
  * Name: sim_update_hosttimer
  *
  * Description:
- *   Ths function is called periodically to deliver the tick events to the
+ *   This function is called periodically to deliver the tick events to the
  *   NuttX simulation.
  *
  ****************************************************************************/
@@ -183,7 +183,7 @@ static void sim_update_hosttimer(void)
  * Name: sim_timer_update_internal
  *
  * Description:
- *   Ths function is called periodically to deliver the tick events to the
+ *   This function is called periodically to deliver the tick events to the
  *   NuttX simulation.
  *
  ****************************************************************************/


### PR DESCRIPTION

## Summary

This removes drift in tick start times, by aligning the tick start time to be even multiple of the tick time.

## Impact

This fixes random failures in sim:citest (cmocka_posix_timers), where it often sleeps one tick too long initially.

## Testing

Tested on sim:citest, cmocka.
