### PR TITLE
arch/arm/src/*/stm32_fdcan_sock.c: prevent interrupt flood on errors.

### DIFF
--- a/arch/arm/src/stm32/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32/stm32_fdcan_sock.c
@@ -2050,6 +2050,7 @@ static void fdcan_error_work(void *arg)
   ie = fdcan_getreg(priv, STM32_FDCAN_IE_OFFSET);
 
   pending = (ir & ie);
+  ie |= FDCAN_ANYERR_INTS;
 
   /* Check for common errors */
 
@@ -2071,7 +2072,6 @@ static void fdcan_error_work(void *arg)
       if ((psr & FDCAN_PSR_LEC_MASK) != 0)
         {
           ie &= ~(FDCAN_INT_PEA | FDCAN_INT_PED);
-          fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
         }
 
       /* Clear the error indications */
@@ -2113,7 +2113,6 @@ static void fdcan_error_work(void *arg)
        */
 
       ie &= ~(pending & FDCAN_RXERR_INTS);
-      fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
 
       /* Clear the error indications */
 
@@ -2128,7 +2127,7 @@ static void fdcan_error_work(void *arg)
 
   /* Re-enable ERROR interrupts */
 
-  fdcan_errint(priv, true);
+  fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f0l0g0/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_fdcan_sock.c
@@ -1746,6 +1746,7 @@ static void fdcan_error_work(void *arg)
   ie = fdcan_getreg(priv, STM32_FDCAN_IE_OFFSET);
 
   pending = (ir & ie);
+  ie |= FDCAN_ANYERR_INTS;
 
   /* Check for common errors */
 
@@ -1767,7 +1768,6 @@ static void fdcan_error_work(void *arg)
       if ((psr & FDCAN_PSR_LEC_MASK) != 0)
         {
           ie &= ~(FDCAN_INT_PEA | FDCAN_INT_PED);
-          fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
         }
 
       /* Clear the error indications */
@@ -1809,7 +1809,6 @@ static void fdcan_error_work(void *arg)
        */
 
       ie &= ~(pending & FDCAN_RXERR_INTS);
-      fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
 
       /* Clear the error indications */
 
@@ -1824,7 +1823,7 @@ static void fdcan_error_work(void *arg)
 
   /* Re-enable ERROR interrupts */
 
-  fdcan_errint(priv, true);
+  fdcan_putreg(priv, STM32_FDCAN_IE_OFFSET, ie);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -2611,6 +2611,7 @@ static void fdcan_error_work(void *arg)
   psr = getreg32(priv->base + STM32_FDCAN_PSR_OFFSET);
 
   pending = (ir);
+  ie |= FDCAN_ANYERR_INTS;
 
   /* Check for common errors */
 
@@ -2630,7 +2631,6 @@ static void fdcan_error_work(void *arg)
       if ((psr & FDCAN_PSR_LEC_MASK) != 0)
         {
           ie &= ~(FDCAN_IE_PEAE | FDCAN_IE_PEDE);
-          putreg32(ie, priv->base + STM32_FDCAN_IE_OFFSET);
         }
 
       /* Clear the error indications */
@@ -2672,7 +2672,6 @@ static void fdcan_error_work(void *arg)
        */
 
       ie &= ~(pending & FDCAN_RXERR_INTS);
-      putreg32(ie, priv->base + STM32_FDCAN_IE_OFFSET);
 
       /* Clear the error indications */
 
@@ -2687,7 +2686,7 @@ static void fdcan_error_work(void *arg)
 
   /* Re-enable ERROR interrupts */
 
-  fdcan_errint(priv, true);
+  putreg32(ie, priv->base + STM32_FDCAN_IE_OFFSET);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Previous code was failing to disable error interrupts which due to standard CAN retransmissions might trigger continusouly (for example, with a disconnected CAN interface) flooding the system and preventing other operations to continue.

Fixes: https://github.com/apache/nuttx/issues/16668

## Impact

This patch fixes the bug on al the affected platforms. Normal behavior on non-bug conditions is not affected.

## Testing

After applying the patch, the test program provided on the bug description runs as expected (counting continues after frames are send, and using gdb I have checked `fdcan_interrupt` is only triggered once).

