### PR TITLE
doc: Small Raspberry Pi fixes

### DIFF
--- a/Documentation/platforms/arm/rp2040/boards/raspberrypi-pico-w/index.rst
+++ b/Documentation/platforms/arm/rp2040/boards/raspberrypi-pico-w/index.rst
@@ -5,7 +5,7 @@ Raspberry Pi Pico W
 .. tags:: chip:rp2040, wifi
 
 The `Raspberry Pi Pico <https://www.raspberrypi.com/products/raspberry-pi-pico/>`_ is a general purpose board supplied by
-the Raspberry Pi Foundation. The W variant adds built in WiFi communications.
+Raspberry Pi. The W variant adds built in WiFi and Bluetooth communications.
 
 .. figure:: RaspberryPiPicoW.png
    :align: center

--- a/Documentation/platforms/arm/rp2040/boards/raspberrypi-pico/index.rst
+++ b/Documentation/platforms/arm/rp2040/boards/raspberrypi-pico/index.rst
@@ -5,7 +5,7 @@ Raspberry Pi Pico
 .. tags:: chip:rp2040
 
 The `Raspberry Pi Pico <https://www.raspberrypi.com/products/raspberry-pi-pico/>`_ is a general purpose board supplied by
-the Raspberry Pi Foundation.
+Raspberry Pi.
 
 .. figure:: RaspberryPiPico.png
    :align: center

--- a/Documentation/platforms/arm/rp2040/index.rst
+++ b/Documentation/platforms/arm/rp2040/index.rst
@@ -1,6 +1,6 @@
-==================
-RaspberryPi rp2040
-==================
+===================
+Raspberry Pi rp2040
+===================
 
 .. tags:: chip:rp2040
 
@@ -8,7 +8,7 @@ RaspberryPi rp2040
    :align: center
    :scale: 50 %
 
-The RP2040 is a dual core chip produced by the RaspberryPi Foundation that
+The RP2040 is a dual core chip produced by Raspberry Pi that
 is based on ARM Cortex-M0+.
 
 Peripheral Support

--- a/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
+++ b/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
@@ -155,7 +155,6 @@ There is currently no direct user mode access to these RP2350 hardware features:
 
 * SPI Slave Mode
 * SSI
-* RTC
 * Timers
 
 Installation

--- a/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
+++ b/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
@@ -5,7 +5,7 @@ Raspberry Pi Pico 2
 .. tags:: chip:rp2350
 
 The `Raspberry Pi Pico 2 <https://www.raspberrypi.com/products/raspberry-pi-pico-2/>`_ is a general purpose board supplied by
-the Raspberry Pi Foundation.
+Raspberry Pi.
 
 .. figure:: pico-2.png
    :align: center

--- a/Documentation/platforms/arm/rp23xx/boards/xiao-rp2350/index.rst
+++ b/Documentation/platforms/arm/rp23xx/boards/xiao-rp2350/index.rst
@@ -5,7 +5,7 @@ Seeed Studio XIAO RP2350
 .. tags:: chip:rp2350
 
 The `Seeed Studio XIAO RP2350 <https://wiki.seeedstudio.com/getting-started-xiao-rp2350/>`_ is a general purpose board supplied by
-Seeed Studio and it is compatible with the Rapiberry RP2350 ecosystem, sharing the same MCU as Rapiberry Pi Pico 2.
+Seeed Studio and it is compatible with the Raspberry Pi RP2350 ecosystem, sharing the same MCU as Raspberry Pi Pico 2.
 
 .. figure:: xiao-rp2350.jpg
    :align: center

--- a/Documentation/platforms/arm/rp23xx/index.rst
+++ b/Documentation/platforms/arm/rp23xx/index.rst
@@ -1,10 +1,10 @@
-==================
-RaspberryPi rp2350
-==================
+===================
+Raspberry Pi rp2350
+===================
 
 .. tags:: chip:rp2350
 
-The rp2350 is a dual core chip produced by the RaspberryPi Foundation that
+The rp2350 is a dual core chip produced by Raspberry Pi that
 is based on ARM Cortex-M33 or the Hazard3 RISC-V.
 
 ARM Cortex-M33 and Hazard3 RISC-V cores are supported.

--- a/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
+++ b/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
@@ -5,7 +5,7 @@ Raspberry Pi Pico 2 RISC-V
 .. tags:: chip:rp2350
 
 The `Raspberry Pi Pico 2 <https://www.raspberrypi.com/products/raspberry-pi-pico-2/>`_ is a general purpose board supplied by
-the Raspberry Pi Foundation.
+Raspberry Pi.
 
 .. figure:: pico-2.png
    :align: center

--- a/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
+++ b/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
@@ -155,7 +155,6 @@ There is currently no direct user mode access to these RP2350 hardware features:
 
 * SPI Slave Mode
 * SSI
-* RTC
 * Timers
 
 RICS-V toolchain

--- a/Documentation/platforms/risc-v/rp23xx-rv/index.rst
+++ b/Documentation/platforms/risc-v/rp23xx-rv/index.rst
@@ -1,10 +1,10 @@
-=========================
-RaspberryPi rp2350 RISC-V
-=========================
+==========================
+Raspberry Pi rp2350 RISC-V
+==========================
 
 .. tags:: chip:rp2350
 
-The rp2350 is a dual core chip produced by the RaspberryPi Foundation that
+The rp2350 is a dual core chip produced by Raspberry Pi that
 is based on ARM Cortex-M33 or the Hazard3 RISC-V.
 
 ARM Cortex-M33 and Hazard3 RISC-V cores are supported.


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

RP2040, RP2350, Pico, Pico W, Pico 2 and Pico 2 W are all produced by [Raspberry Pi](https://www.raspberrypi.com) which is [a separate organisation](https://www.raspberrypi.com/news/new-raspberry-pi-website/) from the [Raspberry Pi Foundation](https://www.raspberrypi.org).

## Impact

This PR updates the NuttX documentation to change "the Raspberry Pi Foundation" to "Raspberry Pi".

It also removes "RTC" from the list of peripherals not supported by `raspberrypi-pico-2` and `raspberrypi-pico-2-rv`, as the RP2350 doesn't contain an RTC. (This was probably just a copy'n'paste mistake from the RP2040 boards?)

## Testing

No testing was performed, as this only makes small wording tweaks to the documentation.