### PR TITLE
sched/event: add nxevent_clear api

### DIFF
--- a/Documentation/reference/os/events.rst
+++ b/Documentation/reference/os/events.rst
@@ -116,6 +116,12 @@ Notifier Chain Interfaces
   :param events: Set of events to wait, 0 will indicate wait from any events
   :param eflags: Events flags
 
+.. c:function:: nxevent_mask_t nxevent_clear(FAR nxevent_t *event, nxevent_mask_t mask)
+
+  This function is used to clear specific bits from the event mask of the given event object.
+
+  :param event: Address of the event object
+  :param mask: Bit mask specifying which event flags should be cleared
 
 .. c:function:: nxevent_mask_t nxevent_tickwait_wait(FAR nxevent_t *event, FAR nxevent_wait_t *wait, nxevent_mask_t events, nxevent_flags_t eflags, uint32_t delay);
 

--- a/include/nuttx/event.h
+++ b/include/nuttx/event.h
@@ -310,6 +310,29 @@ nxevent_mask_t nxevent_trywait(FAR nxevent_t *event, nxevent_mask_t events,
                                nxevent_flags_t eflags);
 
 /****************************************************************************
+ * Name: nxevent_clear
+ *
+ * Description:
+ *   Clear specific bits from the event mask of the given event object.
+ *
+ * Input Parameters:
+ *   event - Address of the event object
+ *   mask  - Bit mask specifying which event flags should be cleared
+ *
+ * Returned Value:
+ *   Returns the previous event mask value of the event object before
+ *   applying the clear operation.
+ *
+ * Notes:
+ *   - This is an internal OS interface and must not be invoked directly
+ *     by user applications.
+ *   - This function is safe to call from an interrupt handler.
+ *
+ ****************************************************************************/
+
+nxevent_mask_t nxevent_clear(FAR nxevent_t *event, nxevent_mask_t mask);
+
+/****************************************************************************
  * Name: nxevent_open
  *
  * Description:

--- a/sched/event/CMakeLists.txt
+++ b/sched/event/CMakeLists.txt
@@ -30,7 +30,8 @@ if(CONFIG_SCHED_EVENTS)
     event_post.c
     event_reset.c
     event_destroy.c
-    event_wait.c)
+    event_wait.c
+    event_clear.c)
 endif()
 
 target_sources(sched PRIVATE ${CSRCS})

--- a/sched/event/Make.defs
+++ b/sched/event/Make.defs
@@ -23,7 +23,7 @@
 # Add event-related files to the build
 
 ifeq ($(CONFIG_SCHED_EVENTS),y)
-  CSRCS += event_init.c event_post.c event_reset.c event_destroy.c event_wait.c
+  CSRCS += event_init.c event_post.c event_reset.c event_destroy.c event_wait.c event_clear.c
 endif
 
 # Include event build support

--- a/sched/event/event_clear.c
+++ b/sched/event/event_clear.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * sched/event/event_clear.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/sched.h>
+
+#include "event.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxevent_clear
+ *
+ * Description:
+ *   Clear specific bits from the event mask of the given event object.
+ *
+ * Input Parameters:
+ *   event - Address of the event object
+ *   mask  - Bit mask specifying which event flags should be cleared
+ *
+ * Returned Value:
+ *   Returns the previous event mask value of the event object before
+ *   applying the clear operation.
+ *
+ * Notes:
+ *   - This is an internal OS interface and must not be invoked directly
+ *     by user applications.
+ *   - This function is safe to call from an interrupt handler.
+ *
+ ****************************************************************************/
+
+nxevent_mask_t nxevent_clear(FAR nxevent_t *event, nxevent_mask_t mask)
+{
+  nxevent_mask_t events;
+  irqstate_t flags;
+
+  DEBUGASSERT(event != NULL);
+
+  flags = spin_lock_irqsave(&event->lock);
+
+  events = event->events;
+  event->events &= ~mask;
+
+  spin_unlock_irqrestore(&event->lock, flags);
+
+  return events;
+}


### PR DESCRIPTION
  Add nxevent_clear to clear event mask to an event object.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

new event api is added: nxevent_clear, which can be used to manually clear event mask

## Impact

A new event module api is added.

## Testing

**add event clear test**

**Enable event:**
<img width="703" height="417" alt="image" src="https://github.com/user-attachments/assets/7fad205e-22e1-48d8-a258-64632cb8465f" />

**ostest pass**
<img width="586" height="571" alt="image" src="https://github.com/user-attachments/assets/cbe6f6ef-8fee-4be9-81eb-081cc9ba1a90" />

