### PR TITLE
libc/stream: Rename lib_xsprintfyyy to lib_xprintfyyy 

### DIFF
--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -802,9 +802,9 @@ static int noteram_dump_header(FAR struct lib_outstream_s *s,
   int cpu = 0;
 #endif
 
-  ret = lib_sprintf(s, "%8s-%-3u [%d] %3" PRIu64 ".%09lu: ",
-                    get_taskname(pid), get_pid(pid), cpu,
-                    (uint64_t)ts.tv_sec, ts.tv_nsec);
+  ret = lib_printf(s, "%8s-%-3u [%d] %3" PRIu64 ".%09lu: ",
+                   get_taskname(pid), get_pid(pid), cpu,
+                   (uint64_t)ts.tv_sec, ts.tv_nsec);
 
   return ret;
 }
@@ -838,13 +838,13 @@ static int noteram_dump_sched_switch(FAR struct lib_outstream_s *s,
   current_priority = cctx->current_priority;
   next_priority = cctx->next_priority;
 
-  ret = lib_sprintf(s, "sched_switch: prev_comm=%s prev_pid=%u "
-                    "prev_prio=%u prev_state=%c ==> "
-                    "next_comm=%s next_pid=%u next_prio=%u\n",
-                    get_taskname(current_pid), get_pid(current_pid),
-                    current_priority, get_task_state(cctx->current_state),
-                    get_taskname(next_pid), get_pid(next_pid),
-                    next_priority);
+  ret = lib_printf(s, "sched_switch: prev_comm=%s prev_pid=%u "
+                   "prev_prio=%u prev_state=%c ==> "
+                   "next_comm=%s next_pid=%u next_prio=%u\n",
+                   get_taskname(current_pid), get_pid(current_pid),
+                   current_priority, get_task_state(cctx->current_state),
+                   get_taskname(next_pid), get_pid(next_pid),
+                   next_priority);
 
   cctx->current_pid = cctx->next_pid;
   cctx->current_priority = cctx->next_priority;
@@ -865,7 +865,7 @@ static int noteram_dump_printf(FAR struct lib_outstream_s *s,
 
   if (note->npt_type == 0)
     {
-      ret = lib_bsprintf(s, note->npt_fmt, note->npt_data);
+      ret = lib_oprintf(s, note->npt_fmt, note->npt_data);
     }
   else
     {
@@ -874,7 +874,7 @@ static int noteram_dump_printf(FAR struct lib_outstream_s *s,
       size_t i;
 
       fmt[0] = '\0';
-      ret += lib_sprintf(s, "%p", note->npt_fmt);
+      ret += lib_printf(s, "%p", note->npt_fmt);
       for (i = 0; i < count; i++)
         {
           int type = NOTE_PRINTF_GET_TYPE(note->npt_type, i);
@@ -903,7 +903,7 @@ static int noteram_dump_printf(FAR struct lib_outstream_s *s,
             }
         }
 
-        ret += lib_bsprintf(s, fmt, note->npt_data);
+        ret += lib_oprintf(s, fmt, note->npt_data);
         lib_stream_putc(s, '\n');
         ret++;
     }
@@ -945,9 +945,9 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
     case NOTE_START:
       {
         ret += noteram_dump_header(s, note, ctx);
-        ret += lib_sprintf(s, "sched_wakeup_new: comm=%s pid=%d "
-                           "target_cpu=%d\n",
-                           get_taskname(pid), get_pid(pid), cpu);
+        ret += lib_printf(s, "sched_wakeup_new: comm=%s pid=%d "
+                          "target_cpu=%d\n",
+                          get_taskname(pid), get_pid(pid), cpu);
       }
       break;
 
@@ -998,10 +998,10 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
              */
 
             ret += noteram_dump_header(s, note, ctx);
-            ret += lib_sprintf(s, "sched_waking: comm=%s "
-                               "pid=%d target_cpu=%d\n",
-                               get_taskname(cctx->next_pid),
-                               get_pid(cctx->next_pid), cpu);
+            ret += lib_printf(s, "sched_waking: comm=%s "
+                              "pid=%d target_cpu=%d\n",
+                              get_taskname(cctx->next_pid),
+                              get_pid(cctx->next_pid), cpu);
             cctx->pendingswitch = true;
           }
       }
@@ -1023,23 +1023,23 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
           }
 
         ret += noteram_dump_header(s, note, ctx);
-        ret += lib_sprintf(s, "sys_%s(",
-                           g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED]);
+        ret += lib_printf(s, "sys_%s(",
+                          g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED]);
 
         for (i = 0; i < nsc->nsc_argc; i++)
           {
             arg = nsc->nsc_args[i];
             if (i == 0)
               {
-                ret += lib_sprintf(s, "arg%d: 0x%" PRIxPTR, i, arg);
+                ret += lib_printf(s, "arg%d: 0x%" PRIxPTR, i, arg);
               }
             else
               {
-                ret += lib_sprintf(s, ", arg%d: 0x%" PRIxPTR, i, arg);
+                ret += lib_printf(s, ", arg%d: 0x%" PRIxPTR, i, arg);
               }
           }
 
-        ret += lib_sprintf(s, ")\n");
+        ret += lib_printf(s, ")\n");
       }
       break;
 
@@ -1057,7 +1057,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 
         ret += noteram_dump_header(s, note, ctx);
         result = nsc->nsc_result;
-        ret += lib_sprintf(s, "sys_%s -> 0x%" PRIxPTR "\n",
+        ret += lib_printf(s, "sys_%s -> 0x%" PRIxPTR "\n",
                           g_funcnames[nsc->nsc_nr - CONFIG_SYS_RESERVED],
                           result);
       }
