### PR TITLE
tools/rp{2040,23xx}: Ensure that picotool is found or built

### DIFF
--- a/tools/rp2040/Config.mk
+++ b/tools/rp2040/Config.mk
@@ -26,7 +26,9 @@
 
 # POSTBUILD -- Perform post build operations
 
-PICOTOOL_BIN_PATH?=$(PICO_SDK_PATH)$(DELIM)_deps$(DELIM)picotool$(DELIM)picotool
+PICOTOOL_FOUND := $(shell command -v picotool 2> /dev/null)
+
+PICOTOOL_BIN_PATH ?= $(PICO_SDK_PATH)$(DELIM)_deps$(DELIM)picotool$(DELIM)picotool
 
 define GEN_PICO_UF2
   $(Q)echo "Generating: nuttx.uf2"; \
@@ -36,23 +38,26 @@ define GEN_PICO_UF2
 endef
 
 ifeq ($(CONFIG_RP2040_UF2_BINARY),y)
-  ifneq ($(shell which picotool),)
+  ifdef PICOTOOL_FOUND
     define POSTBUILD
       $(call GEN_PICO_UF2, picotool)
     endef
-  else ifdef PICO_SDK_PATH
-    define POSTBUILD
-      $(Q)(if ! $(PICOTOOL_BIN_PATH) help >&/dev/null; then \
-              echo "Building: picotool"; \
-              cd $(PICO_SDK_PATH); \
-              cmake . >&/dev/null; \
-              make picotoolBuild >&/dev/null; \
-           fi;)
-      $(call GEN_PICO_UF2, $(PICOTOOL_BIN_PATH))
-    endef
   else
-    define POSTBUILD
-      $(Q) echo "PICO_SDK_PATH/picotool must be specified/installed for flash boot"
-    endef
+    ifdef PICO_SDK_PATH
+      define POSTBUILD
+        $(warning "picotool not found in $$PATH, it will be sourced from pico-sdk")
+        $(Q)if [[ ! -x "$(PICOTOOL_BIN_PATH)" ]]; then \
+          echo "Warning: building picotool from pico-sdk will skip USB support! See https://github.com/raspberrypi/pico-sdk/issues/1827" >&2; \
+          cd $(PICO_SDK_PATH); \
+          cmake . >&/dev/null; \
+          make picotoolBuild >/dev/null; \
+        fi
+        $(call GEN_PICO_UF2, $(PICOTOOL_BIN_PATH))
+      endef
+    else
+      define POSTBUILD
+        $(error "Generating UF2 files requires picotool to be available in $$PATH, or $$PICO_SDK_PATH must be specified")
+      endef
+    endif
   endif
 endif


### PR DESCRIPTION
## Summary

The current Makefile logic failed silently on some systems, maybe because of a different default shell (ZSH, in my case)? This resulted in builds that completed successfully but generated invalid UF2 files, which were then refused by the uC bootloader.

Now the check is properly enforced and picotool is either found in the $PATH or built from the pico-sdk source.

## Impact

No more silently corrupted UF2 files if neither picotool nor pico-sdk are found.

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using today's NuttX master.

I would anyway **encourage other people to test these changes** to ensure that they do not break anyone's workspace.


