### PR TITLE
arch/arm/stm32{h5|h7|l4}/adc: move ADC_MAX_SAMPLES to Kconfig

### DIFF
--- a/arch/arm/src/stm32h5/Kconfig
+++ b/arch/arm/src/stm32h5/Kconfig
@@ -4553,6 +4553,17 @@ endmenu # U[S]ART Configuration
 menu "ADC Configuration"
 	depends on STM32H5_ADC
 
+config STM32H5_ADC_MAX_SAMPLES
+	int "The maximum number of channels that can be sampled"
+	default 16
+	---help---
+		The maximum number of samples which can be handled without
+		overrun depends on various factors. This is the user's
+		responsibility to correctly select this value.
+		Since the interface to update the sampling time is available
+		for all supported devices, the user can change the default
+		values in the board initialization logic and avoid ADC overrun.
+
 config STM32H5_ADC1_DMA
 	bool "ADC1 DMA (not supported yet)"
 	depends on STM32H5_ADC1 && EXPERIMENTAL

--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -64,18 +64,9 @@
 
 /* ADC Channels/DMA *********************************************************/
 
-#define ADC_MAX_CHANNELS_DMA   20
-#define ADC_MAX_CHANNELS_NODMA 20
-
 #ifdef ADC_HAVE_DMA
 #  error "STM32H5 ADC does not have DMA support."
 #  undef ADC_HAVE_DMA
-#endif
-
-#ifdef ADC_HAVE_DMA
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA
-#else
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_NODMA
 #endif
 
 #define ADC_SMPR_DEFAULT    ADC_SMPR_640p5
@@ -153,7 +144,7 @@ struct stm32_dev_s
 
   /* List of selected ADC channels to sample */
 
-  uint8_t  chanlist[ADC_MAX_SAMPLES];
+  uint8_t  chanlist[CONFIG_STM32H5_ADC_MAX_SAMPLES];
 };
 
 /****************************************************************************
@@ -232,7 +223,7 @@ static const struct adc_ops_s g_adcops =
 #ifdef CONFIG_STM32H5_ADC1
 
 #ifdef ADC1_HAVE_DMA
-static uint16_t g_adc1_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc1_dmabuffer[CONFIG_STM32H5_ADC_MAX_SAMPLES *
                                  CONFIG_STM32H5_ADC1_DMA_BATCH];
 #endif
 
@@ -1079,7 +1070,7 @@ static int adc_set_ch(struct adc_dev_s *dev, uint8_t ch)
       priv->rnchannels = 1;
     }
 
-  DEBUGASSERT(priv->rnchannels <= ADC_MAX_SAMPLES);
+  DEBUGASSERT(priv->rnchannels <= CONFIG_STM32H5_ADC_MAX_SAMPLES);
 
   bits = adc_sqrbits(priv, ADC_SQR4_FIRST, ADC_SQR4_LAST,
                      ADC_SQR4_SQ_OFFSET);
@@ -1930,10 +1921,10 @@ struct adc_dev_s *stm32h5_adc_initialize(int intf,
   priv = (struct stm32_dev_s *)dev->ad_priv;
   priv->cb = NULL;
 
-  DEBUGASSERT(cchannels <= ADC_MAX_SAMPLES);
-  if (cchannels > ADC_MAX_SAMPLES)
+  DEBUGASSERT(cchannels <= CONFIG_STM32H5_ADC_MAX_SAMPLES);
+  if (cchannels > CONFIG_STM32H5_ADC_MAX_SAMPLES)
     {
-      cchannels = ADC_MAX_SAMPLES;
+      cchannels = CONFIG_STM32H5_ADC_MAX_SAMPLES;
     }
 
   priv->cchannels = cchannels;

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1830,6 +1830,17 @@ endmenu # U[S]ART Configuration
 menu "ADC Configuration"
 	depends on STM32H7_ADC
 
+config STM32H7_ADC_MAX_SAMPLES
+	int "The maximum number of channels that can be sampled"
+	default 16
+	---help---
+		The maximum number of samples which can be handled without
+		overrun depends on various factors. This is the user's
+		responsibility to correctly select this value.
+		Since the interface to update the sampling time is available
+		for all supported devices, the user can change the default
+		values in the board initialization logic and avoid ADC overrun.
+
 config STM32H7_ADC1_DMA
 	bool "ADC1 DMA (not supported yet)"
 	depends on STM32H7_ADC1 && EXPERIMENTAL

--- a/arch/arm/src/stm32h7/stm32_adc.c
+++ b/arch/arm/src/stm32h7/stm32_adc.c
@@ -91,25 +91,11 @@
 
 /* ADC Channels/DMA *********************************************************/
 
