### PR TITLE
sem/trywait/atomic: Fix the try wait abort by interrupted caused false failure report.

### DIFF
--- a/libs/libc/semaphore/sem_trywait.c
+++ b/libs/libc/semaphore/sem_trywait.c
@@ -107,8 +107,8 @@ int sem_trywait(FAR sem_t *sem)
 
 int nxsem_trywait(FAR sem_t *sem)
 {
-  bool mutex;
   bool fastpath = true;
+  bool mutex;
 
   DEBUGASSERT(sem != NULL);
 
@@ -119,32 +119,25 @@ int nxsem_trywait(FAR sem_t *sem)
               up_interrupt_context());
 #endif
 
-  /* We don't do atomic fast path in case of LIBC_ARCH_ATOMIC because that
-   * uses spinlocks, which can't be called from userspace. Also in the kernel
-   * taking the slow path directly is faster than locking first in here
-   */
-
-#ifndef CONFIG_LIBC_ARCH_ATOMIC
-
   mutex = NXSEM_IS_MUTEX(sem);
 
   /* Disable fast path if priority protection is enabled on the semaphore */
 
-#  ifdef CONFIG_PRIORITY_PROTECT
+#ifdef CONFIG_PRIORITY_PROTECT
   if ((sem->flags & SEM_PRIO_MASK) == SEM_PRIO_PROTECT)
     {
       fastpath = false;
     }
-#  endif
+#endif
 
   /* Disable fast path on a counting semaphore with priority inheritance */
 
-#  ifdef CONFIG_PRIORITY_INHERITANCE
+#ifdef CONFIG_PRIORITY_INHERITANCE
   if (!mutex && (sem->flags & SEM_PRIO_MASK) != SEM_PRIO_NONE)
     {
       fastpath = false;
     }
-#  endif
+#endif
 
   while (fastpath)
     {
@@ -176,11 +169,6 @@ int nxsem_trywait(FAR sem_t *sem)
           return OK;
         }
     }
-
-#else
-  UNUSED(mutex);
-  UNUSED(fastpath);
-#endif
 
   return nxsem_trywait_slow(sem);
 }


### PR DESCRIPTION
## Summary
When we locate the internal ostest sometime failure, find this bug.

If atomic_try_cmpxchg_xxxx runs on LL/SC architectures (e.g.ARMv7,
ARMv8, RISC-V), the weak CAS expands to a single LDREX/STREX pair.

If the CPU takes an IRQ/FIQ/SVC between the two instructions,
hardware performs an implicit CLREX and the following STREX returns
1, therefore atomic_try_cmpxchg_xxxx return failure even though
*addr* still holds the expected value.

[arm/CLREX](https://developer.arm.com/documentation/dui0646/c/The-Cortex-M7-Instruction-Set/Memory-access-instructions/CLREX)

Tested by
```C
int main(int argc, FAR char *argv[])
{
  pthread_rwlock_t rw_lock;
  int i = 0;

  while(true)
    {
      printf("%d\n", i++);
      ASSERT(pthread_rwlock_init(&rw_lock, NULL) == 0);
      ASSERT(pthread_rwlock_trywrlock(&rw_lock) == 0);
      ASSERT(pthread_rwlock_unlock(&rw_lock) == 0);
      ASSERT(pthread_rwlock_trywrlock(&rw_lock) == 0);
      ASSERT(pthread_rwlock_tryrdlock(&rw_lock) == EBUSY);
      ASSERT(pthread_rwlock_tryrdlock(&rw_lock) == EBUSY);
      ASSERT(pthread_rwlock_unlock(&rw_lock) == 0);
    }

  return 0;
}
```
If tickless not enabled, will quickly(<30s) failed. before fix.
And will never fail again after fixed.

## Impact
Before Fix, the ostest sometimes report first rwlock_trywrlock failed even when first rwlock_init.
After Fix, Add a check again even atomic_try_cmpxchg_acquire report failure, problem fixed.

## Testing
CI-test, internal board, qemu-mps3 ostest.


