### PR TITLE
analog/ads1115: Speed up channel measurement delays

### DIFF
--- a/drivers/analog/ads1115.c
+++ b/drivers/analog/ads1115.c
@@ -423,7 +423,7 @@ static int ads1115_readchannel(FAR struct ads1115_dev_s *priv,
             {
               /* ADS1115 takes ~25 usec to wake up */
 
-              nxsig_usleep(25);
+              up_udelay(4000);
               ret = ads1115_read_current_register(priv, &buf);
               count++;
             }


### PR DESCRIPTION
## Summary

The ADS1115 driver uses the `nxsig_usleep()` function to sleep for a 65us delay, but with a 1ms tick resolution and the context-switching overhead, this is much more than 1ms. Introducing `up_udelay` (even with a larger duration because of the unreliability of busy-waiting) speeds up sampling noticeably.

## Impact

The ADS1115 driver samples more quickly than before, but is dependent on `up_udelay` instead of `nxsig_usleep`.

## Testing

This was tested by comparing the speed at which the ADC could be sampled using either sleep implementation, where the `up_udelay` implementation was faster.

The delay was increased to 4000us since lower values caused a sampling failure. The busy-wait delay is not very precise.