### PR TITLE
arch/*/*_sigdeliver.c: Fix a race condition is signal delivery for SMP

### DIFF
--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -160,9 +160,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section((uint16_t)regs[REG_PRIMASK]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   g_running_tasks[this_cpu()] = NULL;

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -158,9 +158,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section(regs[REG_CPSR]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -160,9 +160,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section((uint8_t)regs[REG_BASEPRI]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -155,9 +155,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section(regs[REG_CPSR]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -160,9 +160,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section((uint8_t)regs[REG_BASEPRI]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;

--- a/arch/arm/src/armv8-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-r/arm_sigdeliver.c
@@ -153,9 +153,7 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 #ifdef CONFIG_SMP
-  rtcb->irqcount++;
-  leave_critical_section(regs[REG_CPSR]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;

--- a/arch/arm64/src/common/arm64_sigdeliver.c
+++ b/arch/arm64/src/common/arm64_sigdeliver.c
@@ -158,9 +158,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section(flags);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   arm64_fullcontextrestore();

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -159,9 +159,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section(regs[REG_INT_CTX]);
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
 
   rtcb->xcp.regs = regs;

--- a/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_sigdeliver.c
@@ -209,9 +209,7 @@ retry:
 #ifdef CONFIG_SMP
   /* We need to keep the IRQ lock until task switching */
 
-  rtcb->irqcount++;
-  leave_critical_section((regs[REG_PSR]));
-  rtcb->irqcount--;
+  leave_critical_section(up_irq_save());
 #endif
   sparc_fullcontextrestore(regs);
 }


### PR DESCRIPTION

## Summary

I just realized that the same issue, which just happened to manifest on me on xtensa, is there for other platforms as well.

Even though I haven't experienced crashes on these platforms, I believe that it is just pure luck, and this same race
should be fixed also for these. I boldly made the same correction only based on code inspection/review, I don't have a change to really test it on all of these architectures.

So, this fixes the same issue for other targets, which was already fixed for xtensa in commit 50d94863.

After the signals have been delivered, the local irqs need to be disabled until the context switch. But just calling leave_critical_section(regs[xx]) will enable them if they were enabled in the context.

## Impact

Impacts the signal delivery, fixing a possible full system crash in case the race condition manifests when restoring the context after the signal delivery.

## Testing

Tested on qemu: rv-virt:smp64, real HW: MPFS (4 cores), IMX93 (2 cores) (both are on custom HW & configuration, unfortunately I don't have public EVK boards at hand atm).