@@ -1071,8 +1071,8 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 
         nih = (FAR struct note_irqhandler_s *)p;
         ret += noteram_dump_header(s, note, ctx);
-        ret += lib_sprintf(s, "irq_handler_entry: irq=%u name=%pS\n",
-                           nih->nih_irq, (FAR void *)nih->nih_handler);
+        ret += lib_printf(s, "irq_handler_entry: irq=%u name=%pS\n",
+                          nih->nih_irq, (FAR void *)nih->nih_handler);
         cctx->intr_nest++;
       }
       break;
@@ -1083,8 +1083,8 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 
         nih = (FAR struct note_irqhandler_s *)p;
         ret += noteram_dump_header(s, note, ctx);
-        ret += lib_sprintf(s, "irq_handler_exit: irq=%u ret=handled\n",
-                           nih->nih_irq);
+        ret += lib_printf(s, "irq_handler_exit: irq=%u ret=handled\n",
+                          nih->nih_irq);
         cctx->intr_nest--;
 
         if (cctx->intr_nest <= 0)
@@ -1116,9 +1116,9 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 
         nw = (FAR struct note_wdog_s *)p;
         ret += noteram_dump_header(s, note, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: I|%d|wdog: %s-%pS %p\n",
-                           pid, name[note->nc_type - NOTE_WDOG_START],
-                           (FAR void *)nw->handler, (FAR void *)nw->arg);
+        ret += lib_printf(s, "tracing_mark_write: I|%d|wdog: %s-%pS %p\n",
+                          pid, name[note->nc_type - NOTE_WDOG_START],
+                          (FAR void *)nw->handler, (FAR void *)nw->arg);
       }
       break;
 #endif
@@ -1130,9 +1130,9 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         struct note_csection_s *ncs;
         ncs = (FAR struct note_csection_s *)p;
         ret += noteram_dump_header(s, &ncs->ncs_cmn, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: %c|%d|critical_section\n",
-                           note->nc_type == NOTE_CSECTION_ENTER ?
-                           'B' : 'E', pid);
+        ret += lib_printf(s, "tracing_mark_write: %c|%d|critical_section\n",
+                          note->nc_type == NOTE_CSECTION_ENTER ?
+                          'B' : 'E', pid);
       }
       break;
 #endif
@@ -1146,10 +1146,10 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         npr = (FAR struct note_preempt_s *)p;
         count = npr->npr_count;
         ret += noteram_dump_header(s, &npr->npr_cmn, ctx);
-        ret += lib_sprintf(s,  "tracing_mark_write: "
-                          "%c|%d|sched_lock:%d\n",
-                          note->nc_type == NOTE_PREEMPT_LOCK ?
-                          'B' : 'E', pid, count);
+        ret += lib_printf(s,  "tracing_mark_write: "
+                         "%c|%d|sched_lock:%d\n",
+                         note->nc_type == NOTE_PREEMPT_LOCK ?
+                         'B' : 'E', pid, count);
       }
       break;
 #endif
@@ -1161,7 +1161,7 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 
         npt = (FAR struct note_printf_s *)p;
         ret += noteram_dump_header(s, &npt->npt_cmn, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: ");
+        ret += lib_printf(s, "tracing_mark_write: ");
         ret += noteram_dump_printf(s, npt);
       }
       break;
@@ -1177,13 +1177,13 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         ret += noteram_dump_header(s, &nbi->nev_cmn, ctx);
         if (len > 0)
           {
-            ret += lib_sprintf(s, "tracing_mark_write: %c|%d|%.*s\n",
-                               c, pid, len, (FAR const char *)nbi->nev_data);
+            ret += lib_printf(s, "tracing_mark_write: %c|%d|%.*s\n",
+                              c, pid, len, (FAR const char *)nbi->nev_data);
           }
         else
           {
-            ret += lib_sprintf(s, "tracing_mark_write: %c|%d|%pS\n",
-                               c, pid, (FAR void *)ip);
+            ret += lib_printf(s, "tracing_mark_write: %c|%d|%pS\n",
+                              c, pid, (FAR void *)ip);
           }
       }
       break;
@@ -1192,8 +1192,8 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         int len = note->nc_length - sizeof(struct note_event_s);
         FAR struct note_event_s *nbi = (FAR struct note_event_s *)p;
         ret += noteram_dump_header(s, &nbi->nev_cmn, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: I|%d|%.*s\n",
-                           pid, len, (FAR const char *)nbi->nev_data);
+        ret += lib_printf(s, "tracing_mark_write: I|%d|%.*s\n",
+                          pid, len, (FAR const char *)nbi->nev_data);
       }
       break;
     case NOTE_DUMP_COUNTER:
@@ -1202,8 +1202,8 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
         FAR struct note_counter_s *counter;
         counter = (FAR struct note_counter_s *)nbi->nev_data;
         ret += noteram_dump_header(s, &nbi->nev_cmn, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: C|%d|%s|%ld\n",
-                           pid, counter->name, counter->value);
+        ret += lib_printf(s, "tracing_mark_write: C|%d|%s|%ld\n",
+                          pid, counter->name, counter->value);
       }
       break;
 #endif
@@ -1220,11 +1220,11 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
           };
 
         ret += noteram_dump_header(s, &nmm->nhp_cmn, ctx);
