### PR TITLE
drivers/sensors/l86xxx: Fix driver registration crashes

### DIFF
--- a/drivers/sensors/l86xxx_uorb.c
+++ b/drivers/sensors/l86xxx_uorb.c
@@ -548,7 +548,6 @@ static int l86xxx_thread(int argc, FAR char *argv[])
       (FAR l86xxx_dev_s *)((uintptr_t)strtoul(argv[1], NULL, 16));
   struct sensor_gnss gps;
   memset(&gps, 0, sizeof(gps));
-  dev->enabled = true;
   int err;
   int bw;
 
@@ -792,6 +791,7 @@ int l86xxx_register(FAR const char *uartpath, int devno)
   if (err < 0)
     {
       snwarn("Couldn't set baud rate of device: %d\n", err);
+      goto close_file;
     }
   #endif
 
@@ -799,6 +799,7 @@ int l86xxx_register(FAR const char *uartpath, int devno)
   if (err < 0)
     {
       snwarn("Couldn't set position fix interval, %d\n", err);
+      goto close_file;
     }
 
   /* Register UORB Sensor */


### PR DESCRIPTION
## Summary

Sometimes this driver will boot when the serial port is of the wrong baud rate, and it cannot set the correct baud rate or verify communication. This commit prevents registration if any settings fail to be set, and also prevents the kernel thread from setting the L86 to enabled (this is done only by the uORB upper half).

## Impact

Impacts only this driver. Removes possibility for kernel crash, instead fails gracefully.

## Testing

Prior to this change, a misconfiguration of the serial baud rate would result in a kernel crash.

Now this is the behaviour:

```console
l86xxx_register: Waiting for GNSS to start...
send_command: Sending command: $PMTK251,9600 to L86
send_command: Sending command: $PMTK220,1000 to L86
send_command: Waiting for ACK from L86...
send_command: Did not get ACK!
l86xxx_register: Couldn't set position fix interval, -5
Failed to register L86-M33: -5

NuttShell (NSH) NuttX-12.8.0
nsh>
```


