### PR TITLE
fs/vfs/fs_close.c: avoid double free if CONFIG_FS_NOTIFY is set

### DIFF
--- a/fs/vfs/fs_close.c
+++ b/fs/vfs/fs_close.c
@@ -139,9 +139,8 @@ int file_close(FAR struct file *filep)
 
           inode_release(inode);
         }
-
 #ifdef CONFIG_FS_NOTIFY
-      if (path != NULL)
+      else if (path != NULL)
         {
           lib_put_pathbuffer(path);
         }


### PR DESCRIPTION
## Summary
Double free occurred in `lib_put_pathbuffer` if `CONFIG_FS_NOTIFY` option was enabled. The second if statement has to be called only if the close operation returned error. The bug was introduced in 14f5c48 and was causing `misc/lib_tempbuffer.c:141` debug assertion.

## Impact

Fixed system failing on assertion during close operation if `CONFIG_FS_NOTIFY` is set. This should close #16531.

## Testing

System doesn't fail on an assertion with this change. GDB backtrace for samv7 custom board before the change showing the double free.

```gdb
Breakpoint 2, lib_put_tempbuffer (buffer=0x20400eb4 <g_tempbuffer+4> "tmpc000001") at misc/lib_tempbuffer.c:137
137	{
(gdb) bt
#0  lib_put_tempbuffer (buffer=0x20400eb4 <g_tempbuffer+4> "tmpc000001") at misc/lib_tempbuffer.c:137
#1  0x0043749c in file_close (filep=0x20419808) at vfs/fs_close.c:136
#2  0x00436d5a in file_put (filep=0x20419808) at inode/fs_files.c:897
#3  file_put (filep=0x20419808) at /home/michal/Michal/Elektroline/jessie/nuttx/brc_upstream/nuttx/core/include/nuttx/fs/fs.h:1309
#4  0x00437502 in close (fd=fd@entry=3) at vfs/fs_close.c:218
#5  0x0044522c in issmartfs (pathname=0x20414d88 "/dev/smart0p2") at board/sam_w25qxxxjv.c:154
#6  sam_w25qxxxjv_init () at board/sam_w25qxxxjv.c:399
#7  0x00444ad4 in sam_bringup () at board/sam_bringup.c:140
#8  0x00444a46 in board_app_initialize (arg=arg@entry=0) at board/sam_appinit.c:89
#9  0x0045061c in boardctl (cmd=cmd@entry=65281, arg=arg@entry=0) at boardctl.c:370
#10 0x0042f164 in nsh_initialize () at nsh_init.c:149
#11 0x0042f024 in startup_main (argc=1, argv=0x20413ea0) at startup_main.c:127
#12 0x00428b0e in nxtask_startup (entrypt=0x42f005 <startup_main>, argc=1, argv=0x20413ea0) at sched/task_startup.c:72
#13 0x004249f2 in nxtask_start () at task/task_start.c:104
#14 0x00000000 in ?? ()
(gdb) c
Continuing.
halted: PC: 0x0042c19c

Breakpoint 2, lib_put_tempbuffer (buffer=0x20400eb4 <g_tempbuffer+4> "tmpc000001") at misc/lib_tempbuffer.c:137
137	{
(gdb) bt
#0  lib_put_tempbuffer (buffer=0x20400eb4 <g_tempbuffer+4> "tmpc000001") at misc/lib_tempbuffer.c:137
#1  0x004374aa in file_close (filep=0x20419808) at vfs/fs_close.c:146
#2  0x00436d5a in file_put (filep=0x20419808) at inode/fs_files.c:897
#3  file_put (filep=0x20419808) at /home/michal/Michal/Elektroline/jessie/nuttx/brc_upstream/nuttx/core/include/nuttx/fs/fs.h:1309
#4  0x00437502 in close (fd=fd@entry=3) at vfs/fs_close.c:218
#5  0x0044522c in issmartfs (pathname=0x20414d88 "/dev/smart0p2") at board/sam_w25qxxxjv.c:154
#6  sam_w25qxxxjv_init () at board/sam_w25qxxxjv.c:399
#7  0x00444ad4 in sam_bringup () at board/sam_bringup.c:140
#8  0x00444a46 in board_app_initialize (arg=arg@entry=0) at board/sam_appinit.c:89
#9  0x0045061c in boardctl (cmd=cmd@entry=65281, arg=arg@entry=0) at boardctl.c:370
#10 0x0042f164 in nsh_initialize () at nsh_init.c:149
#11 0x0042f024 in startup_main (argc=1, argv=0x20413ea0) at startup_main.c:127
#12 0x00428b0e in nxtask_startup (entrypt=0x42f005 <startup_main>, argc=1, argv=0x20413ea0) at sched/task_startup.c:72
#13 0x004249f2 in nxtask_start () at task/task_start.c:104
#14 0x00000000 in ?? ()
(gdb) c
```




