### PR TITLE
tools/nix: Add Nix flake for reproducible dev environment

### DIFF
--- a/Documentation/guides/index.rst
+++ b/Documentation/guides/index.rst
@@ -7,6 +7,7 @@ Guides
 
 .. toctree::
   nfs.rst
+  nix_flake.rst
   usbtrace.rst
   simulator.rst
   rndis.rst

--- a/Documentation/guides/nix_flake.rst
+++ b/Documentation/guides/nix_flake.rst
@@ -1,0 +1,88 @@
+======================================
+Nix Flake for Reproducible Development
+======================================
+
+This guide explains how to use the Nix flake to set up a reproducible development environment for NuttX. The Nix flake ensures that all required build tools and dependencies are consistently available, simplifying onboarding and reducing "works on my machine" issues.
+
+Prerequisites
+-------------
+
+*   `Nix <https://nixos.org/download/>`_ installed on your system.
+*   Nix flakes enabled (add ``experimental-features = nix-command flakes`` to your ``nix.conf``).
+
+Setting up the Development Environment
+--------------------------------------
+
+To enter the NuttX development shell, navigate to the root of the NuttX directory and run:
+
+.. code-block:: bash
+
+    nix develop
+
+This command will:
+
+*   Download and set up all necessary build tools and dependencies, including:
+    *   CMake, Ninja, GNU Make
+    *   Clang tools
+    *   ARM toolchain (gcc-arm-embedded)
+    *   Automake, Bison, Flex, Genromfs, Gettext, Gperf
+    *   Kconfig-frontends, libelf, expat, gmp, isl, libmpc, mpfr, ncurses, zlib
+    *   Python with kconfiglib
+*   Set the ``CMAKE_EXPORT_COMPILE_COMMANDS`` environment variable to ``ON``.
+*   Display a welcome message.
+
+Once inside the development shell, you can proceed with building NuttX as usual.
+
+Benefits
+--------
+
+*   **Reproducibility:** Ensures a consistent build environment across all developers and machines.
+*   **Simplified Onboarding:** New contributors can quickly set up their development environment with a single command.
+*   **Dependency Management:** All dependencies are managed by Nix, avoiding conflicts with system-wide packages.
+
+Contents of the Nix Flake
+-------------------------
+
+The `flake.nix` file defines a `devShell` that includes the following build inputs:
+
+.. code-block:: nix
+
+    buildInputs = [
+      # Build tools
+      pkgs.cmake
+      pkgs.ninja
+      pkgs.gnumake
+      pkgs.clang-tools
+
+      # ARM toolchain
+      pkgs.gcc-arm-embedded
+
+      # NuttX dependencies
+      pkgs.automake
+      pkgs.bison
+      pkgs.flex
+      pkgs.genromfs
+      pkgs.gettext
+      pkgs.gperf
+      pkgs.kconfig-frontends
+      pkgs.libelf
+      pkgs.expat.dev
+      pkgs.gmp.dev
+      pkgs.isl
+      pkgs.libmpc
+      pkgs.mpfr.dev
+      pkgs.ncurses.dev
+      pkgs.zlib
+      pkgs.python313Packages.kconfiglib
+    ];
+
+The `shellHook` sets up the `CMAKE_EXPORT_COMPILE_COMMANDS` and provides a welcome message:
+
+.. code-block:: nix
+
+    shellHook = ''
+      export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+      echo "Welcome to NuttX devShell"
+    '';
+
+This setup ensures that the development environment is fully configured for NuttX development.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753250450,
+        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "NuttX : devShell flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            # Build tools
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.gnumake
+            pkgs.clang-tools
+
+            # ARM toolchain
+            pkgs.gcc-arm-embedded
+
+            # NuttX dependencies
+            pkgs.automake
+            pkgs.bison
+            pkgs.flex
+            pkgs.genromfs
+            pkgs.gettext
+            pkgs.gperf
+            pkgs.kconfig-frontends
+            pkgs.libelf
+            pkgs.expat.dev
+            pkgs.gmp.dev
+            pkgs.isl
+            pkgs.libmpc
+            pkgs.mpfr.dev
+            pkgs.ncurses.dev
+            pkgs.zlib
+            pkgs.python313Packages.kconfiglib
+
+            # NuttX Documentation
+            pkgs.sphinx
+            pkgs.python313Packages.sphinx_rtd_theme
+            pkgs.python313Packages.myst-parser
+            pkgs.python313Packages.sphinx-tabs
+            pkgs.python313Packages.sphinx-autobuild
+            pkgs.python313Packages.sphinx-copybutton
+            pkgs.python313Packages.sphinx-togglebutton
+            pkgs.python313Packages.pytz
+            pkgs.python313Packages.importlib-metadata
+            pkgs.python313Packages.sphinx-design
+          ];
+          shellHook = ''
+            export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+            echo "Welcome to NuttX devShell"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
# Add Nix flake for reproducible development environment

This pull request introduces a Nix flake (`flake.nix` and `flake.lock`) to provide a reproducible development shell for NuttX using Nix and flakes.

## Summary

- Adds a `devShell` with all required build tools and dependencies for NuttX, including CMake, Ninja, GNU Make, clang-tools, ARM toolchain, and other utilities (automake, bison, flex, genromfs, gettext, gperf, kconfig-frontends, libelf, expat, gmp, isl, libmpc, mpfr, ncurses, zlib, kconfiglib).
- Uses `flake-utils` to support multiple platforms.
- Sets up a shell hook to enable CMake compile commands and provide a welcome message.
- Based on `nixpkgs` `nixos-unstable` for up-to-date packages.

**Purpose:**  
This change simplifies onboarding and ensures a consistent build environment across contributors. By pinning dependencies, it reduces "works on my machine" issues and makes it easier for new developers to get started with NuttX.

**References:**  
- Nix Flakes documentation: https://nixos.wiki/wiki/Flakes
- Dependencies gathered from `tools/configure.sh`

## Impact

- **Users:** No impact on runtime or target builds; this only affects developer tooling.
- **Build Process:** Developers can now use `nix develop` to enter a fully provisioned shell with all necessary dependencies.
- **Documentation:** Usage instructions can be added to the repository documentation if desired.
- **Compatibility:** The flake is designed to work on all major platforms supported by Nix.

## Testing

- Verified by running `nix develop` and building NuttX on `x86_64-linux` with `cmake` and `make` (NixOS unstable, GCC ARM toolchain).
- Confirmed that all required tools are available in the shell and that the build completes successfully.
- No changes to target firmware or runtime behavior.
