### PR TITLE
boards/xtensa/esp32: add GC9A01 LCD driver support for esp32 based boards

### DIFF
--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -130,6 +130,10 @@ ifeq ($(CONFIG_LCD_ILI9341),y)
   CSRCS += esp32_ili9341.c
 endif
 
+ifeq ($(CONFIG_LCD_GC9A01),y)
+  CSRCS += esp32_gc9a01.c
+endif
+
 ifeq ($(CONFIG_LCD_ST7789),y)
   CSRCS += esp32_st7789.c
 endif

--- a/boards/xtensa/esp32/common/src/esp32_board_spi.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spi.c
@@ -73,7 +73,7 @@ static inline uint8_t spi_status(struct spi_dev_s *dev, uint32_t devid)
 static inline int spi_cmddata(struct spi_dev_s *dev, uint32_t devid,
                               bool cmd)
 {
-#if defined(CONFIG_LCD_ILI9341) || defined(CONFIG_LCD_SSD1680) || defined(CONFIG_LCD_ST7789)
+#if defined(CONFIG_LCD_ILI9341) || defined(CONFIG_LCD_SSD1680) || defined(CONFIG_LCD_ST7789) || defined(CONFIG_LCD_GC9A01)
   if (devid == SPIDEV_DISPLAY(0))
     {
       /*  This is the Data/Command control pad which determines whether the

--- a/boards/xtensa/esp32/common/src/esp32_gc9a01.c
+++ b/boards/xtensa/esp32/common/src/esp32_gc9a01.c
@@ -1,0 +1,132 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_gc9a01.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <arch/board/board.h>
+#include <debug.h>
+#include <errno.h>
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/config.h>
+#include <nuttx/lcd/gc9a01.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/spi/spi.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "esp32_gpio.h"
+#include "esp32_spi.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  g_spidev = esp32_spibus_initialize(DISPLAY_SPI);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", DISPLAY_SPI);
+      return -ENODEV;
+    }
+
+  lcdinfo("Initialized SPI port %d\n", DISPLAY_SPI);
+
+  /* SPI RX is not used. Same pin is used as LCD Data/Command control */
+
+  esp32_configgpio(DISPLAY_DC, OUTPUT);
+  esp32_gpiowrite(DISPLAY_DC, true);
+
+  /* Pull LCD_RESET high */
+
+  esp32_configgpio(DISPLAY_RST, OUTPUT);
+  esp32_gpiowrite(DISPLAY_RST, false);
+  up_mdelay(50);
+  esp32_gpiowrite(DISPLAY_RST, true);
+  up_mdelay(50);
+
+  /* Set full brightness */
+
+  esp32_configgpio(DISPLAY_BCKL, OUTPUT);
+  esp32_gpiowrite(DISPLAY_BCKL, true);
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  g_lcd = gc9a01_lcdinitialize(g_spidev);
+  if (!g_lcd)
+    {
+      lcderr("ERROR: Failed to bind SPI port %d to LCD %d\n",
+             DISPLAY_SPI, devno);
+    }
+  else
+    {
+      lcdinfo("SPI port %d bound to LCD %d\n", DISPLAY_SPI, devno);
+      return g_lcd;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}


### PR DESCRIPTION
## Summary

ESP32 boards will now be able to use GC9A01 LCDs by enabling CONFIG_LCD_GC9A01.

## Impact

Might impact all the esp32 based boards. The code has been only tested on ESP32-WROVER-IE based kit.

## Testing
Tested LVGL demo example on ESP32-WROVER-IE kit.
It worked as shown in the attached picture.
![image](https://github.com/user-attachments/assets/553e0f61-3ae3-45cc-800a-88e51610180a)



