### PR TITLE
pci: imx95 add pcie ep support

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -308,6 +308,12 @@ config IMX9_FLEXSPI
 	bool "ENABLE FLEXSPI interface"
 	default n
 
+config IMX9_PCI_EP
+	bool "Enable PCI EP"
+	default n
+	---help---
+		Imx9 add pcie ep support.
+
 config IMX9_FLEXSPI_NOR
 	bool "Enable NOR flash on FLEXSPI interface"
 	select IMX9_FLEXSPI

--- a/arch/arm64/src/imx9/Make.defs
+++ b/arch/arm64/src/imx9/Make.defs
@@ -102,6 +102,10 @@ ifeq ($(CONFIG_IMX9_DDR_TRAINING),y)
   CHIP_CSRCS += $(DDR_CSRCS)
 endif
 
+ifeq ($(CONFIG_IMX9_PCI_EP),y)
+  CHIP_CSRCS += imx95_pci.c
+endif
+
 ifeq ($(CONFIG_IMX9_FLEXCAN), y)
   CHIP_CSRCS += imx9_flexcan.c
 endif

--- a/arch/arm64/src/imx9/hardware/imx95_pcie.h
+++ b/arch/arm64/src/imx9/hardware/imx95_pcie.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/hardware/imx95_pcie.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX95_PCIE_H_
+#define __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX95_PCIE_H_
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register offsets *********************************************************/
+
+#define PCIE1_DBI_BASE   0x4c380000
+#define PCIE1_DBI_SIZE   0x10000
+#define PCIE1_ATU_BASE   0x4c3e0000
+#define PCIE1_ATU_SIZE   0x10000
+#define PCIE1_DBI2_BASE  0x4c3a0000
+#define PCIE1_DBI2_SIZE  0x10000
+#define PCIE1_APP_BASE   0x4c3c0000
+#define PCIE1_APP_SIZE   0x4000
+#define PCIE1_OB_BASE    0xa00000000
+#define PCIE1_OB_SIZE    0x100000000
+#define PCIE1_DMA_BASE   0xa8100000
+#define PCIE1_DMA_SIZE   0x2000000
+#define PCIE1_LINK_SPEED 3
+#define PCIE1_LINK_LANES 1
+
+#endif /* __ARCH_ARM64_SRC_IMX9_HARDWARE_IMX95_PCIE_H_ */

