### PR TITLE
cmake: enhance the function of cmake nuttx_wildcard_sources

### DIFF
--- a/cmake/nuttx_extensions.cmake
+++ b/cmake/nuttx_extensions.cmake
@@ -120,6 +120,31 @@ function(nuttx_wildcard_sources)
   nuttx_sources(${SRCS})
 endfunction()
 
+# Function: nuttx_wildcard_sources_ifdef
+#
+# Conditionally adds source files matching a wildcard pattern to the current
+# library target if the given condition is true.
+#
+# Usage: nuttx_wildcard_sources_ifdef(MY_CONDITION "*.c" EXCLUDE "exclude_me.c")
+function(nuttx_wildcard_sources_ifdef cond)
+  if(${cond})
+    nuttx_wildcard_sources(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_wildcard_sources_ifndef
+#
+# Conditionally adds source files matching a wildcard pattern to the current
+# library target if the given condition is false.
+#
+# Usage: nuttx_wildcard_sources_ifndef(MY_CONDITION "*.c" EXCLUDE
+# "exclude_me.c")
+function(nuttx_wildcard_sources_ifndef cond)
+  if(NOT ${cond})
+    nuttx_wildcard_sources(${ARGN})
+  endif()
+endfunction()
+
 # Function: nuttx_include_directories
 #
 # Adds include directories to the current library target.


### PR DESCRIPTION
## Summary

cmake: enhance the function of cmake nuttx_wildcard_sources

align already used cmake ifdef/ifndef nuttx_xxx functions, reference:
- https://github.com/apache/nuttx/pull/14747

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
cmake build

## Testing

local repo build


