### PR TITLE
arch/arm/rp23xx: xosc: Update startup delay calculation

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_xosc.c
+++ b/arch/arm/src/rp23xx/rp23xx_xosc.c
@@ -54,6 +54,13 @@
 #include "hardware/rp23xx_xosc.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define XOSC_STARTUPDELAY_MULT 6
+#define XOSC_STARTUPDELAY (BOARD_XOSC_STARTUPDELAY * XOSC_STARTUPDELAY_MULT)
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -78,8 +85,8 @@ void rp23xx_xosc_init(void)
 
   /* Set xosc startup delay */
 
-  uint32_t startup_delay = ((BOARD_XOSC_FREQ / 1000) *
-                            BOARD_XOSC_STARTUPDELAY + 255) / 256;
+  uint32_t startup_delay = (((BOARD_XOSC_FREQ / 1000) + 128) / 256) *
+                              XOSC_STARTUPDELAY;
   ASSERT(startup_delay < 1 << 13);
   putreg32(startup_delay, RP23XX_XOSC_STARTUP);
 


### PR DESCRIPTION
## Summary

Use upstream function to calculate XOSC startup delay
