### PR TITLE
tools/CMakeLists.txt: Improvements to CMakeLists.txt file

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,6 +19,7 @@
 # the License.
 #
 # ##############################################################################
+
 # Configure project
 cmake_minimum_required(VERSION 3.16)
 project(nuttx_tools LANGUAGES C)
@@ -29,7 +30,31 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Build type" FORCE)
 endif()
 
+option(NUTTX_INCLUDE_ALL_TOOLS "Build all NuttX Host Tools" ON)
+option(NUTTX_INCLUDE_CONFIGURE "Build configure" OFF)
+option(NUTTX_INCLUDE_GENCROMFS "Build gencromfs" OFF)
+option(NUTTX_INCLUDE_INCDIR "Build incdir" OFF)
+option(NUTTX_INCLUDE_MKCONFIG "Build mkconfig" OFF)
+option(NUTTX_INCLUDE_MKDEPS "Build mkdeps" OFF)
+option(NUTTX_INCLUDE_MKSYMTAB "Build mksymtab" OFF)
+option(NUTTX_INCLUDE_MKSYSCALL "Build mksyscall" OFF)
+option(NUTTX_INCLUDE_MKVERSION "Build mkversion" OFF)
+option(NUTTX_INCLUDE_NXSTYLE "Build nxstyle" OFF)
+
 message(STATUS "NuttX Host Tools")
+
+message(STATUS "CMake C compiler: ${CMAKE_C_COMPILER_ID}")
+message(STATUS "CMake system name: ${CMAKE_SYSTEM_NAME}")
+message(STATUS "CMake host system processor: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+
+if(TOOLS_DIR)
+  message("   TOOLS_DIR path is \"${TOOLS_DIR}\"")
+else()
+  set(TOOLS_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+  cmake_path(GET TOOLS_PATH PARENT_PATH TOOLS_DIR)
+
+  message("   TOOLS_DIR path is \"${TOOLS_DIR}\"")
+endif()
 
 # set basic warnings
 
@@ -37,37 +62,115 @@ add_compile_options(-Wall -Wstrict-prototypes -Wshadow -Wundef)
 
 # configure according to platform
 
-if(MSYS)
+if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+  message("   HOST = WINDOWS NATIVE")
   add_compile_definitions(CONFIG_WINDOWS_NATIVE=y)
 else()
   # GCC or clang is assumed in all other POSIX environments (Linux, Cygwin,
-  # MSYS2, macOS). strtok_r is used in some tools, but does not seem to be
-  # available in the MinGW environment.
+  # MSYS2, macOS). strtok_r and strndup is used in some tools, but does not seem
+  # to be available in the MinGW environment.
 
   add_compile_definitions(HAVE_STRTOK_C=1)
+  add_compile_definitions(HAVE_STRNDUP=1)
 
-  if(CYGWIN)
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
+    message("   HOST = Linux")
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    message("   HOST = Darwin")
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "FreeBSD")
+    message("   HOST = FreeBSD")
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "CYGWIN")
+    message("   HOST = WINDOWS CYGWIN")
     add_compile_definitions(HOST_CYGWIN=1)
+  elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "MSYS")
+    message("   HOST = WINDOWS MSYS")
   endif()
 endif()
 
 # define targets
 
-add_library(csvparser csvparser.c)
+# ============================================================================
+# configure binaries Configure a work-alike program as a replacement for
+# configure.sh
+# ============================================================================
 
-add_executable(mksyscall mksyscall.c)
-target_link_libraries(mksyscall PRIVATE csvparser)
-install(TARGETS mksyscall DESTINATION bin)
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_CONFIGURE)
+  add_executable(configure configure.c cfgparser.c)
+  install(TARGETS configure DESTINATION bin)
+endif()
 
-add_executable(nxstyle nxstyle.c)
-install(TARGETS nxstyle DESTINATION bin)
+# ============================================================================
+# gencromfs binaries Generate a CROMFS file system images
+# ============================================================================
 
