### PR TITLE
arch/sim/Kconfig: simulated CAN depends on LINUX host

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -481,7 +481,7 @@ config SIM_FRAMEBUFFER_COUNT
 	default 2
 	---help---
 		Framebuffer count.
-		Simulated frambuffer count.  Default: 2
+		Simulated framebuffer count.  Default: 2
 
 config SIM_FB_INTERVAL_LINE
 	int "The line between non-consecutive framebuffers"
@@ -684,7 +684,7 @@ config SIM_UART_NUMBER
 		the same name that the host is using for this port (e.g.
 		/dev/ttyUSB0).
 
-		Alternativelly, a "simulated" host port may be used to.
+		Alternatively, a "simulated" host port may be used to.
 		This is useful if you need to also simulate the external
 		hardware, or to have NuttX communicate with any other
 		software in your system.
@@ -829,7 +829,7 @@ config SIM_USB_RAW_GADGET
 		Make Raw Gadget:
 		Run make in the raw_gadget and dummy_hcd directory. If raw_gadget
 		build fail, you need to check which register interface meets your
-		kenel version, usb_gadget_probe_driver or usb_gadget_register_driver.
+		kernel version, usb_gadget_probe_driver or usb_gadget_register_driver.
 
 		Install Raw Gadget:
 		Run ./insmod.sh in the raw_gadget and dummy_hcd directory.

--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -229,6 +229,7 @@ endchoice
 
 config SIM_CANDEV
 	bool "Simulated CAN Device"
+	depends on HOST_LINUX
 	default n
 	---help---
 		Build in support for a simulated CAN device.


### PR DESCRIPTION
## Summary
arch/sim/Kconfig: simulated CAN depends on LINUX host

## Impact

in reference to https://github.com/apache/nuttx/issues/16317

## Testing

CI

