### PR TITLE
Fix typo in scheduling docs

### DIFF
--- a/Documentation/reference/user/02_task_scheduling.rst
+++ b/Documentation/reference/user/02_task_scheduling.rst
@@ -12,7 +12,7 @@ Optionally, a NuttX task or thread can be configured with round-robin or
 *except* that tasks with equal priority and share CPU time via
 *time-slicing*. The time-slice interval is a constant determined by the
 configuration setting ``CONFIG_RR_INTERVAL`` to a positive, non-zero
-value. Sporadic scheduling scheduling is more complex, varying the
+value. Sporadic scheduling is more complex, varying the
 priority of a thread over a *replenishment* period. Support for sporadic
 scheduling is enabled by the configuration option
 ``CONFIG_SCHED_SPORADIC``.


### PR DESCRIPTION
## Summary

Remove repeated word in

> Sporadic scheduling scheduling is more complex

in the _[Task Scheduling Interfaces](https://nuttx.apache.org/docs/latest/reference/user/02_task_scheduling.html#task-scheduling-interfaces)_ page in the documentation.

## Impact

Just slightly easier reading.

## Testing

None. Would like to verify that docs render correctly.

Should I reflow the text to fit a specific line width?

