### PR TITLE
arch/stm32h7: Fix timer capture

### DIFF
--- a/arch/arm/src/stm32h7/stm32_capture.h
+++ b/arch/arm/src/stm32h7/stm32_capture.h
@@ -204,11 +204,11 @@ struct stm32_cap_ops_s
 
 /* Power-up timer and get its structure */
 
-struct stm32_cap_dev_s *stm32_cap_init(int timer, uint8_t channel);
+struct stm32_cap_dev_s *stm32_cap_init(int timer);
 
 /* Power-down timer, mark it as unused */
 
-int stm32_cap_deinit(struct stm32_cap_dev_s *dev, uint8_t channel);
+int stm32_cap_deinit(struct stm32_cap_dev_s *dev);
 
 /****************************************************************************
  * Name: stm32_cap_initialize
@@ -228,7 +228,7 @@ int stm32_cap_deinit(struct stm32_cap_dev_s *dev, uint8_t channel);
  ****************************************************************************/
 
 #ifdef CONFIG_CAPTURE
-struct cap_lowerhalf_s *stm32_cap_initialize(int timer, uint8_t channel);
+struct cap_lowerhalf_s *stm32_cap_initialize(int timer);
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/stm32h7/stm32_capture_lowerhalf.c
+++ b/arch/arm/src/stm32h7/stm32_capture_lowerhalf.c
@@ -576,7 +576,7 @@ struct cap_lowerhalf_s *stm32_cap_initialize(int timer)
   /* Initialize the elements of lower half state structure */
 
   lower->started  = false;
-  lower->cap      = stm32_cap_init(timer, lower->channel);
+  lower->cap      = stm32_cap_init(timer);
 
   if (lower->cap == NULL)
     {


### PR DESCRIPTION
## Summary

This patch fixes an incorrect call to stm32_cap_initialize() in stm32_bringup.c: the call was made without the channel parameter. Instead of adding the channel in the call, the channel is selected by stm32_cap_gpio() (first available channel).

This patch also fixes incorrect driver registration in drivers/timers/capture.c: the driver was registered with the wrong name (/dev/cap -> /dev/capture). Also added more error checking in cap_register_multiple().

## Impact

Upper half timer capture driver for stm32h7 is now properly registered.

## Testing

Ran examples/capture on the board, sent PWM signals to the gpio pins and observed proper duty and frequency.