### PR TITLE
sensors/bmi160,270: Fix a bug sensor_time is truncated

### DIFF
--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -145,11 +145,11 @@ static ssize_t bmi160_read(FAR struct file *filep, FAR char *buffer,
       return 0;
     }
 
+  /* Set sensor_time to the lower 24 bits of SENSORTIME. */
+
+  p->sensor_time = 0;
+
   bmi160_getregs(priv, BMI160_DATA_8, (FAR uint8_t *)buffer, 15);
-
-  /* Adjust sensing time into 24 bit */
-
-  p->sensor_time >>= 8;
 
   return len;
 }

--- a/drivers/sensors/bmi270.c
+++ b/drivers/sensors/bmi270.c
@@ -141,11 +141,11 @@ static ssize_t bmi270_read(FAR struct file *filep, FAR char *buffer,
       return 0;
     }
 
+  /* Set sensor_time to the lower 24 bits of SENSORTIME. */
+
+  p->sensor_time = 0;
+
   bmi270_getregs(priv, BMI270_DATA_8, (FAR uint8_t *)p, 15);
-
-  /* Adjust sensing time into 24 bit */
-
-  p->sensor_time >>= 8;
 
   return len;
 }


### PR DESCRIPTION
## Summary
Fix a bug that sensor_time resolution is lost by bit shift.

## Impact
bmi160 and bmi270 sensor drivers.

## Testing
Run and test `examples/bmi160`.
