### PR TITLE
arch/arm/rp2040: Support pico-sdk 2.2.0

### DIFF
--- a/Documentation/platforms/arm/rp2040/index.rst
+++ b/Documentation/platforms/arm/rp2040/index.rst
@@ -21,14 +21,14 @@ Peripheral     Notes
 ============== =====
 GPIO           See Supported Boards documentation for available pins.
 UART           GPIO 0 (UART0 TX) and GPIO 1 (UART0 RX) are often used for the console.
-I2C            
-SPI         
-DMAC        
-PWM         
-USB         
+I2C
+SPI
+DMAC
+PWM
+USB
 PIO            RP2040 Programmable I/O
-IRQs        
-DMA         
+IRQs
+DMA
 Clock Output
 ws2812         Smart pixels (e.g. Neopixel)
 Flash ROM Boot
@@ -37,7 +37,7 @@ BMP180         Requires I2C0
 INA219         Requires I2C0
 ============== =====
 
-The Pico Display Pack (ST7789 LCD) and Pico Audio Pack (PCM5100A I2S DAC) are 
+The Pico Display Pack (ST7789 LCD) and Pico Audio Pack (PCM5100A I2S DAC) are
 also available.
 
 There is currently no direct user mode access to these RP2040 hardware features:
@@ -59,16 +59,20 @@ Installation
 1. Download the Raspberry Pi Pico SDK:
 
    .. code:: console
-   
-      $ git clone -b 2.0.0 https://github.com/raspberrypi/pico-sdk.git
 
-2. Download and install the ``picotool``
+      $ git clone -b 2.2.0 --recurse-submodules https://github.com/raspberrypi/pico-sdk.git
 
-   Instructions for installing/building it can be found here:
-   https://github.com/raspberrypi/picotool
+2. Download and install ``picotool``
 
-   If you are on Arch Linux, you can also install the ``picotool`` through the
-   AUR:
+   .. note::
+
+      If not found at build time, this tool will also be automatically compiled
+      from the SDK sources. Manually downloading or compiling it is
+      `preferred <https://github.com/raspberrypi/pico-sdk/issues/1827>`__, though.
+
+   Instructions can be found here: https://github.com/raspberrypi/picotool
+
+   If you are on Arch Linux, you can also install ``picotool`` through the AUR:
 
    .. code-block:: console
 
@@ -83,12 +87,13 @@ Installation
    You will have to do this every time you restart the terminal where you are
    building NuttX, so it might be best to include this command in your
    ``bashrc`` so NuttX's build system always knows where to find the SDK.
+   You may also want to look into tools like `direnv <https://direnv.net/>`__.
 
 4. Download NuttX and NuttX applications. These must both be contained in the
    same directory:
 
    .. code:: console
-  
+
       $ git clone https://github.com/apache/nuttx.git nuttx
       $ git clone https://github.com/apache/nuttx-apps.git apps
 
@@ -130,7 +135,7 @@ Building NuttX
 5. Build NuttX:
 
    .. code:: console
- 
+
       $ make
 
 The output of the build process will be a file called ``nuttx.uf2``, which you

--- a/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
+++ b/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
@@ -164,17 +164,23 @@ Installation
 
 .. code-block:: console
 
-  $ git clone -b 2.1.1 https://github.com/raspberrypi/pico-sdk.git
+  $ git clone -b 2.2.0 --recurse-submodules https://github.com/raspberrypi/pico-sdk.git
 
-2. Download and install picotool
+2. Download and install ``picotool``
 
-  Instructions can be found here: https://github.com/raspberrypi/picotool
+   .. note::
 
-  If you are on Arch Linux, you can install the picotool through the AUR:
+      If not found at build time, this tool will also be automatically compiled
+      from the SDK sources. Manually downloading or compiling it is
+      `preferred <https://github.com/raspberrypi/pico-sdk/issues/1827>`__, though.
 
-.. code-block:: console
+   Instructions can be found here: https://github.com/raspberrypi/picotool
 
-  $ yay -S picotool
+   If you are on Arch Linux, you can also install ``picotool`` through the AUR:
+
+   .. code-block:: console
+
+      $ yay -S picotool
 
 3. Set PICO_SDK_PATH environment variable
 

--- a/arch/arm/src/rp2040/boot2/Make.defs
+++ b/arch/arm/src/rp2040/boot2/Make.defs
@@ -39,7 +39,8 @@ BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/hardware_regs/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/hardware_base/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/common/pico_base_headers/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/boards/include
-BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/pico_platform/include
+BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/pico_platform/include					# pico-sdk <2.2.0
+BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_common/include		# pico-sdk >=2.2.0
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_compiler/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_sections/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_panic/include


### PR DESCRIPTION
## Summary

Version 2.2.0 of the pico-sdk seems to have unified some RP2040 and RP2350 headers under a new path. Now both the old and the new paths are searched during compilation.

The commands in the documentation have been updated and a tip about not necessarily having to compile picotool manually has been added. The RP2040 has SDK instructions in its main arch page, while the RP2350 has them in a board page; due to the smaller number of RP230 boards currently documented, this may not be an issue (yet).

## Impact

It will now be possible to compile RP2040 binaries with newer pico-sdk versions (namely 2.2.0). Compatibility with version 2.1.1 has been preserved.

## Testing

These changes were tested on a Linux host, targeting a custom RP2040 board using today's NuttX master as the baseline. The pico-sdk versions tested were 2.1.1 (known working) and 2.2.0 (latest release, previously breaking in CI); older versions were not tested since they are not currently targeted by either the docs or the build system.

Compilation of the RP2350 `raspberrypi-pico-2/usbnsh` target has been tested, but I don't have any real hardware to upload the final binary to.


