### PR TITLE
arch/arm/rp2040: Fix typos in ADC and GPIO macro names

### DIFF
--- a/arch/arm/src/rp2040/Kconfig
+++ b/arch/arm/src/rp2040/Kconfig
@@ -619,31 +619,31 @@ if RP2040_ADC
 
 if ADC
 
-config RPC2040_ADC_CHANNEL0
+config RP2040_ADC_CHANNEL0
 	bool "Read ADC channel 0"
 	default n
 	---help---
 		If y, then ADC0 will be read.
 
-config RPC2040_ADC_CHANNEL1
+config RP2040_ADC_CHANNEL1
 	bool "Read ADC channel 1"
 	default n
 	---help---
 		If y, then ADC1 will be read.
 
-config RPC2040_ADC_CHANNEL2
+config RP2040_ADC_CHANNEL2
 	bool "Read ADC channel 2"
 	default n
 	---help---
 		If y, then ADC2 will be read.
 
-config RPC2040_ADC_CHANNEL3
+config RP2040_ADC_CHANNEL3
 	bool "Read ADC channel 3"
 	default n
 	---help---
 		If y, then ADC3 will be read.
 
-config RPC2040_ADC_TEMPERATURE
+config RP2040_ADC_TEMPERATURE
 	bool "Read ADC chip temperature channel"
 	default n
 	---help---

--- a/arch/arm/src/rp2040/hardware/rp2040_adc.h
+++ b/arch/arm/src/rp2040/hardware/rp2040_adc.h
@@ -73,9 +73,9 @@
 /* Register bit definitions *************************************************/
 
 #define RP2040_ADC_CS_RROBIN_SHIFT     (16)
-#define RP2040_ADC_CS_RROBIN_MASK      (0x001fl << RPC2040_ADC_CS_RROBIN_SHIFT)
+#define RP2040_ADC_CS_RROBIN_MASK      (0x001fl << RP2040_ADC_CS_RROBIN_SHIFT)
 #define RP2040_ADC_CS_AINSEL_SHIFT     (12)
-#define RP2040_ADC_CS_AINSEL_MASK      (0x0007l << RPC2040_ADC_CS_AINSEL_SHIFT)
+#define RP2040_ADC_CS_AINSEL_MASK      (0x0007l << RP2040_ADC_CS_AINSEL_SHIFT)
 #define RP2040_ADC_CS_ERR_STICKY       (1 << 10)
 #define RP2040_ADC_CS_ERR              (1 <<  9)
 #define RP2040_ADC_CS_READY            (1 <<  8)

--- a/arch/arm/src/rp2040/hardware/rp2040_io_bank0.h
+++ b/arch/arm/src/rp2040/hardware/rp2040_io_bank0.h
@@ -82,29 +82,29 @@
 #define RP2040_IO_BANK0_GPIO_STATUS_OUTFROMPERI                         (1 << 8)   /* output signal from selected peripheral, before register override is applied */
 
 #define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT                         (28)
-#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_MASK                          (0x03 << RP2040_IO_BANK0_GPIO0_CTRL_IRQOVER_SHIFT)
-#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_NORMAL                        (0x0 << RP2040_IO_BANK0_GPIO0_CTRL_IRQOVER_SHIFT)  /* don't invert the interrupt */
-#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_INVERT                        (0x1 << RP2040_IO_BANK0_GPIO0_CTRL_IRQOVER_SHIFT)  /* invert the interrupt */
-#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_LOW                           (0x2 << RP2040_IO_BANK0_GPIO0_CTRL_IRQOVER_SHIFT)  /* drive interrupt low */
-#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_HIGH                          (0x3 << RP2040_IO_BANK0_GPIO0_CTRL_IRQOVER_SHIFT)  /* drive interrupt high */
+#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_MASK                          (0x03 << RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT)
+#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_NORMAL                        (0x0 << RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT)  /* don't invert the interrupt */
+#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_INVERT                        (0x1 << RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT)  /* invert the interrupt */
+#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_LOW                           (0x2 << RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT)  /* drive interrupt low */
+#define RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_HIGH                          (0x3 << RP2040_IO_BANK0_GPIO_CTRL_IRQOVER_SHIFT)  /* drive interrupt high */
 #define RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT                          (16)
-#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_MASK                           (0x03 << RP2040_IO_BANK0_GPIO0_CTRL_INOVER_SHIFT)
-#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_NORMAL                         (0x0 << RP2040_IO_BANK0_GPIO0_CTRL_INOVER_SHIFT)  /* don't invert the peri input */
-#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_INVERT                         (0x1 << RP2040_IO_BANK0_GPIO0_CTRL_INOVER_SHIFT)  /* invert the peri input */
-#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_LOW                            (0x2 << RP2040_IO_BANK0_GPIO0_CTRL_INOVER_SHIFT)  /* drive peri input low */
-#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_HIGH                           (0x3 << RP2040_IO_BANK0_GPIO0_CTRL_INOVER_SHIFT)  /* drive peri input high */
+#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_MASK                           (0x03 << RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT)
+#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_NORMAL                         (0x0 << RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT)  /* don't invert the peri input */
+#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_INVERT                         (0x1 << RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT)  /* invert the peri input */
+#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_LOW                            (0x2 << RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT)  /* drive peri input low */
+#define RP2040_IO_BANK0_GPIO_CTRL_INOVER_HIGH                           (0x3 << RP2040_IO_BANK0_GPIO_CTRL_INOVER_SHIFT)  /* drive peri input high */
 #define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT                          (12)
