### PR TITLE
arm64/toolchain: Add -fstack-usage for stack analysis

### DIFF
--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -76,6 +76,14 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
+ifeq ($(CONFIG_STACK_USAGE),y)
+  ARCHOPTIMIZATION += -fstack-usage
+endif
+
+ifneq ($(CONFIG_STACK_USAGE_WARNING),0)
+  ARCHOPTIMIZATION += -Wstack-usage=$(CONFIG_STACK_USAGE_WARNING)
+endif
+
 ifeq ($(CONFIG_MM_UBSAN_ALL),y)
   ARCHOPTIMIZATION += $(CONFIG_MM_UBSAN_OPTION)
 endif

--- a/arch/arm64/src/cmake/Toolchain.cmake
+++ b/arch/arm64/src/cmake/Toolchain.cmake
@@ -105,6 +105,14 @@ if(CONFIG_STACK_CANARIES)
   add_compile_options(-fstack-protector-all)
 endif()
 
+if(CONFIG_STACK_USAGE)
+  add_compile_options(-fstack-usage)
+endif()
+
+if(CONFIG_STACK_USAGE_WARNING)
+  add_compile_options(-Wstack-usage=${CONFIG_STACK_USAGE_WARNING})
+endif()
+
 if(CONFIG_MM_UBSAN_ALL)
   add_compile_options(${CONFIG_MM_UBSAN_OPTION})
 endif()


### PR DESCRIPTION
## Summary
Add -fstack-usage to arch/arm64/src/Toolchain.defs for stack analysis. The problem is that after `CONFIG_STACK_USAGE` enabled, no "*.su" file was generated, tools/showstack.sh output nothing.

**Referenced to https://github.com/apache/nuttx/pull/8177**

## Impact
arm64/toolchain

## Testing
qemu-armv8a:nsh

