### PR TITLE
Add oversampling and resolution support for STM32H5 ADC

### DIFF
--- a/arch/arm/src/stm32h5/Kconfig
+++ b/arch/arm/src/stm32h5/Kconfig
@@ -895,6 +895,14 @@ config STM32H5_ADC_MAX_SAMPLES
 		for all supported devices, the user can change the default
 		values in the board initialization logic and avoid ADC overrun.
 
+config STM32H5_ADC1_RESOLUTION
+	int "ADC1 resolution"
+	depends on STM32H5_ADC1
+	default 0
+	range 0 3
+	---help---
+		ADC1 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
+
 config STM32H5_ADC1_DMA
 	bool "ADC1 DMA Enable"
 	depends on STM32H5_ADC1 && STM32H5_DMA
@@ -920,6 +928,53 @@ config STM32H5_ADC1_DMA_CFG
 	default n
 	---help---
 		0 - ADC1 DMA in One Shot Mode, 1 - ADC1 DMA in Circular Mode
+
+config STM32H5_ADC1_OVERSAMPLE
+	bool "Enable ADC1 hardware oversampling support"
+	depends on STM32H5_ADC1
+	default n
+	---help---
+		Enable the on-chip ADC oversampling/accumulation block (CFGR2.OVSE).
+		Only STM32G0 and STM32L0 series include this hardware block.
+
+if STM32H5_ADC1_OVERSAMPLE
+
+config STM32H5_ADC1_TROVS
+	bool "Enable triggered oversampling (CFGR2.TROVS)"
+	default n
+	---help---
+		If set, oversampling will only occur when a trigger event occurs.
+		If not set, oversampling occurs continuously (TOVS=0).
+
+config STM32H5_ADC1_OVSR
+	int "Oversampling ratio (CFGR2.OVSR)"
+	default 0
+	range 0 7
+	---help---
+		Sets the oversampling ratio as 2^(OVSR+1). For example:
+		0 -> 2×
+		1 -> 4×
+		2 -> 8×
+		...
+		7 -> 256×
+
+config STM32H5_ADC1_OVSS
+	int "Oversampling right-shift bits (CFGR2.OVSS)"
+	default 0
+	range 0 8
+	---help---
+		Sets how many bits the accumulated result is right-shifted.
+		Max of 8-bits.
+
+endif # STM32H5_ADC1_OVERSAMPLE
+
+config STM32H5_ADC2_RESOLUTION
+	int "ADC2 resolution"
+	depends on STM32H5_ADC2
+	default 0
+	range 0 3
+	---help---
+		ADC1 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
 
 config STM32H5_ADC2_DMA
 	bool "ADC2 DMA Enable"
@@ -947,6 +1002,45 @@ config STM32H5_ADC2_DMA_CFG
 	default 0
 	---help---
 		0 - ADC2 DMA in One Shot Mode, 1 - ADC2 DMA in Circular Mode
+
+config STM32H5_ADC2_OVERSAMPLE
+	bool "Enable ADC2 hardware oversampling support"
+	depends on STM32H5_ADC2
+	default n
+	---help---
+		Enable the on-chip ADC oversampling/accumulation block (CFGR2.OVSE).
+		Only STM32G0 and STM32L0 series include this hardware block.
+
+if STM32H5_ADC2_OVERSAMPLE
+
+config STM32H5_ADC2_TROVS
+	bool "Enable triggered oversampling (CFGR2.TROVS)"
+	default n
+	---help---
+		If set, oversampling will only occur when a trigger event occurs.
+		If not set, oversampling occurs continuously (TOVS=0).
+
+config STM32H5_ADC2_OVSR
+	int "Oversampling ratio (CFGR2.OVSR)"
+	default 0
+	range 0 7
+	---help---
+		Sets the oversampling ratio as 2^(OVSR+1). For example:
+		0 -> 2×
+		1 -> 4×
+		2 -> 8×
+		...
+		7 -> 256×
+
+config STM32H5_ADC2_OVSS
+	int "Oversampling right-shift bits (CFGR2.OVSS)"
+	default 0
+	range 0 8
+	---help---
+		Sets how many bits the accumulated result is right-shifted.
+		Max of 8-bits.
+
+endif # STM32H5_ADC2_OVERSAMPLE
 
 endmenu # ADC Configuration
 

--- a/arch/arm/src/stm32h5/stm32_adc.h
+++ b/arch/arm/src/stm32h5/stm32_adc.h
@@ -97,6 +97,22 @@
 #  define ADC2_HAVE_DMA 1
 #endif
 
+/* Oversampling support */
+
+#undef ADC_HAVE_OVERSAMPLE
+#if defined(CONFIG_STM32H5_ADC1_OVERSAMPLE) || \
+    defined(CONFIG_STM32H5_ADC2_OVERSAMPLE)
+#  define ADC_HAVE_OVERSAMPLE 1
+#endif
+
+#if defined(CONFIG_STM32H5_ADC1_OVERSAMPLE)
+#  define ADC1_HAVE_OVERSAMPLE 1
+#endif
+
+#if defined(CONFIG_STM32H5_ADC2_OVERSAMPLE)
+#  define ADC2_HAVE_OVERSAMPLE 1
+#endif
+
 /* Timer configuration:  If a timer trigger is specified, then get
  * information about the timer.
  */


### PR DESCRIPTION
## Summary

This pull request adds oversampling support and the ability to set the resolution of the adc result through Kconfig options. 
I used the STM32G0 as a reference. 

## Impact

STM32H5 - ADC Driver
Should have no impact outside the STM32H5. 

## Testing

Resolution Test: Set resolution to 1 (10-bits)
Channel 3 = 0V. Channel 10 = 1.66V (Half-scale)

NuttShell (NSH) NuttX-12.10.0
nsh> adc
adc_main: g_adcstate.count: 1
adc_main: Hardware initialized. Opening the ADC device: /dev/adc0
Sample:
1: channel: 3 value: 0
2: channel: 10 value: 516
nsh> 

Oversample Test: Oversampling ratio = 16x. Shift = 0. Result = 16-bit value
Channel 3 = 0V. Channel 10 = 1.66V (Half-scale). 

NuttShell (NSH) NuttX-12.10.0
nsh> adc
adc_main: g_adcstate.count: 1
adc_main: Hardware initialized. Opening the ADC device: /dev/adc0
Sample:
1: channel: 3 value: 40
2: channel: 10 value: 33061
nsh> 