### PR TITLE
arch/avr: fix up_saveusercontext and other smaller changes

### DIFF
--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -110,6 +110,10 @@ ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
   LDFLAGS += -Map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
 endif
 
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GCC),y)
+  LDFLAGS += --print-memory-usage
+endif
+
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += -fno-strict-aliasing
 endif

--- a/arch/avr/src/avr/avr_saveusercontext.S
+++ b/arch/avr/src/avr/avr_saveusercontext.S
@@ -68,5 +68,26 @@ up_saveusercontext:
 
 	USER_SAVE
 
+	/* Main purpose of USER_SAVE macro is to serve as a first half
+	 * of a context switch. To be able to do that, it - among other
+	 * things - pops return address from the stack. The other half
+	 * of context switch procedure then reverses that and pushes
+	 * (different) return address back to the stack and returns
+	 *
+	 * The same needs to be done here, albeit simplified (we are
+	 * not restoring context, just need return address back on the stack
+	 * to be able to return.)
+	 *
+	 * Return address is loaded to r18-r20 in USER_SAVE
+	 */
+
+	push r18
+	push r19
+#if AVR_PC_SIZE > 16
+	push r20
+#endif /* AVR_PC_SIZE */
+
+	ret
+
 	.endfunc
 	.end

--- a/arch/avr/src/avr/excptmacros.h
+++ b/arch/avr/src/avr/excptmacros.h
@@ -346,6 +346,12 @@
 
   /* Pop the return address from the stack (PC0 then PC1).
    *  R18:19 are Call-used
+   *
+   * NOTE: up_saveusercontext in avr_saveusercontext.S uses this macro
+   * and needs to reverse this by pushing the return address back
+   * to the stack. Contents of these two/three registers must not change
+   * throughout whole macro and all changes in registers used and/or
+   * instruction ordering need to be reflected in up_saveusercontext.
    */
 
 #if AVR_PC_SIZE > 16

--- a/arch/avr/src/avrdx/avrdx_serial.c
+++ b/arch/avr/src/avrdx/avrdx_serial.c
@@ -607,7 +607,7 @@ static bool avrdx_usart_txempty(struct uart_dev_s *dev)
  * Name: avrdx_initialize_port
  *
  * Description:
- *   DRY method for USARTn initialization. Allocated data structures
+ *   DRY method for USARTn initialization. Allocates data structures
  *   for USARTn peripheral and assigns into g_usart_ports array
  *
  * Input Parameters:

--- a/boards/avr/avrdx/breadxavr/include/board.h
+++ b/boards/avr/avrdx/breadxavr/include/board.h
@@ -49,13 +49,13 @@
  */
 
 #define LED_STARTED            0
-#define LED_HEAPALLOCATE       1
-#define LED_IRQSENABLED        2
-#define LED_STACKCREATED       3
-#define LED_INIRQ              4
-#define LED_SIGNAL             5
-#define LED_ASSERTION          6
-#define LED_PANIC              7
+#define LED_HEAPALLOCATE       0
+#define LED_IRQSENABLED        0
+#define LED_STACKCREATED       1
+#define LED_INIRQ              2
+#define LED_SIGNAL             2
+#define LED_ASSERTION          2
+#define LED_PANIC              0
 
 /* Button definitions
  *


### PR DESCRIPTION
## Summary

0001 - this patch fixes LED constants for breadxavr board. The code was
developed based on other AVR boards, LED constants were taken from board
that apparently has multiple status LEDs and used on a board that only
has one.

The functionality that was not working properly is blinking LED on
panic, which works correctly now

0002 - while digging around in the code trying to figure out how PANIC()
works, I noticed a bug in up_saveusercontext function that is called
from _assert.

The function makes use of USER_SAVE macro but that macro is designed to
be only a first half of the context switch. It is unsuitable to be used
standalone like it was in up_saveusercontext, it pops return address
from the stack and does not return, meaning that the function also did
not return.

The patch adds what is missing and what would otherwise be done by the
second half of the context switch.

Tested by compiling and verifying the disassembly - the function no
longer falls through to the next function in the program memory,
push/pop instructions are balanced and stack contents preserved

0003 - typo fix

0004 - this patch adds --print-memory-usage flag to the linker if GCC
compiler is used. Memory usage information is then output after linking.
Can't test other supported compilers but they should not be affected
since the patch only takes effect if CONFIG_ARCH_TOOLCHAIN_GCC is set

## Impact

AVR

## Testing

CI
