### PR TITLE
arch/risc-v/src/common/espressif/esp_pcnt.c: counter accumulation fix

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_pcnt.c
+++ b/arch/risc-v/src/common/espressif/esp_pcnt.c
@@ -276,7 +276,7 @@ static int esp_pcnt_ioctl(struct cap_lowerhalf_s *dev, int cmd,
         ret = esp_pcnt_unit_get_count(dev, (int *)arg);
         if (ret != OK)
           {
-            cperr("Could not clear pcnt-%d!\n", priv->unit_id);
+            cperr("Could not get count from pcnt-%d!\n", priv->unit_id);
           }
 
         break;
@@ -857,6 +857,10 @@ struct cap_lowerhalf_s *esp_pcnt_new_unit(
     }
 
   pcnt_ll_disable_all_events(ctx.dev, unit_id);
+
+  pcnt_ll_enable_high_limit_event(ctx.dev, unit_id, config->accum_count);
+  pcnt_ll_enable_low_limit_event(ctx.dev, unit_id, config->accum_count);
+
   pcnt_ll_enable_glitch_filter(ctx.dev, unit_id, false);
   pcnt_ll_set_high_limit_value(ctx.dev, unit_id, config->high_limit);
   pcnt_ll_set_low_limit_value(ctx.dev, unit_id, config->low_limit);


### PR DESCRIPTION
## Summary

In #15079, support for PCNT pulse counter was introduced, an implementation for the counter accumulation functionality is included, but due to a bug, the counter value is not accumulated and overflows at pulse counter's respective MIN and MAX limits.

This is caused by all interrupt events being disabled during the initialization of the PCNT unit and the interrupt events associated with limit overflows are not enabled on the periphery, therefore the ISR responsible for the accumulation never gets called.

Fixed by enabling the associated interrupt events during the PCNT unit initialization when the `accum_count` field in  the `esp_pcnt_unit_config_s` config structure is set to true by the board code.

## Impact

This PR enables PCNT pulse counter value accumulation in Espressif boards.

## Testing

The fix was tested on the ESP32-C6 devkitC board with a DC motor quadrature encoder as a source of the pulses.
Modified board code was used
1) to overcome bugs in the board code: code from @Vajnar 's  PR #16391 was used 
2) to enable the accumulation functionality: `accum_count` set to `true` in the `esp_pcnt_unit_config_s` config structure