### PR TITLE
libc: fix assert "Free memory from the wrong heap" with flat mode and…

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -45,7 +45,7 @@
  * then only the first mode is supported.
  */
 
-#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#if defined(__KERNEL__)
 
   /* Domain-specific allocations */
 


### PR DESCRIPTION
## Summary

libc: fix assert "Free memory from the wrong heap" with flat mode and user separated heap enabled mode

In flat mode:
kernel code, like net driver...
strdup    -> nx_strdup -> kmm_malloc
lib_free  -> kmm_free

app code, like stdlib...
strdup -> malloc
free   -> free

## Impact

user separated heap enabled mode

## Testing

To fix the issue described by:
https://github.com/apache/nuttx/pull/16766



## Let me introduce the history:


1. https://github.com/apache/nuttx/pull/6445
-#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#if defined(__KERNEL__)

2. https://github.com/apache/nuttx/pull/9600
-#if defined(__KERNEL__)
+#if  !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)

3. issue https://github.com/apache/nuttx/pull/16766

4. https://github.com/apache/nuttx/pull/16768 (current patch)
-#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#if defined(__KERNEL__)



