### PR TITLE
debug/0 address: Add 0 address access panic configuration

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2432,6 +2432,14 @@ endif # DEBUG_CORESIGHT
 
 endif # DEBUG_FEATURES
 
+config ARCH_PROTECT_ZERO_ADDRESS
+	bool "Protect address zero"
+	depends on ARCH_HAVE_DEBUG
+	default n
+	---help---
+		When the program accesses address 0, it will assert automatically.
+		Hardware support is required, such as ARM V8M DWT watchpoint
+
 config ARCH_HAVE_STACKCHECK
 	bool
 	default n

--- a/sched/irq/irq_initialize.c
+++ b/sched/irq/irq_initialize.c
@@ -29,6 +29,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/trace.h>
 
+#include <assert.h>
 #include "irq/irq.h"
 
 /****************************************************************************
@@ -59,6 +60,14 @@ struct irq_info_s g_irqvector[NR_IRQS];
  * Public Functions
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_PROTECT_ZERO_ADDRESS
+static void zero_addr_handler(int type, FAR void *addr, size_t size,
+                              FAR void *arg)
+{
+  PANIC();
+}
+#endif
+
 /****************************************************************************
  * Name: irq_initialize
  *
@@ -87,5 +96,11 @@ void irq_initialize(void)
 #endif
 
   up_irqinitialize();
+
+#ifdef CONFIG_ARCH_PROTECT_ZERO_ADDRESS
+  up_debugpoint_add(DEBUGPOINT_WATCHPOINT_RW, 0, 0,
+                    zero_addr_handler, NULL);
+#endif
+
   sched_trace_end();
 }


### PR DESCRIPTION
Implemented using up_debugpoint_add

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Use watchpoint to protect address 0, which is used as a debugging method in some scenarios

## Impact

None
## Testing

1. enable CONFIG_ARCH_PROTECT_ZERO_ADDRESS，if access 0 address panic()


