### PR TITLE
Enhanced Kasan

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -546,6 +546,10 @@ config ARCH_HAVE_DEBUG
 	bool "Architecture have debug support"
 	default n
 
+config ARCH_HAVE_MEMTAG
+	bool "Architecture have memory tagging support"
+	default n
+
 config ARCH_HAVE_PERF_EVENTS
 	bool
 	default n

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -185,6 +185,7 @@ menu "ARMv8.5 architectural features"
 
 config ARM64_MTE
 	bool "Memory Tagging Extension support"
+	select ARCH_HAVE_MEMTAG
 	select ARM64_TBI
 	default y
 

--- a/arch/arm64/src/a527/a527_boot.c
+++ b/arch/arm64/src/a527/a527_boot.c
@@ -238,10 +238,6 @@ void arm64_chip_boot(void)
 
   arm64_mmu_init(true);
 
-  /* Optional: Enable the Memory Tagging Extension */
-
-  arm64_enable_mte();
-
 #if defined(CONFIG_ARM64_PSCI)
   /* Init the Power State Coordination Interface */
 

--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -506,11 +506,15 @@ uint64_t arm64_get_mpid(int cpu);
 int arm64_get_cpuid(uint64_t mpid);
 #endif
 
-#ifdef CONFIG_ARM64_MTE
-void arm64_enable_mte(void);
-#else
-#define arm64_enable_mte()
-#endif
+/****************************************************************************
+ * Name: arm64_mte_init
+ *
+ * Description:
+ *   Initialize MTE settings and enable memory tagging
+ *
+ ****************************************************************************/
+
+void arm64_mte_init(void);
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/arm64/src/common/arm64_mmu.h
+++ b/arch/arm64/src/common/arm64_mmu.h
@@ -170,8 +170,10 @@
  * in the address range [59:55] = 0b00000 are unchecked accesses.
  */
 
-#define TCR_TCMA0                   (1ULL << 57)
-#define TCR_TCMA1                   (1ULL << 58)
+#define TCR_TCMA0                   BIT(57)
+#define TCR_TCMA1                   BIT(58)
+#define TCR_MTX0_SHIFT              BIT(60)
+#define TCR_MTX1_SHIFT              BIT(61)
 
 #define TCR_PS_BITS_4GB             0x0ULL
 #define TCR_PS_BITS_64GB            0x1ULL

--- a/arch/arm64/src/common/arm64_mte.c
+++ b/arch/arm64/src/common/arm64_mte.c
@@ -29,18 +29,24 @@
 #include <stdio.h>
 
 #include "arm64_arch.h"
+#include "arm64_mmu.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
 #define GCR_EL1_VAL     0x10001
