### PR TITLE
arch/stm32h5: Fix FLASH bank logic during erase operations.

### DIFF
--- a/arch/arm/src/stm32h5/stm32_start.c
+++ b/arch/arm/src/stm32h5/stm32_start.c
@@ -237,7 +237,7 @@ void __start(void)
 
   nx_start();
 
-  /* Shoulnd't get here */
+  /* Shouldn't get here */
 
   for (; ; );
 }


### PR DESCRIPTION
## Summary
Properly select physical bank for block erase based on block number.

Previously, it would configure flash erase bank select based on the logical bank. If banks were swapped, and user application tried to erase the first block of logical bank 2 (expecting to erase starting at 0x08100000), it would actually erase starting at 0x0800000. This is fixed in this commit.

This is the fix for the bug reported in #16417.

## Impact

- Fix for #16417
- Allows progmem interface on STM32H5 MCUs when flash banks are swapped with option byte `SWAP_BANK = 1`

## Testing

Target: STM32H563ZIT6U
Board: Nucleo H563ZI
Config: Modified version of nucleo-h563zi:nsh
- Enables progmem driver in system type and MTD device driver.
- Adds access to custom app for testing (See below)

Result of ostest from this build: [ostest.log](https://github.com/user-attachments/files/20374960/ostest.log)
Testing was done using a simple custom test application. 

1. Use STM32CubeProgrammer to wipe clear flash memory and set the SWAP_BANK option bit.
2. Reset device for update to SWAP_BANK to take effect.
3. Load nuttx onto the board and begin debug session
4. Use breakpoints on each erase/write in the custom app to stop and investigate memory of block starting at `0x08100000`.
  - Confirmed that the memory erase and write operations behave as expected, and memory block at `0x08000000` remains untouched.

**Note:** This chip can only be debugged once before having to wipe flash. See behavior described in #16416. Without debugger attached (just load app and let it run) this DOES NOT OCCUR. We have a separate custom application that uses bank swapping for IAP and as long as no debugger connects, this works as expected. It appears there is something wrong with the debugger/STM32H5. 

### Custom Test App:
Used this app to test progmem write and erase:
```c
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>

#include <nuttx/config.h>
#include <nuttx/mtd/mtd.h>
#include <nuttx/progmem.h>

#define H563ZI

#ifdef H563ZI
#  define BLOCK_SIZE (8 * 1024)
#  define BANK2_STARTADDR 0x08100000
#endif

static uint8_t *buff;

int main(int argc, char *argv[])
{
  size_t i;
  int ret;
  uint32_t pattern = 0xDEADBEEF;
  buff = (uint8_t *)malloc(BLOCK_SIZE);

  if (!buff)
    {
      printf("Failed to allocate buffer: %s\n", strerror(errno));
      return -EIO;
    }

  for (i = 0; i < BLOCK_SIZE; i += sizeof(pattern))
    {
      if (i + sizeof(pattern) <= BLOCK_SIZE)
        {
          memcpy(buff + i, &pattern, sizeof(pattern));
        }
    }

  ret = up_progmem_write(BANK2_STARTADDR, (const void *)buff, BLOCK_SIZE);
  if (ret < 0)
    {
      printf("Progmem write failed: %d\n", ret);
      goto exit_with_free;
    }

  /* Basically, trying to erase and then write the first block of the bank.
   * Then, do a bank swap. On POR, the banks will flip, and this should STILL
   * work. If it breaks when the banks are swapped, it is erasing the improper
   * bank block.
   */

  ret = up_progmem_eraseblock(128);
  if (ret < 0)
    {
     printf("Progmem erase block 128 failed: %d\n", ret);
     goto exit_with_free;
    }

  ret = up_progmem_write(BANK2_STARTADDR, (const void *)buff, BLOCK_SIZE);
  if (ret < 0)
    {
      printf("Progmem write failed: %d\n", ret);
      goto exit_with_free;
    }

exit_with_free:
  free(buff);

  return 0;
}
```