--- a/arch/arm64/src/imx9/imx95_pci.c
+++ b/arch/arm64/src/imx9/imx95_pci.c
@@ -1,0 +1,391 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx95_pci.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
+#include <nuttx/mm/mm.h>
+#include <nuttx/pci/pcie_dw.h>
+#include "imx95_pci.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IMX95_PCIE_PHY_GEN_CTRL     0x0
+#define IMX95_PCIE_REF_USE_PAD      BIT(17)
+
+#define IMX95_PCIE_SS_RW_REG_0      0xf0
+#define IMX95_PCIE_REF_CLKEN        BIT(23)
+#define IMX95_PCIE_PHY_CR_PARA_SEL  BIT(9)
+#define IMX95_PCIE_SS_RW_REG_1      0xf4
+#define IMX95_PCIE_SYS_AUX_PWR_DET  BIT(31)
+
+#define IMX95_PE0_GEN_CTRL_1        0x1050
+#define IMX95_PCIE_DEVICE_TYPE      GENMASK(3, 0)
+
+#define IMX95_PE0_GEN_CTRL_3        0x1058
+#define IMX95_PCIE_LTSSM_EN         BIT(0)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct imx95_pcie_s
+{
+  struct dw_pcie_s    pci;
+  FAR void            *iomuxc_gpr;
+  bool                link_is_up;
+  mutex_t             lock;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void
+reg_update_bits(void *base, uint32_t reg, uint32_t mask, uint32_t val);
+static int imx95_pcie_start_link(struct dw_pcie_s *pci);
+static void imx95_pcie_stop_link(struct dw_pcie_s *pci);
+static uint64_t
+imx95_pcie_cpu_addr_fixup(struct dw_pcie_s *pcie, uint64_t cpu_addr);
+static int imx95_pcie_host_init(struct dw_pcie_rp_s *pp);
+static void imx95_pcie_host_exit(struct dw_pcie_rp_s *pp);
+static int imx95_pcie_init_phy(struct imx95_pcie_s *imx95_pcie_s);
+static void imx95_pcie_configure_type(struct imx95_pcie_s *imx95_pcie_s);
+static void imx95_pcie_ltssm_enable(struct imx95_pcie_s *imx95_pcie_s);
+static void imx95_pcie_ltssm_disable(struct imx95_pcie_s *imx95_pcie_s);
+static void imx95_pcie_ep_init(struct dw_pcie_ep_s *ep);
+static int
+imx95_pcie_ep_raise_irq(struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      enum pci_epc_irq_type_e type, uint16_t interrupt_num);
+static const struct pci_epc_features_s *
+imx95_pcie_ep_get_features(struct dw_pcie_ep_s *ep);
+static int imx95_add_pcie_ep(struct imx95_pcie_s *imx95_pcie_s);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct pci_epc_features_s g_imx95_pcie_epc_features =
+{
+  .msi_capable = true,
+  .align       = SZ_4K,
+};
+
+static const struct dw_pcie_ops_s g_dw_pcie_ops =
+{
+  .start_link     = imx95_pcie_start_link,
+  .stop_link      = imx95_pcie_stop_link,
+  .cpu_addr_fixup = imx95_pcie_cpu_addr_fixup,
+};
+
+static const struct dw_pcie_host_ops g_imx95_pcie_host_dw_pme_ops =
+{
+  .init   = imx95_pcie_host_init,
+  .deinit = imx95_pcie_host_exit,
+};
+
+struct imx95_pcie_s g_imx95_pcie =
+{
+  .pci =
+    {
+      .dbi_base = (void *)PCIE1_DBI_BASE,
+      .dbi_base2 = (void *)PCIE1_DBI2_BASE,
+      .atu_base = (void *)PCIE1_ATU_BASE,
+      .atu_size = PCIE1_ATU_SIZE,
+      .ep.phys_base = PCIE1_OB_BASE,
+      .ep.addr_size = PCIE1_OB_SIZE,
+      .ep.dma_addr = (void *)PCIE1_DMA_BASE,
+      .ep.dma_len = PCIE1_DMA_SIZE,
+      .max_link_speed = PCIE1_LINK_SPEED,
+      .num_lanes = PCIE1_LINK_LANES,
+      .ops = &g_dw_pcie_ops,
+      .pp.ops = &g_imx95_pcie_host_dw_pme_ops,
+    },
+  .iomuxc_gpr = (void *)PCIE1_APP_BASE,
+};
+
+static const struct dw_pcie_ep_ops g_pcie_ep_ops =
+{
+  .init         = imx95_pcie_ep_init,
+  .raise_irq    = imx95_pcie_ep_raise_irq,
+  .get_features = imx95_pcie_ep_get_features,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void
+reg_update_bits(void *base, uint32_t reg, uint32_t mask, uint32_t val)
+{
+  uint32_t tmp;
+  uint32_t orig;
+  orig = readl(base + reg);
+  tmp = orig & ~mask;
+  tmp |= val & mask;
+  writel(tmp, base + reg);
+}
+
+static int imx95_pcie_init_phy(struct imx95_pcie_s *imx95_pcie_s)
+{
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr, IMX95_PCIE_SS_RW_REG_1,
+      IMX95_PCIE_SYS_AUX_PWR_DET, IMX95_PCIE_PHY_CR_PARA_SEL);
+
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr,
+      IMX95_PCIE_SS_RW_REG_0,
+      IMX95_PCIE_PHY_CR_PARA_SEL,
+      IMX95_PCIE_PHY_CR_PARA_SEL);
+
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr,
+         IMX95_PCIE_PHY_GEN_CTRL,
+         IMX95_PCIE_REF_USE_PAD, 0);
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr,
+         IMX95_PCIE_SS_RW_REG_0,
+         IMX95_PCIE_REF_CLKEN,
+         IMX95_PCIE_REF_CLKEN);
+
+  return 0;
+}
+
+static void imx95_pcie_configure_type(struct imx95_pcie_s *imx95_pcie_s)
+{
+  unsigned int val;
+
+  val = PCI_EXP_TYPE_ENDPOINT << (ffs(IMX95_PCIE_DEVICE_TYPE) - 1);
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr, IMX95_PE0_GEN_CTRL_1,
+                  IMX95_PCIE_DEVICE_TYPE, val);
+}
+
+static void imx95_pcie_ltssm_enable(struct imx95_pcie_s *imx95_pcie_s)
+{
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr, IMX95_PE0_GEN_CTRL_3,
+                  IMX95_PCIE_LTSSM_EN, IMX95_PCIE_LTSSM_EN);
+}
+
+static void imx95_pcie_ltssm_disable(struct imx95_pcie_s *imx95_pcie_s)
+{
+  reg_update_bits(imx95_pcie_s->iomuxc_gpr, IMX95_PE0_GEN_CTRL_3,
+         IMX95_PCIE_LTSSM_EN, 0);
+}
+
+static int imx95_pcie_start_link(struct dw_pcie_s *pci)
+{
+  struct imx95_pcie_s *imx95_pcie_s = pci->priv;
+  uint32_t link_cap;
+  uint32_t tmp;
+  int ret;
+
+  /* Force Gen1 operation when starting the link.  In case the link is
+   * started in Gen2 mode, there is a possibility the devices on the
+   * bus will not be detected at all.  This happens with PCIe switches.
+   */
+
+  link_cap = dw_pcie_get_link_cap(pci);
+  dw_pcie_linkcap_update(pci, PCI_EXP_LNKCAP_SLS_2_5GB);
+
+  /* Start LTSSM. */
+
+  imx95_pcie_ltssm_enable(imx95_pcie_s);
+
+  ret = dw_pcie_wait_for_link(pci);
+  if (ret)
+    {
+      goto err_reset_phy;
+    }
+
+  if (pci->max_link_speed > 1)
+    {
+      /* Allow faster modes after the link is up */
+
+      dw_pcie_linkcap_update(pci, pci->max_link_speed);
+
+      /* Start Directed Speed Change so the best possible
+       * speed both link partners support can be negotiated.
+       */
+
+      dw_pcie_chang_speed(pci);
+
+      /* Make sure link training is finished as well! */
+
+      ret = dw_pcie_wait_for_link(pci);
+      if (ret)
+        {
+          goto err_reset_phy;
+        }
+    }
+  else
+    {
+      pciinfo("Link: Only Gen1 is enabled\n");
+    }
+
+  imx95_pcie_s->link_is_up = true;
+  tmp = dw_pcie_get_link_state(pci);
+  pciinfo("Link up, Gen%i\n", tmp);
+  return 0;
+
+err_reset_phy:
+  imx95_pcie_s->link_is_up = false;
+  pcierr("Pcie start err\n");
+  dw_pcie_linkcap_update(pci, link_cap);
+
+  return 0;
+}
+
+static void imx95_pcie_stop_link(struct dw_pcie_s *pci)
+{
+  /* Turn off PCIe LTSSM */
+
+  imx95_pcie_ltssm_disable(pci->priv);
+}
+
+static int imx95_pcie_host_init(struct dw_pcie_rp_s *pp)
+{
+  struct dw_pcie_s *pci = to_dw_pcie_from_pp(pp);
+  struct imx95_pcie_s *imx95_pcie_s = pci->priv;
+
+  imx95_pcie_init_phy(imx95_pcie_s);
+  imx95_pcie_configure_type(imx95_pcie_s);
+
+  return 0;
+}
+
+static void imx95_pcie_host_exit(struct dw_pcie_rp_s *pp)
+{
+}
+
+static uint64_t
+imx95_pcie_cpu_addr_fixup(struct dw_pcie_s *pcie, uint64_t cpu_addr)
+{
+  return cpu_addr;
+}
+
+static void imx95_pcie_ep_init(struct dw_pcie_ep_s *ep)
+{
+  int bar;
+  struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  for (bar = 0; bar <= 5; bar++)
+    {
+      dw_pcie_ep_reset_bar(pci, bar);
+    }
+}
+
+static int
+imx95_pcie_ep_raise_irq(struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      enum pci_epc_irq_type_e type, uint16_t interrupt_num)
+{
+  switch (type)
+    {
+      case PCI_EPC_IRQ_LEGACY:
+        return dw_pcie_ep_raise_intx_irq(ep, funcno);
+      case PCI_EPC_IRQ_MSI:
+        return dw_pcie_ep_raise_msi_irq(ep, funcno, interrupt_num);
+      case PCI_EPC_IRQ_MSIX:
+        return dw_pcie_ep_raise_msix_irq(ep, funcno, interrupt_num);
+      default:
+        pcierr("UNKNOWN IRQ type\n");
+        return -EINVAL;
+    }
+
+  return 0;
+}
+
+static const struct pci_epc_features_s *
+imx95_pcie_ep_get_features(struct dw_pcie_ep_s *ep)
+{
+  return &g_imx95_pcie_epc_features;
+}
+
+static int imx95_add_pcie_ep(struct imx95_pcie_s *imx95_pcie)
+{
+  struct dw_pcie_s *pci = &imx95_pcie->pci;
+  struct dw_pcie_rp_s *pp = &pci->pp;
+  struct dw_pcie_ep_s *ep;
+  int ret;
+
+  imx95_pcie_host_init(pp);
+  ep = &pci->ep;
+  ep->ops = &g_pcie_ep_ops;
+  ep->page_size = g_imx95_pcie_epc_features.align;
+
+  ret = dw_pcie_ep_init(ep, "imx95_epc");
+  if (ret)
+    {
+      pcierr("failed to initialize endpoint\n");
+      return ret;
+    }
+
+  /* Start LTSSM. */
+
+  imx95_pcie_ltssm_enable(imx95_pcie);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx95_pcie_init
+ *
+ * Description:
+ *   Init imx95 pcie
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *  0 if success, a negated errno value if failed
+ *
+ ****************************************************************************/
+
+int imx95_pcie_init(void)
+{
+  g_imx95_pcie.pci.priv = &g_imx95_pcie;
+  nxmutex_init(&g_imx95_pcie.lock);
+  return imx95_add_pcie_ep(&g_imx95_pcie);
+}
+
+/****************************************************************************
+ * Name: imx95_pcie_uninit
+ *
+ * Description:
+ *   Init imx95 pcie
+ *
+ * Input Parameters:
+ *  None
+ *
+ * Returned Value:
+ *  None
+ *
+ ****************************************************************************/
+
+void imx95_pcie_uninit(void)
+{
+  imx95_pcie_stop_link(&g_imx95_pcie.pci);
+}

--- a/arch/arm64/src/imx9/imx95_pci.h
+++ b/arch/arm64/src/imx9/imx95_pci.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * arch/arm64/src/imx9/imx95_pci.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_IMX9_IMX95_PCIE_H
+#define __ARCH_ARM64_SRC_IMX9_IMX95_PCIE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+
+#include "chip.h"
+#include "hardware/imx95_pcie.h"
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: imx95_pcie_init
+ *
+ * Description:
+ *   Init imx95 pcie
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *  0 if success, a negated errno value if failed
+ *
+ ****************************************************************************/
+
+int imx95_pcie_init(void);
+
+/****************************************************************************
+ * Name: imx95_pcie_uninit
+ *
+ * Description:
+ *   Init imx95 pcie
+ *
+ * Input Parameters:
+ *   imx95_pci  - The imx95 pcie controller
+ *
+ * Returned Value:
+ *  None
+ *
+ ****************************************************************************/
+
+void imx95_pcie_uninit(void);
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_ARM64_SRC_IMX9_IMX95_PCIE_H */

--- a/drivers/pci/CMakeLists.txt
+++ b/drivers/pci/CMakeLists.txt
@@ -56,6 +56,10 @@ if(CONFIG_PCI_ENDPOINT)
     list(APPEND SRCS pci_qemu_epc.c)
   endif() # CONFIG_PCI_QEMU_EPC
 
+  if(CONFIG_PCI_QEMU_EPC)
+    list(APPEND SRCS pcie_dw.c pcie_dw_ep.c)
+  endif() # CONFIG_PCI_DWC_EPC
+
   if(CONFIG_PCI_EPF_TEST)
     list(APPEND SRCS pci_epf_test.c)
   endif() # CONFIG_PCI_EPF_TEST

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -95,6 +95,11 @@ config PCI_QEMU_EPC
 	---help---
 		Enable qemu ep controller
 
+config PCI_DWC_EPC
+	bool "DWC Ep Controller Support"
+	---help---
+		Enable dwc ep controller
+
 config PCI_EPF_TEST
 	bool "PCI epf test"
 	---help---

--- a/drivers/pci/Make.defs
+++ b/drivers/pci/Make.defs
@@ -51,6 +51,10 @@ ifeq ($(CONFIG_PCI_QEMU_EPC),y)
 CSRCS += pci_qemu_epc.c
 endif
 
+ifeq ($(CONFIG_PCI_DWC_EPC),y)
+CSRCS += pcie_dw.c pcie_dw_ep.c
+endif
+
 ifeq ($(CONFIG_PCI_EPF_TEST),y)
 CSRCS += pci_epf_test.c
 endif

--- a/drivers/pci/pcie_dw.c
+++ b/drivers/pci/pcie_dw.c
@@ -1,0 +1,1058 @@
+/****************************************************************************
+ * drivers/pci/pcie_dw.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/pci/pci_regs.h>
+#include <sys/param.h>
+
+#include "pcie_dw.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static uint8_t
+__dw_pcie_find_next_cap(FAR struct dw_pcie_s *pci, uint8_t cap_ptr,
+                        uint8_t cap);
+FAR static void *
+dw_pcie_select_atu(FAR struct dw_pcie_s *pci, uint32_t dir,
+                   uint32_t index);
+static uint32_t
+dw_pcie_readl_atu(FAR struct dw_pcie_s *pci, uint32_t dir, uint32_t index,
+                  uint32_t reg);
+static void
+dw_pcie_writel_atu(FAR struct dw_pcie_s *pci, uint32_t dir, uint32_t index,
+                   uint32_t reg, uint32_t val);
+static uint32_t
+dw_pcie_readl_atu_ob(FAR struct dw_pcie_s *pci, uint32_t index,
+                     uint32_t reg);
+static inline void
+dw_pcie_writel_atu_ob(FAR struct dw_pcie_s *pci, uint32_t index,
+                      uint32_t reg, uint32_t val);
+static uint32_t dw_pcie_enable_ecrc(uint32_t val);
+static uint32_t
+dw_pcie_readl_atu_ib(FAR struct dw_pcie_s *pci, uint32_t index,
+                     uint32_t reg);
+static void
+dw_pcie_writel_atu_ib(FAR struct dw_pcie_s *pci, uint32_t index,
+                      uint32_t reg, uint32_t val);
+static void dw_pcie_link_set_max_speed(FAR struct dw_pcie_s *pci);
+static void
+dw_pcie_link_set_max_link_width(FAR struct dw_pcie_s *pci,
+                                uint32_t num_lanes);
+static int dw_pcie_link_up(FAR struct dw_pcie_s *pci);
+static uint8_t
+dw_pcie_find_capability(FAR struct dw_pcie_s *pci, uint8_t cap);
+static int dw_pcie_write(FAR void *addr, int size, uint32_t val);
+static int dw_pcie_read(FAR void *addr, int size, FAR uint32_t *val);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint8_t
+__dw_pcie_find_next_cap(FAR struct dw_pcie_s *pci, uint8_t cap_ptr,
+                        uint8_t cap)
+{
+  uint8_t next_cap_ptr;
+  uint8_t cap_id;
+  uint16_t reg;
+
+  if (!cap_ptr)
+    {
+      return 0;
+    }
+
+  reg = dw_pcie_readw_dbi(pci, cap_ptr);
+  cap_id = (reg & 0x00ff);
+
+  if (cap_id > PCI_CAP_ID_MAX)
+    {
+      return 0;
+    }
+
+  if (cap_id == cap)
+    {
+      return cap_ptr;
+    }
+
+  next_cap_ptr = (reg & 0xff00) >> 8;
+  return __dw_pcie_find_next_cap(pci, next_cap_ptr, cap);
+}
+
+FAR static void *
+dw_pcie_select_atu(FAR struct dw_pcie_s *pci, uint32_t dir,
+                   uint32_t index)
+{
+  if (dw_pcie_cap_is(pci, IATU_UNROLL))
+    {
+      return pci->atu_base + DW_PCIE_ATU_UNROLL_BASE(dir, index);
+    }
+
+  dw_pcie_writel_dbi(pci, DW_PCIE_ATU_VIEWPORT, dir | index);
+  return pci->atu_base;
+}
+
+static uint32_t
+dw_pcie_readl_atu(FAR struct dw_pcie_s *pci, uint32_t dir, uint32_t index,
+                  uint32_t reg)
+{
+  FAR void *base;
+  int ret;
+  uint32_t val;
+
+  base = dw_pcie_select_atu(pci, dir, index);
+
+  if (pci->ops && pci->ops->read_dbi)
+    {
+      return pci->ops->read_dbi(pci, base, reg, 4);
+    }
+
+  ret = dw_pcie_read(base + reg, 4, &val);
+  if (ret)
+    {
+      pcierr("Read ATU address failed\n");
+    }
+
+  return val;
+}
+
+static void
+dw_pcie_writel_atu(FAR struct dw_pcie_s *pci, uint32_t dir, uint32_t index,
+                   uint32_t reg, uint32_t val)
+{
+  void  *base;
+  int ret;
+
+  base = dw_pcie_select_atu(pci, dir, index);
+
+  if (pci->ops && pci->ops->write_dbi)
+    {
+      pci->ops->write_dbi(pci, base, reg, 4, val);
+      return;
+    }
+
+  ret = dw_pcie_write(base + reg, 4, val);
+  if (ret)
+    {
+      pcierr("Write ATU address failed\n");
+    }
+}
+
+static uint32_t
+dw_pcie_readl_atu_ob(FAR struct dw_pcie_s *pci, uint32_t index, uint32_t reg)
+{
+  return dw_pcie_readl_atu(pci, DW_PCIE_ATU_REGION_DIR_OB, index, reg);
+}
+
+static void
+dw_pcie_writel_atu_ob(FAR struct dw_pcie_s *pci, uint32_t index,
+                      uint32_t reg, uint32_t val)
+{
+  dw_pcie_writel_atu(pci, DW_PCIE_ATU_REGION_DIR_OB, index, reg, val);
+}
+
+static uint32_t dw_pcie_enable_ecrc(uint32_t val)
+{
+  return val | DW_PCIE_ATU_TD;
+}
+
+static uint32_t
+dw_pcie_readl_atu_ib(FAR struct dw_pcie_s *pci, uint32_t index, uint32_t reg)
+{
+  return dw_pcie_readl_atu(pci, DW_PCIE_ATU_REGION_DIR_IB, index, reg);
+}
+
+static void
+dw_pcie_writel_atu_ib(FAR struct dw_pcie_s *pci, uint32_t index,
+                      uint32_t reg, uint32_t val)
+{
+  dw_pcie_writel_atu(pci, DW_PCIE_ATU_REGION_DIR_IB, index, reg, val);
+}
+
+static void dw_pcie_link_set_max_speed(FAR struct dw_pcie_s *pci)
+{
+  uint32_t cap;
+  uint32_t ctrl2;
+  uint32_t link_speed;
+  uint8_t offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+
+  cap = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+
+  /* Even if the platform doesn't want to limit the maximum link speed,
+   * just cache the hardware default value so that the vendor drivers can
+   * use it to do any link specific configuration.
+   */
+
+  if (pci->max_link_speed < 1)
+    {
+      pci->max_link_speed = FIELD_GET(PCI_EXP_LNKCAP_SLS, cap);
+      return;
+    }
+
+  ctrl2 = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCTL2);
+  ctrl2 &= ~PCI_EXP_LNKCTL2_TLS;
+
+  link_speed = pci->max_link_speed;
+  if (link_speed > PCI_EXP_LNKCTL2_TLS_16_0GT)
+    {
+      link_speed = FIELD_GET(PCI_EXP_LNKCAP_SLS, cap);
+      ctrl2 &= ~PCI_EXP_LNKCTL2_HASD;
+    }
+
+  dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCTL2, ctrl2 | link_speed);
+
+  cap &= ~((uint32_t)PCI_EXP_LNKCAP_SLS);
+  dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, cap | link_speed);
+}
+
+static void
+dw_pcie_link_set_max_link_width(FAR struct dw_pcie_s *pci,
+                                uint32_t num_lanes)
+{
+  uint32_t lnkcap;
+  uint32_t lwsc;
+  uint32_t plc;
+  uint8_t cap;
+
+  if (!num_lanes)
+    {
+      return;
+    }
+
+  /* Set the number of lanes */
+
+  plc = dw_pcie_readl_dbi(pci, DW_PCIE_PORT_LINK_CONTROL);
+  plc &= ~DW_PCIE_PORT_LINK_FAST_LINK_MODE;
+  plc &= ~DW_PCIE_PORT_LINK_MODE_MASK;
+
+  /* Set link width speed control register */
+
+  lwsc = dw_pcie_readl_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL);
+  lwsc &= ~DW_PCIE_PORT_LOGIC_LINK_WIDTH_MASK;
+  switch (num_lanes)
+    {
+      case 1:
+        plc |= DW_PCIE_PORT_LINK_MODE_1_LANES;
+        lwsc |= DW_PCIE_PORT_LOGIC_LINK_WIDTH_1_LANES;
+        break;
+      case 2:
+        plc |= DW_PCIE_PORT_LINK_MODE_2_LANES;
+        lwsc |= DW_PCIE_PORT_LOGIC_LINK_WIDTH_2_LANES;
+        break;
+      case 4:
+        plc |= DW_PCIE_PORT_LINK_MODE_4_LANES;
+        lwsc |= DW_PCIE_PORT_LOGIC_LINK_WIDTH_4_LANES;
+        break;
+      case 8:
+        plc |= DW_PCIE_PORT_LINK_MODE_8_LANES;
+        lwsc |= DW_PCIE_PORT_LOGIC_LINK_WIDTH_8_LANES;
+        break;
+      default:
+        pcierr("num-lanes %u: invalid value\n", num_lanes);
+        return;
+    }
+
+  dw_pcie_writel_dbi(pci, DW_PCIE_PORT_LINK_CONTROL, plc);
+  dw_pcie_writel_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL, lwsc);
+
+  cap = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+  lnkcap = dw_pcie_readl_dbi(pci, cap + PCI_EXP_LNKCAP);
+  lnkcap &= ~PCI_EXP_LNKCAP_MLW;
+  lnkcap |= FIELD_PREP(PCI_EXP_LNKCAP_MLW, num_lanes);
+  dw_pcie_writel_dbi(pci, cap + PCI_EXP_LNKCAP, lnkcap);
+}
+
+static int dw_pcie_link_up(FAR struct dw_pcie_s *pci)
+{
+  uint32_t val;
+
+  if (pci->ops && pci->ops->link_up)
+    {
+      return pci->ops->link_up(pci);
+    }
+
+  val = dw_pcie_readl_dbi(pci, DW_PCIE_PORT_DEBUG1);
+  return ((val & DW_PCIE_PORT_DEBUG1_LINK_UP) &&
+    (!(val & DW_PCIE_PORT_DEBUG1_LINK_IN_TRAINING)));
+}
+
+static uint8_t
+dw_pcie_find_capability(FAR struct dw_pcie_s *pci, uint8_t cap)
+{
+  uint8_t next_cap_ptr;
+  uint16_t reg;
+
+  reg = dw_pcie_readw_dbi(pci, PCI_CAPABILITY_LIST);
+  next_cap_ptr = (reg & 0x00ff);
+
+  return __dw_pcie_find_next_cap(pci, next_cap_ptr, cap);
+}
+
+static int dw_pcie_read(FAR void *addr, int size, FAR uint32_t *val)
+{
+  if (!IS_ALIGNED((uintptr_t)addr, size))
+    {
+      *val = 0;
+      return -EFAULT;
+    }
+
+  if (size == 4)
+    {
+      *val = readl(addr);
+    }
+  else if (size == 2)
+    {
+      *val = readw(addr);
+    }
+  else if (size == 1)
+    {
+    *val = readb(addr);
+    }
+  else
+    {
+      *val = 0;
+      return -EFAULT;
+    }
+
+  return OK;
+}
+
+static int dw_pcie_write(FAR void *addr, int size, uint32_t val)
+{
+  if (!IS_ALIGNED((uintptr_t)addr, size))
+    {
+      return -EFAULT;
+    }
+
+  if (size == 4)
+    {
+      writel(val, addr);
+    }
+  else if (size == 2)
+    {
+      writew(val, addr);
+    }
+  else if (size == 1)
+    {
+      writeb(val, addr);
+    }
+  else
+    {
+      return -EFAULT;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void dw_pcie_version_detect(FAR struct dw_pcie_s *pci)
+{
+  uint32_t ver;
+
+  /* The content of the CSR is zero on DWC PCIe older than v4.70a */
+
+  ver = dw_pcie_readl_dbi(pci, DW_PCIE_VERSION_NUMBER);
+  if (!ver)
+    {
+      return;
+    }
+
+  if (pci->version && pci->version != ver)
+    {
+      pcierr("Versions don't match (%08x != %08x)\n",
+             pci->version, ver);
+    }
+  else
+    {
+      pci->version = ver;
+    }
+
+  ver = dw_pcie_readl_dbi(pci, DW_PCIE_VERSION_TYPE);
+
+  if (pci->type && pci->type != ver)
+    {
+      pcierr("Types don't match (%08x != %08x)\n",
+             pci->type, ver);
+    }
+  else
+    {
+      pci->type = ver;
+    }
+}
+
+uint32_t
+dw_pcie_read_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, size_t size)
+{
+  int ret;
+  uint32_t val;
+
+  if (pci->ops && pci->ops->read_dbi)
+    {
+      return pci->ops->read_dbi(pci, pci->dbi_base, reg, size);
+    }
+
+  ret = dw_pcie_read(pci->dbi_base + reg, size, &val);
+  if (ret)
+    {
+      pcierr("Read DBI address failed\n");
+    }
+
+  return val;
+}
+
+void
+dw_pcie_write_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, size_t size,
+                  uint32_t val)
+{
+  int ret;
+
+  if (pci->ops && pci->ops->write_dbi)
+    {
+      pci->ops->write_dbi(pci, pci->dbi_base, reg, size, val);
+      return;
+    }
+
+  ret = dw_pcie_write(pci->dbi_base + reg, size, val);
+  if (ret)
+    {
+      pcierr("Write DBI address failed\n");
+    }
+}
+
+void
+dw_pcie_write_dbi2(FAR struct dw_pcie_s *pci, uint32_t reg, size_t size,
+                   uint32_t val)
+{
+  int ret;
+
+  if (pci->ops && pci->ops->write_dbi2)
+    {
+      pci->ops->write_dbi2(pci, pci->dbi_base2, reg, size, val);
+      return;
+    }
+
+  ret = dw_pcie_write(pci->dbi_base2 + reg, size, val);
+  if (ret)
+    {
+      pcierr("write DBI address failed\n");
+    }
+}
+
+void
+dw_pcie_writel_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint32_t val)
+{
+  dw_pcie_write_dbi(pci, reg, 0x4, val);
+}
+
+uint32_t dw_pcie_readl_dbi(FAR struct dw_pcie_s *pci, uint32_t reg)
+{
+  return dw_pcie_read_dbi(pci, reg, 0x4);
+}
+
+void
+dw_pcie_writew_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint16_t val)
+{
+  dw_pcie_write_dbi(pci, reg, 0x2, val);
+}
+
+uint16_t dw_pcie_readw_dbi(FAR struct dw_pcie_s *pci, uint32_t reg)
+{
+  return dw_pcie_read_dbi(pci, reg, 0x2);
+}
+
+void dw_pcie_writeb_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint8_t val)
+{
+  dw_pcie_write_dbi(pci, reg, 0x1, val);
+}
+
+uint8_t dw_pcie_readb_dbi(FAR struct dw_pcie_s *pci, uint32_t reg)
+{
+  return dw_pcie_read_dbi(pci, reg, 0x1);
+}
+
+void
+dw_pcie_writel_dbi2(FAR struct dw_pcie_s *pci, uint32_t reg, uint32_t val)
+{
+  dw_pcie_write_dbi2(pci, reg, 0x4, val);
+}
+
+uint32_t
+dw_pcie_ep_get_dbi_offset(FAR struct dw_pcie_ep_s *ep, uint8_t funcno)
+{
+  unsigned int dbi_offset = 0;
+
+  if (ep->ops->get_dbi_offset)
+    dbi_offset = ep->ops->get_dbi_offset(ep, funcno);
+
+  return dbi_offset;
+}
+
+uint32_t dw_pcie_ep_read_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                    uint32_t reg, size_t size)
+{
+  unsigned int offset = dw_pcie_ep_get_dbi_offset(ep, funcno);
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  return dw_pcie_read_dbi(pci, offset + reg, size);
+}
+
+void dw_pcie_ep_write_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                     uint32_t reg, size_t size, uint32_t val)
+{
+  unsigned int offset = dw_pcie_ep_get_dbi_offset(ep, funcno);
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  dw_pcie_write_dbi(pci, offset + reg, size, val);
+}
+
+void dw_pcie_ep_writel_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      uint32_t reg, uint32_t val)
+{
+  dw_pcie_ep_write_dbi(ep, funcno, reg, 0x4, val);
+}
+
+uint32_t dw_pcie_ep_readl_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                     uint32_t reg)
+{
+  return dw_pcie_ep_read_dbi(ep, funcno, reg, 0x4);
+}
+
+void dw_pcie_ep_writew_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      uint32_t reg, uint16_t val)
+{
+  dw_pcie_ep_write_dbi(ep, funcno, reg, 0x2, val);
+}
+
+uint16_t dw_pcie_ep_readw_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                     uint32_t reg)
+{
+  return dw_pcie_ep_read_dbi(ep, funcno, reg, 0x2);
+}
+
+void dw_pcie_ep_writeb_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      uint32_t reg, uint8_t val)
+{
+  dw_pcie_ep_write_dbi(ep, funcno, reg, 0x1, val);
+}
+
+uint8_t dw_pcie_ep_readb_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                     uint32_t reg)
+{
+  return dw_pcie_ep_read_dbi(ep, funcno, reg, 0x1);
+}
+
+uint32_t
+dw_pcie_ep_get_dbi2_offset(FAR struct dw_pcie_ep_s *ep, uint8_t funcno)
+{
+  unsigned int dbi2_offset = 0;
+
+  if (ep->ops->get_dbi2_offset)
+    {
+      dbi2_offset = ep->ops->get_dbi2_offset(ep, funcno);
+    }
+  else if (ep->ops->get_dbi_offset)     /* for backward compatibility */
+    {
+      dbi2_offset = ep->ops->get_dbi_offset(ep, funcno);
+    }
+
+  return dbi2_offset;
+}
+
+void dw_pcie_ep_write_dbi2(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      uint32_t reg, size_t size, uint32_t val)
+{
+  unsigned int offset = dw_pcie_ep_get_dbi2_offset(ep, funcno);
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  dw_pcie_write_dbi2(pci, offset + reg, size, val);
+}
+
+void dw_pcie_ep_writel_dbi2(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                       uint32_t reg, uint32_t val)
+{
+  dw_pcie_ep_write_dbi2(ep, funcno, reg, 0x4, val);
+}
+
+void dw_pcie_dbi_ro_wr_en(FAR struct dw_pcie_s *pci)
+{
+  uint32_t reg;
+  uint32_t val;
+
+  reg = DW_PCIE_MISC_CONTROL_1_OFF;
+  val = dw_pcie_readl_dbi(pci, reg);
+  val |= DW_PCIE_DBI_RO_WR_EN;
+  dw_pcie_writel_dbi(pci, reg, val);
+}
+
+void dw_pcie_dbi_ro_wr_dis(FAR struct dw_pcie_s *pci)
+{
+  uint32_t reg;
+  uint32_t val;
+
+  reg = DW_PCIE_MISC_CONTROL_1_OFF;
+  val = dw_pcie_readl_dbi(pci, reg);
+  val &= ~DW_PCIE_DBI_RO_WR_EN;
+  dw_pcie_writel_dbi(pci, reg, val);
+}
+
+int dw_pcie_start_link(FAR struct dw_pcie_s *pci)
+{
+  if (pci->ops && pci->ops->start_link)
+    {
+      return pci->ops->start_link(pci);
+    }
+
+  return 0;
+}
+
+void dw_pcie_stop_link(FAR struct dw_pcie_s *pci)
+{
+  if (pci->ops && pci->ops->stop_link)
+    {
+      pci->ops->stop_link(pci);
+    }
+}
+
+enum dw_pcie_ltssm dw_pcie_get_ltssm(FAR struct dw_pcie_s *pci)
+{
+  uint32_t val;
+
+  if (pci->ops && pci->ops->get_ltssm)
+    {
+      return pci->ops->get_ltssm(pci);
+    }
+
+  val = dw_pcie_readl_dbi(pci, DW_PCIE_PORT_DEBUG0);
+
+  return (enum dw_pcie_ltssm)FIELD_GET(
+          DW_PCIE_PORT_LOGIC_LTSSM_STATE_MASK, val);
+}
+
+int dw_pcie_prog_outbound_atu(FAR struct dw_pcie_s *pci,
+                              FAR const struct dw_pcie_ob_atu_cfg_s *atu)
+{
+  uint64_t cpu_addr = atu->cpu_addr;
+  uint32_t retries;
+  uint32_t val;
+  uint64_t limit_addr;
+
+  if (pci->ops && pci->ops->cpu_addr_fixup)
+    {
+      cpu_addr = pci->ops->cpu_addr_fixup(pci, cpu_addr);
+    }
+
+  limit_addr = cpu_addr + atu->size - 1;
+
+  if ((limit_addr & ~pci->region_limit) != (cpu_addr & ~pci->region_limit) ||
+      !IS_ALIGNED(cpu_addr, pci->region_align) ||
+      !IS_ALIGNED(atu->pci_addr, pci->region_align) || !atu->size)
+    {
+      return -EINVAL;
+    }
+
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_LOWER_BASE,
+            lower_32_bits(cpu_addr));
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_UPPER_BASE,
+            upper_32_bits(cpu_addr));
+
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_LIMIT,
+            lower_32_bits(limit_addr));
+  if (dw_pcie_ver_is_ge(pci, 460A))
+    {
+      dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_UPPER_LIMIT,
+                upper_32_bits(limit_addr));
+    }
+
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_LOWER_TARGET,
+            lower_32_bits(atu->pci_addr));
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_UPPER_TARGET,
+            upper_32_bits(atu->pci_addr));
+
+  val = atu->type | atu->routing | DW_PCIE_ATU_FUNC_NUM(atu->funcno);
+  if (upper_32_bits(limit_addr) > upper_32_bits(cpu_addr) &&
+      dw_pcie_ver_is_ge(pci, 460A))
+    {
+      val |= DW_PCIE_ATU_INCREASE_REGION_SIZE;
+    }
+
+  if (dw_pcie_ver_is(pci, 490A))
+    {
+      val = dw_pcie_enable_ecrc(val);
+    }
+
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_REGION_CTRL1, val);
+
+  val = DW_PCIE_ATU_ENABLE;
+  if (atu->type == DW_PCIE_ATU_TYPE_MSG)
+    {
+      /* The data-less messages only for now */
+
+      val |= DW_PCIE_ATU_INHIBIT_PAYLOAD | atu->code;
+    }
+
+  dw_pcie_writel_atu_ob(pci, atu->index, DW_PCIE_ATU_REGION_CTRL2, val);
+
+  /* Make sure ATU enable takes effect before any subsequent config
+   * and I/O accesses.
+   */
+
+  for (retries = 0; retries < DW_PCIE_LINK_WAIT_MAX_IATU_RETRIES; retries++)
+    {
+      val = dw_pcie_readl_atu_ob(pci, atu->index, DW_PCIE_ATU_REGION_CTRL2);
+      if (val & DW_PCIE_ATU_ENABLE)
+        {
+          return 0;
+        }
+
+      up_mdelay(DW_PCIE_LINK_WAIT_IATU);
+    }
+
+  pcierr("Outbound iATU is not being enabled\n");
+
+  return -ETIMEDOUT;
+}
+
+int dw_pcie_prog_inbound_atu(FAR struct dw_pcie_s *pci, int index, int type,
+                             uint64_t cpu_addr, uint64_t pci_addr,
+                             uint64_t size)
+{
+  uint64_t limit_addr = pci_addr + size - 1;
+  uint32_t retries;
+  uint32_t val;
+
+  if ((limit_addr & ~pci->region_limit) != (pci_addr & ~pci->region_limit) ||
+      !IS_ALIGNED(cpu_addr, pci->region_align) ||
+      !IS_ALIGNED(pci_addr, pci->region_align) || !size)
+    {
+      return -EINVAL;
+    }
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_LOWER_BASE,
+            lower_32_bits(pci_addr));
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_UPPER_BASE,
+            upper_32_bits(pci_addr));
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_LIMIT,
+            lower_32_bits(limit_addr));
+  if (dw_pcie_ver_is_ge(pci, 460A))
+    {
+      dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_UPPER_LIMIT,
+                upper_32_bits(limit_addr));
+    }
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_LOWER_TARGET,
+            lower_32_bits(cpu_addr));
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_UPPER_TARGET,
+            upper_32_bits(cpu_addr));
+
+  val = type;
+  if (upper_32_bits(limit_addr) > upper_32_bits(pci_addr) &&
+      dw_pcie_ver_is_ge(pci, 460A))
+    {
+      val |= DW_PCIE_ATU_INCREASE_REGION_SIZE;
+    }
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL1, val);
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL2,
+                        DW_PCIE_ATU_ENABLE);
+
+  /* Make sure ATU enable takes effect before any subsequent config
+   * and I/O accesses.
+   */
+
+  for (retries = 0; retries < DW_PCIE_LINK_WAIT_MAX_IATU_RETRIES; retries++)
+    {
+      val = dw_pcie_readl_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL2);
+      if (val & DW_PCIE_ATU_ENABLE)
+        {
+          return 0;
+        }
+
+      up_mdelay(DW_PCIE_LINK_WAIT_IATU);
+    }
+
+  pcierr("Inbound iATU is not being enabled\n");
+
+  return -ETIMEDOUT;
+}
+
+int
+dw_pcie_prog_ep_inbound_atu(FAR struct dw_pcie_s *pci, uint8_t funcno,
+                            int index, int type, uint64_t cpu_addr,
+                            uint8_t bar)
+{
+  uint32_t retries;
+  uint32_t val;
+
+  if (!IS_ALIGNED(cpu_addr, pci->region_align))
+    {
+      return -EINVAL;
+    }
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_LOWER_TARGET,
+            lower_32_bits(cpu_addr));
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_UPPER_TARGET,
+            upper_32_bits(cpu_addr));
+
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL1, type |
+            DW_PCIE_ATU_FUNC_NUM(funcno));
+  dw_pcie_writel_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL2,
+            DW_PCIE_ATU_ENABLE | DW_PCIE_ATU_FUNC_NUM_MATCH_EN |
+            DW_PCIE_ATU_BAR_MODE_ENABLE | (bar << 8));
+
+  /* Make sure ATU enable takes effect before any subsequent config
+   * and I/O accesses.
+   */
+
+  for (retries = 0; retries < DW_PCIE_LINK_WAIT_MAX_IATU_RETRIES; retries++)
+    {
+      val = dw_pcie_readl_atu_ib(pci, index, DW_PCIE_ATU_REGION_CTRL2);
+      if (val & DW_PCIE_ATU_ENABLE)
+        {
+          return 0;
+        }
+
+      up_udelay(DW_PCIE_LINK_WAIT_IATU * 1000);
+    }
+
+  pcierr("Inbound iATU is not being enabled\n");
+
+  return -ETIMEDOUT;
+}
+
+void dw_pcie_disable_atu(FAR struct dw_pcie_s *pci, uint32_t dir, int index)
+{
+  dw_pcie_writel_atu(pci, dir, index, DW_PCIE_ATU_REGION_CTRL2, 0);
+}
+
+int dw_pcie_wait_for_link(FAR struct dw_pcie_s *pci)
+{
+  uint32_t offset;
+  uint32_t val;
+  int retries;
+
+  /* Check if the link is up or not */
+
+  for (retries = 0; retries < DW_PCIE_LINK_WAIT_MAX_RETRIES; retries++)
+    {
+      if (dw_pcie_link_up(pci))
+        {
+          break;
+        }
+
+      up_mdelay(DW_PCIE_LINK_WAIT_SLEEP_MS * 100);
+    }
+
+  if (retries >= DW_PCIE_LINK_WAIT_MAX_RETRIES)
+    {
+      pcierr("Phy link never came up\n");
+      return -ETIMEDOUT;
+    }
+
+  offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+  val = dw_pcie_readw_dbi(pci, offset + PCI_EXP_LNKSTA);
+
+  pcierr("PCIe Gen.%u x%u link up\n",
+         FIELD_GET(PCI_EXP_LNKSTA_CLS, val),
+         FIELD_GET(PCI_EXP_LNKSTA_NLW, val));
+
+  return 0;
+}
+
+void dw_pcie_linkcap_update(FAR struct dw_pcie_s *pci, uint32_t new)
+{
+  uint32_t val;
+  uint8_t offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+
+  val = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+  dw_pcie_dbi_ro_wr_en(pci);
+  val &= ~PCI_EXP_LNKCAP_SLS;
+  val |= new;
+  dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, val);
+  dw_pcie_dbi_ro_wr_dis(pci);
+}
+
+int dw_pcie_get_link_cap(FAR struct dw_pcie_s *pci)
+{
+  uint8_t offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+
+  return dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+}
+
+void dw_pcie_chang_speed(FAR struct dw_pcie_s *pci)
+{
+  uint32_t tmp;
+
+  dw_pcie_dbi_ro_wr_en(pci);
+  tmp = dw_pcie_readl_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL);
+  tmp |= DW_PCIE_PORT_LOGIC_SPEED_CHANGE;
+  dw_pcie_writel_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL, tmp);
+  dw_pcie_dbi_ro_wr_dis(pci);
+}
+
+int dw_pcie_get_link_state(FAR struct dw_pcie_s *pci)
+{
+  uint8_t offset = dw_pcie_find_capability(pci, PCI_CAP_ID_EXP);
+
+  return dw_pcie_readw_dbi(pci, offset + PCI_EXP_LNKSTA) &
+         PCI_EXP_LNKSTA_CLS;
+}
+
+void dw_pcie_iatu_detect(FAR struct dw_pcie_s *pci)
+{
+  int max_region;
+  uint64_t max;
+  uint32_t val;
+  uint32_t min;
+  uint32_t dir;
+  int ob;
+  int ib;
+
+  val = dw_pcie_readl_dbi(pci, DW_PCIE_ATU_VIEWPORT);
+  if (val == 0xffffffff)
+    {
+      dw_pcie_cap_set(pci, IATU_UNROLL);
+
+      max_region = MIN((int)pci->atu_size / 512, 256);
+    }
+  else
+    {
+      pci->atu_base = pci->dbi_base + DW_PCIE_ATU_VIEWPORT_BASE;
+      pci->atu_size = DW_PCIE_ATU_VIEWPORT_SIZE;
+
+      dw_pcie_writel_dbi(pci, DW_PCIE_ATU_VIEWPORT, 0xff);
+      max_region = dw_pcie_readl_dbi(pci, DW_PCIE_ATU_VIEWPORT) + 1;
+    }
+
+  for (ob = 0; ob < max_region; ob++)
+    {
+      dw_pcie_writel_atu_ob(pci, ob, DW_PCIE_ATU_LOWER_TARGET, 0x11110000);
+      val = dw_pcie_readl_atu_ob(pci, ob, DW_PCIE_ATU_LOWER_TARGET);
+      if (val != 0x11110000)
+        {
+          break;
+        }
+    }
+
+  for (ib = 0; ib < max_region; ib++)
+    {
+      dw_pcie_writel_atu_ib(pci, ib, DW_PCIE_ATU_LOWER_TARGET, 0x11110000);
+      val = dw_pcie_readl_atu_ib(pci, ib, DW_PCIE_ATU_LOWER_TARGET);
+      if (val != 0x11110000)
+        {
+          break;
+        }
+    }
+
+  if (ob)
+    {
+      dir = DW_PCIE_ATU_REGION_DIR_OB;
+    }
+  else if (ib)
+    {
+      dir = DW_PCIE_ATU_REGION_DIR_IB;
+    }
+  else
+    {
+      pcierr("No iATU regions found\n");
+      return;
+    }
+
+  dw_pcie_writel_atu(pci, dir, 0, DW_PCIE_ATU_LIMIT, 0x0);
+  min = dw_pcie_readl_atu(pci, dir, 0, DW_PCIE_ATU_LIMIT);
+
+  if (dw_pcie_ver_is_ge(pci, 460A))
+    {
+      dw_pcie_writel_atu(pci, dir, 0, DW_PCIE_ATU_UPPER_LIMIT, 0xffffffff);
+      max = dw_pcie_readl_atu(pci, dir, 0, DW_PCIE_ATU_UPPER_LIMIT);
+    }
+  else
+    {
+      max = 0;
+    }
+
+  pci->num_ob_windows = ob;
+  pci->num_ib_windows = ib;
+  pci->region_align = 1 << fls(min);
+  pci->region_limit = (max << 32) | (SZ_4G - 1);
+
+  pcierr("iATU: unroll %s, %u ob, %u ib, align %uK, limit %luG\n",
+         dw_pcie_cap_is(pci, IATU_UNROLL) ? "T" : "F",
+         pci->num_ob_windows, pci->num_ib_windows,
+         pci->region_align / SZ_1K, (pci->region_limit + 1) / SZ_1G);
+  dw_pcie_dbi_ro_wr_en(pci);
+  dw_pcie_dbi_ro_wr_dis(pci);
+}
+
+void dw_pcie_setup(FAR struct dw_pcie_s *pci)
+{
+  uint32_t val;
+
+  dw_pcie_link_set_max_speed(pci);
+
+  /* Configure Gen1 N_FTS */
+
+  if (pci->n_fts[0])
+    {
+      val = dw_pcie_readl_dbi(pci, DW_PCIE_PORT_AFR);
+      val &= ~(DW_PCIE_PORT_AFR_N_FTS_MASK | DW_PCIE_PORT_AFR_CC_N_FTS_MASK);
+      val |= DW_PCIE_PORT_AFR_N_FTS(pci->n_fts[0]);
+      val |= DW_PCIE_PORT_AFR_CC_N_FTS(pci->n_fts[0]);
+      dw_pcie_writel_dbi(pci, DW_PCIE_PORT_AFR, val);
+    }
+
+  /* Configure Gen2+ N_FTS */
+
+  if (pci->n_fts[1])
+    {
+      val = dw_pcie_readl_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL);
+      val &= ~DW_PCIE_PORT_LOGIC_N_FTS_MASK;
+      val |= pci->n_fts[1];
+      dw_pcie_writel_dbi(pci, DW_PCIE_LINK_WIDTH_SPEED_CONTROL, val);
+    }
+
+  if (dw_pcie_cap_is(pci, CDM_CHECK))
+    {
+      val = dw_pcie_readl_dbi(pci, DW_PCIE_PL_CHK_REG_CONTROL_STATUS);
+      val |= DW_PCIE_PL_CHK_REG_CHK_REG_CONTINUOUS |
+             DW_PCIE_PL_CHK_REG_CHK_REG_START;
+      dw_pcie_writel_dbi(pci, DW_PCIE_PL_CHK_REG_CONTROL_STATUS, val);
+    }
+
+  val = dw_pcie_readl_dbi(pci, DW_PCIE_PORT_LINK_CONTROL);
+  val &= ~DW_PCIE_PORT_LINK_FAST_LINK_MODE;
+  val |= DW_PCIE_PORT_LINK_DLL_LINK_EN;
+  dw_pcie_writel_dbi(pci, DW_PCIE_PORT_LINK_CONTROL, val);
+
+  dw_pcie_link_set_max_link_width(pci, pci->num_lanes);
+}

