### PR TITLE
Drivers net ksz9477 fixes

### DIFF
--- a/drivers/net/ksz9477.c
+++ b/drivers/net/ksz9477.c
@@ -640,6 +640,14 @@ int ksz9477_init(ksz9477_port_t master_port)
       return ret ? ret : -EINVAL;
     }
 
+  /* Errata 16: SGMII registers are not initialized by hardware reset
+   * To ensure clean environment, reset the switch now.
+   */
+
+  regval16 = SGMII_CONTROL_SOFT_RESET;
+  ret = ksz9477_sgmii_write_indirect(KSZ9477_SGMII_CONTROL,
+                                     &regval16, 1);
+
   /* Check that indirect access to PHY MMD works.
    * Write LED mode to single-LED mode and verify access by
    * reading back the value.

--- a/drivers/net/ksz9477_reg.h
+++ b/drivers/net/ksz9477_reg.h
@@ -61,6 +61,11 @@
 #define KSZ9477_PHY_CONTROL(p)             KSZ9477_PORT_REG(p, 0x100)
 #define KSZ9477_PHY_STATUS(p)              KSZ9477_PORT_REG(p, 0x102)
 
+#define KSZ9477_PHY_MMD_SETUP(p)           KSZ9477_PORT_REG(p, 0x11A)
+#define KSZ9477_PHY_MMD_DATA(p)            KSZ9477_PORT_REG(p, 0x11C)
+
+#define KSZ9477_PHY_REMOTE_LP(p)           KSZ9477_PORT_REG(p, 0x122)
+
 /* Note! Unlike in data sheet, the indirect data register reads and
  * writes must be done with 32-bit accesses and the address is
  * 0x204
@@ -119,6 +124,21 @@
 #define SGMII_AUTONEG_CONTROL_PCS_SGMII    (2 << 1)
 #define SGMII_AUTONEG_CONTROL_TC_MASTER    (1 << 3)
 #define SGMII_AUTONEG_CONTROL_LINK_STATUS  (1 << 4)
+
+/* MMD device addresses */
+
+#define KSZ9477_MMD_DEV_SIGNAL_QUALITY     0x1
+#define KSZ9477_MMD_DEV_LED_MODE           0x2
+#define KSZ9477_MMD_DEV_EEE_ADVERTISEMENT  0x7
+#define KSZ9477_MMD_DEV_QUIET_WIRE         0x1C
+
+/* MMD operation modes */
+
+#define KSZ9477_MMD_OP_MODE_SHIFT          14
+#define KSZ9477_MMD_OP_MODE_REGISTER       (0 << KSZ9477_MMD_OP_MODE_SHIFT)
+#define KSZ9477_MMD_OP_MODE_NO_INCREMENT   (1 << KSZ9477_MMD_OP_MODE_SHIFT)
+#define KSZ9477_MMD_OP_MODE_RW_INCREMENT   (2 << KSZ9477_MMD_OP_MODE_SHIFT)
+#define KSZ9477_MMD_OP_MODE_W_INCREMENT    (3 << KSZ9477_MMD_OP_MODE_SHIFT)
 
 /* Port Mirroring Control Register */
 

--- a/drivers/net/ksz9477_reg.h
+++ b/drivers/net/ksz9477_reg.h
@@ -100,6 +100,10 @@
 
 /* Register bit definitions */
 
+/* KSZ9477_SGMII_CONTROL */
+
+#define SGMII_CONTROL_SOFT_RESET          (1 << 15)
+
 /* KSZ9477_ID2, KSZ9477_ID1 */
 
 #define KSZ9477_ID                         0x9477


### PR DESCRIPTION
## Summary

This improves the functionality of the ksz9477 i2c controlled ethernet switch driver, by implementing manufacturer's recommended errata workarounds.

## Impact

Impacts only using ksz9477. Fixes connection issues and random failures after boot/initialization.

## Testing

Tested on a custom hardware, where ksz9477 is initialized by NuttX via I2C on an MFPS250T SoC, and connects to several etherenet devices on the same board.
