### PR TITLE
{bp-16545} sched/wqueue: Fix windows compilation errors.

### DIFF
--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -80,16 +80,16 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
     {
       int wndx;
       pid_t pid = nxsched_gettid();
+      FAR struct kworker_s *worker = wq_get_worker(wqueue);
 
       /* Wait until the worker thread finished the work. */
 
       for (wndx = 0; wndx < wqueue->nthreads; wndx++)
         {
-          if (wqueue->worker[wndx].work == work &&
-              wqueue->worker[wndx].pid != pid)
+          if (worker[wndx].work == work && worker[wndx].pid != pid)
             {
-              wqueue->worker[wndx].wait_count++;
-              sync_wait = &wqueue->worker[wndx].wait;
+              worker[wndx].wait_count++;
+              sync_wait = &worker[wndx].wait;
               break;
             }
         }

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -327,6 +327,7 @@ static int work_thread_create(FAR const char *name, int priority,
                               FAR void *stack_addr, int stack_size,
                               FAR struct kwork_wqueue_s *wqueue)
 {
+  FAR struct kworker_s *worker = wq_get_worker(wqueue);
   FAR char *argv[3];
   char arg0[32];
   char arg1[32];
@@ -341,10 +342,10 @@ static int work_thread_create(FAR const char *name, int priority,
 
   for (wndx = 0; wndx < wqueue->nthreads; wndx++)
     {
-      nxsem_init(&wqueue->worker[wndx].wait, 0, 0);
+      nxsem_init(&worker[wndx].wait, 0, 0);
 
       snprintf(arg0, sizeof(arg0), "%p", wqueue);
-      snprintf(arg1, sizeof(arg1), "%p", &wqueue->worker[wndx]);
+      snprintf(arg1, sizeof(arg1), "%p", &worker[wndx]);
       argv[0] = arg0;
       argv[1] = arg1;
       argv[2] = NULL;
@@ -360,7 +361,7 @@ static int work_thread_create(FAR const char *name, int priority,
           return pid;
         }
 
-      wqueue->worker[wndx].pid = pid;
+      worker[wndx].pid = pid;
     }
 
   sched_unlock();
@@ -525,6 +526,7 @@ int work_queue_free(FAR struct kwork_wqueue_s *wqueue)
 
 int work_queue_priority_wq(FAR struct kwork_wqueue_s *wqueue)
 {
+  FAR struct kworker_s *worker;
   FAR struct tcb_s *tcb;
 
   if (wqueue == NULL)
@@ -534,7 +536,10 @@ int work_queue_priority_wq(FAR struct kwork_wqueue_s *wqueue)
 
   /* Find for the TCB associated with matching PID */
 
-  tcb = nxsched_get_tcb(wqueue->worker[0].pid);
+  worker = wq_get_worker(wqueue);
+
+  tcb = nxsched_get_tcb(worker[0].pid);
+
   if (!tcb)
     {
       return -ESRCH;

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -48,6 +48,13 @@
 #define HPWORKNAME "hpwork"
 #define LPWORKNAME "lpwork"
 
+/* Get the worker structure from the work queue.
+ * This function requires the workers are located next to the wqueue.
+ */
+
+#define wq_get_worker(wq) \
+  (FAR struct kworker_s *)((FAR char *)(wq) + sizeof(struct kwork_wqueue_s))
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -74,7 +81,6 @@ struct kwork_wqueue_s
   uint8_t          nthreads;  /* Number of worker threads */
   bool             exit;      /* A flag to request the thread to exit */
   struct wdog_s    timer;     /* Timer to pending. */
-  struct kworker_s worker[0]; /* Describes a worker thread */
 };
 
 /* This structure defines the state of one high-priority work queue.  This


### PR DESCRIPTION
## Summary
This commit fixed windows compilation errors `struct lp_wqueue_s/hp_wqueue_s has an illegal zero-sized array`.

## Impact

RELEASE

## Testing

CI