### PR TITLE
arm64/qemu: decouple qemu board from chip

### DIFF
--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -179,7 +179,9 @@ void arm64_chip_boot(void)
    * configuration of board specific resources such as GPIOs, LEDs, etc.
    */
 
+#ifndef CONFIG_ARCH_CHIP_CUSTOM
   qemu_board_initialize();
+#endif
 
 #ifdef USE_EARLYSERIALINIT
   /* Perform early serial initialization if we are going to use the serial


### PR DESCRIPTION
## Summary

arm64/qemu: decouple qemu board from chip

decouple qemu board from chip to support custom boards

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

add support of custom board

## Testing

enable CONFIG_ARCH_BOARD_CUSTOM and check the build

fix build issue:
```
[1177/1180] Linking CXX executable nuttx
FAILED: nuttx
: && prebuilts/gcc/linux/arm64/bin/aarch64-none-elf-g++  --entry=__start -nostdlib -Wl,--gc-sections -Wl,-cref,-Map=nuttx.map -Wl,--print-memory-usage -Wl,--no-warn-rwx-segments @CMakeFiles/nuttx.rsp -o nuttx && :
prebuilts/gcc/linux/arm64/bin/../lib/gcc/aarch64-none-elf/14.2.1/../../../../aarch64-none-elf/bin/ld: arch/libarch.a(qemu_boot.c.obj): in function `arm64_chip_boot':
nuttx/arch/arm64/src/qemu/qemu_boot.c:180:(.text.arm64_chip_boot+0x30): undefined reference to `qemu_board_initialize'
```
