### PR TITLE
arch/arm/src/samv7/sam_start.c: init perf events if enabled

### DIFF
--- a/arch/arm/src/samv7/sam_start.c
+++ b/arch/arm/src/samv7/sam_start.c
@@ -243,6 +243,12 @@ void __start(void)
   up_enable_icache();
   up_enable_dcache();
 
+#ifdef CONFIG_ARCH_PERF_EVENTS
+  /* Enable hardware performance counter support for perf events */
+
+  up_perf_init((void *)BOARD_CPU_FREQUENCY);
+#endif
+
   /* Perform early serial initialization */
 
 #ifdef USE_EARLYSERIALINIT


### PR DESCRIPTION
## Summary
`__start` should call `up_perf_init`, initialization of hardware performance counter, if `CONFIG_ARCH_PERF_EVENTS` option is set. This allows the usage of ARM cycle count register `DWT_CYCCNT` in benchmark measurements instead of software clock.

## Impact

SAMv7 MCU can now utilize `DWT_CYCCNT` register as hardware performance counter.

## Testing

Tested on a custom board with SAMv7 MCU and `osperf` applications. Results without hardware performance counter (normal mode with `CONFIG_USEC_PER_TICK=100`)

```
NuttShell (NSH) NuttX-12.9.0
brcg2> 
brcg2> osperf
OS performance args: count:100, detail:false
==============================================================
Describe                                Max        Min        Avg
pthread-create                       100000          0      19000
pthread-switch                            0          0          0
pthread-mutex                             0          0          0
context-switch                       100000          0       4000
hpwork                               100000          0       3000
poll-write                           100000     100000      24000
pipe                                      0          0          0
semwait                                   0          0          0
sempost                                   0          0          0
```

Results with the change and `CONFIG_ARCH_PERF_EVENTS` enabled

```
NuttShell (NSH) NuttX-12.9.0
brcg2> 
brcg2> osperf
OS performance args: count:100, detail:false
==============================================================
Describe                                Max        Min        Avg
pthread-create                        25063      19220      21120
pthread-switch                         4070       2640       3109
pthread-mutex                          5086       1923       2118
context-switch                         5926       1876       2515
hpwork                                13623       3666       4452
poll-write                            48900      41163      44407
pipe                                   7466       5626       6471
semwait                                1336        610        699
sempost                                 833        476        542
```