### PR TITLE
Fix ILI9342C color inversion on esp32s3-box-3

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
+#include <endian.h>
 #include <sys/param.h>
 
 #include <nuttx/arch.h>
@@ -419,6 +420,11 @@ static int ili9342c_sendgram(struct ili9341_lcd_s *lcd,
                              uint32_t nwords)
 {
   struct ili9342c_lcd_dev *priv = (struct ili9342c_lcd_dev *)lcd;
+
+  for (uint32_t i = 0; i < nwords; i++)
+    {
+      ((uint16_t *)wd)[i] = swap16(wd[i]);
+    }
 
   lcdinfo("lcd:%p, wd=%p, nwords=%" PRIu32 "\n", lcd, wd, nwords);
 


### PR DESCRIPTION
## Summary

When using the ILI9342C LCD on the esp32s3-box-3 development board, the displayed colors are inverted. After investigation, the issue is caused by a byte-order mismatch between the LCD controller (big-endian) and the LVGL graphics library (little-endian).

## Workaround Explanation

This is a temporary solution that manually converts the byte order of color data from little-endian (LVGL default) to big-endian (required by ILI9342C) before transmission.