### PR TITLE
drivers/l86xxx: Mutex fixes & performance improvements

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -858,15 +858,6 @@ config L86_XXX_BAUD
 	---help---
 		Supported values are: 4800, 9600, 14400, 19200, 38400, 57600 and 115200
 
-config L86_XXX_FIX_INT
-	int "Quectel L86-XXX fix interval rate"
-	default 1000
-	depends on SENSORS_L86_XXX
-	range 100 10000
-	---help---
-		Rate in ms at which module obtains satellite fix. Supported values
-		are integers between 100 10000
-	
 config SENSORS_LIS2DH
 	bool "STMicro LIS2DH device support"
 	default n


### PR DESCRIPTION
## Summary

Fix mutex locking bugs and improve performance. Fix interval no longer set statically since it is available via `set_interval` uORB function. Activation/deactivation no longer triggers standby/hotstart since this functionality was very unstable.

## Impact

Makes the GPS driver much more reliable, but removes having standby mode when sensor is deactivated. In fairness, this feature didn't work properly and caused failures.

Also removes build system option for fix interval, which is still an available feature, just cannot be configured at compile time. This was removed because waiting for the ACK at driver registration slows down boot time significantly.

## Testing

Tested on STM32H743 based board, verified in console with `uorb_listener` and also via custom telemetry application.