### PR TITLE
Documentation/sama5d3-xplained: Remove duplicate link.

### DIFF
--- a/Documentation/platforms/arm/sama5/boards/sam5d3-xplained/index.rst
+++ b/Documentation/platforms/arm/sama5/boards/sam5d3-xplained/index.rst
@@ -1,7 +1,0 @@
-================
-sama5d3-xplained
-================
-
-This is the  port of NuttX to the Atmel SAMA5D3x-Xplained development board.
-This board features the Atmel SAMA5D36.  See
-http://www.atmel.com/devices/sama5d36.aspx.

--- a/Documentation/platforms/arm/sama5/boards/sama5d3-xplained/index.rst
+++ b/Documentation/platforms/arm/sama5/boards/sama5d3-xplained/index.rst
@@ -2,6 +2,10 @@
 sama5d3-xplained
 ================
 
+This is the  port of NuttX to the Atmel SAMA5D3x-Xplained development board.
+This board features the Atmel SAMA5D36.  See
+http://www.atmel.com/devices/sama5d36.aspx.
+
 For details look at ``Documentation/platforms/arm/sama5/boards/sama5d3-xplained/README.txt``
 
 .. this breaks latexpdf build


### PR DESCRIPTION
## Summary

There were two sama5d3-xplained links in the Supported Boards section.

## Impact

None

## Testing

Only one sama5d3-xplained link seen in the file generated by make html.
