### PR TITLE
{bp-16490} fs/vfs: check if all iov_base are accessible

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -159,10 +159,22 @@ ssize_t file_readv(FAR struct file *filep,
                    FAR const struct iovec *iov, int iovcnt)
 {
   FAR struct inode *inode;
-  ssize_t ret = -EBADF;
+  ssize_t ret;
 
   DEBUGASSERT(filep);
   inode = filep->f_inode;
+
+  /* Are all iov_base accessible? */
+
+  for (ret = 0; ret < iovcnt; ret++)
+    {
+      if (iov[ret].iov_base == NULL && iov[ret].iov_len != 0)
+        {
+          return -EFAULT;
+        }
+    }
+
+  ret = -EBADF;
 
   /* Was this file opened for read access? */
 

--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -164,6 +164,18 @@ ssize_t file_readv(FAR struct file *filep,
   DEBUGASSERT(filep);
   inode = filep->f_inode;
 
+  /* Check buffer count and pointer for iovec */
+
+  if (iovcnt == 0)
+    {
+      return 0;
+    }
+
+  if (iov == NULL)
+    {
+      return -EFAULT;
+    }
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -153,6 +153,18 @@ ssize_t file_writev(FAR struct file *filep,
       return -EACCES;
     }
 
+  /* Check buffer count and pointer for iovec */
+
+  if (iovcnt == 0)
+    {
+      return 0;
+    }
+
+  if (iov == NULL)
+    {
+      return -EFAULT;
+    }
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -144,7 +144,7 @@ ssize_t file_writev(FAR struct file *filep,
                     FAR const struct iovec *iov, int iovcnt)
 {
   FAR struct inode *inode;
-  ssize_t ret = -EBADF;
+  ssize_t ret;
 
   /* Was this file opened for write access? */
 
@@ -153,10 +153,21 @@ ssize_t file_writev(FAR struct file *filep,
       return -EACCES;
     }
 
+  /* Are all iov_base accessible? */
+
+  for (ret = 0; ret < iovcnt; ret++)
+    {
+      if (iov[ret].iov_base == NULL && iov[ret].iov_len != 0)
+        {
+          return -EFAULT;
+        }
+    }
+
   /* Is a driver registered? Does it support the write method?
    * If yes, then let the driver perform the write.
    */
 
+  ret = -EBADF;
   inode = filep->f_inode;
   if (inode != NULL && inode->u.i_ops)
     {


### PR DESCRIPTION
## Summary

Check if all iov_base are inside accessible address space.
e.g.

  ret = write(fd, NULL, 3);

The iov.iov_base is NULL but iov.iov_len is NOT zero.

[nuttx/fs/vfs/fs_write.c](https://github.com/apache/nuttx/blob/dd07367f4eeb5ebe785c601e84143cfaf6ad411a/fs/vfs/fs_write.c#L425-L432)

Lines 425 to 432 in [dd07367](https://github.com/apache/nuttx/commit/dd07367f4eeb5ebe785c601e84143cfaf6ad411a)
 ssize_t write(int fd, FAR const void *buf, size_t nbytes) 
 { 
   struct iovec iov; 
  
   iov.iov_base = (void *)buf; 
   iov.iov_len = nbytes; 
   return writev(fd, &iov, 1); 
 } 

And, if iov.iov_base is not NULL but iov.iov_len is zero, skipped (same as Linux).

## Impact

RELEASE

## Testing

CI