### PR TITLE
arch/xtensa/esp32s2: Remove duplicated lines to fix warning

### DIFF
--- a/arch/xtensa/src/esp32s2/hal.mk
+++ b/arch/xtensa/src/esp32s2/hal.mk
@@ -211,12 +211,8 @@ ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_crc.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_cache_esp32s2_esp32s3.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)src$(DELIM)esp_efuse_fields.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)src$(DELIM)esp_efuse_utility.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)src$(DELIM)esp_efuse_api.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)src$(DELIM)efuse_controller$(DELIM)keys$(DELIM)with_key_purposes$(DELIM)esp_efuse_api_key.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)$(CHIP_SERIES)$(DELIM)esp_efuse_fields.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)$(CHIP_SERIES)$(DELIM)esp_efuse_table.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)efuse$(DELIM)$(CHIP_SERIES)$(DELIM)esp_efuse_utility.c
 
   LDFLAGS += --wrap=bootloader_print_banner
 endif


### PR DESCRIPTION
## Summary

* arch/xtensa/esp32s2: Remove duplicated lines to fix warning

Remove duplicated lines to fix build warning for esp32s2


## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, warning during build fixed
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, warning during build fixed
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

`esp32s2-saola-1:nsh` config used to test it. Here is the command:
```
make distclean && ./tools/configure.sh esp32s2-saola-1:nsh && make -j
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

Just build commands applied. This fix related to a build warning.

### Results
<!-- Provide tests' results and runtime logs -->

These warnings should not appear on build logs.

```
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_utility.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_api.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_table.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_utility.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_utility.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_api.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_table.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_utility.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_utility.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/src/esp_efuse_api.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_table.o' given more than once in the same rule
Makefile:145: target 'chip/esp-hal-3rdparty/components/efuse/esp32s2/esp_efuse_utility.o' given more than once in the same rule
```