### PR TITLE
drivers/fs:Always use register_mtddriver() to register the MTD device (patch2)

### DIFF
--- a/boards/arm/at32/at32f437-mini/src/at32_at24.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_at24.c
@@ -108,14 +108,15 @@ int at32_at24_automount(int minor)
           return ret;
         }
 #else
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      finfo("Initialize the FTL layer to create /dev/mtdblock%d\n",
-            AT24_MINOR);
-      ret = ftl_initialize(AT24_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT24_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 #endif

--- a/boards/arm/at32/at32f437-mini/src/at32_w25.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_w25.c
@@ -78,7 +78,7 @@
 
 #define FLASH_PART_NAMES "w25qxx"
 
-#define FLASH_PART 1 
+#define FLASH_PART 1
 
 #define FLASH_PART_LIST "4096, 4096, 4096"
 
@@ -126,12 +126,15 @@ int at32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_SMARTFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Initialize the FTL layer\n");
+      syslog(LOG_ERR, "ERROR: Failed to register the MTD driver %s ret %d\n",
+             path, ret);
       return ret;
     }
 #else

--- a/boards/arm/cxd56xx/common/src/cxd56_flash.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_flash.c
@@ -64,6 +64,7 @@ int board_flash_initialize(void)
 {
   int ret;
   struct mtd_dev_s *mtd;
+  char path[32];
 
   mtd = cxd56_sfc_initialize();
   if (!mtd)
@@ -72,12 +73,14 @@ int board_flash_initialize(void)
       return -ENODEV;
     }
 
-  /* use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(CONFIG_SFC_DEVNO, mtd);
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", CONFIG_SFC_DEVNO);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initializing the FTL layer: %d\n", ret);
+      ferr("ERROR: Register the MTD driver %s ret %d\n",
+            path, ret);
       return ret;
     }
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_gd25.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_gd25.c
@@ -90,15 +90,16 @@ int gd32_gd25_automount(int minor)
         }
 
 #if defined(CONFIG_GD32F450ZK_EVAL_GD25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver at /dev/mtdblockN, where N=minor device number.
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(minor, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-                 ret);
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register the MTD driver %s, ret %d\n",
+                 path, ret);
           return ret;
         }
 

--- a/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_gd25.c
+++ b/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_gd25.c
@@ -90,15 +90,16 @@ int gd32_gd25_automount(int minor)
         }
 
 #if defined(CONFIG_GD32F470ZK_EVAL_GD25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver at /dev/mtdblockN, where N=minor device number.
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(minor, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-                 ret);
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register the MTD driver %s, ret %d\n",
+                 path, ret);
           return ret;
         }
 

--- a/boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_gd25.c
+++ b/boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_gd25.c
@@ -90,15 +90,16 @@ int gd32_gd25_automount(int minor)
         }
 
 #if defined(CONFIG_GD32F470ZK_EVAL_GD25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver at /dev/mtdblockN, where N=minor device number.
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(minor, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-                 ret);
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register the MTD driver %s, ret %d\n",
+                 path, ret);
           return ret;
         }
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_gd25.c
+++ b/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_gd25.c
@@ -90,15 +90,16 @@ int gd32_gd25_automount(int minor)
         }
 
 #if defined(CONFIG_GD32F470ZK_EVAL_GD25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver at /dev/mtdblockN, where N=minor device number.
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(minor, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-                 ret);
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register the MTD driver %s, ret %d\n",
+                 path, ret);
           return ret;
         }
 

--- a/boards/arm/lpc43xx/bambino-200e/src/lpc43_appinit.c
+++ b/boards/arm/lpc43xx/bambino-200e/src/lpc43_appinit.c
@@ -91,12 +91,15 @@ static int nsh_spifi_initialize(void)
     }
 
 #ifndef CONFIG_SPFI_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(CONFIG_SPIFI_DEVNO, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", CONFIG_SPIFI_DEVNO);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initializing the FTL layer: %d\n", ret);
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/lpc43xx/lpc4330-xplorer/src/lpc43_appinit.c
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/src/lpc43_appinit.c
@@ -83,12 +83,15 @@ static int nsh_spifi_initialize(void)
     }
 
 #ifndef CONFIG_SPFI_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(CONFIG_SPIFI_DEVNO, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", CONFIG_SPIFI_DEVNO);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initializing the FTL layer: %d\n", ret);
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/lpc43xx/lpc4357-evb/src/lpc43_appinit.c
+++ b/boards/arm/lpc43xx/lpc4357-evb/src/lpc43_appinit.c
@@ -83,12 +83,15 @@ static int nsh_spifi_initialize(void)
     }
 
 #ifndef CONFIG_SPFI_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(CONFIG_SPIFI_DEVNO, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", CONFIG_SPIFI_DEVNO);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initializing the FTL layer: %d\n", ret);
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/sam34/sam4e-ek/src/sam_at25.c
+++ b/boards/arm/sam34/sam4e-ek/src/sam_at25.c
@@ -88,17 +88,17 @@ int sam_at25_automount(int minor)
         }
 
 #if defined(CONFIG_SAM4EEK_AT25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver at /dev/mtdblockN, where N=minor device number.
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(minor, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+                path, ret);
           return ret;
         }
-
 #elif defined(CONFIG_SAM4EEK_AT25_NXFFS)
       /* Initialize to provide NXFFS on the MTD interface */
 

