### PR TITLE
arch/arm/imx9/imx95: eDMA5 Allow sharing with Linux

### DIFF
--- a/arch/arm/src/imx9/Kconfig
+++ b/arch/arm/src/imx9/Kconfig
@@ -652,6 +652,26 @@ config IMX9_EDMA_NTCD
 		which case only the TCD channel registers will be used and scatter-
 		will not be supported.
 
+config IMX9_EDMA5_CHAN_OFFSET
+	int "Offset of 1st EDMA5 channel"
+	default 30
+	depends on ARCH_CHIP_IMX95_M7
+	---help---
+		The EDMA5 controller on the i.MX95 can be accessed by multiple cores.
+		However, TCD (Transfer Control Descriptor) mappings are not shareable
+		between instances. Instead, each instance must specify its usable TCD
+		channels using an offset and count to define a dedicated range.
+
+config IMX9_EDMA5_CHAN_COUNT
+	int "Number of EDMA5 channels"
+	default 34
+	depends on ARCH_CHIP_IMX95_M7
+	---help---
+		The EDMA5 controller on the i.MX95 can be accessed by multiple cores.
+		However, TCD (Transfer Control Descriptor) mappings are not shareable
+		between instances. Instead, each instance must specify its usable TCD
+		channels using an offset and count to define a dedicated range.
+
 config IMX9_EDMA_ELINK
 	bool "Channeling Linking"
 	default n

--- a/arch/arm/src/imx9/hardware/imx95/imx95_edma.h
+++ b/arch/arm/src/imx9/hardware/imx95/imx95_edma.h
@@ -345,8 +345,18 @@
 /* Amount of channels */
 
 #define DMA3_CHANNEL_COUNT                (31)
-#define DMA4_CHANNEL_COUNT                (64)
-#define IMX9_EDMA_NCHANNELS               (DMA3_CHANNEL_COUNT + DMA4_CHANNEL_COUNT)
+#ifdef IMX9_DMA4_BASE
+#  define DMA4_CHANNEL_COUNT              (64)
+#else
+#  define DMA4_CHANNEL_COUNT              (0)
+#endif
+#ifdef IMX9_EDMA5_2_BASE
+#define DMA5_CHANNEL_COUNT                (64 - CONFIG_IMX9_EDMA5_CHAN_COUNT)
+#else
+#  define DMA5_CHANNEL_COUNT              (0)
+#endif
+
+#define IMX9_EDMA_NCHANNELS               (DMA3_CHANNEL_COUNT + DMA4_CHANNEL_COUNT + DMA5_CHANNEL_COUNT)
 
 /* Amount of interrupt sources */
 #ifdef CONFIG_ARCH_CHIP_IMX95_M7

--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -909,7 +909,8 @@ void weak_function arm_dma_initialize(void)
 
   /* Initialize the channel */
 
-  for (i = 0; i < DMA4_CHANNEL_COUNT; i++, dmach++)
+  for (i = CONFIG_IMX9_EDMA5_CHAN_OFFSET;
+       i < CONFIG_IMX9_EDMA5_CHAN_COUNT; i++, dmach++)
     {
       dmach->base = IMX9_EDMA5_2_BASE;
       dmach->chan = i;


### PR DESCRIPTION

## Summary
Allows to offset channels and thus sharing the controller with A-core.
The EDMA5 controller on the i.MX95 can be accessed by multiple cores. However, TCD (Transfer Control Descriptor) mappings are not shareable between instances. Instead, each instance must specify its usable TCD
channels using an offset and count to define a dedicated range.


## Impact
imx95

## Testing
imx95


