### PR TITLE
{bp-16494} net/utils: avoid unalign access g_tcp_connections_buffer

### DIFF
--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -28,6 +28,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdlib.h>
 
@@ -88,7 +89,7 @@
   (dynalloc) <= 0 ? (prealloc) : ((maxalloc) > 0 ? (maxalloc) : INT16_MAX)
 
 #define NET_BUFPOOL_DECLARE(pool, nodesize, prealloc, dynalloc, maxalloc) \
-  static char pool##_buffer[prealloc][nodesize]; \
+  static char pool##_buffer[prealloc][nodesize] aligned_data(sizeof(uintptr_t)); \
   static struct net_bufpool_s pool = \
     { \
       pool##_buffer[0], \


### PR DESCRIPTION
## Summary

the address is 0x3c270203, cause unaligned access usage Fault (gdb) p g_tcp_connections
$1 = {pool = 0x3c270203 <g_tcp_connections_buffer> <error: Cannot access memory at address 0x3c270203>, prealloc = 8, dynalloc = 1, nodesize = -376, sem = {semcount = 32767, flags = 0 '\000', waitlist = {head = 0x0, tail = 0x0}}, freebuffers = {head = 0x0, tail = 0x0}}

## Impact

RELEASE

## Testing

CI
