### PR TITLE
libc/idr: Fix Use-After-Free during idr_destroy()

### DIFF
--- a/libs/libc/misc/lib_idr.c
+++ b/libs/libc/misc/lib_idr.c
@@ -329,11 +329,13 @@ void idr_destroy(FAR struct idr_s *idr)
   nxmutex_lock(&idr->lock);
   RB_FOREACH_SAFE(node, idr_tree_s, &idr->removed, temp)
     {
+      RB_REMOVE(idr_tree_s, &idr->removed, node);
       lib_free(node);
     }
 
   RB_FOREACH_SAFE(node, idr_tree_s, &idr->alloced, temp)
     {
+      RB_REMOVE(idr_tree_s, &idr->alloced, node);
       lib_free(node);
     }
 


### PR DESCRIPTION
## Summary

libc lib_idr maintains 2 RB trees to efficiently handle node allocations. Removed nodes are not freed, but rather added to the "removed" RB tree, for potential re-use during subsequent allocations.

`idr_destroy()` would loop over the nodes of the "removed" and "alloced" RB trees, freeing them but not removing them from the trees. From the perspective of the RB tree those nodes would remain valid, while in fact, they were dangling pointers. This would cause (seemingly random) memory corruption crashes during subsequent iterations within the same tree triggered by the RB tree code trying to access linkage fields (`left`, `right`, `parent`) from the dangling pointers

Fix this by removing the nodes before freeing them.

I have observed this issue when using the optee driver with an app I cannot share. Every time I isolated `idr_alloc()/remove()` sequences to re-produce the issue in a neutral context, the bug didn't manifest. I suspect this might have to do with high memory pressure causing the allocator to re-arrange free chunks or something along those lines.

So, while I unfortunately cannot share reproduction code, the issue & fix should be relatively obvious.

## Impact

For users of lib_idr (or users of optee or v9fs), this might solve (seemingly random) crashes, and will definitely make it more reliable during destruction (or calls to `close(fd)` resp.).

## Testing

My crashing use-case no longer crashes after this patch. All other tests ran in arm64 NXP iMX93 SoC generate positive results.
