### PR TITLE
tools/nxstyle.c: Updating white list to xedge example

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -217,6 +217,12 @@ static const char *g_white_prefix[] =
   "ub32",    /* Ref:  include/fixedmath.h */
   "lua_",    /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lua.h */
   "luaL_",   /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lauxlib.h */
+  "Ba",      /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
+  "Thread",  /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
+  "LThread", /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
+  "Http",    /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
+  "Disk",    /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
+  "Xedge",   /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
   NULL
 };
 
@@ -650,6 +656,19 @@ static const char *g_white_content_list[] =
   "timeLow",
   "timeMid",
   "timeHiAndVersion",
+
+  /* Ref:
+   * apps/netutils/xedge/BAS/examples/xedge/src/xedge.h
+   */
+
+  "ltMgr",
+  "Lt",
+  "setDispExit",
+  "baGetUnixTime",
+  "platformInitDiskIo",
+  "xedgeInitDiskIo",
+  "xedgeOpenAUX",
+  "baParseDate",
 
   NULL
 };


### PR DESCRIPTION
## Summary

Update nxstyle whitelist to allow MixedCase identifiers used by the Xedge (Barracuda App Server) example.

  The following prefixes were added to g_white_prefix[]:
  - Ba
  - Thread
  - LThread
  - Http
  - Disk
  - Xedge

  The following exact identifiers were added to g_white_content_list[]:
  - baGetUnixTime
  - baParseDate
  - setDispExit
  - xedgeInitDiskIo
  - xedgeOpenAUX
  - platformInitDiskIo
  - ltMgr
  - Lt

## Impact

Developers working with Xedge examples will no longer encounter nxstyle violations

## Testing

This PR is part of a series and requires the following PRs to be applied for proper testing:

nuttx-apps#3120: https://github.com/apache/nuttx-apps/pull/3120 (Barracuda App Server library)
nuttx#16665: https://github.com/apache/nuttx/pull/16665 (Xedge example implementation)

With both dependency PRs applied, run the following command to verify nxstyle compliance:

```
./nuttx/tools/checkpatch.sh -g HEAD~...HEAD
```