### PR TITLE
nuttx/c++runtime:Adapt the C++ runtime environment

### DIFF
--- a/include/nuttx/atexit.h
+++ b/include/nuttx/atexit.h
@@ -62,7 +62,9 @@ struct atexit_s
 struct atexit_list_s
 {
   int             nfuncs;
+  int             capacity;
   struct atexit_s funcs[ATEXIT_MAX];
+  FAR struct atexit_s *exfuncs;
 };
 
 /****************************************************************************


### PR DESCRIPTION
Adapt the C++ runtime environment in NuttX to ensure that global and static object initialization and destruction behave consistently with those in Linux processes. In NuttX's flat mode, the construction and destruction of global and static variables in C++ tasks are inconsistent with those in Linux, which makes it necessary to be especially cautious when using global or static variables in application development, and in practice, they are almost unusable.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

* In NuttX's flat mode, the construction and destruction of global and static variables in C++ tasks are inconsistent with those in Linux, which makes it necessary to be especially cautious when using global or static variables in application development, and in practice, they are almost unusable. etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


