### PR TITLE
net/arp/arp_table.c:  fix ARP table validity time calculation overflow issue

### DIFF
--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -71,7 +71,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ARP_MAXAGE_TICK SEC2TICK(10 * CONFIG_NET_ARP_MAXAGE)
+#define ARP_MAXAGE_TICK SEC2TICK(10 * (clock_t)CONFIG_NET_ARP_MAXAGE)
 
 /****************************************************************************
  * Private Types


### PR DESCRIPTION
## Summary
net/arp/arp_table.c: prevent overflow in macro expansion when setting a long ARP timeout.
Currently, when tickless mode is enabled, the value of `CONFIG_USEC_PER_TICK=100`. During the macro expansion of `SEC2TICK()`, the calculated value exceeds `UINT32_MAX`, leading to an overflow problem.

## Impact
New Feature/Change: Issue fix (no new feature).
User Impact: Prevent file descriptor leakage.
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
Overflow issue occurred:
SEC2TICK(10*8640)=5006541 
Correctly convert results:
SEC2TICK(10*8640)=864000000
