### PR TITLE
sched/init/nx_bringup.c: Add support for CONFIG_INIT_NONE in a flat build

### DIFF
--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -65,10 +65,9 @@
 /* Configuration */
 
 #if defined(CONFIG_INIT_NONE)
-  /* Kconfig logic will set CONFIG_INIT_NONE if dependencies are not met */
-
-#  error No initialization mechanism selected (CONFIG_INIT_NONE)
-
+#  ifndef CONFIG_BUILD_FLAT
+#    error No initialization mechanism selected (CONFIG_INIT_NONE)
+#  endif
 #else
 #  if !defined(CONFIG_INIT_ENTRY) && !defined(CONFIG_INIT_FILE)
   /* For backward compatibility with older defconfig files when this was
@@ -326,6 +325,14 @@ static inline void nx_start_application(void)
   coredump_initialize();
 #endif
 
+#ifdef CONFIG_INIT_NONE
+
+  UNUSED(ret);
+
+  /* In a flat build, init thread is not mandatory */
+
+  sinfo("No init thread\n");
+#else
   posix_spawnattr_init(&attr);
   attr.priority  = CONFIG_INIT_PRIORITY;
   attr.stacksize = CONFIG_INIT_STACKSIZE;
@@ -378,6 +385,7 @@ static inline void nx_start_application(void)
 #endif
   posix_spawnattr_destroy(&attr);
   DEBUGASSERT(ret > 0);
+#endif /* CONFIG_INIT_NONE */
 }
 
 /****************************************************************************


### PR DESCRIPTION

In a flat build, a separate init thread should not be mandatory, users can create a user task in the board early initialization or late initialization hook.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add support for CONFIG_INIT_NONE in a flat build.

## Impact

In a flat build, a init thread will not be mandatory, users can create a user task in the board early initialization or late initialization hook

## Testing

N/A

