### PR TITLE
boards/arm/imxrt: CMake added imxrt1060-evk imxrt1064-evk imxrt1170-evk boards

### DIFF
--- a/boards/arm/imxrt/imxrt1060-evk/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1060-evk/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1060-evk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/imxrt/imxrt1060-evk/src/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1060-evk/src/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1060-evk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_boot.c imxrt_flexspi_nor_boot.c imxrt_flexspi_nor_flash.c)
+
+if(CONFIG_IMXRT_SDRAMC)
+  list(APPEND SRCS imxrt_sdram.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS imxrt_buttons.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS imxrt_mmcsd_spi.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT_ADC)
+  list(APPEND SRCS imxrt_adc.c)
+endif()
+
+if(CONFIG_INPUT_FT5X06)
+  list(APPEND SRCS imxrt_ft5x06.c)
+endif()
+
+if(CONFIG_IMXRT_LCD)
+  list(APPEND SRCS imxrt_lcd.c)
+endif()
+
+if(CONFIG_IMXRT_USBOTG)
+  list(APPEND SRCS imxrt_usbhost.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXCAN)
+  list(APPEND SRCS imxrt_flexcan.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_BOOT_RUNFROMFLASH)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+elseif(CONFIG_BOOT_RUNFROMISRAM)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+endif()

--- a/boards/arm/imxrt/imxrt1064-evk/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1064-evk/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1064-evk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/imxrt/imxrt1064-evk/src/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1064-evk/src/CMakeLists.txt
@@ -1,0 +1,121 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1064-evk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_boot.c imxrt_flexspi_nor_boot.c imxrt_flexspi_nor_flash.c)
+
+if(CONFIG_IMXRT_SDRAMC)
+  list(APPEND SRCS imxrt_sdram.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS imxrt_buttons.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS imxrt_mmcsd_spi.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT_ADC)
+  list(APPEND SRCS imxrt_adc.c)
+endif()
+
+if(CONFIG_INPUT_FT5X06)
+  list(APPEND SRCS imxrt_ft5x06.c)
+endif()
+
+if(CONFIG_IMXRT_LCD)
+  list(APPEND SRCS imxrt_lcd.c)
+endif()
+
+if(CONFIG_IMXRT_USBOTG)
+  list(APPEND SRCS imxrt_usbhost.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXCAN)
+  list(APPEND SRCS imxrt_flexcan.c)
+endif()
+
+if(CONFIG_IMXRT1064_EVK_SDRAM)
+  list(APPEND SRCS imxrt_sdram_ini_dcd.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXSPI)
+  list(APPEND SRCS imxrt_flexspi_nor.c)
+endif()
+
+if(CONFIG_IMXRT_PROGMEM)
+  list(APPEND SRCS imxrt_progmem.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS imxrt_reset.c)
+endif()
+
+if(CONFIG_BOARDCTL_BOOT_IMAGE)
+  list(APPEND SRCS imxrt_boot_image.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_IMXRT_APP_FORMAT_MCUBOOT)
+  if(CONFIG_MCUBOOT_BOOTLOADER)
+    set_property(
+      GLOBAL PROPERTY LD_SCRIPT
+                      "${NUTTX_BOARD_DIR}/scripts/flash-mcuboot-loader.ld")
+  else()
+    set_property(
+      GLOBAL PROPERTY LD_SCRIPT
+                      "${NUTTX_BOARD_DIR}/scripts/flash-mcuboot-app.ld")
+  endif()
+else()
+  if(CONFIG_BOOT_RUNFROMFLASH)
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+  elseif(CONFIG_BOOT_RUNFROMISRAM)
+    set_property(GLOBAL PROPERTY LD_SCRIPT
+                                 "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+  endif()
+endif()

--- a/boards/arm/imxrt/imxrt1170-evk/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1170-evk/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1170-evk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/imxrt/imxrt1170-evk/src/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1170-evk/src/CMakeLists.txt
@@ -1,0 +1,101 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1170-evk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_boot.c imxrt_flexspi_nor_boot.c imxrt_flexspi_nor_flash.c
+         imxrt_clockconfig.c)
+
+if(CONFIG_IMXRT_SDRAMC)
+  list(APPEND SRCS imxrt_sdram.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS imxrt_buttons.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS imxrt_mmcsd_spi.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT_ADC)
+  list(APPEND SRCS imxrt_adc.c)
+endif()
+
+if(CONFIG_INPUT_FT5X06)
+  list(APPEND SRCS imxrt_ft5x06.c)
+endif()
+
+if(CONFIG_IMXRT_LCD)
+  list(APPEND SRCS imxrt_lcd.c)
+endif()
+
+if(CONFIG_IMXRT_USBOTG)
+  list(APPEND SRCS imxrt_usbhost.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXCAN)
+  list(APPEND SRCS imxrt_flexcan.c)
+endif()
+
+if(CONFIG_IMXRT1170_EVK_SDRAM)
+  list(APPEND SRCS imxrt_sdram_ini_dcd.c)
+endif()
+
+if(CONFIG_IMXRT1170_FLEXSPI_NOR)
+  list(APPEND SRCS imxrt_flexspi_nor.c)
+endif()
+
+if(CONFIG_IMXRT1170_FLEXSPI_FRAM)
+  list(APPEND SRCS imxrt_flexspi_fram.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_BOOT_RUNFROMFLASH)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+elseif(CONFIG_BOOT_RUNFROMISRAM)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+endif()


### PR DESCRIPTION
## Summary

Added CMake build for boards:

- imxrt1060-evk
- imxrt1064-evk
- imxrt1170-evk

## Impact

Impact on user: This PR adds imxrt1060-evk, imxrt1064-evk, and imxrt1170-evk boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
Locally

**imxrt1060-evk**
```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=imxrt1060-evk:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  imxrt1060-evk
--   Config: nsh
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (8.5s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[39/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[41/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[1100/1101] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       95400 B         8 MB      1.14%
            sram:        6588 B       512 MB      0.00%
            itcm:          0 GB       128 KB      0.00%
            dtcm:          0 GB       128 KB      0.00%
[1101/1101] Generating nuttx.hex
```
**imxrt1064-evk**
```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=imxrt1064-evk:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  imxrt1064-evk
--   Config: nsh
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (7.7s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[38/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[39/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[1100/1101] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       95400 B         4 MB      2.27%
            sram:        6588 B       512 MB      0.00%
            itcm:          0 GB       128 KB      0.00%
            dtcm:          0 GB       128 KB      0.00%
[1101/1101] Generating nuttx.hex
```
**imxrt1170-evk**
```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=imxrt1170-evk:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  imxrt1170-evk
--   Config: nsh
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (7.6s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[26/1106] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_start.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_start.c: In function 'imxrt_tcmenable':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_start.c:132:2: warning: #warning Missing logic [-Wcpp]
  132 | #warning Missing logic
      |  ^~~~~~~
[36/1106] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[38/1106] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[1104/1106] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      132540 B        16 MB      0.79%
            sram:        7352 B         1 MB      0.70%
            itcm:          0 GB       256 KB      0.00%
            dtcm:          0 GB       256 KB      0.00%
[1106/1106] Generating nuttx.bin
```