### PR TITLE
arch/arm/stm32h5: Use double-buffer for ADC DMA in Circular Mode

### DIFF
--- a/arch/arm/src/stm32h5/stm32_dma.c
+++ b/arch/arm/src/stm32h5/stm32_dma.c
@@ -182,10 +182,6 @@ static struct gpdma_ch_s g_chan[] =
 #endif
 };
 
-static uint32_t circ_addr_1;
-
-static uint32_t circ_addr_1;
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -358,18 +354,6 @@ static int gpdma_setup(struct gpdma_ch_s *chan,
   /* Calculate block number of data bytes to transfer, update BR1 */
 
   reg = cfg->ntransfers;
-
-  if (cfg->mode & GPDMACFG_MODE_CIRC)
-    {
-      /* This only targets peripheral to memory, with memory increment */
-
-      circ_addr_1 = cfg->dest_addr;
-      gpdmach_putreg(chan, CH_CXLBAR_OFFSET,
-                    (uint32_t)&circ_addr_1 & (0xffff << 16));
-
-      reg = GPDMA_CXLLR_UDA | ((uint32_t)&circ_addr_1 & GPDMA_CXLLR_LA_MASK);
-      gpdmach_putreg(chan, CH_CXLLR_OFFSET, reg);
-    }
 
   gpdmach_putreg(chan, CH_CXBR1_OFFSET, reg);
 
@@ -595,7 +579,7 @@ void stm32_dmasetup(DMA_HANDLE handle, struct stm32_gpdma_cfg_s *cfg)
 
   /* Clear any unhandled flags from previous transactions */
 
-  /* gpdmach_putreg(chan, CH_CXFCR_OFFSET, 0x7f << 8); */
+  gpdmach_putreg(chan, CH_CXFCR_OFFSET, ~0);
 
   if (cfg->mode & GPDMACFG_MODE_CIRC)
     {

--- a/arch/arm/src/stm32h5/stm32_dma.h
+++ b/arch/arm/src/stm32h5/stm32_dma.h
@@ -60,8 +60,8 @@
 #define DMA_STATUS_SUSPF      (1 << 5) /* Completed suspension flag */
 #define DMA_STATUS_TOF        (1 << 6) /* Trigger overrun flag */
 
-#define DMA_STATUS_ERROR      (DMA_STATUS_DTEF | DMA_STATUS_ULEF | DMA_STATUS_USEF | DMA_STATUS_TOF)
-#define DMA_STATUS_SUCCESS    (DMA_STATUS_TCF | DMA_STATUS_HTEF)
+#define DMA_STATUS_FATAL      (DMA_STATUS_DTEF | DMA_STATUS_ULEF | DMA_STATUS_USEF)
+#define DMA_STATUS_SUCCESS    (DMA_STATUS_TCF | DMA_STATUS_HTF)
 
 /* GPDMA Mode Flags: WARNING!! NOT YET IMPLEMENTED! */
 


### PR DESCRIPTION
## Summary

This patch introduces optional double-buffered DMA support for STM32H5 ADC drivers when operating in circular mode. When `CONFIG_STM32H5_ADCx_DMA_CFG` is enabled, the DMA buffer size is doubled and half-transfer interrupts are enabled to allow the CPU to process one half of the buffer while DMA fills the other.

In one-shot mode (non-circular), DMA and ADC are restarted after each complete transfer using the new helper `adc_restart_dma()`. This avoids code duplication and ensures correctness in single-shot conversions.

The DMA configuration has been improved:
- `ntransfers` now accounts for `circular` mode buffer doubling.
- Interrupt flags are now unconditionally cleared to prevent re-entry or missed interrupts.
- Removed legacy circular DMA logic using `circ_addr_1`, which was unused and not compatible with GPDMA on STM32H5.

This also improves error handling in `adc_dmaconvcallback()`. Fatal DMA error flags are detected (e.g., DTEF, ULEF, USEF), logged, and the DMA is safely stopped. For non-circular mode, DMA is rearmed after such errors to preserve recoverability.

## Impact

- Adds double-buffered DMA functionality for STM32H5 ADC in circular mode.
- One-shot DMA mode now correctly restarts transfers.
- Acknowledge DMA errors in ADC DMA callback routine.
- Removes dead code related to legacy circular address register usage.
- No impact on existing platforms unless `ADCx_DMA_CFG` is enabled.
## Testing

Testing was performed on a Nucleo-H563ZI board using the `nucleo-h563zi:adc` configuration as a base. The following system and build environment were used:

- **Host OS:** Ubuntu 24.04 LTS
- **Compiler:** arm-none-eabi-gcc (gcc-arm-none-eabi-10.3-2021.10)
- **Target:** STM32H563ZI
- **App Used:** `examples/adc`

### Configuration Details:

The following defconfig values were changed to test double-buffered DMA:

```
CONFIG_STM32H5_ADC1_DMA_BATCH=2
CONFIG_STM32H5_ADC1_DMA_CFG=y
CONFIG_STM32H5_ADC1_OVERSAMPLE=256
CONFIG_STM32H5_ADC1_OVSR_SHIFT=4
CONFIG_EXAMPLES_ADC_NSAMPLES=10
CONFIG_EXAMPLES_ADC_GROUPSIZ=4
```

All other settings were left unchanged from the base `nucleo-h563zi:adc` configuration.

### What was tested:

1. Verified successful data acquisition using the `adc` example app.
2. Stepped through `adc_dmaconvcallback()` using GDB to confirm that:
   - HTF and TCF were handled correctly.
   - Correct buffer offsets were used in circular mode.
   - One-shot DMA mode correctly restarted transfers.
3. Tested several `dmabatch` and `CONFIG_ADC_FIFOSIZE` combinations to validate correct FIFO handling and sample delivery.
4. Tested **one-shot mode** using software triggers:
   - Confirmed that `dmabatch = 1` is required in this mode.
   - Verified that DMA and ADC restarted properly using the new `adc_restart_dma()` helper.

### Example Output

Below is a sample run from the `adc` example in circular double-buffered mode (2 channels × 2 batch):

```
NuttShell (NSH) NuttX-12.10.0
nsh> adc
adc_main: g_adcstate.count: 10
adc_main: Hardware initialized. Opening the ADC device: /dev/adc0
Sample:
1: channel: 3 value: 19984
2: channel: 10 value: 65416
3: channel: 3 value: 19980
4: channel: 10 value: 65412
Sample:
1: channel: 3 value: 19999
2: channel: 10 value: 65427
3: channel: 3 value: 20005
4: channel: 10 value: 65418
Sample:
1: channel: 3 value: 20008
2: channel: 10 value: 65419
3: channel: 3 value: 19986
4: channel: 10 value: 65419
...
```

Values were consistent and interleaved as expected. No dropped samples were observed.



