### PR TITLE
arch: Add Cmake build support for raspberrypi-4b board & bcm2711 chip

### DIFF
--- a/arch/arm64/src/bcm2711/CMakeLists.txt
+++ b/arch/arm64/src/bcm2711/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# arch/arm64/src/bcm2711/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# BCM2711 specific C source files
+
+set(SRCS bcm2711_boot.c bcm2711_serial.c bcm2711_gpio.c bcm2711_timer.c)
+
+# Early boot logging
+
+if(CONFIG_ARCH_EARLY_PRINT)
+  list(APPEND SRCS bcm2711_lowputc.c)
+endif()
+
+# I2C interfaces
+
+if(CONFIG_BCM2711_I2C)
+  list(APPEND SRCS bcm2711_i2c.c)
+endif()
+
+# SPI interfaces
+#
+if(CONFIG_BCM2711_SPI)
+  list(APPEND SRCS bcm2711_spi.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm64/bcm2711/raspberrypi-4b/CMakeLists.txt
+++ b/boards/arm64/bcm2711/raspberrypi-4b/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm64/bcm2711/raspberrypi-4b/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/dramboot.ld")
+
+add_subdirectory(src)

--- a/boards/arm64/bcm2711/raspberrypi-4b/src/CMakeLists.txt
+++ b/boards/arm64/bcm2711/raspberrypi-4b/src/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# boards/arm64/bcm2711/raspberrypi-4b/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rpi4b_boardinitialize.c rpi4b_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rpi4b_appinit.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rpi4b_gpio.c)
+endif()
+
+if(CONFIG_BCM2711_I2C_DRIVER)
+  list(APPEND SRCS bcm2711_i2cdev.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
closed previous pull request and just reopen this new pull request

Add:
arch/arm64/src/bcm2711/CMakeLists.txt
boards/arm64/bcm2711/raspberrypi-4b/CMakeLists.txt 
boards/arm64/bcm2711/raspberrypi-4b/src/CMakeLists.txt

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

add cmake build support for bcm2711 chip and raspberrypi-4b board

## Impact

people can enjoy cmake build for raspberrypi-4b board

## Testing

**cmake build pass log:**

```
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_mbsrtowcs.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_mbsinit.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsrtombs.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcscpy.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcscat.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcslcat.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncat.c.obj
[ 97%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsrchr.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcschr.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncpy.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncmp.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcscspn.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcspbrk.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsspn.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcsstr.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcswcs.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcstok.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcwidth.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wchar/lib_wcswidth.c.obj
[ 98%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_wctype.c.obj
[ 99%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_iswctype.c.obj
[ 99%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_towlower.c.obj
[ 99%] Building C object libs/libc/CMakeFiles/c.dir/wctype/lib_towupper.c.obj
[ 99%] Linking C static library libc.a
[ 99%] Built target c
[ 99%] Building CXX object CMakeFiles/nuttx.dir/empty.cxx.obj
[ 99%] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
[ 99%] Built target nuttx
[ 99%] Generating nuttx.hex
[ 99%] Generating nuttx.bin
[100%] Generating System.map
[100%] Built target nuttx-bin
[100%] Built target nuttx-hex
[100%] Built target systemmap
```




