### PR TITLE
net/arp: avoid unnecessary ARP requests

### DIFF
--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -425,7 +425,7 @@ void arp_notify(in_addr_t ipaddr);
 
 struct ether_addr;  /* Forward reference */
 int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
-             FAR struct net_driver_s *dev);
+             FAR struct net_driver_s *dev, bool check_expiry);
 
 /****************************************************************************
  * Name: arp_delete
@@ -620,7 +620,7 @@ void arp_acd_setup(FAR struct net_driver_s *dev);
 #  define arp_wait_cancel(n) (0)
 #  define arp_wait(n,t) (0)
 #  define arp_notify(i)
-#  define arp_find(i,e,d) (-ENOSYS)
+#  define arp_find(i,e,d,u) (-ENOSYS)
 #  define arp_delete(i,d) (-ENOSYS)
 #  define arp_cleanup(d)
 #  define arp_update(d,i,m);

--- a/net/arp/arp_out.c
+++ b/net/arp/arp_out.c
@@ -262,7 +262,7 @@ void arp_out(FAR struct net_driver_s *dev)
 
   /* Check if we already have this destination address in the ARP table */
 
-  ret = arp_find(ipaddr, ethaddr.ether_addr_octet, dev);
+  ret = arp_find(ipaddr, ethaddr.ether_addr_octet, dev, false);
   if (ret < 0)
     {
       ninfo("ARP request for IP %08lx\n", (unsigned long)ipaddr);

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -314,7 +314,7 @@ int arp_send(in_addr_t ipaddr)
        * issue.
        */
 
-      ret = arp_find(ipaddr, NULL, dev);
+      ret = arp_find(ipaddr, NULL, dev, true);
       if (ret >= 0)
         {
           /* We have it!  Break out with success */

--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -128,7 +128,8 @@ netdev_prefixlen_findby_lipv4addr(in_addr_t lipaddr, FAR int8_t *prefixlen)
 
               if (len > bestpref
 #ifdef CONFIG_NET_ARP
-                  || (len == bestpref && arp_find(lipaddr, NULL, dev) == OK)
+                  || (len == bestpref
+                      && arp_find(lipaddr, NULL, dev, true) == OK)
 #endif
                   )
                 {

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1452,7 +1452,7 @@ static int netdev_arp_ioctl(FAR struct socket *psock, int cmd,
               req->arp_pa.sa_family == AF_INET)
             {
               ret = arp_find(addr->sin_addr.s_addr,
-                            (FAR uint8_t *)req->arp_ha.sa_data, dev);
+                            (FAR uint8_t *)req->arp_ha.sa_data, dev, true);
               if (ret >= 0)
                 {
                   /* Return the mapped hardware address. */


### PR DESCRIPTION
## Summary
The ARP implementation overly strict expiration check mechanism. When an ARP entry expires, data packets are immediately discarded, causing TCP connections to pause and wait for ARP to resolve again.
Reducing unnecessary ARP requests can mitigate network congestion and avoid packet delays caused by waiting for ARP responses.

## Impact
New Feature/Change: arp optimize
User Impact: Prevent file descriptor leakage.
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
Verification phenomenon: iperf+TCP communication
1. During high-speed communication (e.g., iperf), an abnormal throughput drop occurs due to ARP expiration checks.
2. The problem reproduction cycle is consistent with the NET_ARP_MAXAGE duration.
(To facilitate issue reproduction, temporarily reduce NET_ARP_MAXAGE)
```
       Interval         Transfer         Bandwidth
   0.00-   1.00 sec    2310144 Bytes   18.47 Mbits/sec
   1.00-   2.00 sec    2326528 Bytes   18.60 Mbits/sec
   2.00-   3.00 sec    2326528 Bytes   18.60 Mbits/sec
   3.00-   4.00 sec    2342912 Bytes   18.73 Mbits/sec
   4.00-   5.00 sec    2326528 Bytes   18.60 Mbits/sec
   5.00-   6.00 sec    2326528 Bytes   18.60 Mbits/sec
   6.00-   7.00 sec    2326528 Bytes   18.60 Mbits/sec
   7.00-   8.00 sec    2326528 Bytes   18.60 Mbits/sec
   8.00-   9.00 sec    2326528 Bytes   18.60 Mbits/sec
   9.00-  10.01 sec    2375680 Bytes   18.99 Mbits/sec
  10.01-  11.01 sec    2375680 Bytes   18.99 Mbits/sec
  11.01-  12.01 sec    1064960 Bytes    **8.51 Mbits/sec**
  12.01-  13.01 sec     114688 Bytes    **0.92 Mbits/sec**
  13.01-  14.01 sec    2326528 Bytes   18.60 Mbits/sec
  14.01-  15.01 sec    2326528 Bytes   18.60 Mbits/sec
```
After fixed, there is no longer a through exception reduction issue.
