### PR TITLE
tools/espressif: Add risc-v compiler info dump for Espressif devices

### DIFF
--- a/tools/espressif/chip_info.py
+++ b/tools/espressif/chip_info.py
@@ -213,6 +213,7 @@ def get_espressif_toolchain_version():
         "xtensa-esp32-elf-gcc",
         "xtensa-esp32s2-elf-gcc",
         "xtensa-esp32s3-elf-gcc",
+        "riscv-none-elf-gcc",
         "riscv32-esp-elf-gcc",
         "riscv64-unknown-elf-gcc",
     ]


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* tools/espressif: Add risc-v compiler info dump for Espressif devices

Add xpack risc-v compiler info on diagnostic tool

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No, addition just added on diagnostic tool
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command used to build:

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:nsh && kconfig-tweak -e CONFIG_SYSTEM_NXDIAG && kconfig-tweak -e CONFIG_SYSTEM_NXDIAG_ESPRESSIF && make olddefconfig -s -j && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BAUD=921600 ESPTOOL_BINDIR=../esp-bin
```

Alternatively `make host_info` command can be used after configuration.

### Running
<!-- Provide how to run the test for each SoC being tested -->

`nxdiag --all` command used

### Results

Output before:

```
...
Toolchain version:
	clang: Not found
	gcc: gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
	xtensa-esp32-elf-gcc: xtensa-esp32-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
	xtensa-esp32s2-elf-gcc: xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0
	xtensa-esp32s3-elf-gcc: xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0
	riscv32-esp-elf-gcc: Not found
	riscv64-unknown-elf-gcc: Not found
...
```

After

```
...

Toolchain version:
	clang: Not found
	gcc: gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
	xtensa-esp32-elf-gcc: xtensa-esp32-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
	xtensa-esp32s2-elf-gcc: xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0
	xtensa-esp32s3-elf-gcc: xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0
	riscv-none-elf-gcc: riscv-none-elf-gcc (xPack GNU RISC-V Embedded GCC x86_64) 14.2.0
	riscv32-esp-elf-gcc: Not found
	riscv64-unknown-elf-gcc: Not found
...
```