### PR TITLE
arch/arm/rp2040: Silence "LOAD segment with RWX permissions" linker warnings

### DIFF
--- a/arch/arm/src/rp2040/boot2/Make.defs
+++ b/arch/arm/src/rp2040/boot2/Make.defs
@@ -44,6 +44,7 @@ BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_common/include		#
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_compiler/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_sections/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_panic/include
+BOOT2CFLAGS += -Wl,--no-warn-rwx-segments
 
 $(BOOT_STAGE2).S: %.S: %.bin
 	python3 $(BOOT2DIR)/pad_checksum -s 0xffffffff $< $@


### PR DESCRIPTION
## Summary

This arch uses code relocation to SRAM through a XIP unit, so forcing segment permissions manually in the linker script could create unforeseen issues. A quick fix is setting the `--no-warn-rwx-segments` linker option just for the incriminated _stage2_ bootloader binary.

This PR goes back to #11462 and adopts the approach seen in #14724.

## Impact

```diff
[...]
CC:  src/rp2040_common_bringup.c
CC:  src/rp2040_common_initialize.c
CC:  src/rp2040_reset.c
IN: arch/arm/src/board/libboard.a -> staging/libboard.a
-/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: warning: rp2040_boot_stage2.elf has a LOAD segment with RWX permissions
AS:  rp2040_boot_stage2.S
CPP:  <path_to_repo>/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld-> <path_to_repo>/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld.tmp
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        152 KB         2 MB      7.42%
            sram:        8768 B       264 KB      3.24%
Generating: nuttx.uf2
Done.
```

## Testing

These changes were tested on a Linux host, targeting a custom RP2040 board using today's NuttX master as the baseline.


