### PR TITLE
Increase buffer sizes for uORB devices

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -1668,6 +1668,13 @@ config SENSORS_LIS2MDL_THREAD_STACKSIZE
 	---help---
 		The stack size for the worker thread that performs measurements
 
+config SENSORS_LIS2MDL_ORB_BUFSIZE
+	int "LIS2MDL uORB buffer size"
+	default 10
+	range 0 100
+	---help---
+		The size of the uORB circular buffer for storing measurements.
+
 config SENSORS_LIS2MDL_FETCH
 	bool "Enable LIS2MDL fetch capability"
 	default n

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -980,8 +980,25 @@ config SENSORS_LSM6DSO32_I2C_FREQUENCY
 config SENSORS_LSM6DSO32_THREAD_STACKSIZE
 	int "LSM6DSO32 worker thread stack size"
 	default 1024
+	depends on SENSORS_LSM6DSO32
 	---help---
 		The stack size for the worker threads that perform measurements.
+
+config SENSORS_LSM6DSO32_ACCEL_ORB_BUFSIZE
+	int "LSM6DSO32 accelerometer uORB buffer size"
+	default 10
+	range 0 500
+	depends on SENSORS_LSM6DSO32
+	---help---
+		The circular buffer size for the accelerometer uORB measurements
+
+config SENSORS_LSM6DSO32_GYRO_ORB_BUFSIZE
+	int "LSM6DSO32 gyro uORB buffer size"
+	default 10
+	range 0 500
+	depends on SENSORS_LSM6DSO32
+	---help---
+		The circular buffer size for the gyroscope uORB measurements
 
 config SENSORS_LSM9DS1
 	bool "STMicro LSM9DS1 support"

--- a/drivers/sensors/lis2mdl_uorb.c
+++ b/drivers/sensors/lis2mdl_uorb.c
@@ -1307,6 +1307,7 @@ int lis2mdl_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr,
 
   priv->lower.ops = &g_sensor_ops;
   priv->lower.type = SENSOR_TYPE_MAGNETIC_FIELD;
+  priv->lower.nbuffer = CONFIG_SENSORS_LIS2MDL_ORB_BUFSIZE;
   priv->enabled = false;
   priv->lowpower = false;
   priv->offsets = false;

--- a/drivers/sensors/lsm6dso32_uorb.c
+++ b/drivers/sensors/lsm6dso32_uorb.c
@@ -1905,6 +1905,7 @@ int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
 
   priv->gyro.lower.type = SENSOR_TYPE_GYROSCOPE;
   priv->gyro.lower.ops = &g_sensor_ops;
+  priv->gyro.lower.nbuffer = CONFIG_SENSORS_LSM6DSO32_GYRO_ORB_BUFSIZE;
   priv->gyro.enabled = false;
   priv->gyro.odr = ODR_OFF;                 /* Default off */
   priv->gyro.fsr = LSM6DSO32_FSR_GY_125DPS; /* Default 125dps */
@@ -1923,6 +1924,7 @@ int lsm6dso32_register(FAR struct i2c_master_s *i2c, uint8_t addr,
 
   priv->accel.lower.type = SENSOR_TYPE_ACCELEROMETER;
   priv->accel.lower.ops = &g_sensor_ops;
+  priv->accel.lower.nbuffer = CONFIG_SENSORS_LSM6DSO32_ACCEL_ORB_BUFSIZE;
   priv->accel.enabled = false;
   priv->accel.odr = ODR_OFF;             /* Default off */
   priv->accel.fsr = LSM6DSO32_FSR_XL_4G; /* Default 4g */


### PR DESCRIPTION
## Summary

Updates internal buffer size for two high-ODR sensors.

## Impact

Makes these drivers usable at a high ODR. Only affects these two drivers by increasing buffer size.

## Testing

Verified compiling with these sensors still works.