### PR TITLE
net/can: fixes and cleanups

### DIFF
--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -68,6 +68,10 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
   uint16_t recvlen;
   uint16_t ret;
 
+#ifdef CONFIG_NET_TIMESTAMP
+  buflen -= sizeof(struct timeval);
+#endif
+
   ret = (flags & ~CAN_NEWDATA);
 
   /* Save as the packet data as in the read-ahead buffer.  NOTE that

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -243,8 +243,8 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
   pstate->pr_recvlen = -1;
 
-  if ((iob = iob_peek_queue(&conn->readahead)) != NULL &&
-      pstate->pr_buflen > 0)
+  if (pstate->pr_buflen > 0 &&
+      (iob = iob_remove_queue(&conn->readahead)) != NULL)
     {
       DEBUGASSERT(iob->io_pktlen > 0);
 
@@ -256,17 +256,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
       if (can_recv_filter(conn, can_id) == 0)
         {
-          FAR struct iob_s *tmp;
-
-          /* Remove the I/O buffer chain from the head of the read-ahead
-           * buffer queue.
-           */
-
-          tmp = iob_remove_queue(&conn->readahead);
-          DEBUGASSERT(tmp == iob);
-          UNUSED(tmp);
-
-          /* And free the I/O buffer chain */
+          /* Free the I/O buffer chain */
 
           iob_free_chain(iob);
           return 0;
@@ -295,17 +285,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
       static_assert(sizeof(struct can_frame) <= CONFIG_IOB_BUFSIZE);
 
-      FAR struct iob_s *tmp;
-
-      /* Remove the I/O buffer chain from the head of the read-ahead
-       * buffer queue.
-       */
-
-      tmp = iob_remove_queue(&conn->readahead);
-      DEBUGASSERT(tmp == iob);
-      UNUSED(tmp);
-
-      /* And free the I/O buffer chain */
+      /* Free the I/O buffer chain */
 
       iob_free_chain(iob);
 


### PR DESCRIPTION

## Summary

These are cherry-picks from TII repositories. The patches simplify readahead queue handling and fix
an error in buffer length calculation in can_callback when CONFIG_NET_TIMESTAMP is enabled.

## Impact

Reduces complexity a bit, fixes a bug in net timestamp handling in socketcan.

## Testing

These patches have been tested with UAVCAN library, using Zubax Myxa ESCs (CAN motor controllers), together with MPFS platform.
