### PR TITLE
include: Fix bug related to string.h's str[|n]dup

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -110,7 +110,7 @@ FAR void  *memmem(FAR const void *haystack, size_t haystacklen,
 void explicit_bzero(FAR void *s, size_t n);
 int timingsafe_bcmp(FAR const void *b1, FAR const void *b2, size_t n);
 
-#ifdef __KERNEL__
+#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
 #  define strdup(s)       nx_strdup(s)
 #  define strndup(s,sz)   nx_strndup(s,sz)
 #endif


### PR DESCRIPTION
## Summary

* include: Fix bug related to string.h's str[|n]dup

Defining `strdup` and `strndup` to (respectively) `nx_strdup` and `nx_strndup` should only apply when `CONFIG_BUILD_FLAT` is not set. Otherwise, the device may assert (if `CONFIG_DEBUG_ASSERTIONS` is enabled) at `DEBUGASSERT(mm_heapmember(heap, mem))` because `strdup` would allocate memory from the kernel heap, but freeing it would call `umm_free` (from the user heap).

## Impact

Impact on user: Yes. Enables `ifconfig` command to work as expected when `CONFIG_DEBUG_ASSERTIONS` is enabled.

Impact on build: Yes. If `CONFIG_BUILD_FLAT` is set and there is a user heap, its memory will be allocated from the user's heap (as well as `free` refers to `umm_free`).

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

This can be tested with `CONFIG_DEBUG_ASSERTIONS` set, on a flat build config that enables the kernel heap (both kernel and user heaps available). For instance, testing can be performed by building the firmware and flashing it to a ESP32-S3 board with a PSRAM module (this example uses an ESP32-S3-DevKitC-1 v1.1 board with an ESP32-S3-WROOM-2 module). The device asserts after running the `ifconfig` before applying this patch.

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:sta_softap && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e DEBUG_ASSERTIONS && kconfig-tweak -e ESP32S3_FLASH_MODE_OCT && kconfig-tweak -e ESP32S3_SPIRAM && kconfig-tweak -e ESP32S3_SPIRAM_MODE_OCT && kconfig-tweak -e ESP32S3_SPIRAM_USER_HEAP && make olddefconfig && make EXTRAFLAGS="-Wno-cpp -Werror" bootloader && make flash EXTRAFLAGS="-Wno-cpp -Werror" ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

Run the `ifconfig` command:
```
$ picocom -b 115200 /dev/ttyUSB0
...
NuttShell (NSH) NuttX-10.4.0
nsh> ifconfig
```

### Results

#### Before
```
nsh> ifconfig
[CPU0] dump_assert_info: Current Version: NuttX  10.4.0 f7f1bb863f Jul 15 2025 17:38:32 xtensa
[CPU0] dump_assert_info: Assertion failed : at file: mm_heap/mm_free.c:243 task(CPU0): nsh_main process: nsh_main 0x4201b1ac
[CPU0] up_dump_register:    PC: 420376ab    PS: 00060322
[CPU0] up_dump_register:    A0: 8037a62c    A1: 3c0c1da0    A2: 00000000    A3: 3fc9be40
[CPU0] up_dump_register:    A4: 00000000    A5: 3c0c2020    A6: 00000004    A7: 7ffffffe
[CPU0] up_dump_register:    A8: 00000000    A9: 00060322   A10: 00000000   A11: 0000007e
[CPU0] up_dump_register:   A12: 00000000   A13: 00000000   A14: 3fcb2388   A15: 3fcbe970
[CPU0] up_dump_register:   SAR: 0000000f CAUSE: 9cc37aea VADDR: aaaaadba
[CPU0] up_dump_register:  LBEG: 400554b9  LEND: 400554dd  LCNT: 82023245
[CPU0] dump_stackinfo: User Stack:
[CPU0] dump_stackinfo:   base: 0x3c0c03c0
[CPU0] dump_stackinfo:   size: 00008144
[CPU0] dump_stackinfo:     sp: 0x3c0c1da0
[CPU0] stack_dump: 0x3c0c1d80: 82017048 3c0c1dc0 3c0a09fd 3c0c1dd0 3fcbe970 000000f3 3c0a09fd 3fc921a8
[CPU0] stack_dump: 0x3c0c1da0: 3c0c2390 00001fd0 3c0c03c0 00000000 82018afc 3c0c1eb0 3c0a09fd 000000f3
[CPU0] stack_dump: 0x3c0c1dc0: 00000000 3fcb2098 3fcb2098 4201b1ac 7474754e 3fcb0058 00000000 00060022
[CPU0] stack_dump: 0x3c0c1de0: 00000001 000000a4 00000000 00000001 000ff000 3fcb2cc8 0000001f 40056fc5
[CPU0] stack_dump: 0x3c0c1e00: 40056fe7 2e303100 00302e34 400570e8 400570f3 00000000 3766509e 62623166
[CPU0] stack_dump: 0x3c0c1e20: 66333638 6c754a20 20353120 35323032 3a373120 333a3833 00000032 00000000
[CPU0] stack_dump: 0x3c0c1e40: 00000000 00000000 00000000 65747800 0061736e 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c1e60: 3c0c1f80 3fcb1fe8 3fc9be40 00000000 3c0a09fd 000000f3 00000000 3c0c1e70
[CPU0] stack_dump: 0x3c0c1e80: 00060320 000000f3 3fcb1fe8 3fcb66a8 3c0a593b 3fc9be40 00000006 3fcb1fe8
[CPU0] stack_dump: 0x3c0c1ea0: 820185f3 3c0c1ed0 3c0c0000 3fcbe990 00000000 0000002a 00000010 3fcaca10
[CPU0] stack_dump: 0x3c0c1ec0: 8203ec19 3c0c1ef0 3fcbe990 00000000 000000ff 0000ff00 00ff0000 40404040
[CPU0] stack_dump: 0x3c0c1ee0: 82027afd 3c0c1f10 fffffff3 3c0c2076 3c0c207a 0000ff00 0000000a 3fcbe994
[CPU0] stack_dump: 0x3c0c1f00: 82026464 3c0c1f30 fffffffe 3c0c2076 00000001 3fc9cdc0 3fcbe970 3fcbe990
[CPU0] stack_dump: 0x3c0c1f20: 820264fa 3c0c1f60 00000000 000001b6 000001b6 3c0c0390 3c0c03c0 3c0c2010
[CPU0] stack_dump: 0x3c0c1f40: 00000401 3c0a828c 0000000a 3fcbe970 820265cd 3c0c1fa0 00000004 3c0c2070
[CPU0] stack_dump: 0x3c0c1f60: 3c0c2076 3fcb2388 3fcb0d98 3fcb0d70 3c0c2076 00000000 3fcb2100 3c0c2070
[CPU0] stack_dump: 0x3c0c1f80: 00000401 00000000 3fcb2388 3fcbe970 82020ec8 3c0c1ff0 3c0c2070 00000401
[CPU0] stack_dump: 0x3c0c1fa0: 3c0c2020 3c0c2000 00000008 00000001 3fcbe970 3fcbe980 3fcb211c 3c0c2080
[CPU0] stack_dump: 0x3c0c1fc0: 3c0c2020 3c0c2000 00000008 00000000 00000401 3c0c2020 3fcbe970 3fcb211c
[CPU0] stack_dump: 0x3c0c1fe0: 820213c2 3c0c2040 3c0c2398 3c0a1484 3c0c2020 3c0c2000 00000008 3c0c269d
[CPU0] stack_dump: 0x3c0c2000: 0000000f 00000000 3c0c2050 3c0c2030 0000000c 3fcbe980 3c0c2070 0000003b
[CPU0] stack_dump: 0x3c0c2020: 3c0c2050 3c0c2030 0000000c 3fcbe980 8202141d 3c0c2070 3c0c2398 3c0c269d
[CPU0] stack_dump: 0x3c0c2040: 3c0c2060 3c0c2040 3c0c2080 3fcbe980 3c0c2070 3c0c269d 3c0c2060 3c0c2040
[CPU0] stack_dump: 0x3c0c2060: 820214d5 3c0c20d0 3c0c2398 3c0a1484 6f72702f 656e2f63 6c772f74 00306e61
[CPU0] stack_dump: 0x3c0c2080: 6e616c77 00000030 00000000 00000000 00000000 00003002 00000000 00000000
[CPU0] stack_dump: 0x3c0c20a0: 00000000 3c0c20d0 3c0c2398 3c0a1484 00000000 00000001 00000000 00000004
[CPU0] stack_dump: 0x3c0c20c0: 8201f76f 3c0c2100 3c0c2398 00000001 00001f02 3c0c0390 3c0c03c0 00000000
[CPU0] stack_dump: 0x3c0c20e0: 3c0c2140 3c0c2160 3c0c2698 3c0c269d 8201cc82 3c0c2160 3c0c2398 00000001
[CPU0] stack_dump: 0x3c0c2100: 820268b9 3c0c2130 00000001 3c0c2170 00000008 3c0c2398 00000000 3c0c21d0
[CPU0] stack_dump: 0x3c0c2120: 8202692d 3c0c2170 00000000 3c0c21f0 0000000a 3fca00ff 3c0c2280 3fcbe960
[CPU0] stack_dump: 0x3c0c2140: 3c0c21d0 0000ff00 3fc92240 40404040 8201d699 3c0c2190 3c0c2398 00000001
[CPU0] stack_dump: 0x3c0c2160: 3c0c2650 3c0c21a0 00000000 3c0c21f0 3c0c21d0 3c0c2248 3c0a7d7c 3c0c2398
[CPU0] stack_dump: 0x3c0c2180: 8201d75f 3c0c21d0 3c0c226c 00000000 3c0c2268 00000000 3c0c2210 00000000
[CPU0] stack_dump: 0x3c0c21a0: 3fcb0eb8 00000000 00000001 00000001 3c0c21d0 00000000 3c0c2598 00000001
[CPU0] stack_dump: 0x3c0c21c0: 8201b367 3c0c22a0 0000000a 3c0c2650 3c0c2650 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c21e0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c2200: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c2220: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c2240: 00000000 00000000 ffffffff ffffffff 00000000 00000000 00000000 00000000
[CPU0] stack_dump: 0x3c0c2260: 00000000 00000000 00000000 3c0c2659 00000000 00000000 00000000 3c0c2268
[CPU0] stack_dump: 0x3c0c2280: 00000000 00000001 3c0c2650 3c0c2398 8201b206 3c0c22e0 3c0c2398 00000001
[CPU0] stack_dump: 0x3c0c22a0: 4201b6ec 4201b6b4 4201b680 00000000 3c0c2650 00000005 00ff0000 00000003
[CPU0] stack_dump: 0x3c0c22c0: 00000001 3c0c2598 3c0c2398 3c0c2650 8201b1d4 3c0c2300 00000001 3c0c03a0
[CPU0] stack_dump: 0x3c0c22e0: 00000001 3c0c2650 00000020 3fcac860 8201724d 3c0c2320 00000001 3c0c03a0
[CPU0] stack_dump: 0x3c0c2300: 00000000 00000001 00000001 3c0c2398 82013b7f 3c0c2350 4201b1ac 00000001
[CPU0] stack_dump: 0x3c0c2320: 00000064 3c0c2370 00000000 00000000 42015844 3fcb20bc 3fc92cb4 3fcb2368
[CPU0] stack_dump: 0x3c0c2340: 00000000 3c0c2370 00000000 00000000 3c0c03a0 00000016 3fcb2104 3c0a76f8
[CPU0] stack_dump: 0x3c0c2360: 00000000 3c0c2390 00000000 00000000 00000000 00000000 3fcb1fe8 00000000
[CPU0] stack_dump: 0x3c0c2380: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
```

#### After
```
NuttShell (NSH) NuttX-10.4.0
nsh> ifconfig
wlan0	Link encap:Ethernet HWaddr 68:b6:b3:3b:b0:68 at UP mtu 1500
	inet addr:10.0.0.2 DRaddr:10.0.0.1 Mask:255.255.255.0

wlan1	Link encap:Ethernet HWaddr 68:b6:b3:3b:b0:69 at DOWN mtu 1500
	inet addr:0.0.0.0 DRaddr:0.0.0.0 Mask:0.0.0.0
```