### PR TITLE
include/nuttx/compiler.h:

### DIFF
--- a/arch/tricore/include/arch.h
+++ b/arch/tricore/include/arch.h
@@ -42,13 +42,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Address <--> Context Save Areas */
-
-#define tricore_csa2addr(csa) ((uintptr_t *)((((csa) & 0x000F0000) << 12) \
-                                             | (((csa) & 0x0000FFFF) << 6)))
-#define tricore_addr2csa(addr) ((uintptr_t)(((((uintptr_t)(addr)) & 0xF0000000) >> 12) \
-                                            | (((uintptr_t)(addr) & 0x003FFFC0) >> 6)))
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/arch/tricore/include/irq.h
+++ b/arch/tricore/include/irq.h
@@ -48,6 +48,13 @@
  * Pre-processor Prototypes
  ****************************************************************************/
 
+/* Address <--> Context Save Areas */
+
+#define tricore_csa2addr(csa) ((uintptr_t *)((((csa) & 0x000F0000) << 12) \
+                                             | (((csa) & 0x0000FFFF) << 6)))
+#define tricore_addr2csa(addr) ((uintptr_t)(((((uintptr_t)(addr)) & 0xF0000000) >> 12) \
+                                            | (((uintptr_t)(addr) & 0x003FFFC0) >> 6)))
+
 #ifndef __ASSEMBLY__
 
 #ifdef __cplusplus

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -268,7 +268,7 @@
 
 /* The nooptimiziation_function attribute no optimize */
 
-#  if defined(__clang__)
+#  if defined(__clang__) || defined(CONFIG_TRICORE_TOOLCHAIN_GNU)
 #    define nooptimiziation_function __attribute__((optnone))
 #  else
 #    define nooptimiziation_function __attribute__((optimize("O0")))


### PR DESCRIPTION
include/nuttx/compiler.h:
            fix nooptimiziation_function definition problem for tricore gnu compiler
arch/tricore:
            move tricore_csa2addr and tricore_addr2csa definition from include/arch.h to include/irq.h to fix build error

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
change nooptimiziation_function definition in include/nuttx/compiler.h and relocate tricore_csa2addr and tricore_addr2csa definition in tricore/arch to fix tc397 bord build error

## Impact

 fix tc397 bord build error

## Testing

**before updating include/nuttx/compiler.h:**

```
[  5%] Building C object fs/CMakeFiles/fs.dir/procfs/fs_procfstcbinfo.c.obj
cd /home/lixiang/repos/nuttxspace/output/fs && /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/tricore-elf-gcc -D__KERNEL__ -D__NuttX__ -I/home/lixiang/repos/nuttxspace/nuttx/fs -I/home/lixiang/repos/nuttxspace/nuttx/sched -isystem /home/lixiang/repos/nuttxspace/nuttx/include -isystem /home/lixiang/repos/nuttxspace/output/include -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -nostdlib -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -fdiagnostics-color=always -DNDEBUG -fmacro-prefix-map=/home/lixiang/repos/nuttxspace/nuttx= -fmacro-prefix-map=/home/lixiang/repos/nuttxspace/nuttx-apps= -fmacro-prefix-map=/home/lixiang/repos/nuttxspace/nuttx/boards/tricore/tc3xx/tc397= -fmacro-prefix-map=/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx= -MD -MT fs/CMakeFiles/fs.dir/procfs/fs_procfstcbinfo.c.obj -MF CMakeFiles/fs.dir/procfs/fs_procfstcbinfo.c.obj.d -o CMakeFiles/fs.dir/procfs/fs_procfstcbinfo.c.obj -c /home/lixiang/repos/nuttxspace/nuttx/fs/procfs/fs_procfstcbinfo.c
during RTL pass: reload
/home/lixiang/repos/nuttxspace/nuttx/fs/procfs/fs_procfstcbinfo.c: 在函数‘tcbinfo_read’中:
/home/lixiang/repos/nuttxspace/nuttx/fs/procfs/fs_procfstcbinfo.c:239:1: 编译器内部错误： 在 check_bool_attrs 中，于 recog.c:2644
  239 | }
      | ^

```

**before updating arch/tricore/include/arch.h and rch/tricore/include/irq.h:**

