### PR TITLE
boards/arm/stm32f401rc-rs485: Add support to HX711 ADC

### DIFF
--- a/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
+++ b/Documentation/platforms/arm/stm32f4/boards/stm32f401rc-rs485/index.rst
@@ -943,3 +943,60 @@ NSH usage
      4: ( 56, 44) ( 48, 40)
      5: ( 70, 55) ( 20, 18)
     Test finished
+
+HX711
+-----
+
+HX711 is a precision 24-bit analog-to-digital converter (ADC)
+designed for weigh scales and industrial control applications.
+It interfaces load cells via a simple two-wire serial interface
+(clock and data) and provides high-resolution digital weight
+measurements.
+
+**Enable the following options using ``make menuconfig``:**
+
+::
+
+    CONFIG_ADC=y
+    CONFIG_ANALOG=y
+    CONFIG_ADC_HX711=y
+    CONFIG_EXAMPLES_HX711=y
+
+**Wiring:**
+
+Connect the HX711 to the STM32F4 board using the following pins:
+
++--------+------+
+| HX711  | PIN  |
++========+======+
+| SCK    | PB1  |
++--------+------+
+| DT     | PB2  |
++--------+------+
+
+**NSH usage:**
+
+::
+
+    NuttShell (NSH) NuttX-12.10.0-RC0
+    nsh> hx711 -D
+    Current settings for: /dev/hx711_0
+    average.............: 1
+    channel.............: a
+    gain................: 128
+    value per unit......: 0
+    nsh> hx711 -v 813 -t 10
+    Taring with *float*g precision
+    nsh> hx711 -r 10
+    11
+    9
+    9
+    10
+    11
+    11
+    11
+    12
+    11
+    10
+
+For more details, refer to the official `HX711 NuttX documentation <https://nuttx.apache.org/docs/latest/components/drivers/character/analog/adc/hx711/index.html>`_.

--- a/boards/arm/stm32/stm32f401rc-rs485/src/CMakeLists.txt
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/CMakeLists.txt
@@ -78,6 +78,10 @@ if(CONFIG_VIDEO_FB)
   endif()
 endif()
 
+if(CONFIG_ADC_HX711)
+  list(APPEND SRCS stm32_hx711.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})
 
 if(CONFIG_ARCH_CHIP_STM32F401RC)

--- a/boards/arm/stm32/stm32f401rc-rs485/src/Make.defs
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/Make.defs
@@ -80,6 +80,10 @@ ifeq ($(CONFIG_DEV_GPIO),y)
 CSRCS += stm32_gpio.c
 endif
 
+ifeq ($(CONFIG_ADC_HX711),y)
+CSRCS += stm32_hx711.c
+endif
+
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board

--- a/boards/arm/stm32/stm32f401rc-rs485/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/stm32_bringup.c
@@ -211,7 +211,7 @@ int stm32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ADC
+#if defined(CONFIG_ADC) && defined(CONFIG_STM32_ADC1)
   /* Initialize ADC and register the ADC driver. */
 
   ret = stm32_adc_setup();
@@ -366,6 +366,14 @@ int stm32_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize BMP180, error %d\n", ret);
       return ret;
