### PR TITLE
arch/arm/rp2040: Implement support for custom SWD DAP instance IDs

### DIFF
--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -35,6 +35,7 @@ CHIP_CSRCS += rp2040_pio.c
 CHIP_CSRCS += rp2040_clock.c
 CHIP_CSRCS += rp2040_xosc.c
 CHIP_CSRCS += rp2040_pll.c
+CHIP_CSRCS += rp2040_syscfg.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += rp2040_cpustart.c

--- a/arch/arm/src/rp2040/hardware/rp2040_syscfg.h
+++ b/arch/arm/src/rp2040/hardware/rp2040_syscfg.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/hardware/rp2040_syscfg.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_SYSCFG_H
+#define __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_SYSCFG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "hardware/rp2040_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register offsets *********************************************************/
+
+#define RP2040_SYSCFG_PROC_CONFIG_OFFSET                  (0x00000008)  /* Configuration for processors. */
+
+/* Register definitions *****************************************************/
+
+#define RP2040_SYSCFG_PROC_CONFIG                         (RP2040_SYSCFG_BASE + RP2040_SYSCFG_PROC_CONFIG_OFFSET)
+
+/* Register bit definitions *************************************************/
+
+#define RP2040_SYSCFG_PROC_CONFIG_MASK                    (0xff000003)
+#define RP2040_SYSCFG_PROC_CONFIG_PROC1_DAP_INSTID_SHIFT  (28)
+#define RP2040_SYSCFG_PROC_CONFIG_PROC1_DAP_INSTID_MASK   (0xf << RP2040_SYSCFG_PROC_CONFIG_PROC1_DAP_INSTID_SHIFT)
+#define RP2040_SYSCFG_PROC_CONFIG_PROC0_DAP_INSTID_SHIFT  (24)
+#define RP2040_SYSCFG_PROC_CONFIG_PROC0_DAP_INSTID_MASK   (0xf << RP2040_SYSCFG_PROC_CONFIG_PROC0_DAP_INSTID_SHIFT)
+
+#endif /* __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_SYSCFG_H */

--- a/arch/arm/src/rp2040/rp2040_syscfg.c
+++ b/arch/arm/src/rp2040/rp2040_syscfg.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/rp2040_syscfg.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+
+#include <arch/board/board.h>
+
+#include "arm_internal.h"
+#include "chip.h"
+
+#include "rp2040_syscfg.h"
+#include "hardware/rp2040_syscfg.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rp2040_set_proc_dap_instid
+ *
+ * Description:
+ *   Configure proc{0,1} DAP instance ID.
+ *   Recommend that this is NOT changed until you require debug access in
+ *   multichip environment. WARNING: do not set to 15 as this is reserved for
+ *   RescueDP.
+ *
+ ****************************************************************************/
+
+void rp2040_set_proc_dap_instid(uint8_t proc, uint8_t dap_instid)
+{
+  /* Proc number must be either 0 or 1 */
+
+  ASSERT(proc <= 1);
+  const uint32_t shift = (proc == 0)
+                        ? RP2040_SYSCFG_PROC_CONFIG_PROC0_DAP_INSTID_SHIFT
+                        : RP2040_SYSCFG_PROC_CONFIG_PROC1_DAP_INSTID_SHIFT;
+  const uint32_t mask = (proc == 0)
+                        ? RP2040_SYSCFG_PROC_CONFIG_PROC0_DAP_INSTID_MASK
+                        : RP2040_SYSCFG_PROC_CONFIG_PROC1_DAP_INSTID_MASK;
+
+  /* ID must be 4 bits and different from 15 (0xf) */
+
+  ASSERT(dap_instid < 0xf);
+
+  /* Set the configurable ID bits */
+
+  clrbits_reg32(mask, RP2040_SYSCFG_PROC_CONFIG);
+  setbits_reg32(dap_instid << shift, RP2040_SYSCFG_PROC_CONFIG);
+}

--- a/arch/arm/src/rp2040/rp2040_syscfg.h
+++ b/arch/arm/src/rp2040/rp2040_syscfg.h
@@ -1,0 +1,78 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/rp2040_syscfg.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_RP2040_RP2040_SYSCFG_H
+#define __ARCH_ARM_SRC_RP2040_RP2040_SYSCFG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rp2040_set_proc0_dap_instid
+  *
+  * Description:
+  *   Configure proc1 DAP instance ID.
+  *   Recommend that this is NOT changed until you require debug access in
+  *   multichip environment. WARNING: do not set to 15 as this is reserved
+  *   for RescueDP.
+ *
+ ****************************************************************************/
+
+void rp2040_set_proc_dap_instid(uint8_t proc, uint8_t dap_instid);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_ARM_SRC_RP2040_RP2040_SYSCFG_H */


### PR DESCRIPTION
## Summary

Both cores of this uC can have a custom SWD DAP instance ID set. Changing these from the default values is uncommon but can help with multi-drop debugging where more than one board is daisy-chained to the same debug probe.

Currently, this can be achieved with a custom OpenOCD config like in the following example, but such a technique needs more testing before it can be considered stable for a broader use.

<details>
  <summary>rp2040-custom_instid.cfg</summary>
  