-        ret += lib_sprintf(s, "tracing_mark_write: C|%d|Heap Usage|%d|%s"
-                           ": heap: %p size:%" PRIiPTR ", address: %p\n",
-                           pid, nmm->used,
-                           name[note->nc_type - NOTE_HEAP_ADD],
-                           nmm->heap, nmm->size, nmm->mem);
+        ret += lib_printf(s, "tracing_mark_write: C|%d|Heap Usage|%d|%s"
+                          ": heap: %p size:%" PRIiPTR ", address: %p\n",
+                          pid, nmm->used,
+                          name[note->nc_type - NOTE_HEAP_ADD],
+                          nmm->heap, nmm->size, nmm->mem);
       }
       break;
 #endif
@@ -1250,7 +1250,7 @@ static void noteram_dump(FAR struct noteram_driver_s *drv)
   uint8_t note[256];
 
   lib_syslograwstream_open(&stream);
-  lib_sprintf(&stream.common, "# tracer:nop\n#\n");
+  lib_printf(&stream.common, "# tracer:nop\n#\n");
 
   while (1)
     {

--- a/drivers/note/notesnap_driver.c
+++ b/drivers/note/notesnap_driver.c
@@ -397,18 +397,18 @@ void notesnap_dump_with_stream(FAR struct lib_outstream_s *stream)
       struct timespec time;
 
       perf_convert(note->count, &time);
-      lib_sprintf(stream,
-                  "snapshoot: [%" PRIu64 ".%09u] "
+      lib_printf(stream,
+                 "snapshoot: [%" PRIu64 ".%09u] "
 #ifdef CONFIG_SMP
-                  "[CPU%d] "
+                 "[CPU%d] "
 #endif
-                  "[%d] %-16s %#" PRIxPTR "\n",
-                  (uint64_t)time.tv_sec,
-                  (unsigned)time.tv_nsec,
+                 "[%d] %-16s %#" PRIxPTR "\n",
+                 (uint64_t)time.tv_sec,
+                 (unsigned)time.tv_nsec,
 #ifdef CONFIG_SMP
-                  note->cpu,
+                 note->cpu,
 #endif
-                  note->pid, g_notesnap_type[note->type], note->args);
+                 note->pid, g_notesnap_type[note->type], note->args);
     }
 
   atomic_set(&g_notesnap.dumping, false);

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -96,7 +96,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #  endif
 #endif
 
-  /* Wrap the low-level output in a stream object and let lib_vsprintf
+  /* Wrap the low-level output in a stream object and let lib_vprintf
    * do the work.
    */
 
@@ -152,110 +152,110 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
     defined(CONFIG_SYSLOG_PRIORITY) || defined(CONFIG_SYSLOG_PREFIX) || \
     defined(CONFIG_SYSLOG_PROCESS_NAME)
 
-  ret = lib_sprintf_internal(&stream.common,
+  ret = lib_printf_internal(&stream.common,
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Reset the terminal style. */
 
-                             "\e[0m"
+                            "\e[0m"
 #endif
 
 #ifdef CONFIG_SYSLOG_TIMESTAMP
 #  if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
 #    if defined(CONFIG_SYSLOG_TIMESTAMP_FORMAT_MICROSECOND)
-                             "[%s.%06ld] "
+                            "[%s.%06ld] "
 #    else
-                             "[%s] "
+                            "[%s] "
 #    endif
 #  else
-                             "[%5ju.%06ld] "
+                            "[%5ju.%06ld] "
 #  endif
 #endif
 
 #if defined(CONFIG_SMP)
-                             "[CPU%d] "
+                            "[CPU%d] "
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)
   /* Prepend the Thread ID */
 
-                             "[%2d] "
+                            "[%2d] "
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 
-                             "%s"
+                            "%s"
 #endif
 
 #if defined(CONFIG_SYSLOG_PRIORITY)
   /* Prepend the message priority. */
 
-                             "[%6s] "
+                            "[%6s] "
 #endif
 
 #if defined(CONFIG_SYSLOG_PREFIX)
   /* Prepend the prefix, if available */
 
-                             "[%s] "
+                            "[%s] "
 #endif
 #ifdef CONFIG_SYSLOG_PROCESS_NAME
   /* Prepend the thread name */
 
-                             "%s: "
+                            "%s: "
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
 #  if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
 #    if defined(CONFIG_SYSLOG_TIMESTAMP_FORMAT_MICROSECOND)
-                             , date_buf, ts.tv_nsec / NSEC_PER_USEC
+                            , date_buf, ts.tv_nsec / NSEC_PER_USEC
 #    else
-                             , date_buf
+                            , date_buf
 #    endif
 #  else
-                             , (uintmax_t)ts.tv_sec
-                             , ts.tv_nsec / NSEC_PER_USEC
+                            , (uintmax_t)ts.tv_sec
+                            , ts.tv_nsec / NSEC_PER_USEC
 #  endif
 #endif
 
 #if defined(CONFIG_SMP)
-                             , this_cpu()
+                            , this_cpu()
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)
   /* Prepend the Thread ID */
 
-                             , nxsched_gettid()
+                            , nxsched_gettid()
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 
-                             , g_priority_color[LOG_PRI(priority)]
+                            , g_priority_color[LOG_PRI(priority)]
 #endif
 
 #if defined(CONFIG_SYSLOG_PRIORITY)
   /* Prepend the message priority. */
 
-                             , g_priority_str[LOG_PRI(priority)]
+                            , g_priority_str[LOG_PRI(priority)]
 #endif
 
 #if defined(CONFIG_SYSLOG_PREFIX)
   /* Prepend the prefix, if available */
 
-                             , CONFIG_SYSLOG_PREFIX_STRING
+                            , CONFIG_SYSLOG_PREFIX_STRING
 #endif
 
 #ifdef CONFIG_SYSLOG_PROCESS_NAME
   /* Prepend the thread name */
 
-                             , get_task_name(tcb)
+                            , get_task_name(tcb)
 #endif
