### PR TITLE
Revert "libs/libc/stdlib/lib_exit.c: fix multiple definition of __dso…

### DIFF
--- a/libs/libc/stdlib/lib_exit.c
+++ b/libs/libc/stdlib/lib_exit.c
@@ -47,10 +47,7 @@
  ****************************************************************************/
 
 extern FAR void *__dso_handle weak_data;
-
-#ifndef CONFIG_HOST_WINDOWS
 FAR void *__dso_handle = &__dso_handle;
-#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
…_handle in msys2"

This reverts commit 8f96e59aee9cd0c5bbb82e01044d109f8588fec2.

The implementation of __dso_handle is independent of the HOST OS but dependent on the specific compiler. Therefore, this patch will cause compilation failures for other cross-compilers on the Windows platform, such as arm-none-eabi-gcc and aarch64-none-elf-gcc. Constraints should be applied to compiler target rather than compiler host.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The implementation of __dso_handle is independent of the HOST OS but dependent on the specific compiler. Therefore, this patch will cause compilation failures for other cross-compilers on the Windows platform, such as arm-none-eabi-gcc and aarch64-none-elf-gcc. Constraints should be applied to compiler target rather than compiler host.

**This is reproduce steps on Windows MSYS2:**
```
git clone https://github.com/apache/nuttx.git
git clone https://github.com/apache/nuttx-apps.git
git clone -b dev --depth 1 https://github.com/open-vela/prebuilts_gcc_windows-x86_64_aarch64-none-elf.git gcc-aarch64-none-elf
```
```
export PATH=$PWD/gcc-aarch64-none-elf/bin:$PATH
export CROSSDEV=aarch64-none-elf-
```
```
cd nuttx
./tools/configure.sh -g qemu-armv8a:nsh
make menuconfig
```

***select:***
```
CONFIG_LIBC_LOCALE=y
CONFIG_TLS_NELEM=8
CONFIG_TLS_TASK_NELEM=8
CONFIG_LIBCXX=y
CONFIG_LIBCXXABI=y
CONFIG_CXX_STANDARD="gnu++20"
CONFIG_CXX_WCHAR=y
CONFIG_CXX_LOCALIZATION=y
CONFIG_TESTING_CXXTEST=y
```
```
make
```
**The following build errors will occur on Windows, while the build succeeds on Linux with the same configuration.**

```
LD: nuttx
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:/Users/shanmin/github/nuttx/staging\libxx.a(locale.o): in function `std::__1::__time_get_c_storage<char>::__x() const':
C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5126:(.text._ZNKSt3__120__time_get_c_storageIcE3__xEv+0x54): undefined reference to `__dso_handle'
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5126:(.text._ZNKSt3__120__time_get_c_storageIcE3__xEv+0x58): undefined reference to `__dso_handle'
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:/Users/shanmin/github/nuttx/staging\libxx.a(locale.o): in function `std::__1::__time_get_c_storage<char>::__X() const':
C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5144:(.text._ZNKSt3__120__time_get_c_storageIcE3__XEv+0x54): undefined reference to `__dso_handle'
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5144:(.text._ZNKSt3__120__time_get_c_storageIcE3__XEv+0x58): undefined reference to `__dso_handle'
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:/Users/shanmin/github/nuttx/staging\libxx.a(locale.o): in function `std::__1::__time_get_c_storage<char>::__c() const':
C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5162:(.text._ZNKSt3__120__time_get_c_storageIcE3__cEv+0x54): undefined reference to `__dso_handle'
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:/Users/shanmin/github/nuttx/staging\libxx.a(locale.o):C:\Users\shanmin\github\nuttx\libs\libxx/libcxx/libcxx/src/locale.cpp:5162: more undefined references to `__dso_handle' follow
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: C:/Users/shanmin/github/nuttx/nuttx: hidden symbol `__dso_handle' isn't defined
C:\Users\shanmin\vela\vela-opensource\prebuilts\gcc\windows-x86_64\aarch64-none-elf\bin\aarch64-none-elf-ld.exe: final link failed: bad value
make[1]: *** [Makefile:190: nuttx] Error 1
make: *** [tools/Unix.mk:552: nuttx] Error 2
```

Taking ARM as an example, consistent bare metal toolchains are provided for Linux, Windows, and macOS, employing a uniform approach to handling __dso_handle.
> https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

Based on the build log provided in your patch, the linker (ld) selected the path **/usr/lib/gcc/x86_64-pc-msys/13.2.0/../../../../x86_64-pc-msys/bin/ld**, indicating that the toolchain's target is ‌**x86_64-pc-msys‌**. It would therefore be more appropriate to apply restrictions specifically targeting ‌**x86_64-pc-msys‌**.

## Impact

**No impact has been observed on toolchains beyond the target ‌x86_64-pc-msys‌.**

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


