### PR TITLE
{bp-16608} fs/partition: fix uninitialized file struct on fs_txtable

### DIFF
--- a/fs/partition/fs_txtable.c
+++ b/fs/partition/fs_txtable.c
@@ -115,6 +115,8 @@ int parse_txtable_partition(FAR struct partition_state_s *state,
         {
           struct file f;
 
+          memset(&f, 0, sizeof(struct file));
+
           ret = file_open(&f, CONFIG_TXTABLE_DEFAULT_PARTITION_PATH,
                           O_RDONLY);
           if (ret < 0)


### PR DESCRIPTION
## Summary
This fixes a crashing scenario where file->f_pos would have garbage value, causing a crash.

This problem has been happening for a while (and recently mentioned in https://github.com/apache/nuttx/issues/16600). The system would crash during bring up on esp32s3-devkit:txtable.

The issue happens when trying to open the txtable.txt file. By tracking the file struct, the f_pos member was not zeroed as expected, and obtained garbage values which would result in invalid region accessed when romfs_read was called.

It was fixed by setting the file struct to 0 before using it.

Here are the crash logs obtained using ESP32S3 on master:

*** Booting NuttX ***
I (55) boot: chip revision: v0.1
I (56) boot.esp32s3: Boot SPI Speed : 40MHz
I (56) boot.esp32s3: SPI Mode       : DIO
I (59) boot.esp32s3: SPI Flash Size : 8MB
I (64) boot: Enabling RNG early entropy source...
dram: lma 0x00000020 vma 0x3fc8c740 len 0x16bc   (5820)
iram: lma 0x000016e4 vma 0x40374000 len 0x6000   (24576)
padd: lma 0x000076f8 vma 0x00000000 len 0x8900   (35072)
imap: lma 0x00010000 vma 0x42010000 len 0x24a60  (150112)
padd: lma 0x00034a68 vma 0x00000000 len 0xb590   (46480)
dmap: lma 0x00040000 vma 0x3c050000 len 0x4b4c   (19276)
total segments stored 6
ABxtensa_user_panic: User Exception: EXCCAUSE=001c task: nsh_main
dump_assert_info: Current Version: NuttX  10.4.0 e0b22c8d8e-dirty Jun 23 2025 20:29:20 xtensa
dump_assert_info: Assertion failed user panic: at file: :0 task: nsh_main process: nsh_main 0x4201af30
[....]
sched_dumpstack: backtrace| 2: 0x42027ae0 0x40377a11 0x40377501 0x40377270 0x40374ec5 0x40056fc0 0x42022734 0x42021068
sched_dumpstack: backtrace| 2: 0x4202109c 0x42032e2a 0x42032d0a 0x42032da2 0x4202f51c 0x4202f497 0x4202f465 0x42027678
sched_dumpstack: backtrace| 2: 0x42022734
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x3fc8c740      2048      1168    57.0%    irq
dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x3fc8bb90      2992       688    22.9%    Idle_Task
dump_task:       1     0 224 RR       Kthread -   Waiting Semaphore  0000000000000000 0x3fc8e3d0      8064       608     7.5%    hpwork 0x3fc8cf40 0x3fc8cf88
dump_task:       2     2 100 RR       Task    -   Running            0000000000000000 0x3fc90ab8      3976      1120    28.1%    nsh_main
sched_dumpstack: backtrace| 0: 0x42011840 0x40375036 0x40375122 0x40045c04 0x40043ab9 0x40034c48 0x40000000
sched_dumpstack: backtrace| 1: 0x42015bb0 0x42012441 0x42011ec7 0x4201292c 0x40000000 0x40000000
sched_dumpstack: backtrace| 2: 0x42027ae0 0x403776b4 0x42024e9a 0x40377abd 0x40377501 0x40377270 0x40374ec5 0x40056fc0
sched_dumpstack: backtrace| 2: 0x42022734 0x42021068 0x4202109c 0x42032e2a 0x42032d0a 0x42032da2 0x4202f51c 0x4202f497
sched_dumpstack: backtrace| 2: 0x42022734

And the stack dump:

Backtrace for task 2:
0x42027ae0: sched_dumpstack at sched_dumpstack.c:71
0x403776b4: dump_backtrace at assert.c:455
0x42024e9a: nxsched_foreach at sched_foreach.c:69 (discriminator 2)
0x40377abd: dump_fatal_info at assert.c:773
 (inlined by) _assert at assert.c:909
0x40377501: xtensa_user_panic at xtensa_assert.c:191 (discriminator 1)
0x40377270: spiflash_start at esp32s3_spiflash.c:338
0x40374ec5: _xtensa_user_handler at xtensa_user_handler.S:190
0x40056fc0: ?? ??:0
0x42022734: romfs_read at fs_romfs.c:530
0x42021068: file_readv_compat at fs_read.c:109
 (inlined by) file_readv at fs_read.c:221
0x4202109c: file_read at fs_read.c:267
0x42032e2a: parse_txtable_partition at fs_txtable.c:125
0x42032d0a: parse_partition at fs_partition.c:165
0x42032da2: parse_mtd_partition at fs_partition.c:291
0x4202f51c: init_storage_partition at esp32s3_board_spiflash.c:345
 (inlined by) board_spiflash_init at esp32s3_board_spiflash.c:380
0x4202f497: esp32s3_bringup at esp32s3_bringup.c:261
0x42022734: romfs_read at fs_romfs.c:530

## Impact

RELEASE

## Testing

CI

