### PR TITLE
MPFS SMP interrupt handling fixes

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -986,6 +986,20 @@ static int mpfs_emmcsd_interrupt(int irq, void *context, void *arg)
 
   DEBUGASSERT(priv != NULL);
 
+#ifdef CONFIG_SPINLOCK
+  spin_lock(&priv->lock);
+
+  /* Check if any of the interrupt sources are even enabled */
+
+  if (priv->xfrmask == 0 && priv->waitmask == 0 && priv->xfr_blkmask == 0)
+    {
+      spin_unlock(&priv->lock);
+      return OK;
+    }
+
+  spin_unlock(&priv->lock);
+#endif
+
   status = getreg32(MPFS_EMMCSD_SRS12);
 
   mcinfo("status: %08" PRIx32 "\n", status);

--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -3430,6 +3430,10 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
   uint16_t pending_tx_ep;
   int i;
 
+#ifdef CONFIG_SMP
+  irqstate_t flags = enter_critical_section();
+#endif
+
   /* Get the device interrupts */
 
   isr = getreg8(MPFS_USB_IRQ);
@@ -3455,6 +3459,9 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
       priv->usbdev.dualspeed = 1;
 #endif
 
+#ifdef CONFIG_SMP
+      leave_critical_section(flags);
+#endif
       return OK;
     }
 
@@ -3532,6 +3539,9 @@ static int mpfs_usb_interrupt(int irq, void *context, void *arg)
       mpfs_resume(priv);
     }
 
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
   return OK;
 }
 


### PR DESCRIPTION

## Summary

This PR picks two patches from TII repositories, fixing thread mutual exclusion issues in MPFS USB and MMC drivers.

## Impact

Impacts only MPFS based HW designs with CONFIG_BUILD_SMP=y

## Testing

Tested on several MPFS hardware designs, using both CONFIG_BUILD_FLAT and CONFIG_BUILD_KERNEL.