```plaintext
# SPDX-License-Identifier: GPL-2.0-or-later

# RP2040 is a microcontroller with dual Cortex-M0+ core.
# https://www.raspberrypi.com/documentation/microcontrollers/rp2040.html

# The device requires multidrop SWD for debug.
transport select swd

source [find target/swj-dp.tcl]

if { [info exists CHIPNAME] } {
	set _CHIPNAME $CHIPNAME
} else {
	set _CHIPNAME rp2040
}

if { [info exists WORKAREASIZE] } {
	set _WORKAREASIZE $WORKAREASIZE
} else {
	set _WORKAREASIZE 0x10000
}

if { [info exists CPUTAPID] } {
	set _CPUTAPID $CPUTAPID
} else {
	set _CPUTAPID 0x01002927
}

if { [info exists DAP_INSTID_0] } {
	set _DAP_INSTID_0 $DAP_INSTID_0
} else {
	set _DAP_INSTID_0 0
}

if { [info exists DAP_INSTID_1] } {
	set _DAP_INSTID_1 $DAP_INSTID_1
} else {
	set _DAP_INSTID_1 1
}

# Set to '1' to start rescue mode
if { [info exists RESCUE] } {
	set _RESCUE $RESCUE
} else {
	set _RESCUE 0
}

# Set to '0' or '1' for single core configuration, 'SMP' for -rtos hwthread
# handling of both cores, anything else for isolated debugging of both cores
if { [info exists USE_CORE] } {
	set _USE_CORE $USE_CORE
} else {
	set _USE_CORE SMP
}
set _BOTH_CORES [expr { $_USE_CORE != 0 && $_USE_CORE != 1 }]

swj_newdap $_CHIPNAME cpu -expected-id $_CPUTAPID

# The rescue debug port uses the DP CTRL/STAT bit DBGPWRUPREQ to reset the
# PSM (power on state machine) of the RP2040 with a flag set in the
# VREG_AND_POR_CHIP_RESET register. Once the reset is released
# (by clearing the DBGPWRUPREQ flag), the bootrom will run, see this flag,
# and halt. Allowing the user to load some fresh code, rather than loading
# the potentially broken code stored in flash
if { $_RESCUE } {
	dap create $_CHIPNAME.rescue_dap -chain-position $_CHIPNAME.cpu -dp-id $_CPUTAPID -instance-id 0xf -ignore-syspwrupack
	init

	# Clear DBGPWRUPREQ
	$_CHIPNAME.rescue_dap dpreg 0x4 0x00000000

	# Verifying CTRL/STAT is 0
	set _CTRLSTAT [$_CHIPNAME.rescue_dap dpreg 0x4]
	if {[expr {$_CTRLSTAT & 0xf0000000}]} {
		echo "Rescue failed, DP CTRL/STAT readback $_CTRLSTAT"
	} else {
		echo "Now restart OpenOCD without RESCUE flag and load code to RP2040"
	}
	shutdown
}

# core 0
if { $_USE_CORE != 1 } {
	dap create $_CHIPNAME.dap0 -chain-position $_CHIPNAME.cpu -dp-id $_CPUTAPID -instance-id $_DAP_INSTID_0
	set _TARGETNAME_0 $_CHIPNAME.core0
	target create $_TARGETNAME_0 cortex_m -dap $_CHIPNAME.dap0 -coreid 0
	# srst does not exist; use SYSRESETREQ to perform a soft reset
	$_TARGETNAME_0 cortex_m reset_config sysresetreq
}

# core 1
if { $_USE_CORE != 0 } {
	dap create $_CHIPNAME.dap1 -chain-position $_CHIPNAME.cpu -dp-id $_CPUTAPID -instance-id $_DAP_INSTID_1
	set _TARGETNAME_1 $_CHIPNAME.core1
	target create $_TARGETNAME_1 cortex_m -dap $_CHIPNAME.dap1 -coreid 1
	$_TARGETNAME_1 cortex_m reset_config sysresetreq
}

if {[string compare $_USE_CORE SMP] == 0} {
	$_TARGETNAME_0 configure  -rtos nuttx
	$_TARGETNAME_1 configure  -rtos nuttx
	target smp $_TARGETNAME_0 $_TARGETNAME_1
}

if { $_USE_CORE == 1 } {
	set _FLASH_TARGET $_TARGETNAME_1
} else {
	set _FLASH_TARGET $_TARGETNAME_0
}
# Backup the work area. The flash probe runs an algorithm on the target CPU.
# The flash is probed during gdb connect if gdb_memory_map is enabled (by default).
$_FLASH_TARGET configure -work-area-phys 0x20010000 -work-area-size $_WORKAREASIZE -work-area-backup 1
set _FLASHNAME $_CHIPNAME.flash
flash bank $_FLASHNAME rp2040_flash 0x10000000 0 0 0 $_FLASH_TARGET

if { $_BOTH_CORES } {
	# Alias to ensure gdb connecting to core 1 gets the correct memory map
	flash bank $_CHIPNAME.alias virtual 0x10000000 0 0 0 $_TARGETNAME_1 $_FLASHNAME

	# Select core 0
	targets $_TARGETNAME_0
}
```
</details>

<details>
  <summary>openocd.cfg</summary>
  
```plaintext
source [find interface/cmsis-dap.cfg]
adapter driver picoprobe
transport select swd
adapter speed 5000

set DAP_INSTID_0 4
set DAP_INSTID_1 5
source [find rp2040-custom_instid.cfg]

```
</details>

## Impact

Users will be able to debug boards with non-standard SWD DAP IDs.

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using NuttX v12.8.0 as the baseline. They were then manually ported to the current master branch.

The OpenOCD version used in the tests was 0.12.0+dev-gcf9c0b4.