+#define MTE_TAG_SHIFT   56
+
+/* The alignment length of the MTE must be a multiple of sixteen */
+
+#define MTE_MM_AILGN    16
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
-static int arm64_mte_is_support(void)
+static int mte_is_support(void)
 {
   int supported;
   __asm__ volatile (
@@ -57,11 +63,67 @@ static int arm64_mte_is_support(void)
  * Public Functions
  ****************************************************************************/
 
-void arm64_enable_mte(void)
+uint8_t up_memtag_get_tag(const void *addr)
+{
+  return 0xf0 | (uint8_t)(((uint64_t)addr) >> MTE_TAG_SHIFT);
+}
+
+uint8_t up_memtag_get_random_tag(const void *addr)
+{
+  asm("irg %0, %0" : "=r" (addr));
+
+  return up_memtag_get_tag(addr);
+}
+
+void *up_memtag_set_tag(const void *addr, uint8_t tag)
+{
+  return (FAR void *)
+         ((((uint64_t)addr) & ~((uint64_t)0xff << MTE_TAG_SHIFT)) |
+          ((uint64_t)tag << MTE_TAG_SHIFT));
+}
+
+/* Set MTE state */
+
+bool up_memtag_bypass(bool bypass)
+{
+  uint64_t val = read_sysreg(sctlr_el1);
+  bool state = !(val & SCTLR_TCF1_BIT);
+
+  if (bypass)
+    {
+      val &= ~SCTLR_TCF1_BIT;
+    }
+  else
+    {
+      val |= SCTLR_TCF1_BIT;
+    }
+
+  write_sysreg(val, sctlr_el1);
+  return state;
+}
+
+/* Set memory tags for a given memory range */
+
+void up_memtag_tag_mem(const void *addr, size_t size)
+{
+  size_t i;
+
+  DEBUGASSERT((uintptr_t)addr % MTE_MM_AILGN == 0);
+  DEBUGASSERT(size % MTE_MM_AILGN == 0);
+
+  for (i = 0; i < size; i += MTE_MM_AILGN)
+    {
+      asm("stg %0, [%0]" : : "r"(addr + i));
+    }
+}
+
+/* Initialize MTE settings and enable memory tagging */
+
+void arm64_mte_init(void)
 {
   uint64_t val;
 
-  if (!arm64_mte_is_support())
+  if (!mte_is_support())
     {
       return;
     }
@@ -77,6 +139,14 @@ void arm64_enable_mte(void)
 
   assert(!(read_sysreg(ttbr0_el1) & TTBR_CNP_BIT));
   assert(!(read_sysreg(ttbr1_el1) & TTBR_CNP_BIT));
+
+  /* Controls the default value for skipping high bytes */
+
+  val = read_sysreg(tcr_el1);
+  val |= TCR_TCMA1;
+  write_sysreg(val, tcr_el1);
+
+  /* Enable the MTE function */
 
   val = read_sysreg(sctlr_el1);
   val |= SCTLR_ATA_BIT | SCTLR_TCF1_BIT;

--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -161,7 +161,9 @@ void arm64_chip_boot(void)
 
   arm64_mmu_init(true);
 
-  arm64_enable_mte();
+#ifdef CONFIG_ARM64_MTE
+  arm64_mte_init();
+#endif
 
 #ifdef CONFIG_DEVICE_TREE
   fdt_register((const char *)0x40000000);

--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -344,17 +344,17 @@ static int virtio_mmio_config_virtqueue(FAR struct metal_io_region *io,
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_NUM, vq->vq_nentries);
 
       addr = (uint64_t)((uintptr_t)
-                        kasan_reset_tag((FAR void *)vq->vq_ring.desc));
+                        kasan_clear_tag((FAR void *)vq->vq_ring.desc));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_DESC_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_DESC_HIGH, addr >> 32);
 
       addr = (uint64_t)((uintptr_t)
-                        kasan_reset_tag((FAR void *)vq->vq_ring.avail));
+                        kasan_clear_tag((FAR void *)vq->vq_ring.avail));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_AVAIL_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_AVAIL_HIGH, addr >> 32);
 
       addr = (uint64_t)((uintptr_t)
-                        kasan_reset_tag((FAR void *)vq->vq_ring.used));
+                        kasan_clear_tag((FAR void *)vq->vq_ring.used));
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_USED_LOW, addr);
       metal_io_write32(io, VIRTIO_MMIO_QUEUE_USED_HIGH, addr >> 32);
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -3067,6 +3067,65 @@ int up_get_legacy_irq(uint32_t devfn, uint8_t line, uint8_t pin);
 
 #endif
 
+#ifdef CONFIG_ARCH_HAVE_SYSCALL
+
+/****************************************************************************
+ * Name: up_assert
+ ****************************************************************************/
+
+void up_assert(FAR const char *filename, int linenum, FAR const char *msg);
+#endif
+
+#ifdef CONFIG_ARCH_HAVE_MEMTAG
+
+/****************************************************************************
+ * Name: up_memtag_bypass
+ *
+ * Description:
+ *   Set MTE state bypass or not
+ *
+ ****************************************************************************/
+
+bool up_memtag_bypass(bool bypass);
+
+/****************************************************************************
+ * Name: up_memtag_get_tag
+ ****************************************************************************/
+
+uint8_t up_memtag_get_tag(const void *addr);
+
+/****************************************************************************
+ * Name: up_memtag_get_random_tag
+ *
+ * Description:
+ *   Get a random label based on the address through the mte register
+ *
+ ****************************************************************************/
+
+uint8_t up_memtag_get_random_tag(const void *addr);
+
+/****************************************************************************
+ * Name: up_memtag_set_tag
+ *
+ * Description:
+ *   Get the address with label
+ *
+ ****************************************************************************/
+
+void *up_memtag_set_tag(const void *addr, uint8_t tag);
+
+/****************************************************************************
+ * Name: up_memtag_tag_mem
+ *
+ * Description:
+ *   Set memory tags for a given memory range
+ *
+ ****************************************************************************/
+
+void up_memtag_tag_mem(const void *addr, size_t size);
+
+#endif /* CONFIG_ARCH_HAVE_MEMTAG */
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -41,6 +41,8 @@
 #  define kasan_unpoison(addr, size) addr
 #  define kasan_register(addr, size)
 #  define kasan_unregister(addr)
