### PR TITLE
tools/ci: Include fetching pico-sdk in the CI environment setup

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -294,6 +294,15 @@ RUN mkdir -p wamrc && \
   | tar -C wamrc -xz
 
 ###############################################################################
+# Build image for tool required by Raspberry Pi pico-sdk builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-raspberrypi-pico-sdk
+# Download the latest pico-sdk source archive
+RUN mkdir -p pico-sdk && \
+  curl -s -L "https://github.com/raspberrypi/pico-sdk/releases/download/2.2.0/pico-sdk-2.2.0.tar.gz" \
+  | tar -C pico-sdk --strip-components 1 -xz
+
+###############################################################################
 # Final Docker image used for running CI system.  This includes all toolchains
 # supported by the CI system.
 ###############################################################################
@@ -478,6 +487,11 @@ COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/
 COPY --from=nuttx-toolchain-wasm /tools/wasi-sdk/ wasi-sdk/
 ENV WASI_SDK_PATH="/tools/wasi-sdk"
 ENV PATH="/tools/wamr:$PATH"
+COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/
+
+# Raspberry Pi pico-sdk source
+COPY --from=nuttx-toolchain-raspberrypi-pico-sdk /tools/pico-sdk/ pico-sdk/
+ENV PICO_SDK_PATH="/tools/pico-sdk"
 
 # gn tool
 RUN mkdir -p /tools/gn

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -299,6 +299,27 @@ wasi_sdk() {
   command wamrc --version
 }
 
+raspberrypi_pico_sdk() {
+  if [ ! -f "${NUTTXTOOLS}/pico-sdk" ]; then
+    local release
+    local basefile
+    release="2.2.0"
+    basefile="pico-sdk-${release}"
+    cd "${NUTTXTOOLS}"
+    mkdir -p pico-sdk
+
+    # Download the latest pico-sdk source archive
+    curl -O -L -s https://github.com/raspberrypi/pico-sdk/releases/download/${release}/${basefile}.tar.gz
+    tar xzf "${basefile}.tar.gz"
+    mv "${basefile}" pico-sdk
+    rm "${basefile}.tar.gz"
+
+  fi
+
+  export PICO_SDK_PATH="${NUTTXTOOLS}/pico-sdk"
+  echo "export PICO_SDK_PATH=${NUTTXTOOLS}/pico-sdk" >> "${NUTTXTOOLS}"/env.sh
+}
+
 setup_links() {
   # Configure ccache
   mkdir -p "${NUTTXTOOLS}"/ccache/bin/
@@ -334,7 +355,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain bloaty kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp_gcc_toolchain util_linux wasi_sdk"
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain bloaty kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp_gcc_toolchain util_linux wasi_sdk raspberrypi_pico_sdk"
 
   oldpath=$(cd . && pwd -P)
   for func in ${install}; do

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -379,6 +379,27 @@ wasi_sdk() {
   command wamrc --version
 }
 
+raspberrypi_pico_sdk() {
+  if [ ! -f "${NUTTXTOOLS}/pico-sdk" ]; then
+    local release
+    local basefile
+    release="2.2.0"
+    basefile="pico-sdk-${release}"
+    cd "${NUTTXTOOLS}"
+    mkdir -p pico-sdk
+
+    # Download the latest pico-sdk source archive
+    curl -O -L -s https://github.com/raspberrypi/pico-sdk/releases/download/${release}/${basefile}.tar.gz
+    tar xzf "${basefile}.tar.gz"
+    mv "${basefile}" pico-sdk
+    rm "${basefile}.tar.gz"
+
+  fi
+
+  export PICO_SDK_PATH="${NUTTXTOOLS}/pico-sdk"
+  echo "export PICO_SDK_PATH=${NUTTXTOOLS}/pico-sdk" >> "${NUTTXTOOLS}"/env.sh
+}
+
 setup_links() {
   # Configure ccache
   mkdir -p "${NUTTXTOOLS}"/ccache/bin/
@@ -414,7 +435,7 @@ install_build_tools() {
   mkdir -p "${NUTTXTOOLS}"
   echo "#!/usr/bin/env sh" > "${NUTTXTOOLS}"/env.sh
 
-  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty clang_tidy gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache"
+  install="arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain avr_gcc_toolchain binutils bloaty clang_tidy gen_romfs gperf kconfig_frontends mips_gcc_toolchain python_tools riscv_gcc_toolchain rust dlang rx_gcc_toolchain sparc_gcc_toolchain xtensa_esp_gcc_toolchain u_boot_tools util_linux wasi_sdk c_cache raspberrypi_pico_sdk"
 
   oldpath=$(cd . && pwd -P)
   for func in ${install}; do


### PR DESCRIPTION
## Summary

Part of #16855.

The Raspberry Pi pico-sdk was not available in the CI build process, so the test builds for the rp2040 and rp2350 uCs could not execute the last packaging stage. The SDK is now fetched and included, both at runtime and in the Docker image.

## Impact

The Raspberry Pi pico-sdk will now be available in the CI build process.

## Testing

Limited testing was done locally on a Linux host, but the full CI pipeline can only be tested here.


