### PR TITLE
{bp-16499} [BREAKING] fs/vfs: Separate file descriptors from file descriptions

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -590,7 +590,7 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           audinfo("AUDIOIOC_REGISTERMQ\n");
 
-          ret = fs_getfilep((mqd_t)arg, &upper->usermq);
+          ret = file_get((mqd_t)arg, &upper->usermq);
         }
         break;
 
@@ -603,7 +603,7 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           audinfo("AUDIOIOC_UNREGISTERMQ\n");
 
-          fs_putfilep(upper->usermq);
+          file_put(upper->usermq);
           upper->usermq = NULL;
           ret = OK;
         }

--- a/boards/arm/stm32/olimex-stm32-p407/configs/kmodule/defconfig
+++ b/boards/arm/stm32/olimex-stm32-p407/configs/kmodule/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_FS_REFCOUNT is not set
 CONFIG_ARCH="arm"
 CONFIG_ARCH_BOARD="olimex-stm32-p407"
 CONFIG_ARCH_BOARD_OLIMEX_STM32P407=y

--- a/boards/arm/stm32/stm3240g-eval/configs/knxwm/defconfig
+++ b/boards/arm/stm32/stm3240g-eval/configs/knxwm/defconfig
@@ -6,7 +6,6 @@
 # modifications.
 #
 # CONFIG_ARCH_FPU is not set
-# CONFIG_FS_REFCOUNT is not set
 # CONFIG_NXFONTS_DISABLE_16BPP is not set
 # CONFIG_NXTK_DEFAULT_BORDERCOLORS is not set
 # CONFIG_NXWM_NXTERM is not set

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -1028,8 +1028,7 @@ static int cryptoioctl(FAR struct file *filep, int cmd, unsigned long arg)
         TAILQ_INIT(&fcr->csessions);
         TAILQ_INIT(&fcr->crpk_ret);
 
-        fd = file_allocate(&g_cryptoinode, 0,
-                           0, fcr, 0, true);
+        fd = file_allocate_from_inode(&g_cryptoinode, 0, 0, fcr, 0);
         if (fd < 0)
           {
             kmm_free(fcr);

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -539,14 +539,14 @@ static int optee_close(FAR struct file *filep)
 
   idr_for_each_entry(priv->shms, shm, id)
     {
-      if (shm->fd > -1 && fs_getfilep(shm->fd, &shm_filep) >= 0)
+      if (shm->fd > -1 && fs_get(shm->fd, &shm_filep) >= 0)
         {
           /* The user did not call close(), prevent vfs auto-close from
            * double-freeing our SHM
            */
 
           shm_filep->f_priv = NULL;
-          fs_putfilep(shm_filep);
+          fs_put(shm_filep);
         }
 
       optee_shm_free(shm);

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -1038,7 +1038,8 @@ optee_ioctl_shm_register(FAR struct optee_priv_data *priv,
       return ret;
     }
 
-  ret = file_allocate(&g_optee_shm_inode, O_CLOEXEC, 0, shm, 0, true);
+  ret = file_allocate_from_inode(&g_optee_shm_inode, O_CLOEXEC,
+                                 0, shm, 0, true);
   if (ret < 0)
     {
       optee_shm_free(shm);

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -943,7 +943,7 @@ static int telnet_session(FAR struct telnet_session_s *session)
     }
 
   ret = psock_dup2(psock, &priv->td_psock);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       nerr("ERROR: psock_dup2 failed: %d\n", ret);

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -127,19 +127,6 @@ config FS_HEAPBUF_SECTION
 		Allocated fs heap from the specified section. If not
 		specified, it will alloc from kernel heap.
 
-config FS_REFCOUNT
-	bool "File reference count"
-	default !DISABLE_PTHREAD
-	---help---
-		Enable will Records the number of filep references. The file is
-		actually closed when the count reaches 0
-
-		Note that this option will ensure the safety of access to the file
-		system from multi-tasks (thread A blocking rw(fd), then thread B close(fd)),
-		the disadvantage is that it will increase the amount of code-size,
-		there is no need to enable this option if the application could ensure
-		he file operations are safe.
-
 source "fs/vfs/Kconfig"
 source "fs/aio/Kconfig"
 source "fs/semaphore/Kconfig"

--- a/fs/aio/aioc_contain.c
+++ b/fs/aio/aioc_contain.c
@@ -70,7 +70,7 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(aiocbp->aio_fildes, &filep);
+  ret = file_get(aiocbp->aio_fildes, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -115,7 +115,7 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
   return aioc;
 
 err_putfilep:
-  fs_putfilep(filep);
+  file_put(filep);
 errout:
   set_errno(-ret);
   return NULL;
@@ -155,7 +155,7 @@ FAR struct aiocb *aioc_decant(FAR struct aio_container_s *aioc)
        */
 
       aiocbp = aioc->aioc_aiocbp;
-      fs_putfilep(aioc->aioc_filep);
+      file_put(aioc->aioc_filep);
       aioc_free(aioc);
 
       aio_unlock();

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -263,12 +263,6 @@ int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags)
   FAR struct filelist *list;
   FAR struct file *filep1;
   FAR struct file *filep;
-#ifdef CONFIG_FDCHECK
-  uint8_t f_tag_fdcheck;
-#endif
-#ifdef CONFIG_FDSAN
-  uint64_t f_tag_fdsan;
-#endif
   bool new = false;
   int count;
   int ret;
@@ -313,14 +307,6 @@ int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags)
                               fd2 % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK,
                               &new);
 
-#ifdef CONFIG_FDSAN
-  f_tag_fdsan = filep->f_tag_fdsan;
-#endif
-
-#ifdef CONFIG_FDCHECK
-  f_tag_fdcheck = filep->f_tag_fdcheck;
-#endif
-
   /* Perform the dup3 operation */
 
   ret = file_dup3(filep1, filep, flags);
@@ -335,14 +321,6 @@ int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags)
 
       return ret;
     }
-
-#ifdef CONFIG_FDSAN
-  filep->f_tag_fdsan = f_tag_fdsan;
-#endif
-
-#ifdef CONFIG_FDCHECK
-  filep->f_tag_fdcheck = f_tag_fdcheck;
-#endif
 
 #ifdef CONFIG_FDCHECK
   return fdcheck_protect(fd2);

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -227,7 +227,7 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
               ctcb = nxsched_get_tcb(pid);
               if (ctcb != NULL && ctcb->group != NULL && ctcb == tcb)
                 {
-                  fs_putfilep(filep);
+                  file_put(filep);
                 }
             }
         }
@@ -310,13 +310,13 @@ int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags)
   /* Perform the dup3 operation */
 
   ret = file_dup3(filep1, filep, flags);
-  fs_putfilep(filep1);
-  fs_putfilep(filep);
+  file_put(filep1);
+  file_put(filep);
   if (ret < 0)
     {
       if (new)
         {
-          fs_putfilep(filep);
+          file_put(filep);
         }
 
       return ret;
@@ -413,7 +413,7 @@ void files_dumplist(FAR struct filelist *list)
             , buf
 #endif
             );
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   lib_put_pathbuffer(path);
@@ -666,20 +666,20 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
 #endif
               if (!spawn_file_is_duplicateable(actions, fd, fcloexec))
                 {
-                  fs_putfilep(filep);
+                  file_put(filep);
                   continue;
                 }
             }
           else if (fcloexec)
             {
-              fs_putfilep(filep);
+              file_put(filep);
               continue;
             }
 
           ret = files_extend(clist, i + 1);
           if (ret < 0)
             {
-              fs_putfilep(filep);
+              file_put(filep);
               return ret;
             }
 
@@ -687,13 +687,13 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
 
           filep2 = files_fget_by_index(clist, i, j, &new);
           ret = file_dup2(filep, filep2);
-          fs_putfilep(filep2);
-          fs_putfilep(filep);
+          file_put(filep2);
+          file_put(filep);
           if (ret < 0)
             {
               if (new)
                 {
-                  fs_putfilep(filep2);
+                  file_put(filep2);
                 }
 
               return ret;
@@ -705,7 +705,7 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
 }
 
 /****************************************************************************
- * Name: fs_getfilep
+ * Name: file_get
  *
  * Description:
  *   Given a file descriptor, return the corresponding instance of struct
@@ -721,7 +721,7 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist,
  *
  ****************************************************************************/
 
