### PR TITLE
toolchain/arm: Fix crash caused by clang compiling with -mfpu=fpv5-d16 and -march=armv8.1-m.main+mve.fp+fp.dp

### DIFF
--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -81,14 +81,22 @@ else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
   TOOLCHAIN_MARCH    := -march=armv8.1-m.main$(EXTCPUFLAGS)
   LLVM_CPUTYPE       := cortex-m55
   ifeq ($(CONFIG_ARCH_FPU),y)
-    TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
+    ifeq ($(CONFIG_ARCH_TOOLCHAIN_GCC),y)
+      TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
+    else ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
+      TOOLCHAIN_MFLOAT := -mfpu=fp-armv8-fullfp16-d16
+    endif
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM85),y)
   TOOLCHAIN_MTUNE    := -mtune=cortex-m85
   TOOLCHAIN_MARCH    := -march=armv8.1-m.main$(EXTCPUFLAGS)
   LLVM_CPUTYPE       := cortex-m85
   ifeq ($(CONFIG_ARCH_FPU),y)
-    TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
+    ifeq ($(CONFIG_ARCH_TOOLCHAIN_GCC),y)
+      TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16
+    else ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
+      TOOLCHAIN_MFLOAT := -mfpu=fp-armv8-fullfp16-d16
+    endif
   endif
 endif
 


### PR DESCRIPTION
## Summary

The above combination of compilation causes the compiler to crash:
 #1 0x0000000001fbe154 llvm::sys::CleanupOnSignal(unsigned long) (clang18/bin/clang-19+0x1fbe154)
 #2 0x0000000001f21203 llvm::CrashRecoveryContext::HandleExit(int) (clang18/bin/clang-19+0x1f21203)
 #3 0x0000000001fb7b7e llvm::sys::Process::Exit(int, bool) (clang18/bin/clang-19+0x1fb7b7e)
 #4 0x0000000000b25f0d (clang18/bin/clang-19+0xb25f0d)
................................................................................
................................................................................
This problem occurs in clang18 and above, and there are compilation instructions that are incompatible with GCC.
By following the recommended v8.1m corresponding fpu modification, no crash will occur
➜  NX git:(master) ✗ clang --target=arm-none-eabi -mfpu=help
clang: note: available multilibs are:
--target=thumbv8m.main-unknown-none-eabi -mfpu=none
--target=thumbv8m.main-unknown-none-eabi -mfpu=none -fno-exceptions -fno-rtti
--target=thumbv8m.main-unknown-none-eabihf -mfpu=fpv5-sp-d16
--target=thumbv8m.main-unknown-none-eabihf -mfpu=fpv5-sp-d16 -fno-exceptions -fno-rtti
--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none
--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -fno-exceptions -fno-rtti
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none
--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti

## Impact

No impact

## Testing

ci