+#  define kasan_get_tag(addr) 0
+#  define kasan_set_tag(addr, tag) addr
 #  define kasan_clear_tag(addr) addr
 #  define kasan_start()
 #  define kasan_stop()
@@ -133,6 +135,12 @@ void kasan_register(FAR void *addr, FAR size_t *size);
 void kasan_unregister(FAR void *addr);
 
 /****************************************************************************
+ * Name: kasan_set_tag
+ ****************************************************************************/
+
+FAR void *kasan_set_tag(FAR const void *addr, uint8_t tag);
+
+/****************************************************************************
  * Name: kasan_clear_tag
  *
  * Input Parameters:
@@ -144,6 +152,19 @@ void kasan_unregister(FAR void *addr);
  ****************************************************************************/
 
 FAR void *kasan_clear_tag(FAR const void *addr);
+
+/****************************************************************************
+ * Name: kasan_get_tag
+ *
+ * Input Parameters:
+ *   addr - The address of the memory to get the tag.
+ *
+ * Returned Value:
+ *   address tag
+ *
+ ****************************************************************************/
+
+uint8_t kasan_get_tag(FAR const void *addr);
 
 /****************************************************************************
  * Name: kasan_start

--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -48,7 +48,7 @@
 #  define kasan_stop()
 #  define kasan_debugpoint(t,a,s) 0
 #  define kasan_init_early()
-#  define kasan_bypass(state) (state)
+#  define kasan_bypass(state) false
 #else
 
 #  define kasan_init_early() kasan_stop()

--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -48,6 +48,7 @@
 #  define kasan_stop()
 #  define kasan_debugpoint(t,a,s) 0
 #  define kasan_init_early()
+#  define kasan_bypass(state) (state)
 #else
 
 #  define kasan_init_early() kasan_stop()
@@ -180,7 +181,11 @@ uint8_t kasan_get_tag(FAR const void *addr);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_MM_KASAN_INSTRUMENT
 void kasan_start(void);
+#else
+#  define kasan_start()
+#endif
 
 /****************************************************************************
  * Name: kasan_stop
@@ -198,7 +203,11 @@ void kasan_start(void);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_MM_KASAN_INSTRUMENT
 void kasan_stop(void);
+#else
+#  define kasan_stop()
+#endif
 
 /****************************************************************************
  * Name: kasan_debugpoint
@@ -221,6 +230,12 @@ void kasan_stop(void);
  ****************************************************************************/
 
 int kasan_debugpoint(int type, FAR void *addr, size_t size);
+
+/****************************************************************************
+ * Name: kasan_bypass
+ ****************************************************************************/
+
+bool kasan_bypass(bool state);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -41,7 +41,7 @@
 #  define kasan_unpoison(addr, size) addr
 #  define kasan_register(addr, size)
 #  define kasan_unregister(addr)
-#  define kasan_reset_tag(addr) addr
+#  define kasan_clear_tag(addr) addr
 #  define kasan_start()
 #  define kasan_stop()
 #  define kasan_debugpoint(t,a,s) 0
