### PR TITLE
drivers/analog/ads1115.h: Add ioctl for conversion trigger

### DIFF
--- a/Documentation/components/drivers/character/analog/adc/ads1115/index.rst
+++ b/Documentation/components/drivers/character/analog/adc/ads1115/index.rst
@@ -235,3 +235,13 @@ of type uint16_t, which corresponds to the LOW_THRESH register value.
 
 This command reads a value from a specific channel of the ADS1115. The argument passed should
 be a pointer to a struct adc_msg_s.
+
+.. c:macro:: ANIOC_ADS1115_TRIGGER_CONVERSION
+
+This command triggers an analog conversion on the ADS1115. The argument passed should be a pointer to a ``struct
+adc_msg_s``, where the member ``am_channel`` is initialized to the channel number the conversion should be started for.
+
+.. c:macro:: ANIOC_ADS1115_READ_CHANNEL_NO_CONVERSION
+
+This command reads the result of the last conversion on the ADS1115. The argument passed should be a pointer to a
+``struct adc_msg_s``, where the result of the conversion will be stored.

--- a/include/nuttx/analog/ads1115.h
+++ b/include/nuttx/analog/ads1115.h
@@ -36,28 +36,32 @@
  ****************************************************************************/
 
 /* IOCTL Commands
- * Cmd: ANIOC_ADS1115_SET_PGA         Arg: enum ads1115_pga_e
- * Cmd: ANIOC_ADS1115_SET_MODE        Arg: enum ads1115_mode_e
- * Cmd: ANIOC_ADS1115_SET_DR          Arg: enum ads1115_dr_e
- * Cmd: ANIOC_ADS1115_SET_COMP_MODE   Arg: enum ads1115_comp_mode_e
- * Cmd: ANIOC_ADS1115_SET_COMP_POL    Arg: enum ads1115_comp_pol_e
- * Cmd: ANIOC_ADS1115_SET_COMP_LAT    Arg: enum ads1115_comp_lat_e
- * Cmd: ANIOC_ADS1115_SET_COMP_QUEUE  Arg: enum ads1115_comp_queue_e
- * Cmd: ANIOC_ADS1115_READ_CHANNEL    Arg: struct adc_msg_s *channel
- * Cmd: ANIOC_ADS1115_SET_HI_THRESH   Arg: uint16_t value
- * Cmd: ANIOC_ADS1115_SET_LO_THRESH   Arg: uint16_t value
+ * Cmd: ANIOC_ADS1115_SET_PGA            Arg: enum ads1115_pga_e
+ * Cmd: ANIOC_ADS1115_SET_MODE           Arg: enum ads1115_mode_e
+ * Cmd: ANIOC_ADS1115_SET_DR             Arg: enum ads1115_dr_e
+ * Cmd: ANIOC_ADS1115_SET_COMP_MODE      Arg: enum ads1115_comp_mode_e
+ * Cmd: ANIOC_ADS1115_SET_COMP_POL       Arg: enum ads1115_comp_pol_e
+ * Cmd: ANIOC_ADS1115_SET_COMP_LAT       Arg: enum ads1115_comp_lat_e
+ * Cmd: ANIOC_ADS1115_SET_COMP_QUEUE     Arg: enum ads1115_comp_queue_e
+ * Cmd: ANIOC_ADS1115_READ_CHANNEL       Arg: struct adc_msg_s *channel
+ * Cmd: ANIOC_ADS1115_SET_HI_THRESH      Arg: uint16_t value
+ * Cmd: ANIOC_ADS1115_SET_LO_THRESH      Arg: uint16_t value
+ * Cmd: ANIOC_ADS1115_TRIGGER_CONVERSION Arg: struct adc_msg_s
+ * Cmd: ANIOC_ADS1115_READ_CHANNEL_NO_CONVERSION Arg: struct adc_msg_s
  */
 
-#define ANIOC_ADS1115_SET_PGA _ANIOC(AN_ADS1115_FIRST + 0)
-#define ANIOC_ADS1115_SET_MODE _ANIOC(AN_ADS1115_FIRST + 1)
-#define ANIOC_ADS1115_SET_DR _ANIOC(AN_ADS1115_FIRST + 2)
-#define ANIOC_ADS1115_SET_COMP_MODE _ANIOC(AN_ADS1115_FIRST + 3)
-#define ANIOC_ADS1115_SET_COMP_POL _ANIOC(AN_ADS1115_FIRST + 4)
-#define ANIOC_ADS1115_SET_COMP_LAT _ANIOC(AN_ADS1115_FIRST + 5)
-#define ANIOC_ADS1115_SET_COMP_QUEUE _ANIOC(AN_ADS1115_FIRST + 6)
-#define ANIOC_ADS1115_READ_CHANNEL _ANIOC(AN_ADS1115_FIRST + 7)
-#define ANIOC_ADS1115_SET_HI_THRESH _ANIOC(AN_ADS1115_FIRST + 8)
-#define ANIOC_ADS1115_SET_LO_THRESH _ANIOC(AN_ADS1115_FIRST + 9)
+#define ANIOC_ADS1115_SET_PGA                    _ANIOC(AN_ADS1115_FIRST + 0)
+#define ANIOC_ADS1115_SET_MODE                   _ANIOC(AN_ADS1115_FIRST + 1)
+#define ANIOC_ADS1115_SET_DR                     _ANIOC(AN_ADS1115_FIRST + 2)
+#define ANIOC_ADS1115_SET_COMP_MODE              _ANIOC(AN_ADS1115_FIRST + 3)
+#define ANIOC_ADS1115_SET_COMP_POL               _ANIOC(AN_ADS1115_FIRST + 4)
+#define ANIOC_ADS1115_SET_COMP_LAT               _ANIOC(AN_ADS1115_FIRST + 5)
+#define ANIOC_ADS1115_SET_COMP_QUEUE             _ANIOC(AN_ADS1115_FIRST + 6)
+#define ANIOC_ADS1115_READ_CHANNEL               _ANIOC(AN_ADS1115_FIRST + 7)
+#define ANIOC_ADS1115_SET_HI_THRESH              _ANIOC(AN_ADS1115_FIRST + 8)
+#define ANIOC_ADS1115_SET_LO_THRESH              _ANIOC(AN_ADS1115_FIRST + 9)
+#define ANIOC_ADS1115_TRIGGER_CONVERSION         _ANIOC(AN_ADS1115_FIRST + 10)
+#define ANIOC_ADS1115_READ_CHANNEL_NO_CONVERSION _ANIOC(AN_ADS1115_FIRST + 11)
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary

Since the ADS1115 has a relatively slow conversion rate, this additional ioctl command makes it possible to trigger a conversion before reading the reading the conversion result, allowing the user to perform other computation in between instead of waiting for the conversion time to complete. It improves sampling time.

## Impact

Users can parallelize sampling of the ADS1115 ADC to avoid delays from sleeping while waiting for the conversion time duration.

## Testing

Tested on a rocketry system with 4 ADS1115s in the sensor array. This change allowed parallezation to speed up sampling from 10Hz to 15Hz per channel per ADC.

@bskdany performed this testing, as did I.