### PR TITLE
arch/arm/src/samv7/sam_serial_spi.c: set correct SPI mode during init

### DIFF
--- a/arch/arm/src/samv7/sam_serial_spi.c
+++ b/arch/arm/src/samv7/sam_serial_spi.c
@@ -818,9 +818,10 @@ struct spi_dev_s *sam_serial_spi_initialize(int port)
 
       leave_critical_section(flags);
 
-      /* Configure mode register. */
+      /* Configure mode register. Set master mode, 8 bits and SPI Mode 0 */
 
-      regval = UART_MR_MODE_SPIMSTR | UART_MR_CLKO | UART_MR_CHRL_8BITS;
+      regval = UART_MR_MODE_SPIMSTR | UART_MR_CLKO | UART_MR_CHRL_8BITS |
+               UART_MR_CPHA;
       serial_putreg(priv, SAM_UART_MR_OFFSET, regval);
 
       /* Enable receiver & transmitter */


### PR DESCRIPTION
## Summary
Bitfield `CPHA` has to be set to run SPI in mode 0. This is a default mode, therefore it should be set during the peripheral initialization.

## Impact

Samv7 only. SPI on USART is now initialized in a correct mode.

## Testing

Tested against icjx io expander. The mode selection is now correct also according to an oscilloscope (previous behavior had data change on leading edge and sampled on falling edge)


