### PR TITLE
drivers/pci: epc add dma heap

### DIFF
--- a/drivers/pci/pci_epf.c
+++ b/drivers/pci/pci_epf.c
@@ -254,7 +254,7 @@ FAR void *pci_epf_alloc_space(FAR struct pci_epf_device_s *epf, int barno,
 
   bar = epf->bar;
 
-  space = kmm_zalloc(size);
+  space = pci_epc_dma_memalign(epf->epc, align, size);
   if (space == NULL)
     {
       pcierr("Failed to allocate mem space\n");

--- a/drivers/pci/pci_qemu_epc.c
+++ b/drivers/pci/pci_qemu_epc.c
@@ -803,10 +803,10 @@ static int qemu_epc_probe(FAR struct pci_device_s *dev)
     }
 
   qep->pdev = dev;
-  epc = pci_epc_create("qemu_epc", qep, &g_qemu_epc_ops);
+  epc = pci_epc_create("qemu_epc", qep, NULL, 0, &g_qemu_epc_ops);
   if (epc == NULL)
     {
-      pcierr("Failed to create epc device\n");
+      pcierr("Failed to create qemu_epc device\n");
       ret = -ENOMEM;
       goto err_free_epc;
     }

--- a/include/nuttx/pci/pci_epc.h
+++ b/include/nuttx/pci/pci_epc.h
@@ -181,6 +181,7 @@ struct pci_epc_mem_s
  * num_windows: Number of mem supported by device
  * max_functions: Max number of functions that can be configured in this EPC
  * node: The node of epc list
+ * dmaheap: The dma heap
  * lock: Mutex to protect pci_epc ops
  * funcno_map: Bitmap to manage physical function number
  * priv: The private data
@@ -195,6 +196,7 @@ struct pci_epc_ctrl_s
   unsigned int num_windows;
   uint8_t max_functions;
   struct list_node node;
+  FAR struct mm_heap_s *dmaheap;
 
   /* Mutex to protect against concurrent access of EP controller */
 
@@ -714,9 +716,11 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc);
  *   Invoke to create a new EPC device and add it to pci_epc class.
  *
  * Input Parameters:
- *   name - EPC name strings
- *   priv - The epc priv data
- *   ops  - Function pointers for performing EPC operations
+ *   name        - EPC name strings
+ *   priv        - The epc priv data
+ *   dma_addr    - Used for inbound address
+ *   dma_len     - The dma memory len
+ *   ops         - Function pointers for performing EPC operations
  *
  * Returned Value:
  *   Return struct pci_epc_ctrl_s * if success, NULL if failed.
@@ -724,9 +728,8 @@ void pci_epc_bme_notify(FAR struct pci_epc_ctrl_s *epc);
  ****************************************************************************/
 
 FAR struct pci_epc_ctrl_s *
-pci_epc_create(FAR const char *name, FAR void *priv,
-               FAR const struct pci_epc_ops_s *ops);
-
+pci_epc_create(FAR const char *name, FAR void *priv, FAR void *dma_addr,
+               size_t dma_len, FAR const struct pci_epc_ops_s *ops);
 /****************************************************************************
  * Name: pci_epc_destroy
  *
@@ -851,5 +854,64 @@ FAR void *pci_epc_mem_alloc_addr(FAR struct pci_epc_ctrl_s *epc,
 
 void pci_epc_mem_free_addr(FAR struct pci_epc_ctrl_s *epc,
                            uintptr_t phys_addr, size_t size);
+
+/****************************************************************************
+ * Name: pci_epc_dma_alloc
+ *
+ * Description:
+ *   This function is used to create a new endpoint controller (EPC) device.
+ *
+ *   Invoke to destroy the PCI EPC device.
+ *
+ * Input Parameters:
+ *   epc  - The EPC device that has to be destroyed
+ *   size - The dma memory size
+ *
+ * Returned Value:
+ *   The point of dma memory if success, NULL if failed
+ *
+ ****************************************************************************/
+
+FAR void *pci_epc_dma_alloc(FAR struct pci_epc_ctrl_s *epc, size_t size);
+
+/****************************************************************************
+ * Name: pci_epc_dma_memalign
+ *
+ * Description:
+ *   This function is used to create a new endpoint controller (EPC) device.
+ *
+ *   Invoke to destroy the PCI EPC device.
+ *
+ * Input Parameters:
+ *   epc       - The EPC device that has to be destroyed
+ *   alignment - Alignment size
+ *   size      - The dma memory size
+ *
+ * Returned Value:
+ *   The point of dma memory if success, NULL if failed
+ *
+ ****************************************************************************/
+
+FAR void *pci_epc_dma_memalign(FAR struct pci_epc_ctrl_s *epc,
+                               size_t alignment, size_t size);
+
+/****************************************************************************
+ * Name: pci_epc_dma_free
+ *
+ * Description:
+ *   This function is used to create a new endpoint controller (EPC) device.
+ *
+ *   Invoke to destroy the PCI EPC device.
+ *
+ * Input Parameters:
+ *   epc       - The EPC device that has to be destroyed
+ *   mem       - The dma memory need ed to be free
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pci_epc_dma_free(FAR struct pci_epc_ctrl_s *epc, FAR void *mem);
 
 #endif /* __INCLUDE_NUTTX_PCI_PCI_EPC_H */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
add pci epc dma heap,The PCI inbound address space and the CPU cache need to maintain cache coherence.

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


