### PR TITLE
syslog/rpmsg: disable force put char to lower putc

### DIFF
--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -245,7 +245,7 @@ static void syslog_rpmsg_addbuf(FAR struct syslog_rpmsg_s *priv,
 
   if (priv->flush)
     {
-#if defined(CONFIG_ARCH_LOWPUTC)
+#if defined(CONFIG_ARCH_LOWPUTC) && !defined(CONFIG_SYSLOG_DEFAULT)
       up_nputs(buffer, len);
 #endif
       priv->flush += len;
@@ -394,13 +394,15 @@ int syslog_rpmsg_flush(FAR syslog_channel_t *channel)
       priv->flush = priv->tail;
     }
 
+#if defined(CONFIG_ARCH_LOWPUTC) && !defined(CONFIG_SYSLOG_DEFAULT)
   while (priv->flush < priv->head)
     {
-#if defined(CONFIG_ARCH_LOWPUTC)
       up_putc(priv->buffer[SYSLOG_RPMSG_FLUSHOFF(priv)]);
-#endif
       priv->flush++;
     }
+#else
+  priv->flush = priv->head;
+#endif
 
   leave_critical_section(flags);
 


### PR DESCRIPTION

## Summary

syslog/rpmsg: disable force put char to lower putc

```
if rpmsg triggers force flushing when the master core provides lower putc,
characters will be duplicated caused by SYSLOG_DEFAULT also send the char to lower half.
in this PR, we disable force put char to lower putc if CONFIG_SYSLOG_DEFAULT is enabled
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

enable CONFIG_SYSLOG_DEFAULT and CONFIG_SYSLOG_RPMSG and check char output