### PR TITLE
Segger sysview improvements

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -611,7 +611,7 @@ void sched_note_add(FAR const void *data, size_t len)
           note_add(*driver, note, notelen);
         }
 
-      data += notelen;
+      data = (FAR void *)((uintptr_t)data + notelen);
       len -= notelen;
     }
 }
@@ -1224,7 +1224,9 @@ void sched_note_syscall_enter(int nr, int argc, ...)
   unsigned int length = 0;
   uintptr_t arg;
   va_list ap;
+#ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
   int argc_bak = argc;
+#endif
   int i;
 
   va_start(ap, argc);

--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -246,6 +246,12 @@ config SEGGER_SYSVIEW_RAM_BASE
 	---help---
 		The lowest RAM address used for IDs
 
+config SEGGER_SYSVIEW_POST_MORTEM
+	bool "Segger System View post-mortem mode"
+	default n
+	---help---
+		Configures the System View to record continuously in circular buffer
+
 endif # SEGGER_SYSVIEW
 
 endif # DRIVERS_NOTE

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -124,4 +124,12 @@ extern spinlock_t g_segger_lock;
 
 #define SEGGER_SYSVIEW_PRINTF_IMPLICIT_FORMAT 1
 
+/* Segger sysview post-mortem (circular buffer) mode */
+
+#ifdef CONFIG_SEGGER_SYSVIEW_POST_MORTEM
+#  define SEGGER_SYSVIEW_POST_MORTEM_MODE       1
+#else
+#  define SEGGER_SYSVIEW_POST_MORTEM_MODE       0
+#endif
+
 #endif /* __DRIVERS_SEGGER_CONFIG_SEGGER_RTT_CONF_H */

--- a/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
+++ b/drivers/segger/config/SEGGER_SYSVIEW_Conf.h
@@ -46,6 +46,8 @@
 
 #define SEGGER_SYSVIEW_GET_TIMESTAMP       note_sysview_get_timestamp
 
+#define SEGGER_SYSVIEW_TIMESTAMP_FREQ      note_sysview_timestamp_freq
+
 /* The RTT channel that SystemView will use. */
 
 #define SEGGER_SYSVIEW_RTT_CHANNEL         CONFIG_SEGGER_SYSVIEW_RTT_CHANNEL
@@ -67,6 +69,7 @@
  ****************************************************************************/
 
 #define note_sysview_get_timestamp() perf_gettime()
+#define note_sysview_timestamp_freq() perf_getfreq()
 
 /****************************************************************************
  * Public Data


### PR DESCRIPTION

## Summary

I recently tested segger sysview on MPFS platform, and found out some issues with the driver.

This is a collection of patches which I made in order to make it usable for my purpose, including:

- Compilation errors with -Werr
- In SMP, the driver deadlocks due to entering spinlock recursively. Changed this to critical section, didn't see much performance degredation with that
- up_perf_gettime was assumed to be always nanosecods, this is not true, but segger driver can scale the timestamps correctly. Just need to configure the frequency
- added support to configure "post-mortem" mode, which essentially traces continuously to a circular buffer until the tracing is stopped

## Impact

Impacts only using Segger System View tool to profile a running system

## Testing

Tested on MPFS platform, by configuring 
 CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
CONFIG_SEGGER_SYSVIEW=y
CONFIG_SEGGER_SYSVIEW_RTT_BUFFER_SIZE=155648
CONFIG_SEGGER_SYSVIEW_POST_MORTEM=y

Dumping the buffer memory with JTAG and loading it to SystemView tool. On MPFS, the systemview tool can't directly connect to the target for some reason.
