### PR TITLE
arch/risc-v/src/mpfs/mpfs_clockconfig.c: Flag out code only used in b…

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_clockconfig.c
+++ b/arch/risc-v/src/mpfs/mpfs_clockconfig.c
@@ -145,6 +145,8 @@ enum part_type_e
 
 static uint64_t g_cpu_clock = MPFS_MSS_EXT_SGMII_REF_CLK;
 
+#ifdef CONFIG_MPFS_BOOTLOADER
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -631,6 +633,8 @@ void mpfs_clockconfig(void)
 
   mpfs_pll_config();
 }
+
+#endif
 
 /****************************************************************************
  * Name: mpfs_get_cpuclk


### PR DESCRIPTION
## Summary

This is just a tiny cleanup to mpfs_clockconfig.c, which allows compiling without several "LIBERODEFS*" configs, when
they are not actually needed or used.

## Impact

No functional impact

## Testing

Compiles in several custom configurations and in NuttX CI

