### PR TITLE
arm64/zynq-mpsoc: fix race condition in txint handler

### DIFF
--- a/arch/arm64/src/zynq-mpsoc/zynq_serial.c
+++ b/arch/arm64/src/zynq-mpsoc/zynq_serial.c
@@ -1024,6 +1024,9 @@ static void zynq_uart_txint(struct uart_dev_s *dev, bool enable)
 {
   struct zynq_uart_port_s *port = (struct zynq_uart_port_s *)dev->priv;
   struct zynq_uart_config *config = &port->config;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
 
   /* Write to Interrupt Enable Register (UART_IER) */
 
@@ -1048,6 +1051,8 @@ static void zynq_uart_txint(struct uart_dev_s *dev, bool enable)
       modreg32(XUARTPS_IXR_TXEMPTY, XUARTPS_IXR_TXEMPTY,
                config->uart + XUARTPS_IDR_OFFSET);
     }
+
+  leave_critical_section(flags);
 }
 
 /***************************************************************************


### PR DESCRIPTION
## Summary

arm64/zynq-mpsoc: fix race condition in txint handler

The tx int handler will call uart_xmitchars() to make a fake interrupt event,
but this is unsafe after enabling interrupts. This PR will add a critical section
to ensure that the txint process will not be interrupted by the IRQ

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

Testing on z19-p FPGA, Check that the UART terminal output without garbled