-                    );
+                            );
 
 #endif /* CONFIG_SYSLOG_COLOR_OUTPUT || CONFIG_SYSLOG_TIMESTAMP || ... */
 
   /* Generate the output */
 
-  ret += lib_vsprintf_internal(&stream.common, fmt, *ap);
+  ret += lib_vprintf_internal(&stream.common, fmt, *ap);
 
   if (stream.last_ch != '\n')
     {

--- a/include/debug.h
+++ b/include/debug.h
@@ -1335,7 +1335,7 @@
     { \
        struct lib_outstream_s stream; \
        lib_lowoutstream(&stream); \
-       lib_sprintf(&stream, __VA_ARGS__); \
+       lib_printf(&stream, __VA_ARGS__); \
     } \
   while (0)
 

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -798,55 +798,55 @@ int lib_noflush(FAR struct lib_outstream_s *self);
 int lib_snoflush(FAR struct lib_sostream_s *self);
 
 /****************************************************************************
- * Name: lib_sprintf
+ * Name: lib_printf
  *
  * Description:
- *  Stream-oriented implementation of sprintf.  Used only by the SYSLOG.
+ *  Stream-oriented implementation of printf.  Used only by the SYSLOG.
  *
  ****************************************************************************/
 
-int lib_sprintf(FAR struct lib_outstream_s *stream,
-                FAR const IPTR char *fmt, ...) printf_like(2, 3);
+int lib_printf(FAR struct lib_outstream_s *stream,
+               FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
- * Name: lib_bsprintf
+ * Name: lib_oprintf
  *
  * Description:
- *  Implementation of sprintf formatted output buffer data. Structure data
+ *  Implementation of printf formatted output stream. Object data
  *  types must be one-byte aligned.
  *
  ****************************************************************************/
 
-int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
-                 FAR const void *buf);
+int lib_oprintf(FAR struct lib_outstream_s *stream,
+                FAR const IPTR char *fmt, FAR const void *obj);
 
 /****************************************************************************
- * Name: lib_sprintf_internal
+ * Name: lib_printf_internal
  *
  * Description:
  *   This function does not take numbered arguments in printf.
- *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *   Equivalent to lib_printf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
  *
  ****************************************************************************/
 
-int lib_sprintf_internal(FAR struct lib_outstream_s *stream,
-                         FAR const IPTR char *fmt, ...) printf_like(2, 3);
+int lib_printf_internal(FAR struct lib_outstream_s *stream,
+                        FAR const IPTR char *fmt, ...) printf_like(2, 3);
 
 /****************************************************************************
- * Name: lib_vsprintf_internal
+ * Name: lib_vprintf_internal
  *
  * Description:
  *   This function does not take numbered arguments in printf.
- *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *   Equivalent to lib_printf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
  *
  ****************************************************************************/
 
-int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
-                          FAR const IPTR char *fmt, va_list ap)
-                          printf_like(2, 0);
+int lib_vprintf_internal(FAR struct lib_outstream_s *stream,
+                         FAR const IPTR char *fmt, va_list ap)
+                         printf_like(2, 0);
 
 /****************************************************************************
- * Name: lib_vsprintf
+ * Name: lib_vprintf
  *
  * Description:
  *  Stream-oriented implementation that underlies printf family:  printf,
@@ -854,8 +854,8 @@ int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
  *
  ****************************************************************************/
 
-int lib_vsprintf(FAR struct lib_outstream_s *stream,
-                 FAR const IPTR char *src, va_list ap) printf_like(2, 0);
+int lib_vprintf(FAR struct lib_outstream_s *stream,
+                FAR const IPTR char *tmp, va_list ap) printf_like(2, 0);
 
 /****************************************************************************
  * Name: lib_vscanf
@@ -870,17 +870,17 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
                FAR const IPTR char *src, va_list ap) scanf_like(3, 0);
 
 /****************************************************************************
- * Name: lib_bscanf
+ * Name: lib_oscanf
  *
  * Description:
- *  Convert data into a structure according to standard formatting protocols.
+ *  Convert stream into an object according to standard formatting protocols.
  *  For string arrays, please use "%{length}s" or "%{length}c" to specify
  *  the length.
  *
  ****************************************************************************/
 
-int lib_bscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
-               FAR const IPTR char *fmt, FAR void *data);
+int lib_oscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
+               FAR const IPTR char *fmt, FAR void *obj);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -45,8 +45,8 @@
 
 #ifdef CONFIG_LIB_GDBSTUB_DEBUG
 #  define GDB_DEBUG(stat, ...) \
