### PR TITLE
ci: update toolchain for Espressif

### DIFF
--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -20,6 +20,7 @@ ESP32 Toolchain
 ===============
 
 The toolchain used to build ESP32 firmware can be either downloaded or built from the sources.
+
 It is **highly** recommended to use (download or build) the same toolchain version that is being
 used by the NuttX CI.
 
@@ -33,20 +34,12 @@ check for the current compiler version being used. For instance:
   # Build image for tool required by ESP32 builds
   ###############################################################################
   FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
-  # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-  RUN mkdir -p xtensa-esp32-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+  # Download the latest ESP32, ESP32-S2 and ESP32-S3 GCC toolchain prebuilt by Espressif
+  RUN mkdir -p xtensa-esp-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
-  RUN mkdir -p xtensa-esp32s2-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
-
-  RUN mkdir -p xtensa-esp32s3-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
-
-For ESP32, the toolchain version is based on GGC 12.2.0 (``xtensa-esp32-elf-12.2.0_20230208``)
+For ESP32, the toolchain version is based on GGC 14.2.0 (``xtensa-esp-elf-14.2.0_20241119``)
 
 The prebuilt Toolchain (Recommended)
 ------------------------------------
@@ -55,20 +48,20 @@ First, create a directory to hold the toolchain:
 
 .. code-block:: console
 
-  $ mkdir -p /path/to/your/toolchain/xtensa-esp32-elf-gcc
+  $ mkdir -p /path/to/your/toolchain/xtensa-esp-elf-gcc
 
 Download and extract toolchain:
 
 .. code-block:: console
 
-  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
 Add the toolchain to your `PATH`:
 
 .. code-block:: console
 
-  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp32-elf-gcc/bin:$PATH" >> ~/.bashrc
+  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp-elf-gcc/bin:$PATH" >> ~/.bashrc
 
 You can edit your shell's rc files if you don't use bash.
 

--- a/Documentation/platforms/xtensa/esp32s2/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/index.rst
@@ -13,6 +13,7 @@ ESP32-S2 Toolchain
 ==================
 
 The toolchain used to build ESP32-S2 firmware can be either downloaded or built from the sources.
+
 It is **highly** recommended to use (download or build) the same toolchain version that is being
 used by the NuttX CI.
 
@@ -26,20 +27,12 @@ check for the current compiler version being used. For instance:
   # Build image for tool required by ESP32 builds
   ###############################################################################
   FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
-  # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-  RUN mkdir -p xtensa-esp32-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+  # Download the latest ESP32, ESP32-S2 and ESP32-S3 GCC toolchain prebuilt by Espressif
+  RUN mkdir -p xtensa-esp-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
-  RUN mkdir -p xtensa-esp32s2-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
-
-  RUN mkdir -p xtensa-esp32s3-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
-
-For ESP32-S2, the toolchain version is based on GGC 12.2.0 (``xtensa-esp32s2-elf-12.2.0_20230208``)
+For ESP32-S2, the toolchain version is based on GGC 14.2.0 (``xtensa-esp-elf-14.2.0_20241119``)
 
 The prebuilt Toolchain (Recommended)
 ------------------------------------
@@ -48,20 +41,20 @@ First, create a directory to hold the toolchain:
 
 .. code-block:: console
 
-  $ mkdir -p /path/to/your/toolchain/xtensa-esp32s2-elf-gcc
+  $ mkdir -p /path/to/your/toolchain/xtensa-esp-elf-gcc
 
 Download and extract toolchain:
 
 .. code-block:: console
 
-  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
+  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
 Add the toolchain to your `PATH`:
 
 .. code-block:: console
 
-  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp32s2-elf-gcc/bin:$PATH" >> ~/.bashrc
+  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp-elf-gcc/bin:$PATH" >> ~/.bashrc
 
 You can edit your shell's rc files if you don't use bash.
 

