### PR TITLE
arch: cxd56xx: Fix bug that causes wake-up by unused gpio interrupt

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gpioint.c
+++ b/arch/arm/src/cxd56xx/cxd56_gpioint.c
@@ -433,6 +433,10 @@ int cxd56_gpioint_config(uint32_t pin, uint32_t gpiocfg, xcpt_t isr,
       irq_attach(irq, NULL, NULL);
       g_isr[slot] = NULL;
 
+      /* Set level high for unused interrupt trigger to avoid waking up. */
+
+      set_gpioint_config(slot, GPIOINT_LEVEL_HIGH);
+
       flags = spin_lock_irqsave(&g_cxd56_lock);
       g_bothedge &= ~(1 << slot);
       spin_unlock_irqrestore(&g_cxd56_lock, flags);


### PR DESCRIPTION
## Summary
Set level high for unused interrupt trigger to avoid waking up from cold sleeping.

## Impact
Only for spresense.

## Testing

