### PR TITLE
arch/xtensa/esp32s3: Fix syslog output failure on ESP32-S3-Box

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_serial.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_serial.c
@@ -1212,6 +1212,9 @@ void xtensa_serialinit(void)
 
 void up_putc(int ch)
 {
+#ifdef CONFIG_ESP32S3_USBSERIAL
+  esp32s3_usbserial_write(ch);
+#else
 #ifdef CONSOLE_UART
   uint32_t int_status;
 
@@ -1222,6 +1225,7 @@ void up_putc(int ch)
 
 #ifdef CONSOLE_UART
   esp32s3_lowputc_restore_all_uart_int(CONSOLE_DEV.priv, &int_status);
+#endif
 #endif
 }
 


### PR DESCRIPTION
## Summary

Syslog messages failed to output on the ESP32-S3-Box Development Board due to the board's use of usbserial for console output, while the `up_putc()` function was hardcoded to use the standard UART driver. 

Defconfig:[defconfig](https://github.com/apache/nuttx/blob/master/boards/xtensa/esp32s3/esp32s3-box/configs/lvgl-3/defconfig)

Nuttx version:12.10.0-RC0
This code is based on the latest commit on the `master` branch, with hash `e57d2a5247`. This commit was made on June 13, 2025.

GCC verison:11.4.0

## Modify

Call esp32s3_usbserial_write() inside up_putc().