### PR TITLE
ci/platforms: bump risc-v toolchain

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -275,12 +275,12 @@ riscv_gcc_toolchain() {
 
   if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
     local basefile
-    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-darwin-x64
+    basefile=xpack-riscv-none-elf-gcc-14.2.0-3-darwin-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    mv xpack-riscv-none-elf-gcc-14.2.0-3 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
 

--- a/tools/ci/platforms/darwin_arm64.sh
+++ b/tools/ci/platforms/darwin_arm64.sh
@@ -271,12 +271,12 @@ riscv_gcc_toolchain() {
 
   if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
     local basefile
-    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-darwin-arm64
+    basefile=xpack-riscv-none-elf-gcc-14.2.0-3-darwin-arm64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    mv xpack-riscv-none-elf-gcc-14.2.0-3 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
 

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -163,12 +163,12 @@ riscv_gcc_toolchain() {
 
   if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
     local basefile
-    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64
+    basefile=xpack-riscv-none-elf-gcc-14.2.0-3-linux-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    wget --quiet https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    mv xpack-riscv-none-elf-gcc-14.2.0-3 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
   command riscv-none-elf-gcc --version

--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -158,12 +158,12 @@ riscv_gcc_toolchain() {
 
   if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
     local basefile
-    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64
+    basefile=xpack-riscv-none-elf-gcc-14.2.0-3-win32-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.zip
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/${basefile}.zip
     unzip -qo ${basefile}.zip
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    mv xpack-riscv-none-elf-gcc-14.2.0-3 riscv-none-elf-gcc
     rm ${basefile}.zip
   fi
   command riscv-none-elf-gcc --version

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -216,12 +216,12 @@ riscv_gcc_toolchain() {
 
   if [ ! -f "${NUTTXTOOLS}/riscv-none-elf-gcc/bin/riscv-none-elf-gcc" ]; then
     local basefile
-    basefile=xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64
+    basefile=xpack-riscv-none-elf-gcc-14.2.0-3-linux-x64
     cd "${NUTTXTOOLS}"
     # Download the latest RISCV GCC toolchain prebuilt by xPack
-    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/${basefile}.tar.gz
+    curl -O -L -s https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/${basefile}.tar.gz
     tar zxf ${basefile}.tar.gz
-    mv xpack-riscv-none-elf-gcc-13.2.0-2 riscv-none-elf-gcc
+    mv xpack-riscv-none-elf-gcc-14.2.0-3 riscv-none-elf-gcc
     rm ${basefile}.tar.gz
   fi
 

--- a/tools/ci/platforms/windows.ps1
+++ b/tools/ci/platforms/windows.ps1
@@ -231,12 +231,12 @@ function riscv_gcc_toolchain() {
       add_path "$NUTTXTOOLS\riscv-none-elf-gcc\bin"
       if (-not (Test-Path -Path "$NUTTXTOOLS\riscv-none-elf-gcc\bin\riscv-none-elf-gcc.exe")) {
         Write-Host "Download: RISCV GCC toolchain" -ForegroundColor Green
-        $basefile = "xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64"
+        $basefile = "xpack-riscv-none-elf-gcc-14.2.0-3-win32-x64"
         Set-Location "$NUTTXTOOLS"
         # Download the latest RISCV GCC toolchain prebuilt by xPack
-        Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+        Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
         Expand-Archive "$NUTTXTOOLS\$basefile.zip"
-        Move-Item -Path "$basefile\xpack-riscv-none-elf-gcc-13.2.0-2" -Destination "riscv-none-elf-gcc"
+        Move-Item -Path "$basefile\xpack-riscv-none-elf-gcc-14.2.0-3" -Destination "riscv-none-elf-gcc"
         Remove-Item "$basefile*" -Force
       }
     }


### PR DESCRIPTION

## Summary

Bump xPack GNU RISC-V Embedded GCC v14.2.0-3

ci/platforms/darwin.sh
ci/platforms/darwin_arm64.sh
ci/platforms/linux.sh
ci/platforms/msys2.sh 
ci/platforms/ubuntu.sh
ci/platforms/windows.ps1

aligned with docker #16645

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

CI