+    }
+#endif
+
+#ifdef CONFIG_ADC_HX711
+  ret = stm32_hx711_initialize();
+  if (ret != OK)
+    {
+      aerr("ERROR: Failed to initialize hx711: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32/stm32f401rc-rs485/src/stm32_hx711.c
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/stm32_hx711.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * boards/arm/stm32/stm32f401rc-rs485/src/stm32_hx711.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/analog/hx711.h>
+#include <nuttx/compiler.h>
+#include <arch/board/board.h>
+#include <arch/stm32/chip.h>
+#include <debug.h>
+
+#include "stm32_gpio.h"
+#include "stm32f401rc-rs485.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int stm32_hx711_clock_set(unsigned char minor, int value);
+static int stm32_hx711_data_read(unsigned char minor);
+static int stm32_hx711_data_irq(unsigned char minor,
+                                xcpt_t handler, void *arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+struct hx711_lower_s g_lower =
+{
+  .data_read = stm32_hx711_data_read,
+  .clock_set = stm32_hx711_clock_set,
+  .data_irq  = stm32_hx711_data_irq,
+  .cleanup = NULL
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int stm32_hx711_clock_set(unsigned char minor, int value)
+{
+  UNUSED(minor);
+
+  stm32_gpiowrite(HX711_CLK_PIN, value);
+  return OK;
+}
+
+static int stm32_hx711_data_read(unsigned char minor)
+{
+  UNUSED(minor);
+
+  return stm32_gpioread(HX711_DATA_PIN);
+}
+
+static int stm32_hx711_data_irq(unsigned char minor,
+                                xcpt_t handler, void *arg)
+{
+  UNUSED(minor);
+
+  return stm32_gpiosetevent(HX711_DATA_PIN, false, true, true, handler, arg);
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int stm32_hx711_initialize(void)
+{
+  int ret;
+
+  stm32_configgpio(HX711_DATA_PIN);
+  stm32_configgpio(HX711_CLK_PIN);
+
+  ret = hx711_register(0, &g_lower);
+  if (ret != 0)
+    {
+      aerr("ERROR: Failed to register hx711 device: %d\n", ret);
+      return -1;
+    }
+
+  return OK;
+}

--- a/boards/arm/stm32/stm32f401rc-rs485/src/stm32f401rc-rs485.h
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/stm32f401rc-rs485.h
@@ -159,6 +159,15 @@
 #define GPIO_INT1         (GPIO_INPUT | GPIO_PULLDOWN | GPIO_SPEED_2MHz | \
                            GPIO_PORTC | GPIO_PIN4)
 
+/* HX711 PINs */
+#ifdef CONFIG_ADC_HX711
+#  define HX711_CLK_PIN  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_OUTPUT_SET|\
+                          GPIO_SPEED_2MHz|GPIO_PULLUP|\
+                          GPIO_PORTB|GPIO_PIN1)
+#  define HX711_DATA_PIN (GPIO_INPUT|GPIO_SPEED_2MHz|GPIO_PULLUP|GPIO_EXTI|\
+                          GPIO_PORTB|GPIO_PIN2)
+#endif /* CONFIG_ADC_HX711 */
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -303,6 +312,18 @@ int stm32_gpio_initialize(void);
 
 #ifdef CONFIG_ADC
 int stm32_adc_setup(void);
+#endif
+
+/****************************************************************************
+ * Name: stm32_hx711_initialize
+ *
+ * Description:
+ *   Initialize hx711 chip
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ADC_HX711
+int stm32_hx711_initialize(void);
 #endif
 
 #endif /* __BOARDS_ARM_STM32_STM32F401RC_RS485_SRC_STM32F401RC_RS485_H */


### PR DESCRIPTION
## Summary

This commit adds support for the HX711 ADC in the STM32F401RC-RS485 board and updates the board documentation accordingly.

## Impact

Is new feature added? Is existing feature changed? Yes, Added HX711 support to STM32F401RC-RS485.
Impact on user (will user need to adapt to change)? Yes, users will be able to user HX711 on STM32F401RC-RS485.
Impact on build (will build process change)? No
Impact on hardware (will arch(s) / board(s) / driver(s) change)? Yes, ARM/STM32F401RC-RS485.
Impact on documentation (is update required / provided)? Yes, STM32F401RC-RS485 was updated.
Impact on security (any sort of implications)? No.
Impact on compatibility (backward/forward/interoperability)? No

## Testing

I confirm that changes are verified on the local setup and work as intended:

Build Host(s): OS: Ubuntu 24.04, CPU: Intel i7-8850H, Compiler: GCC 13.3.0
Target(s): arch: arm, board: stm32f401rc-rs485, config: usbnsh

Configuration:
    CONFIG_ADC=y
    CONFIG_ANALOG=y
    CONFIG_ADC_HX711=y
    CONFIG_EXAMPLES_HX711=y

Test:
    NuttShell (NSH) NuttX-12.10.0-RC0
    nsh> hx711 -D
    Current settings for: /dev/hx711_0
    average.............: 1
    channel.............: a
    gain................: 128
    value per unit......: 0
    nsh> hx711 -v 813 -t 10
    Taring with *float*g precision
    nsh> hx711 -r 10
    11
    9
    9
    10
    11


