### PR TITLE
arch/xtensa/esp32,esp32s3: Start the "spiflash_op" thread with corret affinity

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -2530,8 +2530,8 @@ static int spi_flash_op_block_task(int argc, char *argv[])
 
 int spiflash_init_spi_flash_op_block_task(int cpu)
 {
-  int pid;
-  int ret = OK;
+  FAR struct tcb_s *tcb;
+  int ret;
   char *argv[2];
   char arg1[32];
   cpu_set_t cpuset;
@@ -2540,28 +2540,40 @@ int spiflash_init_spi_flash_op_block_task(int cpu)
   argv[0] = arg1;
   argv[1] = NULL;
 
-  pid = kthread_create("spiflash_op",
-                       SCHED_PRIORITY_MAX,
-                       CONFIG_ESP32_SPIFLASH_OP_TASK_STACKSIZE,
-                       spi_flash_op_block_task,
-                       argv);
-  if (pid > 0)
+  /* Allocate a TCB for the new task. */
+
+  tcb = kmm_zalloc(sizeof(struct tcb_s));
+  if (!tcb)
     {
-      if (cpu < CONFIG_SMP_NCPUS)
-        {
-          CPU_ZERO(&cpuset);
-          CPU_SET(cpu, &cpuset);
-          ret = nxsched_set_affinity(pid, sizeof(cpuset), &cpuset);
-          if (ret < 0)
-            {
-              return ret;
-            }
-        }
+      serr("ERROR: Failed to allocate TCB\n");
+      return -ENOMEM;
     }
-  else
+
+  /* Setup the task type */
+
+  tcb->flags = TCB_FLAG_TTYPE_KERNEL | TCB_FLAG_FREE_TCB;
+
+  /* Initialize the task */
+
+  ret = nxtask_init((FAR struct task_tcb_s *)tcb, "spiflash_op",
+                    SCHED_PRIORITY_MAX,
+                    NULL, CONFIG_ESP32_SPIFLASH_OP_TASK_STACKSIZE,
+                    spi_flash_op_block_task, argv, environ, NULL);
+  if (ret < OK)
     {
-      return -EPERM;
+      kmm_free(tcb);
+      return ret;
     }
+
+  /* Set the affinity */
+
+  CPU_ZERO(&cpuset);
+  CPU_SET(cpu, &cpuset);
+  tcb->affinity = cpuset;
+
+  /* Activate the task */
+
+  nxtask_activate(tcb);
 
   return ret;
 }


### PR DESCRIPTION
## Summary

This fixes a bug where esp32_spiflash driver starts on a wrong CPU, before it's affinity gets set.

This solution first creates the thread, then sets the affinity and finally activates the task.

## Impact

Only for esp32 spiflash

## Testing

Tested on qemu that the tasks start on correct CPUs