@@ -133,7 +133,7 @@ void kasan_register(FAR void *addr, FAR size_t *size);
 void kasan_unregister(FAR void *addr);
 
 /****************************************************************************
- * Name: kasan_reset_tag
+ * Name: kasan_clear_tag
  *
  * Input Parameters:
  *   addr - The address of the memory to reset the tag.
@@ -143,7 +143,7 @@ void kasan_unregister(FAR void *addr);
  *
  ****************************************************************************/
 
-FAR void *kasan_reset_tag(FAR const void *addr);
+FAR void *kasan_clear_tag(FAR const void *addr);
 
 /****************************************************************************
  * Name: kasan_start

--- a/include/nuttx/mm/kasan.h
+++ b/include/nuttx/mm/kasan.h
@@ -48,7 +48,7 @@
 #  define kasan_stop()
 #  define kasan_debugpoint(t,a,s) 0
 #  define kasan_init_early()
-#  define kasan_bypass(state) false
+#  define kasan_bypass(state) ((void)state, state)
 #else
 
 #  define kasan_init_early() kasan_stop()

--- a/libs/libc/machine/arm64/arch_elf.c
+++ b/libs/libc/machine/arm64/arch_elf.c
@@ -184,8 +184,8 @@ aarch64_insn_encode_immediate(enum insn_imm_type_e type,
 static uint64_t do_reloc(enum reloc_op_e op,
                          uintptr_t place, uint64_t val)
 {
-  val = (uint64_t)kasan_reset_tag((const void *)val);
-  place = (uint64_t)kasan_reset_tag((const void *)place);
+  val = (uint64_t)kasan_clear_tag((FAR const void *)val);
+  place = (uint64_t)kasan_clear_tag((FAR const void *)place);
 
   switch (op)
     {

--- a/mm/kasan/CMakeLists.txt
+++ b/mm/kasan/CMakeLists.txt
@@ -25,6 +25,12 @@ if(CONFIG_MM_KASAN)
   list(APPEND FLAGS ${NO_LTO})
   list(APPEND FLAGS -fno-builtin)
   list(APPEND FLAGS -fno-sanitize=kernel-address)
+
+  if(NOT "${CONFIG_MM_KASAN_MARK_LOCATION}" STREQUAL "")
+    target_compile_definitions(
+      mm PRIVATE -DMM_KASAN_MARK_LOCATION="${CONFIG_MM_KASAN_MARK_LOCATION}")
+  endif()
+
 endif()
 
 target_sources(mm PRIVATE ${SRCS})

--- a/mm/kasan/Kconfig
+++ b/mm/kasan/Kconfig
@@ -57,6 +57,13 @@ config MM_KASAN_INSTRUMENT_ALL
 		to check. Enabling this option will get image size increased
 		and performance decreased significantly.
 
+config MM_KASAN_MARK_LOCATION
+	string "Kasan's mark storage location"
+	---help---
+		The section where KASan mark is located. It can prevent
+		variables located in non-chip memory, and crashes
+		caused by instrumentation access
+
 if MM_KASAN_INSTRUMENT
 
 config MM_KASAN_REGIONS

--- a/mm/kasan/Kconfig
+++ b/mm/kasan/Kconfig
@@ -32,14 +32,19 @@ config MM_KASAN_GENERIC
 		KASan generic mode that does not require hardware support at all
 
 config MM_KASAN_SW_TAGS
-	bool "KAsan SW tags"
-	select ARM64_TBI
+	bool "KAsan softtags tags"
+	select ARM64_TBI if ARCH_ARM64
 	select MM_KASAN_INSTRUMENT
-	depends on ARCH_ARM64
 	---help---
 		KAsan based on software tags
 
-endchoice # KAsan Mode
+config MM_KASAN_HW_TAGS
+	bool "KAsan hardware tags"
+	select ARM64_MTE if ARCH_ARM64
+	---help---
+		KAsan based on hardware tags
+
+endchoice
 
 config MM_KASAN_INSTRUMENT_ALL
 	bool "Enable KASan for the entire image"
@@ -51,6 +56,8 @@ config MM_KASAN_INSTRUMENT_ALL
 		"-fsanitize=kernel-address" for the files/directories you want
 		to check. Enabling this option will get image size increased
 		and performance decreased significantly.
+
+if MM_KASAN_INSTRUMENT
 
 config MM_KASAN_REGIONS
 	int "Kasan region count"
@@ -126,4 +133,5 @@ config MM_KASAN_GLOBAL_ALIGN
 		It is recommended to use 1, 2, 4, 8, 16, 32.
 		The maximum value is 32.
 
+endif # MM_KASAN_INSTRUMENT
 endif # MM_KASAN

--- a/mm/kasan/Make.defs
+++ b/mm/kasan/Make.defs
@@ -28,6 +28,10 @@ ifeq ($(CONFIG_MM_KASAN),y)
   CFLAGS += -fno-sanitize=kernel-address
 endif
 
+ifneq ($(CONFIG_MM_KASAN_MARK_LOCATION),"")
+  CFLAGS += ${DEFINE_PREFIX}MM_KASAN_MARK_LOCATION=CONFIG_MM_KASAN_MARK_LOCATION
+endif
+
 # Add the core heap directory to the build
 
 DEPPATH += --dep-path kasan

--- a/mm/kasan/generic.c
+++ b/mm/kasan/generic.c
@@ -230,6 +230,11 @@ FAR void *kasan_unpoison(FAR const void *addr, size_t size)
   return (FAR void *)addr;
 }
 
+bool kasan_bypass(bool state)
+{
+  return false;
+}
+
 void kasan_register(FAR void *addr, FAR size_t *size)
 {
   FAR struct kasan_region_s *region;

--- a/mm/kasan/generic.c
+++ b/mm/kasan/generic.c
@@ -204,7 +204,7 @@ static void kasan_set_poison(FAR const void *addr, size_t size,
  * Public Functions
  ****************************************************************************/
 
