### PR TITLE
Cmake: add defconfig preprocess capability in Cmake build environment (recursively expand #include)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,27 @@ if(NOT EXISTS "${NUTTX_DEFCONFIG}")
   message(FATAL_ERROR "No config file found at ${NUTTX_DEFCONFIG}")
 endif()
 
+# Custom board ###################################################
+
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/boards/dummy)
+if(CONFIG_ARCH_BOARD_CUSTOM)
+  get_filename_component(NUTTX_BOARD_ABS_DIR ${CONFIG_ARCH_BOARD_CUSTOM_DIR}
+                         ABSOLUTE BASE_DIR ${NUTTX_DIR})
+else()
+  set(NUTTX_BOARD_ABS_DIR ${NUTTX_BOARD_DIR})
+  file(TOUCH ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
+endif()
+
+# Process initial defconfig ###################################################
+# Process initial defoconfig to recursively expaned #include in it
+
+include(nuttx_process_config)
+process_config(
+  ${CMAKE_BINARY_DIR}/.defconfig.processed ${NUTTX_DEFCONFIG} INCLUDE_PATHS
+  ${NUTTX_BOARD_ABS_DIR}/../../common/configs ${NUTTX_BOARD_ABS_DIR}/../common
+  ${NUTTX_BOARD_ABS_DIR})
+set(NUTTX_DEFCONFIG ${CMAKE_BINARY_DIR}/.defconfig.processed)
+
 # Generate initial .config ###################################################
 # This is needed right before any other configure step so that we can source
 # Kconfig variables into CMake variables
@@ -237,17 +258,6 @@ endif()
 if(NOT EXISTS "${NUTTX_BOARD_DIR}/CMakeLists.txt"
    AND NOT EXISTS "${NUTTX_BOARD_DIR}/../common/CMakeLists.txt")
   message(FATAL_ERROR "No CMakeLists.txt found at ${NUTTX_BOARD_DIR}")
-endif()
-
-# Custom board ###################################################
-
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/boards/dummy)
-if(CONFIG_ARCH_BOARD_CUSTOM)
-  get_filename_component(NUTTX_BOARD_ABS_DIR ${CONFIG_ARCH_BOARD_CUSTOM_DIR}
-                         ABSOLUTE BASE_DIR ${NUTTX_DIR})
-else()
-  set(NUTTX_BOARD_ABS_DIR ${NUTTX_BOARD_DIR})
-  file(TOUCH ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
 endif()
 
 # check if board custom dir points to NuttX upstream board. This is useful when

--- a/cmake/nuttx_process_config.cmake
+++ b/cmake/nuttx_process_config.cmake
@@ -1,0 +1,48 @@
+# ##############################################################################
+# cmake/nuttx_process_config.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+function(process_config OUTPUT INPUT)
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs INCLUDE_PATHS)
+  cmake_parse_arguments(PARSE_ARGV 2 PROCESS_INCLUDES "${options}"
+                        "${oneValueArgs}" "${multiValueArgs}")
+
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+  set(include_args "")
+  foreach(path IN LISTS PROCESS_INCLUDES_INCLUDE_PATHS)
+    list(APPEND include_args "${path}")
+  endforeach()
+
+  message(STATUS "Processing includes: ${INPUT} → ${OUTPUT}")
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/process_config.py
+            ${OUTPUT} ${INPUT} ${include_args} COMMAND_ECHO STDOUT
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE out
+    ERROR_VARIABLE err)
+
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Failed to process includes:\n${err}")
+  endif()
+endfunction()

--- a/tools/process_config.py
+++ b/tools/process_config.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# tools/parsecallstack.py
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+import re
+import sys
+from pathlib import Path
+
+
+def expand_file(input_path, include_paths, processed=None):
+    """
+    Recursively expand the file, returning its contents in order as a list of lines.
+    """
+    if processed is None:
+        processed = set()
+
+    input_path = Path(input_path).resolve()
+    if input_path in processed:
+        return []  # Already processed, avoid duplicate includes
+    processed.add(input_path)
+
+    expanded_lines = []
+
+    with input_path.open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for line in lines:
+        line_strip = line.strip()
+        match = re.match(r'#include\s*[<"]([^">]+)[">]', line_strip)
+        if match:
+            include_file = match.group(1)
+            found = False
+
+            # Check the current directory first
+
+            direct_path = input_path.parent / include_file
+            if direct_path.exists():
+                expanded_lines.extend(
+                    expand_file(direct_path, include_paths, processed)
+                )
+                found = True
+            else:
+                # Then check in the include paths
+
+                for path in include_paths:
+                    candidate = Path(path) / include_file
+                    if candidate.exists():
+                        expanded_lines.extend(
+                            expand_file(candidate, include_paths, processed)
+                        )
+                        found = True
+                        break
+
+            if not found:
+                print(
+                    f'ERROR: Cannot find "{include_file}" from {input_path}',
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        else:
+            expanded_lines.append(line)
+
+    expanded_lines.append("\n")  # Keep separation between files
+    return expanded_lines
+
+
+def process_file(output_path, input_path, include_paths):
+    lines = expand_file(input_path, include_paths)
+    with open(output_path, "w", encoding="utf-8") as out:
+        out.writelines(lines)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(
+            "Usage: process_includes.py <output_file> <input_file> [include_paths...]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output_file = Path(sys.argv[1])
+    input_file = sys.argv[2]
+    include_dirs = sys.argv[3:]
+
+    if output_file.exists():
+        output_file.unlink()
+
+    process_file(output_file, input_file, include_dirs)


### PR DESCRIPTION
Add:
     cmake/nuttx_process_config.cmake
     tools/process_config.py

Update nuttx/CMakeLists.txt to call process_config defined in nuttx_process_config.cmake to process defconfig before actually using it

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

add defconfig preprocess capabilty to cmake build system

## Impact

Cmake build system will enjoy the same defconfig preprocess capability as the make builld system.
The preprocess script is implemented in python, so it is OK in both Windows and Linux

## Testing

**Split defconfig into two files as below:**
<img width="1449" height="563" alt="image" src="https://github.com/user-attachments/assets/87e7c172-cf77-4c27-ab7f-91c35454e407" />

**After doing Cmake config generating:**
<img width="1252" height="783" alt="image" src="https://github.com/user-attachments/assets/f5ce7cd7-ec81-41e9-a7f4-7e2504c5cf18" />

**Cmake config gen log:**
-- Processing includes: /home/lixiang/repos/nuttxspace/nuttx/boards/arm64/bcm2711/raspberrypi-4b/configs/nsh/defconfig → /home/lixiang/repos/nuttxspace/output/.config.processed
'/usr/bin/python3.9' '/home/lixiang/repos/nuttxspace/nuttx/tools/process_config.py' '/home/lixiang/repos/nuttxspace/output/.config.processed' '/home/lixiang/repos/nuttxspace/nuttx/boards/arm64/bcm2711/raspberrypi-4b/configs/nsh/defconfig' '/../../common/configs' '/../common'
-- Initializing NuttX
Select HOST_LINUX=y
-- CMake: 3.27.1
-- Board: raspberrypi-4b
-- Config: nsh
-- Appdir: /home/lixiang/repos/nuttxspace/nuttx-apps
-- The C compiler identification is GNU 14.2.1
-- The CXX compiler identification is GNU 14.2.1
-- The ASM compiler identification is GNU