### PR TITLE
sensors/nau7802: Fix format warning

### DIFF
--- a/drivers/sensors/nau7802.c
+++ b/drivers/sensors/nau7802.c
@@ -688,7 +688,7 @@ static int nau7802_control(FAR struct sensor_lowerhalf_s *lower,
 
     default:
       err = -EINVAL;
-      snerr("Unknown command for NAU7802: lu\n", cmd);
+      snerr("Unknown command for NAU7802: %d\n", cmd);
       break;
     }
 


### PR DESCRIPTION
## Summary

Silence format string warning by adding missing '%' sign.

## Impact

Impacts only the build system for the NAU7802 to remove the warning (and now the logging statement will work correctly).

## Testing

Compiled after the change and verified that the warning disappeared. Old warning shown below:

```console
sensors/nau7802.c: In function 'nau7802_control':
sensors/nau7802.c:691:13: warning: too many arguments for format [-Wformat-extra-args]
  691 |       snerr("Unknown command for NAU7802: lu\n", cmd);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```