### PR TITLE
fs/vfs: check if all `iov_base` are accessible

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -164,6 +164,18 @@ ssize_t file_readv(FAR struct file *filep,
   DEBUGASSERT(filep);
   inode = filep->f_inode;
 
+  /* Check buffer count and pointer for iovec */
+
+  if (iovcnt == 0)
+    {
+      return 0;
+    }
+
+  if (iov == NULL)
+    {
+      return -EFAULT;
+    }
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -153,6 +153,18 @@ ssize_t file_writev(FAR struct file *filep,
       return -EACCES;
     }
 
+  /* Check buffer count and pointer for iovec */
+
+  if (iovcnt == 0)
+    {
+      return 0;
+    }
+
+  if (iov == NULL)
+    {
+      return -EFAULT;
+    }
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)


### PR DESCRIPTION
## Summary
Check if all `iov_base` are inside accessible address space.
e.g.
```
  ret = write(fd, NULL, 3);
```
The `iov.iov_base` is NULL but `iov.iov_len` is NOT zero.
https://github.com/apache/nuttx/blob/dd07367f4eeb5ebe785c601e84143cfaf6ad411a/fs/vfs/fs_write.c#L425-L432

And, if `iov.iov_base` is not NULL but `iov.iov_len` is zero, skipped (same as Linux).
## Impact
fs/vfs

## Testing
CI


