### PR TITLE
arch/arm/src/stm32f7/stm32_ethernet.c: Fix "unused variable" warning

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -3130,7 +3130,9 @@ static inline int stm32_dm9161(struct stm32_ethmac_s *priv)
 
 static int stm32_phyinit(struct stm32_ethmac_s *priv)
 {
+#ifdef CONFIG_STM32F7_AUTONEG
   volatile uint32_t timeout;
+#endif
   uint32_t regval;
   uint16_t phyval;
   int ret;


### PR DESCRIPTION
## Summary

Fix an "unused variable" compiler warning when CONFIG_STM32F7_AUTONEG is not set

## Impact

No functional impact, enables building with CONFIG_STM32F7_AUTONEG=n and -Werr.

## Testing

Tested building on stm32f7 (pixhawk 5x) board.