-int fs_getfilep(int fd, FAR struct file **filep)
+int file_get(int fd, FAR struct file **filep)
 {
   FAR struct filelist *list;
 
@@ -767,7 +767,7 @@ int fs_getfilep(int fd, FAR struct file **filep)
 }
 
 /****************************************************************************
- * Name: fs_reffilep
+ * Name: file_ref
  *
  * Description:
  *   To specify filep increase the reference count.
@@ -780,7 +780,7 @@ int fs_getfilep(int fd, FAR struct file **filep)
  *
  ****************************************************************************/
 
-void fs_reffilep(FAR struct file *filep)
+void file_ref(FAR struct file *filep)
 {
   /* This interface is used to increase the reference count of filep */
 
@@ -789,7 +789,7 @@ void fs_reffilep(FAR struct file *filep)
 }
 
 /****************************************************************************
- * Name: fs_putfilep
+ * Name: file_put
  *
  * Description:
  *   Handles reference counts for files, less than or equal to 0 and close
@@ -800,7 +800,7 @@ void fs_reffilep(FAR struct file *filep)
  *            file' instance.
  ****************************************************************************/
 
-int fs_putfilep(FAR struct file *filep)
+int file_put(FAR struct file *filep)
 {
   int ret = 0;
 
@@ -895,15 +895,15 @@ int nx_close_from_tcb(FAR struct tcb_s *tcb, int fd)
     }
 
 
-  /* files_fget will increase the reference count, there call fs_putfilep
+  /* files_fget will increase the reference count, there call file_put
    * reduce reference count.
    */
 
-  fs_putfilep(filep);
+  file_put(filep);
 
   /* Undo the last reference count from file_allocate_from_tcb */
 
