### PR TITLE
arch/stm32f0l0g0: remove references to CONFIG_STM32F0L0G0_FORCEPOWER

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32c0_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32c0_rcc.c
@@ -163,17 +163,13 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_TIM2
   /* Timer 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM3
   /* Timer 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_FDCAN
@@ -203,33 +199,25 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_USART2
   /* USART 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART3
   /* USART 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART4
   /* USART 4 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C1
   /* I2C 1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_PWR
@@ -268,9 +256,7 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_TIM1
   /* TIM1 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_SPI1
@@ -282,41 +268,31 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_USART1
   /* USART1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM14
   /* TIM14 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM14EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM15
   /* TIM5 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM15EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM16
   /* TIM16 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM16EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM17
   /* TIM17 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM17EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_ADC1

--- a/arch/arm/src/stm32f0l0g0/stm32f0_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32f0_rcc.c
@@ -155,49 +155,37 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_TIM2
   /* Timer 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM3
   /* Timer 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM4
   /* Timer 4 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM6
   /* Timer 6 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM6EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM7
   /* Timer 7 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM7EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM14
   /* Timer 14 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM14EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_WWDG
@@ -215,49 +203,37 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_USART2
   /* USART 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART3
   /* USART 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART4
   /* USART 4 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART5
   /* USART 5 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART5EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C1
   /* I2C 1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C2
   /* I2C 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USB
@@ -326,25 +302,19 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_USART6
   /* USART 6 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART6EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART7
   /* USART 7 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART7EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART8
   /* USART 8 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART8EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_ADC1
@@ -356,9 +326,7 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_TIM1
   /* Timer 1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_SPI1
@@ -370,33 +338,25 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_USART1
   /* USART1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM15
   /* Timer 15 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM15EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM16
   /* Timer 16 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM16EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM17
   /* Timer 17 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM17EN;
-#endif
 #endif
 
 #if 0

--- a/arch/arm/src/stm32f0l0g0/stm32g0_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32g0_rcc.c
@@ -173,33 +173,25 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_TIM2
   /* Timer 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM3
   /* Timer 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM6
   /* Timer 6 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM6EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM7
   /* Timer 7 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM7EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_SPI2
@@ -211,50 +203,39 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_USART2
   /* USART 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART3
   /* USART 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART4
   /* USART 4 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_LPUSART1
   /* USART 5 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_LPUSART1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C1
   /* I2C 1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C2
   /* I2C 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C2EN;
 #endif
-#endif
+
 #ifdef CONFIG_STM32F0L0G0_PWR
   /* Power interface clock enable */
 
@@ -309,9 +290,7 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_TIM1
   /* TIM1 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_SPI1
@@ -323,41 +302,31 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_USART1
   /* USART1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM14
   /* TIM14 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM14EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM15
   /* TIM5 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM15EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM16
   /* TIM16 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM16EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM17
   /* TIM17 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM17EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_ADC1

--- a/arch/arm/src/stm32f0l0g0/stm32l0_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32l0_rcc.c
@@ -182,33 +182,25 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_TIM2
   /* Timer 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM3
   /* Timer 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM6
   /* Timer 6 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM6EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM7
   /* Timer 7 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_TIM7EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_LCD
@@ -232,49 +224,37 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_USART2
   /* USART 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART3
   /* USART 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART3EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART4
   /* USART 4 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USART5
   /* USART 5 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_USART5EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C1
   /* I2C 1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C1EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_I2C2
   /* I2C 2 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C2EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_USB
@@ -304,9 +284,7 @@ static inline void rcc_enableapb1(void)
 #ifdef CONFIG_STM32F0L0G0_I2C3
   /* I2C 3 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB1ENR_I2C4EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_LPTIM1
@@ -345,17 +323,13 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_TIM21
   /* TIM21 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM21EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_TIM22
   /* TIM22 Timer clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_TIM10EN;
-#endif
 #endif
 
 #ifdef CONFIG_STM32F0L0G0_ADC1
@@ -373,9 +347,7 @@ static inline void rcc_enableapb2(void)
 #ifdef CONFIG_STM32F0L0G0_USART1
   /* USART1 clock enable */
 
-#ifdef CONFIG_STM32F0L0G0_FORCEPOWER
   regval |= RCC_APB2ENR_USART1EN;
-#endif
 #endif
 
 #if 0


### PR DESCRIPTION
## Summary

- arch/stm32f0l0g0: remove references to CONFIG_STM32F0L0G0_FORCEPOWER
this is copy-paste from stm32, but CONFIG_STM32F0L0G0_FORCEPOWER is not used in stm32f0l0g0

## Impact

remove dead code

## Testing

CI