-FAR void *kasan_reset_tag(FAR const void *addr)
+FAR void *kasan_clear_tag(FAR const void *addr)
 {
   return (FAR void *)addr;
 }

--- a/mm/kasan/generic.c
+++ b/mm/kasan/generic.c
@@ -204,6 +204,16 @@ static void kasan_set_poison(FAR const void *addr, size_t size,
  * Public Functions
  ****************************************************************************/
 
+uint8_t kasan_get_tag(FAR const void *addr)
+{
+  return 0;
+}
+
+FAR void *kasan_set_tag(FAR const void *addr, uint8_t tag)
+{
+  return (FAR void *)addr;
+}
+
 FAR void *kasan_clear_tag(FAR const void *addr)
 {
   return (FAR void *)addr;

--- a/mm/kasan/hook.c
+++ b/mm/kasan/hook.c
@@ -120,7 +120,11 @@ static struct kasan_watchpoint_s g_watchpoint[MM_KASAN_WATCHPOINT];
 #endif
 
 #ifdef CONFIG_MM_KASAN
+#  ifdef MM_KASAN_MARK_LOCATION
+static uint32_t g_region_init locate_data(MM_KASAN_MARK_LOCATION);
+#  else
 static uint32_t g_region_init;
+#  endif
 #endif
 
 /****************************************************************************

--- a/mm/kasan/hook.c
+++ b/mm/kasan/hook.c
@@ -42,6 +42,8 @@
 #  include "generic.c"
 #elif defined(CONFIG_MM_KASAN_SW_TAGS)
 #  include "sw_tags.c"
+#elif defined(CONFIG_MM_KASAN_HW_TAGS)
+#  include "hw_tags.c"
 #else
 #  define kasan_is_poisoned(addr, size) false
 #endif
@@ -95,6 +97,8 @@
 #endif
 
 #define KASAN_INIT_VALUE 0xcafe
+
+#ifdef CONFIG_MM_KASAN_INSTRUMENT
 
 /****************************************************************************
  * Private Types
@@ -405,3 +409,6 @@ DEFINE_ASAN_LOAD_STORE(2)
 DEFINE_ASAN_LOAD_STORE(4)
 DEFINE_ASAN_LOAD_STORE(8)
 DEFINE_ASAN_LOAD_STORE(16)
+
+#endif /* CONFIG_MM_KASAN_INSTRUMENT */
+

--- a/mm/kasan/hw_tags.c
+++ b/mm/kasan/hw_tags.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * mm/kasan/hw_tags.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/arch.h>
+
+/****************************************************************************
+ * Private Function
+ ****************************************************************************/
+
+static FAR void *
+kasan_poison_tag(FAR const void *addr, size_t size, uint8_t tag)
+{
+  FAR void *tag_addr;
+
+  /* Label this address pointer */
+
+  tag_addr = up_memtag_set_tag(addr, tag);
+
+  /* Add MTE hardware label to memory block */
+
+  up_memtag_tag_mem(tag_addr, size);
+
+  return tag_addr;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+bool kasan_bypass(bool state)
+{
+  return up_memtag_bypass(state);
+}
+
+FAR void *kasan_clear_tag(FAR const void *addr)
+{
+  return up_memtag_set_tag(addr, 0);
+}
+
+void kasan_poison(FAR const void *addr, size_t size)
+{
+  uint8_t tag = up_memtag_get_random_tag(addr);
+
+  kasan_poison_tag(addr, size, tag);
+}
+
+uint8_t kasan_get_tag(FAR const void *addr)
+{
+  return up_memtag_get_tag(addr);
+}
+
+FAR void *kasan_set_tag(FAR const void *addr, uint8_t tag)
+{
+  return up_memtag_set_tag(addr, tag);
+}
+
+FAR void *kasan_unpoison(FAR const void *addr, size_t size)
+{
+  uint8_t tag = up_memtag_get_random_tag(addr);
+
+  return kasan_poison_tag(addr, size, tag);
+}
+
+void kasan_register(FAR void *addr, FAR size_t *size)
+{
+  uint8_t tag = up_memtag_get_random_tag(addr);
+
+  kasan_poison_tag(addr, *size, tag);
+}
+
+void kasan_unregister(FAR void *addr)
+{
+}

--- a/mm/kasan/sw_tags.c
+++ b/mm/kasan/sw_tags.c
@@ -81,7 +81,7 @@ kasan_mem_to_shadow(FAR const void *ptr, size_t size)
   uintptr_t addr;
   int i;
 
-  addr = (uintptr_t)kasan_reset_tag(ptr);
+  addr = (uintptr_t)kasan_clear_tag(ptr);
 
   for (i = 0; i < g_region_count; i++)
     {
@@ -156,7 +156,7 @@ static void kasan_set_poison(FAR const void *addr,
  * Public Functions
  ****************************************************************************/
 
-FAR void *kasan_reset_tag(FAR const void *addr)
+FAR void *kasan_clear_tag(FAR const void *addr)
 {
   return (FAR void *)
          (((uint64_t)(addr)) & ~((uint64_t)0xff << KASAN_TAG_SHIFT));

--- a/mm/kasan/sw_tags.c
+++ b/mm/kasan/sw_tags.c
@@ -36,13 +36,6 @@
 
 #define KASAN_TAG_SHIFT 56
 
-#define kasan_get_tag(addr) \
-  ((uint8_t)((uint64_t)(addr) >> KASAN_TAG_SHIFT))
-
-#define kasan_set_tag(addr, tag) \
-  (FAR void *)((((uint64_t)(addr)) & ~((uint64_t)0xff << KASAN_TAG_SHIFT)) | \
-               (((uint64_t)(tag)) << KASAN_TAG_SHIFT))
-
 #define kasan_random_tag() (1 + rand() % ((1 << (64 - KASAN_TAG_SHIFT)) - 2))
 
 #define KASAN_SHADOW_SCALE (sizeof(uintptr_t))

--- a/mm/kasan/sw_tags.c
+++ b/mm/kasan/sw_tags.c
@@ -156,15 +156,31 @@ static void kasan_set_poison(FAR const void *addr,
  * Public Functions
  ****************************************************************************/
 
-FAR void *kasan_clear_tag(FAR const void *addr)
+FAR void *kasan_set_tag(FAR const void *addr, uint8_t tag)
 {
-  return (FAR void *)
-         (((uint64_t)(addr)) & ~((uint64_t)0xff << KASAN_TAG_SHIFT));
+  return (FAR void *)((uint64_t)kasan_clear_tag(addr) |
+                      (((uint64_t)tag) << KASAN_TAG_SHIFT));
 }
 
 void kasan_poison(FAR const void *addr, size_t size)
 {
   kasan_set_poison(addr, size, 0xff);
+}
+
+FAR void *kasan_clear_tag(FAR const void *addr)
+{
+  return (FAR void *)
+         (((uint64_t)addr) & ~((uint64_t)0xff << KASAN_TAG_SHIFT));
+}
+
+uint8_t kasan_get_tag(FAR const void *addr)
+{
+  return (uint8_t)((uint64_t)addr >> KASAN_TAG_SHIFT);
+}
+
+bool kasan_bypass(bool state)
+{
+  return false;
 }
 
 FAR void *kasan_unpoison(FAR const void *addr, size_t size)

--- a/mm/mempool/mempool_multiple.c
+++ b/mm/mempool/mempool_multiple.c
@@ -309,7 +309,7 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
     }
 
   addr = (FAR void *)ALIGN_DOWN((uintptr_t)blk, mpool->expandsize);
-  if (kasan_reset_tag(blk) == kasan_reset_tag(addr))
+  if (kasan_clear_tag(blk) == kasan_clear_tag(addr))
     {
       /* It is not a memory block allocated by mempool
        * Because the blk is need not aligned with the expandsize
@@ -328,10 +328,10 @@ mempool_multiple_get_dict(FAR struct mempool_multiple_s *mpool,
   row = index >> mpool->dict_col_num_log2;
   col = index - (row << mpool->dict_col_num_log2);
 
-  addr = kasan_reset_tag(addr);
-  if (kasan_reset_tag(mpool->dict[row]) == NULL ||
-      kasan_reset_tag(mpool->dict[row][col].addr) != addr ||
-      ((FAR char *)kasan_reset_tag(blk) -
+  addr = kasan_clear_tag(addr);
+  if (kasan_clear_tag(mpool->dict[row]) == NULL ||
+      kasan_clear_tag(mpool->dict[row][col].addr) != addr ||
+      ((FAR char *)kasan_clear_tag(blk) -
        (FAR char *)addr >= mpool->dict[row][col].size))
     {
       return NULL;
@@ -630,8 +630,8 @@ int mempool_multiple_free(FAR struct mempool_multiple_s *mpool,
       return -EINVAL;
     }
 
-  blk = (FAR char *)blk - (((FAR char *)kasan_reset_tag(blk) -
-                            ((FAR char *)kasan_reset_tag(dict->addr) +
+  blk = (FAR char *)blk - (((FAR char *)kasan_clear_tag(blk) -
+                            ((FAR char *)kasan_clear_tag(dict->addr) +
                              mpool->minpoolsize)) %
                            MEMPOOL_REALBLOCKSIZE(dict->pool));
   mempool_release(dict->pool, blk);

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -128,7 +128,7 @@ void mm_delayfree(FAR struct mm_heap_s *heap, FAR void *mem, bool delay)
   /* Map the memory chunk into a free node */
 
   node = (FAR struct mm_freenode_s *)
-         ((FAR char *)kasan_reset_tag(mem) - MM_SIZEOF_ALLOCNODE);
+         ((FAR char *)kasan_clear_tag(mem) - MM_SIZEOF_ALLOCNODE);
   nodesize = MM_SIZEOF_NODE(node);
 
   /* Sanity check against double-frees */

--- a/mm/mm_heap/mm_heapmember.c
+++ b/mm/mm_heap/mm_heapmember.c
@@ -57,7 +57,7 @@
 
 bool mm_heapmember(FAR struct mm_heap_s *heap, FAR void *mem)
 {
-  mem = kasan_reset_tag(mem);
+  mem = kasan_clear_tag(mem);
 #if CONFIG_MM_REGIONS > 1
   int i;
 

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <debug.h>
 
+#include <nuttx/mm/kasan.h>
 #include <nuttx/mm/mm.h>
 
 #include "mm_heap/mm.h"
@@ -40,12 +41,17 @@
 size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
 {
   FAR struct mm_freenode_s *node;
+  ssize_t size;
+  bool flag;
+
+  flag = kasan_bypass(true);
 #ifdef CONFIG_MM_HEAP_MEMPOOL
   if (heap->mm_mpool)
     {
-      ssize_t size = mempool_multiple_alloc_size(heap->mm_mpool, mem);
+      size = mempool_multiple_alloc_size(heap->mm_mpool, mem);
       if (size >= 0)
         {
+          kasan_bypass(flag);
           return size;
         }
     }
@@ -66,5 +72,8 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
 
   DEBUGASSERT(MM_NODE_IS_ALLOC(node));
 
-  return MM_SIZEOF_NODE(node) - MM_ALLOCNODE_OVERHEAD;
+  size = MM_SIZEOF_NODE(node) - MM_ALLOCNODE_OVERHEAD;
+
+  kasan_bypass(flag);
+  return size;
 }

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -75,6 +75,5 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
   size = MM_SIZEOF_NODE(node) - MM_ALLOCNODE_OVERHEAD;
 
   kasan_bypass(flag);
-  UNUSED(flag);
   return size;
 }

--- a/mm/mm_heap/mm_malloc_size.c
+++ b/mm/mm_heap/mm_malloc_size.c
@@ -75,5 +75,6 @@ size_t mm_malloc_size(FAR struct mm_heap_s *heap, FAR void *mem)
   size = MM_SIZEOF_NODE(node) - MM_ALLOCNODE_OVERHEAD;
 
   kasan_bypass(flag);
+  UNUSED(flag);
   return size;
 }

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -142,7 +142,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   kasan_poison((FAR void *)rawchunk,
                mm_malloc_size(heap, (FAR void *)rawchunk));
 
-  rawchunk = (uintptr_t)kasan_reset_tag((FAR void *)rawchunk);
+  rawchunk = (uintptr_t)kasan_clear_tag((FAR void *)rawchunk);
 
   /* We need to hold the MM mutex while we muck with the chunks and
    * nodelist.

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -132,7 +132,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   /* Map the memory chunk into an allocated node structure */
 
   oldnode = (FAR struct mm_allocnode_s *)
-    ((FAR char *)kasan_reset_tag(oldmem) - MM_SIZEOF_ALLOCNODE);
+    ((FAR char *)kasan_clear_tag(oldmem) - MM_SIZEOF_ALLOCNODE);
 
   /* We need to hold the MM mutex while we muck with the nodelist. */
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -388,11 +388,12 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                       heap->mm_curused - newsize);
       sched_note_heap(NOTE_HEAP_ALLOC, heap, newmem, newsize,
                       heap->mm_curused);
+
+      size = MM_SIZEOF_NODE(oldnode);
       mm_unlock(heap);
       MM_ADD_BACKTRACE(heap, (FAR char *)newmem - MM_SIZEOF_ALLOCNODE);
 
-      newmem = kasan_unpoison(newmem, MM_SIZEOF_NODE(oldnode) -
-                              MM_ALLOCNODE_OVERHEAD);
+      newmem = kasan_unpoison(newmem, size - MM_ALLOCNODE_OVERHEAD);
 
       oldmem = kasan_set_tag(oldmem, kasan_get_tag(newmem));
       if (newmem != oldmem)

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -393,7 +393,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
       newmem = kasan_unpoison(newmem, MM_SIZEOF_NODE(oldnode) -
                               MM_ALLOCNODE_OVERHEAD);
-      if (kasan_reset_tag(newmem) != kasan_reset_tag(oldmem))
+
+      oldmem = kasan_set_tag(oldmem, kasan_get_tag(newmem));
+      if (newmem != oldmem)
         {
           /* Now we have to move the user contents 'down' in memory.  memcpy
            * should be safe for this.


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. Introduced the implementation of ARM64 MTE KASan to support hardware detection of memory errors
2. Software kasan supports mapping of initialization flags to solve kasan early access errors caused by non-on-chip memory
3. Fixed some kasan errors

## Impact

no

## Testing

ci


