### PR TITLE
arch/risc-v/mpfs: Add optimized perf timer functions

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -214,6 +214,8 @@ config ARCH_CHIP_MPFS
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_HAVE_S_MODE
 	select ARCH_RV_CPUID_MAP
+	select ARCH_HAVE_PERF_EVENTS
+	select ARCH_PERF_EVENTS
 	select ONESHOT
 	select ALARM_ARCH
 	---help---

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -35,6 +35,7 @@ CHIP_CSRCS += mpfs_lowputc.c mpfs_serial.c
 CHIP_CSRCS += mpfs_start.c mpfs_timerisr.c
 CHIP_CSRCS += mpfs_gpio.c mpfs_systemreset.c
 CHIP_CSRCS += mpfs_plic.c mpfs_dsn.c
+CHIP_CSRCS += mpfs_perf.c
 
 ifeq ($(CONFIG_MPFS_CLKINIT),y)
 CHIP_CSRCS += mpfs_clockconfig.c

--- a/arch/risc-v/src/mpfs/mpfs_perf.c
+++ b/arch/risc-v/src/mpfs/mpfs_perf.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * arch/risc-v/src/mpfs/mpfs_perf.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this args for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/clock.h>
+#include <nuttx/arch.h>
+
+#include <stdint.h>
+#include <time.h>
+
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "hardware/mpfs_memorymap.h"
+#include "hardware/mpfs_clint.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_perf_init
+ ****************************************************************************/
+
+void up_perf_init(void *arg)
+{
+}
+
+/****************************************************************************
+ * Name: up_perf_gettime
+ ****************************************************************************/
+
+clock_t up_perf_gettime(void)
+{
+  return getreg64(MPFS_CLINT_MTIME);
+}
+
+/****************************************************************************
+ * Name: up_perf_getfreq
+ ****************************************************************************/
+
+unsigned long up_perf_getfreq(void)
+{
+  return MPFS_MSS_RTC_TOGGLE_CLK;
+}
+
+/****************************************************************************
+ * Name: up_perf_convert
+ ****************************************************************************/
+
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
+{
+  ts->tv_sec  = elapsed / MPFS_MSS_RTC_TOGGLE_CLK;
+  elapsed    -= ts->tv_sec * MPFS_MSS_RTC_TOGGLE_CLK;
+  ts->tv_nsec = elapsed * NSEC_PER_SEC / MPFS_MSS_RTC_TOGGLE_CLK;
+}
+
+/****************************************************************************
+ * Name: up_udelay
+ *
+ * Description:
+ *   Delay for the requested number of microseconds.
+ *
+ ****************************************************************************/
+
+void up_udelay(useconds_t microseconds)
+{
+  clock_t start = up_perf_gettime();
+  clock_t end = microseconds * up_perf_getfreq() / USEC_PER_SEC + start + 1;
+  while (((sclock_t)(up_perf_gettime() - end)) < 0)
+    {
+    }
+}
+
+/****************************************************************************
+ * Name: up_ndelay
+ *
+ * Description:
+ *   Delay for the requested number of nanoseconds.
+ *
+ ****************************************************************************/
+
+void up_ndelay(unsigned long nanoseconds)
+{
+  up_udelay((nanoseconds + NSEC_PER_USEC - 1) / NSEC_PER_USEC);
+}


### PR DESCRIPTION

## Summary

Add up_perf_ functions for MPFS, which don't rely on alarm/oneshot interface.

Also add optimized up_udelay and up_ndelay functions, which use the MTIMER directly to measure time; making them accurate and more multithreading friendly.

## Impact

Only for MPFS platform;
- makes up_perf_gettime faster, when the call doesn't go through the alarm framework. which in turns helps profiling
- uses the 1MHz MTIME counter on MPFS to directly measure up_udelay, preventing unnecessary delays when call is pre-empted by another task or interrupt.

## Testing

Tested on a custom MPFS250T based board & segger system view tool to compare the overhead  with and without this patch.
