### PR TITLE
Documentation/xedge_demo: Fix RST formatting issues

### DIFF
--- a/Documentation/applications/examples/xedge_demo/index.rst
+++ b/Documentation/applications/examples/xedge_demo/index.rst
@@ -31,11 +31,6 @@ Writing embedded business logic purely in C often means hundreds of lines of boi
 
 This shift doesn't just make development easier; it makes it faster. What used to take weeks in C can now be done in days. Lua's simplicity encourages rapid prototyping and quick iteration, which is essential in modern IoT and embedded development, where both time-to-market and security are critical. For a conceptual overview of why this hybrid development model is so powerful, check out the tutorial `Why Smart C Coders Love Lua <https://realtimelogic.com/articles/Using-Lua-for-Embedded-Development-vs-Traditional-C-Code>`_.
 
-.. figure:: https://realtimelogic.com/blogmedia/lots-of-embedded-c-code-cartoon-600.jpg
-   :align: center
-   :alt: Too much C code
-
-
 Getting Started
 ---------------
 
@@ -56,7 +51,6 @@ To install and configure **QEMU** and **aarch64-none-elf-gcc**, follow the instr
       $ make
 
    Running with QEMU::
-
       $ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
       -machine virt,virtualization=on,gic-version=3 \
       -chardev stdio,id=con,mux=on -serial chardev:con \

--- a/Documentation/platforms/arm64/qemu/boards/qemu-armv8a/index.rst
+++ b/Documentation/platforms/arm64/qemu/boards/qemu-armv8a/index.rst
@@ -324,13 +324,13 @@ Running with QEMU:
 
 .. note:: Replace **/mnt/xxx** with your actual host directory path. This directory will be shared between your host system and the NuttX environment.
 
-Before running Xedge, you need to create and mount a filesystem that Xedge will use for storing configuration files and web content::
+Before running Xedge, you need to create and mount a filesystem that Xedge will use for storing configuration files and web content:
 
 .. code:: console
 
-      nsh> mkdir mnt
-      nsh> mount -t v9fs -o trans=virtio,tag=host mnt
-      nsh> mkdir /mnt/lfs
+   nsh> mkdir mnt
+   nsh> mount -t v9fs -o trans=virtio,tag=host mnt
+   nsh> mkdir /mnt/lfs
 
 Running Xedge in NuttX terminal
 
@@ -373,7 +373,9 @@ Running Xedge in NuttX terminal
 
 Launch your web browser and access 127.0.0.1:8080
 
-You should see the Xedge IDE, which is enabled in developer mode:
+You should see the Xedge IDE, which is enabled in developer mode.
+
+For more details about the xedge example, please refer to the `xedge_demo documentation <https://nuttx.apache.org/docs/latest/applications/examples/xedge_demo/index.html>`_.
 
 Single Core /w kernel mode (GICv3)
 ----------------------------------


### PR DESCRIPTION
## Summary

Fixed RST (reStructuredText) formatting issues in xedge_demo documentation 

## Impact

Fixes broken formatting that was affecting the visual presentation of the docs

## Testing

Verified if RST syntax is valid and follows formatting rules

```bash
~/nuttxspace/nuttx$ ./tools/checkpatch.sh -g HEAD~...HEAD
```
