### PR TITLE
drivers/syslog/syslog_channel.c: fix incompatible-pointer-types compile errors

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -69,9 +69,9 @@ static ssize_t syslog_default_write(FAR syslog_channel_t *channel,
 #endif
 
 #ifdef CONFIG_SYSLOG_CDCACM
-static int syslog_cdcacm_putc(FAR struct syslog_channel_s *channel,
+static int syslog_cdcacm_putc(FAR syslog_channel_t *channel,
                               int ch);
-static ssize_t syslog_cdcacm_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_cdcacm_write(FAR syslog_channel_t *channel,
                                    FAR const char *buffer, size_t buflen);
 #endif
 
@@ -331,7 +331,7 @@ static ssize_t syslog_default_write(FAR syslog_channel_t *channel,
 #endif
 
 #ifdef CONFIG_SYSLOG_CDCACM
-static int syslog_cdcacm_putc(FAR struct syslog_channel_s *channel, int ch)
+static int syslog_cdcacm_putc(FAR syslog_channel_t *channel, int ch)
 {
   char tmp;
 
@@ -342,7 +342,7 @@ static int syslog_cdcacm_putc(FAR struct syslog_channel_s *channel, int ch)
   return ch;
 }
 
-static ssize_t syslog_cdcacm_write(FAR struct syslog_channel_s *channel,
+static ssize_t syslog_cdcacm_write(FAR syslog_channel_t *channel,
                                    FAR const char *buffer, size_t buflen)
 {
   UNUSED(channel);


### PR DESCRIPTION
## Summary
Use typedef `syslog_channel_t` instead of `struct syslog_channel_s`. The error occurred if `CONFIG_SYSLOG_CDCACM` was set.

```console
CC:  dirent/lib_telldir.c syslog/syslog_channel.c:151:3: error: initialization of ‘int (*)(const syslog_channel_t *, int)’ {aka ‘int (*)(const struct syslog_channel_s *, int)’} from incompatible pointer type ‘int (*)(struct syslog_channel_s *, int)’ [-Wincompatible-pointer-types]
  151 |   syslog_cdcacm_putc,
      |   ^~~~~~~~~~~~~~~~~~
syslog/syslog_channel.c:151:3: note: (near initialization for ‘g_cdcacm_channel_ops.sc_putc’)
syslog/syslog_channel.c:152:3: error: initialization of ‘int (*)(const syslog_channel_t *, int)’ {aka ‘int (*)(const struct syslog_channel_s *, int)’} from incompatible pointer type ‘int (*)(struct syslog_channel_s *, int)’ [-Wincompatible-pointer-types]
  152 |   syslog_cdcacm_putc,
      |   ^~~~~~~~~~~~~~~~~~
syslog/syslog_channel.c:152:3: note: (near initialization for ‘g_cdcacm_channel_ops.sc_force’)
syslog/syslog_channel.c:154:3: error: initialization of ‘ssize_t (*)(const syslog_channel_t *, const char *, size_t)’ {aka ‘int (*)(const struct syslog_channel_s *, const char *, unsigned int)’} from incompatible pointer type ‘ssize_t (*)(struct syslog_channel_s *, const char *, size_t)’ {aka ‘int (*)(struct syslog_channel_s *, const char *, unsigned int)’} [-Wincompatible-pointer-types]
  154 |   syslog_cdcacm_write,
      |   ^~~~~~~~~~~~~~~~~~~
syslog/syslog_channel.c:154:3: note: (near initialization for ‘g_cdcacm_channel_ops.sc_write’)
syslog/syslog_channel.c:155:3: error: initialization of ‘ssize_t (*)(const syslog_channel_t *, const char *, size_t)’ {aka ‘int (*)(const struct syslog_channel_s *, const char *, unsigned int)’} from incompatible pointer type ‘ssize_t (*)(struct syslog_channel_s *, const char *, size_t)’ {aka ‘int (*)(struct syslog_channel_s *, const char *, unsigned int)’} [-Wincompatible-pointer-types]
  155 |   syslog_cdcacm_write
      |   ^~~~~~~~~~~~~~~~~~~
syslog/syslog_channel.c:155:3: note: (near initialization for ‘g_cdcacm_channel_ops.sc_write_force’)
syslog/syslog_channel.c:243:3: warning: excess elements in array initializer
  243 |   &g_cdcacm_channel
      |   ^
syslog/syslog_channel.c:243:3: note: (near initialization for ‘g_syslog_channel’)
```

## Impact
Fixes build.

## Testing
Any build with `CONFIG_SYSLOG_CDCACM` enabled. CDC ACM syslog compiles after the change and works (more or less, but that's a different issue).


