### PR TITLE
drivers/net: various fixes for e1000 and igc

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -48,12 +48,12 @@
  * Pre-processor Definitions
  *****************************************************************************/
 
-#if CONFIG_NET_E1000_TXDESC % 2 != 0
-#  error CONFIG_NET_E1000_TXDESC must be multiple of 2
+#if CONFIG_NET_E1000_TXDESC % 8 != 0
+#  error CONFIG_NET_E1000_TXDESC must be multiple of 8
 #endif
 
-#if CONFIG_NET_E1000_RXDESC % 2 != 0
-#  error CONFIG_NET_E1000_RXDESC must be multiple of 2
+#if CONFIG_NET_E1000_RXDESC % 8 != 0
+#  error CONFIG_NET_E1000_RXDESC must be multiple of 8
 #endif
 
 /* Packet buffer size */

--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -1168,14 +1168,6 @@ static void e1000_disable(FAR struct e1000_driver_s *priv)
 {
   int i = 0;
 
-  /* Reset Tx tail */
-
-  e1000_txclean(priv);
-
-  /* Reset Rx tail */
-
-  e1000_rxclean(priv);
-
   /* Disable interrupts */
 
   e1000_putreg_mem(priv, E1000_IMC, priv->irqs);
@@ -1188,6 +1180,14 @@ static void e1000_disable(FAR struct e1000_driver_s *priv)
   /* Disable Receiver */
 
   e1000_putreg_mem(priv, E1000_RCTL, 0);
+
+  /* Reset Tx tail */
+
+  e1000_txclean(priv);
+
+  /* Reset Rx tail */
+
+  e1000_rxclean(priv);
 
   /* Free RX packets */
 

--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -1161,7 +1161,8 @@ static int e1000_rmmac(FAR struct netdev_lowerhalf_s *dev,
 
 static void e1000_disable(FAR struct e1000_driver_s *priv)
 {
-  int i = 0;
+  uint32_t regval;
+  int      i = 0;
 
   /* Disable interrupts */
 
@@ -1170,7 +1171,9 @@ static void e1000_disable(FAR struct e1000_driver_s *priv)
 
   /* Disable Transmitter */
 
-  e1000_putreg_mem(priv, E1000_TCTL, 0);
+  regval = e1000_getreg_mem(priv, E1000_TCTL);
+  regval &= ~E1000_TCTL_EN;
+  e1000_putreg_mem(priv, E1000_TCTL, regval);
 
   /* Disable Receiver */
 

--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -757,15 +757,11 @@ static void e1000_link_work(FAR void *arg)
       ninfo("Link up, status = 0x%x\n", tmp);
 
       netdev_lower_carrier_on(&priv->dev);
-
-      /* Clear Tx and RX rings */
-
-      e1000_txclean(priv);
-      e1000_rxclean(priv);
     }
   else
     {
       ninfo("Link down\n");
+
       netdev_lower_carrier_off(&priv->dev);
     }
 }

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -48,12 +48,12 @@
  * Pre-processor Definitions
  *****************************************************************************/
 
-#if CONFIG_NET_IGC_TXDESC % 2 != 0
-#  error CONFIG_NET_IGC_TXDESC must be multiple of 2
+#if CONFIG_NET_IGC_TXDESC % 8 != 0
+#  error CONFIG_NET_IGC_TXDESC must be multiple of 8
 #endif
 
-#if CONFIG_NET_IGC_RXDESC % 2 != 0
-#  error CONFIG_NET_IGC_RXDESC must be multiple of 2
+#if CONFIG_NET_IGC_RXDESC % 8 != 0
+#  error CONFIG_NET_IGC_RXDESC must be multiple of 8
 #endif
 
 /* Packet buffer size */

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -1048,14 +1048,6 @@ static void igc_disable(FAR struct igc_driver_s *priv)
 {
   int i = 0;
 
-  /* Reset Tx tail */
-
-  igc_txclean(priv);
-
-  /* Reset Rx tail */
-
-  igc_rxclean(priv);
-
   /* Disable interrupts */
 
   igc_putreg_mem(priv, IGC_EIMC, IGC_MSIX_EIMS);
@@ -1069,6 +1061,14 @@ static void igc_disable(FAR struct igc_driver_s *priv)
   /* Disable Receiver */
 
   igc_putreg_mem(priv, IGC_RCTL, 0);
+
+  /* Reset Tx tail */
+
+  igc_txclean(priv);
+
+  /* Reset Rx tail */
+
+  igc_rxclean(priv);
 
   /* Free RX packets */
 

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -711,16 +711,13 @@ static void igc_link_work(FAR void *arg)
   if (tmp & IGC_STATUS_LU)
     {
       ninfo("Link up, status = 0x%x\n", tmp);
+
       netdev_lower_carrier_on(&priv->dev);
-
-      /* Clear Tx and RX rings */
-
-      igc_txclean(priv);
-      igc_rxclean(priv);
     }
   else
     {
       ninfo("Link down\n");
+
       netdev_lower_carrier_off(&priv->dev);
     }
 }

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -1042,7 +1042,8 @@ static int igc_rmmac(FAR struct netdev_lowerhalf_s *dev,
 
 static void igc_disable(FAR struct igc_driver_s *priv)
 {
-  int i = 0;
+  uint32_t regval;
+  int      i = 0;
 
   /* Disable interrupts */
 
@@ -1052,7 +1053,9 @@ static void igc_disable(FAR struct igc_driver_s *priv)
 
   /* Disable Transmitter */
 
-  igc_putreg_mem(priv, IGC_TCTL, 0);
+  regval = igc_getreg_mem(priv, IGC_TCTL);
+  regval &= ~IGC_TCTL_EN;
+  igc_putreg_mem(priv, IGC_TCTL, regval);
 
   /* Disable Receiver */
 


### PR DESCRIPTION
## Summary

- drivers/net/{e1000|igc}: reset RX/TX rings after RX/TX disabled  
    reset RX/TX rings **after** RX/TX are disabled to make sure the rings are
    not used by hardware when software modify rings state.
    
- drivers/net/{e1000|igc}: do not touch RX/TX rings when link status change
    Do not reset RX/TX rings when link status change.
    This can break internal card state which is imposible to recovery.
    
-  drivers/net/{e1000|igc}: update link status when card is enabled
    Update link status in case link status interrupt is missing.  

- drivers/net/{e1000|igc}: disable TX by modify only TX enable bit
    disable TX by modify only TX enable bit, otherwise we lose TX configuration
    
- drivers/net/{e1000|igc}: fix reinit for RX/TX rings
    Descriptor head is managed by HW and should not be modified by SW unless:
    1. device is after a reset
    2. device is before enabling TX or RX
    
    Also set correct tail for RX which should point at the end of ring
    (descriptor ring is zero-indexed).
    
- drivers/net/{e1000|igc}: drop TX packets if TX ring is full
    drop TX packets if TX ring is full, so we don't overwrite
    not handled TX descriptors
    
- drivers/net/{e1000|igc}: align descriptors to 8
    A descriptor ring length must be aligned to 128, one descriptor is 16B length,
    so we can provide this condition with the appropriate number of descriptors

## Impact

various fixes for Intel NICs

## Testing

intel HW and qemu


