### PR TITLE
netdb/lib_dnsquery.c: prevent file descriptor leakage

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -902,6 +902,7 @@ try_stream:
                 {
                   if (!stream && should_try_stream)
                     {
+                      close(sd);  /* Close current socket before trying stream mode */
                       stream = true;
                       goto try_stream; /* Don't consume retry count */
                     }
@@ -961,6 +962,7 @@ try_stream:
                 {
                   if (!stream && should_try_stream)
                     {
+                      close(sd);  /* Close current socket before trying stream mode */
                       stream = true;
                       goto try_stream; /* Don't consume retry count */
                     }


### PR DESCRIPTION
## Summary
netdb/lib_dnsquery.c: In the IPv6 or IPv4 dns_query_callback() block, if dns_recv_response() fails, dns_bind() is called again at try_stream to create a new socket. However, the original socket descriptor sd isn't closed.
## Impact
New Feature/Change: Issue fix (no new feature).
User Impact: Prevent file descriptor leakage.
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.
## Testing
When DNS query fails and a switch from UDP to TCP streaming mode is required, UDP connections will continue to increase as follows:
![图片](https://github.com/user-attachments/assets/6a94c623-4720-4de1-9f90-b709f126cec1)
Afer fix, UDP connections do not increase like before.


