### PR TITLE
include/nuttx/can.h: remove dependency on CONFIG_NET_CAN

### DIFF
--- a/include/nuttx/can.h
+++ b/include/nuttx/can.h
@@ -33,8 +33,6 @@
 #include <sys/socket.h>
 #include <stdint.h>
 
-#ifdef CONFIG_NET_CAN
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -383,5 +381,4 @@ extern "C"
 }
 #endif
 
-#endif /* CONFIG_CAN */
 #endif /* __INCLUDE_NUTTX_CAN_H */


### PR DESCRIPTION
## Summary
- include/nuttx/can.h: remove dependency on CONFIG_NET_CAN
Definitions from this file are also used by `arch/sim` CAN implementation, which is based on host socketCAN interface.

## Impact
With this change CONFIG_NET and CONFIG_NET_CAN don't need to be enabled to support CAN character driver on sim.

## Testing
CAN application on simulator with CAN character driver enabled and socketCAN disabled


