### PR TITLE
arch/arm64_schedulesigaction.c: Fix signal delivery in EL1 when MMU is enabled

### DIFF
--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -72,7 +72,8 @@ static void arm64_init_signal_process(struct tcb_s *tcb, uint64_t *regs)
   tcb->xcp.regs[REG_SP_EL0] = regs[REG_SP_ELX] - XCPTCONTEXT_SIZE * 2;
 #endif
   tcb->xcp.regs[REG_SP_ELX] = regs[REG_SP_ELX] - XCPTCONTEXT_SIZE;
-  tcb->xcp.regs[REG_EXE_DEPTH]  = 1;
+  tcb->xcp.regs[REG_EXE_DEPTH] = 1;
+  tcb->xcp.regs[REG_SCTLR_EL1] = regs[REG_SCTLR_EL1];
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

When delivering a signal to a kernel task, or any task in CONFIG_BUILD_FLAT with MMU enabled, the REG_SCTLR_EL1 needs to be stored for exception return.

Otherwise 0 is restored to the register at exception return, MMU is switched off and the  system crashes.

## Impact

Impacts arm64 signal delivery, fixes a system crash when signal is delivered to EL1 with MMU enabled.

## Testing

Tested on imx93 custom HW with 
- CONFIG_BUILD_FLAT: running in EL1, MMU enabled, SMP 2 cores, running "ostest"
- CONFIG_BUILD_KERNEL
