### PR TITLE
net/netdev/netdev_ioctl.c: Add new ioctls for MMD register access

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -172,6 +172,18 @@ struct mii_ioctl_data_s
   uint16_t val_out;     /* PHY output data */
 };
 
+/* Structure passed to read from or write to the MMD
+ * registers via the SIOCxMMDREG ioctl commands.
+ */
+
+struct mmd_ioctl_data_s
+{
+  uint8_t  phy_id;      /* PHY device address */
+  uint8_t  mmd;         /* MMD number */
+  uint16_t addr;        /* Address in the selected MMD */
+  uint16_t data;        /* Input / Output data */
+};
+
 /* Structure passed to get or set the CAN bitrate
  * SIOCxCANBITRATE ioctl commands.
  */
@@ -238,6 +250,7 @@ struct lifreq
     uint32_t                   lifru_flags;          /* Interface flags */
     struct mii_ioctl_notify_s  llfru_mii_notify;     /* PHY event notification */
     struct mii_ioctl_data_s    lifru_mii_data;       /* MII request data */
+    struct mmd_ioctl_data_s    ifru_mmd_data;        /* MMD request data */
     struct can_ioctl_data_s    lifru_can_data;       /* CAN bitrate request data */
     struct can_ioctl_filter_s  lifru_can_filter;     /* CAN filter request data */
     struct can_ioctl_state_s   lifru_can_state;      /* CAN/LIN controller state */
@@ -292,6 +305,7 @@ struct ifreq
     uint32_t                   ifru_flags;          /* Interface flags */
     struct mii_ioctl_notify_s  ifru_mii_notify;     /* PHY event notification */
     struct mii_ioctl_data_s    ifru_mii_data;       /* MII request data */
+    struct mmd_ioctl_data_s    ifru_mmd_data;       /* MMD request data */
     struct can_ioctl_data_s    ifru_can_data;       /* CAN bitrate request data */
     struct can_ioctl_filter_s  ifru_can_filter;     /* CAN filter request data */
     struct can_ioctl_state_s   ifru_can_state;      /* CAN/LIN controller state */

--- a/include/nuttx/net/ioctl.h
+++ b/include/nuttx/net/ioctl.h
@@ -100,6 +100,9 @@
 #define SIOCGMIIREG      _SIOC(0x0025)  /* Get a MII register via MDIO */
 #define SIOCSMIIREG      _SIOC(0x0026)  /* Set a MII register via MDIO */
 
+#define SIOCGMMDREG      _SIOC(0x0043)  /* Get a MMD register via MDIO */
+#define SIOCSMMDREG      _SIOC(0x0044)  /* Set a MMD register via MDIO */
+
 /* Unix domain sockets ******************************************************/
 
 #define SIOCINQ          _SIOC(0x0027)  /* Returns the amount of queued unread

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -719,6 +719,8 @@ static ssize_t net_ioctl_ifreq_arglen(uint8_t domain, int cmd)
       case SIOCGMIIPHY:
       case SIOCGMIIREG:
       case SIOCSMIIREG:
+      case SIOCGMMDREG:
+      case SIOCSMMDREG:
       case SIOCGCANBITRATE:
       case SIOCSCANBITRATE:
       case SIOCACANEXTFILTER:
@@ -1167,6 +1169,21 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
               &req->ifr_ifru.ifru_mii_data;
             ret = dev->d_ioctl(dev, cmd,
                                (unsigned long)(uintptr_t)mii_data);
+          }
+        else
+          {
+            ret = -ENOSYS;
+          }
+        break;
+
+      case SIOCGMMDREG: /* Get MMD register via MDIO */
+      case SIOCSMMDREG: /* Set MMD register via MDIO */
+        if (dev->d_ioctl)
+          {
+            FAR struct mmd_ioctl_data_s *mmd_data =
+              &req->ifr_ifru.ifru_mmd_data;
+            ret = dev->d_ioctl(dev, cmd,
+                               (unsigned long)(uintptr_t)mmd_data);
           }
         else
           {


### PR DESCRIPTION
## Summary
This patch adds SIOCGMMDREG and SIOCSMMDREG ioctl commands with accompanying logic.
SIOCGMMDREG: Get MMD register.
SIOCGMMDREG: Set MMD register.
A new structure `mmd_ioctl_data_s` is introduced into `include/net/if.h` in order to accommodate command data.
MMD registers are an extension to the MII management interface, both are defined in IEEE 802.3.

## Impact
Network drivers may implement these ioctl commands. When implemented, PHY features configurable by
MMD access can now be managed from the user application.

## Testing
The testing was performed by a testing application during development of a driver for 10BASE-T1x SPI MAC-PHYs.
This mechanism was used to control PHY behavior, especially to configure 10BASE-T1S PLCA access method.