### PR TITLE
arch/risc-v: Fix `rv-virt:nsbi[|64]` defconfigs

### DIFF
--- a/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
+++ b/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
@@ -371,6 +371,39 @@ nsh64
 
 Identical to the `nsh`_ configuration, but for 64-bit RISC-V.
 
+nsbi
+----
+
+This is similar to the `knsh`, but using NuttX's native (minimalistic)
+SBI. It uses `hostfs` and QEMU in semi-hosting mode to load the
+user-space applications. This is intended for 32-bit RISC-V.
+
+To build it, use the following command::
+
+    $ make V=1 -j$(nproc)
+    $ make export V=1 -j$(nproc)
+    $ pushd ../apps
+    $ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
+    $ make import V=1 -j$(nproc)
+    $ popd
+
+Run it with QEMU using the default command for 32-bit RISC-V without
+the ``-bios none`` option. Please note that it still runs in S-mode,
+but bypasses QEMU's OpenSBI.
+
+In `nsh`, applications can be run directly::
+
+    nsh> hello
+
+nsbi64
+------
+
+Identical to the `nsbi`_ configuration, but for 64-bit RISC-V.
+
+Run it with QEMU using the default command for 64-bit RISC-V without
+the ``-bios none`` option. Please note that it still runs in S-mode,
+but bypasses QEMU's OpenSBI.
+
 smp
 ---
 

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -312,10 +312,10 @@ int riscv_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (cmd <= SYS_switch_context)
+  if (regs[REG_A0] <= SYS_switch_context)
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(tcb.xcp.regs);
+      up_dump_register(tcb->xcp.regs);
     }
   else
     {

--- a/boards/risc-v/qemu-rv/rv-virt/scripts/ld-nuttsbi.script
+++ b/boards/risc-v/qemu-rv/rv-virt/scripts/ld-nuttsbi.script
@@ -155,6 +155,12 @@ SECTIONS
       _edata = . ;
     }
 
+  .noinit (NOLOAD) : ALIGN(4)
+    {
+      *(.noinit)
+      *(.noinit.*)
+    } > ksram
+
   .bss :
     {
       _sbss = . ;


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* boards/risc-v/qemu-rv: Add missing section on `ld-nuttsbi.script`
  * Fix an issue regarding the `rv-virt:nsbi` defconfig, which wasn't booting properly because `sbi_set_mtimecmp` failed to get the `mtimecmp`'s register address when evaluating `g_mtimecmp`. This variable, which should be located at the `.noinit` section, wasn't being set accordingly by the linker script, ending up on `bss` section which is zero-initialized, overwriting its value previously set by `sbi_init_mtimer`.

* Documentation/rv-virt: Add entries for `nsbi[|64]` defconfigs

* arch/risc-v: Fix debugging syscall info

## Impact

Impact on user: YES. Fix boot problem on `rv-virt:nsbi[|64]`

Impact on build: NO.

Impact on hardware: NO.

Impact on documentation: YES. Adds related documentation about such configurations.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Test building and running it on QEMU before and after applying the patch (please note that for 64-bit system the testing method is the same):

### Building

```
make -j distclean && ./tools/configure.sh rv-virt:nsbi && make -j$(nproc) && make export -j$(nproc) && pushd ../apps && ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz && make import -j$(nproc) && popd
```

### Running

Tested with:
```
qemu-system-riscv32 --version
QEMU emulator version 10.0.0
```

#### Before

It fails to boot...

```
qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 1 -bios none -kernel nuttx -nographic
ABC
```

#### After

Boots normally:
```
qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 1 -bios none -kernel nuttx -nographic
ABC
NuttShell (NSH) NuttX-10.4.0
nsh> hello
Hello, World!!
nsh>
```

### Results

After applying this PR's patch, the device boots properly. This PR also adds the relevant documentation and enables setting `CONFIG_DEBUG_SYSCALL_INFO=y`.