```
[ 96%] Linking C executable nuttx
/home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_link_script CMakeFiles/nuttx.dir/link.txt --verbose=1
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/tricore-elf-gcc -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map -Wl,--no-warn-rwx-segments -Xlinker -nostdlib CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Configurations/Ifx_Cfg_Ssw.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Asclin/Std/IfxAsclin.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std/IfxCpu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Trap/IfxCpu_Trap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxAsclin_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCif_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCpu_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxPort_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxStm_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_PinMap/IfxAsclin_PinMap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsEvr.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsPm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Port/Std/IfxPort.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuCcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuEru.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuLbist.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuRcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuWdt.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Src/Std/IfxSrc.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Stm/Std/IfxStm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform/Tricore/Compilers/CompilerTasking.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Infra.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc0.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc1.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc2.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc3.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc4.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc5.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/common/tricore_doirq.c.obj CMakeFiles/nuttx.dir/empty.c.obj -o nuttx  -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -fdiagnostics-color=always -T Lcf_Gnuc_Tricore_Tc.lsl.tmp -Wl,--start-group arch/libarch.a binfmt/libbinfmt.a drivers/libdrivers.a fs/libfs.a libs/libc/libc.a mm/libmm.a sched/libsched.a boards/libboard.a apps/libapps.a apps/builtin/libapps_builtin.a apps/system/dd/libapps_dd.a apps/system/nsh/libapps_nsh.a apps/system/nsh/libapps_sh.a apps/testing/ostest/libapps_ostest.a apps/testing/sched/getprime/libapps_getprime.a apps/examples/hello/libapps_hello.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/tc162/libgcc.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/lib/tc162/libm.a -Wl,--end-group 
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/bin/ld: arch/libarch.a(tricore_schedulesigaction.c.obj): in function `up_schedule_sigaction':
(.text.up_schedule_sigaction+0x38): undefined reference to `tricore_csa2addr'
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/bin/ld: (.text.up_schedule_sigaction+0x5c): undefined reference to `tricore_csa2addr'
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/bin/ld: (.text.up_schedule_sigaction+0x78): undefined reference to `tricore_csa2addr'
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/bin/ld: (.text.up_schedule_sigaction+0x9c): undefined reference to `tricore_csa2addr'
```

**build pass log:**
```
[ 96%] Linking C executable nuttx
/home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_link_script CMakeFiles/nuttx.dir/link.txt --verbose=1
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/tricore-elf-gcc -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map -Wl,--no-warn-rwx-segments -Xlinker -nostdlib CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Configurations/Ifx_Cfg_Ssw.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Asclin/Std/IfxAsclin.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std/IfxCpu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Trap/IfxCpu_Trap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxAsclin_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCif_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCpu_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxPort_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxStm_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_PinMap/IfxAsclin_PinMap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsEvr.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsPm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Port/Std/IfxPort.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuCcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuEru.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuLbist.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuRcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuWdt.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Src/Std/IfxSrc.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Stm/Std/IfxStm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform/Tricore/Compilers/CompilerTasking.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Infra.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc0.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc1.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc2.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc3.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc4.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc5.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/common/tricore_doirq.c.obj CMakeFiles/nuttx.dir/empty.c.obj -o nuttx  -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -fdiagnostics-color=always -T Lcf_Gnuc_Tricore_Tc.lsl.tmp -Wl,--start-group arch/libarch.a binfmt/libbinfmt.a drivers/libdrivers.a fs/libfs.a libs/libc/libc.a mm/libmm.a sched/libsched.a boards/libboard.a apps/libapps.a apps/builtin/libapps_builtin.a apps/system/dd/libapps_dd.a apps/system/nsh/libapps_nsh.a apps/system/nsh/libapps_sh.a apps/testing/ostest/libapps_ostest.a apps/testing/sched/getprime/libapps_getprime.a apps/examples/hello/libapps_hello.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/tc162/libgcc.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/lib/tc162/libm.a -Wl,--end-group 
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
[ 99%] Built target nuttx
/usr/bin/make  -f CMakeFiles/systemmap.dir/build.make CMakeFiles/systemmap.dir/depend
make[2]: 进入目录“/home/lixiang/repos/nuttxspace/output”
cd /home/lixiang/repos/nuttxspace/output && /home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_depends "Unix Makefiles" /home/lixiang/repos/nuttxspace/nuttx /home/lixiang/repos/nuttxspace/nuttx /home/lixiang/repos/nuttxspace/output /home/lixiang/repos/nuttxspace/output /home/lixiang/repos/nuttxspace/output/CMakeFiles/systemmap.dir/DependInfo.cmake "--color="
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
/usr/bin/make  -f CMakeFiles/systemmap.dir/build.make CMakeFiles/systemmap.dir/build
make[2]: 进入目录“/home/lixiang/repos/nuttxspace/output”
[100%] Generating System.map
tricore-elf-gcc-nm nuttx | grep -v '(compiled)|($)|( [aUw] )|(..ng$)|(LASH[RL]DI)' | sort > System.map
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
[100%] Built target systemmap
make[1]: 离开目录“/home/lixiang/repos/nuttxspace/output”
/home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_progress_start /home/lixiang/repos/nuttxspace/output/CMakeFiles 0
```
