### PR TITLE
arch/arm/imxrt: rt117x fix TCM/OCRAM ECC backdoor access

### DIFF
--- a/arch/arm/src/imxrt/hardware/rt117x/imxrt117x_iomuxc.h
+++ b/arch/arm/src/imxrt/hardware/rt117x/imxrt117x_iomuxc.h
@@ -2397,6 +2397,10 @@
 #  define GPR_GPR16_FLEXRAM_BANK_CFG_SEL_FUSE (0 << 2) /*          Use fuse value to configure */
 #  define GPR_GPR16_FLEXRAM_BANK_CFG_SEL_REG  (1 << 2) /*          Use FLEXRAM_BANK_CFG to configure */
 
+#define GPR_GPR16_CM7_FORCE_HCLK            (1 << 3) /* Bit 3:   Force FlexRAM AHB clock during CM7 sleep (CM7_FORCE_HCLK) */
+#  define GPR_GPR16_CM7_FORCE_HCLK_GATED    (0 << 3) /*          When CM7 is sleeping and TCM is not accessible */
+#  define GPR_GPR16_CM7_FORCE_HCLK_ENABLED  (1 << 3) /*          When CM7 is sleeping and TCM is accessible */
+
                                                     /* Bit 4:      Reserved */
 
 #define GPR_GPR16_M7_GPC_SLEEP_SEL             (1 << 5) /* Bit 5:  CM7 sleep request selection (M7_GPC_SLEEP_SEL) */

--- a/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
+++ b/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
@@ -130,8 +130,16 @@ static void imxrt_oscsetup(void)
 
   /* FlexRAM AXI CLK ROOT */
 
-  putreg32(CCM_CG_CTRL_RSTDIV(1) | CCM_CG_CTRL_DIV0(1),
+  putreg32(CCM_CG_CTRL_RSTDIV(3) | CCM_CG_CTRL_DIV0(3),
   IMXRT_CCM_CG_CTRL(0));
+
+  /* Keep TCM clock running during M7 sleep
+   * needed for DMA to read/write from TCM or OCRAM-M7 FlexRAM ECC
+   */
+
+  reg = getreg32(IMXRT_IOMUXC_GPR_GPR16);
+  putreg32(reg | GPR_GPR16_CM7_FORCE_HCLK_ENABLED,
+  IMXRT_IOMUXC_GPR_GPR16);
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

Fixes issues with CPU hanging when accessing OCRAM M7 ECC memory region.
And corruption from eDMA writing into DTCM memory.

This was caused because FlexRAM peripheral was incorrectly clocked and turned during off M7 sleep. 
This patch fixes clock setting and ensure that clock stays on during M7 for backdoor access from for example eDMA.

## Impact
rt117x

## Testing
V6X-RT with memory testing tools


