### PR TITLE
arch/arm/src/stm32f0l0g0: UID support for F0, L0 and C0

### DIFF
--- a/arch/arm/src/stm32f0l0g0/hardware/stm32c0_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32c0_memorymap.h
@@ -111,4 +111,8 @@
 #define STM32_SCS_BASE       0xe000e000
 #define STM32_DEBUGMCU_BASE  0xe0042000
 
+/* System Memory Addresses **************************************************/
+
+#define STM32_SYSMEM_UID     0x1fff7550     /* The 96-bit unique device identifier */
+
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32C0_MEMORYMAP_H */

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32f03x_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32f03x_memorymap.h
@@ -137,4 +137,8 @@
 #define STM32_SCS_BASE       0xe000e000
 #define STM32_DEBUGMCU_BASE  0xe0042000
 
+/* System Memory Addresses **************************************************/
+
+#define STM32_SYSMEM_UID     0x1ffff7ac     /* The 96-bit unique device identifier */
+
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32F03X_MEMORYMAP_H */

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32f05xf07xf09x_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32f05xf07xf09x_memorymap.h
@@ -141,4 +141,8 @@
 #define STM32_SCS_BASE       0xe000e000
 #define STM32_DEBUGMCU_BASE  0xe0042000
 
+/* System Memory Addresses **************************************************/
+
+#define STM32_SYSMEM_UID     0x1ffff7ac     /* The 96-bit unique device identifier */
+
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32F05XF07XF09X_MEMORYMAP_H */

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32g0_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32g0_memorymap.h
@@ -123,8 +123,11 @@
  * this address range
  */
 
-#define STM32_SYSMEM_UID     0x1fff7590     /* The 96-bit unique device identifier */
 #define STM32_SCS_BASE       0xe000e000
 #define STM32_DEBUGMCU_BASE  0xe0042000
+
+/* System Memory Addresses **************************************************/
+
+#define STM32_SYSMEM_UID     0x1fff7590     /* The 96-bit unique device identifier */
 
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32G0_MEMORYMAP_H */

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32l0_memorymap.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32l0_memorymap.h
@@ -114,4 +114,8 @@
 #define STM32_GPIOE_BASE     0x50001000     /* 0x50001000-0x500013ff GPIO Port E */
 #define STM32_GPIOH_BASE     0x50001c00     /* 0x50001c00-0x50001fff GPIO Port H */
 
+/* System Memory Addresses **************************************************/
+
+#define STM32_SYSMEM_UID     0x1ff80050     /* The 96-bit unique device identifier */
+
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32L0_MEMORYMAP_H */


### PR DESCRIPTION
## Summary
arch/arm/src/stm32f0l0g0: UID support for F0, L0 and C0

## Impact

follow up to https://github.com/apache/nuttx/pull/16489
UID now supported for all STM32 M0 chips in NuttX.

## Testing
not tested, appropriate UID addresses taken from reference manuals


