### PR TITLE
[utsname] libc: Link dependency on `.version` file

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -198,7 +198,7 @@ makekdepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
 	$(call CATFILE, kbin/Make.dep, $^)
 	$(call DELFILE, $^)
 
-.depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
+.depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config $(TOPDIR)$(DELIM).version
 	$(Q) $(MAKE) makedepfile OBJPATH="bin"
 ifneq ($(CONFIG_BUILD_FLAT),y)
 	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)" OBJPATH="kbin"


### PR DESCRIPTION
## Summary

The `utsname` library has a direct dependency with `nuttx/version.h` to grab the release information. However, it was detected that changes to the `.version` - which trigger the update of `nuttx/version.h` - were not propagated to some files with a direct dependency to it.

To trigger a recompilation of the `libc` whenever the `.version` changes, a dependency was added to the `.depend` rule.

## Impact

* When the `.version` file gets updated, the whole `libc` is recompiled.

## Testing

N/A


