### PR TITLE
arm64/riscv schedulesigaction: Remove redundant zeroing of tcb->sigdeliver

### DIFF
--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -131,7 +131,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        */
 
       (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
     }
   else
     {

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -96,7 +96,6 @@ void up_schedule_sigaction(struct tcb_s *tcb)
        */
 
       (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
     }
   else
     {


### PR DESCRIPTION
## Summary

The tcb->sigdeliver is already set to NULL in the signal delivery, and it must be done only there. Zeroing it again after the signal has been delivered is a potential race condition, the interrupts may be enabled at this point again.

## Impact

All risc-v and arm64 signal delivery, fixes a potential crash on signal delivery.

## Testing

Tested on custom MPFS (risc-v) and IMX93 (arm64) hardware using "ostest". Verified that the signals are delivered correctly still after this fix.
