### PR TITLE
arch/arm/stm32f0l0g0/: Fix I2C IRQ numbers

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -534,7 +534,7 @@ static const struct stm32_i2c_config_s stm32_i2c2_config =
   .scl_pin       = GPIO_I2C2_SCL,
   .sda_pin       = GPIO_I2C2_SDA,
 #ifndef CONFIG_I2C_POLLED
-  .irq        = STM32_IRQ_I2C1
+  .irq        = STM32_IRQ_I2C2
 #endif
 };
 
@@ -569,7 +569,7 @@ static const struct stm32_i2c_config_s stm32_i2c3_config =
   .scl_pin       = GPIO_I2C3_SCL,
   .sda_pin       = GPIO_I2C3_SDA,
 #ifndef CONFIG_I2C_POLLED
-  .irq        = STM32_IRQ_I2C1
+  .irq        = STM32_IRQ_I2C3
 #endif
 };
 
@@ -604,7 +604,7 @@ static const struct stm32_i2c_config_s stm32_i2c4_config =
   .scl_pin       = GPIO_I2C4_SCL,
   .sda_pin       = GPIO_I2C4_SDA,
 #ifndef CONFIG_I2C_POLLED
-  .irq        = STM32_IRQ_I2C1
+  .irq        = STM32_IRQ_I2C4
 #endif
 };
 


### PR DESCRIPTION
This patch sets the correct interrupt vector number
for each I2C controller.

## Summary

The patch fixes a trivial copy&paste error. Before, each I2C controller had an interrupt vector number set to the I2C1 vector number, while each of them must have a dedicated one. 

## Impact

STM32 F0/L0/G0/C0 MCU I2C controllers will generate interrupts properly.

## Testing

Verified with the I2C2 controller on a custom board.


