### PR TITLE
fs/vfs/fs_rename: fix directory move operation.

### DIFF
--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -80,7 +80,6 @@ static int pseudorename(FAR const char *oldpath, FAR struct inode *oldinode,
    * first, provided that it is not a directory.
    */
 
-next_subdir:
   SETUP_SEARCH(&newdesc, newpath, true);
   ret = inode_find(&newdesc);
   if (ret >= 0)
@@ -120,16 +119,6 @@ next_subdir:
         {
           FAR char *subdirname;
 
-          inode_release(newinode);
-
-          /* Free memory may be allocated in previous loop */
-
-          if (subdir != NULL)
-            {
-              fs_heap_free(subdir);
-              subdir = NULL;
-            }
-
           /* Yes.. In this case, the target of the rename must be a
            * subdirectory of newinode, not the newinode itself.  For
            * example: mv b a/ must move b to a/b.
@@ -145,14 +134,6 @@ next_subdir:
             }
 
           newpath = subdir;
-
-          /* This can be a recursive case, another inode may already exist
-           * at oldpth/subdirname.  In that case, we need to do this all
-           * over again.  A nasty goto is used because I am lazy.
-           */
-
-          RELEASE_SEARCH(&newdesc);
-          goto next_subdir;
         }
       else
         {
@@ -354,7 +335,6 @@ static int mountptrename(FAR const char *oldpath, FAR struct inode *oldinode,
     {
       struct stat buf;
 
-next_subdir:
       ret = oldinode->u.i_mops->stat(oldinode, newrelpath, &buf);
       if (ret >= 0)
         {
@@ -384,19 +364,8 @@ next_subdir:
                 }
               else
                 {
-                  /* Save subdir to free memory may be allocated in
-                   * previous loop.
-                   */
-
-                  FAR void *tmp = subdir;
-
                   ret = fs_heap_asprintf(&subdir, "%s/%s", newrelpath,
                                  subdirname);
-                  if (tmp != NULL)
-                    {
-                      lib_free(tmp);
-                    }
-
                   if (ret < 0)
                     {
                       subdir = NULL;
@@ -406,14 +375,6 @@ next_subdir:
 
                   newrelpath = subdir;
                 }
-
-              /* This can be a recursive, another directory may already
-               * exist at the newrelpath.  In that case, we need to
-               * do this all over again.  A nasty goto is used because
-               * I am lazy.
-               */
-
-              goto next_subdir;
             }
           else
             {


### PR DESCRIPTION
## Summary

* Recurrency is removed from filesystem directory rename.
* Fixes use after free in buffer that was used as output and argument.
* Patch provided by @richyliu.

## Impact

fs/vfs bug fix of possible use after free.

## Testing

@cederom: esp32c6-xiao:usbnsh.
@richyliu: STM32 Nucleo H743ZI + FTP.

Reviewers please double check locally if the issue is reproducible and there are no side effects after patch :-)
