### PR TITLE
{bp-16533} Update MCUBoot build process for Espressif devices

### DIFF
--- a/arch/risc-v/src/common/espressif/.gitignore
+++ b/arch/risc-v/src/common/espressif/.gitignore
@@ -2,3 +2,4 @@
 /esp-nuttx-bootloader
 /*.zip
 /esp-hal-3rdparty
+/esp-hal-3rdparty-mcuboot

--- a/arch/xtensa/src/esp32/.gitignore
+++ b/arch/xtensa/src/esp32/.gitignore
@@ -1,3 +1,4 @@
 /esp-hal-3rdparty
+/esp-hal-3rdparty-mcuboot
 /esp-wireless-drivers-3rdparty
 /*.zip

--- a/arch/xtensa/src/esp32s2/.gitignore
+++ b/arch/xtensa/src/esp32s2/.gitignore
@@ -1,3 +1,4 @@
 /bootloader
 /esp-hal-3rdparty
+/esp-hal-3rdparty-mcuboot
 /esp-nuttx-bootloader

--- a/arch/xtensa/src/esp32s2/Bootloader.mk
+++ b/arch/xtensa/src/esp32s2/Bootloader.mk
@@ -22,9 +22,10 @@
 
 ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
 
+ESP_HAL_3RDPARTY_REPO_FOR_MCUBOOT = esp-hal-3rdparty-mcuboot
+
 TOOLSDIR           = $(TOPDIR)/tools/espressif
 CHIPDIR            = $(TOPDIR)/arch/xtensa/src/chip
-HALDIR             = $(CHIPDIR)/esp-hal-3rdparty
 
 BOOTLOADER_DIR     = $(CHIPDIR)/bootloader
 BOOTLOADER_SRCDIR  = $(BOOTLOADER_DIR)/esp-nuttx-bootloader
@@ -32,16 +33,22 @@ BOOTLOADER_VERSION = main
 BOOTLOADER_URL     = https://github.com/espressif/esp-nuttx-bootloader
 BOOTLOADER_OUTDIR  = out
 BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
+HALDIR             = $(BOOTLOADER_DIR)/$(ESP_HAL_3RDPARTY_REPO_FOR_MCUBOOT)
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s2/mcuboot_toolchain_esp32s2.cmake
+
 ifndef MCUBOOT_VERSION
 	MCUBOOT_VERSION = $(CONFIG_ESP32S2_MCUBOOT_VERSION)
 endif
 
 ifndef MCUBOOT_URL
 	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
+
+ifndef ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT
+	ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT = 3f02f2139e79ddc60f98ca35ed65c62c6914f079
 endif
 
 $(BOOTLOADER_DIR):
@@ -124,13 +131,23 @@ else
 BOOTLOADER_BIN        = $(TOPDIR)/mcuboot-esp32s2.bin
 BOOTLOADER_SIGNED_BIN = $(TOPDIR)/mcuboot-esp32s2.signed.bin
 
+define CLONE_ESP_HAL_3RDPARTY_REPO_MCUBOOT
+	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),$(HALDIR))
+endef
+
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_DIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
-$(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)
+$(HALDIR):
+	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms (MCUBoot build)"
+	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO_MCUBOOT)
+	$(Q) echo "Espressif HAL for 3rd Party Platforms (MCUBoot build): ${ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT}"
+	$(Q) git -C $(HALDIR) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT)
+
+$(BOOTLOADER_BIN): $(HALDIR) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)
 	$(Q) echo "Building Bootloader"
 	$(Q) $(TOOLSDIR)/build_mcuboot.sh \
 		-c esp32s2 \
@@ -165,6 +182,7 @@ endif
 endif
 
 clean_bootloader:
+	$(call DELDIR,$(HALDIR))
 	$(call DELDIR,$(BOOTLOADER_DIR))
 	$(call DELFILE,$(BOOTLOADER_BIN))
 	$(if $(CONFIG_ESP32S2_SECURE_BOOT_BUILD_SIGNED_BINARIES),$(call DELFILE,$(BOOTLOADER_SIGNED_BIN)))

--- a/arch/xtensa/src/esp32s3/.gitignore
+++ b/arch/xtensa/src/esp32s3/.gitignore
@@ -1,3 +1,4 @@
 /bootloader
 /esp-hal-3rdparty
+/esp-hal-3rdparty-mcuboot
 /esp-nuttx-bootloader

--- a/arch/xtensa/src/esp32s3/Bootloader.mk
+++ b/arch/xtensa/src/esp32s3/Bootloader.mk
@@ -24,7 +24,6 @@ ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),)
 
 TOOLSDIR           = $(TOPDIR)/tools/espressif
 CHIPDIR            = $(TOPDIR)/arch/xtensa/src/chip
-HALDIR             = $(CHIPDIR)/esp-hal-3rdparty
 
 BOOTLOADER_DIR     = $(CHIPDIR)/bootloader
 BOOTLOADER_SRCDIR  = $(BOOTLOADER_DIR)/esp-nuttx-bootloader
@@ -32,16 +31,22 @@ BOOTLOADER_VERSION = main
 BOOTLOADER_URL     = https://github.com/espressif/esp-nuttx-bootloader
 BOOTLOADER_OUTDIR  = out
 BOOTLOADER_CONFIG  = $(BOOTLOADER_DIR)/bootloader.conf
+HALDIR             = $(BOOTLOADER_DIR)/esp-hal-3rdparty-mcuboot
 
 MCUBOOT_SRCDIR     = $(BOOTLOADER_DIR)/mcuboot
 MCUBOOT_ESPDIR     = $(MCUBOOT_SRCDIR)/boot/espressif
 MCUBOOT_TOOLCHAIN  = $(TOPDIR)/tools/esp32s3/mcuboot_toolchain_esp32s3.cmake
+
 ifndef MCUBOOT_VERSION
 	MCUBOOT_VERSION = $(CONFIG_ESP32S3_MCUBOOT_VERSION)
 endif
 
 ifndef MCUBOOT_URL
 	MCUBOOT_URL = https://github.com/mcu-tools/mcuboot
+endif
+
+ifndef ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT
+	ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT = 3f02f2139e79ddc60f98ca35ed65c62c6914f079
 endif
 
 $(BOOTLOADER_DIR):
@@ -101,13 +106,23 @@ else ifeq ($(CONFIG_ESP32S3_APP_FORMAT_MCUBOOT),y)
 
 BOOTLOADER_BIN        = $(TOPDIR)/mcuboot-esp32s3.bin
 
+define CLONE_ESP_HAL_3RDPARTY_REPO_MCUBOOT
+	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),$(HALDIR))
+endef
+
 $(MCUBOOT_SRCDIR): $(BOOTLOADER_DIR)
 	$(Q) echo "Cloning MCUboot"
 	$(Q) git clone --quiet $(MCUBOOT_URL) $(MCUBOOT_SRCDIR)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" checkout --quiet $(MCUBOOT_VERSION)
 	$(Q) git -C "$(MCUBOOT_SRCDIR)" submodule --quiet update --init --recursive ext/mbedtls
 
-$(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)
+$(HALDIR):
+	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms (MCUBoot build)"
+	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO_MCUBOOT)
+	$(Q) echo "Espressif HAL for 3rd Party Platforms (MCUBoot build): ${ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT}"
+	$(Q) git -C $(HALDIR) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION_FOR_MCUBOOT)
+
+$(BOOTLOADER_BIN): $(HALDIR) $(MCUBOOT_SRCDIR) $(BOOTLOADER_CONFIG)
 	$(Q) echo "Building Bootloader"
 	$(Q) $(TOOLSDIR)/build_mcuboot.sh \
 		-c esp32s3 \
@@ -120,6 +135,7 @@ $(BOOTLOADER_BIN): chip/$(ESP_HAL_3RDPARTY_REPO) $(MCUBOOT_SRCDIR) $(BOOTLOADER_
 bootloader: $(BOOTLOADER_CONFIG) $(BOOTLOADER_BIN)
 
 clean_bootloader:
+	$(call DELDIR,$(HALDIR))
 	$(call DELDIR,$(BOOTLOADER_DIR))
 	$(call DELFILE,$(BOOTLOADER_BIN))
 
@@ -135,6 +151,7 @@ bootloader: $(BOOTLOADER_SRCDIR) $(BOOTLOADER_CONFIG)
 	$(call COPYFILE,$(BOOTLOADER_SRCDIR)/$(BOOTLOADER_OUTDIR)/partition-table-esp32s3.bin,$(TOPDIR))
 
 clean_bootloader:
+	$(call DELDIR,$(HALDIR))
 	$(call DELDIR,$(BOOTLOADER_DIR))
 	$(call DELFILE,$(TOPDIR)/bootloader-esp32s3.bin)
 	$(call DELFILE,$(TOPDIR)/partition-table-esp32s3.bin)


### PR DESCRIPTION
## Summary

    arch/risc-v: decouple common source for Espressif's MCUBoot port
    Decouples the NuttX build from the MCUBoot common source on RISC-V Espressif
    devices. Allows using different branches for each.

    arch/xtensa: decouple common source for Espressif's MCUBoot port
    Decouples the NuttX build from the MCUBoot common source on Xtensa
    devices. Allows using different branches for each.

This PR changes MCUBoot build process for Xtensa and RISC-V Espressif devices.
No changes on user side or build process.

## Impact

RELEASE

## Testing

CI