### PR TITLE
board/esp: Revert mtdblock registeration

### DIFF
--- a/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c3/common/src/esp_board_spiflash.c
@@ -442,10 +442,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 

--- a/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_spiflash.c
@@ -438,10 +438,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 

--- a/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
+++ b/boards/risc-v/esp32h2/common/src/esp_board_spiflash.c
@@ -437,10 +437,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/espflash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD espflash: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -411,10 +411,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/esp32flash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 

--- a/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c
@@ -408,11 +408,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/esp32s2flash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD esp32s2flash: %d\n",
-             ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -407,11 +407,10 @@ static int init_storage_partition(void)
 
 #else
 
-  ret = register_mtddriver("/dev/esp32s3flash", mtd, 0755, NULL);
+  ret = register_mtddriver("/dev/mtdblock0", mtd, 0755, NULL);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD esp32s3flash: %d\n",
-             ret);
+      syslog(LOG_ERR, "ERROR: Failed to register MTD mtdblock0: %d\n", ret);
       return ret;
     }
 


### PR DESCRIPTION
## Summary
Fixing wrong deletion for creating raw mtd partition.

* boards/xtensa: Revert mdtblock initialization for esp32[-|-s2|-s3]

boards/risc-v: Revert mdtblock initialization for Xtensa based Espressif devices

* boards/risc-v: Revert mdtblock initialization for esp32[-c3|-c6|-h2]

boards/risc-v: Revert mdtblock initialization for risc-v based Espressif devices

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, reverting back mtdblock registiration for needed applications.

<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, mtdblock char driver is reverting back
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

### Running
<!-- Provide how to run the test for each SoC being tested -->

### Results
<!-- Provide tests' results and runtime logs -->