### PR TITLE
libs/libc/semaphore: Enable semaphore fast wait/post paths for counting semaphores

### DIFF
--- a/libs/libc/semaphore/sem_post.c
+++ b/libs/libc/semaphore/sem_post.c
@@ -119,6 +119,9 @@ int sem_post(FAR sem_t *sem)
 
 int nxsem_post(FAR sem_t *sem)
 {
+  bool mutex;
+  bool fastpath = true;
+
   DEBUGASSERT(sem != NULL);
 
   /* We don't do atomic fast path in case of LIBC_ARCH_ATOMIC because that
@@ -128,20 +131,60 @@ int nxsem_post(FAR sem_t *sem)
 
 #ifndef CONFIG_LIBC_ARCH_ATOMIC
 
-  if (NXSEM_IS_MUTEX(sem)
+  mutex = NXSEM_IS_MUTEX(sem);
+
+  /* Disable fast path if priority protection is enabled on the semaphore */
+
 #  ifdef CONFIG_PRIORITY_PROTECT
-      && (sem->flags & SEM_PRIO_MASK) != SEM_PRIO_PROTECT
-#  endif
-      )
+  if ((sem->flags & SEM_PRIO_MASK) == SEM_PRIO_PROTECT)
     {
-      int32_t old = _SCHED_GETTID();
-      if (atomic_try_cmpxchg_release(NXSEM_MHOLDER(sem), &old,
-                                     NXSEM_NO_MHOLDER))
+      fastpath = false;
+    }
+#  endif
+
+  /* Disable fast path on a counting semaphore with priority inheritance */
+
+#  ifdef CONFIG_PRIORITY_INHERITANCE
+  if (!mutex && (sem->flags & SEM_PRIO_MASK) != SEM_PRIO_NONE)
+    {
+      fastpath = false;
+    }
+#  endif
+
+  if (fastpath)
+    {
+      int32_t old;
+      int32_t new;
+      FAR atomic_t *val = mutex ? NXSEM_MHOLDER(sem) : NXSEM_COUNT(sem);
+
+      if (mutex)
+        {
+          old = _SCHED_GETTID();
+          new = NXSEM_NO_MHOLDER;
+        }
+      else
+        {
+          old = atomic_read(val);
+
+          if (old < 0)
+            {
+              goto out;
+            }
+
+          new = old + 1;
+        }
+
+      if (atomic_try_cmpxchg_release(val, &old, new))
         {
           return OK;
         }
     }
 
+out:
+
+#else
+  UNUSED(mutex);
+  UNUSED(fastpath);
 #endif
 
   return nxsem_post_slow(sem);

--- a/libs/libc/semaphore/sem_trywait.c
+++ b/libs/libc/semaphore/sem_trywait.c
@@ -107,6 +107,9 @@ int sem_trywait(FAR sem_t *sem)
 
 int nxsem_trywait(FAR sem_t *sem)
 {
+  bool mutex;
+  bool fastpath = true;
+
   DEBUGASSERT(sem != NULL);
 
   /* This API should not be called from the idleloop or interrupt */
@@ -123,18 +126,68 @@ int nxsem_trywait(FAR sem_t *sem)
 
 #ifndef CONFIG_LIBC_ARCH_ATOMIC
 
-  if (NXSEM_IS_MUTEX(sem)
+  mutex = NXSEM_IS_MUTEX(sem);
+
+  /* Disable fast path if priority protection is enabled on the semaphore */
+
 #  ifdef CONFIG_PRIORITY_PROTECT
-      && (sem->flags & SEM_PRIO_MASK) != SEM_PRIO_PROTECT
-#  endif
-      )
+  if ((sem->flags & SEM_PRIO_MASK) == SEM_PRIO_PROTECT)
     {
-      int32_t tid = _SCHED_GETTID();
-      int32_t old = NXSEM_NO_MHOLDER;
-      return atomic_try_cmpxchg_acquire(NXSEM_MHOLDER(sem), &old, tid) ?
-        OK : -EAGAIN;
+      fastpath = false;
+    }
+#  endif
+
+  /* Disable fast path on a counting semaphore with priority inheritance */
+
+#  ifdef CONFIG_PRIORITY_INHERITANCE
+  if (!mutex && (sem->flags & SEM_PRIO_MASK) != SEM_PRIO_NONE)
+    {
+      fastpath = false;
+    }
+#  endif
+
+  if (fastpath)
+    {
+      bool ret = false;
+      int32_t old;
+      int32_t new;
+      FAR atomic_t *val = mutex ? NXSEM_MHOLDER(sem) : NXSEM_COUNT(sem);
+
+      if (mutex)
+        {
+          old = NXSEM_NO_MHOLDER;
+        }
+      else
+        {
+          old = atomic_read(val);
+        }
+
+      do
+        {
+          if (!mutex)
+            {
+              if (old < 1)
+                {
+                  break;
+                }
+
+              new = old - 1;
+            }
+          else
+            {
+              new = _SCHED_GETTID();
+            }
+
+          ret = atomic_try_cmpxchg_acquire(NXSEM_MHOLDER(sem), &old, new);
+        }
+      while (!mutex && !ret);
+
+      return ret ? OK : -EAGAIN;
     }
 
+#else
+  UNUSED(mutex);
+  UNUSED(fastpath);
 #endif
 
   return nxsem_trywait_slow(sem);


### PR DESCRIPTION

## Summary

This PR completes the semaphore "fast path" in libc, by enabling the fast path also for counting semaphores, when they
have the priority inheritance disabled.

This is beneficial for the performance especially in SMP and memory protected builds, in cases where the signalling semaphore is used as a counter. For example a "multiple writer <-> single reader" queue, where a lower priority reader sleeps on a semaphore when the queue is empty, and several high-speed writers post to the queue. As long as the semaphore value remains >= 0, the operations reduce to simple atomic increase/decrease without need for a syscall to kernel, or aquire the big kernel lock in SMP system.

This optimization opportunity was discussed in https://github.com/apache/nuttx/pull/16194#issuecomment-2853322370 .

## Impact

This boosts the signalling semaphore performance, but how much depends a lot on the use case. This has neglible effect on image size: decreases the image size by 42 bytes is 32-bit builds with CONFIG_PRIORITY_INHERITANCE=n and increases the image size by 56 bytes with CONFIG_PRIORITY_INHERITANCE=y (measured from rv-virt:smp target).

## Testing

Tested on real applications on real HW:
IMX93, CONFIG_BUILD_FLAT and CONFIG_BUILD_KERNEL, CONFIG_PRIORITY_INHERITANCE=y
MPFS with SMP 4 cores, CONFIG_BUILD_FLAT and CONFIG_BUILD_KERNEL, CONFIG_PRIORITY_INHERITANCE=y

Tested with ostest with real HW:
MPFS with SMP 4 cores, CONFIG_BUILD_FLAT, CONFIG_PRIORITY_INHERITANCE=y

Tested with osteset on virtual HW:
rv-virt:smp , CONFIG_PRIORITY_INHERITANCE=n
rv-virt:smp , CONFIG_PRIORITY_INHERITANCE=y
