### PR TITLE
sched: Remove checking of WDOG_ISACTIVE when cancelling wdog

### DIFF
--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -253,10 +253,7 @@ void nxmq_notify_receive(FAR struct mqueue_inode_s *msgq)
 
       DEBUGASSERT(btcb != NULL);
 
-      if (WDOG_ISACTIVE(&btcb->waitdog))
-        {
-          wd_cancel(&btcb->waitdog);
-        }
+      wd_cancel(&btcb->waitdog);
 
       msgq->cmn.nwaitnotfull--;
 

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -286,10 +286,7 @@ void nxmq_notify_send(FAR struct mqueue_inode_s *msgq)
 
       DEBUGASSERT(btcb);
 
-      if (WDOG_ISACTIVE(&btcb->waitdog))
-        {
-          wd_cancel(&btcb->waitdog);
-        }
+      wd_cancel(&btcb->waitdog);
 
       msgq->cmn.nwaitnotempty--;
 

--- a/sched/mqueue/msgrcv.c
+++ b/sched/mqueue/msgrcv.c
@@ -252,10 +252,7 @@ ssize_t msgrcv(int msqid, FAR void *msgp, size_t msgsz, long msgtyp,
 
       DEBUGASSERT(btcb != NULL);
 
-      if (WDOG_ISACTIVE(&btcb->waitdog))
-        {
-          wd_cancel(&btcb->waitdog);
-        }
+      wd_cancel(&btcb->waitdog);
 
       msgq->cmn.nwaitnotfull--;
 

--- a/sched/mqueue/msgsnd.c
+++ b/sched/mqueue/msgsnd.c
@@ -245,10 +245,7 @@ int msgsnd(int msqid, FAR const void *msgp, size_t msgsz, int msgflg)
 
           DEBUGASSERT(btcb);
 
-          if (WDOG_ISACTIVE(&btcb->waitdog))
-            {
-              wd_cancel(&btcb->waitdog);
-            }
+          wd_cancel(&btcb->waitdog);
 
           msgq->cmn.nwaitnotempty--;
 

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -209,10 +209,7 @@ int nxsem_post_slow(FAR sem_t *sem)
 
           /* Stop the watchdog timer */
 
-          if (WDOG_ISACTIVE(&stcb->waitdog))
-            {
-              wd_cancel(&stcb->waitdog);
-            }
+          wd_cancel(&stcb->waitdog);
 
           /* Indicate that the wait is over. */
 

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -544,11 +544,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
             }
 
           sigemptyset(&stcb->sigwaitmask);
-
-          if (WDOG_ISACTIVE(&stcb->waitdog))
-            {
-              wd_cancel(&stcb->waitdog);
-            }
+          wd_cancel(&stcb->waitdog);
 
           /* Remove the task from waiting list */
 
@@ -606,11 +602,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
             }
 
           sigemptyset(&stcb->sigwaitmask);
-
-          if (WDOG_ISACTIVE(&stcb->waitdog))
-            {
-              wd_cancel(&stcb->waitdog);
-            }
+          wd_cancel(&stcb->waitdog);
 
           /* Remove the task from waiting list */
 


### PR DESCRIPTION
## Summary

This fixes random crashes now happening on SMP systems; easiest to re-produce the crashes is with rv-virt:smp , running ostest/wdog.

The biggest problem is usage of "WDOG_ISACTIVE" macro, which is racy. I removed checking that condition before every wd_cancel.

Another issue is perhaps only related to ostest, which tries to do maximum delay.

I didn't look through the wqueue/kwork_thread, or drivers/power/pm, which also use WDOG_IS_ACTIVE is quite suspicious way. Those should be still inspected.

## Impact

Fixes random crashes and ostest failures on SMP

## Testing

Tested on rv-virt:smp , ostest.
