### PR TITLE
drivers/segger/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/drivers/segger/CMakeLists.txt
+++ b/drivers/segger/CMakeLists.txt
@@ -23,7 +23,7 @@
 if(CONFIG_SEGGER_RTT OR CONFIG_SEGGER_SYSVIEW)
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/SystemView)
 
-    set(SYSVIEW_VERSION 354)
+    set(SYSVIEW_VERSION 356)
 
     FetchContent_Declare(
       systemview


### PR DESCRIPTION
## Summary

Segger SysView has been upgraded to version V3.5.6

 PR #13847

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

CI


