### PR TITLE
Make/Toolchain.defs: add the AR_EXTRACT command

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -214,6 +214,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
   LD      = ld.lld -m armelf
   STRIP   = llvm-strip --strip-unneeded
   AR      = llvm-ar rcs
+  UNAR    = llvm-ar x
   NM      = llvm-nm
   OBJCOPY = llvm-objcopy
   OBJDUMP = llvm-objdump
@@ -257,6 +258,7 @@ else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   LD      = armlink
   STRIP   = llvm-strip --strip-unneeded
   AR      = armar -rcs
+  UNAR    = armar -x
   NM      = llvm-nm
   OBJCOPY = llvm-objcopy
   OBJDUMP = llvm-objdump
@@ -314,15 +316,17 @@ else
   LD      = $(CROSSDEV)ld
   STRIP   = $(CROSSDEV)strip --strip-unneeded
   AR      = $(CROSSDEV)ar rcs
+  UNAR    = $(CROSSDEV)ar x
   NM      = $(CROSSDEV)nm
   OBJCOPY = $(CROSSDEV)objcopy
   OBJDUMP = $(CROSSDEV)objdump
 
   ifeq ($(CONFIG_LTO_FULL),y)
     ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
-      LD := $(CROSSDEV)gcc
-      AR := $(CROSSDEV)gcc-ar rcs
-      NM := $(CROSSDEV)gcc-nm
+      LD   := $(CROSSDEV)gcc
+      AR   := $(CROSSDEV)gcc-ar rcs
+      UNAR := $(CROSSDEV)gcc-ar x
+      NM   := $(CROSSDEV)gcc-nm
       ARCHOPTIMIZATION += -fno-builtin
     endif
   endif

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -225,6 +225,7 @@ ifeq ($(CONFIG_ARCH_TOOLCHAIN_GCC),y)
   OBJDUMP = $(CROSSDEV)objdump
   LD = $(CROSSDEV)ld
   AR = $(CROSSDEV)ar rcs
+  UNAR = $(CROSSDEV)ar x
   NM = $(CROSSDEV)nm
 else ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
   CC      = clang
@@ -233,6 +234,7 @@ else ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
   LD      = ld.lld -m aarch64elf
   STRIP   = llvm-strip --strip-unneeded
   AR      = llvm-ar rcs
+  UNAR    = llvm-ar x
   NM      = llvm-nm
   OBJCOPY = llvm-objcopy
   OBJDUMP = llvm-objdump

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -188,6 +188,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -84,6 +84,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -299,6 +299,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -115,6 +115,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -59,6 +59,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -101,6 +101,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -353,6 +353,7 @@ ifeq ($(CONFIG_ARCH_TOOLCHAIN_CLANG),y)
   LD      = $(CROSSDEV)clang
   STRIP   = $(CROSSDEV)llvm-strip --strip-unneeded
   AR      = $(CROSSDEV)llvm-ar rcs
+  UNAR    = $(CROSSDEV)llvm-ar x
   NM      = $(CROSSDEV)llvm-nm
   OBJCOPY = $(CROSSDEV)llvm-objcopy
   OBJDUMP = $(CROSSDEV)llvm-objdump
@@ -377,6 +378,7 @@ else
   OBJDUMP = $(CROSSDEV)objdump
   LD      = $(CROSSDEV)ld
   AR      = $(CROSSDEV)ar rcs
+  UNAR    = $(CROSSDEV)ar x
   NM      = $(CROSSDEV)nm
 
 # Link Time Optimization

--- a/arch/sparc/src/sparc_v8/Toolchain.defs
+++ b/arch/sparc/src/sparc_v8/Toolchain.defs
@@ -122,6 +122,7 @@ CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/tricore/src/common/ToolchainGnuc.defs
+++ b/arch/tricore/src/common/ToolchainGnuc.defs
@@ -111,6 +111,7 @@ CPP     = $(CROSSDEV)tricore-elf-gcc -E -P -x c
 LD      = $(CROSSDEV)tricore-elf-gcc
 STRIP   = $(CROSSDEV)tricore-elf-strip --strip-unneeded
 AR      = $(CROSSDEV)tricore-elf-gcc-ar rcs
