### PR TITLE
docs/conf.py: Fix missing `nuttx_versions`

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -85,8 +85,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "legacy_README.md", "ven
 # overridden by command line option but we can provide a sane default
 # this way
 
-html_context = dict()
-html_context["nuttx_versions"] = "latest"
 
 # TODO: append other options using releases detected from git (or maybe just
 # a few hand-selected ones, or maybe just a "stable" option)
@@ -101,6 +99,15 @@ html_theme = "sphinx_rtd_theme"
 html_show_sphinx = False
 
 html_theme_options = {"navigation_depth": 5}
+
+html_context = {
+    "display_github": True,
+    "github_user": "apache",
+    "github_repo": "nuttx",
+    "github_version": "master",
+    "conf_py_path": "/Documentation/",
+    "nuttx_versions": "latest",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -134,14 +141,6 @@ copybutton_exclude = ".linenos, .gp, .go"
 # -- Options for warnings_filter ------------------------------------------
 
 warnings_filter_config = "known-warnings.txt"
-
-html_context = {
-    "display_github": True,
-    "github_user": "apache",
-    "github_repo": "nuttx",
-    "github_version": "master",
-    "conf_py_path": "/Documentation/",
-}
 
 # -- Options for sphinx_tags ----------------------------------------------
 


### PR DESCRIPTION
## Summary

Add `nuttx_versions` back into the `html_context` variable after it was re-defined in #16440 to include more options. This fixes the failing Pphinx autobuild. I also moved the options into the HTML option section.

## Impact

`make autobuild` now works properly again. This change only affects the Documentation system.

## Testing

Tested by performing `make autobuild` locally after the change an observing a successful build and render.