### PR TITLE
drivers/ctucanfd_pci.c: fix frame reception

### DIFF
--- a/drivers/can/ctucanfd_pci.c
+++ b/drivers/can/ctucanfd_pci.c
@@ -766,11 +766,15 @@ static void ctucanfd_chardev_receive(FAR struct ctucanfd_can_s *priv)
 
       frame = (struct ctucanfd_frame_s *)&buff;
 
-      for (i = 0; i < sizeof(struct ctucanfd_frame_s) / 4; i++)
-        {
-          /* RX buffer in automatic mode */
+      /* RX buffer in automatic mode */
 
-          buff[i] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+      buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+
+      /* Read the rest of data */
+
+      for (i = 0; i < frame->fmt.rwcnt; i++)
+        {
+          buff[i + 1] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
         }
 
       /* Get the DLC */
@@ -1369,11 +1373,15 @@ static void ctucanfd_sock_receive(FAR struct ctucanfd_can_s *priv)
 
       rxframe = (struct ctucanfd_frame_s *)&buff;
 
-      for (i = 0; i < sizeof(struct ctucanfd_frame_s) / 4; i++)
-        {
-          /* RX buffer in automatic mode */
+      /* RX buffer in automatic mode */
 
-          buff[i] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+      buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+
+      /* Read the rest of data */
+
+      for (i = 0; i < rxframe->fmt.rwcnt; i++)
+        {
+          buff[i + 1] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
         }
 
       /* CAN 2.0 or CAN FD */


### PR DESCRIPTION
## Summary

Fix frame reception when CANFD is not enabled and there are many message in the RX buffer.

The previous implementation assumed that the size of the data in the RX buffer is constant, which is not true. Fortunately, the amount of data in the buffer can be easily read from frame->fmt.rwcnt.

## Impact

fix CAN CTU FD when used in non CANFD mode.

## Testing

CAN network simulated on host doesn't lose frames:
- qemu-x86 with canctufd and candump tool
- qemu-arm and canctufd runs simple CAN node with socketcan
- arm and canctufd runs simple CAN node with char dev
- sim runs simple CAN node with socketcan
- sim runs simple CAN node with char dev

<img width="1921" alt="image" src="https://github.com/user-attachments/assets/6b5827f3-f1c4-4a42-bdbb-4611414b471d" />


