### PR TITLE
audio/comp: fix build warning caused by invalid return value

### DIFF
--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -955,7 +955,7 @@ FAR struct audio_lowerhalf_s *audio_comp_initialize(FAR const char *name,
 
   if (i == 0)
     {
-      return -EINVAL;
+      return NULL;
     }
 
   priv = kmm_zalloc(sizeof(struct audio_comp_priv_s) +


### PR DESCRIPTION
## Summary

audio/comp: fix build warning caused by invalid return value

```
audio/audio_comp.c:958:14: warning: returning ‘int’ from a function with return
                                    type ‘struct audio_lowerhalf_s *’ makes pointer
                                    from integer without a cast [-Wint-conversion]
  958 |       return -EINVAL;
      |              ^
```

Signed-off-by: chao an <anchao.archer@bytedance.com>



## Impact

N/A

## Testing

enable CONFIG_AUDIO_COMP without warning
