### PR TITLE
arch/arm64/gicv3: Improve initialization in warm reboot case

### DIFF
--- a/arch/arm64/src/common/arm64_arch.h
+++ b/arch/arm64/src/common/arm64_arch.h
@@ -207,12 +207,14 @@
 #define ICC_EOIR0_EL1               S3_0_C12_C8_1
 #define ICC_EOIR1_EL1               S3_0_C12_C12_1
 #define ICC_SGI0R_EL1               S3_0_C12_C11_7
+#define ICC_DIR_EL1                 S3_0_C12_C11_1
 
 /* register constants */
 #define ICC_SRE_ELX_SRE_BIT         BIT(0)
 #define ICC_SRE_ELX_DFB_BIT         BIT(1)
 #define ICC_SRE_ELX_DIB_BIT         BIT(2)
 #define ICC_SRE_EL3_EN_BIT          BIT(3)
+#define ICC_CTLR_EOIMODE_BIT        BIT(1)
 
 /* ICC SGI macros */
 #define SGIR_TGT_MASK               (0xffff)

--- a/arch/arm64/src/common/arm64_gic.h
+++ b/arch/arm64/src/common/arm64_gic.h
@@ -86,6 +86,8 @@
 #define ICENABLER(base, n)      (base + GIC_DIST_ICENABLER + (n) * 4)
 #define ISPENDR(base, n)        (base + GIC_DIST_ISPENDR + (n) * 4)
 #define ICPENDR(base, n)        (base + GIC_DIST_ICPENDR + (n) * 4)
+#define ISACTIVER(base, n)      (base + GIC_DIST_ISACTIVER + (n) * 4)
+#define ICACTIVER(base, n)      (base + GIC_DIST_ICACTIVER + (n) * 4)
 #define IPRIORITYR(base, n)     (base + GIC_DIST_IPRIORITYR + n)
 #define ITARGETSR(base, n)      (base + GIC_DIST_ITARGETSR + (n) * 4)
 #define ICFGR(base, n)          (base + GIC_DIST_ICFGR + (n) * 4)


### PR DESCRIPTION

## Summary

I have a case where I want to do a very quick warm reboot without going through a bootloader, by just entering nuttx
__start again. This works fine, except that GICv3 initialization may leave interrupts active.

The warm reboot case can be fixed by simply disabling all interrupts at GICv3 initialization, which is implemented in this PR:

- In case of warm reboot, clear active and pending interrupts from GICv3 and also from the CPU interface.
- Fix default IGROUPMODR to the reset value (0)
- Move gic_wait_rwp calls to after modifying ICENABLER
- Improve some comments

## Impact

Impacts arm64 boot, GICv3 initialization. Ensures that there are not active or pending interrupts left after GIC init.

## Testing

Tested on IMX93 platform in SMP and in single core cases.
