### PR TITLE
net/local: correct shutdown state when use UDP mode (To fix issue: https://github.com/apache/nuttx/issues/16555)

### DIFF
--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -539,18 +539,10 @@ errout_with_halfduplex:
 ssize_t local_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
                       int flags)
 {
-  FAR struct local_conn_s *conn = psock->s_conn;
   FAR socklen_t *fromlen = &msg->msg_namelen;
   FAR struct sockaddr *from = msg->msg_name;
   FAR void *buf = msg->msg_iov->iov_base;
   size_t len = msg->msg_iov->iov_len;
-
-  /* Check shutdown state */
-
-  if (conn->lc_infile.f_inode == NULL)
-    {
-      return 0;
-    }
 
   if (msg->msg_iovlen != 1)
     {

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -431,20 +431,13 @@ errout_with_lock:
 ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
                       int flags)
 {
-  FAR struct local_conn_s *conn = psock->s_conn;
   FAR const struct sockaddr *to = msg->msg_name;
   FAR const struct iovec *buf = msg->msg_iov;
   socklen_t tolen = msg->msg_namelen;
   size_t len = msg->msg_iovlen;
 
-  /* Check shutdown state */
-
-  if (conn->lc_outfile.f_inode == NULL)
-    {
-      return -EPIPE;
-    }
-
 #ifdef CONFIG_NET_LOCAL_SCM
+  FAR struct local_conn_s *conn = psock->s_conn;
   int count = 0;
 
   if (msg->msg_control &&


### PR DESCRIPTION


## Summary

local: correct shutdown state when use UDP mode (To fix issue: https://github.com/apache/nuttx/issues/16555)

## Impact

local socket

## Testing

See the https://github.com/apache/nuttx/issues/16555


