### PR TITLE
Resolving the issue of fdcheck reporting errors when an epoll file descriptor (fd) is closed

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1676,9 +1676,8 @@ int file_fcntl(FAR struct file *filep, int cmd, ...);
  * Name: file_poll
  *
  * Description:
- *   Low-level poll operation based on struct file.  This is used both to (1)
- *   support detached file, and also (2) by poll_fdsetup() to perform all
- *   normal operations on file descriptors.
+ *   Low-level poll operation based on struct file.  This is used to
+ *   support detached file.
  *
  * Input Parameters:
  *   file     File structure instance

--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -154,7 +154,6 @@ int ppoll(FAR struct pollfd *fds, nfds_t nfds,
           FAR const struct timespec *timeout_ts,
           FAR const sigset_t *sigmask);
 
-int poll_fdsetup(int fd, FAR struct pollfd *fds, bool setup);
 void poll_default_cb(FAR struct pollfd *fds);
 void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset);
 


### PR DESCRIPTION

## Summary

Resolving the issue of fdcheck reporting errors when an epoll file descriptor (fd) is closed.

The primary cause of the error is as follows: 
When a task exits by calling exit, it closes all file descriptors (fds) associated with the current task. 
When the epoll fd is closed, if there are still fds in the epoll queue that have values greater than the epoll fd, these fds may be closed first. This can lead to fdcheck failures when call epoll_close
To resolve this, we should use a file-based approach instead of directly managing fds in epoll.

## Impact

fix epoll fdcheck issue

## Testing

open vela monkey