--- a/Documentation/platforms/xtensa/esp32s3/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/index.rst
@@ -20,6 +20,7 @@ ESP32-S3 Toolchain
 ==================
 
 The toolchain used to build ESP32-S3 firmware can be either downloaded or built from the sources.
+
 It is **highly** recommended to use (download or build) the same toolchain version that is being
 used by the NuttX CI.
 
@@ -33,20 +34,12 @@ check for the current compiler version being used. For instance:
   # Build image for tool required by ESP32 builds
   ###############################################################################
   FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
-  # Download the latest ESP32 GCC toolchain prebuilt by Espressif
-  RUN mkdir -p xtensa-esp32-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+  # Download the latest ESP32, ESP32-S2 and ESP32-S3 GCC toolchain prebuilt by Espressif
+  RUN mkdir -p xtensa-esp-elf-gcc && \
+    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+    | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
-  RUN mkdir -p xtensa-esp32s2-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
-
-  RUN mkdir -p xtensa-esp32s3-elf-gcc && \
-    curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-    | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
-
-For ESP32-S3, the toolchain version is based on GGC 12.2.0 (``xtensa-esp32s3-elf-12.2.0_20230208``)
+For ESP32-S3, the toolchain version is based on GGC 14.2.0 (``xtensa-esp-elf-14.2.0_20241119``)
 
 The prebuilt Toolchain (Recommended)
 ------------------------------------
@@ -55,20 +48,20 @@ First, create a directory to hold the toolchain:
 
 .. code-block:: console
 
-  $ mkdir -p /path/to/your/toolchain/xtensa-esp32s3-elf-gcc
+  $ mkdir -p /path/to/your/toolchain/xtensa-esp-elf-gcc
 
 Download and extract toolchain:
 
 .. code-block:: console
 
-  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
+  $ curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
 Add the toolchain to your `PATH`:
 
 .. code-block:: console
 
-  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp32s3-elf-gcc/bin:$PATH" >> ~/.bashrc
+  $ echo "export PATH=/path/to/your/toolchain/xtensa-esp-elf-gcc/bin:$PATH" >> ~/.bashrc
 
 You can edit your shell's rc files if you don't use bash.
 

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -259,18 +259,10 @@ RUN mkdir -p sparc-gaisler-elf-gcc && \
 # Build image for tool required by ESP32 builds
 ###############################################################################
 FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
-# Download the latest ESP32 GCC toolchain prebuilt by Espressif
-RUN mkdir -p xtensa-esp32-elf-gcc && \
-  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
-
-RUN mkdir -p xtensa-esp32s2-elf-gcc && \
-  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s2-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xJ
-
-RUN mkdir -p xtensa-esp32s3-elf-gcc && \
-  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-12.2.0_20230208/xtensa-esp32s3-elf-12.2.0_20230208-x86_64-linux-gnu.tar.xz" \
-  | tar -C xtensa-esp32s3-elf-gcc --strip-components 1 -xJ
+# Download the latest ESP32, ESP32-S2 and ESP32-S3 GCC toolchain prebuilt by Espressif
+RUN mkdir -p xtensa-esp-elf-gcc && \
+  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz" \
+  | tar -C xtensa-esp-elf-gcc --strip-components 1 -xJ
 
 RUN echo "ESP Binaries: 2022/01/26"
 RUN mkdir -p /tools/blobs && cd /tools/blobs \
@@ -470,17 +462,9 @@ ENV PATH="/tools/riscv-none-elf-gcc/bin:$PATH"
 COPY --from=nuttx-toolchain-sparc /tools/sparc-gaisler-elf-gcc/ sparc-gaisler-elf-gcc/
 ENV PATH="/tools/sparc-gaisler-elf-gcc/bin:$PATH"
 
