### PR TITLE
{bp-16506} docs: Add missing CFLAGS to the ELF guides

### DIFF
--- a/Documentation/guides/fully_linked_elf.rst
+++ b/Documentation/guides/fully_linked_elf.rst
@@ -209,7 +209,7 @@ Below is the ``Makefile`` used to create the ELF program:
    ARCHOPTIMIZATION = -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
    ARCHINCLUDES = -I. -isystem  nuttx-export-7.25/include
    
-   CFLAGS = $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
+   CFLAGS = $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
    
    CROSSDEV = arm-none-eabi-
    CC = $(CROSSDEV)gcc

--- a/Documentation/guides/partially_linked_elf.rst
+++ b/Documentation/guides/partially_linked_elf.rst
@@ -241,7 +241,7 @@ The Makefile used to create the ELF program is as follows:
     ARCHOPTIMIZATION = -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
     ARCHINCLUDES = -I. -isystem  nuttx-export-7.25/include
     
-    CFLAGS = $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
+    CFLAGS = $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHINCLUDES) -pipe
     
     CROSSDEV = arm-none-eabi-
     CC = $(CROSSDEV)gcc


### PR DESCRIPTION
## Summary

As reported in apache/nuttx-apps#1828

## Impact

RELEASE

## Testing

CI
