### PR TITLE
arch/riscv/ricv_exception.c: Dump the process name at exception in user space

### DIFF
--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -106,7 +106,9 @@ int riscv_exception(int mcause, void *regs, void *args)
   if (((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL) &&
       ((tcb->flags & TCB_FLAG_SYSCALL) == false))
     {
-      _alert("Segmentation fault in PID %d: %s\n",
+      struct tcb_s *ptcb = nxsched_get_tcb(tcb->group->tg_pid);
+
+      _alert("Segmentation fault in %s (PID %d: %s)\n", get_task_name(ptcb),
              tcb->pid, get_task_name(tcb));
 
       tcb->flags |= TCB_FLAG_FORCED_CANCEL;


### PR DESCRIPTION

## Summary

This helps in debugging loaded elf files in CONFIG_BUILD_KERNEL. If a user space exception occurs, one would beed the process name in order to debug the correct process/elf file.

Only dumping the pid and name of the crashed task/thread doesn't help, since different processes may have helper threads with the same name.

## Impact

Only risc-v exception output in user-space

## Testing

Tested on MPFS platform with CONFIG_BUILD_KERNEL, by artificially generating null-pointer reference in user-space applications and monitoring the output.
