### PR TITLE
driver/segger: define a macro using a configuration variable

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -33,9 +33,16 @@ config SEGGER_RTT_CPU_CACHE_LINE_SIZE
 	---help---
 		Largest cache line size (in bytes) in the target system.
 
+config SEGGER_RTT_UNCACHED_OFF_VARIABLE
+	bool
+	default n
+	---help---
+		Converting the macro for Segger RTT uncached offset to variable representation
+
 config SEGGER_RTT_UNCACHED_OFF
 	int "Segger RTT uncached offset"
 	default 0
+	depends on !SEGGER_RTT_UNCACHED_OFF_VARIABLE
 	---help---
 		Address alias where RTT CB and buffers can be accessed uncached
 

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -41,6 +41,10 @@
 extern struct rspinlock_s g_segger_lock;
 #endif
 
+#ifdef CONFIG_SEGGER_RTT_UNCACHED_OFF_VARIABLE
+extern ptrdiff_t g_segger_offset;
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -53,7 +57,11 @@ extern struct rspinlock_s g_segger_lock;
 
 /* Address alias where RTT CB and buffers can be accessed uncached */
 
-#define SEGGER_RTT_UNCACHED_OFF         CONFIG_SEGGER_RTT_UNCACHED_OFF
+#ifdef CONFIG_SEGGER_RTT_UNCACHED_OFF_VARIABLE
+#  define SEGGER_RTT_UNCACHED_OFF         g_segger_offset
+#else
+#  define SEGGER_RTT_UNCACHED_OFF         CONFIG_SEGGER_RTT_UNCACHED_OFF
+#endif
 
 /* Number of up-buffers (T->H) available on this target */
 

--- a/drivers/segger/segger.c
+++ b/drivers/segger/segger.c
@@ -31,6 +31,7 @@
  ****************************************************************************/
 
 struct rspinlock_s g_segger_lock = RSPINLOCK_INITIALIZER;
+ptrdiff_t g_segger_offset = PTRDIFF_MAX;
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary


 we are using segger RTT protocol over shared memory for two core log/trace: one is NuttX another Linux/Windows. But the base address of shared memory can only be known at runtime, so we change SEGGER_RTT_UNCACHED_OFF from macro to global variable, and update to the correct g_segger_offset after the shared memory is initialized by:
    g_segger_offset = (uintptr_t)ishmem - (uintptr_t)&_SEGGER_RTT;


*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
noimpact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
ostest

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


