### PR TITLE
spinlock: Better recursive spinlock implementation.

### DIFF
--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -61,7 +61,7 @@ struct btn_upperhalf_s
 
   FAR const struct btn_lowerhalf_s *bu_lower;
 
-  btn_buttonset_t bu_sample;  /* Last sampled button states */
+  btn_buttonset_t bu_sample; /* Last sampled button states */
   bool bu_enabled;
 
   /* The following is a singly linked list of open references to the

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -38,7 +38,7 @@
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
-extern struct rspinlock_s g_segger_lock;
+extern rspinlock_t g_segger_lock;
 #endif
 
 #ifdef CONFIG_SEGGER_RTT_UNCACHED_OFF_VARIABLE

--- a/drivers/segger/segger.c
+++ b/drivers/segger/segger.c
@@ -30,7 +30,7 @@
  * Public Data
  ****************************************************************************/
 
-struct rspinlock_s g_segger_lock = RSPINLOCK_INITIALIZER;
+rspinlock_t g_segger_lock = RSPINLOCK_INITIALIZER;
 ptrdiff_t g_segger_offset = PTRDIFF_MAX;
 
 /****************************************************************************

--- a/include/nuttx/notifier.h
+++ b/include/nuttx/notifier.h
@@ -30,7 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 #include <nuttx/mutex.h>
-#include <nuttx/spinlock.h>
+#include <nuttx/spinlock_type.h>
 
 #include <debug.h>
 #include <errno.h>

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -36,7 +36,7 @@
 
 #include <nuttx/macro.h>
 #include <nuttx/sched.h>
-#include <nuttx/spinlock.h>
+#include <nuttx/spinlock_type.h>
 
 /* For system call numbers definition */
 

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -595,8 +595,8 @@ irqstate_t rspin_lock_irqsave(FAR rspinlock_t *lock)
 
   /* Try seize the ownership of the lock. */
 
-  while (!atomic_cmpxchg_acquire((atomic_t *)&lock->val,
-                                 (atomic_t *)&old_val.val, new_val.val))
+  while (!atomic_cmpxchg_acquire((FAR atomic_t *)&lock->val,
+                                 (FAR atomic_t *)&old_val.val, new_val.val))
     {
       /* Already owned this lock. */
 
@@ -821,7 +821,7 @@ void rspin_unlock_irqrestore(FAR rspinlock_t *lock, irqstate_t flags)
 
   if (--lock->count == 0)
     {
-      atomic_set_release((atomic_t *)&lock->val, 0);
+      atomic_set_release((FAR atomic_t *)&lock->val, 0);
       up_irq_restore(flags);
     }
 

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -37,9 +37,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 
-#if defined(CONFIG_TICKET_SPINLOCK) || defined(CONFIG_RW_SPINLOCK)
-#  include <nuttx/atomic.h>
-#endif
+#include <nuttx/atomic.h>
 
 #include <nuttx/spinlock_type.h>
 

--- a/include/nuttx/spinlock_type.h
+++ b/include/nuttx/spinlock_type.h
@@ -81,6 +81,21 @@ typedef struct spinlock_s
 
 #endif /* CONFIG_SPINLOCK */
 
+#define RSPINLOCK_CPU_INVALID (-1)
+#define RSPINLOCK_INITIALIZER {0}
+
+typedef union rspinlock_u
+{
+  /* Which cpu is holding spinlock, and taking recursive count */
+
+  uint32_t val;
+  struct
+    {
+      uint16_t owner;
+      uint16_t count;
+    };
+} rspinlock_t;
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/include/nuttx/spinlock_type.h
+++ b/include/nuttx/spinlock_type.h
@@ -29,10 +29,6 @@
 
 #include <nuttx/config.h>
 
-#if defined(CONFIG_RW_SPINLOCK) || defined(CONFIG_TICKET_SPINLOCK)
-#include <nuttx/atomic.h>
-#endif
-
 #undef EXTERN
 #if defined(__cplusplus)
 #define EXTERN extern "C"
@@ -43,7 +39,7 @@ extern "C"
 #endif
 
 #if defined(CONFIG_RW_SPINLOCK)
-typedef atomic_t rwlock_t;
+typedef uint32_t rwlock_t;
 #  define RW_SP_UNLOCKED      0
 #  define RW_SP_READ_LOCKED   1
 #  define RW_SP_WRITE_LOCKED -1
@@ -58,8 +54,8 @@ typedef uint8_t spinlock_t;
 
 typedef struct spinlock_s
 {
-  atomic_t owner;
-  atomic_t next;
+  uint32_t owner;
+  uint32_t next;
 } spinlock_t;
 
 #  define SP_UNLOCKED (spinlock_t){0, 0}

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -40,6 +40,8 @@
 #include <nuttx/clock.h>
 #include <nuttx/trace.h>
 
+#include <nuttx/spinlock.h>
+
 #include "clock/clock.h"
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 #  include "clock/clock_timekeeping.h"

--- a/sched/misc/panic_notifier.c
+++ b/sched/misc/panic_notifier.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/notifier.h>
+#include <nuttx/spinlock.h>
 
 #include <sys/types.h>
 


### PR DESCRIPTION
## Summary

This commit provided a better recursive spinlock implementation with less memory-overhead and better performance.

E.g.
**Memory-overhead**: 32 + 32(padding) + 64 + 32 = 160 bits decrease to 32 bits on AArch64.
**Performance**: 160-bits data may cross the cache-line, result in significant performance degradation. 32-bits lock-data will not cross the cache-line in any case.

## Impact

This commit may have an impact on memory usage and performance on SMP systems.

## Testing

Tested on `qemu-armv8a:nsh_smp`.

Tested on `qemu-intel64:nsh` using `sudo qemu-system-x86_64 -enable-kvm -cpu host,+invtsc,+vmware-cpuid-freq,kvmclock=off -m 2G -kernel nuttx -nographic -serial mon:stdio` (`kvm`).
The simple 1M lock-and-add loop test result on a Intel Core 12700 machine shows the latency of per-operation under no contention:

| spinlock | rspinlock(without this commit) | rspinlock |
| - | - | - |
| 19ns | 54ns | 37ns |

The throughput of the rspinlock implementation is 1.45x better than the previous implementation.