--- a/drivers/pci/pcie_dw.h
+++ b/drivers/pci/pcie_dw.h
@@ -1,0 +1,348 @@
+/****************************************************************************
+ * drivers/pci/pcie_dw.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _PCIE_DW_H
+#define _PCIE_DW_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+
+#include <nuttx/bits.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/pci/pci.h>
+#include <nuttx/pci/pci_epc.h>
+#include <nuttx/pci/pci_epf.h>
+#include <nuttx/pci/pcie_dw.h>
+#include <nuttx/spinlock.h>
+#include <nuttx/list.h>
+#include <nuttx/nuttx.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define __bf_shf(x)                               (ffsll(x) - 1)
+#define FIELD_PREP(_mask, _val)                   \
+    (((_val) << __bf_shf(_mask)) & (_mask))
+#define FIELD_GET(_mask, _reg)                    \
+    (((_reg) & (_mask)) >> __bf_shf(_mask))
+
+/* DWC PCIe IP-core versions (native support since v4.70a) */
+
+#define DW_PCIE_VER_365A                          0x3336352a
+#define DW_PCIE_VER_460A                          0x3436302a
+#define DW_PCIE_VER_470A                          0x3437302a
+#define DW_PCIE_VER_480A                          0x3438302a
+#define DW_PCIE_VER_490A                          0x3439302a
+#define DW_PCIE_VER_520A                          0x3532302a
+#define DW_PCIE_VER_540A                          0x3534302a
+
+#define __dw_pcie_ver_cmp(_pci, _ver, _op)        \
+    ((_pci)->version _op DW_PCIE_VER_ ## _ver)
+
+#define dw_pcie_ver_is(_pci, _ver)                \
+    __dw_pcie_ver_cmp(_pci, _ver, ==)
+
+#define dw_pcie_ver_is_ge(_pci, _ver)             \
+    __dw_pcie_ver_cmp(_pci, _ver, >=)
+
+#define dw_pcie_ver_type_is(_pci, _ver, _type)    \
+  (__dw_pcie_ver_cmp(_pci, _ver, ==) && \
+   __dw_pcie_ver_cmp(_pci, TYPE_ ## _type, ==))
+
+#define dw_pcie_ver_type_is_ge(_pci, _ver, _type) \
+  (__dw_pcie_ver_cmp(_pci, _ver, ==) && \
+   __dw_pcie_ver_cmp(_pci, TYPE_ ## _type, >=))
+
+/* DWC PCIe controller capabilities */
+
+#define DW_PCIE_CAP_REQ_RES                       0
+#define DW_PCIE_CAP_IATU_UNROLL                   1
+#define DW_PCIE_CAP_CDM_CHECK                     2
+
+#define dw_pcie_cap_is(_pci, _cap) \
+  test_bit(DW_PCIE_CAP_ ## _cap, &(_pci)->caps)
+
+#define dw_pcie_cap_set(_pci, _cap) \
+  set_bit(DW_PCIE_CAP_ ## _cap, &(_pci)->caps)
+
+/* Parameters for the waiting for link up routine */
+
+#define DW_PCIE_LINK_WAIT_MAX_RETRIES             10
+#define DW_PCIE_LINK_WAIT_SLEEP_MS                90
+
+/* Parameters for the waiting for iATU enabled routine */
+
+#define DW_PCIE_LINK_WAIT_MAX_IATU_RETRIES        5
+#define DW_PCIE_LINK_WAIT_IATU                    9
+
+/* Synopsys-specific PCIe configuration registers */
+
+#define DW_PCIE_PORT_FORCE                        0x708
+#define DW_PCIE_PORT_FORCE_DO_DESKEW_FOR_SRIS     BIT(23)
+
+#define DW_PCIE_PORT_AFR                          0x70C
+#define DW_PCIE_PORT_AFR_N_FTS_MASK               GENMASK(15, 8)
+#define DW_PCIE_PORT_AFR_N_FTS(n)                 FIELD_PREP(DW_PCIE_PORT_AFR_N_FTS_MASK, n)
+#define DW_PCIE_PORT_AFR_CC_N_FTS_MASK            GENMASK(23, 16)
+#define DW_PCIE_PORT_AFR_CC_N_FTS(n)              FIELD_PREP(DW_PCIE_PORT_AFR_CC_N_FTS_MASK, n)
+#define DW_PCIE_PORT_AFR_ENTER_ASPM               BIT(30)
+#define DW_PCIE_PORT_AFR_L0S_ENTRANCE_LAT_SHIFT   24
+#define DW_PCIE_PORT_AFR_L0S_ENTRANCE_LAT_MASK    GENMASK(26, 24)
+#define DW_PCIE_PORT_AFR_L1_ENTRANCE_LAT_SHIFT    27
+#define DW_PCIE_PORT_AFR_L1_ENTRANCE_LAT_MASK     GENMASK(29, 27)
+
+#define DW_PCIE_PORT_LINK_CONTROL                 0x710
+#define DW_PCIE_PORT_LINK_DLL_LINK_EN             BIT(5)
+#define DW_PCIE_PORT_LINK_FAST_LINK_MODE          BIT(7)
+#define DW_PCIE_PORT_LINK_MODE_MASK               GENMASK(21, 16)
+#define DW_PCIE_PORT_LINK_MODE(n)                 FIELD_PREP(DW_PCIE_PORT_LINK_MODE_MASK, n)
+#define DW_PCIE_PORT_LINK_MODE_1_LANES            DW_PCIE_PORT_LINK_MODE(0x1)
+#define DW_PCIE_PORT_LINK_MODE_2_LANES            DW_PCIE_PORT_LINK_MODE(0x3)
+#define DW_PCIE_PORT_LINK_MODE_4_LANES            DW_PCIE_PORT_LINK_MODE(0x7)
+#define DW_PCIE_PORT_LINK_MODE_8_LANES            DW_PCIE_PORT_LINK_MODE(0xf)
+
+#define DW_PCIE_PORT_LANE_SKEW                    0x714
+#define DW_PCIE_PORT_LANE_SKEW_INSERT_MASK        GENMASK(23, 0)
+
+#define DW_PCIE_PORT_DEBUG0                       0x728
+#define DW_PCIE_PORT_LOGIC_LTSSM_STATE_MASK       0x1f
+#define DW_PCIE_PORT_LOGIC_LTSSM_STATE_L0         0x11
+#define DW_PCIE_PORT_DEBUG1                       0x72C
+#define DW_PCIE_PORT_DEBUG1_LINK_UP               BIT(4)
+#define DW_PCIE_PORT_DEBUG1_LINK_IN_TRAINING      BIT(29)
+
+#define DW_PCIE_LINK_WIDTH_SPEED_CONTROL          0x80C
+#define DW_PCIE_PORT_LOGIC_N_FTS_MASK             GENMASK(7, 0)
+#define DW_PCIE_PORT_LOGIC_SPEED_CHANGE           BIT(17)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH_MASK        GENMASK(12, 8)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH(n)          FIELD_PREP(DW_PCIE_PORT_LOGIC_LINK_WIDTH_MASK, n)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH_1_LANES     DW_PCIE_PORT_LOGIC_LINK_WIDTH(0x1)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH_2_LANES     DW_PCIE_PORT_LOGIC_LINK_WIDTH(0x2)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH_4_LANES     DW_PCIE_PORT_LOGIC_LINK_WIDTH(0x4)
+#define DW_PCIE_PORT_LOGIC_LINK_WIDTH_8_LANES     DW_PCIE_PORT_LOGIC_LINK_WIDTH(0x8)
+
+#define DW_PCIE_MSI_ADDR_LO                       0x820
+#define DW_PCIE_MSI_ADDR_HI                       0x824
+#define DW_PCIE_MSI_INTR0_ENABLE                  0x828
+#define DW_PCIE_MSI_INTR0_MASK                    0x82C
+#define DW_PCIE_MSI_INTR0_STATUS                  0x830
+
+#define DW_PCIE_PORT_MULTI_LANE_CTRL              0x8C0
+#define DW_PCIE_PORT_MLTI_UPCFG_SUPPORT           BIT(7)
+
+#define DW_PCIE_VERSION_NUMBER                    0x8F8
+#define DW_PCIE_VERSION_TYPE                      0x8FC
+
+/* iATU inbound and outbound windows CSRs. Before the IP-core v4.80a each
+ * iATU region CSRs had been indirectly accessible by means of the dedicated
+ * viewport selector. The iATU/eDMA CSRs space was re-designed in DWC PCIe
+ * v4.80a in a way so the viewport was unrolled into the directly accessible
+ * iATU/eDMA CSRs space.
+ */
+
+#define DW_PCIE_ATU_VIEWPORT                      0x900
+#define DW_PCIE_ATU_REGION_DIR_IB                 BIT(31)
+#define DW_PCIE_ATU_REGION_DIR_OB                 0
+#define DW_PCIE_ATU_VIEWPORT_BASE                 0x904
+#define DW_PCIE_ATU_UNROLL_BASE(dir, index) \
+  (((index) << 9) | ((dir == DW_PCIE_ATU_REGION_DIR_IB) ? BIT(8) : 0))
+#define DW_PCIE_ATU_VIEWPORT_SIZE                 0x2C
+#define DW_PCIE_ATU_REGION_CTRL1                  0x000
+#define DW_PCIE_ATU_INCREASE_REGION_SIZE          BIT(13)
+#define DW_PCIE_ATU_TYPE_MEM                      0x0
+#define DW_PCIE_ATU_TYPE_IO                       0x2
+#define DW_PCIE_ATU_TYPE_CFG0                     0x4
+#define DW_PCIE_ATU_TYPE_CFG1                     0x5
+#define DW_PCIE_ATU_TYPE_MSG                      0x10
+#define DW_PCIE_ATU_TD                            BIT(8)
+#define DW_PCIE_ATU_FUNC_NUM(pf)                  ((pf) << 20)
+#define DW_PCIE_ATU_REGION_CTRL2                  0x004
+#define DW_PCIE_ATU_ENABLE                        BIT(31)
+#define DW_PCIE_ATU_BAR_MODE_ENABLE               BIT(30)
+#define DW_PCIE_ATU_INHIBIT_PAYLOAD               BIT(22)
+#define DW_PCIE_ATU_FUNC_NUM_MATCH_EN             BIT(19)
+#define DW_PCIE_ATU_LOWER_BASE                    0x008
+#define DW_PCIE_ATU_UPPER_BASE                    0x00C
+#define DW_PCIE_ATU_LIMIT                         0x010
+#define DW_PCIE_ATU_LOWER_TARGET                  0x014
+#define DW_PCIE_ATU_BUS(x)                        FIELD_PREP(GENMASK(31, 24), x)
+#define DW_PCIE_ATU_DEV(x)                        FIELD_PREP(GENMASK(23, 19), x)
+#define DW_PCIE_ATU_FUNC(x)                       FIELD_PREP(GENMASK(18, 16), x)
+#define DW_PCIE_ATU_UPPER_TARGET                  0x018
+#define DW_PCIE_ATU_UPPER_LIMIT                   0x020
+
+#define DW_PCIE_MISC_CONTROL_1_OFF                0x8BC
+#define DW_PCIE_DBI_RO_WR_EN                      BIT(0)
+
+#define DW_PCIE_MSIX_DOORBELL                     0x948
+#define DW_PCIE_MSIX_DOORBELL_PF_SHIFT            24
+
+#define DW_PCIE_DMA_VIEWPORT_BASE                 0x970
+#define DW_PCIE_DMA_UNROLL_BASE                   0x80000
+#define DW_PCIE_DMA_CTRL                          0x008
+#define DW_PCIE_DMA_NUM_WR_CHAN                   GENMASK(3, 0)
+#define DW_PCIE_DMA_NUM_RD_CHAN                   GENMASK(19, 16)
+
+#define DW_PCIE_PL_CHK_REG_CONTROL_STATUS         0xB20
+#define DW_PCIE_PL_CHK_REG_CHK_REG_START          BIT(0)
+#define DW_PCIE_PL_CHK_REG_CHK_REG_CONTINUOUS     BIT(1)
+#define DW_PCIE_PL_CHK_REG_CHK_REG_COMPARISON_ERR BIT(16)
+#define DW_PCIE_PL_CHK_REG_CHK_REG_LOGIC_ERROR    BIT(17)
+#define DW_PCIE_PL_CHK_REG_CHK_REG_COMPLETE       BIT(18)
+
+#define DW_PCIE_PL_CHK_REG_ERR_ADDR               0xB28
+
+/* 16.0 GT/s (Gen 4) lane margining register definitions
+ */
+
+#define DW_PCIE_GEN4_LANE_MARGINING_1_OFF         0xB80
+#define DW_PCIE_MARGINING_MAX_VOLTAGE_OFFSET      GENMASK(29, 24)
+#define DW_PCIE_MARGINING_NUM_VOLTAGE_STEPS       GENMASK(22, 16)
+#define DW_PCIE_MARGINING_MAX_TIMING_OFFSET       GENMASK(13, 8)
+#define DW_PCIE_MARGINING_NUM_TIMING_STEPS        GENMASK(5, 0)
+
+#define DW_PCIE_GEN4_LANE_MARGINING_2_OFF         0xB84
+#define DW_PCIE_MARGINING_IND_ERROR_SAMPLER       BIT(28)
+#define DW_PCIE_MARGINING_SAMPLE_REPORTING_METHOD BIT(27)
+#define DW_PCIE_MARGINING_IND_LEFT_RIGHT_TIMING   BIT(26)
+#define DW_PCIE_MARGINING_IND_UP_DOWN_VOLTAGE     BIT(25)
+#define DW_PCIE_MARGINING_VOLTAGE_SUPPORTED       BIT(24)
+#define DW_PCIE_MARGINING_MAXLANES                GENMASK(20, 16)
+#define DW_PCIE_MARGINING_SAMPLE_RATE_TIMING      GENMASK(13, 8)
+#define DW_PCIE_MARGINING_SAMPLE_RATE_VOLTAGE     GENMASK(5, 0)
+
+/* iATU Unroll-specific register definitions
+ * From 4.80 core version the address translation will be made by unroll
+ */
+
+#define DW_PCIE_ATU_UNR_REGION_CTRL1              0x00
+#define DW_PCIE_ATU_UNR_REGION_CTRL2              0x04
+#define DW_PCIE_ATU_UNR_LOWER_BASE                0x08
+#define DW_PCIE_ATU_UNR_UPPER_BASE                0x0C
+#define DW_PCIE_ATU_UNR_LOWER_LIMIT               0x10
+#define DW_PCIE_ATU_UNR_LOWER_TARGET              0x14
+#define DW_PCIE_ATU_UNR_UPPER_TARGET              0x18
+#define DW_PCIE_ATU_UNR_UPPER_LIMIT               0x20
+
+/* RAS-DES register definitions
+ */
+#define DW_PCIE_RAS_DES_EVENT_COUNTER_CONTROL     0x8
+#define DW_PCIE_EVENT_COUNTER_ALL_CLEAR           0x3
+#define DW_PCIE_EVENT_COUNTER_ENABLE_ALL          0x7
+#define DW_PCIE_EVENT_COUNTER_ENABLE_SHIFT        2
+#define DW_PCIE_EVENT_COUNTER_EVENT_SEL_MASK      GENMASK(7, 0)
+#define DW_PCIE_EVENT_COUNTER_EVENT_SEL_SHIFT     16
+#define DW_PCIE_EVENT_COUNTER_EVENT_Tx_L0S        0x2
+#define DW_PCIE_EVENT_COUNTER_EVENT_Rx_L0S        0x3
+#define DW_PCIE_EVENT_COUNTER_EVENT_L1            0x5
+#define DW_PCIE_EVENT_COUNTER_EVENT_L1_1          0x7
+#define DW_PCIE_EVENT_COUNTER_EVENT_L1_2          0x8
+#define DW_PCIE_EVENT_COUNTER_GROUP_SEL_SHIFT     24
+#define DW_PCIE_EVENT_COUNTER_GROUP_5             0x5
+
+#define DW_PCIE_RAS_DES_EVENT_COUNTER_DATA        0xc
+
+/* The default address offset between dbi_base and atu_base. Root
+ * controller drivers are not required to initialize atu_base
+ * if the offset matches this default; the driver core
+ * automatically derives atu_base From dbi_base using this offset,
+ * if atu_base not set.
+ */
+
+#define DW_PCIE_DEFAULT_DBI_ATU_OFFSET            (0x3 << 20)
+#define DW_PCIE_DEFAULT_DBI_DMA_OFFSET            DW_PCIE_DMA_UNROLL_BASE
+
+/* Maximum number of inbound/outbound iATUs */
+
+#define DW_PCIE_MAX_IATU_IN                       256
+#define DW_PCIE_MAX_IATU_OUT                      256
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+void dw_pcie_version_detect(FAR struct dw_pcie_s *pci);
+uint32_t dw_pcie_read_dbi(FAR struct dw_pcie_s *pci, uint32_t reg,
+                          size_t size);
+void dw_pcie_write_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, size_t size,
+                       uint32_t val);
+void dw_pcie_write_dbi2(FAR struct dw_pcie_s *pci, uint32_t reg, size_t size,
+                        uint32_t val);
+void
+dw_pcie_writel_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint32_t val);
+uint32_t dw_pcie_readl_dbi(FAR struct dw_pcie_s *pci, uint32_t reg);
+void
+dw_pcie_writew_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint16_t val);
+uint16_t dw_pcie_readw_dbi(FAR struct dw_pcie_s *pci, uint32_t reg);
+void
+dw_pcie_writeb_dbi(FAR struct dw_pcie_s *pci, uint32_t reg, uint8_t val);
+uint8_t dw_pcie_readb_dbi(FAR struct dw_pcie_s *pci, uint32_t reg);
+void
+dw_pcie_writel_dbi2(FAR struct dw_pcie_s *pci, uint32_t reg, uint32_t val);
+uint32_t dw_pcie_ep_get_dbi_offset(FAR struct dw_pcie_ep_s *ep,
+                                   uint8_t funcno);
+uint32_t dw_pcie_ep_read_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                             uint32_t reg, size_t size);
+void dw_pcie_ep_write_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                          uint32_t reg, size_t size, uint32_t val);
+void dw_pcie_ep_writel_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint32_t reg, uint32_t val);
+uint32_t dw_pcie_ep_readl_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                              uint32_t reg);
+void dw_pcie_ep_writew_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint32_t reg, uint16_t val);
+uint16_t dw_pcie_ep_readw_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                              uint32_t reg);
+void dw_pcie_ep_writeb_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint32_t reg, uint8_t val);
+uint8_t dw_pcie_ep_readb_dbi(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                             uint32_t reg);
+uint32_t
+dw_pcie_ep_get_dbi2_offset(FAR struct dw_pcie_ep_s *ep, uint8_t funcno);
+void
+dw_pcie_ep_write_dbi2(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                      uint32_t reg, size_t size, uint32_t val);
+void dw_pcie_ep_writel_dbi2(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                            uint32_t reg, uint32_t val);
+void dw_pcie_dbi_ro_wr_en(FAR struct dw_pcie_s *pci);
+void dw_pcie_dbi_ro_wr_dis(FAR struct dw_pcie_s *pci);
+void dw_pcie_ep_linkup(FAR struct dw_pcie_ep_s *ep);
+void dw_pcie_ep_linkdown(FAR struct dw_pcie_ep_s *ep);
+int dw_pcie_prog_outbound_atu(FAR struct dw_pcie_s *pci,
+                              const FAR struct dw_pcie_ob_atu_cfg_s *atu);
+int
+dw_pcie_prog_inbound_atu(FAR struct dw_pcie_s *pci, int index, int type,
+                         uint64_t cpu_addr, uint64_t pci_addr,
+                         uint64_t size);
+int
+dw_pcie_prog_ep_inbound_atu(FAR struct dw_pcie_s *pci, uint8_t funcno,
+                            int index, int type, uint64_t cpu_addr,
+                            uint8_t bar);
+void dw_pcie_disable_atu(FAR struct dw_pcie_s *pci, uint32_t dir, int index);
+void dw_pcie_setup(FAR struct dw_pcie_s *pci);
+void dw_pcie_iatu_detect(FAR struct dw_pcie_s *pci);
+
+#endif /* _PCIE_DW_H */

