### PR TITLE
boards/sama5d3-xplained: Use common usb host waiter.

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -4120,6 +4120,7 @@ config SAMA5_OHCI
 	default n
 	select USBHOST
 	select USBHOST_HAVE_ASYNCH
+	select USBHOST_WAITER
 	---help---
 		Build support for the SAMA5 USB full speed Open Host Controller
 		Interface (OHCI).
@@ -4156,6 +4157,7 @@ config SAMA5_EHCI
 	default n
 	select USBHOST
 	select USBHOST_HAVE_ASYNCH
+	select USBHOST_WAITER
 	---help---
 		Build support for the SAMA5 USB high speed Enhanced Host Controller
 		Interface (EHCI).  If low/full speed is needed too, then you must


### PR DESCRIPTION
## Summary

Delete the board-specific usb host waiters and use the common code.

## Impact

Only affects users of sama5d3-xplained

## Testing

Add this to the sama5d3-xplained/configs/nsh/defconfig

CONFIG_SAMA5_EHCI=y
CONFIG_SAMA5_OHCI=y
CONFIG_SAMA5_UHPHS=y
CONFIG_USBHOST_MSC=y

Load and run nuttx.bin at 0x20008000 using u-boot
Plug in a USB storage device.
If "sda" is listed, the waiter is working. (Unplugging will remove the "sda")

nsh> ls /dev
/dev:
 console
 null
 sda
 ttyDBGU
 zero
