### PR TITLE
tools/ci: temporarily disable test of esp32-devkitc:nxlooper

### DIFF
--- a/tools/ci/testlist/xtensa-01.dat
+++ b/tools/ci/testlist/xtensa-01.dat
@@ -2,3 +2,6 @@
 
 # We do not set ESPTOOL_BINDIR in this build
 -esp32-devkitc:qemu_openeth
+
+# Temporary
+-esp32-devkitc:nxlooper


### PR DESCRIPTION
## Summary

esp32-devkitc:nxlooper is currently failing CI due to a linker error, causing esptool to crash.
The fix requires updating esptool to version 5.0.x which is in progress, currently under test.

Temporarily, we should disable this defconfig from CI since it is causing issue with open pull requests.

## Impact

Removes one defconfig from CI.