--- a/boards/arm/sam34/sam4s-xplained-pro/src/sam_nandflash.c
+++ b/boards/arm/sam34/sam4s-xplained-pro/src/sam_nandflash.c
@@ -202,13 +202,16 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAM34_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
       int ret = OK;
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/jupiter-nano/src/sam_at25.c
+++ b/boards/arm/sama5/jupiter-nano/src/sam_at25.c
@@ -87,13 +87,15 @@ int sam_at25_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_AT25_FTL)
+      /* Register the MTD driver */
 
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
-
-      ret = ftl_initialize(AT25_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT25_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/jupiter-nano/src/sam_nandflash.c
+++ b/boards/arm/sama5/jupiter-nano/src/sam_nandflash.c
@@ -172,12 +172,15 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d2-xult/src/sam_at25.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_at25.c
@@ -87,13 +87,15 @@ int sam_at25_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_AT25_FTL)
+      /* Register the MTD driver */
 
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
-
-      ret = ftl_initialize(AT25_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT25_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d2-xult/src/sam_nandflash.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_nandflash.c
@@ -173,12 +173,15 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_at25.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_at25.c
@@ -87,13 +87,15 @@ int sam_at25_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_AT25_FTL)
+      /* Register the MTD driver */
 
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
-
-      ret = ftl_initialize(AT25_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT25_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_nandflash.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_nandflash.c
@@ -173,12 +173,15 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XPLAINED_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_at24.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_at24.c
@@ -108,14 +108,15 @@ int sam_at24_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XEK_AT24_FTL)
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      finfo("Initialize the FTL layer to create /dev/mtdblock%d\n",
-            AT24_MINOR);
-      ret = ftl_initialize(AT24_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT24_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_at25.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_at25.c
@@ -88,14 +88,15 @@ int sam_at25_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XEK_AT25_FTL)
-      /* And finally, use the FTL layer to wrap the MTD driver as a block
-       * driver
-       */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(AT25_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT25_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_nandflash.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_nandflash.c
@@ -173,12 +173,15 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D3XEK_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/sama5/sama5d4-ek/src/sam_nandflash.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_nandflash.c
@@ -173,12 +173,15 @@ int sam_nand_automount(int minor)
         }
 
 #if defined(CONFIG_SAMA5D4EK_NAND_FTL)
