### PR TITLE
drivers/ioexpander/CMakeLists.txt: Aligned Cmake with Make

### DIFF
--- a/drivers/ioexpander/CMakeLists.txt
+++ b/drivers/ioexpander/CMakeLists.txt
@@ -35,12 +35,28 @@ if(CONFIG_IOEXPANDER)
     list(APPEND SRCS ioe_dummy.c)
   endif()
 
+  if(CONFIG_IOEXPANDER_ICJX)
+    list(APPEND SRCS icjx.c)
+  endif()
+
+  if(CONFIG_IOEXPANDER_ISO1H812G)
+    list(APPEND SRCS iso1h812g.c)
+  endif()
+
+  if(CONFIG_IOEXPANDER_ISO1I813T)
+    list(APPEND SRCS iso1i813t.c)
+  endif()
+
   if(CONFIG_IOEXPANDER_PCA9555)
     list(APPEND SRCS pca9555.c)
   endif()
 
   if(CONFIG_IOEXPANDER_PCA9538)
     list(APPEND SRCS pca9538.c)
+  endif()
+
+  if(CONFIG_IOEXPANDER_PCA9557)
+    list(APPEND SRCS pca9557.c)
   endif()
 
   if(CONFIG_IOEXPANDER_TCA64XX)
@@ -53,6 +69,10 @@ if(CONFIG_IOEXPANDER)
 
   if(CONFIG_IOEXPANDER_PCF8575)
     list(APPEND SRCS pcf8575.c)
+  endif()
+
+  if(CONFIG_IOEXPANDER_MCP23X08)
+    list(APPEND SRCS mcp23x08.c)
   endif()
 
   if(CONFIG_IOEXPANDER_MCP23X17)


### PR DESCRIPTION
## Summary

Add:

iC-JX driver #11590

ISO1H812G driver #10426

ISO1I813T driver #10435

PCA9557 driver #16042

mcp23008 driver #10532

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO



## Testing

locally