-  return fs_putfilep(filep);
+  return file_put(filep);
 }
 
 /****************************************************************************

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -46,10 +46,6 @@
 #include <nuttx/spinlock.h>
 #include <nuttx/lib/lib.h>
 
-#ifdef CONFIG_FDSAN
-#  include <android/fdsan.h>
-#endif
-
 #ifdef CONFIG_FDCHECK
 #  include <nuttx/fdcheck.h>
 #endif
@@ -247,6 +243,10 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
 }
 
 /****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: nx_dup3_from_tcb
  *
  * Description:
@@ -266,8 +266,7 @@ static void task_fssync(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-static int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2,
-                            int flags)
+int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags)
 {
   FAR struct filelist *list;
   FAR struct file *filep1;
@@ -359,10 +358,6 @@ static int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2,
   return fd2;
 #endif
 }
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
 
 /****************************************************************************
  * Name: files_initlist
@@ -884,75 +879,6 @@ int nx_dup2_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2)
 }
 
 /****************************************************************************
- * Name: nx_dup2
- *
- * Description:
- *   nx_dup2() is similar to the standard 'dup2' interface except that is
- *   not a cancellation point and it does not modify the errno variable.
- *
- *   nx_dup2() is an internal NuttX interface and should not be called from
- *   applications.
- *
- *   Clone a file descriptor to a specific descriptor number.
- *
- * Returned Value:
- *   fd2 is returned on success; a negated errno value is return on
- *   any failure.
- *
- ****************************************************************************/
-
-int nx_dup2(int fd1, int fd2)
-{
-  return nx_dup2_from_tcb(this_task(), fd1, fd2);
-}
-
-/****************************************************************************
- * Name: dup2
- *
- * Description:
- *   Clone a file descriptor or socket descriptor to a specific descriptor
- *   number
- *
- ****************************************************************************/
-
-int dup2(int fd1, int fd2)
-{
-  int ret;
-
-  ret = nx_dup2(fd1, fd2);
-  if (ret < 0)
-    {
-      set_errno(-ret);
-      ret = ERROR;
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: dup3
- *
- * Description:
- *   Clone a file descriptor or socket descriptor to a specific descriptor
- *   number and specific flags.
- *
- ****************************************************************************/
-
-int dup3(int fd1, int fd2, int flags)
-{
-  int ret;
-
-  ret = nx_dup3_from_tcb(this_task(), fd1, fd2, flags);
-  if (ret < 0)
-    {
-      set_errno(-ret);
-      ret = ERROR;
-    }
-
-  return ret;
-}
-
-/****************************************************************************
  * Name: nx_close_from_tcb
  *
  * Description:
@@ -1016,79 +942,6 @@ int nx_close_from_tcb(FAR struct tcb_s *tcb, int fd)
 #else
   return file_close(filep);
 #endif
-}
-
-/****************************************************************************
- * Name: nx_close
- *
- * Description:
- *   nx_close() is similar to the standard 'close' interface except that is
- *   not a cancellation point and it does not modify the errno variable.
- *
- *   nx_close() is an internal NuttX interface and should not be called from
- *   applications.
- *
- *   Close an inode (if open)
- *
- * Returned Value:
- *   Zero (OK) is returned on success; A negated errno value is returned on
- *   on any failure.
- *
- * Assumptions:
- *   Caller holds the list mutex because the file descriptor will be
- *   freed.
- *
- ****************************************************************************/
-
-int nx_close(int fd)
-{
-  return nx_close_from_tcb(this_task(), fd);
-}
-
-/****************************************************************************
- * Name: close
- *
- * Description:
- *   close() closes a file descriptor, so that it no longer refers to any
- *   file and may be reused. Any record locks (see fcntl(2)) held on the file
- *   it was associated with, and owned by the process, are removed
- *   (regardless of the file descriptor that was used to obtain the lock).
- *
- *   If fd is the last copy of a particular file descriptor the resources
- *   associated with it are freed; if the descriptor was the last reference
- *   to a file which has been removed using unlink(2) the file is deleted.
- *
- * Input Parameters:
- *   fd   file descriptor to close
- *
- * Returned Value:
- *   0 on success; -1 on error with errno set appropriately.
- *
- * Assumptions:
- *
- ****************************************************************************/
-
-int close(int fd)
-{
-  int ret;
-
-#ifdef CONFIG_FDSAN
-  android_fdsan_exchange_owner_tag(fd, 0, 0);
-#endif
-
-  /* close() is a cancellation point */
-
-  enter_cancellation_point();
-
-  ret = nx_close(fd);
-  if (ret < 0)
-    {
-      set_errno(-ret);
-      ret = ERROR;
-    }
-
-  leave_cancellation_point();
-  return ret;
 }
 
 /****************************************************************************

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -72,21 +72,21 @@
   while (0)
 
 #if CONFIG_FS_BACKTRACE > 0
-#  define FS_ADD_BACKTRACE(filep) \
+#  define FS_ADD_BACKTRACE(fd) \
      do \
        { \
           int n = sched_backtrace(_SCHED_GETTID(), \
-                                  (filep)->f_backtrace, \
+                                  (fd)->f_backtrace, \
                                   CONFIG_FS_BACKTRACE, \
                                   CONFIG_FS_BACKTRACE_SKIP); \
           if (n < CONFIG_FS_BACKTRACE) \
             { \
-              (filep)->f_backtrace[n] = NULL; \
+              (fd)->f_backtrace[n] = NULL; \
             } \
        } \
      while (0)
 #else
-#  define FS_ADD_BACKTRACE(filep)
+#  define FS_ADD_BACKTRACE(fd)
 #endif
 
 /****************************************************************************

--- a/fs/mmap/Kconfig
+++ b/fs/mmap/Kconfig
@@ -6,7 +6,6 @@
 config FS_RAMMAP
 	bool "File mapping emulation"
 	default n
-	depends on FS_REFCOUNT
 	---help---
 		NuttX operates in a flat open address space and is focused on MCUs that do
 		support Memory Management Units (MMUs).  Therefore, NuttX generally does not

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -279,7 +279,7 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
   FAR void *mapped = NULL;
   int ret;
 
-  if (fd != -1 && fs_getfilep(fd, &filep) < 0)
+  if (fd != -1 && file_get(fd, &filep) < 0)
     {
       ferr("ERROR: fd:%d referred file whose type is not supported\n", fd);
       ret = -ENODEV;
@@ -290,7 +290,7 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
                    prot, flags, offset, MAP_USER, &mapped);
   if (filep)
     {
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/fs/mmap/fs_rammap.c
+++ b/fs/mmap/fs_rammap.c
@@ -175,7 +175,7 @@ static int unmap_rammap(FAR struct task_group_s *group,
           kumm_free(entry->vaddr);
         }
 
-      fs_putfilep(filep);
+      file_put(filep);
 
       /* Then remove the mapping from the list */
 
@@ -332,7 +332,7 @@ int rammap(FAR struct file *filep, FAR struct mm_map_entry_s *entry,
   /* Add the buffer to the list of regions */
 
 out:
-  fs_reffilep(filep);
+  file_ref(filep);
   entry->priv.p = (FAR void *)((uintptr_t)filep | type);
   entry->munmap = unmap_rammap;
   entry->msync = msync_rammap;

--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -605,14 +605,14 @@ static int inotify_close(FAR struct file *filep)
 static FAR struct inotify_device_s *
 inotify_get_device_from_fd(int fd, FAR struct file **filep)
 {
-  if (fs_getfilep(fd, filep) < 0)
+  if (file_get(fd, filep) < 0)
     {
       return NULL;
     }
 
   if ((*filep)->f_inode != &g_inotify_inode)
     {
-      fs_putfilep(*filep);
+      file_put(*filep);
       return NULL;
     }
 
@@ -1083,7 +1083,7 @@ int inotify_add_watch(int fd, FAR const char *pathname, uint32_t mask)
   abspath = lib_realpath(pathname, NULL, mask & IN_DONT_FOLLOW);
   if (abspath == NULL)
     {
-      fs_putfilep(filep);
+      file_put(filep);
       return ERROR;
     }
 
@@ -1154,7 +1154,7 @@ out:
   nxmutex_unlock(&g_inotify.lock);
 
 out_free:
-  fs_putfilep(filep);
+  file_put(filep);
   fs_heap_free(abspath);
   if (ret < 0)
     {
@@ -1202,7 +1202,7 @@ int inotify_rm_watch(int fd, int wd)
     {
       nxmutex_unlock(&dev->lock);
       nxmutex_unlock(&g_inotify.lock);
-      fs_putfilep(filep);
+      file_put(filep);
       set_errno(EINVAL);
       return ERROR;
     }
@@ -1210,7 +1210,7 @@ int inotify_rm_watch(int fd, int wd)
   inotify_remove_watch(dev, watch);
   nxmutex_unlock(&dev->lock);
   nxmutex_unlock(&g_inotify.lock);
-  fs_putfilep(filep);
+  file_put(filep);
   return OK;
 }
 

--- a/fs/notify/inotify.c
+++ b/fs/notify/inotify.c
@@ -1025,7 +1025,7 @@ static inline void notify_queue_filep_event(FAR struct file *filep,
 
 static void notify_free_entry(FAR ENTRY *entry)
 {
-  /* Key is alloced by lib_malloc, value is alloced by fs_heap_malloc */
+  /* Key is allocated by lib_malloc, value is allocated by fs_heap_malloc */
 
   fs_heap_free(entry->key);
   fs_heap_free(entry->data);
@@ -1255,8 +1255,8 @@ int inotify_init1(int flags)
       goto exit_set_errno;
     }
 
-  ret = file_allocate(&g_inotify_inode, O_RDOK | flags,
-                      0, dev, 0, true);
+  ret = file_allocate_from_inode(&g_inotify_inode, O_RDOK | flags,
+                                 0, dev, 0);
   if (ret < 0)
     {
       ferr("Failed to allocate inotify fd\n");

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1333,7 +1333,7 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
           procfile->line[linesize - 2] = '\n';
         }
 
-      fs_putfilep(filep);
+      file_put(filep);
       copysize   = procfs_memcpy(procfile->line, linesize,
                                  buffer, remaining, &offset);
 

--- a/fs/socket/accept.c
+++ b/fs/socket/accept.c
@@ -264,7 +264,7 @@ int accept4(int sockfd, FAR struct sockaddr *addr, FAR socklen_t *addrlen,
       goto errout_with_psock;
     }
 
-  fs_putfilep(filep);
+  file_put(filep);
 
 #ifdef CONFIG_MM_KMAP
   kmm_unmap(kaddr);
@@ -281,7 +281,7 @@ errout_with_alloc:
   fs_heap_free(newsock);
 
 errout_with_filep:
-  fs_putfilep(filep);
+  file_put(filep);
 
 errout_with_kmap:
 #ifdef CONFIG_MM_KMAP

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -171,7 +171,7 @@ static int sock_file_truncate(FAR struct file *filep, off_t length)
 
 int sockfd_allocate(FAR struct socket *psock, int oflags)
 {
-  return file_allocate(&g_sock_inode, oflags, 0, psock, 0, true);
+  return file_allocate_from_inode(&g_sock_inode, oflags, 0, psock, 0);
 }
 
 /****************************************************************************

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -206,7 +206,7 @@ FAR struct socket *file_socket(FAR struct file *filep)
 int sockfd_socket(int sockfd, FAR struct file **filep,
                   FAR struct socket **socketp)
 {
-  if (fs_getfilep(sockfd, filep) < 0)
+  if (file_get(sockfd, filep) < 0)
     {
       *socketp = NULL;
       return -EBADF;
@@ -215,7 +215,7 @@ int sockfd_socket(int sockfd, FAR struct file **filep,
   *socketp = file_socket(*filep);
   if (*socketp == NULL)
     {
-      fs_putfilep(*filep);
+      file_put(*filep);
     }
 
   return *socketp != NULL ? OK : -ENOTSOCK;

--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRCS
     fs_close.c
     fs_dup.c
     fs_dup2.c
+    fs_dup3.c
     fs_fcntl.c
     fs_epoll.c
     fs_fchstat.c

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -22,8 +22,8 @@
 
 # Common file/socket descriptor support
 
-CSRCS += fs_chstat.c fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c fs_epoll.c
-CSRCS += fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
+CSRCS += fs_chstat.c fs_close.c fs_dup.c fs_dup2.c fs_dup3.c fs_fcntl.c
+CSRCS += fs_epoll.c fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_pread.c fs_pwrite.c fs_read.c
 CSRCS += fs_rename.c fs_rmdir.c fs_select.c fs_sendfile.c fs_stat.c
 CSRCS += fs_statfs.c fs_uio.c fs_unlink.c fs_write.c fs_dir.c fs_fsync.c

--- a/fs/vfs/fs_close.c
+++ b/fs/vfs/fs_close.c
@@ -32,10 +32,16 @@
 #include <errno.h>
 #include <fcntl.h>
 
+#include <nuttx/cancelpt.h>
 #include <nuttx/fs/fs.h>
+
+#ifdef CONFIG_FDSAN
+#  include <android/fdsan.h>
+#endif
 
 #include "notify/notify.h"
 #include "inode/inode.h"
+#include "sched/sched.h"
 #include "vfs/lock.h"
 
 /****************************************************************************
@@ -175,5 +181,78 @@ int file_close(FAR struct file *filep)
       filep->f_inode = NULL;
     }
 
+  return ret;
+}
+
+/****************************************************************************
+ * Name: nx_close
+ *
+ * Description:
+ *   nx_close() is similar to the standard 'close' interface except that is
+ *   not a cancellation point and it does not modify the errno variable.
+ *
+ *   nx_close() is an internal NuttX interface and should not be called from
+ *   applications.
+ *
+ *   Close an inode (if open)
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned on
+ *   on any failure.
+ *
+ * Assumptions:
+ *   Caller holds the list mutex because the file descriptor will be
+ *   freed.
+ *
+ ****************************************************************************/
+
+int nx_close(int fd)
+{
+  return nx_close_from_tcb(this_task(), fd);
+}
+
+/****************************************************************************
+ * Name: close
+ *
+ * Description:
+ *   close() closes a file descriptor, so that it no longer refers to any
+ *   file and may be reused. Any record locks (see fcntl(2)) held on the file
+ *   it was associated with, and owned by the process, are removed
+ *   (regardless of the file descriptor that was used to obtain the lock).
+ *
+ *   If fd is the last copy of a particular file descriptor the resources
+ *   associated with it are freed; if the descriptor was the last reference
+ *   to a file which has been removed using unlink(2) the file is deleted.
+ *
+ * Input Parameters:
+ *   fd   file descriptor to close
+ *
+ * Returned Value:
+ *   0 on success; -1 on error with errno set appropriately.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int close(int fd)
+{
+  int ret;
+
+#ifdef CONFIG_FDSAN
+  android_fdsan_exchange_owner_tag(fd, 0, 0);
+#endif
+
+  /* close() is a cancellation point */
+
+  enter_cancellation_point();
+
+  ret = nx_close(fd);
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  leave_cancellation_point();
   return ret;
 }

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -67,18 +67,18 @@ int file_dup(FAR struct file *filep, int minfd, int flags)
       return fd2;
     }
 
-  ret = fs_getfilep(fd2, &filep2);
+  ret = file_get(fd2, &filep2);
   DEBUGASSERT(ret >= 0);
 
   ret = file_dup3(filep, filep2, flags);
 
-  fs_putfilep(filep2);
+  file_put(filep2);
   if (ret >= 0)
     {
       return fd2;
     }
 
-  fs_putfilep(filep2);
+  file_put(filep2);
   return ret;
 }
 
@@ -97,7 +97,7 @@ int dup(int fd)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto err;
@@ -106,7 +106,7 @@ int dup(int fd)
   /* Let file_dup() do the real work */
 
   ret = file_dup(filep, 0, 0);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       goto err;

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -33,7 +33,9 @@
 #include <fcntl.h>
 
 #include <nuttx/fs/fs.h>
+
 #include "inode/inode.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Public Functions
@@ -54,32 +56,8 @@
 
 int file_dup(FAR struct file *filep, int minfd, int flags)
 {
-  FAR struct file *filep2;
-  int fd2;
-  int ret;
-#ifdef CONFIG_FDCHECK
-  minfd = fdcheck_restore(minfd);
-#endif
-
-  fd2 = file_allocate(g_root_inode, 0, 0, NULL, minfd, true);
-  if (fd2 < 0)
-    {
-      return fd2;
-    }
-
-  ret = file_get(fd2, &filep2);
-  DEBUGASSERT(ret >= 0);
-
-  ret = file_dup3(filep, filep2, flags);
-
-  file_put(filep2);
-  if (ret >= 0)
-    {
-      return fd2;
-    }
-
-  file_put(filep2);
-  return ret;
+  return fdlist_dupfile(nxsched_get_fdlist_from_tcb(this_task()),
+                        flags, minfd, filep);
 }
 
 /****************************************************************************

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -57,13 +57,7 @@ int file_dup(FAR struct file *filep, int minfd, int flags)
   FAR struct file *filep2;
   int fd2;
   int ret;
-#ifdef CONFIG_FDSAN
-  uint64_t f_tag_fdsan; /* File owner fdsan tag, init to 0 */
-#endif
-
 #ifdef CONFIG_FDCHECK
-  uint8_t f_tag_fdcheck; /* File owner fdcheck tag, init to 0 */
-
   minfd = fdcheck_restore(minfd);
 #endif
 
@@ -74,23 +68,9 @@ int file_dup(FAR struct file *filep, int minfd, int flags)
     }
 
   ret = fs_getfilep(fd2, &filep2);
-#ifdef CONFIG_FDSAN
-  f_tag_fdsan = filep2->f_tag_fdsan;
-#endif
-
-#ifdef CONFIG_FDCHECK
-  f_tag_fdcheck = filep2->f_tag_fdcheck;
-#endif
   DEBUGASSERT(ret >= 0);
 
   ret = file_dup3(filep, filep2, flags);
-#ifdef CONFIG_FDSAN
-  filep2->f_tag_fdsan = f_tag_fdsan;
-#endif
-
-#ifdef CONFIG_FDCHECK
-  filep2->f_tag_fdcheck = f_tag_fdcheck;
-#endif
 
   fs_putfilep(filep2);
   if (ret >= 0)

--- a/fs/vfs/fs_dup2.c
+++ b/fs/vfs/fs_dup2.c
@@ -35,6 +35,7 @@
 #include <fcntl.h>
 
 #include "inode/inode.h"
+#include "sched/sched.h"
 
 /****************************************************************************
  * Public Functions
@@ -196,4 +197,50 @@ int file_dup3(FAR struct file *filep1, FAR struct file *filep2, int flags)
 int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
 {
   return file_dup3(filep1, filep2, 0);
+}
+
+/****************************************************************************
+ * Name: nx_dup2
+ *
+ * Description:
+ *   nx_dup2() is similar to the standard 'dup2' interface except that is
+ *   not a cancellation point and it does not modify the errno variable.
+ *
+ *   nx_dup2() is an internal NuttX interface and should not be called from
+ *   applications.
+ *
+ *   Clone a file descriptor to a specific descriptor number.
+ *
+ * Returned Value:
+ *   fd2 is returned on success; a negated errno value is return on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int nx_dup2(int fd1, int fd2)
+{
+  return nx_dup2_from_tcb(this_task(), fd1, fd2);
+}
+
+/****************************************************************************
+ * Name: dup2
+ *
+ * Description:
+ *   Clone a file descriptor or socket descriptor to a specific descriptor
+ *   number
+ *
+ ****************************************************************************/
+
+int dup2(int fd1, int fd2)
+{
+  int ret;
+
+  ret = nx_dup2(fd1, fd2);
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
 }

--- a/fs/vfs/fs_dup2.c
+++ b/fs/vfs/fs_dup2.c
@@ -163,16 +163,6 @@ int file_dup3(FAR struct file *filep1, FAR struct file *filep2, int flags)
         }
     }
 
