### PR TITLE
{bp-16473} drivers/mtd: fix compile warning

### DIFF
--- a/drivers/mtd/mtd_rwbuffer.c
+++ b/drivers/mtd/mtd_rwbuffer.c
@@ -186,7 +186,7 @@ static int mtd_erase(FAR struct mtd_dev_s *dev,
   size_t nsectors;
   int ret;
 
-  finfo("block: %08zx nsectors: %zu\n",
+  finfo("block: %08jx nsectors: %zu\n",
         (intmax_t)block, nsectors);
 
   /* Convert to logical sectors and sector numbers */
@@ -295,7 +295,8 @@ static int mtd_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
               geo->neraseblocks = priv->rwb.nblocks / priv->spb;
               ret               = OK;
 
-              finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
+              finfo("blocksize: %" PRIu32 " erasesize: %" PRIu32
+                    "neraseblocks: %" PRIu32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
         }


### PR DESCRIPTION
## Summary
mtd/mtd_rwbuffer.c:42:
mtd/mtd_rwbuffer.c: In function 'mtd_erase':
mtd/mtd_rwbuffer.c:189:9: warning: format '%zx' expects argument of type 'size_t', but argument 3 has type 'long long int' [-Wformat=]
  189 |   finfo("block: %08zx nsectors: %zu\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  190 |         (intmax_t)block, nsectors);
      |         ~~~~~~~~~~~~~~~
      |         |
      |         long long int
mtd/mtd_rwbuffer.c:189:21: note: format string is defined here
  189 |   finfo("block: %08zx nsectors: %zu\n",
      |                 ~~~~^
      |                     |
      |                     unsigned int
      |                 %08llx
mtd/mtd_rwbuffer.c: In function 'mtd_ioctl':
mtd/mtd_rwbuffer.c:298:21: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  298 |               finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  299 |                     geo->blocksize, geo->erasesize, geo->neraseblocks);
      |                     ~~~~~~~~~~~~~~
      |                        |
      |                        uint32_t {aka long unsigned int}
...

## Impact

RELEASE

## Testing

CI