### PR TITLE
gitignore: add more vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 *.rel
 *.src
 *.srec
+*.swn
+*.swo
 *.swp
 *.sym
 *.wsp
@@ -60,7 +62,7 @@
 /nuttx.*
 /nuttx_user*
 /staging
-/tags
+**/tags
 /TAGS
 core
 Make*.dep


### PR DESCRIPTION
## Summary
Add more vim swap files(".swo", ".swn") and ignore "tags" files for all directories.
1. Ignore "tags" files for all directories.
2. Add more vim swap files(".swo", ".swn") according to  https://vimdoc.sourceforge.net/htmldoc/recover.html.
    ```
    - If this file already exists (e.g., when you are recovering from a crash) a warning is given and another extension is used, ".swo", ".swn", etc.
    ```
## Impact
- .gitignore

## Testing
CI