### PR TITLE
nuttx/spinlock: Define empty macro for spin_unlock

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -448,6 +448,8 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 #  else
 #    define spin_unlock(l)  do { *(l) = SP_UNLOCKED; } while (0)
 #  endif
+#else
+#  define spin_unlock(lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************


### PR DESCRIPTION
So that the same code can be used with and without spinlocks.

## Summary

This complements the commit 225d6fb0a73, which missed the spin_unlock()

## Impact

Allows compiling non-smp target, which calls spin_unlock.

## Testing

Fixes compilation on a custom target
