### PR TITLE
esp32s3_extraheaps.c: add a missing include for xtensa_imm_initialize

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_extraheaps.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_extraheaps.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
 
 #ifdef CONFIG_ESP32S3_RTC_HEAP


### PR DESCRIPTION
## Summary

esp32s3_extraheaps.c: add a missing include for xtensa_imm_initialize

## Impact

build fix

## Testing

i have had an equivalent of this in my local tree for a while without noticing any issues.


