### PR TITLE
tools/process_config.sh: Fix sed errors

### DIFF
--- a/tools/process_config.sh
+++ b/tools/process_config.sh
@@ -57,8 +57,10 @@ process_file() {
             fi
         else
             if [[ -n "$line" ]]; then
-                local key_config="$(echo "$line" | cut -d= -f1)="
-                sed -i.backup "/^$key_config/d" "$output_file"
+                if [[ ! "$line" == \#* ]]; then
+                    local key_config="$(echo "$line" | cut -d= -f1)="
+                    sed -i.backup "/^$key_config/d" "$output_file"
+                fi
                 echo "$line" >> "$output_file"
             fi
         fi


### PR DESCRIPTION
Ignore commented-out lines when deleting repeated defines in defconfig

## Summary

As reported [here](https://github.com/apache/nuttx/pull/14552#issuecomment-2627446272) on #14552, there are cases where a sed error would be thrown while processing the defconfig.  
After further investigation, it seems to be happening when commented-out lines contain the / character. sed would then interpret the following character as a command and crash.

This PR fixes this behaviour by ignoring all commented-out lines when removing duplicates.

## Impact

Minimal.  
In case where a configuration is defined in both commented and uncommented formats, the uncommented entries will now stay present in the defconfig.

## Testing

Tested on Ubuntu 22, with sed 4.8, on a custom target (STM32F7-based).

configure output before this fix
```
  Copy files
sed: -e expression #1, char 12: unknown command: `C'
sed: -e expression #1, char 10: unknown command: `C'
sed: -e expression #1, char 17: unknown command: `O'
sed: -e expression #1, char 18: extra characters after command
sed: -e expression #1, char 15: unknown command: `S'
sed: -e expression #1, char 14: unknown command: `O'
sed: -e expression #1, char 18: unknown command: `O'
sed: -e expression #1, char 12: unknown command: `m'
sed: -e expression #1, char 15: unknown command: `Z'
sed: -e expression #1, char 16: unknown command: `O'
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to nuttx/boards/dummy/dummy_kconfig
LN: platform/board to apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to nuttx/boards/arm/stm32f7/cust/include
LN: drivers/platform to nuttx/drivers/dummy
LN: include/arch/chip to arch/arm/include/stm32f7
LN: arch/arm/src/chip to arch/arm/src/stm32f7
LN: arch/arm/src/board to nuttx/boards/arm/stm32f7/cust/../common
LN: arch/arm/src/board/board to nuttx/boards/arm/stm32f7/cust/src
.config:2122:warning: override: reassigning to symbol BASE_DEFCONFIG
#
# configuration written to .config
#
```

configure output after this fix
```
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to nuttx/boards/dummy/dummy_kconfig
LN: platform/board to apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to nuttx/boards/arm/stm32f7/cust/include
LN: drivers/platform to nuttx/drivers/dummy
LN: include/arch/chip to arch/arm/include/stm32f7
LN: arch/arm/src/chip to arch/arm/src/stm32f7
LN: arch/arm/src/board to nuttx/boards/arm/stm32f7/cust/../common
LN: arch/arm/src/board/board to nuttx/boards/arm/stm32f7/cust/src
.config:2122:warning: override: reassigning to symbol BASE_DEFCONFIG
#
# configuration written to .config
#
```