### PR TITLE
arch/xtensa: fix spiflash task init bug

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -2535,10 +2535,13 @@ int spiflash_init_spi_flash_op_block_task(int cpu)
   char *argv[2];
   char arg1[32];
   cpu_set_t cpuset;
+  irqstate_t flags;
 
   snprintf(arg1, sizeof(arg1), "%p", &cpu);
   argv[0] = arg1;
   argv[1] = NULL;
+
+  flags = enter_critical_section();
 
   pid = kthread_create("spiflash_op",
                        SCHED_PRIORITY_MAX,
@@ -2552,16 +2555,14 @@ int spiflash_init_spi_flash_op_block_task(int cpu)
           CPU_ZERO(&cpuset);
           CPU_SET(cpu, &cpuset);
           ret = nxsched_set_affinity(pid, sizeof(cpuset), &cpuset);
-          if (ret < 0)
-            {
-              return ret;
-            }
         }
     }
   else
     {
-      return -EPERM;
+      ret = -EPERM;
     }
+
+  leave_critical_section(flags);
 
   return ret;
 }

--- a/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiflash.c
@@ -1004,10 +1004,13 @@ static int spiflash_init_spi_flash_op_block_task(int cpu)
   char *argv[2];
   char arg1[32];
   cpu_set_t cpuset;
+  irqstate_t flags;
 
   snprintf(arg1, sizeof(arg1), "%p", &cpu);
   argv[0] = arg1;
   argv[1] = NULL;
+
+  flags = enter_critical_section();
 
   pid = kthread_create("spiflash_op",
                        SCHED_PRIORITY_MAX,
@@ -1021,16 +1024,14 @@ static int spiflash_init_spi_flash_op_block_task(int cpu)
           CPU_ZERO(&cpuset);
           CPU_SET(cpu, &cpuset);
           ret = nxsched_set_affinity(pid, sizeof(cpuset), &cpuset);
-          if (ret < 0)
-            {
-              return ret;
-            }
         }
     }
   else
     {
-      return -EPERM;
+      ret = -EPERM;
     }
+
+  leave_critical_section(flags);
 
   return ret;
 }


### PR DESCRIPTION
## Summary

This fixes a bug where esp32_spiflash driver starts on a wrong CPU, before it's affinity gets set.

This solution uses a critical section to prevent scheduling on other CPUs while creating task, and additionally sched lock on the task/cpu which is creating the tasks

## Impact
Only for esp32 spiflash

## Testing

Tested on qemu that the tasks start on correct CPUs