### PR TITLE
arch/arm/src/samv7/sam_emac.c: fix compile warning

### DIFF
--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -4755,7 +4755,9 @@ int sam_emac_initialize(int intf)
 {
   struct sam_emac_s *priv;
   const struct sam_emacattr_s *attr;
+#ifndef CONFIG_ARCH_CHIP_PIC32CZCA70
   uint32_t regval;
+#endif
   uint8_t *pktbuf;
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
   uint8_t phytype;


### PR DESCRIPTION
## Summary
The following warning occurred if `ARCH_CHIP_PIC32CZCA70` option was selected. The variable is not used in case of PIC32CZ CA70 series.

```
CC:  task/task_getgroup.c chip/sam_emac.c: In function ‘sam_emac_initialize’: chip/sam_emac.c:4758:12: warning: unused variable ‘regval’ [-Wunused-variable]
 4758 |   uint32_t regval;
      |
```

## Impact

SAMv7 code only. Fixes compile warnings.

## Testing
Build passes without warnings.


