### PR TITLE
[CI] build.yml: fix ERROR: Dangerous symbolic link path was ignored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Extract sources
         run: |
           7z x sources.tar.gz -y
-          7z x sources.tar -y
+          7z x sources.tar -y -snld
 
       - name: Run Builds
         run: |


### PR DESCRIPTION
## Summary
fix

ERROR: Dangerous symbolic link path was ignored : sources\nuttx\boards\sim\sim\sim\configs\citest\run : ..\..\..\..\..\..\tools\ci\cirun.sh
ERROR: Dangerous symbolic link path was ignored : sources\nuttx\boards\risc-v\qemu-rv\rv-virt\configs\citest\run : ..\..\..\..\..\..\tools\ci\cirun.sh
ERROR: Dangerous symbolic link path was ignored : sources\nuttx\boards\risc-v\qemu-rv\rv-virt\configs\citest64\run : ..\..\..\..\..\..\tools\ci\cirun.sh
ERROR: Dangerous symbolic link path was ignored : sources\nuttx\boards\arm\imx6\sabre-6quad\configs\citest\run : ..\..\..\..\..\..\tools\ci\cirun.sh

https://github.com/apache/nuttx/actions/runs/16238197687/job/45851083159?pr=16714#logs

add:
Command Line Switch -snld

-snld ->  allow extracting of denagerous symbolic links.

https://sourceforge.net/p/sevenzip/discussion/45798/thread/187ce54fb0/

## Impact
Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

CI


