### PR TITLE
mtd/ftl: Rename ftl_initialize_by_path to ftl_initialize

### DIFF
--- a/Documentation/applications/examples/media/index.rst
+++ b/Documentation/applications/examples/media/index.rst
@@ -22,5 +22,13 @@ to convert the MTD driver to a block device:
 
 .. code-block:: C
 
-  int ret = ftl_initialize(<N>, mtd);
+  int ret = ftl_initialize(/dev/mtdblock<N>, mtd);
   ret = bchdev_register(/dev/mtdblock<N>, <path-to-character-driver>, false);
+
+But since mtd driver could expose to the userspace through register_mtddriver,
+it's better to register mtd driver directly and let fs layer add FTL/BCH wrapper
+automatically:
+
+.. code-block:: C
+
+  int ret = register_mtddriver(/dev/mtdblock<N>, mtd);

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -872,7 +872,7 @@ static int ftl_unlink(FAR struct inode *inode)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ftl_initialize_by_path
+ * Name: ftl_initialize
  *
  * Description:
  *   Initialize to provide a block driver wrapper around an MTD interface
@@ -883,8 +883,8 @@ static int ftl_unlink(FAR struct inode *inode)
  *
  ****************************************************************************/
 
-int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd,
-                           int oflags)
+int ftl_initialize(FAR const char *path, FAR struct mtd_dev_s *mtd,
+                   int oflags)
 {
   struct ftl_struct_s *dev;
   int ret = -ENOMEM;
@@ -979,36 +979,4 @@ out:
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: ftl_initialize
- *
- * Description:
- *   Initialize to provide a block driver wrapper around an MTD interface
- *
- * Input Parameters:
- *   minor - The minor device number.  The MTD block device will be
- *           registered as as /dev/mtdblockN where N is the minor number.
- *   mtd   - The MTD device that supports the FLASH interface.
- *
- ****************************************************************************/
-
-int ftl_initialize(int minor, FAR struct mtd_dev_s *mtd)
-{
-  char path[DEV_NAME_MAX];
-
-#ifdef CONFIG_DEBUG_FEATURES
-  /* Sanity check */
-
-  if (minor < 0 || minor > 255)
-    {
-      return -EINVAL;
-    }
-#endif
-
-  /* Do the real work by ftl_initialize_by_path */
-
-  snprintf(path, DEV_NAME_MAX, "/dev/mtdblock%d", minor);
-  return ftl_initialize_by_path(path, mtd, O_RDWR);
 }

--- a/fs/driver/fs_mtdproxy.c
+++ b/fs/driver/fs_mtdproxy.c
@@ -165,11 +165,11 @@ int mtd_proxy(FAR const char *mtddev, int mountflags,
       goto out_with_blkdev;
     }
 
-  ret = ftl_initialize_by_path(blkdev, mtd->u.i_mtd, mountflags);
+  ret = ftl_initialize(blkdev, mtd->u.i_mtd, mountflags);
   inode_release(mtd);
   if (ret < 0)
     {
-      ferr("ERROR: ftl_initialize_by_path(%s, %s) failed: %d\n",
+      ferr("ERROR: ftl_initialize(%s, %s) failed: %d\n",
            mtddev, blkdev, ret);
       goto out_with_blkdev;
     }

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -290,7 +290,7 @@ FAR struct mtd_dev_s *mtd_rwb_initialize(FAR struct mtd_dev_s *mtd);
 #endif
 
 /****************************************************************************
- * Name: ftl_initialize_by_path
+ * Name: ftl_initialize
  *
  * Description:
  *   Initialize to provide a block driver wrapper around an MTD interface
@@ -315,22 +315,8 @@ FAR struct mtd_dev_s *mtd_rwb_initialize(FAR struct mtd_dev_s *mtd);
  *
  ****************************************************************************/
 
-int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd,
-                           int oflags);
-
-/****************************************************************************
- * Name: ftl_initialize
- *
- * Description:
- *   Initialize to provide a block driver wrapper around an MTD interface
- *
- * Input Parameters:
- *   minor - The minor device number.  The MTD block device will be
- *      registered as as /dev/mtdblockN where N is the minor number.
- *   mtd - The MTD device that supports the FLASH interface.
- ****************************************************************************/
-
-int ftl_initialize(int minor, FAR struct mtd_dev_s *mtd);
+int ftl_initialize(FAR const char *path, FAR struct mtd_dev_s *mtd,
+                   int oflags);
 
 /****************************************************************************
  * Name: smart_initialize


### PR DESCRIPTION
## Summary

* ftl_initialize isn't used anymore after:
  * https://github.com/apache/nuttx/pull/16642
  * https://github.com/apache/nuttx/pull/16738
* required for https://github.com/apache/nuttx-apps/pull/3147.

## Impact

* API break in drivers/mtd/ftl:
  * `int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd, int oflags)` becomes `int ftl_initialize(FAR const char *path, FAR struct mtd_dev_s *mtd, int oflags)`.
  * Old `int ftl_initialize(int minor, FAR struct mtd_dev_s *mtd)` is gone. It wrapped `ftl_initialize_by_path()` before, now it is used directly where path and oflags needs to be passed as described above.

## Testing

* ci
* We need breaking change to be verified on real world hardware.
