### PR TITLE
tools/nxstyle.c: fix defined but not used warning

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -756,6 +756,7 @@ char *my_strndup(const char *s, size_t size)
 #  define strndup my_strndup
 #endif
 
+#ifdef CONFIG_WINDOWS_NATIVE
 /********************************************************************************
  * Name: backslash_to_slash
  *
@@ -781,6 +782,7 @@ static void backslash_to_slash(char *str)
         }
     }
 }
+#endif
 
 /********************************************************************************
  * Name: skip


### PR DESCRIPTION
## Summary
fix defined but not used warning from CI:

  Warning: nxstyle.c:767:13: warning: ‘backslash_to_slash’ defined but not used [-Wunused-function]
    767 | static void backslash_to_slash(char *str)


## Impact
fix warning

## Testing
CI

