### PR TITLE
arch/xtensa/esp32: fix some compilation warnings

### DIFF
--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -256,7 +256,7 @@ static int ota_get_bootseq(struct mtd_dev_priv *dev, uint32_t *seqptr)
         }
     }
 
-  finfo("seq=%u\n", seq);
+  finfo("seq=%" PRIu32 "\n", seq);
 
   if (seq > 0)
     {
@@ -345,7 +345,8 @@ static int ota_set_bootseq(struct mtd_dev_priv *dev, int num)
         ret = MTD_ERASE(dev->mtd_part, sec, 1);
         if (ret != 1)
           {
-            ferr("ERROR: Failed to erase OTA%d data error=%d\n", sec, ret);
+            ferr("ERROR: Failed to erase OTA%" PRId32 "data error=%d\n",
+                  sec, ret);
             return -EIO;
           }
 
@@ -377,7 +378,7 @@ static int ota_set_bootseq(struct mtd_dev_priv *dev, int num)
             kmm_free(buffer);
             if (ret != blkcnt)
               {
-                ferr("ERROR: Failed to write OTA%d data error=%d\n",
+                ferr("ERROR: Failed to write OTA%" PRId32 "data error=%d\n",
                       sec, ret);
                 return -EIO;
               }
@@ -389,7 +390,7 @@ static int ota_set_bootseq(struct mtd_dev_priv *dev, int num)
                             (uint8_t *)&ota_data);
             if (ret != sizeof(struct ota_data_entry))
               {
-                ferr("ERROR: Failed to write OTA%d data error=%d\n",
+                ferr("ERROR: Failed to write OTA%" PRId32 "data error=%d\n",
                       sec, ret);
                 return -1;
               }
@@ -432,7 +433,8 @@ static int ota_invalidate_bootseq(struct mtd_dev_priv *dev, int num)
         ret = MTD_ERASE(dev->mtd_part, sec, 1);
         if (ret != 1)
           {
-            ferr("ERROR: Failed to erase OTA%d data error=%d\n", sec, ret);
+            ferr("ERROR: Failed to erase OTA%" PRId32 "data error=%d\n",
+                  sec, ret);
             return -EIO;
           }
 


### PR DESCRIPTION
## Summary
esp32/esp32_partition.c: based on the latest revision, in the ESP32 compilation environment, uint32_t is defined as long unsigned int (i.e., unsigned long)

## Impact

New Feature/Change: No
User Impact: No
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
```
chip/esp32_partition.c:348:18: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  348 |             ferr("ERROR: Failed to erase OTA%d data error=%d\n", sec, ret);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~
      |                                                                  |
      |                                                                  uint32_t {aka long unsigned int
......
```
After the fix, check that there are no compilation warnings. 


