### PR TITLE
arch/arm64/imx9: Guard EL3-only features when booting at EL1

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -69,12 +69,12 @@ config IMX9_HAVE_ATF_FIRMWARE
 
 config IMX9_BOOTLOADER
 	bool "Bootloader"
-	select ARM64_DECODEFIQ
-	select IMX9_DDR_TRAINING
+	select ARM64_DECODEFIQ if ARCH_ARM64_EXCEPTION_LEVEL = 3
+	select IMX9_DDR_TRAINING if ARCH_ARM64_EXCEPTION_LEVEL = 3
 	default n
 	---help---
 		Configure NuttX as the bootloader. NuttX will be compiled
-		into OCRAM. It will run in EL3 secure state.
+		into OCRAM if we are in EL3.
 
 config BOOTLOADER_SYS_CLOCK
 	int "Bootloader system clock for timer"

--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -126,7 +126,7 @@ void arm64_el_init(void)
 
 void arm64_chip_boot(void)
 {
-#ifdef CONFIG_IMX9_BOOTLOADER
+#if defined(CONFIG_IMX9_BOOTLOADER) && CONFIG_ARCH_ARM64_EXCEPTION_LEVEL == 3
   imx9_mix_powerup();
 
   /* Before DDR init we need to initialize clocks and trdc */


### PR DESCRIPTION
## Summary
Originally the i.MX9 bootloader was only supposed to run at EL3. However in some scenarios, for instance in a TF-A
deployment, the nuttx bootloader is the BL33 payload and runs at EL1.
To make the bootloader run at EL1 we need to remove parts of the initialization that are only expected to happen at EL3.

This PR is minimal, and  doesn't auto select DDR training and FIQ decoding if   `ARCH_ARM64_EXCEPTION_LEVEL != 3`.
Additionally `arm64_chip_boot()` excludes `imx9_mix_powerup()`, `imx9_ccm_clock_init()`, `imx9_trdc_init()` and `imx9_dram_init()` if `ARCH_ARM64_EXCEPTION_LEVEL != 3`

## Impact
Boards without `CONFIG_IMX9_BOOTLOADER` or boards with `CONFIG_IMX9_BOOTLOADER=y` that already run the bootloader at EL3 behave exactly as before.
Boards built with `CONFIG_IMX9_BOOTLOADER=y` and `ARCH_ARM64_EXCEPTION_LEVEL=1` will operate correctly, provided they are paired with an EL3-level bootloader that performs the required EL3 initialization.

## Testing
**Hardware**: custom i.MX93 board
**Build**: `CONFIG_IMX9_BOOTLOADER=y`, `ARCH_ARM64_EXCEPTION_LEVEL=1` + custom defconfig that matches the hardware characteristics of the board
**Scenario**: Minimal EL3 nuttx bootloader as BL2, TF-A as BL31, an EL1 nuttx bootloader as BL33 which in turn boots another image
**Result**: OS boots; serial console and user tasks run normally.



