### PR TITLE
Update debugging.rst

### DIFF
--- a/Documentation/quickstart/debugging.rst
+++ b/Documentation/quickstart/debugging.rst
@@ -66,13 +66,13 @@ This will start a ``gdb`` server. Then, start ``gdb`` with:
 .. code-block:: console
 
   $ cd nuttx/
-  $ gdb-multiarch nuttx/nuttx
+  $ gdb-multiarch ./nuttx
 
 Inside ``gdb`` console, connect to the ``gdb`` server with:
 
 .. code-block::
 
-  (gdb) target extended-remote :3333
+  (gdb) tar remote :3333
 
 You can now use standard ``gdb`` commands. For example, to
 reset the board:


### PR DESCRIPTION
- Add right path for debug (nuttx /)
- Support for debug not only on ESP32 arch (target extended-remote) but also for STM32 chip arch (target remote :3333)

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


