### PR TITLE
bugfix: share kernel thread group should not dup files from caller group

### DIFF
--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -79,15 +79,19 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
 #ifndef CONFIG_FDCLONE_DISABLE
   DEBUGASSERT(rtcb->group);
 
-  /* Duplicate the parent task's file descriptors */
+  /* With the exception of kernel threads, duplicate the parent task's
+   * file descriptors.
+   */
 
-  if (group != rtcb->group)
+  if (group != rtcb->group &&
+      (tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
       ret = fdlist_copy(&rtcb->group->tg_fdlist,
                         &group->tg_fdlist, actions, cloexec);
     }
 
-  if (ret >= 0 && actions != NULL)
+  if (ret >= 0 && actions != NULL &&
+      (tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
       ret = spawn_file_actions(&tcb->cmn, actions);
     }


### PR DESCRIPTION

## Summary

bugfix: share kernel thread group should not dup files from caller group

after this commits
  commit e7fa4cae6cbf567266985c8072db1f51ad480943
  Author: Yanfeng Liu <yfliu2008@qq.com>
  Date: Fri May 17 06:11:52 2024 +0800

  sched/tcb: use shared group for kthreads

all kernel thread share group 
and should not dup filelist to this group

## Impact

https://github.com/apache/nuttx/issues/16560, bug fix

## Testing

test code:
add test code to dev_zero driver
![image](https://github.com/user-attachments/assets/32bb4e83-9d25-4c83-ae03-dcd2a4e73a31)

add test code to examples hello:
![image](https://github.com/user-attachments/assets/ec1fe961-06b1-4f3b-9304-4e0a29a12333)


