### PR TITLE
docs/contributing: Add a commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,20 @@
+# EXAMPLE: net/can: Add g_ prefix to can_dlc_to_len and len_to_can_dlc.
+maintopic/subtopic: Short, explanatory context about this commit.
+
+Here you should write a description on what's changed, how, and why. You
+can use several lines, short sentences or even bullet points. You can
+even mention a specific issue/pull request using `#` followed by the
+numerical ID. For more pointers, please see `nuttx/CONTRIBUTING.md`.
+
+# Don't forget to run `git commit` with the `-s` option to sign-off your
+# commit!
+
+# Some questions to help you write a clear commit message
+# - What is the purpose of change?
+# - Why it is necessary
+# - What it does / adds / fixes
+# - How things are added / changed / fixed / updated
+# - What is the impact (build / runtime / api / what area)
+# - How it was tested (build host, compiler, target, logs)
+# - References (i.e. nuttx and nuttx-apps changes).
+# - Dependencies (if change depends on another change).

--- a/Documentation/contributing/making-changes.rst
+++ b/Documentation/contributing/making-changes.rst
@@ -207,6 +207,19 @@ squash before submitting the Pull Request:
 
    It is important to include an informative commit title and a commit message.
 
+   .. note::
+
+      You can setup the Git configuration local to your cloned copy of NuttX to
+      use the provided commit template every time you commit.
+
+      .. code:: console
+
+         $ cd nuttx
+         $ git config commit.template .gitmessage
+
+      This will pre-populate the commit message in your editor with the
+      template, which you can edit as a starting point.
+
    In the commit title please include the subsystem/area related to your contribution,
    followed by a descriptive message. Some examples:
 


### PR DESCRIPTION
## Summary

Introduces a commit message template with instructions in the contributing documentation about how to set it up. This way users are reminded of what makes a "good" NuttX commit as they write their commit, and don't need to re-consult the documentation every time.

## Impact

Impacts the Documentation for contributing, and also creates a template that users will be using for (presumably) every commit they write once they configure git templates.

## Testing

Tested locally by:

1) Verifying documentation build and render
2) Running the provided command in the documentation to set the template, and then using it to write this PR's commit message