### PR TITLE
crypto/hmac: Fix typo in function implementation names

### DIFF
--- a/crypto/hmac.c
+++ b/crypto/hmac.c
@@ -39,7 +39,7 @@
  * Public Functions
  ****************************************************************************/
 
-void hmca_md5_init(FAR HMAC_MD5_CTX *ctx,
+void hmac_md5_init(FAR HMAC_MD5_CTX *ctx,
                    FAR const uint8_t *key,
                    u_int key_len)
 {
@@ -141,7 +141,7 @@ void hmac_sha1_update(FAR HMAC_SHA1_CTX *ctx,
   sha1update(&ctx->ctx, data, len);
 }
 
-void hmca_sha1_final(FAR uint8_t *digest, FAR HMAC_SHA1_CTX *ctx)
+void hmac_sha1_final(FAR uint8_t *digest, FAR HMAC_SHA1_CTX *ctx)
 {
   uint8_t k_opad[SHA1_BLOCK_LENGTH];
   int i;

--- a/include/crypto/hmac.h
+++ b/include/crypto/hmac.h
@@ -26,6 +26,9 @@
  ****************************************************************************/
 
 #include <sys/types.h>
+#include <crypto/md5.h>
+#include <crypto/sha1.h>
+#include <crypto/sha2.h>
 
 typedef struct _HMAC_MD5_CTX
 {


### PR DESCRIPTION
## Summary

In the crypto implementations, "hmac" was mistyped as "hmca". This was breaking the linkage to the respective [prototype functions](https://github.com/apache/nuttx/blob/25fe6b07494a3fc5291c0c170637517aa2996954/include/crypto/hmac.h#L51) in the headers. Also, a couple of necessary includes were missing.

## Impact

Built-in HMAC crypto functions will become usable again.

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using NuttX v12.8.0 as the baseline. They were then manually ported to the current master branch.

