### PR TITLE
fs/procfs: fix output format of fd info

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1330,7 +1330,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
                                        fdp->f_backtrace,
                                        CONFIG_FS_BACKTRACE);
 #endif
-          procfile->line[linesize - 2] = '\n';
+          procfile->line[linesize - 1] = '\n';
         }
 
       file_put(filep);


### PR DESCRIPTION
## Summary
Fix output format of fd info.  Refered to PRINTF(3), the [v]snprintf returns the number of characters printed (excluding the null byte used to end output to strings).
> Upon successful return, these functions return the number of characters printed (excluding the null byte used to end output to strings).    -- PRINTF(3)

## Impact
- fs/procfs

## Testing
- Currently
1. Extra blank at line start, e.g. fd num 1 and below
2. Truncated print, see fd num 3, missing end bracked "]"
```
nsh> fdinfo 9

FD  OFLAGS  TYPE POS       PATH           
0   3       1    0         /dev/console 
 1   3       1    0         /dev/console 
 2   3       1    0         /dev/console 
 3   3       9    0         tcp:[0.0.0.0:5554<->0.0.0.0:0, st 01, flg 31
 4   1089    1    0         /dev/fastboot/ep
 5   1090    1    0         /dev/fastboot/ep
 6   0       1    0                      
 nsh> 
nsh>
```
- With this patch
```
nsh> fdinfo 9

FD  OFLAGS  TYPE POS       PATH           BACKTRACE
0   3       1    0         /dev/console  
1   3       1    0         /dev/console  
2   3       1    0         /dev/console  
3   3       9    0         tcp:[0.0.0.0:5554<->0.0.0.0:0, st 01, flg 31]
4   1089    1    0         /dev/fastboot/ep2
5   1090    1    0         /dev/fastboot/ep1
6   0       1    0                       
nsh>
```