-# ESP32 toolchain
-COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32-elf-gcc/ xtensa-esp32-elf-gcc/
-ENV PATH="/tools/xtensa-esp32-elf-gcc/bin:$PATH"
-
-# ESP32-S2 toolchain
-COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32s2-elf-gcc/ xtensa-esp32s2-elf-gcc/
-ENV PATH="/tools/xtensa-esp32s2-elf-gcc/bin:$PATH"
-
-# ESP32-S3 toolchain
-COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32s3-elf-gcc/ xtensa-esp32s3-elf-gcc/
-ENV PATH="/tools/xtensa-esp32s3-elf-gcc/bin:$PATH"
+# ESP32, ESP32-S2, ESP32-S3 toolchain
+COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp-elf-gcc/ xtensa-esp-elf-gcc/
+ENV PATH="/tools/xtensa-esp-elf-gcc/bin:$PATH"
 
 RUN mkdir -p /tools/blobs/esp-bins
 COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/


### PR DESCRIPTION
## Summary

- documentation: update Xtensa ESP32|S2|S3 toolchain version

Updates the instructions to install the ESP toolchain 14.2.0.

- ci: update ESP32 Xtensa compiler version

Updates ESP32, ESP32S2 and ESP32S3 compiler version to 14.2.0 of 20241119.

Hi all,

This PR updates the ESP32, ESP32S2 and ESP32S3 compiler version from version 12.2.0 to 14.2.0.

A difference that might be observed from the previous version is that instead of downloading and extracting one toolchain file for each SoC, we just download one file that contains all toolchains required. That simplifies the CI Dockerfile a little bit but has all xtensa-esp32, xtensa-esp32s2 and xtensa-esp32s3 under one directory.

## Impact

- Impact on user: No.
- Impact on build: Yes, changes the CI build system by updating toolchain version.
- Impact on hardware: No.
- Impact on documentation: Yes, updates documentation for ESP32, ESP32S2 and ESP32S3.
- Impact on security: No.
- Impact on compatibility: No.

## Testing

Built the Dockerfile locally and verified all gcc and g++ are available.

### Building

- cd tools/ci/docker/linux
- docker build -t nuttx-ci .

### Running

- docker run -it nuttx-ci:latest

### Results

```
root@3545c6cdbeff:/tools# xtensa-esp32-elf-gcc --version
xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```

```
root@3545c6cdbeff:/tools# xtensa-esp32-elf-g++ --version
xtensa-esp-elf-g++ (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```

```
root@3545c6cdbeff:/tools# xtensa-esp32s2-elf-gcc --version
xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```

```
root@3545c6cdbeff:/tools# xtensa-esp32s2-elf-g++ --version
xtensa-esp-elf-g++ (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```

```
root@3545c6cdbeff:/tools# xtensa-esp32s3-elf-gcc --version
xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```
```
root@3545c6cdbeff:/tools# xtensa-esp32s3-elf-g++ --version
xtensa-esp-elf-g++ (crosstool-NG esp-14.2.0_20241119) 14.2.0 Copyright (C) 2024 Free Software Foundation, Inc.
```

