### PR TITLE
arch/arm64/imx9: Extend ELE API with RNG support

### DIFF
--- a/arch/arm64/src/imx9/hardware/imx9_ele.h
+++ b/arch/arm64/src/imx9/hardware/imx9_ele.h
@@ -28,24 +28,35 @@
  ****************************************************************************/
 
 #include <hardware/imx9_memorymap.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
 #define ELE_MAX_MSG               255U
-#define AHAB_VERSION              0x6
-#define AHAB_CMD_TAG              0x17
-#define AHAB_RESP_TAG             0xe1
-#define ELE_RELEASE_RDC_REQ       0xc4
-#define ELE_READ_FUSE_REQ         0x97
-#define ELE_GET_EVENTS_REQ        0xa2
+
+#define ELE_CMD_TAG               0x17
+#define ELE_VERSION               0x6
+#define ELE_VERSION_FW            0x7
+#define ELE_RESP_TAG              0xe1
+#define ELE_OK                    0xd6
+
+/* ELE commands. */
+
 #define ELE_DERIVE_KEY_REQ        0xa9
+#define ELE_GET_EVENTS_REQ        0xa2
+#define ELE_GET_TRNG_STATE_REQ    0xa4
+#define ELE_GET_RNG_REQ           0xcd
 #define ELE_FWD_LIFECYCLE_UP_REQ  0x95
 #define ELE_OEM_CNTN_AUTH_REQ     0x87
-#define ELE_VERIFY_IMAGE_REQ      0x88
+#define ELE_READ_FUSE_REQ         0x97
 #define ELE_RELEASE_CONTAINER_REQ 0x89
-#define ELE_OK                    0xd6
+#define ELE_RELEASE_RDC_REQ       0xc4
+#define ELE_START_RNG_REQ         0xa3
+#define ELE_VERIFY_IMAGE_REQ      0x88
+
+/* Messaging Unit registers. */
 
 #define ELE_MU_TCR (IMX9_S3MUA_BASE + 0x120)
 #define ELE_MU_TSR (IMX9_S3MUA_BASE + 0x124)
@@ -57,7 +68,13 @@
 #define ELE_MU_TR(i) (IMX9_S3MUA_BASE + 0x200 + (i) * 4)
 #define ELE_MU_RR(i) (IMX9_S3MUA_BASE + 0x280 + (i) * 4)
 
+/* Fuse and Status Block lifecycle register. */
+
 #define FSB_LC_REG              0x4751041cUL
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
 
 struct ele_header_t
 {

--- a/arch/arm64/src/imx9/imx9_ele.h
+++ b/arch/arm64/src/imx9/imx9_ele.h
@@ -27,8 +27,9 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
 #include "hardware/imx9_ele.h"
+#include <sys/types.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Public Function Prototypes
@@ -219,4 +220,51 @@ int imx9_ele_release_container(uint32_t *response);
  ****************************************************************************/
 
 int imx9_ele_verify_image(uint32_t img_id, uint32_t *response);
+
+/****************************************************************************
+ * Name: imx9_ele_start_rng
+ *
+ * Description:
+ *   Sends command to initialize the ELE RNG context.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned for success. A negated errno value is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_start_rng(void);
+
+/****************************************************************************
+ * Name: imx9_ele_get_trng_state
+ *
+ * Description:
+ *   Query the state of the True Random Number Generator.
+ *
+ * Returned Value:
+ *   Zero is returned if the Random Number Generator (RNG) is ready for use.
+ *   A negated errno value (-EBUSY) or another is returned on failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_trng_state(void);
+
+/****************************************************************************
+ * Name: imx9_ele_get_random
+ *
+ * Description:
+ *   Request from the ELE the generation of a random number of specified
+ *   length.
+ *
+ * Input Parameters:
+ *   paddr  -  32bit physical address to store the random number.
+ *   len    -  Length in bytes of the random number.
+ *
+ * Returned Value:
+ *   Zero is returned if ELE successfully generated the random number.
+ *   A negated errno value (-EBUSY) or another is returned on failure.
+ *
+ ****************************************************************************/
+
+int imx9_ele_get_random(uint32_t paddr, size_t len);
 #endif /* __ARCH_ARM64_SRC_IMX9_IMX9_ELE_H */


### PR DESCRIPTION

## Summary

This PR extends the ELE API with support for Random Number Generation for i.MX9.
It includes 3 new calls:

1. `imx9_ele_start_rng()` -> Request ELE  to initialize the RNG context so it can generate random numbers
2. `imx9_ele_get_trng_state()` -> Poll the state of the random generator
3. `imx9_ele_get_random()` -> Request generation of a random number of arbitrary size.

The initial need to create this PR stemmed from optee requiring prior initialization of the RNG engine in order to generate the 
ASLR seed. It seemed logical to include the rest of the associated functions as well for completion.

## Impact
Users that want to build a custom nuttx BL2 bootloader (for a TF-A setup) can now also initialize the Random Number Generator through `imx9_ele_start_rng()`, in order to have it usable for later stages (i.e for BL32/optee).

Additionally (true) random number generation can be performed through `imx9_ele_get_random()`


## Testing

The tests were performed on a custom i.MX93 board.

The following numbers were generated through invocations of `imx9_ele_get_random()` on a 32 byte buffer.
The whole buffer was printed to ensure ELE didn't write out of bounds.

```
Generated 7 random bytes:
0xf28a242c5db23a00000000000000000000000000000000000000000000000000
Generated 8 random bytes:
0x280b967bcfc4a992000000000000000000000000000000000000000000000000
Generated 9 random bytes:
0xdca38fd9731b6929450000000000000000000000000000000000000000000000
Generated 10 random bytes:
0x50ec44bc3b387522173400000000000000000000000000000000000000000000
Generated 11 random bytes:
0x6ae492f7d87aff039e3b3f000000000000000000000000000000000000000000
Generated 12 random bytes:
0x82be5d37d71ac9b65c590adf0000000000000000000000000000000000000000
Generated 13 random bytes:
0x7e102f63b5a9322f0ac4c4204f00000000000000000000000000000000000000
Generated 14 random bytes:
0x94f8dd2b55916b287869a0ca9280000000000000000000000000000000000000
Generated 15 random bytes:
0x9212cd99282c85fbc930695a8aa95b0000000000000000000000000000000000
Generated 16 random bytes:
0x5bea9783ca982ae13f34b97b6ce6866500000000000000000000000000000000
Generated 17 random bytes:
0xfdb4a380150e5b9924c18e6d59da6f40a7000000000000000000000000000000
Generated 18 random bytes:
0x4836f21f6d8a0a4eb09620aed552db6e63960000000000000000000000000000
Generated 19 random bytes:
0xa8275644ac6738d087be4b3887a42303aa5bb000000000000000000000000000
Generated 20 random bytes:
0xac7c0552c3a0f929a4e09f62868e9bff2a7495ab000000000000000000000000
Generated 21 random bytes:
0x8dbecb4bd60a297a1f4759d582af78bbd40caf632d0000000000000000000000

```