-  /* Copy tag */
-
-#ifdef CONFIG_FDSAN
-  filep2->f_tag_fdsan = filep1->f_tag_fdsan;
-#endif
-
-#ifdef CONFIG_FDCHECK
-  filep2->f_tag_fdcheck = filep1->f_tag_fdcheck;
-#endif
-
   FS_ADD_BACKTRACE(filep2);
   return OK;
 }

--- a/fs/vfs/fs_dup3.c
+++ b/fs/vfs/fs_dup3.c
@@ -49,7 +49,8 @@ int dup3(int fd1, int fd2, int flags)
 {
   int ret;
 
-  ret = nx_dup3_from_tcb(this_task(), fd1, fd2, flags);
+  ret = fdlist_dup3(nxsched_get_fdlist_from_tcb(this_task()),
+                    fd1, fd2, flags);
   if (ret < 0)
     {
       set_errno(-ret);

--- a/fs/vfs/fs_dup3.c
+++ b/fs/vfs/fs_dup3.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * fs/vfs/fs_dup3.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/fs/fs.h>
+
+#include <unistd.h>
+#include <sched.h>
+#include <errno.h>
+
+#include "sched/sched.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dup3
+ *
+ * Description:
+ *   Clone a file descriptor or socket descriptor to a specific descriptor
+ *   number and specific flags.
+ *
+ ****************************************************************************/
+
+int dup3(int fd1, int fd2, int flags)
+{
+  int ret;
+
+  ret = nx_dup3_from_tcb(this_task(), fd1, fd2, flags);
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
+}

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -258,7 +258,7 @@ static int epoll_do_create(int size, int flags)
 
   /* Alloc the file descriptor */
 
-  fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0, true);
+  fd = file_allocate_from_inode(&g_epoll_inode, flags, 0, eph, 0);
   if (fd < 0)
     {
       nxmutex_destroy(&eph->lock);

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -528,8 +528,8 @@ int eventfd(unsigned int count, int flags)
     }
 
   new_dev->counter = count;
-  new_fd = file_allocate(&g_eventfd_inode, O_RDWR | flags,
-                         0, new_dev, 0, true);
+  new_fd = file_allocate_from_inode(&g_eventfd_inode, O_RDWR | flags,
+                                    0, new_dev, 0);
   if (new_fd < 0)
     {
       ret = new_fd;

--- a/fs/vfs/fs_fchstat.c
+++ b/fs/vfs/fs_fchstat.c
@@ -50,10 +50,10 @@ static int fchstat(int fd, FAR struct stat *buf, int flags)
   int ret;
 
   /* First, get the file structure.  Note that on failure,
-   * fs_getfilep() will return the errno.
+   * file_get() will return the errno.
    */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -62,7 +62,7 @@ static int fchstat(int fd, FAR struct stat *buf, int flags)
   /* Perform the fchstat operation */
 
   ret = file_fchstat(filep, buf, flags);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret >= 0)
     {
       /* Successfully fchstat'ed the file */

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -349,7 +349,7 @@ int fcntl(int fd, int cmd, ...)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret >= 0)
     {
       /* Let file_vfcntl() do the real work.  The errno is not set on
@@ -357,7 +357,7 @@ int fcntl(int fd, int cmd, ...)
        */
 
       ret = file_vfcntl(filep, cmd, ap);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -231,16 +231,16 @@ int nx_fstat(int fd, FAR struct stat *buf)
   int ret;
 
   /* First, get the file structure.  Note that on failure,
-   * fs_getfilep() will return the errno.
+   * file_get() will return the errno.
    */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret >= 0)
     {
       /* Perform the fstat operation */
 
       ret = file_fstat(filep, buf);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   return ret;

--- a/fs/vfs/fs_fstatfs.c
+++ b/fs/vfs/fs_fstatfs.c
@@ -67,10 +67,10 @@ int fstatfs(int fd, FAR struct statfs *buf)
   DEBUGASSERT(buf != NULL);
 
   /* First, get the file structure.  Note that on failure,
-   * fs_getfilep() will return the errno.
+   * file_get() will return the errno.
    */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -113,7 +113,7 @@ int fstatfs(int fd, FAR struct statfs *buf)
 
   /* Check if the fstat operation was successful */
 
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret >= 0)
     {
       /* Successfully statfs'ed the file */

--- a/fs/vfs/fs_fsync.c
+++ b/fs/vfs/fs_fsync.c
@@ -106,7 +106,7 @@ int fsync(int fd)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -115,7 +115,7 @@ int fsync(int fd)
   /* Perform the fsync operation */
 
   ret = file_fsync(filep);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       goto errout;

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -89,22 +89,6 @@ static int file_vioctl(FAR struct file *filep, int req, va_list ap)
           }
         break;
 
-      case FIOCLEX:
-        if (ret == OK || ret == -ENOTTY)
-          {
-            filep->f_oflags |= O_CLOEXEC;
-            ret = OK;
-          }
-        break;
-
-      case FIONCLEX:
-        if (ret == OK || ret == -ENOTTY)
-          {
-            filep->f_oflags &= ~O_CLOEXEC;
-            ret = OK;
-          }
-        break;
-
       case FIOC_FILEPATH:
         if (ret == -ENOTTY && !INODE_IS_MOUNTPT(inode))
           {
@@ -134,30 +118,6 @@ static int file_vioctl(FAR struct file *filep, int req, va_list ap)
                              false);
           }
         break;
