### PR TITLE
{bp-16514} arch/stm32f0l0g0/stm32_tim.c: fix compilation when TIM6/TIM7 is missing

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_tim.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_tim.c
@@ -897,11 +897,19 @@ static int stm32_tim_setmode(struct stm32_tim_dev_s *dev,
    * disable it, simply set its clock to valid frequency or zero.
    */
 
-  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM6_BASE || \
-      ((struct stm32_tim_priv_s *)dev)->base == STM32_TIM7_BASE)
+#ifdef STM32_TIM6_BASE
+  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM6_BASE)
     {
       return -EINVAL;
     }
+#endif
+
+#ifdef STM32_TIM7_BASE
+  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM7_BASE)
+    {
+      return -EINVAL;
+    }
+#endif
 
   /* Decode operational modes */
 
@@ -985,11 +993,19 @@ static int stm32_tim_setchannel(struct stm32_tim_dev_s *dev,
    * disable it, simply set its clock to valid frequency or zero.
    */
 
-  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM6_BASE || \
-      ((struct stm32_tim_priv_s *)dev)->base == STM32_TIM7_BASE)
+#ifdef STM32_TIM6_BASE
+  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM6_BASE)
     {
       return -EINVAL;
     }
+#endif
+
+#ifdef STM32_TIM7_BASE
+  if (((struct stm32_tim_priv_s *)dev)->base == STM32_TIM7_BASE)
+    {
+      return -EINVAL;
+    }
+#endif
 
   /* Decode configuration */
 


### PR DESCRIPTION
## Summary

Fix compilation when TIM6/TIM7 is missing for stm32-m0.

## Impact

RELEASE

## Testing

CI