-#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_MASK                           (0x03 << RP2040_IO_BANK0_GPIO0_CTRL_OEOVER_SHIFT)
-#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_NORMAL                         (0x0 << RP2040_IO_BANK0_GPIO0_CTRL_OEOVER_SHIFT)  /* drive output enable from peripheral signal selected by funcsel */
-#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_INVERT                         (0x1 << RP2040_IO_BANK0_GPIO0_CTRL_OEOVER_SHIFT)  /* drive output enable from inverse of peripheral signal selected by funcsel */
-#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_DISABLE                        (0x2 << RP2040_IO_BANK0_GPIO0_CTRL_OEOVER_SHIFT)  /* disable output */
-#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_ENABLE                         (0x3 << RP2040_IO_BANK0_GPIO0_CTRL_OEOVER_SHIFT)  /* enable output */
+#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_MASK                           (0x03 << RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT)
+#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_NORMAL                         (0x0 << RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT)  /* drive output enable from peripheral signal selected by funcsel */
+#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_INVERT                         (0x1 << RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT)  /* drive output enable from inverse of peripheral signal selected by funcsel */
+#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_DISABLE                        (0x2 << RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT)  /* disable output */
+#define RP2040_IO_BANK0_GPIO_CTRL_OEOVER_ENABLE                         (0x3 << RP2040_IO_BANK0_GPIO_CTRL_OEOVER_SHIFT)  /* enable output */
 #define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT                         (8)
-#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_MASK                          (0x03 << RP2040_IO_BANK0_GPIO0_CTRL_OUTOVER_SHIFT)
-#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_NORMAL                        (0x0 << RP2040_IO_BANK0_GPIO0_CTRL_OUTOVER_SHIFT)  /* drive output from peripheral signal selected by funcsel */
-#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_INVERT                        (0x1 << RP2040_IO_BANK0_GPIO0_CTRL_OUTOVER_SHIFT)  /* drive output from inverse of peripheral signal selected by funcsel */
-#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_LOW                           (0x2 << RP2040_IO_BANK0_GPIO0_CTRL_OUTOVER_SHIFT)  /* drive output low */
-#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_HIGH                          (0x3 << RP2040_IO_BANK0_GPIO0_CTRL_OUTOVER_SHIFT)  /* drive output high */
+#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_MASK                          (0x03 << RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT)
+#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_NORMAL                        (0x0 << RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT)  /* drive output from peripheral signal selected by funcsel */
+#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_INVERT                        (0x1 << RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT)  /* drive output from inverse of peripheral signal selected by funcsel */
+#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_LOW                           (0x2 << RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT)  /* drive output low */
+#define RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_HIGH                          (0x3 << RP2040_IO_BANK0_GPIO_CTRL_OUTOVER_SHIFT)  /* drive output high */
 #define RP2040_IO_BANK0_GPIO_CTRL_FUNCSEL_MASK                          (0x1f)
 #define RP2040_IO_BANK0_GPIO_CTRL_FUNCSEL_JTAG                          (0x0)
 #define RP2040_IO_BANK0_GPIO_CTRL_FUNCSEL_SPI                           (0x1)

--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -621,31 +621,31 @@ int rp2040_common_bringup(void)
 
 #if defined(CONFIG_ADC) && defined(CONFIG_RP2040_ADC)
 
-#  ifdef CONFIG_RPC2040_ADC_CHANNEL0
+#  ifdef CONFIG_RP2040_ADC_CHANNEL0
 #    define ADC_0 true
 #  else
 #    define ADC_0 false
 #  endif
 
-#  ifdef CONFIG_RPC2040_ADC_CHANNEL1
+#  ifdef CONFIG_RP2040_ADC_CHANNEL1
 #    define ADC_1 true
 #  else
 #    define ADC_1 false
 #  endif
 
-#  ifdef CONFIG_RPC2040_ADC_CHANNEL2
+#  ifdef CONFIG_RP2040_ADC_CHANNEL2
 #    define ADC_2 true
 #  else
 #    define ADC_2 false
 #  endif
 
-#  ifdef CONFIG_RPC2040_ADC_CHANNEL3
+#  ifdef CONFIG_RP2040_ADC_CHANNEL3
 #    define ADC_3 true
 #  else
 #    define ADC_3 false
 #  endif
 
-#  ifdef CONFIG_RPC2040_ADC_TEMPERATURE
+#  ifdef CONFIG_RP2040_ADC_TEMPERATURE
 #    define ADC_TEMP true
 #  else
 #    define ADC_TEMP false


### PR DESCRIPTION
## Summary

The strings "RP**C**2040" and "RP2040_IO_BANK0_GPIO**0**" were being used, probably by mistake, in some macros. In the latter case, the affected macros were not resolving correctly at all.

## Impact

Users that changed `RP2040_ADC_*` options in their configs will face a conflict and, I suppose, will probably need to update their respective entries.

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using NuttX v12.8.0 as the baseline. They were then manually ported to the current master branch.


