### PR TITLE
{bp-16565} Fix arch perf events ifdef in alarm 

### DIFF
--- a/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
+++ b/Documentation/platforms/risc-v/qemu-rv/boards/rv-virt/index.rst
@@ -371,6 +371,39 @@ nsh64
 
 Identical to the `nsh`_ configuration, but for 64-bit RISC-V.
 
+nsbi
+----
+
+This is similar to the `knsh`, but using NuttX's native (minimalistic)
+SBI. It uses `hostfs` and QEMU in semi-hosting mode to load the
+user-space applications. This is intended for 32-bit RISC-V.
+
+To build it, use the following command::
+
+    $ make V=1 -j$(nproc)
+    $ make export V=1 -j$(nproc)
+    $ pushd ../apps
+    $ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
+    $ make import V=1 -j$(nproc)
+    $ popd
+
+Run it with QEMU using the default command for 32-bit RISC-V without
+the ``-bios none`` option. Please note that it still runs in S-mode,
+but bypasses QEMU's OpenSBI.
+
+In `nsh`, applications can be run directly::
+
+    nsh> hello
+
+nsbi64
+------
+
+Identical to the `nsbi`_ configuration, but for 64-bit RISC-V.
+
+Run it with QEMU using the default command for 64-bit RISC-V without
+the ``-bios none`` option. Please note that it still runs in S-mode,
+but bypasses QEMU's OpenSBI.
+
 smp
 ---
 

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -312,10 +312,10 @@ int riscv_swint(int irq, void *context, void *arg)
    */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-  if (cmd <= SYS_switch_context)
+  if (regs[REG_A0] <= SYS_switch_context)
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_dump_register(tcb.xcp.regs);
+      up_dump_register(tcb->xcp.regs);
     }
   else
     {

--- a/boards/risc-v/qemu-rv/rv-virt/scripts/ld-nuttsbi.script
+++ b/boards/risc-v/qemu-rv/rv-virt/scripts/ld-nuttsbi.script
@@ -155,6 +155,12 @@ SECTIONS
       _edata = . ;
     }
 
+  .noinit (NOLOAD) : ALIGN(4)
+    {
+      *(.noinit)
+      *(.noinit.*)
+    } > ksram
+
   .bss :
     {
       _sbss = . ;


### PR DESCRIPTION
## Summary

This fixes the ifdef in drivers/timers/arch_alarm.c, which may cause linking errors when architecture defines up_perf_* functions, but doesn't enable ARCH_PERF_EVENTS.

## Impact

RELEASE

## Testing

CI