### PR TITLE
arch/risc-v/src/qemu-rv/CMakeLists.txt: removed repeated addition of the file qemu_rv_userspace.c

### DIFF
--- a/arch/risc-v/src/qemu-rv/CMakeLists.txt
+++ b/arch/risc-v/src/qemu-rv/CMakeLists.txt
@@ -33,8 +33,6 @@ list(
 
 if(CONFIG_BUILD_KERNEL)
   list(APPEND SRCS qemu_rv_mm_init.c)
-elseif(CONFIG_BUILD_PROTECTED)
-  list(APPEND SRCS qemu_rv_userspace.c)
 endif()
 
 if(CONFIG_MM_PGALLOC)


### PR DESCRIPTION
## Summary

removed repeated addition of the file qemu_rv_userspace.c

https://github.com/apache/nuttx/blob/9897ef3cdbc55f4bf830e5be3ee11223cc1e3b56/arch/risc-v/src/qemu-rv/CMakeLists.txt#L44

aligned with the make.def file


## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally


