### PR TITLE
arch/arm/stm32f7: Add missing RCC include

### DIFF
--- a/arch/arm/src/stm32f7/stm32_capture.c
+++ b/arch/arm/src/stm32f7/stm32_capture.c
@@ -41,6 +41,7 @@
 #include "arm_internal.h"
 #include "stm32_gpio.h"
 #include "stm32_capture.h"
+#include "stm32_rcc.h"
 
 /****************************************************************************
  * Private Types


### PR DESCRIPTION
## Summary

Enabling the Timer Capture feature causes the compilation to fail due to undeclared RCC stuff.

This PR aims to fix this issue,

Thanks to @acassis for assisting me, 

## Impact

Adds the include of "stm32_rcc." to the "stm32_capture.c" to fix the undeclared RCC settings.

## Testing

Before PR:
![image](https://github.com/user-attachments/assets/42d4e5b4-6060-4930-87af-eb7f0600efc6)
After PR:
![image](https://github.com/user-attachments/assets/1dad9333-d8bd-4108-99bc-f96615cd02a5)



