### PR TITLE
drivers/misc/optee_smc: Explicitly yield during NW interrupts

### DIFF
--- a/drivers/misc/optee_smc.c
+++ b/drivers/misc/optee_smc.c
@@ -207,6 +207,10 @@ static void optee_smc_handle_rpc(FAR struct optee_priv_data *priv_,
         break;
 
       case OPTEE_SMC_RPC_FUNC_FOREIGN_INTR:
+
+        /* yield to tasks of same priority to avoid starving the NW */
+
+        sched_yield();
         break;
 
       default:


### PR DESCRIPTION

## Summary

Long OP-TEE calls would starve the Normal World tasks. OP-TEE foreign interrupts were delivered to NW but we would resume OP-TEE immediately without giving any potentially unblocked tasks a chance to run. This breaks real-time guarantees.

Fix it by calling `sched_yield()` during OP-TEE return with reason foreign interrupts (`OPTEE_SMC_RETURN_RPC_FOREIGN_INTR`).

## Impact

Users of `CONFIG_DEV_OPTEE_SMC`:
 - Better cooperation with OP-TEE's foreign interrupt delivery mechanism. Fixes scheduling during long OP-TEE calls with the SMC driver.

Other users:
 - No impact.

## Testing

Tested on custom i.MX93 board and i.MX93 EVK with `imx93-evk:koptee` to fix the issue of starving normal world tasks during CPU-heavy OP-TEE calls.


