### PR TITLE
arch/arm/src/mcx-nxxx/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/arch/arm/src/mcx-nxxx/CMakeLists.txt
+++ b/arch/arm/src/mcx-nxxx/CMakeLists.txt
@@ -37,4 +37,8 @@ if(CONFIG_NXXX_GPIO_IRQ)
   list(APPEND SRCS nxxx_gpioirq.c)
 endif()
 
+if(CONFIG_NXXX_LPI2C)
+  list(APPEND SRCS nxxx_lpi2c.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

Aligned Cmakefile with Make.defs PR #16469

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

local


