### PR TITLE
add spin_lock_irqsave_nopreempt rspin_lock_irqsave_noprempt implement.

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -205,6 +205,8 @@ static inline_function void spin_lock_notrace(FAR volatile spinlock_t *lock)
 
   UP_DMB();
 }
+#else
+#  define spin_lock_notrace(lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
@@ -245,6 +247,8 @@ static inline_function void spin_lock(FAR volatile spinlock_t *lock)
 
   sched_note_spinlock_locked(lock);
 }
+#else
+#  define spin_lock(lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************
@@ -370,6 +374,8 @@ spin_unlock_notrace(FAR volatile spinlock_t *lock)
   UP_DSB();
   UP_SEV();
 }
+#else
+#  define spin_unlock_notrace(lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
As our previous discussion, we should use a new API spin_lock_irqsave_nopreempt to handle the spin_lock with sched locked, and did not change the default behavior of original spin_lock_irqsave.

Also for the drivers etc. those by design need recursive lock behavior, if we did not support recursive API call, have to use critical_section, that is not a good idea. critical_section should not be abused for this scene. 

For drivers implement those possible recusive, native spinlock
will cause deadlock directly, critial_section is use globally,
will make lock parallel to serial, add API to keep recursive
support but isolate each other.

for example #16483

## Impact
Only add API in .h, did not change or modify user usage.
Able to call new API with spinlock & sched disabled with one call.
Able to support drivers, etc, those want to use recursive spinlock, before this patch have to use critical_section.

## Testing
CI-test, internal boards, qemu-armv7a:smp ostest.