-          lib_sprintf((FAR struct lib_outstream_s *)&state->stream, \
-                      ##__VA_ARGS__)
+          lib_printf((FAR struct lib_outstream_s *)&state->stream, \
+                     ##__VA_ARGS__)
 #  define GDB_ASSERT() __assert(__FILE__, __LINE__, 0)
 #else
 #  define GDB_DEBUG(...)

--- a/libs/libc/obstack/lib_obstack_vprintf.c
+++ b/libs/libc/obstack/lib_obstack_vprintf.c
@@ -98,7 +98,7 @@ int obstack_vprintf(FAR struct obstack *h, FAR const char *fmt, va_list ap)
   outstream.common.nput = 0;
   outstream.h = h;
 
-  int nbytes = lib_vsprintf(&outstream.common, fmt, ap);
+  int nbytes = lib_vprintf(&outstream.common, fmt, ap);
 
   if (nbytes < 0)
     {

--- a/libs/libc/stdio/README.md
+++ b/libs/libc/stdio/README.md
@@ -1,5 +1,5 @@
-# lib_bsprintf
-  This function is mainly used to output the contents of the input structure. Supports standard formats for printf and scanf.
+# lib_oprintf
+  This function is mainly used to output the contents of the input object. Supports standard formats for printf and scanf.
   For detailed parameters, see:
   1. https://en.cppreference.com/w/c/io/fprintf
   2. https://en.cppreference.com/w/c/io/fscanf
@@ -77,8 +77,8 @@
     lib_stdoutstream(&stdoutstream, stdout);
 
     flockfile(stdout);
-    lib_bsprintf(&stdoutstream.common, sv, &test_v);
-    lib_bsprintf(&stdoutstream.common, sg, &test_g);
+    lib_oprintf(&stdoutstream.common, sv, &test_v);
+    lib_oprintf(&stdoutstream.common, sg, &test_g);
     funlockfile(stdout);
   #else
     struct lib_rawoutstream_s rawoutstream;
@@ -87,15 +87,15 @@
     lib_rawoutstream(&rawoutstream, STDOUT_FILENO);
     lib_bufferedoutstream(&outstream, &rawoutstream.common);
 
-    lib_bsprintf(&outstream.common, sv, &test_v);
-    lib_bsprintf(&outstream.common, sg, &test_g);
+    lib_oprintf(&outstream.common, sv, &test_v);
+    lib_oprintf(&outstream.common, sg, &test_g);
 
     lib_stream_flush(&outstream.common);
   #endif
    ~~~
 
-# lib_bscanf
-  This function adds a formatted standard scanf string to the structure(lib_bscanf).
+# lib_oscanf
+  This function adds a formatted standard scanf string to the object(lib_oscanf).
   1. https://zh.cppreference.com/w/c/io/fscanf
 
 - **special**:
@@ -151,5 +151,5 @@
   3. **use**:
   ~~~
   struct test vg;
-  ret = lib_bscanf(binput, bflag, &vg);
+  ret = lib_oscanf(binput, bflag, &vg);
   ~~~

--- a/libs/libc/stdio/lib_snprintf.c
+++ b/libs/libc/stdio/lib_snprintf.c
@@ -67,10 +67,10 @@ int snprintf(FAR char *buf, size_t size, FAR const IPTR char *format, ...)
       stream = &u.nulloutstream;
     }
 
-  /* Then let lib_vsprintf do the real work */
+  /* Then let lib_vprintf do the real work */
 
   va_start(ap, format);
-  n = lib_vsprintf(stream, format, ap);
+  n = lib_vprintf(stream, format, ap);
   va_end(ap);
   return n;
 }

--- a/libs/libc/stdio/lib_sprintf.c
+++ b/libs/libc/stdio/lib_sprintf.c
@@ -44,10 +44,10 @@ int sprintf(FAR char *buf, FAR const IPTR char *fmt, ...)
 
   lib_memoutstream(&memoutstream, buf, INT_MAX);
 
-  /* Then let lib_vsprintf do the real work */
+  /* Then let lib_vprintf do the real work */
 
   va_start(ap, fmt);
-  n = lib_vsprintf(&memoutstream.common, fmt, ap);
+  n = lib_vprintf(&memoutstream.common, fmt, ap);
   va_end(ap);
   return n;
 }

--- a/libs/libc/stdio/lib_vasprintf.c
+++ b/libs/libc/stdio/lib_vasprintf.c
@@ -81,7 +81,7 @@ int nx_vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
    */
 
   lib_nulloutstream(&nulloutstream);
-  lib_vsprintf(&nulloutstream, fmt, ap);
+  lib_vprintf(&nulloutstream, fmt, ap);
 
   /* Then allocate a buffer to hold that number of characters, adding one
    * for the null terminator.
@@ -103,13 +103,13 @@ int nx_vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
 
   lib_memoutstream(&memoutstream, buf, nulloutstream.nput + 1);
 
-  /* Then let lib_vsprintf do it's real thing */
+  /* Then let lib_vprintf do it's real thing */
 
 #ifdef va_copy
-  nbytes = lib_vsprintf(&memoutstream.common, fmt, ap2);
+  nbytes = lib_vprintf(&memoutstream.common, fmt, ap2);
   va_end(ap2);
 #else
-  nbytes = lib_vsprintf(&memoutstream.common, fmt, ap);
+  nbytes = lib_vprintf(&memoutstream.common, fmt, ap);
 #endif
 
   /* Return a pointer to the string to the caller.  NOTE: the memstream put()
@@ -177,7 +177,7 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
    */
 
   lib_nulloutstream(&nulloutstream);
-  lib_vsprintf(&nulloutstream, fmt, ap);
+  lib_vprintf(&nulloutstream, fmt, ap);
 
   /* Then allocate a buffer to hold that number of characters, adding one
    * for the null terminator.
@@ -199,13 +199,13 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
 
   lib_memoutstream(&memoutstream, buf, nulloutstream.nput + 1);
 
-  /* Then let lib_vsprintf do it's real thing */
+  /* Then let lib_vprintf do it's real thing */
 
 #ifdef va_copy
-  nbytes = lib_vsprintf(&memoutstream.common, fmt, ap2);
+  nbytes = lib_vprintf(&memoutstream.common, fmt, ap2);
   va_end(ap2);
 #else
