### PR TITLE
crypto/cryptosoft: fix aadlen used uninitialized warning

### DIFF
--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -291,11 +291,11 @@ int swcr_authenc(FAR struct cryptop *crp)
   caddr_t buf = (caddr_t)crp->crp_buf;
   caddr_t aad = (caddr_t)crp->crp_aad;
   FAR uint32_t *blkp;
+  int aadlen = 0;
   int blksz = 0;
   int ivlen = 0;
   int iskip = 0;
   int oskip = 0;
-  int aadlen;
   int len;
   int i;
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Initializing aadlen fix uninitialized warning
*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