-/* The maximum number of channels that can be sampled.  While DMA support is
- * very nice for reliable multi-channel sampling, the STM32H7 can function
- * without, although there is a risk of overrun.
- */
-
-#define ADC_MAX_CHANNELS_DMA   20
-#define ADC_MAX_CHANNELS_NODMA 20
-
 #ifdef ADC_HAVE_DMA
 #  if !defined(CONFIG_STM32H7_DMA1) && !defined(CONFIG_STM32H7_DMA2)
 #    /* REVISIT: check accordingly to which one is configured in board.h */
 #    error "STM32H7 ADC DMA support requires CONFIG_STM32H7_DMA1 or CONFIG_STM32H7_DMA2"
 #  endif
-#endif
-
-#ifdef ADC_HAVE_DMA
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA
-#else
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_NODMA
 #endif
 
 #define ADC_DMA_CONTROL_WORD (DMA_CCR_MSIZE_16BITS | \
@@ -205,7 +191,7 @@ struct stm32_dev_s
 
   /* List of selected ADC channels to sample */
 
-  uint8_t  chanlist[ADC_MAX_SAMPLES];
+  uint8_t  chanlist[CONFIG_STM32H7_ADC_MAX_SAMPLES];
 };
 
 /****************************************************************************
@@ -306,7 +292,7 @@ static const struct adc_ops_s g_adcops =
 #ifdef CONFIG_STM32H7_ADC1
 
 #ifdef ADC1_HAVE_DMA
-static uint16_t g_adc1_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc1_dmabuffer[CONFIG_STM32H7_ADC_MAX_SAMPLES *
                                  CONFIG_STM32H7_ADC1_DMA_BATCH];
 #endif
 
@@ -356,7 +342,7 @@ static struct adc_dev_s g_adcdev1 =
 #ifdef CONFIG_STM32H7_ADC2
 
 #ifdef ADC2_HAVE_DMA
-static uint16_t g_adc2_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc2_dmabuffer[CONFIG_STM32H7_ADC_MAX_SAMPLES *
                                  CONFIG_STM32H7_ADC2_DMA_BATCH];
 #endif
 
@@ -406,7 +392,7 @@ static struct adc_dev_s g_adcdev2 =
 #ifdef CONFIG_STM32H7_ADC3
 
 #ifdef ADC3_HAVE_DMA
-static uint16_t g_adc3_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc3_dmabuffer[CONFIG_STM32H7_ADC_MAX_SAMPLES *
                                  CONFIG_STM32H7_ADC3_DMA_BATCH];
 #endif
 
@@ -1894,7 +1880,7 @@ static int adc_set_ch(struct adc_dev_s *dev, uint8_t ch)
       priv->rnchannels = 1;
     }
 
-  DEBUGASSERT(priv->rnchannels <= ADC_MAX_SAMPLES);
+  DEBUGASSERT(priv->rnchannels <= CONFIG_STM32H7_ADC_MAX_SAMPLES);
 
   bits = adc_sqrbits(priv, ADC_SQR4_FIRST, ADC_SQR4_LAST,
                      ADC_SQR4_SQ_OFFSET);
@@ -2354,10 +2340,10 @@ struct adc_dev_s *stm32h7_adc_initialize(int intf,
   priv = (struct stm32_dev_s *)dev->ad_priv;
   priv->cb = NULL;
 
-  DEBUGASSERT(cchannels <= ADC_MAX_SAMPLES);
-  if (cchannels > ADC_MAX_SAMPLES)
+  DEBUGASSERT(cchannels <= CONFIG_STM32H7_ADC_MAX_SAMPLES);
+  if (cchannels > CONFIG_STM32H7_ADC_MAX_SAMPLES)
     {
-      cchannels = ADC_MAX_SAMPLES;
+      cchannels = CONFIG_STM32H7_ADC_MAX_SAMPLES;
     }
 
   priv->cchannels = cchannels;

--- a/arch/arm/src/stm32l4/Kconfig
+++ b/arch/arm/src/stm32l4/Kconfig
@@ -5199,6 +5199,17 @@ endmenu # Timer Configuration
 menu "ADC Configuration"
 	depends on STM32L4_ADC
 
+config STM32L4_ADC_MAX_SAMPLES
+	int "The maximum number of channels that can be sampled"
+	default 16
+	---help---
+		The maximum number of samples which can be handled without
+		overrun depends on various factors. This is the user's
+		responsibility to correctly select this value.
+		Since the interface to update the sampling time is available
+		for all supported devices, the user can change the default
+		values in the board initialization logic and avoid ADC overrun.
+
 config STM32L4_ADC_NO_STARTUP_CONV
 	bool "Do not start conversion when opening ADC device"
 	default n

--- a/arch/arm/src/stm32l4/stm32l4_adc.c
+++ b/arch/arm/src/stm32l4/stm32l4_adc.c
@@ -94,25 +94,11 @@
 
 /* ADC Channels/DMA *********************************************************/
 
