### PR TITLE
[Fix] Esp32S3 LCD FB resolution.

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_lcd.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_lcd.c
@@ -312,8 +312,8 @@ static struct esp32s3_lcd_s g_lcd_priv;
 static const struct fb_videoinfo_s g_base_videoinfo =
 {
   .fmt      = ESP32S3_LCD_COLOR_FMT,
-  .xres     = CONFIG_ESP32S3_LCD_VRES,
-  .yres     = CONFIG_ESP32S3_LCD_HRES,
+  .xres     = CONFIG_ESP32S3_LCD_HRES,
+  .yres     = CONFIG_ESP32S3_LCD_VRES,
   .nplanes  = 1
 };
 


### PR DESCRIPTION
## Summary

The PR aims to fix an issue with the framebuffer resolution, which was inverted.
## Impact
Probably this impacts the ESP32S3_LCD_EV board, but considering the resolution (480x480), nothing changes  
## Testing
I tested during the contribution of a new board with similar hardware (ESP32S3-WROOM1 and TFT LCD RGB).
- https://github.com/apache/nuttx/pull/16558) 

https://github.com/user-attachments/assets/93d4b0a3-4424-4d3f-93a3-901dda42da69

![resolution-fixed](https://github.com/user-attachments/assets/f55e81b4-88dd-45cb-a9d8-b057b4d8c72e)

