### PR TITLE
drivers/video: add sched_note_mark at fb_remove_paninfo and fb_notify_vsync

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -45,6 +45,8 @@
 #include <nuttx/clock.h>
 #include <nuttx/wdog.h>
 #include <nuttx/circbuf.h>
+#include <nuttx/sched_note.h>
+
 #ifdef CONFIG_VIDEO_FB_SPLASHSCREEN
 #  include <nuttx/signal.h>
 #endif
@@ -1685,6 +1687,8 @@ void fb_notify_vsync(FAR struct fb_vtable_s *vtable)
   FAR struct fb_priv_s    *priv;
   irqstate_t flags;
 
+  sched_note_mark(NOTE_TAG_GRAPHICS, __func__);
+
   fb = vtable->priv;
   if (fb != NULL)
     {
@@ -1772,6 +1776,8 @@ int fb_remove_paninfo(FAR struct fb_vtable_s *vtable, int overlay)
   irqstate_t               flags;
   ssize_t                  ret;
   bool                     full;
+
+  sched_note_mark(NOTE_TAG_GRAPHICS, __func__);
 
   fb = vtable->priv;
   if (fb == NULL)


### PR DESCRIPTION

## Summary

fb_notify_vsync is called when TE irq comming, and fb_remove_paninfo is called after paninfo comsumed

## Impact

trace

## Testing

enable trace and run fb demo, then grab trace data.


