### PR TITLE
arch/arm64/imx9: Fix first trace

### DIFF
--- a/arch/arm64/src/imx9/imx9_boot.c
+++ b/arch/arm64/src/imx9/imx9_boot.c
@@ -216,12 +216,6 @@ void arm64_chip_boot(void)
   imx9_gpioirq_initialize();
 #endif
 
-  /* Perform board-specific device initialization. This would include
-   * configuration of board specific resources such as GPIOs, LEDs, etc.
-   */
-
-  imx9_board_initialize();
-
 #ifdef USE_EARLYSERIALINIT
   /* Perform early serial initialization if we are going to use the serial
    * driver.
@@ -229,4 +223,10 @@ void arm64_chip_boot(void)
 
   arm64_earlyserialinit();
 #endif
+
+  /* Perform board-specific device initialization. This would include
+   * configuration of board specific resources such as GPIOs, LEDs, etc.
+   */
+
+  imx9_board_initialize();
 }


### PR DESCRIPTION
## Summary

Swap board init and uart init.
Reason is that trace might be used on board initialize function.

## Impact

Impacts only imx9 hw
No new feature
No impact on user
No impact on build
No impact on documentation
No impact on security
No impact on compability

## Testing

Tested on custom imx9 hardware

