### PR TITLE
Add a header file as a dependency

### DIFF
--- a/include/nuttx/sensors/cxd5602pwbimu.h
+++ b/include/nuttx/sensors/cxd5602pwbimu.h
@@ -30,7 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/fs/ioctl.h>
 #include <sys/types.h>
-
+#include <nuttx/irq.h>
 #include <nuttx/spi/spi.h>
 #include <nuttx/i2c/i2c_master.h>
 


### PR DESCRIPTION
## Summary
There is insufficient definition information for a dependency, so add the include header file.

## Impact
Only cases using IMU driver. 

## Testing
Build check.
