### PR TITLE
fs/vfs/fs_dup.c: before file_allocate should restore minfd if define …

### DIFF
--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -63,6 +63,8 @@ int file_dup(FAR struct file *filep, int minfd, int flags)
 
 #ifdef CONFIG_FDCHECK
   uint8_t f_tag_fdcheck; /* File owner fdcheck tag, init to 0 */
+
+  minfd = fdcheck_restore(minfd);
 #endif
 
   fd2 = file_allocate(g_root_inode, 0, 0, NULL, minfd, true);


### PR DESCRIPTION
## Summary

before file_allocate should restore minfd if define FDCHECK
## Impact

The modification of fcntl dup failed

## Testing

open FDCHECK and test this：

`
#include <fcntl.h>
#include <errno.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <unistd.h>
#include <stdio.h>

int main(int ac, char **av)
{
  int fd1= open("./1.txt", O_WRONLY | O_CREAT, 0666);
  if (fd1 < 0)
 

{     printf("open err %d\n",__LINE__);     return 0;   }

  int fd2= open("./2.txt", O_WRONLY | O_CREAT, 0666);
  if (fd2 < 0)
  {     printf("open err %dn",__LINE__);     return 0;   }
  //close(fd2);
  int fd3 = fcntl(fd1, F_DUPFD, fd2);
  printf("fd3 = %d\n", fd3);
  close(fd1);
 // close(fd3);
  return 0;
}
`