+UNAR    = $(CROSSDEV)tricore-elf-gcc-ar x
 NM      = $(CROSSDEV)tricore-elf-gcc-nm
 OBJCOPY = $(CROSSDEV)tricore-elf-objcopy
 OBJDUMP = $(CROSSDEV)tricore-elf-objdump

--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -50,6 +50,7 @@ CPP               = cctc $(ARCHOPTIMIZATION)
 LD                = cctc
 STRIP             = strip --strip-unneeded
 AR                = artc -r
+UNAR              = artc -x
 NM                = nm
 OBJCOPY           = echo
 OBJDUMP           = elfdump

--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -56,6 +56,7 @@ CPP = $(CROSSDEV)gcc -E -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -166,6 +166,7 @@ CPP = $(CROSSDEV)gcc -E -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -191,6 +191,7 @@ endif
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -195,6 +195,7 @@ endif
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/arch/z80/src/ez80/Toolchain.defs
+++ b/arch/z80/src/ez80/Toolchain.defs
@@ -102,6 +102,7 @@ STRIP = $(CROSSDEV)strip --strip-unneeded
 LD = $(CROSSDEV)ld
 AS = $(CROSSDEV)as
 AR = $(CROSSDEV)ar -r
+UNAR = $(CROSSDEV)ar -x
 OBJCOPY= $(CROSSDEV)objcopy
 
 # File extensions

--- a/arch/z80/src/z180/Toolchain.defs
+++ b/arch/z80/src/z180/Toolchain.defs
@@ -102,6 +102,7 @@ CPP = sdcpp
 LD = sdldz80
 AS = sdasz80
 AR = sdar -r
+UNAR = sdar -x
 
 # File extensions
 

--- a/arch/z80/src/z80/Toolchain.defs
+++ b/arch/z80/src/z80/Toolchain.defs
@@ -102,6 +102,7 @@ CPP = sdcpp
 LD = sdldz80
 AS = sdasz80
 AR = sdar -r
+UNAR = sdar -x
 
 # File extensions
 

--- a/boards/renesas/rx65n/rx65n-grrose/scripts/Make.defs
+++ b/boards/renesas/rx65n/rx65n-grrose/scripts/Make.defs
@@ -32,6 +32,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 AS = $(CROSSDEV)as
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy

--- a/boards/renesas/rx65n/rx65n-rsk1mb/scripts/Make.defs
+++ b/boards/renesas/rx65n/rx65n-rsk1mb/scripts/Make.defs
@@ -32,6 +32,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 AS = $(CROSSDEV)as
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy

--- a/boards/renesas/rx65n/rx65n-rsk2mb/scripts/Make.defs
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/scripts/Make.defs
@@ -32,6 +32,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 AS = $(CROSSDEV)as
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy

--- a/boards/renesas/rx65n/rx65n/scripts/Make.defs
+++ b/boards/renesas/rx65n/rx65n/scripts/Make.defs
@@ -32,6 +32,7 @@ CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 AS = $(CROSSDEV)as
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy

--- a/boards/renesas/sh1/us7032evb1/scripts/Make.defs
+++ b/boards/renesas/sh1/us7032evb1/scripts/Make.defs
@@ -42,6 +42,7 @@ CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
+UNAR = $(CROSSDEV)ar x
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump


### PR DESCRIPTION
Use this command to extract archives.
Not all architectures are modified, only those commands I know or could be logically deducted from the rest were added.

## Summary
A useful multiplatform variable to extract the archives. I plan to use it in this pull request: https://github.com/apache/nuttx-apps/pull/3154, where I need to unpack all archives to create one big archive, containing all .o files.

I still need to add cmake support, and support for other architectures. The problem is I do not know the syntax of all the used commands, especially those proprietary ones for rare architectures.

Please let me know whether you agree with the name of this variable.



