### PR TITLE
arch/xtensa: Fix a race condition in xtensa_sig_deliver for SMP

### DIFF
--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -154,12 +154,11 @@ retry:
    */
 
   board_autoled_off(LED_SIGNAL);
+
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section((regs[REG_PS]));
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;


### PR DESCRIPTION
## Summary

After the signals have been delivered, the local irqs need to be disabled until the context switch. But just calling leave_critical_section(regs[REG_PS]) will enable them if they were enabled in the context.

Any interrupt on this cpu before xtensa_context_restore() would set the rtcb->xcp.regs to NULL, causing a crash in context restore.

Fix this by calling leave_critical_section(up_irq_save()) instead.

## Impact

Fixes a random crash during signal delivery in esp32

## Testing

Tested on esp32 qemu