-      /* Use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(NAND_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", NAND_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/samd5e5/metro-m4/src/sam_at24.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_at24.c
@@ -80,16 +80,15 @@ int sam_at24_automount(int minor)
         }
 
 #if defined(CONFIG_METRO_M4_AT24_FTL)
-      /* And finally, use the FTL layer
-       * to wrap the MTD driver as a block driver
-       */
+      /* Register the MTD driver */
 
-      finfo("Initialize the FTL layer to create /dev/mtdblock%d\n",
-            AT24_MINOR);
-      ret = ftl_initialize(AT24_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT24_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+                path, ret);
           return ret;
         }
 

--- a/boards/arm/stm32/cloudctrl/src/stm32_w25.c
+++ b/boards/arm/stm32/cloudctrl/src/stm32_w25.c
@@ -107,12 +107,15 @@ int stm32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initialize the FTL layer\n");
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/stm32/fire-stm32v2/src/stm32_w25.c
+++ b/boards/arm/stm32/fire-stm32v2/src/stm32_w25.c
@@ -107,12 +107,15 @@ int stm32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initialize the FTL layer\n");
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/stm32/shenzhou/src/stm32_w25.c
+++ b/boards/arm/stm32/shenzhou/src/stm32_w25.c
@@ -108,12 +108,15 @@ int stm32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initialize the FTL layer\n");
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_at24.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_at24.c
@@ -90,14 +90,15 @@ int stm32_at24_automount(int minor)
         }
 
 #if defined(CONFIG_STM32F103MINIMUM_AT24_FTL)
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      finfo("Initialize the FTL layer to create /dev/mtdblock%d\n",
-            AT24_MINOR);
-      ret = ftl_initialize(AT24_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT24_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          ferr("ERROR: Failed to initialize the FTL layer: %d\n", ret);
+          ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+               path, ret);
           return ret;
         }
 

--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_w25.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_w25.c
@@ -120,12 +120,16 @@ int stm32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_SMARTFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Initialize the FTL layer\n");
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the MTD driver %s, ret %d\n",
+             path, ret);
       return ret;
     }
 #else

--- a/boards/arm/stm32/stm32f411-minimum/src/stm32_w25.c
+++ b/boards/arm/stm32/stm32f411-minimum/src/stm32_w25.c
@@ -121,12 +121,16 @@ int stm32_w25initialize(int minor)
     }
 
 #ifndef CONFIG_FS_SMARTFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(minor, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Initialize the FTL layer\n");
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the MTD driver %s, ret %d\n",
+             path, ret);
       return ret;
     }
 #else

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/src/stm32_boot.c
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/src/stm32_boot.c
@@ -144,10 +144,11 @@ void board_late_initialize(void)
       syslog(LOG_ERR, "ERROR: w25qxxxjv_initialize failed\n");
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initialize the FTL layer\n");
+      syslog(LOG_ERR, "ERROR: Failed to register MTD /dev/mtdblock0: %d\n",
+             ret);
     }
 
   meminfo.flags = QSPIMEM_READ | QSPIMEM_QUADIO;

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
@@ -182,6 +182,7 @@ int stm32wl5_flash_init(void)
   int mtdblk_minor;
   int smart_minor;
   int nxf_minor;
+  char path[32];
   int ret;
   int i;
 
@@ -254,12 +255,15 @@ int stm32wl5_flash_init(void)
 
       if (strcmp(fs, "rawfs") == 0)
         {
-          /* for raw fs just create mtdblock using ftl */
+          /* Register the MTD driver */
 
-          if ((ret = ftl_initialize(mtdblk_minor, mtd_part)))
+          snprintf(path, sizeof(path), "/dev/mtdblock%d", mtdblk_minor);
+          ret = register_mtddriver(path, mtd, 0755, NULL);
+          if (ret < 0)
             {
-              ferr("[%s]ERROR: ftl_initialize failed %d\n", name, ret);
-              continue;
+              ferr("[%s]ERROR:Failed to register the MTD driver %s ret %d\n",
+                   name, path, ret);
+              return ret;
             }
 
           mtdblk_minor++;

--- a/boards/arm/tiva/tm4c123g-launchpad/src/tm4c_at24.c
+++ b/boards/arm/tiva/tm4c123g-launchpad/src/tm4c_at24.c
@@ -104,13 +104,16 @@ int tm4c_at24_automount(int minor)
         }
 
 #if defined(CONFIG_TM4C123G_LAUNCHPAD_AT24_FTL)
