### PR TITLE
espressif: PCNT: add high and low limit Kconfig options

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -682,6 +682,22 @@ config ESP_PCNT_TEST_MODE
 		to the receiver internally, being able to test the PCNT
 		peripheral without any external connection.
 
+config ESP_PCNT_HIGH_LIMIT
+	int "PCNT high limit value"
+	default 1024
+	range 1 32767
+	---help---
+		This sets thr_h_lim value for all units. When pulse_cnt reaches
+		this value, the counter will be cleared.
+
+config ESP_PCNT_LOW_LIMIT
+	int "PCNT low limit value"
+	default -1024
+	range -32768 -1
+	---help---
+		This sets thr_l_lim value for all units. When pulse_cnt reaches
+		this value, the counter will be cleared.
+
 config ESP_PCNT_AS_QE
 	bool
 	default n

--- a/arch/xtensa/src/common/espressif/Kconfig
+++ b/arch/xtensa/src/common/espressif/Kconfig
@@ -348,6 +348,22 @@ config ESP_PCNT_TEST_MODE
 		to the receiver internally, being able to test the PCNT
 		peripheral without any external connection.
 
+config ESP_PCNT_HIGH_LIMIT
+	int "PCNT high limit value"
+	default 1024
+	range 1 32767
+	---help---
+		This sets thr_h_lim value for all units. When pulse_cnt reaches
+		this value, the counter will be cleared.
+
+config ESP_PCNT_LOW_LIMIT
+	int "PCNT low limit value"
+	default -1024
+	range -32768 -1
+	---help---
+		This sets thr_l_lim value for all units. When pulse_cnt reaches
+		this value, the counter will be cleared.
+
 config ESP_PCNT_AS_QE
 	bool
 	default n

--- a/boards/risc-v/esp32c6/common/src/esp_board_pcnt.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_pcnt.c
@@ -41,8 +41,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PCNT_HIGH_LIMIT 1000
-#define PCNT_LOW_LIMIT  -1000
+#define PCNT_HIGH_LIMIT CONFIG_ESP_PCNT_HIGH_LIMIT
+#define PCNT_LOW_LIMIT  CONFIG_ESP_PCNT_LOW_LIMIT
 
 #define PCNT_GLITCH_FILTER(pcnt, thres) pcnt->ops->ioctl(pcnt,          \
                                                          CAPIOC_FILTER, \

--- a/boards/risc-v/esp32h2/common/src/esp_board_pcnt.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_pcnt.c
@@ -41,8 +41,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PCNT_HIGH_LIMIT 1000
-#define PCNT_LOW_LIMIT  -1000
+#define PCNT_HIGH_LIMIT CONFIG_ESP_PCNT_HIGH_LIMIT
+#define PCNT_LOW_LIMIT  CONFIG_ESP_PCNT_LOW_LIMIT
 
 #define PCNT_GLITCH_FILTER(pcnt, thres) pcnt->ops->ioctl(pcnt,          \
                                                          CAPIOC_FILTER, \

--- a/boards/xtensa/esp32/common/src/esp32_board_pcnt.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_pcnt.c
@@ -40,8 +40,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PCNT_HIGH_LIMIT 1000
-#define PCNT_LOW_LIMIT  -1000
+#define PCNT_HIGH_LIMIT CONFIG_ESP_PCNT_HIGH_LIMIT
+#define PCNT_LOW_LIMIT  CONFIG_ESP_PCNT_LOW_LIMIT
 
 #define PCNT_GLITCH_FILTER(pcnt, thres) pcnt->ops->ioctl(pcnt,          \
                                                          CAPIOC_FILTER, \

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_pcnt.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_pcnt.c
@@ -40,8 +40,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PCNT_HIGH_LIMIT 1000
-#define PCNT_LOW_LIMIT  -1000
+#define PCNT_HIGH_LIMIT CONFIG_ESP_PCNT_HIGH_LIMIT
+#define PCNT_LOW_LIMIT  CONFIG_ESP_PCNT_LOW_LIMIT
 
 #define PCNT_GLITCH_FILTER(pcnt, thres) pcnt->ops->ioctl(pcnt,          \
                                                          CAPIOC_FILTER, \

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_pcnt.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_pcnt.c
@@ -40,8 +40,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PCNT_HIGH_LIMIT 1000
-#define PCNT_LOW_LIMIT  -1000
+#define PCNT_HIGH_LIMIT CONFIG_ESP_PCNT_HIGH_LIMIT
+#define PCNT_LOW_LIMIT  CONFIG_ESP_PCNT_LOW_LIMIT
 
 #define PCNT_GLITCH_FILTER(pcnt, thres) pcnt->ops->ioctl(pcnt,          \
                                                          CAPIOC_FILTER, \


### PR DESCRIPTION
## Summary

update:
Kconfig
esp_board_pcnt.c

This PR adds possibility of changing low and high PCNT limits in Kconfig. This could help decrease interrupt load in specific applications. Set the default high limit to 1024 and default low limit to -1024.

## Impact

Impact on user: YES, new Kconfig options

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Testing was performed on ESP32-C6 with `qencoder` defconfig. Output of `tools/configure.sh -l esp32c6-devkitc:qencoder` to check for proper parsing of Kconfig:
```
$ tools/configure.sh -l esp32c6-devkitc:qencoder
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/martin/nuttx-upstream-2/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/martin/nuttx-upstream-2/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/martin/nuttx-upstream-2/nuttx-apps/platform/dummy
LN: include/arch to arch/risc-v/include
LN: include/arch/board to /home/martin/nuttx-upstream-2/nuttx/boards/risc-v/esp32c6/esp32c6-devkitc/include
LN: drivers/platform to /home/martin/nuttx-upstream-2/nuttx/drivers/dummy
LN: include/arch/chip to /home/martin/nuttx-upstream-2/nuttx/arch/risc-v/include/esp32c6
LN: arch/risc-v/src/chip to /home/martin/nuttx-upstream-2/nuttx/arch/risc-v/src/esp32c6
LN: arch/risc-v/src/board to /home/martin/nuttx-upstream-2/nuttx/boards/risc-v/esp32c6/esp32c6-devkitc/../common
LN: arch/risc-v/src/board/board to /home/martin/nuttx-upstream-2/nuttx/boards/risc-v/esp32c6/esp32c6-devkitc/src
#
# configuration written to .config
#
```