### PR TITLE
arch/tricore: add up_trigger_irq

### DIFF
--- a/arch/tricore/Kconfig
+++ b/arch/tricore/Kconfig
@@ -25,6 +25,7 @@ endchoice # Tricore Toolchain Selection
 config ARCH_TC3XX
 	bool
 	select ARCH_HAVE_TESTSET
+	select ARCH_HAVE_IRQTRIGGER
 	default n
 
 config ARCH_FAMILY

--- a/arch/tricore/src/common/tricore_irq.c
+++ b/arch/tricore/src/common/tricore_irq.c
@@ -95,6 +95,26 @@ void up_enable_irq(int irq)
   IfxSrc_enable(src);
 }
 
+#ifdef CONFIG_ARCH_HAVE_IRQTRIGGER
+
+/****************************************************************************
+ * Name: up_trigger_irq
+ *
+ * Description:
+ *   Trigger an IRQ by software.
+ *
+ ****************************************************************************/
+
+void up_trigger_irq(int irq, cpu_set_t cpuset)
+{
+  (void) cpuset;
+  volatile Ifx_SRC_SRCR *src = &SRC_CPU_CPU0_SB + irq;
+
+  IfxSrc_setRequest(src);
+}
+
+#endif
+
 /****************************************************************************
  * Name: tricore_ack_irq
  *


### PR DESCRIPTION
  Add up_trigger_irq in arch/tricore/src/common/tricore_irq.c
  Select ARCH_HAVE_IRQTRIGGER in config ARCH_TC3XX

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

add up_trigger_irq for tricore arch

## Impact

tricore arch will have up_trigger_irq 

## Testing

**build pass:**

[ 99%] Linking C executable nuttx
/home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_link_script CMakeFiles/nuttx.dir/link.txt --verbose=1
/home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/tricore-elf-gcc -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map -Wl,--no-warn-rwx-segments -Xlinker -nostdlib CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Configurations/Ifx_Cfg_Ssw.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Asclin/Std/IfxAsclin.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std/IfxCpu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Trap/IfxCpu_Trap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxAsclin_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCif_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxCpu_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxPort_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_Impl/IfxStm_cfg.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/_PinMap/IfxAsclin_PinMap.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsEvr.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Pms/Std/IfxPmsPm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Port/Std/IfxPort.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuCcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuEru.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuLbist.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuRcu.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Scu/Std/IfxScuWdt.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Src/Std/IfxSrc.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Stm/Std/IfxStm.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform/Tricore/Compilers/CompilerTasking.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Infra.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc0.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc1.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc2.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc3.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc4.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Ssw/TC39B/Tricore/Ifx_Ssw_Tc5.c.obj CMakeFiles/nuttx.dir/arch/tricore/src/common/tricore_doirq.c.obj CMakeFiles/nuttx.dir/empty.c.obj -o nuttx  -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -mcpu=tc39xx -mtc162 -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/iLLD/TC39B/Tricore/Cpu/Std -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Libraries/Infra/Platform -I/home/lixiang/repos/nuttxspace/nuttx/arch/tricore/src/tc3xx/tc397/Configurations -fno-common -Wall -Wshadow -Wundef -Os -fno-strict-aliasing -fomit-frame-pointer -ffunction-sections -fdata-sections -g -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -g -fdiagnostics-color=always -T Lcf_Gnuc_Tricore_Tc.lsl.tmp -Wl,--start-group arch/libarch.a binfmt/libbinfmt.a drivers/libdrivers.a fs/libfs.a libs/libc/libc.a mm/libmm.a sched/libsched.a boards/libboard.a apps/libapps.a apps/builtin/libapps_builtin.a apps/system/dd/libapps_dd.a apps/system/nsh/libapps_nsh.a apps/system/nsh/libapps_sh.a apps/testing/ostest/libapps_ostest.a apps/testing/sched/getprime/libapps_getprime.a apps/examples/hello/libapps_hello.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/tc162/libgcc.a /home/lixiang/repos/avatar_master_linux/prebuilts/linux/gcc/tricore/bin/../lib/gcc/tricore-elf/11.3.1/../../../../tricore-elf/lib/tc162/libm.a -Wl,--end-group 
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
[ 99%] Built target nuttx
/usr/bin/make  -f CMakeFiles/systemmap.dir/build.make CMakeFiles/systemmap.dir/depend
make[2]: 进入目录“/home/lixiang/repos/nuttxspace/output”
cd /home/lixiang/repos/nuttxspace/output && /home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_depends "Unix Makefiles" /home/lixiang/repos/nuttxspace/nuttx /home/lixiang/repos/nuttxspace/nuttx /home/lixiang/repos/nuttxspace/output /home/lixiang/repos/nuttxspace/output /home/lixiang/repos/nuttxspace/output/CMakeFiles/systemmap.dir/DependInfo.cmake "--color="
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
/usr/bin/make  -f CMakeFiles/systemmap.dir/build.make CMakeFiles/systemmap.dir/build
make[2]: 进入目录“/home/lixiang/repos/nuttxspace/output”
[100%] Generating System.map
tricore-elf-gcc-nm nuttx | grep -v '(compiled)|($)|( [aUw] )|(..ng$)|(LASH[RL]DI)' | sort > System.map
make[2]: 离开目录“/home/lixiang/repos/nuttxspace/output”
[100%] Built target systemmap
make[1]: 离开目录“/home/lixiang/repos/nuttxspace/output”
/home/lixiang/downloads/cmake-3.27.1-linux-x86_64/bin/cmake -E cmake_progress_start /home/lixiang/repos/nuttxspace/output/CMakeFiles 0


**run ok**
<img width="737" height="362" alt="image" src="https://github.com/user-attachments/assets/4454d1c1-1983-4a86-85fd-ca1279a9864b" />

<img width="702" height="540" alt="image" src="https://github.com/user-attachments/assets/12c7f7c9-1772-4c2d-9bc5-18ec6a9af1a8" />


