### PR TITLE
Add missing CFLAGS to the ELF guides

### DIFF
--- a/Documentation/guides/fully_linked_elf.rst
+++ b/Documentation/guides/fully_linked_elf.rst
@@ -209,7 +209,7 @@ Below is the ``Makefile`` used to create the ELF program:
    ARCHOPTIMIZATION = -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
    ARCHINCLUDES = -I. -isystem  nuttx-export-7.25/include
    
-   CFLAGS = $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
+   CFLAGS = $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
    
    CROSSDEV = arm-none-eabi-
    CC = $(CROSSDEV)gcc

--- a/Documentation/guides/partially_linked_elf.rst
+++ b/Documentation/guides/partially_linked_elf.rst
@@ -241,7 +241,7 @@ The Makefile used to create the ELF program is as follows:
     ARCHOPTIMIZATION = -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
     ARCHINCLUDES = -I. -isystem  nuttx-export-7.25/include
     
-    CFLAGS = $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
+    CFLAGS = $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
     
     CROSSDEV = arm-none-eabi-
     CC = $(CROSSDEV)gcc


### PR DESCRIPTION
## Summary

Following the current ELF guides ([[1]](https://nuttx.apache.org/docs/12.9.0/guides/partially_linked_elf.html), [[2]](https://nuttx.apache.org/docs/12.9.0/guides/fully_linked_elf.html)) produces unusable binaries due to the lack of appropriate architecture flags in the Makefile. This PR adds them.

The fix was originally proposed by @g2gps in apache/nuttx-apps#1828, and I applied it to both the partially-linked and fully-linked variants of the guide.

## Impact

Following the updated guide will yield usable binaries.

## Testing

These changes were tested on a custom Cortex-M0+ (RP2040) board using NuttX v12.8.0 as the baseline.

Output of `arm-none-eabi-objdump -f <binary>` when built without these changes (old guide):

```plaintext
<binary>:     file format elf32-littlearm
architecture: armv4t, flags 0x00000011:
HAS_RELOC, HAS_SYMS
start address 0x00000000
```

And when built with these changes (new guide):

```plaintext
<binary>:     file format elf32-littlearm
architecture: armv6s-m, flags 0x00000011:
HAS_RELOC, HAS_SYMS
start address 0x00000001
```