-  nbytes = lib_vsprintf(&memoutstream.common, fmt, ap);
+  nbytes = lib_vprintf(&memoutstream.common, fmt, ap);
 #endif
 
   /* Return a pointer to the string to the caller.  NOTE: the memstream put()

--- a/libs/libc/stdio/lib_vdprintf.c
+++ b/libs/libc/stdio/lib_vdprintf.c
@@ -51,11 +51,11 @@ int vdprintf(int fd, FAR const IPTR char *fmt, va_list ap)
   struct lib_rawoutstream_s rawoutstream;
   struct lib_bufferedoutstream_s outstream;
 
-  /* Wrap the fd in a stream object and let lib_vsprintf do the work. */
+  /* Wrap the fd in a stream object and let lib_vprintf do the work. */
 
   lib_rawoutstream(&rawoutstream, fd);
   lib_bufferedoutstream(&outstream, &rawoutstream.common);
-  ret = lib_vsprintf(&outstream.common, fmt, ap);
+  ret = lib_vprintf(&outstream.common, fmt, ap);
   lib_stream_flush(&outstream.common);
   return ret;
 }

--- a/libs/libc/stdio/lib_vfprintf.c
+++ b/libs/libc/stdio/lib_vfprintf.c
@@ -35,19 +35,19 @@ int vfprintf(FAR FILE *stream, FAR const IPTR char *fmt, va_list ap)
   struct lib_stdoutstream_s stdoutstream;
   int  n = ERROR;
 
-  /* Wrap the stream in a stream object and let lib_vsprintf
+  /* Wrap the stream in a stream object and let lib_vprintf
    * do the work.
    */
 
   lib_stdoutstream(&stdoutstream, stream);
 
-  /* Hold the stream semaphore throughout the lib_vsprintf
+  /* Hold the stream semaphore throughout the lib_vprintf
    * call so that this thread can get its entire message out
    * before being preempted by the next thread.
    */
 
   flockfile(stream);
-  n = lib_vsprintf(&stdoutstream.common, fmt, ap);
+  n = lib_vprintf(&stdoutstream.common, fmt, ap);
   funlockfile(stream);
 
   return n;

--- a/libs/libc/stdio/lib_vsnprintf.c
+++ b/libs/libc/stdio/lib_vsnprintf.c
@@ -67,8 +67,8 @@ int vsnprintf(FAR char *buf, size_t size, FAR const IPTR char *format,
       stream = &u.nulloutstream;
     }
 
-  /* Then let lib_vsprintf do the real work */
+  /* Then let lib_vprintf do the real work */
 
-  n = lib_vsprintf(stream, format, ap);
+  n = lib_vprintf(stream, format, ap);
   return n;
 }

--- a/libs/libc/stdio/lib_vsprintf.c
+++ b/libs/libc/stdio/lib_vsprintf.c
@@ -39,9 +39,9 @@ int vsprintf(FAR char *dest, FAR const IPTR char *src, va_list ap)
   struct lib_memoutstream_s memoutstream;
 
   /* Wrap the destination buffer in a stream object and let
-   * libs/libc/stdio/lib_vsprintf do the work.
+   * libs/libc/stdio/lib_vprintf do the work.
    */
 
   lib_memoutstream(&memoutstream, dest, INT_MAX);
-  return lib_vsprintf(&memoutstream.common, src, ap);
+  return lib_vprintf(&memoutstream.common, src, ap);
 }

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -45,9 +45,9 @@ list(
   lib_base64outstream.c
   lib_fileinstream.c
   lib_fileoutstream.c
-  lib_libbsprintf.c
+  lib_liboprintf.c
   lib_libvscanf.c
-  lib_libvsprintf.c
+  lib_libvprintf.c
   lib_ultoa_invert.c)
 
 if(CONFIG_LIBC_FLOATINGPOINT)

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -30,8 +30,8 @@ CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
 CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
 CSRCS += lib_hexdumpstream.c lib_base64outstream.c lib_mtdsostream.c
-CSRCS += lib_fileinstream.c lib_fileoutstream.c lib_libbsprintf.c
-CSRCS += lib_libvscanf.c lib_libvsprintf.c lib_ultoa_invert.c
+CSRCS += lib_fileinstream.c lib_fileoutstream.c lib_liboprintf.c
+CSRCS += lib_libvscanf.c lib_libvprintf.c lib_ultoa_invert.c
 
 ifeq ($(CONFIG_LIBC_FLOATINGPOINT),y)
 CSRCS += lib_dtoa_engine.c lib_dtoa_data.c

--- a/libs/libc/stream/lib_liboprintf.c
+++ b/libs/libc/stream/lib_liboprintf.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stream/lib_libbsprintf.c
+ * libs/libc/stream/lib_liboprintf.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -34,8 +34,8 @@
  * Public Functions
  ****************************************************************************/
 
