### PR TITLE
{bp-16466} drivers/serial: fix race conditions

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -492,6 +492,23 @@ config ARCH_HAVE_RESET
 	bool
 	default n
 
+config ARCH_LDST_16BIT_NOT_ATOMIC
+	bool
+	default n
+	select ARCH_HAVE_8BIT_SERIAL_BUFSIZE
+	---help---
+	This configuration option denotes architecture incapable of loading
+	16-bit values atomically, ie. in a single instruction. If this is set,
+	it means that the architecture needs two (or more) instructions
+	to perform such load AND that a interrupt service routine may run
+	between their execution. The same applies for stores.
+
+	If set, any code running in non-interrupt context that reads 16-bit
+	variable that may be written in interrupt context must disable
+	interrupts or use another method that makes the read atomic.
+	(The same applies for non-interrupt context write and interrupt
+	context read.)
+
 config ARCH_HAVE_TESTSET
 	bool
 	default n

--- a/arch/avr/Kconfig
+++ b/arch/avr/Kconfig
@@ -49,6 +49,7 @@ config ARCH_FAMILY_AVR
 	bool
 	default n
 	select ARCH_HAVE_STACKCHECK
+	select ARCH_LDST_16BIT_NOT_ATOMIC
 
 config ARCH_FAMILY_AVR32
 	bool

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -7,6 +7,15 @@ config ARCH_HAVE_SERIAL_TERMIOS
 	bool
 	default n
 
+config ARCH_HAVE_8BIT_SERIAL_BUFSIZE
+	bool
+	default n
+	---help---
+	This is set by ARCH_LDST_16BIT_NOT_ATOMIC if the architecture does
+	not support atomic 16-bit load/store instructions. Receive and transmit
+	buffer sizes are stored in uint8_t (instead of int16_t) variable
+	in such case.
+
 menuconfig SERIAL
 	bool "Serial Driver Support"
 	default y

--- a/drivers/serial/Kconfig-usart
+++ b/drivers/serial/Kconfig-usart
@@ -58,17 +58,25 @@ menu "USART0 Configuration"
 
 config USART0_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART0_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART0_BAUD
 	int "BAUD rate"
@@ -130,17 +138,25 @@ menu "USART1 Configuration"
 
 config USART1_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART1_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART1_BAUD
 	int "BAUD rate"
@@ -202,17 +218,25 @@ menu "USART2 Configuration"
 
 config USART2_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART2_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART2_BAUD
 	int "BAUD rate"
@@ -273,17 +297,25 @@ menu "USART3 Configuration"
 
 config USART3_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART3_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART3_BAUD
 	int "BAUD rate"
@@ -345,17 +377,25 @@ menu "USART4 Configuration"
 
 config USART4_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART4_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART4_BAUD
 	int "BAUD rate"
@@ -417,17 +457,25 @@ menu "USART5 Configuration"
 
 config USART5_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART5_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART5_BAUD
 	int "BAUD rate"
@@ -489,17 +537,25 @@ menu "USART6 Configuration"
 
 config USART6_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART6_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART6_BAUD
 	int "BAUD rate"
@@ -561,17 +617,25 @@ menu "USART7 Configuration"
 
 config USART7_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART7_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART7_BAUD
 	int "BAUD rate"
@@ -633,17 +697,25 @@ menu "USART8 Configuration"
 
 config USART8_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART8_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART8_BAUD
 	int "BAUD rate"
@@ -705,17 +777,25 @@ menu "USART9 Configuration"
 
 config USART9_RXBUFSIZE
 	int "Receive buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered as they are received. This specifies
 		the size of the receive buffer.
 
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
+
 config USART9_TXBUFSIZE
 	int "Transmit buffer size"
-	default 256
+	default 252
 	---help---
 		Characters are buffered before being sent.  This specifies
 		the size of the transmit buffer.
+
+		Note that on architectures that are unable to load 16-bit
+		values atomically without eg. disabling interrupts, the size
+		of the buffer is stored in uint8_t variable.
 
 config USART9_BAUD
 	int "BAUD rate"

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -901,13 +901,13 @@ static ssize_t uart_readv(FAR struct file *filep, FAR struct uio *uio)
 #ifdef CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS
   unsigned int nbuffered;
   unsigned int watermark;
-  int16_t head;
+  sbuf_size_t head;
 #endif
   irqstate_t flags;
   ssize_t recvd = 0;
   ssize_t buflen;
   bool echoed = false;
-  int16_t tail;
+  sbuf_size_t tail;
   char ch;
   int ret;
 
@@ -954,9 +954,13 @@ static ssize_t uart_readv(FAR struct file *filep, FAR struct uio *uio)
        * index is only modified in this function.  Therefore, no
        * special handshaking is required here.
        *
-       * The head and tail pointers are 16-bit values.  The only time that
-       * the following could be unsafe is if the CPU made two non-atomic
-       * 8-bit accesses to obtain the 16-bit head index.
+       * The head and tail pointers values are sized based
+       * on the architecture. If the architecture reads 16-bit values
+       * atomically by nature, they are 16-bit values. On architectures
+       * where 16-bit access is split into two non-atomic 8-bit accesses,
+       * the pointers are 8-bit.
+       *
+       * The following code is therefore safe even with interrupts enabled.
        */
 
       tail = rxbuf->tail;

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -513,7 +513,7 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
 #endif
     }
 
-  /* Get exclusive access to the to dev->tmit.  We cannot permit new data to
+  /* Get exclusive access to the to dev->xmit.  We cannot permit new data to
    * be written while we are trying to flush the old data.
    *
    * A signal received while waiting for access to the xmit.head will abort


### PR DESCRIPTION
## Summary

While going through the code in drivers/serial/serial.c, I noticed this
comment:

The head and tail pointers are 16-bit values. The only time that
the following could be unsafe is if the CPU made two non-atomic
8-bit accesses to obtain the 16-bit head index.

This is what happens for (at least) AVR architecture. These are 8bit
microcontrollers and as such, they will fetch the 16-bit value in two
8-bit load instructions; interrupt routine may execute between those and
change the value being read. This will result in corrupted read (one
byte of the value will be from pre-interrupt state and the other from
post-interrupt state.)

This patch introduces CONFIG_ARCH_LD_16BIT_NOT_ATOMIC configuration
option, which is automatically selected for architectures known to be
unable to load 16bit values in one instruction. (It is currently only
set for AVR. I presume it might be also useful for Z80 but I do not have
any experience with that architecture so I did no changes there.) When
this configuration option is set, reads of recv.head and xmit.tail are
enclosed with enter_critical_section and leave_critical_section calls to
prevent interrupt handlers from running, if needed. Not all reads need
to be protected this way - some are already in existing critical
sections and some happen with the UART-specific interrupt disabled.

If the configuration option is not set, the code simply loads the value
into a local variable. Subsequent direct uses of the unprotected
volatile variable are replaced with the local variables for both cases.

There is also a related change that only applies when
CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS is set. Aside from the protection
selected by CONFIG_ARCH_LD_16BIT_NOT_ATOMIC, this patch also fixes
calculation of the nbuffered value. This calculation is not running with
interrupts disabled and value of rxbuf->head can change between the
condition and actual computation. Even if the load itself is atomic,
this leads to TOCTOU error.

## Impact

RELEASE

## Testing

CI
