### PR TITLE
arch/risc-v: Add LP_I2C support for esp32[-c6]

### DIFF
--- a/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitc/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitc/index.rst
@@ -247,6 +247,11 @@ You can scan for all I2C devices using the following command::
 
     nsh> i2c dev 0x00 0x7f
 
+To use LP_I2C, you can enable `ESPRESSIF_LP_I2C0` option.  When this option is enabled,
+LP_I2C operates on GPIO7 as SCL and GPIO6 as SDA. These pins are fixed and cannot be changed.
+Also enabling LP_I2C will change the default pins of I2C0 due to LP_I2C pin limitation.
+The default I2C0 pins will be remapped to GPIO23 for SCL and GPIO5 for SDA.
+
 To use slave mode, you can enable `ESPRESSIF_I2C0_SLAVE_MODE` option.
 To use slave mode driver following snippet demonstrates how write to i2c bus
 using slave driver:

--- a/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitm/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitm/index.rst
@@ -210,6 +210,11 @@ You can scan for all I2C devices using the following command::
 
     nsh> i2c dev 0x00 0x7f
 
+To use LP_I2C, you can enable `ESPRESSIF_LP_I2C0` option.  When this option is enabled,
+LP_I2C operates on GPIO7 as SCL and GPIO6 as SDA. These pins are fixed and cannot be changed.
+Also enabling LP_I2C will change the default pins of I2C0 due to LP_I2C pin limitation.
+The default I2C0 pins will be remapped to GPIO23 for SCL and GPIO5 for SDA.
+
 To use slave mode, you can enable `ESPRESSIF_I2C0_SLAVE_MODE` option.
 To use slave mode driver following snippet demonstrates how write to i2c bus
 using slave driver:

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -346,7 +346,7 @@ ECC              No
 eFuse            Yes
 GPIO             Yes     Dedicated GPIO supported
 HMAC             No
-I2C              Yes     Master and Slave mode supported
+I2C              Yes     Master and Slave mode also LPI2C supported
 I2S              Yes
 LED/PWM          Yes
 MCPWM            Yes

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -378,6 +378,10 @@ config ESPRESSIF_I2C
 	bool
 	default n
 
+config ESPRESSIF_LPI2C
+	bool
+	default n
+
 config ESPRESSIF_I2C_PERIPH_MASTER_MODE
 	bool
 	depends on (ESPRESSIF_I2C0_MASTER_MODE || ESPRESSIF_I2C1_MASTER_MODE)
@@ -399,6 +403,14 @@ config ESPRESSIF_I2C1
 	default n
 	depends on ARCH_CHIP_ESP32H2
 	select ESPRESSIF_I2C
+	select I2C
+
+config ESPRESSIF_LP_I2C0
+	bool "LP I2C 0"
+	default n
+	depends on ARCH_CHIP_ESP32C6
+	select ESPRESSIF_I2C
+	select ESPRESSIF_LPI2C
 	select I2C
 
 choice ESPRESSIF_I2C0_MODE
@@ -2035,7 +2047,8 @@ if ESPRESSIF_I2C0
 
 config ESPRESSIF_I2C0_SCLPIN
 	int "I2C0 SCL Pin"
-	default 6
+	default 6 if !ESPRESSIF_LPI2C
+	default 23 if ESPRESSIF_LPI2C
 	range 0 21
 
 config ESPRESSIF_I2C0_SDAPIN

--- a/arch/risc-v/src/common/espressif/esp_i2c.h
+++ b/arch/risc-v/src/common/espressif/esp_i2c.h
@@ -49,6 +49,10 @@
 #  define ESPRESSIF_I2C1 1
 #endif
 
+#ifdef CONFIG_ESPRESSIF_LP_I2C0
+#  define ESPRESSIF_LP_I2C0 2
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/risc-v/src/common/espressif/esp_i2c_slave.c
+++ b/arch/risc-v/src/common/espressif/esp_i2c_slave.c
@@ -540,7 +540,7 @@ static void esp_i2c_slave_init(struct esp_i2c_priv_s *priv)
 
   /* Enable I2C hardware */
 
-  periph_module_enable(i2c_periph_signal[priv->id].module);
+  periph_module_enable(PERIPH_I2C0_MODULE);
 
   i2c_hal_init(priv->ctx, priv->id);
 
@@ -551,7 +551,7 @@ static void esp_i2c_slave_init(struct esp_i2c_priv_s *priv)
   /* Initialize I2C Slave */
 
   i2c_hal_slave_init(priv->ctx);
-  i2c_ll_slave_tx_auto_start_en(priv->ctx->dev, true);
+  i2c_ll_slave_enable_auto_start(priv->ctx->dev, true);
   i2c_ll_set_source_clk(priv->ctx->dev, I2C_CLK_SRC_DEFAULT);
   i2c_ll_set_slave_addr(priv->ctx->dev, priv->addr, false);
   i2c_ll_set_rxfifo_full_thr(priv->ctx->dev, I2C_FIFO_FULL_THRESH_VAL);
@@ -583,7 +583,7 @@ static void esp_i2c_slave_deinit(struct esp_i2c_priv_s *priv)
   const struct esp_i2c_config_s *config = priv->config;
 
   i2c_hal_deinit(priv->ctx);
