### PR TITLE
fs/vfs: clear filep when call file_open/file_mq_open to avoid random value[bug fix]

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -206,12 +206,10 @@ static int ptmx_open(FAR struct file *filep)
   /* Open the master device:  /dev/ptyN, where N=minor */
 
   snprintf(devname, sizeof(devname), "/dev/pty%d", minor);
-  memcpy(&temp, filep, sizeof(temp));
-  ret = file_open(filep, devname, O_RDWR | O_CLOEXEC);
+  ret = file_open(&temp, devname, O_RDWR | O_CLOEXEC);
   DEBUGASSERT(ret >= 0);  /* file_open() should never fail */
-
-  /* Close the multiplexor device: /dev/ptmx */
-
+  ret = file_dup2(&temp, filep);
+  DEBUGASSERT(ret >= 0);  /* file_dup2() should never fail) */
   ret = file_close(&temp);
   DEBUGASSERT(ret >= 0);  /* file_close() should never fail */
 

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -800,6 +800,10 @@ int fdlist_copy(FAR struct fdlist *plist, FAR struct fdlist *clist,
                   file_put(filep);
                   continue;
                 }
+
+#ifdef CONFIG_FDCHECK
+              fd = fdcheck_restore(fd);
+#endif
             }
           else if (fcloexec)
             {

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -412,6 +412,8 @@ int file_mq_open(FAR struct file *mq,
   va_list ap;
   int ret;
 
+  memset(mq, 0, sizeof(*mq));
+
   va_start(ap, oflags);
   ret = file_mq_vopen(mq, mq_name, oflags, 0, ap, NULL);
   va_end(ap);

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -366,6 +366,8 @@ int file_open(FAR struct file *filep, FAR const char *path, int oflags, ...)
   va_list ap;
   int ret;
 
+  memset(filep, 0, sizeof(*filep));
+
   va_start(ap, oflags);
   ret = file_vopen(filep, path, oflags, 0, ap);
   va_end(ap);


### PR DESCRIPTION

## Summary

fs/vfs: clear filep when call file_open/file_mq_open to avoid random value
[drivers/serial: fix the issue of the refs count for filep being zeroed out by utilizing dup2


## Impact

bug fix

## Testing

qemu-glodfish armv7a-eabi 
include adb and romfs test
