### PR TITLE
chore: update gitignore for .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ uImage
 .dirlinks
 .fakelnk
 .vscode
+.idea
 .DS_Store
 tools/gdb/__pycache__
 /build


### PR DESCRIPTION
## Summary

Like VSCode, Jetbrains IDEs store local configuration inside a folder called ".idea".

This folder should be ignored by git.

## Impact

Adds the ".idea" entry inside the .gitignore file

## Testing

/


