### PR TITLE
docs/syslogd: Update syslogd docs to reflect implementation

### DIFF
--- a/Documentation/applications/system/syslogd/index.rst
+++ b/Documentation/applications/system/syslogd/index.rst
@@ -27,9 +27,9 @@ not receive or forward logs.
 
 .. warning::
 
-   The daemon is currently runs itself in the background using ``fork()``. On
-   architectures where ``fork()`` is not implemented, the daemon must be
-   "backgrounded" by using the trailing ``&`` in NSH at the moment. It is also
-   possible to us ``posix_spawn()`` from a parent program.
+   The daemon runs itself in the background using ``posix_spawn()`` due to
+   limitations with the NuttX implementation of ``fork()`` being architecture
+   dependent. This results in more consistent behaviour, but requires
+   ``CONFIG_LIBC_EXECFUNCS`` to be enabled.
 
 Read more about ``syslog`` on NuttX: :doc:`/components/drivers/special/syslog`


### PR DESCRIPTION
## Summary

The documentation for `syslogd` is now updated to reflect its use of `posix_spawn` to run the daemon in the background.

## Impact

Impacts only user documentation, making it more accurate.

## Testing

Tested with local documentation build.