-int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
-                 FAR const void *buf)
+int lib_oprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
+                FAR const void *obj)
 {
   begin_packed_struct union
     {
@@ -61,7 +61,7 @@ int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
 
   end_packed_struct *var;
   FAR const char *prec = NULL;
-  FAR const char *data = buf;
+  FAR const char *data = obj;
   char fmtstr[64];
   bool infmt = false;
   size_t offset = 0;
@@ -85,7 +85,7 @@ int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
           memset(fmtstr, 0, sizeof(fmtstr));
         }
 
-      var = (FAR void *)((char *)buf + offset);
+      var = (FAR void *)((char *)obj + offset);
       fmtstr[len++] = c;
 
       if (c == 'c' || c == 'd' || c == 'i' || c == 'u' ||
@@ -94,44 +94,44 @@ int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
           if (*(fmt - 2) == 'j')
             {
               offset += sizeof(var->im);
-              ret += lib_sprintf(s, fmtstr, var->im);
+              ret += lib_printf(s, fmtstr, var->im);
             }
 #ifdef CONFIG_HAVE_LONG_LONG
           else if (*(fmt - 2) == 'l' && *(fmt - 3) == 'l')
             {
               offset += sizeof(var->ll);
-              ret += lib_sprintf(s, fmtstr, var->ll);
+              ret += lib_printf(s, fmtstr, var->ll);
             }
 #endif
           else if (*(fmt - 2) == 'l')
             {
               offset += sizeof(var->l);
-              ret += lib_sprintf(s, fmtstr, var->l);
+              ret += lib_printf(s, fmtstr, var->l);
             }
           else if (*(fmt - 2) == 'z')
             {
               offset += sizeof(var->sz);
-              ret += lib_sprintf(s, fmtstr, var->sz);
+              ret += lib_printf(s, fmtstr, var->sz);
             }
           else if (*(fmt - 2) == 't')
             {
               offset += sizeof(var->pd);
-              ret += lib_sprintf(s, fmtstr, var->pd);
+              ret += lib_printf(s, fmtstr, var->pd);
             }
           else if (*(fmt - 2) == 'h' && *(fmt - 3) == 'h')
             {
               offset += sizeof(var->c);
-              ret += lib_sprintf(s, fmtstr, var->c);
+              ret += lib_printf(s, fmtstr, var->c);
             }
           else if (*(fmt - 2) == 'h')
             {
               offset += sizeof(var->si);
-              ret += lib_sprintf(s, fmtstr, var->si);
+              ret += lib_printf(s, fmtstr, var->si);
             }
           else
             {
               offset += sizeof(var->i);
-              ret += lib_sprintf(s, fmtstr, var->i);
+              ret += lib_printf(s, fmtstr, var->i);
             }
 
           infmt = false;
@@ -143,19 +143,19 @@ int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
           if (*(fmt - 2) == 'h')
             {
               offset += sizeof(var->f);
-              ret += lib_sprintf(s, fmtstr, var->f);
+              ret += lib_printf(s, fmtstr, var->f);
             }
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
           else if (*(fmt - 2) == 'L')
             {
               offset += sizeof(var->ld);
-              ret += lib_sprintf(s, fmtstr, var->ld);
+              ret += lib_printf(s, fmtstr, var->ld);
             }
 #  endif
           else
             {
               offset += sizeof(var->d);
-              ret += lib_sprintf(s, fmtstr, var->d);
+              ret += lib_printf(s, fmtstr, var->d);
             }
 
           infmt = false;
@@ -181,13 +181,13 @@ int lib_bsprintf(FAR struct lib_outstream_s *s, FAR const IPTR char *fmt,
               offset += strlen(value) + 1;
             }
 
-          ret += lib_sprintf(s, fmtstr, value);
+          ret += lib_printf(s, fmtstr, value);
           infmt = false;
         }
       else if (c == 'p')
         {
           offset += sizeof(var->p);
-          ret += lib_sprintf(s, fmtstr, var->p);
+          ret += lib_printf(s, fmtstr, var->p);
           infmt = false;
         }
       else if (c == '.')

--- a/libs/libc/stream/lib_libvprintf.c
+++ b/libs/libc/stream/lib_libvprintf.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stream/lib_libvsprintf.c
+ * libs/libc/stream/lib_libvprintf.c
  *
  * SPDX-License-Identifier: BSD-3-Clause
  * SPDX-FileCopyrightText: 2002, Alexander Popov (sasho@vip.bg)
@@ -146,18 +146,18 @@ static const char g_nullstring[] = "(null)";
  * Private Function Prototypes
  ****************************************************************************/
 
-static int vsprintf_internal(FAR struct lib_outstream_s *stream,
-                             FAR struct arg_s *arglist, int numargs,
-                             FAR const IPTR char *fmt, va_list ap)
+static int vprintf_internal(FAR struct lib_outstream_s *stream,
+                            FAR struct arg_s *arglist, int numargs,
+                            FAR const IPTR char *fmt, va_list ap)
            printf_like(4, 0);
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
-static int vsprintf_internal(FAR struct lib_outstream_s *stream,
-                             FAR struct arg_s *arglist, int numargs,
-                             FAR const IPTR char *fmt, va_list ap)
+static int vprintf_internal(FAR struct lib_outstream_s *stream,
+                            FAR struct arg_s *arglist, int numargs,
+                            FAR const IPTR char *fmt, va_list ap)
 {
   unsigned char c; /* Holds a char from the format string */
   uint16_t flags;
@@ -1127,7 +1127,7 @@ str_lpad:
                     {
                       FAR struct va_format *vaf = (FAR void *)(uintptr_t)x;
 
-                      lib_bsprintf(stream, vaf->fmt, vaf->va);
+                      lib_oprintf(stream, vaf->fmt, vaf->va);
                       continue;
                     }
 
@@ -1138,10 +1138,10 @@ str_lpad:
                       va_list copy;
 
                       va_copy(copy, *vaf->va);
-                      lib_vsprintf(stream, vaf->fmt, copy);
+                      lib_vprintf(stream, vaf->fmt, copy);
                       va_end(copy);
 #  else
-                      lib_vsprintf(stream, vaf->fmt, *vaf->va);
+                      lib_vprintf(stream, vaf->fmt, *vaf->va);
 #  endif
                       continue;
                     }
@@ -1166,10 +1166,10 @@ str_lpad:
                           if (c == 'S')
                             {
                               total_len +=
-                              lib_sprintf_internal(stream,
-                                                   "+%#tx/%#zx",
-                                                   addr - symbol->sym_value,
-                                                   symbolsize);
+                              lib_printf_internal(stream,
+                                                  "+%#tx/%#zx",
+                                                  addr - symbol->sym_value,
+                                                  symbolsize);
                             }
 
                           continue;
@@ -1337,14 +1337,14 @@ ret:
  * Public Functions
  ****************************************************************************/
 
-int lib_vsprintf(FAR struct lib_outstream_s *stream,
-                 FAR const IPTR char *fmt, va_list ap)
+int lib_vprintf(FAR struct lib_outstream_s *stream,
+                FAR const IPTR char *fmt, va_list ap)
 {
 #ifdef CONFIG_LIBC_NUMBERED_ARGS
   /* We do 2 passes of parsing and fill the arglist between the passes. */
 
   struct arg_s arglist;
-  int numargs = vsprintf_internal(NULL, &arglist, NL_ARGMAX, fmt, ap);
+  int numargs = vprintf_internal(NULL, &arglist, NL_ARGMAX, fmt, ap);
   union arg_u argvalue[MAX(numargs, 1)];
   int i;
 
@@ -1380,65 +1380,65 @@ int lib_vsprintf(FAR struct lib_outstream_s *stream,
         }
     }
 
-  return vsprintf_internal(stream, &arglist, numargs, fmt, ap);
+  return vprintf_internal(stream, &arglist, numargs, fmt, ap);
 #else
-  return vsprintf_internal(stream, NULL, 0, fmt, ap);
+  return vprintf_internal(stream, NULL, 0, fmt, ap);
 #endif
 }
 
 /****************************************************************************
- * Name: lib_sprintf
+ * Name: lib_printf
  ****************************************************************************/
 
