### PR TITLE
drivers/sensors/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/drivers/sensors/CMakeLists.txt
+++ b/drivers/sensors/CMakeLists.txt
@@ -20,6 +20,8 @@
 #
 # ##############################################################################
 
+# Include sensor drivers
+
 if(CONFIG_SENSORS)
   set(SRCS sensor.c)
 
@@ -29,6 +31,10 @@ if(CONFIG_SENSORS)
 
   if(CONFIG_SENSORS_RPMSG)
     list(APPEND SRCS sensor_rpmsg.c)
+  endif()
+
+  if(CONFIG_SENSORS_NAU7802)
+    list(APPEND SRCS nau7802.c)
   endif()
 
   if(CONFIG_SENSORS_GNSS)
@@ -62,22 +68,11 @@ if(CONFIG_SENSORS)
     list(APPEND SRCS adxl345_base.c)
   endif()
 
-  if(CONFIG_SENSORS_ADXL362)
-    list(APPEND SRCS adxl362_uorb.c)
-  endif()
-
-  if(CONFIG_SENSORS_BH1749NUC)
-    list(APPEND SRCS bh1749nuc_base.c)
-    if(CONFIG_SENSORS_BH1749NUC_UORB)
-      list(APPEND SRCS bh1749nuc_uorb.c)
-    else()
-      list(APPEND SRCS bh1749nuc.c)
-    endif()
-  endif()
-
   if(CONFIG_SENSORS_DHTXX)
     list(APPEND SRCS dhtxx.c)
   endif()
+
+  # These drivers can be used with sensor connected over SPI or I2C bus
 
   if(CONFIG_SENSORS_BMI270)
     list(APPEND SRCS bmi270_base.c)
@@ -166,7 +161,12 @@ if(CONFIG_SENSORS)
     endif()
 
     if(CONFIG_SENSORS_BH1749NUC)
-      list(APPEND SRCS bh1749nuc.c)
+      list(APPEND SRCS bh1749nuc_base.c)
+      if(CONFIG_SENSORS_BH1749NUC_UORB)
+        list(APPEND SRCS bh1749nuc_uorb.c)
+      else()
+        list(APPEND SRCS bh1749nuc.c)
+      endif()
     endif()
 
     if(CONFIG_SENSORS_BH1750FVI)
@@ -186,6 +186,15 @@ if(CONFIG_SENSORS)
       endif()
     endif()
 
+    if(CONFIG_SENSORS_BMI088)
+      list(APPEND SRCS bmi088_base.c)
+      if(CONFIG_SENSORS_BMI088_UORB)
+        list(APPEND SRCS bmi088_uorb.c)
+      else()
+        list(APPEND SRCS bmi088.c)
+      endif()
+    endif()
+
     if(CONFIG_SENSORS_BMP180)
       list(APPEND SRCS bmp180_base.c)
       if(CONFIG_SENSORS_BMP180_UORB)
@@ -193,7 +202,6 @@ if(CONFIG_SENSORS)
       else()
         list(APPEND SRCS bmp180.c)
       endif()
-
     endif()
 
     if(CONFIG_SENSORS_BMP280)
@@ -216,6 +224,10 @@ if(CONFIG_SENSORS)
       list(APPEND SRCS hts221.c)
     endif()
 
+    if(CONFIG_SENSORS_LIS2MDL)
+      list(APPEND SRCS lis2mdl_uorb.c)
+    endif()
+
     if(CONFIG_LM75_I2C)
       list(APPEND SRCS lm75.c)
     endif()
@@ -230,6 +242,10 @@ if(CONFIG_SENSORS)
 
     if(CONFIG_SENSORS_MB7040)
       list(APPEND SRCS mb7040.c)
+    endif()
+
+    if(CONFIG_SENSORS_MCP9600)
+      list(APPEND SRCS mcp9600_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_MCP9844)
@@ -254,10 +270,6 @@ if(CONFIG_SENSORS)
 
     if(CONFIG_SENSORS_LTC4151)
       list(APPEND SRCS ltc4151.c)
-    endif()
-
-    if(CONFIG_SENSORS_LIS2MDL)
-      list(APPEND SRCS lis2mdl_uorb.c)
     endif()
 
     if(CONFIG_SENSORS_INA219)
@@ -334,6 +346,10 @@ if(CONFIG_SENSORS)
       list(APPEND SRCS adxl345_spi.c)
     endif()
 
+    if(CONFIG_SENSORS_ADXL362)
+      list(APPEND SRCS adxl362_uorb.c)
+    endif()
+
     if(CONFIG_SENSORS_ADXL372)
       if(CONFIG_SENSORS_ADXL372_UORB)
         list(APPEND SRCS adxl372_uorb.c)
@@ -380,16 +396,6 @@ if(CONFIG_SENSORS)
 
     if(CONFIG_SENSORS_AS5048A)
       list(APPEND SRCS as5048a.c)
-    endif()
-
-    if(CONFIG_SENSORS_BMI088)
-      list(APPEND SRCS bmi088_base.c)
-      if(CONFIG_SENSORS_BMI088_UORB)
-        list(APPEND SRCS bmi088_uorb.c)
-      else()
-        list(APPEND SRCS bmi088.c)
-      endif()
-
     endif()
 
   endif() # CONFIG_SPI
@@ -452,6 +458,12 @@ if(CONFIG_SENSORS)
 
   if(CONFIG_SENSORS_HDC1008)
     list(APPEND SRCS hdc1008.c)
+  endif()
+
+  # ANALOG MAX31865
+
+  if(CONFIG_SENSORS_MAX31865)
+    list(APPEND SRCS max31865.c)
   endif()
 
   # SONY CXD5602PWBIMU


### PR DESCRIPTION
## Summary

Add:
    Adafruit NAU7802 ADC sensor
    MCP9600 Thermocouple Amplifier
    Maxim MAX31865

Removed repeated addition of the Rohm BH1749NUC Color Sensor

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally


