### PR TITLE
arch/risc-v/src/mpfs: fixes for coremmc and emmcsd

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -397,6 +397,12 @@ config MPFS_COREMMC_WRCOMPLETE_IRQNUM
 		design, select CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE and configure the
 		correct IRQ line here.
 
+config MPFS_FPGA_FIC0_CLK_FREQ
+	int "FIC0 clk freq"
+	default 125000000
+	---help---
+		Frequency of FPGA FIC0 clock.
+
 config MPFS_IHC_CLIENT
 	bool "IHC slave"
 	depends on RPTUN && !MPFS_BOOTLOADER

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -125,7 +125,7 @@
 
 /* Clocks and timing */
 
-#define MPFS_FPGA_FIC0_CLK                 (125000000)
+#define MPFS_FPGA_FIC0_CLK                 (CONFIG_MPFS_FPGA_FIC0_CLK_FREQ)
 
 #define COREMMC_CMDTIMEOUT                 (100000)
 #define COREMMC_LONGTIMEOUT                (100000000)

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -125,7 +125,7 @@
 
 /* Clocks and timing */
 
-#define MPFS_FPGA_FIC0_CLK                 (50000000)
+#define MPFS_FPGA_FIC0_CLK                 (125000000)
 
 #define COREMMC_CMDTIMEOUT                 (100000)
 #define COREMMC_LONGTIMEOUT                (100000000)
@@ -1039,7 +1039,7 @@ static bool mpfs_device_reset(struct sdio_dev_s *dev)
 
   /* Store fifo size for later to check no fifo overruns occur */
 
-  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 2) & 0x3);
+  fifo_size = ((getreg8(MPFS_COREMMC_VR) >> 4) & 0x3);
   if (fifo_size == 0)
     {
       priv->fifo_depth = 512;
@@ -1120,6 +1120,11 @@ static sdio_capset_t mpfs_capabilities(struct sdio_dev_s *dev)
   if (priv->onebit)
     {
       caps |= SDIO_CAPS_1BIT_ONLY;
+    }
+
+  if (((getreg8(MPFS_COREMMC_VR) >> 2) & 3) == 0x01)
+    {
+      caps |= SDIO_CAPS_4BIT;
     }
 
   return caps;

--- a/arch/risc-v/src/mpfs/mpfs_coremmc.c
+++ b/arch/risc-v/src/mpfs/mpfs_coremmc.c
@@ -1399,16 +1399,6 @@ static int mpfs_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t cmdidx;
 
-  mpfs_reset_lines(priv);
-
-  /* Check if command / data lines are busy */
-
-  if (mpfs_check_lines_busy(priv))
-    {
-      mcerr("Busy!\n");
-      return -EBUSY;
-    }
-
   /* Clear all status interrupts */
 
   mpfs_putreg8(priv, COREMMC_ALL_ICR, MPFS_COREMMC_ICR);

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2769,6 +2769,17 @@ static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
   sdio_eventset_t wkupevent = 0;
   int ret;
 
+#if defined(CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE)
+  if ((priv->waitevents & SDIOWAIT_WRCOMPLETE) != 0)
+    {
+      /* Do not wait for SDIOWAIT_WRCOMPLETE as the SDIOWAIT_TRANSFERDONE
+       * event has already taken care of that part also.
+       */
+
+      return SDIOWAIT_WRCOMPLETE;
+    }
+#endif
+
   mcinfo("wait\n");
 
   /* There is a race condition here... the event may have completed before


### PR DESCRIPTION
## Summary

Fix several issues in mpfs_coremmc:
- Driver polls data lines ready in busyloop when command is being send. This prevents upper lever mmcsd driver to poll card busy status prior next activity. This causes high cpu load.
- Fix check of incorrect fifo depth bits of VR register
- Enable 4bit bus width support
- Define CONFIG_MPFS_FPGA_FIC0_CLK_FREQ for FPGA FIC0 clock freq. Default freq to 125MHz.

Fix for mpfs_emmcsd:
- Ignore unsupported WRCOMPLETE event in case CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE is enabled for coremmc.

## Impact

mpfs_coremmc fixes improves data transfer speed and fixes high cpu load issue.
mpfs_emmcsd fix solves data transfer performance issue in case CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE feature flag is enabled for coremmc.

## Testing

Tested with custom MPFS hardware