-add_executable(gencromfs gencromfs.c)
-install(TARGETS gencromfs DESTINATION bin)
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_GENCROMFS)
+  add_executable(gencromfs gencromfs.c)
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+    target_compile_definitions(gencromfs PRIVATE _POSIX_)
+  endif()
+  install(TARGETS gencromfs DESTINATION bin)
+endif()
 
-add_executable(mkdeps mkdeps.c)
-target_link_libraries(mkdeps PRIVATE csvparser)
-install(TARGETS mkdeps DESTINATION bin)
+# ============================================================================
+# incdir binaries Generate compiler-specific include paths
+# ============================================================================
 
-add_executable(incdir incdir.c)
-install(TARGETS incdir DESTINATION bin)
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_INCDIR)
+  add_executable(incdir incdir.c)
+  install(TARGETS incdir DESTINATION bin)
+endif()
+
+# ============================================================================
+# mkconfig binaries Convert a .config file into a C config.h file
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_MKCONFIG)
+  add_executable(mkconfig mkconfig.c cfgdefine.c)
+  install(TARGETS mkconfig DESTINATION bin)
+endif()
+
+# ============================================================================
+# mkdeps binaries Create dependencies for a list of files
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_MKDEPS)
+  add_executable(mkdeps mkdeps.c cfgdefine.c)
+  install(TARGETS mkdeps DESTINATION bin)
+endif()
+
+# ============================================================================
+# mksyscall binaries Convert a CSV file into syscall stubs and proxies
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_MKSYSCALL)
+  add_executable(mksyscall mksyscall.c csvparser.c)
+  install(TARGETS mksyscall DESTINATION bin)
+endif()
+
+# ============================================================================
+# mksymtab binaries Convert a CSV file into a symbol table
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_MKSYMTAB)
+  add_executable(mksymtab mksymtab.c csvparser.c)
+  install(TARGETS mksymtab DESTINATION bin)
+endif()
+
+# ============================================================================
+# mkversion binaries Convert a .version file into a C version.h file
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_MKVERSION)
+  add_executable(mkversion mkversion.c cfgdefine.c)
+  install(TARGETS mkversion DESTINATION bin)
+endif()
+
+# ============================================================================
+# nxstyle binaries Check a file for compliance to NuttX coding style
+# ============================================================================
+
+if(NUTTX_INCLUDE_ALL_TOOLS OR NUTTX_INCLUDE_NXSTYLE)
+  add_executable(nxstyle nxstyle.c)
+  target_compile_definitions(nxstyle PRIVATE TOOLS_DIR=${TOOLS_DIR})
+  install(TARGETS nxstyle DESTINATION bin)
+endif()


### PR DESCRIPTION
## Summary

More aligned to the tools/Makefile.host file

Added:

- The option() command  It provides a way to enable or disable targets of the project based on the user's preference.
   Default
   option(NUTTX_INCLUDE_ALL_TOOLS "Build all NuttX Host Tools" ON)

- Checking host system for compilation options.

- Tools -> configure, mkconfig, mksymtab and mkversion.

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally  MSYS2  and Windows Native

building only mkversion
cmake -B build -DNUTTX_INCLUDE_ALL_TOOLS=OFF -DNUTTX_INCLUDE_MKVERSION=ON

```
test@TEST MSYS ~/nuttx/tools
$ cmake -B build -DNUTTX_INCLUDE_ALL_TOOLS=OFF -DNUTTX_INCLUDE_MKVERSION=ON
-- The C compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: MSYS
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/test/nuttx"
   HOST = WINDOWS MSYS
-- Configuring done (1.5s)
-- Generating done (0.0s)
-- Build files have been written to: /home/test/nuttx/tools/build

test@TEST MSYS ~/nuttx/tools
$ cmake --build build
[ 33%] Building C object CMakeFiles/mkversion.dir/mkversion.c.o
[ 66%] Building C object CMakeFiles/mkversion.dir/cfgdefine.c.o
[100%] Linking C executable mkversion.exe
[100%] Built target mkversion

```


