### PR TITLE
drivers/segger: Add a kconfig to override Segger SystemView target sources version

### DIFF
--- a/drivers/segger/CMakeLists.txt
+++ b/drivers/segger/CMakeLists.txt
@@ -23,13 +23,11 @@
 if(CONFIG_SEGGER_RTT OR CONFIG_SEGGER_SYSVIEW)
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/SystemView)
 
-    set(SYSVIEW_VERSION 356)
-
     FetchContent_Declare(
       systemview
       DOWNLOAD_NAME "SystemView.zip"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://www.segger.com/downloads/systemview/SystemView_Src_V${SYSVIEW_VERSION}.zip"
+      URL "https://www.segger.com/downloads/systemview/SystemView_Src_V${CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE}.zip"
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/SystemView
           BINARY_DIR

--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -14,6 +14,12 @@ config SEGGER_RTT
 
 if SEGGER_RTT
 
+config SEGGER_SYSVIEW_TARGET_SOURCE
+	string "Segger SystemView target sources version"
+	default "356"
+	---help---
+		The Segger SystemView target sources version to use.
+
 config SEGGER_RTT_SECTION
 	string "Segger RTT Control Block Section"
 	default ""

--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -72,7 +72,7 @@ endif
 ifneq ($(CONFIG_SEGGER_RTT)$(CONFIG_SEGGER_SYSVIEW),)
   CFLAGS += ${INCDIR_PREFIX}segger$(DELIM)SystemView$(DELIM)SEGGER
 
-  SYSVIEW_VERSION ?= 356
+  SYSVIEW_VERSION ?= $(CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE)
   SYSVIEW_ZIP = SystemView_Src_V$(SYSVIEW_VERSION).zip
 
 # Download and unpack tarball if no git repo found


### PR DESCRIPTION
## Summary

update:
    CMakeLists.txt
    Make.defs
    Kconfig

It allows the same version of SystemView target sources to be used for CMake and Make, to avoid discrepancies in the future.

https://github.com/apache/nuttx/pull/16620#issuecomment-3004602498

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
CI

```
====================================================================================
Configuration/Tool: sim/segger
2025-07-22 10:32:20
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Building NuttX...
  [1/1] Normalize sim/segger
====================================================================================

```
https://github.com/simbit18/nuttx_test_pr/actions/runs/16441393116/job/46463008660#logs

