### PR TITLE
arch/x86_64: Allow specifying alternative compilers via CROSSDEV environment variable

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -79,11 +79,11 @@ LLVM_ABITYPE := sysv
 # Cygwin toolchains don't generate ELF binaries.
 
 ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
-CROSSDEV = i486-nuttx-elf-
+CROSSDEV ?= i486-nuttx-elf-
 endif
 
 ifeq ($(CONFIG_HOST_MACOS),y)
-CROSSDEV = x86_64-elf-
+CROSSDEV ?= x86_64-elf-
 endif
 
 ifneq ($(CONFIG_CXX_STANDARD),)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Allow specifying alternative compilers via CROSSDEV for x86_64, rather than restricting to specific compiler.

The -Wa,--divide option should not be restricted to macOS only, as all x86_64-none-elf assemblers universally interpret division operators as comments regardless of the host platform. 

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

git clone -b dev -depth 1 https://github.com/open-vela/prebuilts_gcc_windows-x86_64_x86_64-none-elf.git ${HOME}/x86_64-none-elf
export CROSSDEV=${HOME}/x86_64-none-elf/bin/x86_64-none-elf-
./tools/configure.sh -l qemu-intel64:nsh
make

Output:
Create version.h
LN: platform/board to /home/shanmin/git/nuttx-apps/platform/dummy
Register: hello
Register: dd
Register: nsh
Register: sh
Register: ostest
LD: nuttx


