### PR TITLE
arch/arm64/fvp-v8r: support cmake compile

### DIFF
--- a/arch/arm64/src/fvp-v8r/CMakeLists.txt
+++ b/arch/arm64/src/fvp-v8r/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ##############################################################################
+# arch/arm64/src/fvp-v8r/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+set(SRCS fvp_boot.c fvp_serial.c fvp_timer.c)
+
+if(CONFIG_ARCH_EARLY_PRINT)
+  list(APPEND SRCS fvp_lowputc.S)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm64/fvp-v8r/fvp-armv8r/CMakeLists.txt
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# boards/arm64/fvp-v8r/fvp-armv8r/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/dramboot.ld")
+
+add_subdirectory(src)

--- a/boards/arm64/fvp-v8r/fvp-armv8r/src/CMakeLists.txt
+++ b/boards/arm64/fvp-v8r/fvp-armv8r/src/CMakeLists.txt
@@ -1,0 +1,28 @@
+# ##############################################################################
+# boards/arm64/fvp-v8r/fvp-armv8r/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+set(SRCS fvp_boardinit.c fvp_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS fvp_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

arm64/fvp-v8r: support cmake compile

## Impact

No

## Testing

ci