```
root@3545c6cdbeff:/tools/xtensa-esp-elf-gcc/bin# ls
xtensa-esp-elf-addr2line   xtensa-esp32-elf-addr2line   xtensa-esp32s2-elf-addr2line   xtensa-esp32s3-elf-addr2line
xtensa-esp-elf-ar          xtensa-esp32-elf-ar          xtensa-esp32s2-elf-ar          xtensa-esp32s3-elf-ar
xtensa-esp-elf-as          xtensa-esp32-elf-as          xtensa-esp32s2-elf-as          xtensa-esp32s3-elf-as
xtensa-esp-elf-c++         xtensa-esp32-elf-c++         xtensa-esp32s2-elf-c++         xtensa-esp32s3-elf-c++
xtensa-esp-elf-c++filt     xtensa-esp32-elf-c++filt     xtensa-esp32s2-elf-c++filt     xtensa-esp32s3-elf-c++filt
xtensa-esp-elf-cc          xtensa-esp32-elf-cc          xtensa-esp32s2-elf-cc          xtensa-esp32s3-elf-cc
xtensa-esp-elf-cpp         xtensa-esp32-elf-cpp         xtensa-esp32s2-elf-cpp         xtensa-esp32s3-elf-cpp
xtensa-esp-elf-elfedit     xtensa-esp32-elf-elfedit     xtensa-esp32s2-elf-elfedit     xtensa-esp32s3-elf-elfedit
xtensa-esp-elf-g++         xtensa-esp32-elf-g++         xtensa-esp32s2-elf-g++         xtensa-esp32s3-elf-g++
xtensa-esp-elf-gcc         xtensa-esp32-elf-gcc         xtensa-esp32s2-elf-gcc         xtensa-esp32s3-elf-gcc
xtensa-esp-elf-gcc-14.2.0  xtensa-esp32-elf-gcc-14.2.0  xtensa-esp32s2-elf-gcc-14.2.0  xtensa-esp32s3-elf-gcc-14.2.0
xtensa-esp-elf-gcc-ar      xtensa-esp32-elf-gcc-ar      xtensa-esp32s2-elf-gcc-ar      xtensa-esp32s3-elf-gcc-ar
xtensa-esp-elf-gcc-nm      xtensa-esp32-elf-gcc-nm      xtensa-esp32s2-elf-gcc-nm      xtensa-esp32s3-elf-gcc-nm
xtensa-esp-elf-gcc-ranlib  xtensa-esp32-elf-gcc-ranlib  xtensa-esp32s2-elf-gcc-ranlib  xtensa-esp32s3-elf-gcc-ranlib
xtensa-esp-elf-gcov        xtensa-esp32-elf-gcov        xtensa-esp32s2-elf-gcov        xtensa-esp32s3-elf-gcov
xtensa-esp-elf-gcov-dump   xtensa-esp32-elf-gcov-dump   xtensa-esp32s2-elf-gcov-dump   xtensa-esp32s3-elf-gcov-dump
xtensa-esp-elf-gcov-tool   xtensa-esp32-elf-gcov-tool   xtensa-esp32s2-elf-gcov-tool   xtensa-esp32s3-elf-gcov-tool
xtensa-esp-elf-gprof       xtensa-esp32-elf-gprof       xtensa-esp32s2-elf-gprof       xtensa-esp32s3-elf-gprof
xtensa-esp-elf-ld          xtensa-esp32-elf-ld          xtensa-esp32s2-elf-ld          xtensa-esp32s3-elf-ld
xtensa-esp-elf-ld.bfd      xtensa-esp32-elf-ld.bfd      xtensa-esp32s2-elf-ld.bfd      xtensa-esp32s3-elf-ld.bfd
xtensa-esp-elf-lto-dump    xtensa-esp32-elf-lto-dump    xtensa-esp32s2-elf-lto-dump    xtensa-esp32s3-elf-lto-dump
xtensa-esp-elf-nm          xtensa-esp32-elf-nm          xtensa-esp32s2-elf-nm          xtensa-esp32s3-elf-nm
xtensa-esp-elf-objcopy     xtensa-esp32-elf-objcopy     xtensa-esp32s2-elf-objcopy     xtensa-esp32s3-elf-objcopy
xtensa-esp-elf-objdump     xtensa-esp32-elf-objdump     xtensa-esp32s2-elf-objdump     xtensa-esp32s3-elf-objdump
xtensa-esp-elf-ranlib      xtensa-esp32-elf-ranlib      xtensa-esp32s2-elf-ranlib      xtensa-esp32s3-elf-ranlib
xtensa-esp-elf-readelf     xtensa-esp32-elf-readelf     xtensa-esp32s2-elf-readelf     xtensa-esp32s3-elf-readelf
xtensa-esp-elf-size        xtensa-esp32-elf-size        xtensa-esp32s2-elf-size        xtensa-esp32s3-elf-size
xtensa-esp-elf-strings     xtensa-esp32-elf-strings     xtensa-esp32s2-elf-strings     xtensa-esp32s3-elf-strings
xtensa-esp-elf-strip       xtensa-esp32-elf-strip       xtensa-esp32s2-elf-strip       xtensa-esp32s3-elf-strip
```