-
-#ifdef CONFIG_FDSAN
-      case FIOC_SETTAG_FDSAN:
-        filep->f_tag_fdsan = *(FAR uint64_t *)arg;
-        ret = OK;
-        break;
-
-      case FIOC_GETTAG_FDSAN:
-        *(FAR uint64_t *)arg = filep->f_tag_fdsan;
-        ret = OK;
-        break;
-#endif
-
-#ifdef CONFIG_FDCHECK
-      case FIOC_SETTAG_FDCHECK:
-        filep->f_tag_fdcheck = *(FAR uint8_t *)arg;
-        ret = OK;
-        break;
-
-      case FIOC_GETTAG_FDCHECK:
-        *(FAR uint8_t *)arg = filep->f_tag_fdcheck;
-        ret = OK;
-        break;
-#endif
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
       case BIOC_BLKSSZGET:
@@ -191,6 +151,65 @@ static int file_vioctl(FAR struct file *filep, int req, va_list ap)
 #endif
     }
 
+  return ret;
+}
+
+/****************************************************************************
+ * Name: nx_vioctl
+ ****************************************************************************/
+
+static int nx_vioctl(int fd, int req, va_list ap)
+{
+  FAR struct file *filep;
+  FAR struct fd *fdp;
+  int ret;
+
+  ret = file_get2(fd, &filep, &fdp);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  switch (req)
+    {
+      case FIOCLEX:
+        fdp->f_cloexec = true;
+        break;
+
+      case FIONCLEX:
+        fdp->f_cloexec = false;
+        break;
+
+      case FIOGCLEX:
+        *va_arg(ap, FAR int *) = fdp->f_cloexec ? O_CLOEXEC : 0;
+        break;
+
+#ifdef CONFIG_FDSAN
+      case FIOC_SETTAG_FDSAN:
+        fdp->f_tag_fdsan = *va_arg(ap, FAR uint64_t *);
+        break;
+
+      case FIOC_GETTAG_FDSAN:
+        *va_arg(ap, FAR uint64_t *) = fdp->f_tag_fdsan;
+        break;
+#endif
+
+#ifdef CONFIG_FDCHECK
+      case FIOC_SETTAG_FDCHECK:
+        fdp->f_tag_fdcheck = *va_arg(ap, FAR uint8_t *);
+        break;
+
+      case FIOC_GETTAG_FDCHECK:
+        *va_arg(ap, FAR uint8_t *) = fdp->f_tag_fdcheck;
+        break;
+#endif
+
+      default:
+        ret = file_vioctl(filep, req, ap);
+        break;
+    }
+
+  file_put(filep);
   return ret;
 }
 
@@ -260,33 +279,21 @@ int file_ioctl(FAR struct file *filep, int req, ...)
 
 int ioctl(int fd, int req, ...)
 {
-  FAR struct file *filep;
   va_list ap;
   int ret;
 
-  /* Get the file structure corresponding to the file descriptor. */
+  va_start(ap, req);
 
-  ret = file_get(fd, &filep);
+  /* Let nx_vioctl() do the real work. */
+
+  ret = nx_vioctl(fd, req, ap);
   if (ret < 0)
     {
-      goto err;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
-  /* Let file_vioctl() do the real work. */
-
-  va_start(ap, req);
-  ret = file_vioctl(filep, req, ap);
   va_end(ap);
 
-  file_put(filep);
-  if (ret < 0)
-    {
-      goto err;
-    }
-
   return ret;
-
-err:
-  set_errno(-ret);
-  return ERROR;
 }

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -266,7 +266,7 @@ int ioctl(int fd, int req, ...)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto err;
@@ -278,7 +278,7 @@ int ioctl(int fd, int req, ...)
   ret = file_vioctl(filep, req, ap);
   va_end(ap);
 
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       goto err;

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -732,7 +732,7 @@ retry:
 
   /* Update filep lock state */
 
-  filep->locked = true;
+  filep->f_locked = true;
 
   /* When there is a lock change, we need to wake up the blocking lock */
 
@@ -770,7 +770,7 @@ void file_closelk(FAR struct file *filep)
   bool deleted = false;
   int ret;
 
-  if (!filep->locked)
+  if (!filep->f_locked)
     {
       return;
     }
@@ -807,7 +807,7 @@ void file_closelk(FAR struct file *filep)
         {
           deleted = true;
           file_lock_delete(file_lock);
-          filep->locked = false;
+          filep->f_locked = false;
         }
     }
 

--- a/fs/vfs/fs_lseek.c
+++ b/fs/vfs/fs_lseek.c
@@ -127,7 +127,7 @@ off_t nx_seek(int fd, off_t offset, int whence)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       return ret;
@@ -136,7 +136,7 @@ off_t nx_seek(int fd, off_t offset, int whence)
   /* Then let file_seek do the real work */
 
   ret = file_seek(filep, offset, whence);
