### PR TITLE
drivers/analog/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/drivers/analog/CMakeLists.txt
+++ b/drivers/analog/CMakeLists.txt
@@ -105,6 +105,10 @@ if(CONFIG_ADC)
   if(CONFIG_ADC_MCP3008)
     list(APPEND SRCS mcp3008.c)
   endif()
+
+  if(CONFIG_ADC_ADS1115)
+    list(APPEND SRCS ads1115.c)
+  endif()
 endif()
 
 if(CONFIG_LMP92001)


### PR DESCRIPTION
## Summary

Add Texas Instruments ADS1115

https://github.com/apache/nuttx/pull/16011

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally


