### PR TITLE
{bp-16479} sensors/nau7802: Fix format warning

### DIFF
--- a/drivers/sensors/nau7802.c
+++ b/drivers/sensors/nau7802.c
@@ -688,7 +688,7 @@ static int nau7802_control(FAR struct sensor_lowerhalf_s *lower,
 
     default:
       err = -EINVAL;
-      snerr("Unknown command for NAU7802: lu\n", cmd);
+      snerr("Unknown command for NAU7802: %d\n", cmd);
       break;
     }
 


### PR DESCRIPTION
## Summary
Silence format string warning by adding missing '%' sign.

## Impact

RELEASE

## Testing

CI