### PR TITLE
drivers/usbdev/cdcncm.c: Fix issue with USB unplug/replug not restarted link

### DIFF
--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -2864,6 +2864,9 @@ static int cdcncm_setup(FAR struct usbdevclass_driver_s *driver,
 static void cdcncm_disconnect(FAR struct usbdevclass_driver_s *driver,
                               FAR struct usbdev_s *dev)
 {
+  FAR struct cdcncm_driver_s *self = (FAR struct cdcncm_driver_s *)driver;
+
+  cdcncm_resetconfig(self);
   uinfo("\n");
 }
 


### PR DESCRIPTION
## Summary

See issue 16345 [here](https://github.com/apache/nuttx/issues/16345).

I found that the CDC-NCM link only successfully established on the first connection. If the USB was unplugged then replugged the link was not re-established.

@zhhyu7 provided the fix which I validated, and is now submitted here for all..

## Impact

The change is simple, involving the reset of the CDC-NCM configuration on a disconnect; it is then able to be reconfigured at the next connect. Impact should only be positive.

## Testing

After this fix I have had several weeks of ongoing development using CDC-NCM with 100's of connect/disconnect cycles with NO repeats of the issue.