-int lib_sprintf(FAR struct lib_outstream_s *stream, FAR const IPTR char *fmt,
-                ...)
+int lib_printf(FAR struct lib_outstream_s *stream,
+               FAR const IPTR char *fmt, ...)
 {
   va_list ap;
   int     n;
 
-  /* Let lib_vsprintf do the real work */
+  /* Let lib_vprintf do the real work */
 
   va_start(ap, fmt);
-  n = lib_vsprintf(stream, fmt, ap);
+  n = lib_vprintf(stream, fmt, ap);
   va_end(ap);
   return n;
 }
 
 /****************************************************************************
- * Name: lib_sprintf_internal
+ * Name: lib_printf_internal
  *
  * Description:
  *   This function does not take numbered arguments in printf.
- *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *   Equivalent to lib_printf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
  *
  ****************************************************************************/
 
-int lib_sprintf_internal(FAR struct lib_outstream_s *stream,
-                         FAR const IPTR char *fmt, ...)
+int lib_printf_internal(FAR struct lib_outstream_s *stream,
+                        FAR const IPTR char *fmt, ...)
 {
   va_list ap;
   int     n;
 
-  /* Then let vsprintf_internal do the real work */
+  /* Then let vprintf_internal do the real work */
 
   va_start(ap, fmt);
-  n = vsprintf_internal(stream, NULL, 0, fmt, ap);
+  n = vprintf_internal(stream, NULL, 0, fmt, ap);
   va_end(ap);
 
   return n;
 }
 
 /****************************************************************************
- * Name: lib_vsprintf_internal
+ * Name: lib_vprintf_internal
  *
  * Description:
  *   This function does not take numbered arguments in printf.
- *   Equivalent to lib_sprintf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
+ *   Equivalent to lib_printf when CONFIG_LIBC_NUMBERED_ARGS is not enabled
  *
  ****************************************************************************/
 
-int lib_vsprintf_internal(FAR struct lib_outstream_s *stream,
-                          FAR const IPTR char *fmt, va_list ap)
+int lib_vprintf_internal(FAR struct lib_outstream_s *stream,
+                         FAR const IPTR char *fmt, va_list ap)
 {
-  return vsprintf_internal(stream, NULL, 0, fmt, ap);
+  return vprintf_internal(stream, NULL, 0, fmt, ap);
 }

--- a/libs/libc/stream/lib_libvscanf.c
+++ b/libs/libc/stream/lib_libvscanf.c
@@ -1283,18 +1283,18 @@ int lib_vscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
  * Name: lib_bscanf
  *
  * Description:
- *  Convert data into a structure according to standard formatting protocols.
+ *  Convert data into an object according to standard formatting protocols.
  *  For string arrays, please use "%{length}s" or "%{length}c" to specify
  *  the length.
  *
  ****************************************************************************/
 
-int lib_bscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
-               FAR const IPTR char *fmt, FAR void *data)
+int lib_oscanf(FAR struct lib_instream_s *stream, FAR int *lastc,
+               FAR const IPTR char *fmt, FAR void *obj)
 {
   union vabuf_u vabuf =
     {
-      data
+      obj
     };
 
   return vscanf_internal(stream, lastc, fmt, false, vabuf);

--- a/libs/libc/wchar/lib_swprintf.c
+++ b/libs/libc/wchar/lib_swprintf.c
@@ -50,10 +50,10 @@ int vswprintf(FAR wchar_t *buf, size_t maxlen, FAR const wchar_t *fmt,
   lib_memoutstream((FAR struct lib_memoutstream_s *)&memoutstream,
                    (FAR char *)buf, maxlen);
 
-  /* Then let lib_vsprintf do the real work */
+  /* Then let lib_vprintf do the real work */
 
-  return lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.common,
-                      (FAR const char *)fmt, ap);
+  return lib_vprintf((FAR struct lib_outstream_s *)&memoutstream.common,
+                     (FAR const char *)fmt, ap);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

all lib_xsprintfyyy only accept lib_outstream_s *, so we don't need the different char(e.g. f[ile] or s[tring]).
Since lib_xsprintfyyy is internal implementation for public ANSI C API defined stdio.h, the impact should be minor.

## Impact

stream printf/scanf caller

## Testing

CI.
note: this pr need merge with https://github.com/apache/nuttx-apps/pull/3100.

