### PR TITLE
arch/arm/rp2040: Support non-sequential ADC channels and standardize internal function names

### DIFF
--- a/arch/arm/src/rp2040/rp2040_adc.h
+++ b/arch/arm/src/rp2040/rp2040_adc.h
@@ -68,7 +68,7 @@ extern "C"
 #ifdef CONFIG_ADC
 
 /****************************************************************************
- * Name: rp2040_adc_setup
+ * Name: rp2040_adc_initialize
  *
  * Description:
  *   Initialize and register the ADC driver.
@@ -85,12 +85,12 @@ extern "C"
  *   OK on success or an ERROR on failure
  ****************************************************************************/
 
-int rp2040_adc_setup(const char *path,
-                     bool        read_adc0,
-                     bool        read_adc1,
-                     bool        read_adc2,
-                     bool        read_adc3,
-                     bool        read_temp);
+int rp2040_adc_initialize(const char *path,
+                          bool        read_adc0,
+                          bool        read_adc1,
+                          bool        read_adc2,
+                          bool        read_adc3,
+                          bool        read_temp);
 
 #else /* CONFIG_ADC */
 

--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -651,7 +651,8 @@ int rp2040_common_bringup(void)
 #    define ADC_TEMP false
 #  endif
 
-  ret = rp2040_adc_setup("/dev/adc0", ADC_0, ADC_1, ADC_2, ADC_3, ADC_TEMP);
+  ret = rp2040_adc_initialize("/dev/adc0",
+                              ADC_0, ADC_1, ADC_2, ADC_3, ADC_TEMP);
   if (ret != OK)
     {
       syslog(LOG_ERR, "Failed to initialize ADC Driver: %d\n", ret);


### PR DESCRIPTION
## Summary

Enabling a higher channel of the internal ADC had the effect of initializing the lower ones as well. Now that happens only if actively requested.

Also, the functions for handling the internal ADC did not follow the typical naming used by comparable modules for the same arch and were renamed for coherence. Informational logging calls were also made slightly more useful and discernible in case of having multiple ADCs.

## Impact

Config options seem to already prevent most edge cases. As I see it, this change could only cause troubles in case somebody did not explicitly enable a lower ADC channel yet manually interfaced with it in the board-level code.

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using NuttX v12.8.0 as the baseline. They were then manually ported to the current master branch.