### PR TITLE
{bp-16599} netdb/lib_dnsquery.c: In the IPv6 or IPv4 dns_query_callback() block,…

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -902,6 +902,7 @@ try_stream:
                 {
                   if (!stream && should_try_stream)
                     {
+                      close(sd);  /* Close current socket before trying stream mode */
                       stream = true;
                       goto try_stream; /* Don't consume retry count */
                     }
@@ -961,6 +962,7 @@ try_stream:
                 {
                   if (!stream && should_try_stream)
                     {
+                      close(sd);  /* Close current socket before trying stream mode */
                       stream = true;
                       goto try_stream; /* Don't consume retry count */
                     }


### PR DESCRIPTION
## Summary

… if dns_recv_response() fails, dns_bind() is called again at try_stream to create a new socket. However, the original socket descriptor sd isn't closed

## Impact

RELEASE

## Testing

CI