### PR TITLE
Refactored the btuart_rxwork function to improve data reception stability.

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -109,6 +109,7 @@ static void btuart_rxwork(FAR void *arg)
     {
       struct bt_hci_evt_hdr_s evt;
       struct bt_hci_acl_hdr_s acl;
+      struct bt_hci_iso_hdr_s iso;
     }
 
   *hdr;
@@ -156,6 +157,19 @@ static void btuart_rxwork(FAR void *arg)
           type = BT_ACL_IN;
           pktlen = H4_HEADER_SIZE +
                    sizeof(struct bt_hci_acl_hdr_s) + hdr->acl.len;
+          break;
+
+        case H4_ISO:
+          if (upper->rxlen < H4_HEADER_SIZE +
+              sizeof(struct bt_hci_iso_hdr_s))
+            {
+              wlwarn("WARNING: Incomplete HCI ISO header\n");
+              return;
+            }
+
+          type = BT_ISO_IN;
+          pktlen = H4_HEADER_SIZE +
+                   sizeof(struct bt_hci_iso_hdr_s) + hdr->iso.len;
           break;
 
         default:

--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -86,7 +86,7 @@ static ssize_t btuart_read(FAR struct btuart_upperhalf_s *upper,
       else if (nread < 0)
         {
           wlwarn("Returned error %zd\n", nread);
-          return nread;
+          return ntotal > 0 ? ntotal : nread;
         }
 
       wlinfo("read %zd remaining %zu\n", nread, buflen - nread);

--- a/drivers/wireless/bluetooth/bt_uart.h
+++ b/drivers/wireless/bluetooth/bt_uart.h
@@ -75,6 +75,9 @@ struct btuart_upperhalf_s
 
   FAR const struct btuart_lowerhalf_s *lower;
 
+  uint16_t           rxlen;
+  uint8_t            rxbuf[CONFIG_BLUETOOTH_UART_RXBUFSIZE];
+
   /* Work queue support */
 
   struct work_s work;


### PR DESCRIPTION
Read as much data as possible initially, then process each packet individually. Defined the read buffer within the structure and added a rx_len variable to indicate the current read offset. After processing each complete packet, leftover data is moved to rxbuf[0] and rx_len is reduced by the length of the processed packet. The next packet process will start from rxbuf[0] after the read ends at new rxbuf[rx_len].

PR picks from https://github.com/open-vela/nuttx/pull/38