### PR TITLE
refactor: fix spelling in private field names

### DIFF
--- a/arch/arm/src/phy62xx/mcu_phy_bumbee.h
+++ b/arch/arm/src/phy62xx/mcu_phy_bumbee.h
@@ -166,7 +166,7 @@ typedef struct
 {
     __IO uint32_t  CTRL0;                /* 0x40 */
     __IO uint32_t  CTRL1;                /* 0x44 */
-    uint32_t  reserverd[13];
+    uint32_t reserved[13];
     __IO uint32_t REMAP_TABLE;           /* 0x7c */
     __IO uint32_t REMAP_CTRL[32];        /* 0x80 */
 } AP_CACHE_TypeDef;
@@ -179,9 +179,9 @@ typedef struct
     __O  uint32_t CCVR;                  /* 0x8 */
     __IO uint32_t CRR;                   /* 0xc */
     uint8_t  STAT;                       /* 0x10 */
-    uint8_t  reserverd1[3];
+    uint8_t reserved1[3];
     __IO uint8_t  EOI;                   /* 0x14 */
-    uint8_t  reserverd2[3];
+    uint8_t reserved2[3];
 } AP_WDT_TypeDef;
 
 typedef struct

--- a/arch/arm/src/tlsr82/tlsr82_adc.c
+++ b/arch/arm/src/tlsr82/tlsr82_adc.c
@@ -72,7 +72,7 @@ struct adc_info_s
   uint32_t   vbat_vref;    /* The reference voltage (mV) for vbat mode */
   bool       base_two;     /* Base/Gpio mode two-point calibration or not */
   bool       registered;   /* Have registered a adc device */
-  bool       configed;     /* Adc has been configured or not */
+  bool       configured;   /* Adc has been configured or not */
   uint8_t    channel;      /* Adc current channel */
   uint8_t    channeltype;  /* Adc current channel type */
 };
@@ -123,7 +123,7 @@ static struct adc_info_s g_adc_module0_info =
   .vbat_vref    = ADC_DEFAULT_VREF,
   .base_two     = false,
   .registered   = false,
-  .configed     = false,
+  .configured   = false,
   .channel      = ADC_CHAN_NONE,
   .channeltype  = ADC_CHAN_TYPE_NONE,
 };
@@ -1014,7 +1014,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   /* The same one adc device should be configgured only once */
 
-  if (priv->info->configed)
+  if (priv->info->configured)
     {
       return OK;
     }
@@ -1038,7 +1038,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   /* The ADC device is ready */
 
-  priv->info->configed = true;
+  priv->info->configured = true;
   priv->ref++;
 
   return OK;
@@ -1147,9 +1147,9 @@ static void adc_shutdown(struct adc_dev_s *dev)
 
           tlsr82_adc_clk_ctrl(false);
 
-          /* Clear the configed flag */
+          /* Clear the configured flag */
 
-          priv->info->configed = false;
+          priv->info->configured = false;
         }
     }
 }

--- a/arch/renesas/src/rx65n/rx65n_dtc.c
+++ b/arch/renesas/src/rx65n/rx65n_dtc.c
@@ -180,7 +180,7 @@ struct st_dtc_mrb_bit
 #else /* (DTC_IP_VER == DTC_IP_VER_DTCb) */
 #ifdef __RX_LITTLE_ENDIAN__
   uint8_t SQEND:1;  /* Sequence Transfer End */
-  uint8_t INDX:1;   /* Index Table Reference */
+  uint8_t INDEX:1;  /* Index Table Reference */
   uint8_t DM   :2;  /* Transfer Destination Address Addressing Mode */
   uint8_t DTS  :1;  /* DTC Transfer Mode Select */
   uint8_t DISEL:1;  /* DTC Interrupt Select */
@@ -192,7 +192,7 @@ struct st_dtc_mrb_bit
   uint8_t DISEL:1;  /* DTC Interrupt Select */
   uint8_t DTS  :1;  /* DTC Transfer Mode Select */
   uint8_t DM   :2;  /* Transfer Destination Address Addressing Mode */
-  uint8_t INDX:1;   /* Index Table Reference */
+  uint8_t INDEX:1;  /* Index Table Reference */
   uint8_t SQEND:1;  /* Sequence Transfer End */
 #endif
 #endif

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -323,7 +323,7 @@ begin_packed_struct struct v9fs_stat_s
 begin_packed_struct struct v9fs_rstat_s
 {
   struct v9fs_header_s header;
-  uint64_t vaild;
+  uint64_t valid;
   struct v9fs_qid_s qid;
   uint32_t mode;
   uint32_t uid;

--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -68,13 +68,13 @@ list(APPEND INCDIR ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/include)
 
 if(CONFIG_BUILTIN_COMPILER_RT)
 
-  nuttx_add_system_library(rt.buitlins)
+  nuttx_add_system_library(rt.builtins)
 
   target_include_directories(
-    rt.buitlins PRIVATE ${INCDIR}
+    rt.builtins PRIVATE ${INCDIR}
                         ${CMAKE_CURRENT_LIST_DIR}/compiler-rt/lib/builtins)
 
-  target_compile_options(rt.buitlins PRIVATE -Wno-undef -Wno-macro-redefined)
+  target_compile_options(rt.builtins PRIVATE -Wno-undef -Wno-macro-redefined)
 
   set(SRCSTMP)
   set(RT_BUILTINS_SRCS)
@@ -97,11 +97,11 @@ if(CONFIG_BUILTIN_COMPILER_RT)
   endif()
 
   if(NOT CONFIG_COVERAGE_NONE)
-    target_compile_options(rt.buitlins -fno-profile-instr-generate
+    target_compile_options(rt.builtins -fno-profile-instr-generate
                            -fno-coverage-mapping)
   endif()
 
-  target_sources(rt.buitlins PRIVATE ${RT_BUILTINS_SRCS})
+  target_sources(rt.builtins PRIVATE ${RT_BUILTINS_SRCS})
 
 endif()
 

--- a/tools/pynuttx/nxgdb/stack.py
+++ b/tools/pynuttx/nxgdb/stack.py
@@ -111,7 +111,7 @@ class Stack(object):
 
         return self.check_max_usage()
 
-    def avalaible(self):
+    def available(self):
         cur_usage = self.cur_usage()
         return self._stack_size - cur_usage
 


### PR DESCRIPTION
## Summary

Fix some misspelled field names.


## Impact

These field names seem to be used only in private contexts. Thus, the probability of external code accessing these fields is very low.
In the rare case of external usage, compile time errors will easily direct users to the new field name.

## Testing

The codespell check reports fewer issues.
No other testing was conducted.