-      /* And use the FTL layer to wrap the MTD driver as a block driver */
+      /* Register the MTD driver */
 
-      ret = ftl_initialize(AT24_MINOR, mtd);
+      char path[32];
+      snprintf(path, sizeof(path), "/dev/mtdblock%d", AT24_MINOR);
+      ret = register_mtddriver(path, mtd, 0755, NULL);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-                 ret);
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register the MTD driver %s, ret %d\n",
+                 path, ret);
           return ret;
         }
 

--- a/boards/mips/pic32mx/mirtoo/src/pic32_appinit.c
+++ b/boards/mips/pic32mx/mirtoo/src/pic32_appinit.c
@@ -126,12 +126,15 @@ int board_app_initialize(uintptr_t arg)
     }
 
 #ifndef CONFIG_FS_NXFFS
-  /* And use the FTL layer to wrap the MTD driver as a block driver */
+  /* Register the MTD driver */
 
-  ret = ftl_initialize(CONFIG_NSH_MMCSDMINOR, mtd);
+  char path[32];
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", CONFIG_NSH_MMCSDMINOR);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      ferr("ERROR: Initialize the FTL layer\n");
+      ferr("ERROR: Failed to register the MTD driver %s, ret %d\n",
+           path, ret);
       return ret;
     }
 #else

--- a/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
@@ -375,15 +375,14 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
       return ret;
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 #endif

--- a/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
@@ -447,15 +447,14 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
       return ret;
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 #endif

--- a/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
@@ -375,15 +375,14 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
       return ret;
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 #endif

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -406,6 +406,8 @@ static int init_storage_partition(void)
     }
 
 #else
+  int minor;
+  char path[32];
 
   ret = register_mtddriver("/dev/esp32flash", mtd, 0755, NULL);
   if (ret < 0)
@@ -415,14 +417,16 @@ static int init_storage_partition(void)
     }
 
 #ifdef CONFIG_ESP32_HAVE_OTA_PARTITION
-  ret = ftl_initialize(nitems(g_ota_partition_table), mtd);
+  minor = nitems(g_ota_partition_table);
 #else
-  ret = ftl_initialize(0, mtd);
+  minor = 0;
 #endif
+  snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
+  ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register the MTD driver %s, \
+             ret %d\n", path, ret);
       return ret;
     }
 #endif

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
@@ -334,15 +334,15 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/esp32s2flash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD esp32s2flash: %d\n",
+             ret);
       return ret;
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 #endif

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -329,15 +329,15 @@ static int init_storage_partition(void)
   ret = register_mtddriver("/dev/esp32s3flash", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD esp32s3flash: %d\n",
+             ret);
       return ret;
     }
 
-  ret = ftl_initialize(0, mtd);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
-              ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 


### PR DESCRIPTION
## Summary

This is a supplement to the patch: [drivers/fs:Always use register_mtddriver() to register the MTD device1936126210a56b6d1b033d6d940669413dd6e1b0](https://github.com/jingfei195887/nuttx/commit/d12cf1cb753801a89532f0c90d865de3a1e09be4)

Due to the automatic wrapping of MTD devices during the open() process, the legacy registration methods
`ftl_initialize() ` are no longer required for MTD device registration for user code .
So I have adjusted the registration method for MTD devices in nuttx/boards, replacing the previous approach from using `ftl_initialize()`  to `register_mtddriver()`.

