### PR TITLE
Documentation/drivers/analog/adc/ads1115: Add missing documentation for ioctl

### DIFF
--- a/Documentation/components/drivers/character/analog/adc/ads1115/index.rst
+++ b/Documentation/components/drivers/character/analog/adc/ads1115/index.rst
@@ -230,3 +230,8 @@ of type uint16_t, which corresponds to the HIGH_THRESH register value.
 
 This command changes the LOW_THRESH register of the ADS1115. The argument passed should be 
 of type uint16_t, which corresponds to the LOW_THRESH register value.
+
+.. c:macro:: ANIOC_ADS1115_READ_CHANNEL
+
+This command reads a value from a specific channel of the ADS1115. The argument passed should
+be a pointer to a struct adc_msg_s.


### PR DESCRIPTION
## Summary

Added a missing ioctl command for the ADS1115 (`ANIOC_ADS1115_READ_CHANNEL`) to the documentation. 

## Impact

Adds the missing documentation

## Testing

Used `make html` and checked in browser.


