### PR TITLE
sys/socket.h: wrap the outer layer of struct sockaddr_storage with aligned(SS_ALIGNSIZE)

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -323,7 +323,7 @@
  * the fields of those structures without alignment problems.
  */
 
-struct sockaddr_storage
+struct aligned_data(SS_ALIGNSIZE) sockaddr_storage
 {
   sa_family_t ss_family;       /* Address family */
 


### PR DESCRIPTION
## Summary
Since `ss_family` is of type `uint16_t` (2-byte alignment), packing the internal substructures will reduce the overall alignment of `sockaddr_storage` to 2, which triggers an unaligned access warning in 32-bit systems.  
Add an overall 8-byte alignment to the outermost layer of the structure

Related commit: https://github.com/apache/nuttx/pull/14595#issuecomment-3183104239
Refer to https://datatracker.ietf.org/doc/html/rfc2553#section-3.10

## Impact
New Feature/Change:Bugfix
User Impact: Resolve the risk of misaligned access and performance degradation on 32-bit/64 bit.
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
Run local test program:
- sizeof(sockaddr_storage)=128
- alignof(sockaddr_storage)=8

