### PR TITLE
imx9/lpuart: Fix race condition / regression in imx9_txint

### DIFF
--- a/arch/arm64/src/imx9/imx9_lpuart.c
+++ b/arch/arm64/src/imx9/imx9_lpuart.c
@@ -2340,6 +2340,13 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   irqstate_t flags;
   uint32_t regval;
 
+#ifndef CONFIG_SUPPRESS_SERIAL_INTS
+  if (enable)
+    {
+      uart_xmitchars(dev);
+    }
+#endif
+
   /* Enable interrupt for TX complete */
 
   flags = spin_lock_irqsave(&priv->lock);
@@ -2359,13 +2366,6 @@ static void imx9_txint(struct uart_dev_s *dev, bool enable)
   regval |= priv->ie;
   imx9_serialout(priv, IMX9_LPUART_CTRL_OFFSET, regval);
   spin_unlock_irqrestore(&priv->lock, flags);
-
-#ifndef CONFIG_SUPPRESS_SERIAL_INTS
-  if (enable)
-    {
-      uart_xmitchars(dev);
-    }
-#endif
 }
 #endif
 


### PR DESCRIPTION
## Summary

Commit 83a119160 fixed SMP by removing call to uart_xmitchars from inside spinlock.

This only works for SMP, since uart_xmitchars has a lock only in SMP and the irq lock is ifdeffed away in a single-core system: https://github.com/apache/nuttx/blob/3d37e85b13fb57ae8f1b8f6917e5aaac918d0982/drivers/serial/serial_io.c#L61 . 

Thus, in a single-core configuration the uart_xmitchars can now be called in parallel from the interrupt handler and from the imx9_txint.

Fix this by filling the uart buffers already before enabling the interrupt, this way it is not possible to get the function called in parallel for the same device.

## Impact

Fixes a regression in lpuart for single-core configuration, due to SMP enabling.

## Testing

Tested on a custom imx93 based device, for both SMP 2 cores and in single-core configurations.