--- a/drivers/pci/pcie_dw_ep.c
+++ b/drivers/pci/pcie_dw_ep.c
@@ -1,0 +1,1181 @@
+/****************************************************************************
+ * drivers/pci/pcie_dw_ep.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+
+#include <nuttx/bits.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/pci/pci.h>
+#include <nuttx/pci/pci_regs.h>
+#include <nuttx/pci/pci_epc.h>
+#include <nuttx/pci/pci_epf.h>
+
+#include "pcie_dw.h"
+#include "pci_drivers.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void
+__dw_pcie_ep_reset_bar(FAR struct dw_pcie_s *pci, uint8_t funcno,
+                       int bar, int flags);
+static void
+__dw_pcie_ep_reset_bar(FAR struct dw_pcie_s *pci, uint8_t funcno,
+                       int bar, int flags);
+static uint8_t
+__dw_pcie_ep_find_next_cap(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint8_t cap_ptr, uint8_t cap);
+static uint8_t
+dw_pcie_ep_find_capability(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint8_t cap);
+static int
+dw_pcie_ep_write_header(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                        FAR struct pci_epf_header_s *hdr);
+static int
+dw_pcie_ep_inbound_atu(FAR struct dw_pcie_ep_s *ep, uint8_t funcno, int type,
+                       uintptr_t cpu_addr, uint8_t bar);
+static int
+dw_pcie_ep_outbound_atu(FAR struct dw_pcie_ep_s *ep,
+                        struct dw_pcie_ob_atu_cfg_s *atu);
+static void
+dw_pcie_ep_clear_bar(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                     FAR struct pci_epf_bar_s *epf_bar);
+static int
+dw_pcie_ep_set_bar(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                   FAR struct pci_epf_bar_s *epf_bar);
+static int
+dw_pcie_find_index(FAR struct dw_pcie_ep_s *ep, uintptr_t addr,
+                   FAR uint32_t *atu_index);
+static void
+dw_pcie_ep_unmap_addr(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                      uintptr_t addr);
+static int
+dw_pcie_ep_map_addr(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                    uintptr_t addr, uint64_t pci_addr, size_t size);
+static int
+dw_pcie_ep_get_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno);
+static int
+dw_pcie_ep_set_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                   uint8_t interrupts);
+static int
+dw_pcie_ep_get_msix(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno);
+static int
+dw_pcie_ep_set_msix(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                    uint16_t interrupts, int bir, uint32_t offset);
+static int
+dw_pcie_ep_raise_irq(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                     unsigned int type, uint16_t interrupt_num);
+static void dw_pcie_ep_stop(FAR struct pci_epc_ctrl_s *epc);
+static int dw_pcie_ep_start(FAR struct pci_epc_ctrl_s *epc);
+static FAR const struct pci_epc_features_s *
+dw_pcie_ep_get_features(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno);
+static unsigned int
+dw_pcie_ep_find_ext_capability(FAR struct dw_pcie_s *pci, int cap);
+static void dw_pcie_ep_init_non_sticky_registers(FAR struct dw_pcie_s *pci);
+static int dw_pcie_ep_init_registers(FAR struct dw_pcie_ep_s *ep);
+FAR struct dw_pcie_ep_func_s *dw_pcie_ep_get_func_from_ep(
+  FAR struct dw_pcie_ep_s *ep, uint8_t funcno);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct pci_epc_ops_s g_epc_ops =
+{
+  .write_header   = dw_pcie_ep_write_header,
+  .set_bar        = dw_pcie_ep_set_bar,
+  .clear_bar      = dw_pcie_ep_clear_bar,
+  .map_addr       = dw_pcie_ep_map_addr,
+  .unmap_addr     = dw_pcie_ep_unmap_addr,
+  .set_msi        = dw_pcie_ep_set_msi,
+  .get_msi        = dw_pcie_ep_get_msi,
+  .set_msix       = dw_pcie_ep_set_msix,
+  .get_msix       = dw_pcie_ep_get_msix,
+  .raise_irq      = dw_pcie_ep_raise_irq,
+  .start          = dw_pcie_ep_start,
+  .stop           = dw_pcie_ep_stop,
+  .get_features   = dw_pcie_ep_get_features,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void __dw_pcie_ep_reset_bar(FAR struct dw_pcie_s *pci, uint8_t funcno,
+           int bar, int flags)
+{
+  FAR struct dw_pcie_ep_s *ep = &pci->ep;
+  uint32_t reg;
+
+  reg = PCI_BASE_ADDRESS_0 + (4 * bar);
+  dw_pcie_dbi_ro_wr_en(pci);
+  dw_pcie_ep_writel_dbi2(ep, funcno, reg, 0x0);
+  dw_pcie_ep_writel_dbi(ep, funcno, reg, 0x0);
+  if (flags & PCI_BASE_ADDRESS_MEM_TYPE_64)
+    {
+      dw_pcie_ep_writel_dbi2(ep, funcno, reg + 4, 0x0);
+      dw_pcie_ep_writel_dbi(ep, funcno, reg + 4, 0x0);
+    }
+
+  dw_pcie_dbi_ro_wr_dis(pci);
+}
+
+static uint8_t
+__dw_pcie_ep_find_next_cap(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint8_t cap_ptr, uint8_t cap)
+{
+  uint8_t next_cap_ptr;
+  uint8_t cap_id;
+  uint16_t reg;
+
+  if (!cap_ptr)
+    {
+      return 0;
+    }
+
+  reg = dw_pcie_ep_readw_dbi(ep, funcno, cap_ptr);
+  cap_id = (reg & 0x00ff);
+
+  if (cap_id > PCI_CAP_ID_MAX)
+    {
+      return 0;
+    }
+
+  if (cap_id == cap)
+    {
+      return cap_ptr;
+    }
+
+  next_cap_ptr = (reg & 0xff00) >> 8;
+  return __dw_pcie_ep_find_next_cap(ep, funcno, next_cap_ptr, cap);
+}
+
+static uint8_t
+dw_pcie_ep_find_capability(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                           uint8_t cap)
+{
+  uint8_t next_cap_ptr;
+  uint16_t reg;
+
+  reg = dw_pcie_ep_readw_dbi(ep, funcno, PCI_CAPABILITY_LIST);
+  next_cap_ptr = (reg & 0x00ff);
+
+  return __dw_pcie_ep_find_next_cap(ep, funcno, next_cap_ptr, cap);
+}
+
+static int
+dw_pcie_ep_write_header(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                        FAR struct pci_epf_header_s *hdr)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  dw_pcie_dbi_ro_wr_en(pci);
+  dw_pcie_ep_writew_dbi(ep, funcno, PCI_VENDOR_ID, hdr->vendorid);
+  dw_pcie_ep_writew_dbi(ep, funcno, PCI_DEVICE_ID, hdr->deviceid);
+  dw_pcie_ep_writeb_dbi(ep, funcno, PCI_REVISION_ID, hdr->revid);
+  dw_pcie_ep_writeb_dbi(ep, funcno, PCI_CLASS_PROG, hdr->progif_code);
+  dw_pcie_ep_writew_dbi(ep, funcno, PCI_CLASS_DEVICE,
+            hdr->subclass_code | hdr->baseclass_code << 8);
+  dw_pcie_ep_writeb_dbi(ep, funcno, PCI_CACHE_LINE_SIZE,
+            hdr->cache_line_size);
+  dw_pcie_ep_writew_dbi(ep, funcno, PCI_SUBSYSTEM_VENDOR_ID,
+            hdr->subsys_vendor_id);
+  dw_pcie_ep_writew_dbi(ep, funcno, PCI_SUBSYSTEM_ID, hdr->subsys_id);
+  dw_pcie_ep_writeb_dbi(ep, funcno, PCI_INTERRUPT_PIN,
+            hdr->interrupt_pin);
+  dw_pcie_dbi_ro_wr_dis(pci);
+
+  return 0;
+}
+
+static int
+dw_pcie_ep_inbound_atu(FAR struct dw_pcie_ep_s *ep, uint8_t funcno, int type,
+                       uintptr_t cpu_addr, uint8_t bar)
+{
+  int ret;
+  uint32_t free_win;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  if (!ep->bar_to_atu[bar])
+    {
+      free_win = find_first_zero_bit(ep->ib_window_map, pci->num_ib_windows);
+    }
+  else
+    {
+      free_win = ep->bar_to_atu[bar] - 1;
+    }
+
+  if (free_win >= pci->num_ib_windows)
+    {
+      pcierr("No free inbound window\n");
+      return -EINVAL;
+    }
+
+  ret = dw_pcie_prog_ep_inbound_atu(pci, funcno, free_win, type,
+            cpu_addr, bar);
+  if (ret < 0)
+    {
+      pcierr("Failed to program IB window ret %d bar %d cpuaddr %lx\n",
+             ret, bar, cpu_addr);
+      return ret;
+    }
+
+  /* Always increment free_win before assignment, since value 0
+   * is used to identify unallocated mapping.
+   */
+
+  ep->bar_to_atu[bar] = free_win + 1;
+  set_bit(free_win, ep->ib_window_map);
+
+  return 0;
+}
+
+static int
+dw_pcie_ep_outbound_atu(FAR struct dw_pcie_ep_s *ep,
+                        FAR struct dw_pcie_ob_atu_cfg_s *atu)
+{
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  uint32_t free_win;
+  int ret;
+
+  free_win = find_first_zero_bit(ep->ob_window_map, pci->num_ob_windows);
+  if (free_win >= pci->num_ob_windows)
+    {
+      pcierr("No free outbound window\n");
+      return -EINVAL;
+    }
+
+  atu->index = free_win;
+  ret = dw_pcie_prog_outbound_atu(pci, atu);
+  if (ret)
+    {
+      return ret;
+    }
+
+  set_bit(free_win, ep->ob_window_map);
+  ep->outbound_addr[free_win] = atu->cpu_addr;
+
+  return 0;
+}
+
+static void
+dw_pcie_ep_clear_bar(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                     FAR struct pci_epf_bar_s *epf_bar)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  uint8_t bar = epf_bar->barno;
+  uint32_t atu_index = ep->bar_to_atu[bar] - 1;
+
+  if (!ep->bar_to_atu[bar])
+    {
+      return;
+    }
+
+  __dw_pcie_ep_reset_bar(pci, funcno, bar, epf_bar->flags);
+
+  dw_pcie_disable_atu(pci, DW_PCIE_ATU_REGION_DIR_IB, atu_index);
+  clear_bit(atu_index, ep->ib_window_map);
+  ep->epf_bar[bar] = NULL;
+  ep->bar_to_atu[bar] = 0;
+}
+
+static int
+dw_pcie_ep_set_bar(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                   FAR struct pci_epf_bar_s *epf_bar)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  uint8_t bar = epf_bar->barno;
+  size_t size = epf_bar->size;
+  int flags = epf_bar->flags;
+  uint32_t reg;
+  int ret;
+  int type;
+
+  /* DWC does not allow BAR pairs to overlap, e.g. you cannot combine BARs
+   * 1 and 2 to form a 64-bit BAR.
+   */
+
+  if ((flags & PCI_BASE_ADDRESS_MEM_TYPE_64) && (bar & 1))
+    {
+      return -EINVAL;
+    }
+
+  reg = PCI_BASE_ADDRESS_0 + (4 * bar);
+
+  if (!(flags & PCI_BASE_ADDRESS_SPACE))
+    {
+      type = DW_PCIE_ATU_TYPE_MEM;
+    }
+  else
+    {
+      type = DW_PCIE_ATU_TYPE_IO;
+    }
+
+  ret = dw_pcie_ep_inbound_atu(ep, funcno, type, epf_bar->phys_addr, bar);
+  if (ret)
+    {
+      return ret;
+    }
+
+  if (ep->epf_bar[bar])
+    {
+      return 0;
+    }
+
+  dw_pcie_dbi_ro_wr_en(pci);
+
+  dw_pcie_ep_writel_dbi2(ep, funcno, reg, lower_32_bits(size - 1));
+  dw_pcie_ep_writel_dbi(ep, funcno, reg, flags);
+
+  if (flags & PCI_BASE_ADDRESS_MEM_TYPE_64)
+    {
+      dw_pcie_ep_writel_dbi2(ep, funcno, reg + 4, upper_32_bits(size - 1));
+      dw_pcie_ep_writel_dbi(ep, funcno, reg + 4, 0);
+    }
+
+  ep->epf_bar[bar] = epf_bar;
+  dw_pcie_dbi_ro_wr_dis(pci);
+
+  return 0;
+}
+
+static int
+dw_pcie_find_index(FAR struct dw_pcie_ep_s *ep, uintptr_t addr,
+                   FAR uint32_t *atu_index)
+{
+  uint32_t index;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  for (index = 0; index < pci->num_ob_windows; index++)
+    {
+      if (ep->outbound_addr[index] != addr)
+        {
+          continue;
+        }
+
+      *atu_index = index;
+      return 0;
+    }
+
+  return -EINVAL;
+}
+
+static void
+dw_pcie_ep_unmap_addr(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                      uintptr_t addr)
+{
+  int ret;
+  uint32_t atu_index;
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  ret = dw_pcie_find_index(ep, addr, &atu_index);
+  if (ret < 0)
+    {
+      return;
+    }
+
+  dw_pcie_disable_atu(pci, DW_PCIE_ATU_REGION_DIR_OB, atu_index);
+  clear_bit(atu_index, ep->ob_window_map);
+}
+
+static int
+dw_pcie_ep_map_addr(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                    FAR uintptr_t addr, uint64_t pci_addr, size_t size)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_ob_atu_cfg_s atu =
+    {
+      0
+    };
+
+  int ret;
+
+  atu.funcno = funcno;
+  atu.type = DW_PCIE_ATU_TYPE_MEM;
+  atu.cpu_addr = addr;
+  atu.pci_addr = pci_addr;
+  atu.size = size;
+  ret = dw_pcie_ep_outbound_atu(ep, &atu);
+  if (ret)
+    {
+      pcierr("Failed to enable address\n");
+      return ret;
+    }
+
+  return 0;
+}
+
+static int
+dw_pcie_ep_get_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  uint32_t val;
+  uint32_t reg;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msi_cap)
+    {
+      return -EINVAL;
+    }
+
+  reg = ep_func->msi_cap + PCI_MSI_FLAGS;
+  val = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+  if (!(val & PCI_MSI_FLAGS_ENABLE))
+    {
+      return -EINVAL;
+    }
+
+  val = FIELD_GET(PCI_MSI_FLAGS_QSIZE, val);
+
+  return val;
+}
+
+static int
+dw_pcie_ep_set_msi(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                   uint8_t interrupts)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  uint32_t val;
+  uint32_t reg;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msi_cap)
+    {
+      return -EINVAL;
+    }
+
+  reg = ep_func->msi_cap + PCI_MSI_FLAGS;
+  val = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+  val &= ~PCI_MSI_FLAGS_QMASK;
+  val |= FIELD_PREP(PCI_MSI_FLAGS_QMASK, interrupts);
+  dw_pcie_dbi_ro_wr_en(pci);
+  dw_pcie_ep_writew_dbi(ep, funcno, reg, val);
+  dw_pcie_dbi_ro_wr_dis(pci);
+
+  return 0;
+}
+
+static int
+dw_pcie_ep_get_msix(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno)
+{
+  struct dw_pcie_ep_s *ep = epc->priv;
+  struct dw_pcie_ep_func_s *ep_func;
+  uint32_t val;
+  uint32_t reg;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msix_cap)
+    {
+      return -EINVAL;
+    }
+
+  reg = ep_func->msix_cap + PCI_MSIX_FLAGS;
+  val = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+  if (!(val & PCI_MSIX_FLAGS_ENABLE))
+    {
+      return -EINVAL;
+    }
+
+  val &= PCI_MSIX_FLAGS_QSIZE;
+
+  return val;
+}
+
+static int
+dw_pcie_ep_set_msix(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                    uint16_t interrupts, int bir, uint32_t offset)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  uint32_t val;
+  uint32_t reg;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msix_cap)
+    {
+      return -EINVAL;
+    }
+
+  dw_pcie_dbi_ro_wr_en(pci);
+
+  reg = ep_func->msix_cap + PCI_MSIX_FLAGS;
+  val = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+  val &= ~PCI_MSIX_FLAGS_QSIZE;
+  val |= interrupts;
+  dw_pcie_writew_dbi(pci, reg, val);
+
+  reg = ep_func->msix_cap + PCI_MSIX_TABLE;
+  val = offset | bir;
+  dw_pcie_ep_writel_dbi(ep, funcno, reg, val);
+
+  reg = ep_func->msix_cap + PCI_MSIX_PBA;
+  val = (offset + (interrupts * PCI_MSIX_ENTRY_SIZE)) | bir;
+  dw_pcie_ep_writel_dbi(ep, funcno, reg, val);
+
+  dw_pcie_dbi_ro_wr_dis(pci);
+
+  return 0;
+}
+
+static int
+dw_pcie_ep_raise_irq(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
+                     unsigned int type, uint16_t interrupt_num)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+
+  if (!ep->ops->raise_irq)
+    {
+      return -EINVAL;
+    }
+
+  return ep->ops->raise_irq(ep, funcno, type, interrupt_num);
+}
+
+static void dw_pcie_ep_stop(FAR struct pci_epc_ctrl_s *epc)
+{
+  struct dw_pcie_ep_s *ep = epc->priv;
+  struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  dw_pcie_stop_link(pci);
+}
+
+static int dw_pcie_ep_start(FAR struct pci_epc_ctrl_s *epc)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+
+  return dw_pcie_start_link(pci);
+}
+
+static FAR const struct pci_epc_features_s *
+dw_pcie_ep_get_features(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno)
+{
+  FAR struct dw_pcie_ep_s *ep = epc->priv;
+
+  if (!ep->ops->get_features)
+    {
+      return NULL;
+    }
+
+  return ep->ops->get_features(ep);
+}
+
+static unsigned int
+dw_pcie_ep_find_ext_capability(FAR struct dw_pcie_s *pci, int cap)
+{
+  uint32_t header;
+  int pos = PCI_CFG_SPACE_SIZE;
+
+  while (pos)
+    {
+      header = dw_pcie_readl_dbi(pci, pos);
+      if (PCI_EXT_CAP_ID(header) == cap)
+        {
+          return pos;
+        }
+
+      pos = PCI_EXT_CAP_NEXT(header);
+      if (!pos)
+        {
+          break;
+        }
+    }
+
+  return 0;
+}
+
+static void dw_pcie_ep_init_non_sticky_registers(FAR struct dw_pcie_s *pci)
+{
+  unsigned int offset;
+  unsigned int nbars;
+  uint32_t reg;
+  uint32_t i;
+
+  offset = dw_pcie_ep_find_ext_capability(pci, PCI_EXT_CAP_ID_REBAR);
+
+  dw_pcie_dbi_ro_wr_en(pci);
+
+  if (offset)
+    {
+      reg = dw_pcie_readl_dbi(pci, offset + PCI_REBAR_CTRL);
+      nbars = (reg & PCI_REBAR_CTRL_NBAR_MASK) >>
+               PCI_REBAR_CTRL_NBAR_SHIFT;
+
+      /* PCIe r6.0, sec 7.8.6.2 require us to support at least one
+       * size in the range from 1 MB to 512 GB. Advertise support
+       * for 1 MB BAR size only.
+       */
+
+      for (i = 0; i < nbars; i++, offset += PCI_REBAR_CTRL)
+        {
+          dw_pcie_writel_dbi(pci, offset + PCI_REBAR_CAP, 0x0);
+        }
+    }
+
+  dw_pcie_setup(pci);
+  dw_pcie_dbi_ro_wr_dis(pci);
+}
+
+static int dw_pcie_ep_init_registers(FAR struct dw_pcie_ep_s *ep)
+{
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+  uint32_t ptm_cap_base;
+  size_t bitmap_size;
+  uint8_t hdr_type;
+  uint8_t funcno;
+  FAR void *addr;
+  uint32_t reg;
+
+  hdr_type = dw_pcie_readb_dbi(pci, PCI_HEADER_TYPE) &
+                               PCI_HEADER_TYPE_MASK;
+  pciinfo("hdr_type %x \n", hdr_type);
+
+  if (hdr_type != PCI_HEADER_TYPE_NORMAL)
+    {
+      pcierr("PCIe controller is not set to EP mode (hdr_type:0x%x)!\n",
+             hdr_type);
+      return -EIO;
+    }
+
+  hdr_type = dw_pcie_readl_dbi(pci, 8);
+
+  dw_pcie_version_detect(pci);
+
+  dw_pcie_iatu_detect(pci);
+
+  if (!ep->ib_window_map)
+    {
+      bitmap_size = BITS_TO_LONGS(pci->num_ib_windows) * sizeof(long);
+      ep->ib_window_map = kmm_zalloc(bitmap_size);
+      if (ep->ib_window_map == NULL)
+        {
+          return -ENOMEM;
+        }
+    }
+
+  if (!ep->ob_window_map)
+    {
+      bitmap_size = BITS_TO_LONGS(pci->num_ob_windows) * sizeof(long);
+      ep->ob_window_map = kmm_zalloc(bitmap_size);
+      if (!ep->ob_window_map)
+        {
+          goto err_free_ib_map;
+        }
+    }
+
+  if (!ep->outbound_addr)
+    {
+      addr = kmm_zalloc(pci->num_ob_windows * sizeof(uintptr_t));
+      if (!addr)
+        {
+          goto err_free_ob_map;
+        }
+
+      ep->outbound_addr = addr;
+    }
+
+  for (funcno = 0; funcno < epc->max_functions; funcno++)
+    {
+      ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+      if (ep_func)
+        {
+          continue;
+        }
+
+      ep_func = kmm_zalloc(sizeof(*ep_func));
+      if (!ep_func)
+        {
+          goto err_free_ob_addr;
+        }
+
+      ep_func->funcno = funcno;
+      ep_func->msi_cap
+        = dw_pcie_ep_find_capability(ep, funcno, PCI_CAP_ID_MSI);
+      ep_func->msix_cap
+        = dw_pcie_ep_find_capability(ep, funcno, PCI_CAP_ID_MSIX);
+
+      list_add_tail(&ep->func_list, &ep_func->list);
+    }
+
+  if (ep->ops->init)
+    {
+      ep->ops->init(ep);
+    }
+
+  ptm_cap_base = dw_pcie_ep_find_ext_capability(pci, PCI_EXT_CAP_ID_PTM);
+
+  /* PTM responder capability can be disabled only after disabling
+   * PTM root capability.
+   */
+
+  if (ptm_cap_base)
+    {
+      dw_pcie_dbi_ro_wr_en(pci);
+      reg = dw_pcie_readl_dbi(pci, ptm_cap_base + PCI_PTM_CAP);
+      reg &= ~PCI_PTM_CAP_ROOT;
+      dw_pcie_writel_dbi(pci, ptm_cap_base + PCI_PTM_CAP, reg);
+
+      reg = dw_pcie_readl_dbi(pci, ptm_cap_base + PCI_PTM_CAP);
+      reg &= ~(PCI_PTM_CAP_RES | PCI_PTM_GRANULARITY_MASK);
+      dw_pcie_writel_dbi(pci, ptm_cap_base + PCI_PTM_CAP, reg);
+      dw_pcie_dbi_ro_wr_dis(pci);
+    }
+
+  dw_pcie_ep_init_non_sticky_registers(pci);
+
+  return 0;
+
+err_free_ob_addr:
+  kmm_free(ep->outbound_addr);
+err_free_ob_map:
+  kmm_free(ep->ob_window_map);
+err_free_ib_map:
+  kmm_free(ep->ib_window_map);
+  return -EINVAL;
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_get_func_from_ep
+ *
+ * Description:
+ *   This function is used to Get the struct dw_pcie_ep_func_s corresponding
+ *   to the endpoint function
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   funcno           - Function number of the endpoint device
+ *
+ * Returned Value:
+ *   Return struct dw_pcie_ep_func_s if success, NULL otherwise.
+ *
+ ****************************************************************************/
+
+FAR struct dw_pcie_ep_func_s *dw_pcie_ep_get_func_from_ep(
+  FAR struct dw_pcie_ep_s *ep, uint8_t funcno)
+{
+  FAR struct dw_pcie_ep_func_s *ep_func;
+
+  list_for_every_entry(&ep->func_list, ep_func, struct dw_pcie_ep_func_s,
+                       list)
+    {
+      if (ep_func->funcno == funcno)
+        {
+          return ep_func;
+        }
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dw_pcie_ep_reset_bar
+ *
+ * Description:
+ *   This function is used to Reset endpoint BARMSI-X to the host
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   bar              - BAR number of the endpoint
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+void dw_pcie_ep_reset_bar(FAR struct dw_pcie_s *pci, int bar)
+{
+  uint8_t funcno;
+  uint8_t funcs;
+
+  funcs = pci->ep.epc->max_functions;
+
+  for (funcno = 0; funcno < funcs; funcno++)
+    {
+      __dw_pcie_ep_reset_bar(pci, funcno, bar, 0);
+    }
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_raise_intx_irq
+ *
+ * Description:
+ *   This function is used to Raise MSI-X to the host
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   funcno           - The epc's function number
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+int dw_pcie_ep_raise_intx_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno)
+{
+  pcierr("EP cannot raise INTX IRQs\n");
+  return -EINVAL;
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_raise_msi_irq
+ *
+ * Description:
+ *   This function is used to Raise MSI-X to the host
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   funcno           - The epc's function number
+ *   interrupt_num    - The number of irq
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+int dw_pcie_ep_raise_msi_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                             uint8_t interrupt_num)
+{
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+  uint32_t aligned_offset;
+  uint32_t msg_addr_lower;
+  uint32_t msg_addr_upper;
+  uint64_t msg_addr;
+  uint16_t msg_ctrl;
+  uint16_t msg_data;
+  bool has_upper;
+  uint32_t reg;
+  int ret;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msi_cap)
+    {
+      return -EINVAL;
+    }
+
+  /* Raise MSI per the PCI Local Bus Specification Revision 3.0, 6.8.1. */
+
+  reg = ep_func->msi_cap + PCI_MSI_FLAGS;
+  msg_ctrl = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+  has_upper = !!(msg_ctrl & PCI_MSI_FLAGS_64BIT);
+  reg = ep_func->msi_cap + PCI_MSI_ADDRESS_LO;
+  msg_addr_lower = dw_pcie_ep_readl_dbi(ep, funcno, reg);
+  if (has_upper)
+    {
+      reg = ep_func->msi_cap + PCI_MSI_ADDRESS_HI;
+      msg_addr_upper = dw_pcie_ep_readl_dbi(ep, funcno, reg);
+      reg = ep_func->msi_cap + PCI_MSI_DATA_64;
+      msg_data = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+    }
+  else
+    {
+      msg_addr_upper = 0;
+      reg = ep_func->msi_cap + PCI_MSI_DATA_32;
+      msg_data = dw_pcie_ep_readw_dbi(ep, funcno, reg);
+    }
+
+  msg_addr = ((uint64_t)msg_addr_upper) << 32 | msg_addr_lower;
+
+  aligned_offset = msg_addr & (epc->mem->page_size - 1);
+  msg_addr = ALIGN_DOWN(msg_addr, epc->mem->page_size);
+  ret = dw_pcie_ep_map_addr(epc, funcno, ep->msi_mem_phys, msg_addr,
+                            epc->mem->page_size);
+  if (ret)
+    {
+      return ret;
+    }
+
+  writel(msg_data | (interrupt_num - 1), ep->msi_mem + aligned_offset);
+
+  dw_pcie_ep_unmap_addr(epc, funcno, ep->msi_mem_phys);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_raise_msix_irq_doorbell
+ *
+ * Description:
+ *   This function is used to Raise MSI-X to the host
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   funcno           - The epc's function number
+ *   interrupt_num    - The number of irq
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+int dw_pcie_ep_raise_msix_irq_doorbell(FAR struct dw_pcie_ep_s *ep,
+                                       uint8_t funcno,
+                                       uint16_t interrupt_num)
+{
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  uint32_t msg_data;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msix_cap)
+    {
+      return -EINVAL;
+    }
+
+  msg_data = (funcno << DW_PCIE_MSIX_DOORBELL_PF_SHIFT) |
+             (interrupt_num - 1);
+
+  dw_pcie_writel_dbi(pci, DW_PCIE_MSIX_DOORBELL, msg_data);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_raise_msix_irq
+ *
+ * Description:
+ *   This function is used to Raise MSI-X to the host
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   funcno           - The epc's function number
+ *   interrupt_num    - The number of irq
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+int dw_pcie_ep_raise_msix_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                              uint16_t interrupt_num)
+{
+  FAR struct pci_epf_msix_tbl_s *msix_tbl;
+  FAR struct dw_pcie_ep_func_s *ep_func;
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+  uint32_t aligned_offset;
+  uint32_t tbl_offset;
+  uint32_t msg_data;
+  uint32_t vec_ctrl;
+  uint64_t msg_addr;
+  uint32_t reg;
+  uint8_t bir;
+  int ret;
+
+  ep_func = dw_pcie_ep_get_func_from_ep(ep, funcno);
+  if (!ep_func || !ep_func->msix_cap)
+    {
+      return -EINVAL;
+    }
+
+  reg = ep_func->msix_cap + PCI_MSIX_TABLE;
+  tbl_offset = dw_pcie_ep_readl_dbi(ep, funcno, reg);
+  bir = FIELD_GET(PCI_MSIX_TABLE_BIR, tbl_offset);
+  tbl_offset &= PCI_MSIX_TABLE_OFFSET;
+
+  msix_tbl = ep->epf_bar[bir]->addr + tbl_offset;
+  msg_addr = msix_tbl[(interrupt_num - 1)].msg_addr;
+  msg_data = msix_tbl[(interrupt_num - 1)].msg_data;
+  vec_ctrl = msix_tbl[(interrupt_num - 1)].vector_ctrl;
+
+  if (vec_ctrl & PCI_MSIX_ENTRY_CTRL_MASKBIT)
+    {
+      pcierr("MSI-X entry ctrl set\n");
+      return -EPERM;
+    }
+
+  aligned_offset = msg_addr & (epc->mem->page_size - 1);
+  msg_addr = ALIGN_DOWN(msg_addr, epc->mem->page_size);
+  ret = dw_pcie_ep_map_addr(epc, funcno, ep->msi_mem_phys, msg_addr,
+                            epc->mem->page_size);
+  if (ret)
+    {
+      return ret;
+    }
+
+  writel(msg_data, ep->msi_mem + aligned_offset);
+
+  dw_pcie_ep_unmap_addr(epc, funcno, ep->msi_mem_phys);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_deinit
+ *
+ * Description:
+ *   This function is used to DEInitialize DWC EP specific registers
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+void dw_pcie_ep_deinit(FAR struct dw_pcie_ep_s *ep)
+{
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+
+  pci_epc_mem_free_addr(epc, ep->msi_mem_phys,
+                        epc->mem->page_size);
+
+  pci_epc_mem_exit(epc);
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_linkup
+ *
+ * Description:
+ *   This function is used to start link
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *
+ ****************************************************************************/
+
+void dw_pcie_ep_linkup(FAR struct dw_pcie_ep_s *ep)
+{
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+
+  pci_epc_linkup(epc);
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_linkdown
+ *
+ * Description:
+ *   This function is used to link down with rc.
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *
+ ****************************************************************************/
+
+void dw_pcie_ep_linkdown(FAR struct dw_pcie_ep_s *ep)
+{
+  FAR struct dw_pcie_s *pci = to_dw_pcie_from_ep(ep);
+  FAR struct pci_epc_ctrl_s *epc = ep->epc;
+
+  /* Initialize the non-sticky DWC registers as they would've reset post
+   * Link Down. This is specifically needed for drivers not supporting
+   * PERST# as they have no way to reinitialize the registers before the
+   * link comes back again.
+   */
+
+  dw_pcie_ep_init_non_sticky_registers(pci);
+
+  pci_epc_linkdown(epc);
+}
+
+/****************************************************************************
+ * Name: dw_pcie_ep_init
+ *
+ * Description:
+ *   This function is used to init epc.
+ *
+ * Input Parameters:
+ *   ep               - DWC EP of the endpoint controller
+ *   epc_name         - Device name of the endpoint controller
+ *
+ * Returned Value:
+ *   Return 0, errno otherwise.
+ *
+ ****************************************************************************/
+
+int dw_pcie_ep_init(FAR struct dw_pcie_ep_s *ep, char *epc_name)
+{
+  int ret;
+  FAR struct pci_epc_ctrl_s *epc;
+
+  list_initialize(&ep->func_list);
+
+  if (ep->ops->pre_init)
+    {
+      ep->ops->pre_init(ep);
+    }
+
+  epc = pci_epc_create(epc_name, ep, ep->dma_addr, ep->dma_len, &g_epc_ops);
+  if (epc == NULL)
+    {
+      pcierr("Failed to create epc device\n");
+      return -ENOMEM;
+    }
+
+  ep->epc = epc;
+
+  epc->max_functions = 1;
+
+  ret = pci_epc_mem_init(epc, (void *)ep->phys_base, ep->phys_base,
+                         ep->addr_size, ep->page_size);
+  if (ret < 0)
+    {
+      pcierr("Failed to initialize address space\n");
+      return ret;
+    }
+
+  ep->msi_mem = pci_epc_mem_alloc_addr(epc, &ep->msi_mem_phys,
+               SZ_4K);
+  if (!ep->msi_mem)
+    {
+      ret = -ENOMEM;
+      pcierr("Failed to reserve memory for MSI/MSI-X\n");
+      goto err_exit_epc_mem;
+    }
+
+  ret = dw_pcie_ep_init_registers(ep);
+  if (ret)
+    {
+      pcierr("Failed to initialize DWC endpoint registers\n");
+      goto ep_deinit;
+    }
+
+  pci_epc_init_notify(ep->epc);
+
+  return 0;
+
+ep_deinit:
+      dw_pcie_ep_deinit(ep);
+err_exit_epc_mem:
+  pci_epc_mem_exit(epc);
+
+  return ret;
+}

--- a/include/nuttx/pci/pci_regs.h
+++ b/include/nuttx/pci/pci_regs.h
@@ -23,6 +23,9 @@
 #ifndef __INCLUDE_NUTTX_PCI_PCI_REGS_H
 #define __INCLUDE_NUTTX_PCI_PCI_REGS_H
 
+#define PCI_CFG_SPACE_SIZE                256
+#define PCI_CFG_SPACE_EXP_SIZE            4096
+
 /* Under PCI, each device has 256 bytes of configuration address space,
  * of which the first 64 bytes are standardized as follows:
  */
@@ -69,6 +72,7 @@
 #define PCI_CACHE_LINE_SIZE               0x0c  /* 8 bits */
 #define PCI_LATENCY_TIMER                 0x0d  /* 8 bits */
 #define PCI_HEADER_TYPE                   0x0e  /* 8 bits */
+#define  PCI_HEADER_TYPE_MASK             0x7f
 #define  PCI_HEADER_TYPE_NORMAL           0
 #define  PCI_HEADER_TYPE_BRIDGE           1
 #define  PCI_HEADER_TYPE_CARDBUS          2
@@ -374,6 +378,17 @@
 #define  PCI_CHSWP_PI                     0x30  /* Programming Interface */
 #define  PCI_CHSWP_EXT                    0x40  /* ENUM# status - extraction */
 #define  PCI_CHSWP_INS                    0x80  /* ENUM# status - insertion */
+
+/* Resizable BARs */
+
+#define PCI_REBAR_CAP                     4           /* Capability register */
+#define  PCI_REBAR_CAP_SIZES              0x00FFFFF0  /* Supported BAR sizes */
+#define PCI_REBAR_CTRL                    8           /* Control register */
+#define  PCI_REBAR_CTRL_BAR_IDX           0x00000007  /* BAR index */
+#define  PCI_REBAR_CTRL_NBAR_MASK         0x000000E0  /* # Of resizable BARs */
+#define  PCI_REBAR_CTRL_NBAR_SHIFT        5           /* Shift for # of BARs */
+#define  PCI_REBAR_CTRL_BAR_SIZE          0x00001F00  /* BAR size */
+#define  PCI_REBAR_CTRL_BAR_SHIFT         8           /* shift for BAR size */
 
 /* PCI Advanced Feature registers */
 
@@ -690,6 +705,16 @@
 #define  PCI_EXP_LNKCAP2_SLS_8_0GB        0x00000008 /* Supported Speed 8.0GT/s */
 #define  PCI_EXP_LNKCAP2_CROSSLINK        0x00000100 /* Crosslink supported */
 #define PCI_EXP_LNKCTL2                   48         /* Link Control 2 */
+#define  PCI_EXP_LNKCTL2_TLS              0x000f
+#define  PCI_EXP_LNKCTL2_TLS_2_5GT        0x0001     /* Supported Speed 2.5GT/s */
+#define  PCI_EXP_LNKCTL2_TLS_5_0GT        0x0002     /* Supported Speed 5GT/s */
+#define  PCI_EXP_LNKCTL2_TLS_8_0GT        0x0003     /* Supported Speed 8GT/s */
+#define  PCI_EXP_LNKCTL2_TLS_16_0GT       0x0004     /* Supported Speed 16GT/s */
+#define  PCI_EXP_LNKCTL2_TLS_32_0GT       0x0005     /* Supported Speed 32GT/s */
+#define  PCI_EXP_LNKCTL2_TLS_64_0GT       0x0006     /* Supported Speed 64GT/s */
+#define  PCI_EXP_LNKCTL2_ENTER_COMP       0x0010     /* Enter Compliance */
+#define  PCI_EXP_LNKCTL2_TX_MARGIN        0x0380     /* Transmit Margin */
+#define  PCI_EXP_LNKCTL2_HASD             0x0020     /* HW Autonomous Speed Disable */
 #define PCI_EXP_LNKSTA2                   50         /* Link Status 2 */
 #define PCI_EXP_SLTCAP2                   52         /* Slot Capabilities 2 */
 #define PCI_EXP_SLTCTL2                   56         /* Slot Control 2 */
@@ -728,7 +753,16 @@
 #define PCI_EXT_CAP_ID_SECPCI             0x19  /* Secondary PCIe Capability */
 #define PCI_EXT_CAP_ID_PMUX               0x1a  /* Protocol Multiplexing */
 #define PCI_EXT_CAP_ID_PASID              0x1b  /* Process Address Space ID */
-#define PCI_EXT_CAP_ID_MAX                PCI_EXT_CAP_ID_PASID
+#define PCI_EXT_CAP_ID_DPC                0x1D  /* Downstream Port Containment */
+#define PCI_EXT_CAP_ID_L1SS               0x1E  /* L1 PM Substates */
+#define PCI_EXT_CAP_ID_PTM                0x1F  /* Precision Time Measurement */
+#define PCI_EXT_CAP_ID_DVSEC              0x23  /* Designated Vendor-Specific */
+#define PCI_EXT_CAP_ID_DLF                0x25  /* Data Link Feature */
+#define PCI_EXT_CAP_ID_PL_16GT            0x26  /* Physical Layer 16.0 GT/s */
+#define PCI_EXT_CAP_ID_NPEM               0x29  /* Native PCIe Enclosure Management */
+#define PCI_EXT_CAP_ID_PL_32GT            0x2A  /* Physical Layer 32.0 GT/s */
+#define PCI_EXT_CAP_ID_DOE                0x2E  /* Data Object Exchange */
+#define PCI_EXT_CAP_ID_MAX                PCI_EXT_CAP_ID_DOE
 
 #define PCI_EXT_CAP_DSN_SIZEOF            12
 #define PCI_EXT_CAP_MCAST_ENDPOINT_SIZEOF 40
@@ -1016,5 +1050,16 @@
 #define  PCI_TPH_CAP_ST_MASK              0x07ff0000 /* St table mask */
 #define  PCI_TPH_CAP_ST_SHIFT             16         /* St table shift */
 #define  PCI_TPH_BASE_SIZEOF              12         /* Size with no st table */
+
+/* Precision Time Measurement */
+
+#define PCI_PTM_CAP                       0x04        /* PTM Capability */
+#define  PCI_PTM_CAP_REQ                  0x00000001  /* Requester capable */
+#define  PCI_PTM_CAP_RES                  0x00000002  /* Responder capable */
+#define  PCI_PTM_CAP_ROOT                 0x00000004  /* Root capable */
+#define  PCI_PTM_GRANULARITY_MASK         0x0000FF00  /* Clock granularity */
+#define PCI_PTM_CTRL                      0x08        /* PTM Control */
+#define  PCI_PTM_CTRL_ENABLE              0x00000001  /* PTM enable */
+#define  PCI_PTM_CTRL_ROOT                0x00000002  /* Root select */
 
 #endif /* __INCLUDE_NUTTX_PCI_PCI_REGS_H */

--- a/include/nuttx/pci/pcie_dw.h
+++ b/include/nuttx/pci/pcie_dw.h
@@ -1,0 +1,235 @@
+/****************************************************************************
+ * include/nuttx/pci/pcie_dw.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _PCIE_DESIGNWARE_H
+#define _PCIE_DESIGNWARE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+
+#include <nuttx/bits.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/pci/pci.h>
+#include <nuttx/pci/pci_epc.h>
+#include <nuttx/pci/pci_epf.h>
+#include <nuttx/spinlock.h>
+#include <nuttx/list.h>
+#include <nuttx/nuttx.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SZ_1K                             0x00000400
+#define SZ_4K                             0x00001000
+#define SZ_1G                             0x40000000
+#define SZ_2G                             0x80000000
+#define SZ_4G                             0x100000000
+
+#define upper_32_bits(n)                  ((uint32_t)(((n) >> 16) >> 16))
+#define lower_32_bits(n)                  ((uint32_t)(n))
+#define readb(a)                          (*(FAR volatile uint8_t *)(a))
+#define writeb(v,a)                       (*(FAR volatile uint8_t *)(a) = (v))
+#define readw(a)                          (*(FAR volatile uint16_t *)(a))
+#define writew(v,a)                       (*(FAR volatile uint16_t *)(a) = (v))
+#define readl(a)                          (*(FAR volatile uint32_t *)(a))
+#define writel(v,a)                       (*(FAR volatile uint32_t *)(a) = (v))
+
+#define MAX_MSI_IRQS                         256
+#define MAX_MSI_IRQS_PER_CTRL                32
+#define MAX_MSI_CTRLS                        (MAX_MSI_IRQS / MAX_MSI_IRQS_PER_CTRL)
+#define MSI_REG_CTRL_BLOCK_SIZE              12
+#define MSI_DEF_NUM_VECTORS                  32
+
+#define to_dw_pcie_from_pp(port)             container_of((port), struct dw_pcie_s, pp)
+#define to_dw_pcie_from_ep(endpoint)   \
+    container_of((endpoint), struct dw_pcie_s, ep)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct dw_pcie_ep_s
+{
+  FAR struct pci_epc_ctrl_s       *epc;
+  struct list_node                func_list;
+  FAR const struct dw_pcie_ep_ops *ops;
+  uint64_t                        phys_base;
+  size_t                          addr_size;
+  FAR void                        *dma_addr;
+  size_t                          dma_len;
+  size_t                          page_size;
+  uint8_t                         bar_to_atu[PCI_STD_NUM_BARS];
+  FAR uintptr_t                   *outbound_addr;
+  FAR unsigned long               *ib_window_map;
+  FAR unsigned long               *ob_window_map;
+  FAR void                        *msi_mem;
+  uint64_t                        msi_mem_phys;
+  FAR struct pci_epf_bar_s        *epf_bar[PCI_STD_NUM_BARS];
+};
+
+struct dw_pcie_rp_s
+{
+  bool                              has_msi_ctrl:1;
+  bool                              cfg0_io_shared:1;
+  uint64_t                          cfg0_base;
+  FAR void                          *va_cfg0_base;
+  uint32_t                          cfg0_size;
+  uintptr_t                         io_base;
+  uint64_t                          io_bus_addr;
+  uint32_t                          io_size;
+  int                               irq;
+  FAR const struct dw_pcie_host_ops *ops;
+  int                               msi_irq[MAX_MSI_CTRLS];
+  uint64_t                          msi_data;
+  uint32_t                          num_vectors;
+  uint32_t                          irq_mask[MAX_MSI_CTRLS];
+  FAR struct pci_host_bridge        *bridge;
+  spinlock_t                        lock;
+  DECLARE_BITMAP(msi_irq_in_use, MAX_MSI_IRQS);
+  bool                              use_atu_msg;
+  int                               msg_atu_index;
+  FAR struct resource               *msg_res;
+};
+
+struct dw_pcie_s
+{
+  FAR void                        *dbi_base;
+  FAR uintptr_t                   dbi_phys_addr;
+  FAR void                        *dbi_base2;
+  FAR void                        *atu_base;
+  uintptr_t                       atu_phys_addr;
+  size_t                          atu_size;
+  uint32_t                        num_ib_windows;
+  uint32_t                        num_ob_windows;
+  uint32_t                        region_align;
+  uint64_t                        region_limit;
+  struct dw_pcie_rp_s             pp;
+  struct dw_pcie_ep_s             ep;
+  FAR const struct dw_pcie_ops_s *ops;
+  uint32_t                       version;
+  uint32_t                       type;
+  unsigned long                  caps;
+  int                            num_lanes;
+  int                            max_link_speed;
+  uint8_t                        n_fts[2];
+  FAR void                       *priv;
+};
+
+enum dw_pcie_ltssm
+{
+  /* Need to align with PCIE_PORT_DEBUG0 bits 0:5 */
+
+  DW_PCIE_LTSSM_DETECT_QUIET = 0x0,
+  DW_PCIE_LTSSM_DETECT_ACT = 0x1,
+  DW_PCIE_LTSSM_L0 = 0x11,
+  DW_PCIE_LTSSM_L2_IDLE = 0x15,
+
+  DW_PCIE_LTSSM_UNKNOWN = 0xffffffff,
+};
+
+struct dw_pcie_ob_atu_cfg_s
+{
+  int      index;
+  int      type;
+  uint8_t  funcno;
+  uint8_t  code;
+  uint8_t  routing;
+  uint64_t cpu_addr;
+  uint64_t pci_addr;
+  uint64_t size;
+};
+
+struct dw_pcie_host_ops
+{
+  CODE int (*init)(FAR struct dw_pcie_rp_s *pp);
+  CODE void (*deinit)(FAR struct dw_pcie_rp_s *pp);
+  CODE void (*post_init)(FAR struct dw_pcie_rp_s *pp);
+  CODE int (*msi_init)(FAR struct dw_pcie_rp_s *pp);
+  CODE void (*pme_turn_off)(FAR struct dw_pcie_rp_s *pp);
+};
+
+struct dw_pcie_ep_ops
+{
+  CODE void (*pre_init)(FAR struct dw_pcie_ep_s *ep);
+  CODE void (*init)(FAR struct dw_pcie_ep_s *ep);
+  CODE int (*raise_irq)(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                        unsigned int type, uint16_t interrupt_num);
+  CODE const FAR struct pci_epc_features_s *(*get_features)
+      (FAR struct dw_pcie_ep_s *ep);
+  CODE uint32_t (*get_dbi_offset)(FAR struct dw_pcie_ep_s *ep,
+                                  uint8_t funcno);
+  CODE uint32_t (*get_dbi2_offset)(FAR struct dw_pcie_ep_s *ep,
+                                   uint8_t funcno);
+};
+
+struct dw_pcie_ep_func_s
+{
+  struct list_node  list;
+  uint8_t           funcno;
+  uint8_t           msi_cap;  /* MSI capability offset */
+  uint8_t           msix_cap; /* MSI-X capability offset */
+};
+
+struct dw_pcie_ops_s
+{
+  CODE uint64_t (*cpu_addr_fixup)(FAR struct dw_pcie_s *pcie,
+                                  uint64_t cpu_addr);
+  CODE uint32_t (*read_dbi)(FAR struct dw_pcie_s *pcie, FAR void *base,
+                            uint32_t reg, size_t size);
+  CODE void (*write_dbi)(FAR struct dw_pcie_s *pcie, FAR void *base,
+                         uint32_t reg, size_t size, uint32_t val);
+  CODE void (*write_dbi2)(FAR struct dw_pcie_s *pcie, FAR void *base,
+                          uint32_t reg, size_t size, uint32_t val);
+  CODE int (*link_up)(FAR struct dw_pcie_s *pcie);
+  CODE enum dw_pcie_ltssm (*get_ltssm)(FAR struct dw_pcie_s *pcie);
+  CODE int (*start_link)(FAR struct dw_pcie_s *pcie);
+  CODE void (*stop_link)(FAR struct dw_pcie_s *pcie);
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int dw_pcie_start_link(FAR struct dw_pcie_s *pci);
+void dw_pcie_stop_link(FAR struct dw_pcie_s *pci);
+enum dw_pcie_ltssm dw_pcie_get_ltssm(FAR struct dw_pcie_s *pci);
+int dw_pcie_ep_init(FAR struct dw_pcie_ep_s *ep, FAR char *epc_name);
+void dw_pcie_ep_deinit(FAR struct dw_pcie_ep_s *ep);
+int dw_pcie_ep_raise_intx_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno);
+int dw_pcie_ep_raise_msi_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                             uint8_t interrupt_num);
+int dw_pcie_ep_raise_msix_irq(FAR struct dw_pcie_ep_s *ep, uint8_t funcno,
+                              uint16_t interrupt_num);
+void dw_pcie_ep_reset_bar(FAR struct dw_pcie_s *pci, int bar);
+void dw_pcie_linkcap_update(FAR struct dw_pcie_s *pci, uint32_t new);
+int dw_pcie_get_link_cap(FAR struct dw_pcie_s *pci);
+void dw_pcie_chang_speed(FAR struct dw_pcie_s *pci);
+int dw_pcie_get_link_state(FAR struct dw_pcie_s *pci);
+int dw_pcie_wait_for_link(FAR struct dw_pcie_s *pci);
+int
+dw_pcie_ep_raise_msix_irq_doorbell(FAR struct dw_pcie_ep_s *ep,
+                                   uint8_t funcno, uint16_t interrupt_num);
+#endif /* _PCIE_DESIGNWARE_H */


### PR DESCRIPTION
Only tested on pcie1

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
1. imx95 pcie1 as ep with linux link
  dw_pcie_iatu_detect: iATU: unroll T, 128 ob, 128 ib, align 4K, limit 1024G
  dw_pcie_wait_for_link: PCIe Gen.1 x1 link up
  dw_pcie_wait_for_link: PCIe Gen.3 x1 link up
  imx95_pcie_start_link: Link up, Gen3
  
  NuttShell (NSH) NuttX-12.9.0
  nsh>
  nsh>
  nsh>
  nsh>
2. linux use pcitest to test 
 sh-5.2# cd /root
sh-5.2# ./pcitest -m 1
MSI1:           OKAY
sh-5.2# ./pcitest -m 2
MSI2:           OKAY
sh-5.2# ./pcitest -m 3
MSI3:           OKAY
sh-5.2# ./pcitest -m 4
MSI4:           OKAY
sh-5.2# ./pcitest -m 8
MSI8:           OKAY
sh-5.2# ./pcitest -m 16
MSI16:          OKAY
sh-5.2# ./pcitest -b 0
BAR0:           OKAY
sh-5.2# ./pcitest -b 1
BAR1:           OKAY
sh-5.2# ./pcitest -b 2
BAR2:           OKAY
sh-5.2# ./pcitest -b 3
BAR3:           OKAY
sh-5.2# ./pcitest -b 4
BAR4:           OKAY
sh-5.2# ./pcitest -b 5
BAR5:           OKAY
sh-5.2# ./pcitest -c
COPY ( 102400 bytes):           OKAY
sh-5.2# ./pcitest -w
WRITE ( 102400 bytes):          OKAY
sh-5.2# ./pcitest -r
READ ( 102400 bytes):           OKAY
sh-5.2#

3. imx95 need scmi to config clk,power,iomuxc, but now imx95 a55 do not support scmi,
    so this patch depend on this patch https://github.com/apache/nuttx/pull/16743#issuecomment-3099540021
  
*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


