### PR TITLE
arch/xtensa: fix esp32(s3)_async_op() asynchronous operation race issue

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1732,7 +1732,7 @@ static int esp32_async_op(enum spiflash_op_code_e opcode,
   ret = work_queue(LPWORK, &g_work, esp32_spiflash_work, &work_arg, 0);
   if (ret == 0)
     {
-      nxsem_wait(&work_arg.sem);
+      nxsem_wait_uninterruptible(&work_arg.sem);
       ret = work_arg.ret;
     }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.c
@@ -857,7 +857,7 @@ static int esp32s3_async_op(enum spiflash_op_code_e opcode,
   ret = work_queue(LPWORK, &g_work, esp32s3_spiflash_work, &work_arg, 0);
   if (ret == 0)
     {
-      nxsem_wait(&work_arg.sem);
+      nxsem_wait_uninterruptible(&work_arg.sem);
       ret = work_arg.ret;
     }
 


### PR DESCRIPTION
## Summary
- The `esp32(s3)_async_op()` function uses `nxsem_wait()`, which may cause the thread to return early due to signal interruption (EINTR). This can lead the main thread to assume that the asynchronous operation has completed, while the background worker thread is still running. This may result in accessing freed memory or race conditions, causing crashes or undefined behavior.
- Using `nxsem_wait_uninterruptible()` ensures that the main thread waits until the worker thread completes, avoiding the aforementioned issues.

## Impact
New Feature/Change: Bugfix
User Impact: ESP32/S3 SPI Flash Async Operation Fix - Aggressive Signal issue
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: Compatible with esp32&S3
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
defconfig: esp32-devkitc/psram_usrheap

1. Created an "aggressive" signal - sending thread. During each operation flash. it sends signals (SIGINT) to the main thread at fixed intervals (10ms).
2. The main thread performs multiple Flash operations (erase, write, read - verify), many times. Each time, it uses data of different sizes (512KB for large - block data and 1KB for small - block data) 