-  fs_putfilep(filep);
+  file_put(filep);
   return ret;
 }
 

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -82,7 +82,7 @@ static inline void poll_teardown(FAR struct pollfd *fds, nfds_t nfds,
           FAR struct file *filep;
           int ret;
 
-          ret = fs_getfilep(fds[i].fd, &filep);
+          ret = file_get(fds[i].fd, &filep);
           if (ret >= 0)
             {
               ret = file_poll(filep, &fds[i], false);
@@ -92,8 +92,8 @@ static inline void poll_teardown(FAR struct pollfd *fds, nfds_t nfds,
                * before the poll.
                */
 
-              fs_putfilep(filep);
-              fs_putfilep(filep);
+              file_put(filep);
+              file_put(filep);
             }
 
           if (ret < 0)
@@ -163,7 +163,7 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
           FAR struct file *filep;
           int num = i;
 
-          ret = fs_getfilep(fds[i].fd, &filep);
+          ret = file_get(fds[i].fd, &filep);
           if (ret < 0)
             {
               num -= 1;

--- a/fs/vfs/fs_pread.c
+++ b/fs/vfs/fs_pread.c
@@ -134,7 +134,7 @@ ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = (ssize_t)fs_getfilep(fd, &filep);
+  ret = (ssize_t)file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -143,7 +143,7 @@ ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset)
   /* Let file_pread do the real work */
 
   ret = file_pread(filep, buf, nbytes, offset);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       goto errout;

--- a/fs/vfs/fs_pseudofile.c
+++ b/fs/vfs/fs_pseudofile.c
@@ -493,6 +493,7 @@ int pseudofile_create(FAR struct inode **node, FAR const char *path,
   (*node)->i_flags = 1;
   (*node)->u.i_ops = &g_pseudofile_ops;
   (*node)->i_private = pf;
+  atomic_fetch_add(&(*node)->i_crefs, 1);
 
   inode_unlock();
 #ifdef CONFIG_FS_NOTIFY

--- a/fs/vfs/fs_pwrite.c
+++ b/fs/vfs/fs_pwrite.c
@@ -137,7 +137,7 @@ ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = (ssize_t)fs_getfilep(fd, &filep);
+  ret = (ssize_t)file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -146,7 +146,7 @@ ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset)
   /* Let file_pwrite do the real work */
 
   ret = file_pwrite(filep, buf, nbytes, offset);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret < 0)
     {
       goto errout;

--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -293,17 +293,17 @@ ssize_t nx_readv(int fd, FAR const struct iovec *iov, int iovcnt)
   ssize_t ret;
 
   /* First, get the file structure.  Note that on failure,
-   * fs_getfilep() will return the errno.
+   * file_get() will return the errno.
    */
 
-  ret = (ssize_t)fs_getfilep(fd, &filep);
+  ret = (ssize_t)file_get(fd, &filep);
   if (ret >= 0)
     {
       /* Then let file_readv do all of the work. */
 
       ret = file_readv(filep, iov, iovcnt);
 
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   return ret;

--- a/fs/vfs/fs_sendfile.c
+++ b/fs/vfs/fs_sendfile.c
@@ -337,22 +337,22 @@ ssize_t sendfile(int outfd, int infd, FAR off_t *offset, size_t count)
   FAR struct file *infile;
   int ret;
 
-  ret = fs_getfilep(outfd, &outfile);
+  ret = file_get(outfd, &outfile);
   if (ret < 0)
     {
       goto errout;
     }
 
-  ret = fs_getfilep(infd, &infile);
+  ret = file_get(infd, &infile);
   if (ret < 0)
     {
-      fs_putfilep(outfile);
+      file_put(outfile);
       goto errout;
     }
 
   ret = file_sendfile(outfile, infile, offset, count);
-  fs_putfilep(outfile);
-  fs_putfilep(infile);
+  file_put(outfile);
+  file_put(infile);
   if (ret < 0)
     {
       goto errout;

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -352,8 +352,8 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
       nxmutex_init(&dev->mutex);
 
-      fd = file_allocate(&g_signalfd_inode, O_RDOK | flags,
-                         0, dev, 0, true);
+      fd = file_allocate_from_inode(&g_signalfd_inode, O_RDOK | flags,
+                                    0, dev, 0);
       if (fd < 0)
         {
           ret = -fd;

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -364,7 +364,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
     }
   else
     {
-      if (fs_getfilep(fd, &filep) < 0)
+      if (file_get(fd, &filep) < 0)
         {
           ret = EBADF;
           goto errout;
@@ -372,7 +372,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
       if (filep->f_inode->u.i_ops != &g_signalfd_fileops)
         {
-          fs_putfilep(filep);
+          file_put(filep);
           goto errout;
         }
 
@@ -402,7 +402,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
   if (filep != NULL)
     {
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   return fd;

--- a/fs/vfs/fs_syncfs.c
+++ b/fs/vfs/fs_syncfs.c
@@ -84,11 +84,11 @@ int syncfs(int fd)
 
   enter_cancellation_point();
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret == OK)
     {
       ret = file_syncfs(filep);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   leave_cancellation_point();

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -509,7 +509,7 @@ int timerfd_settime(int fd, int flags,
 
   /* Get file pointer by file descriptor */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -557,7 +557,7 @@ int timerfd_settime(int fd, int flags,
   if (new_value->it_value.tv_sec <= 0 && new_value->it_value.tv_nsec <= 0)
     {
       leave_critical_section(intflags);
-      fs_putfilep(filep);
+      file_put(filep);
       return OK;
     }
 
@@ -607,11 +607,11 @@ int timerfd_settime(int fd, int flags,
     }
 
   leave_critical_section(intflags);
-  fs_putfilep(filep);
+  file_put(filep);
   return OK;
 
 errout_with_filep:
-  fs_putfilep(filep);
+  file_put(filep);
 errout:
   set_errno(-ret);
   return ERROR;
@@ -634,7 +634,7 @@ int timerfd_gettime(int fd, FAR struct itimerspec *curr_value)
 
   /* Get file pointer by file descriptor */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       goto errout;
@@ -642,7 +642,7 @@ int timerfd_gettime(int fd, FAR struct itimerspec *curr_value)
 
   if (filep->f_inode->u.i_ops != &g_timerfd_fops)
     {
-      fs_putfilep(filep);
+      file_put(filep);
       goto errout;
     }
 
@@ -656,7 +656,7 @@ int timerfd_gettime(int fd, FAR struct itimerspec *curr_value)
 
   clock_ticks2time(&curr_value->it_value, ticks);
   clock_ticks2time(&curr_value->it_interval, dev->delay);
-  fs_putfilep(filep);
+  file_put(filep);
   return OK;
 
 errout:

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -462,8 +462,8 @@ int timerfd_create(int clockid, int flags)
   /* Initialize the timer instance */
 
   new_dev->clock = clockid;
-  new_fd = file_allocate(&g_timerfd_inode, O_RDONLY | flags,
-                         0, new_dev, 0, true);
+  new_fd = file_allocate_from_inode(&g_timerfd_inode, O_RDONLY | flags,
+                                    0, new_dev, 0);
   if (new_fd < 0)
     {
       ret = new_fd;

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -170,7 +170,7 @@ int ftruncate(int fd, off_t length)
 
   /* Get the file structure corresponding to the file descriptor. */
 
-  ret = fs_getfilep(fd, &filep);
+  ret = file_get(fd, &filep);
   if (ret < 0)
     {
       ferr("ERROR: Could no get file structure: %d\n", ret);
@@ -180,7 +180,7 @@ int ftruncate(int fd, off_t length)
   /* Perform the truncate operation */
 
   ret = file_truncate(filep, length);
-  fs_putfilep(filep);
+  file_put(filep);
   if (ret >= 0)
     {
 #ifdef CONFIG_FS_NOTIFY

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -276,10 +276,10 @@ ssize_t nx_writev(int fd, FAR const struct iovec *iov, int iovcnt)
   ssize_t ret;
 
   /* First, get the file structure.
-   * Note that fs_getfilep() will return the errno on failure.
+   * Note that file_get() will return the errno on failure.
    */
 
-  ret = (ssize_t)fs_getfilep(fd, &filep);
+  ret = (ssize_t)file_get(fd, &filep);
   if (ret >= 0)
     {
       /* Perform the write operation using the file descriptor as an
@@ -288,7 +288,7 @@ ssize_t nx_writev(int fd, FAR const struct iovec *iov, int iovcnt)
 
       ret = file_writev(filep, iov, iovcnt);
 
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   return ret;

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -477,7 +477,7 @@ struct file
 #endif
 
 #if CONFIG_FS_LOCK_BUCKET_SIZE > 0
-  bool              locked; /* Filelock state: false - unlocked, true - locked */
+  bool              f_locked; /* Filelock state: false - unlocked, true - locked */
 #endif
 };
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -460,9 +460,7 @@ typedef struct cookie_io_functions_t
 struct file
 {
   int               f_oflags;   /* Open mode flags */
-#ifdef CONFIG_FS_REFCOUNT
   atomic_t          f_refs;     /* Reference count */
-#endif
   off_t             f_pos;      /* File position */
   FAR struct inode *f_inode;    /* Driver or file system interface */
   FAR void         *f_priv;     /* Per file driver private data */
@@ -1221,11 +1219,7 @@ void fs_reffilep(FAR struct file *filep);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_FS_REFCOUNT
 int fs_putfilep(FAR struct file *filep);
-#else
-#  define fs_putfilep(f)
-#endif
 
 /****************************************************************************
  * Name: file_close

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1028,6 +1028,27 @@ int file_dup(FAR struct file *filep, int minfd, int flags);
 int file_dup2(FAR struct file *filep1, FAR struct file *filep2);
 
 /****************************************************************************
+ * Name: nx_dup3_from_tcb
+ *
+ * Description:
+ *   nx_dup3_from_tcb() is similar to the standard 'dup3' interface
+ *   except that is not a cancellation point and it does not modify the
+ *   errno variable.
+ *
+ *   nx_dup3_from_tcb() is an internal NuttX interface and should not be
+ *   called from applications.
+ *
+ *   Clone a file descriptor to a specific descriptor number.
+ *
+ * Returned Value:
+ *   fd2 is returned on success; a negated errno value is return on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int nx_dup3_from_tcb(FAR struct tcb_s *tcb, int fd1, int fd2, int flags);
+
+/****************************************************************************
  * Name: nx_dup2_from_tcb
  *
  * Description:

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1171,7 +1171,7 @@ int nx_open_from_tcb(FAR struct tcb_s *tcb,
 int nx_open(FAR const char *path, int oflags, ...);
 
 /****************************************************************************
- * Name: fs_getfilep
+ * Name: file_get
  *
  * Description:
  *   Given a file descriptor, return the corresponding instance of struct
@@ -1188,10 +1188,10 @@ int nx_open(FAR const char *path, int oflags, ...);
  *
  ****************************************************************************/
 
-int fs_getfilep(int fd, FAR struct file **filep);
+int file_get(int fd, FAR struct file **filep);
 
 /****************************************************************************
- * Name: fs_reffilep
+ * Name: file_ref
  *
  * Description:
  *   To specify filep increase the reference count.
@@ -1204,10 +1204,10 @@ int fs_getfilep(int fd, FAR struct file **filep);
  *
  ****************************************************************************/
 
-void fs_reffilep(FAR struct file *filep);
+void file_ref(FAR struct file *filep);
 
 /****************************************************************************
- * Name: fs_putfilep
+ * Name: file_put
  *
  * Description:
  *   Release reference counts for files, less than or equal to 0 and close
@@ -1219,7 +1219,7 @@ void fs_reffilep(FAR struct file *filep);
  *
  ****************************************************************************/
 
-int fs_putfilep(FAR struct file *filep);
+int file_put(FAR struct file *filep);
 
 /****************************************************************************
  * Name: file_close

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -235,6 +235,16 @@
                                            * OUT: Current file xip base address
                                            */
 
+#define FIOC_GETFLAGS       _FIOC(0x0016) /* IN:  None
+                                           * OUT: None
+                                           */
+#define FIOC_SETFLAGS       _FIOC(0x0017) /* IN:  The flags that need to set to file
+                                           * OUT: None
+                                           */
+#define FIOGCLEX            _FIOC(0x0018) /* IN:  FAR int *
+                                           * OUT: None
+                                           */
+
 /* NuttX file system ioctl definitions **************************************/
 
 #define _DIOCVALID(c)   (_IOC_TYPE(c)==_DIOCBASE)

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -539,7 +539,7 @@ struct task_group_s
 
   /* File descriptors *******************************************************/
 
-  struct filelist tg_filelist;      /* Maps file descriptor to file         */
+  struct fdlist tg_fdlist;          /* Maps file descriptor to file         */
 
   /* Virtual memory mapping info ********************************************/
 
@@ -932,10 +932,10 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype);
  */
 
 /****************************************************************************
- * Name: nxsched_get_files_from_tcb
+ * Name: nxsched_get_fdlist_from_tcb
  *
  * Description:
- *   Return a pointer to the file list from task context
+ *   Return a pointer to the file descriptor list from task context.
  *
  * Input Parameters:
  *   tcb - Address of the new task's TCB
@@ -947,25 +947,25 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype);
  *
  ****************************************************************************/
 
-FAR struct filelist *nxsched_get_files_from_tcb(FAR struct tcb_s *tcb);
+FAR struct fdlist *nxsched_get_fdlist_from_tcb(FAR struct tcb_s *tcb);
 
 /****************************************************************************
- * Name: nxsched_get_files
+ * Name: nxsched_get_fdlist
  *
  * Description:
- *   Return a pointer to the file list for this thread
+ *   Return a pointer to the file descriptor list for this thread.
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   A pointer to the errno.
+ *   A pointer to the file descriptor list.
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-FAR struct filelist *nxsched_get_files(void);
+FAR struct fdlist *nxsched_get_fdlist(void);
 
 /****************************************************************************
  * Name: nxtask_init

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -404,6 +404,8 @@ static inline_function void spin_unlock(FAR volatile spinlock_t *lock)
 #  else
 #    define spin_unlock(l)  do { *(l) = SP_UNLOCKED; } while (0)
 #  endif
+#else
+#  define spin_unlock(lock)
 #endif /* CONFIG_SPINLOCK */
 
 /****************************************************************************

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -111,7 +111,7 @@ static int local_sendctl(FAR struct local_conn_s *conn,
 
       for (i = 0; i < count; i++)
         {
-          ret = fs_getfilep(fds[i], &filep);
+          ret = file_get(fds[i], &filep);
           if (ret < 0)
             {
               goto fail;
@@ -120,13 +120,13 @@ static int local_sendctl(FAR struct local_conn_s *conn,
           filep2 = kmm_zalloc(sizeof(*filep2));
           if (!filep2)
             {
-              fs_putfilep(filep);
+              file_put(filep);
               ret = -ENOMEM;
               goto fail;
             }
 
           ret = file_dup2(filep, filep2);
-          fs_putfilep(filep);
+          file_put(filep);
           if (ret < 0)
             {
               kmm_free(filep2);

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -164,7 +164,7 @@ int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
   if (ret == OK)
     {
       ret = psock_bind(psock, addr, addrlen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -241,7 +241,7 @@ int connect(int sockfd, FAR const struct sockaddr *addr, socklen_t addrlen)
   if (ret == OK)
     {
       ret = psock_connect(psock, addr, addrlen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -160,7 +160,7 @@ int getpeername(int sockfd, FAR struct sockaddr *addr,
   if (ret == OK)
     {
       ret = psock_getpeername(psock, addr, addrlen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -158,7 +158,7 @@ int getsockname(int sockfd, FAR struct sockaddr *addr,
   if (ret == OK)
     {
       ret = psock_getsockname(psock, addr, addrlen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -365,7 +365,7 @@ int getsockopt(int sockfd, int level, int option,
   if (ret == OK)
     {
       ret = psock_getsockopt(psock, level, option, value, value_len);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -154,7 +154,7 @@ int listen(int sockfd, int backlog)
   if (ret == OK)
     {
       ret = psock_listen(psock, backlog);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -200,7 +200,7 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
   if (ret == OK)
     {
       ret = psock_recvfrom(psock, buf, len, flags, from, fromlen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
 #ifdef CONFIG_BUILD_KERNEL

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -179,7 +179,7 @@ ssize_t recvmsg(int sockfd, FAR struct msghdr *msg, int flags)
   if (ret == OK)
     {
       ret = psock_recvmsg(psock, msg, flags);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/sendmsg.c
+++ b/net/socket/sendmsg.c
@@ -158,7 +158,7 @@ ssize_t sendmsg(int sockfd, FAR struct msghdr *msg, int flags)
   if (ret == OK)
     {
       ret = psock_sendmsg(psock, msg, flags);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -245,7 +245,7 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
   if (ret == OK)
     {
       ret = psock_sendto(psock, buf, len, flags, to, tolen);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
 #ifdef CONFIG_BUILD_KERNEL

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -401,7 +401,7 @@ int setsockopt(int sockfd, int level, int option, const void *value,
   if (ret == OK)
     {
       ret = psock_setsockopt(psock, level, option, value, value_len);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/net/socket/shutdown.c
+++ b/net/socket/shutdown.c
@@ -141,7 +141,7 @@ int shutdown(int sockfd, int how)
   if (ret == OK)
     {
       ret = psock_shutdown(psock, how);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 
   if (ret < 0)

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -168,7 +168,7 @@ int group_initialize(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   /* Initialize file descriptors for the TCB */
 
-  files_initlist(&group->tg_filelist);
+  fdlist_init(&group->tg_fdlist);
 
   /* Alloc task info for group  */
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -102,7 +102,7 @@ group_release(FAR struct task_group_s *group, uint8_t ttype)
 
   /* Free resources held by the file descriptor list */
 
-  files_putlist(&group->tg_filelist);
+  fdlist_free(&group->tg_fdlist);
 
 #ifndef CONFIG_DISABLE_ENVIRON
   /* Release all shared environment variables */

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -83,8 +83,8 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb,
 
   if (group != rtcb->group)
     {
-      files_duplist(&rtcb->group->tg_filelist,
-                    &group->tg_filelist, actions, cloexec);
+      ret = fdlist_copy(&rtcb->group->tg_fdlist,
+                        &group->tg_fdlist, actions, cloexec);
     }
 
   if (ret >= 0 && actions != NULL)

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -456,10 +456,10 @@ static void dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_DUMP_ON_EXIT
-static void dump_filelist(FAR struct tcb_s *tcb, FAR void *arg)
+static void dump_fdlist(FAR struct tcb_s *tcb, FAR void *arg)
 {
-  FAR struct filelist *filelist = &tcb->group->tg_filelist;
-  files_dumplist(filelist);
+  FAR struct fdlist *list = &tcb->group->tg_fdlist;
+  fdlist_dump(list);
 }
 #endif
 
@@ -548,7 +548,7 @@ static void dump_tasks(void)
 #endif
 
 #ifdef CONFIG_SCHED_DUMP_ON_EXIT
-  nxsched_foreach(dump_filelist, NULL);
+  nxsched_foreach(dump_fdlist, NULL);
 #endif
 }
 

--- a/sched/mqueue/mq_getattr.c
+++ b/sched/mqueue/mq_getattr.c
@@ -105,11 +105,11 @@ int mq_getattr(mqd_t mqdes, struct mq_attr *mq_stat)
   FAR struct file *filep;
   int ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret >= 0)
     {
       ret = file_mq_getattr(filep, mq_stat);
-      fs_putfilep(filep);
+      file_put(filep);
       if (ret >= 0)
         {
           return OK;

--- a/sched/mqueue/mq_notify.c
+++ b/sched/mqueue/mq_notify.c
@@ -104,7 +104,7 @@ int mq_notify(mqd_t mqdes, FAR const struct sigevent *notification)
   irqstate_t flags;
   int errval;
 
-  errval = fs_getfilep(mqdes, &filep);
+  errval = file_get(mqdes, &filep);
   if (errval < 0)
     {
       errval = -errval;
@@ -184,14 +184,14 @@ int mq_notify(mqd_t mqdes, FAR const struct sigevent *notification)
     }
 
   leave_critical_section(flags);
-  fs_putfilep(filep);
+  file_put(filep);
   return OK;
 
 errout:
   leave_critical_section(flags);
 
 errout_with_filep:
-  fs_putfilep(filep);
+  file_put(filep);
 
 errout_without_lock:
   set_errno(errval);

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -371,14 +371,14 @@ ssize_t nxmq_timedreceive(mqd_t mqdes, FAR char *msg, size_t msglen,
   FAR struct file *filep;
   ssize_t ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret < 0)
     {
       return ret;
     }
 
   ret = file_mq_timedreceive_internal(filep, msg, msglen, prio, abstime, -1);
-  fs_putfilep(filep);
+  file_put(filep);
   return ret;
 }
 
@@ -521,14 +521,14 @@ ssize_t nxmq_receive(mqd_t mqdes, FAR char *msg, size_t msglen,
   FAR struct file *filep;
   ssize_t ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret < 0)
     {
       return ret;
     }
 
   ret = file_mq_receive(filep, msg, msglen, prio);
-  fs_putfilep(filep);
+  file_put(filep);
   return ret;
 }
 

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -519,14 +519,14 @@ int nxmq_timedsend(mqd_t mqdes, FAR const char *msg, size_t msglen,
   FAR struct file *filep;
   int ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret < 0)
     {
       return ret;
     }
 
   ret = file_mq_timedsend_internal(filep, msg, msglen, prio, abstime, -1);
-  fs_putfilep(filep);
+  file_put(filep);
   return ret;
 }
 
@@ -671,14 +671,14 @@ int nxmq_send(mqd_t mqdes, FAR const char *msg, size_t msglen,
   FAR struct file *filep;
   int ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret < 0)
     {
       return ret;
     }
 
   ret = file_mq_timedsend_internal(filep, msg, msglen, prio, NULL, -1);
-  fs_putfilep(filep);
+  file_put(filep);
   return ret;
 }
 

--- a/sched/mqueue/mq_setattr.c
+++ b/sched/mqueue/mq_setattr.c
@@ -117,11 +117,11 @@ int mq_setattr(mqd_t mqdes, const struct mq_attr *mq_stat,
   FAR struct file *filep;
   int ret;
 
-  ret = fs_getfilep(mqdes, &filep);
+  ret = file_get(mqdes, &filep);
   if (ret >= 0)
     {
       ret = file_mq_setattr(filep, mq_stat, oldstat);
-      fs_putfilep(filep);
+      file_put(filep);
       if (ret >= 0)
         {
           return OK;

--- a/sched/sched/sched_getfiles.c
+++ b/sched/sched/sched_getfiles.c
@@ -33,22 +33,22 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxsched_get_files_from_tcb
+ * Name: nxsched_get_fdlist_from_tcb
  *
  * Description:
- *   Return a pointer to the file list from task context
+ *   Return a pointer to the file descriptor list from task context.
  *
  * Input Parameters:
  *   tcb - Address of the new task's TCB
  *
  * Returned Value:
- *   A pointer to the errno.
+ *   A pointer to the file descriptor list.
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-FAR struct filelist *nxsched_get_files_from_tcb(FAR struct tcb_s *tcb)
+FAR struct fdlist *nxsched_get_fdlist_from_tcb(FAR struct tcb_s *tcb)
 {
   FAR struct task_group_s *group = tcb->group;
 
@@ -60,7 +60,7 @@ FAR struct filelist *nxsched_get_files_from_tcb(FAR struct tcb_s *tcb)
 
   if (group)
     {
-      return &group->tg_filelist;
+      return &group->tg_fdlist;
     }
 
   /* Higher level logic must handle the NULL gracefully */
@@ -69,22 +69,22 @@ FAR struct filelist *nxsched_get_files_from_tcb(FAR struct tcb_s *tcb)
 }
 
 /****************************************************************************
- * Name: nxsched_get_files
+ * Name: nxsched_get_fdlist
  *
  * Description:
- *   Return a pointer to the file list for this thread
+ *   Return a pointer to the file descriptor list for this thread.
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   A pointer to the errno.
+ *   A pointer to the file descriptor list.
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-FAR struct filelist *nxsched_get_files(void)
+FAR struct fdlist *nxsched_get_fdlist(void)
 {
-  return nxsched_get_files_from_tcb(this_task());
+  return nxsched_get_fdlist_from_tcb(this_task());
 }

--- a/tools/pynuttx/nxgdb/protocols/fs.py
+++ b/tools/pynuttx/nxgdb/protocols/fs.py
@@ -23,6 +23,16 @@
 from .value import Value
 
 
+class Fd(Value):
+    """struct fd"""
+
+    f_file: Value
+    f_cloexec: Value
+    f_tag_fdcheck: Value
+    f_tag_fdsan: Value
+    f_backtrace: Value
+
+
 class File(Value):
     """struct file"""
 
@@ -31,9 +41,6 @@ class File(Value):
     f_pos: Value
     f_inode: Value
     f_priv: Value
-    f_tag_fdsan: Value
-    f_tag_fdcheck: Value
-    f_backtrace: Value
     f_locked: Value
 
 
@@ -58,8 +65,8 @@ class Inode(Value):
     i_name: Value
 
 
-class FileList(Value):
-    """struct filelist_s"""
+class FdList(Value):
+    """struct fdlist"""
 
     fl_rows: Value
-    fl_files: Value
+    fl_fds: Value

--- a/tools/pynuttx/nxgdb/protocols/fs.py
+++ b/tools/pynuttx/nxgdb/protocols/fs.py
@@ -34,7 +34,7 @@ class File(Value):
     f_tag_fdsan: Value
     f_tag_fdcheck: Value
     f_backtrace: Value
-    locked: Value
+    f_locked: Value
 
 
 class Inode(Value):

--- a/tools/pynuttx/nxgdb/protocols/thread.py
+++ b/tools/pynuttx/nxgdb/protocols/thread.py
@@ -20,7 +20,7 @@
 #
 ############################################################################
 
-from .fs import FileList
+from .fs import FdList
 from .value import Value
 
 
@@ -52,7 +52,7 @@ class Group(Value):
     tg_envp: Value
     tg_envc: Value
     itimer: Value
-    tg_filelist: FileList
+    tg_fdlist: FdList
     tg_mm_map: Value
 
 


### PR DESCRIPTION
## Summary

This PR is a rework of the NuttX file descriptor implementation. The
goal is two-fold:

Improve POSIX compliance. The old implementation tied file description
to inode only, not the file struct. POSIX however dictates otherwise.
Fix a bug with descriptor duplication (dup2() and dup3()). There is
an existing race condition with this POSIX API that currently results
in a kernel side crash.
The crash occurs when a partially open / closed file descriptor is
duplicated. The reason for the crash is that even if the descriptor is
closed, the file might still be in use by the kernel (due to e.g. ongoing
write to file). The open file data is changed by file_dup3() and this
causes a crash in the device / drivers themselves as they lose access to
the inode and private data.

The fix is done by separating struct file into file and file descriptor
structs. The file struct can live on even if the descriptor is closed,
fixing the crash. This also fixes the POSIX issue, as two descriptors
can now point to the same file.

The implementation of this PR is based on the modifications made in https://github.com/apache/nuttx/pull/16361.
Thank you @pussuw

DEPENDS ON: https://github.com/apache/nuttx-apps/pull/3091

## Impact

RELEASE

## Testing

CI