### PR TITLE
sched/wdog/wd_cancel: Return 0 (OK) when cancelling an inactive wdog

### DIFF
--- a/sched/wdog/wd_cancel.c
+++ b/sched/wdog/wd_cancel.c
@@ -70,7 +70,7 @@ int wd_cancel(FAR struct wdog_s *wdog)
   if (wdog == NULL || !WDOG_ISACTIVE(wdog))
     {
       spin_unlock_irqrestore(&g_wdspinlock, flags);
-      return -EINVAL;
+      return wdog == NULL ? -EINVAL : 0;
     }
 
   sched_note_wdog(NOTE_WDOG_CANCEL, (FAR void *)wdog->func,


### PR DESCRIPTION

## Summary

In case the wdog has already completed when calling cancel, the cancel is supposed to just return OK.

Currently watchdogs are broken due to this in master, the issue is easy to demonstrate in qemu smp targets. For example ostest in rv-virt:smp fails due to this.

## Impact

Fixes a bug in wd_cancel

## Testing

Tested in rv-virt:smp
