### PR TITLE
drivers/leds/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/drivers/leds/CMakeLists.txt
+++ b/drivers/leds/CMakeLists.txt
@@ -34,6 +34,10 @@ if(CONFIG_LEDS_APA102)
   list(APPEND SRCS apa102.c)
 endif()
 
+if(CONFIG_KTD2052)
+  list(APPEND SRCS ktd2052.c)
+endif()
+
 if(CONFIG_LEDS_MAX7219)
   list(APPEND SRCS max7219.c)
 endif()


### PR DESCRIPTION
## Summary

Add KTD2052 led driver

#16217

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally


