### PR TITLE
boards/qemu-intel64/qemu.ld: add .lbss, .ldata and .lrodata 

### DIFF
--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu-kernel.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu-kernel.ld
@@ -71,6 +71,7 @@ SECTIONS
     {
         _srodata = ABSOLUTE(.);
         *(.rodata .rodata.*)
+        *(.lrodata .lrodata.*)
         *(.fixup)
         *(.gnu.warning)
         *(.glue_7)
@@ -87,6 +88,7 @@ SECTIONS
     {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
+        *(.ldata .ldata.*)
         *(.gnu.linkonce.d.*)
         CONSTRUCTORS
         . = ALIGN(4);
@@ -104,6 +106,7 @@ SECTIONS
     {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
+        *(.lbss .lbss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
         . = ALIGN(16);

--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
@@ -93,6 +93,7 @@ SECTIONS
     {
         _srodata = ABSOLUTE(.);
         *(.rodata .rodata.*)
+        *(.lrodata .lrodata.*)
         *(.fixup)
         *(.gnu.warning)
         *(.glue_7)
@@ -119,6 +120,7 @@ SECTIONS
     {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)
+        *(.ldata .ldata.*)
         *(.gnu.linkonce.d.*)
         CONSTRUCTORS
         . = ALIGN(4);
@@ -129,6 +131,7 @@ SECTIONS
     {
         _sbss = ABSOLUTE(.);
         *(.bss .bss.*)
+        *(.lbss .lbss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
         . = ALIGN(16);


### PR DESCRIPTION
## Summary

boards/qemu-intel64/qemu.ld: add .lbss, .ldata and .lrodata to approriate sections

These sections can be emited by gcc in some cases for huge data blocks. For  example huge global static uninitialzied arrays can be placed in .lbss section which can mess NuttX memory organization and cause hard to find bugs. Unfortunately this is not well documented in GCC and all we have is this bug report: https://sourceware.org/bugzilla/show_bug.cgi?id=22553

## Impact
bugfix  

## Testing
qemu-x86 and intel hardware



