### PR TITLE
net/tcp: Fix keep-alive implementation

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -701,6 +701,8 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
                        * connection.
                        */
 
+                      devif_conn_event(conn->dev, TCP_ABORT,
+                                       conn->sconn.list);
                       tcp_stop_monitor(conn, TCP_ABORT);
                     }
                   else


### PR DESCRIPTION
## Summary

The TCP keep-alive implementation would send the probes and abort the connection correctly, but without waking up the
affected socket and marking the connection as aborted. This patch from @zhhyu7 in #16447 resolves the issue.

## Impact

The TCP keep-alive implementation is functional again, users can expect this feature to behave properly.

 Closes #16447.

## Testing

Testing was performed by using two W5500-EVB Picos connected via TCP over a network. The client Pico would be powered-off while the server Pico was waiting on a blocking `recv`. Before the fix was applied, the server would never wake up despite the TCP connection being aborted. The abort mechanism would also trigger repeatedly. With this patch, the server Pico is woken up from the receive with `errno` set to `ENOTCONN` after the timeout is over.

The code for the test can be seen here:
* Server: https://github.com/CarletonURocketry/hysim/tree/78924ab114c166841417b7e4bc3f4d14ab8ec572/pad_server
* Client: https://github.com/CarletonURocketry/hysim/tree/78924ab114c166841417b7e4bc3f4d14ab8ec572/control_client