-/* The maximum number of channels that can be sampled.  While DMA support is
- * very nice for reliable multi-channel sampling, the STM32L4 can function
- * without, although there is a risk of overrun.
- */
-
-#define ADC_MAX_CHANNELS_DMA   16
-#define ADC_MAX_CHANNELS_NODMA 16
-
 #ifdef ADC_HAVE_DMA
 #  if !defined(CONFIG_STM32L4_DMA1) && !defined(CONFIG_STM32L4_DMA2)
 #    /* REVISIT: check accordingly to which one is configured in board.h */
 #    error "STM32L4 ADC DMA support requires CONFIG_STM32L4_DMA1 or CONFIG_STM32L4_DMA2"
 #  endif
-#endif
-
-#ifdef ADC_HAVE_DMA
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA
-#else
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_NODMA
 #endif
 
 /* DMA channels and interface values */
@@ -233,7 +219,7 @@ struct stm32_dev_s
 
   /* List of selected ADC channels to sample */
 
-  uint8_t  r_chanlist[ADC_MAX_SAMPLES];
+  uint8_t  r_chanlist[CONFIG_STM32L4_ADC_MAX_SAMPLES];
 
 #ifdef ADC_HAVE_INJECTED
   /* List of selected ADC injected channels to sample */
@@ -429,7 +415,7 @@ static const struct stm32_adc_ops_s g_adc_llops =
 #ifdef CONFIG_STM32L4_ADC1
 
 #ifdef ADC1_HAVE_DMA
-static uint16_t g_adc1_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc1_dmabuffer[CONFIG_STM32L4_ADC_MAX_SAMPLES *
                                  CONFIG_STM32L4_ADC1_DMA_BATCH];
 #endif
 
@@ -489,7 +475,7 @@ static struct adc_dev_s g_adcdev1 =
 #ifdef CONFIG_STM32L4_ADC2
 
 #ifdef ADC2_HAVE_DMA
-static uint16_t g_adc2_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc2_dmabuffer[CONFIG_STM32L4_ADC_MAX_SAMPLES *
                                  CONFIG_STM32L4_ADC2_DMA_BATCH];
 #endif
 
@@ -549,7 +535,7 @@ static struct adc_dev_s g_adcdev2 =
 #ifdef CONFIG_STM32L4_ADC3
 
 #ifdef ADC3_HAVE_DMA
-static uint16_t g_adc3_dmabuffer[ADC_MAX_SAMPLES *
+static uint16_t g_adc3_dmabuffer[CONFIG_STM32L4_ADC_MAX_SAMPLES *
                                  CONFIG_STM32L4_ADC3_DMA_BATCH];
 #endif
 
@@ -1907,7 +1893,7 @@ static int adc_set_ch(struct adc_dev_s *dev, uint8_t ch)
       priv->rnchannels = 1;
     }
 
-  DEBUGASSERT(priv->rnchannels <= ADC_MAX_SAMPLES);
+  DEBUGASSERT(priv->rnchannels <= CONFIG_STM32L4_ADC_MAX_SAMPLES);
 
   bits = adc_sqrbits(priv,
                      ADC_SQR4_FIRST, ADC_SQR4_LAST, ADC_SQR4_SQ_OFFSET);
@@ -2819,10 +2805,10 @@ struct adc_dev_s *stm32l4_adc_initialize(int intf,
 
   priv = (struct stm32_dev_s *)dev->ad_priv;
 
-  DEBUGASSERT(crchannels <= ADC_MAX_SAMPLES);
-  if (crchannels > ADC_MAX_SAMPLES)
+  DEBUGASSERT(crchannels <= CONFIG_STM32L4_ADC_MAX_SAMPLES);
+  if (crchannels > CONFIG_STM32L4_ADC_MAX_SAMPLES)
     {
-      crchannels = ADC_MAX_SAMPLES;
+      crchannels = CONFIG_STM32L4_ADC_MAX_SAMPLES;
     }
 
   priv->cchannels = crchannels;


### PR DESCRIPTION
## Summary

move ADC_MAX_SAMPLES to Kconfig so user can fine tune memory usage

follow up to https://github.com/apache/nuttx/pull/16670

## Impact

sync all stm32 implementation, option already present in stm32, stm32f7 and stm32f0l0g0

## Testing

CI only

