### PR TITLE
arch/arm/armv8-r: fix multicore gicv3 init issue

### DIFF
--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -113,14 +113,25 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
 void up_irqinitialize(void)
 {
-  /* The following operations need to be atomic, but since this function is
-   * called early in the initialization sequence, we expect to have exclusive
-   * access to the GIC.
-   */
+#ifdef CONFIG_SMP
+  if (up_cpu_index() == 0)
+    {
+#endif
+      /* Initialize GICD、GICRD and GIC cpu interface for cpu0  */
 
-  /* Initialize the Generic Interrupt Controller (GIC) for CPU0 */
+      arm_gic_initialize();
+#ifdef CONFIG_SMP
+      gicd_ready = 1;
+    }
+  else
+    {
+      /* For other CPUs, we will only initialize GICRD and
+       * GIC cpu interface.
+       */
 
-  arm_gic_initialize();   /* Initialization common to all CPUs */
+      arm_gic_secondary_init();
+    }
+#endif
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 


### PR DESCRIPTION
In multicore situation, it is cpu0 to call arm_gic_initialize to init global GICD and percpu GICRD/GIC cpu interface; other cpus only need to call arm_gic_secondary_init to int percpu GICRD/GIC cpu interface. The current code may int GICD multiple times in multicore situation which is a bug.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Cpu0 call arm_gic_initialize, other Cpus call arm_gic_secondary_init

## Impact

Fix bugs about GIC initialization in multicore situation

## Testing

This was tested in our own multicore arm cortex-r52 board


