### PR TITLE
libc/fdcheck: fix issue about  a double close check

### DIFF
--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -77,6 +77,7 @@ config FDSAN
 config FDCHECK
 	bool "Enable fdcheck"
 	default n
+	depends on LIBC_OPEN_MAX <= 256
 	---help---
 		Enable the fdcheck support
 

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -93,7 +93,7 @@ config LIBC_UNAME_DISABLE_TIMESTAMP
 	---help---
 		Currently uname command will print the timestamp
 		when the binary was built, and it generates an issue
-		because two identical built binaries will have differents
+		because two identical built binaries will have different
 		hashes/CRC.
 
 choice

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -77,7 +77,6 @@ config FDSAN
 config FDCHECK
 	bool "Enable fdcheck"
 	default n
-	depends on SCHED_HAVE_PARENT
 	---help---
 		Enable the fdcheck support
 

--- a/libs/libc/misc/lib_fdcheck.c
+++ b/libs/libc/misc/lib_fdcheck.c
@@ -63,6 +63,7 @@ static uint8_t    g_fdcheck_tag = 0;
 int fdcheck_restore(int val)
 {
   uint8_t tag_store;
+  int ret;
   int fd;
 
   /* If val is a bare fd（0~255）, we should return it directly  */
@@ -73,7 +74,7 @@ int fdcheck_restore(int val)
       return val;
     }
 
-  int ret = ioctl(fd, FIOC_GETTAG_FDCHECK, &tag_store);
+  ret = ioctl(fd, FIOC_GETTAG_FDCHECK, &tag_store);
   if (ret >= 0)
     {
       uint8_t tag_expect = (val >> TAG_SHIFT) & TAG_MASK;
@@ -83,6 +84,12 @@ int fdcheck_restore(int val)
                 tag_expect, tag_store);
           PANIC();
         }
+    }
+  else
+    {
+      ferr("fd is bad, or fd have already been closed, errno:%d",
+           get_errno());
+      PANIC();
     }
 
   return fd;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

* libc/fdcheck: cause system to panic when a double close occurs

 There are many close calls in application without checking return value,
 and wrong code causes the same fd to be closed multi times, we should detect
 this situation and avoud effecting the fd in other threads.

* libs/fdcheck: add dependency LIBC_OPEN_MAX <= 256
    
The maximum of file desciptor is 255 for current fdcheck design

## Impact

fix bug about fdcheck

## Testing

openvela monkey