-  periph_module_disable(i2c_periph_signal[priv->id].module);
+  periph_module_disable(PERIPH_I2C0_MODULE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c6/hal_esp32c6.mk
+++ b/arch/risc-v/src/esp32c6/hal_esp32c6.mk
@@ -211,6 +211,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)rtc_io_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)${CHIP_SERIES}$(DELIM)uart_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)ulp$(DELIM)lp_core$(DELIM)lp_core_i2c.c
 
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)components$(DELIM)esp_driver_gpio$(DELIM)src$(DELIM)gpio.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)components$(DELIM)esp_driver_gpio$(DELIM)src$(DELIM)rtc_io.c

--- a/boards/risc-v/esp32c6/common/src/esp_board_i2c.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_i2c.c
@@ -160,5 +160,9 @@ int board_i2c_init(void)
   ret = i2c_slave_driver_init(ESPRESSIF_I2C0_SLAVE, I2C0_SLAVE_ADDR);
 #endif
 
+#ifdef CONFIG_ESPRESSIF_LP_I2C0
+  ret = i2c_driver_init(ESPRESSIF_LP_I2C0);
+#endif
+
   return ret;
 }


### PR DESCRIPTION
## Summary

Add LP_I2C support for ESP32-C6 to ahve multiple option on I2C peripheral and increase coverage of ESP32-C6's peripherals
Fix I2C Slave build error that happened after Espressif's common layer update.

* arch/xtensa: Bugfix I2C Slave build error for esp32[-|-s2|-s3]

Fix build error for Xtensa based Espressif devices

* arch/risc-v: Bugfix I2C Slave build error for esp32[-c3|-c6|-h2]

Fix build error for risc-v based Espressif devices

* arch/risc-v: Add LP I2C for esp32c6

Add LP I2C peripheral support for esp32c6

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No, just new peripheral support added
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, new hardware support added into NuttX
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, related peripheral docs added
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command used to build and flash:

```
make distclean && ./tools/configure.sh esp32c6-devkitc:i2c && kconfig-tweak -e CONFIG_ESPRESSIF_LP_I2C0 && kconfig-tweak --help --set-val CONFIG_I2CTOOL_MAXBUS 3 &&  make olddefconfig && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BAUD=921600 ESPTOOL_BINDIR=../esp-bin
```

To run another device as slave I used this command:
```
make -j distclean && ./tools/configure.sh esp32c6-devkit:i2c && kconfig-tweak -d CONFIG_ESPRESSIF_I2C0_MASTER_MODE && kconfig-tweak -e CONFIG_ESPRESSIF_I2C0_SLAVE_MODE && make olddefconfig && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_BINDIR=./ ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

Here is the connection list

|     | ESP32-C6 LPI2C | I2C Slave Device |
|-----|----------------|------------------|
| SCL | 7              | 6                |
| SDA | 6              | 5                |

After connection done, `i2c dev 0x28 0x28` command used to test LPI2C is working fine.

Alternatively, this connection can be connect to a logic analyzer too and check the result also with `i2c get -b 2 -a 0x28` and `i2c set -b 2 -a 0x28 0x10`

### Results
<!-- Provide tests' results and runtime logs -->


Outputs should look like this:

```
nsh> i2c dev -b 2 0x28 0x28
NOTE: Some devices may not appear with this scan.
You may also try a scan with the -z flag to discover more devices using a zero-byte write request.
     0  1  2  3  4 Elapsed time: 0
 1. STATUS: 6600c000 COUNT:   1 EVENT: SENDADDR  ( 1) PARM: 00000028 TIME: 0
 2. STATUS: 3700c001 COUNT:   1 EVENT: RCVMODEEN ( 3) PARM: 00000000 TIME: 0
 3. STATUS: 3700c101 COUNT:   1 EVENT: RCVBYTE   ( 4) PARM: 00000000 TIME: 0
 4. STATUS: 3700c101 COUNT:   1 EVENT: STOP      ( 5) PARM: 00000001 TIME: 0
 5  6  7  8  9  a  b  c  d  e  f
00:                                                 
10:                                                 
20:                         28                      
30:                                                 
40:                                                 
50:                                                 
60:                                                 
70:  

nsh> i2c set -b 2 -a 0x28 0x10
Elapsed time: 0
 1. STATUS: 67000001 COUNT:   1 EVENT: SENDADDR  ( 1) PARM: 00000028 TIME: 0
 2. STATUS: 37000001 COUNT:   1 EVENT: SENDBYTE  ( 2) PARM: 00000000 TIME: 0
 3. STATUS: 37000001 COUNT:   1 EVENT: STOP      ( 5) PARM: 00000001 TIME: 0
WROTE Bus: 2 Addr: 28 Subaddr: 00 Value: 10

nsh> i2c get -b 2 -a 0x28
Elapsed time: 0
 1. STATUS: 66000000 COUNT:   1 EVENT: SENDADDR  ( 1) PARM: 00000028 TIME: 0
 2. STATUS: 37000001 COUNT:   1 EVENT: RCVMODEEN ( 3) PARM: 00000000 TIME: 0
 3. STATUS: 37000101 COUNT:   1 EVENT: RCVBYTE   ( 4) PARM: 00000000 TIME: 0
 4. STATUS: 37000101 COUNT:   1 EVENT: STOP      ( 5) PARM: 00000001 TIME: 0
READ Bus: 2 Addr: 28 Subaddr: 00 Value: aa
```