### PR TITLE
build.yml: Excludes the workflow run if the file is AUTHORS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ name: Build
 on:
   pull_request:
     paths-ignore:
+      - 'AUTHORS'
       - 'Documentation/**'
       - 'tools/ci/docker/linux/**'
   push:
     paths-ignore:
+      - 'AUTHORS'
       - 'Documentation/**'
     branches:
       - 'releases/*'


### PR DESCRIPTION
## Summary

CI does not compile everything for a simple modification of the AUTHORS file.

https://github.com/apache/nuttx/pull/16728#issuecomment-3074044118

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

CI

