### PR TITLE
boards/arm/imxrt: CMake added imxrt1020-evk imxrt1050-evk boards

### DIFF
--- a/boards/arm/imxrt/imxrt1020-evk/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1020-evk/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1020-evk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/imxrt/imxrt1020-evk/src/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1020-evk/src/CMakeLists.txt
@@ -1,0 +1,66 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1020-evk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_flexspi_nor_flash.c imxrt_boot.c imxrt_flexspi_nor_boot.c)
+
+if(CONFIG_IMXRT_SDRAMC)
+  list(APPEND SRCS imxrt_sdram.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS imxrt_buttons.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT_USBOTG)
+  list(APPEND SRCS imxrt_usbhost.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(NOT CONFIG_ARMV7M_DTCM)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+endif()

--- a/boards/arm/imxrt/imxrt1050-evk/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1050-evk/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1050-evk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/imxrt/imxrt1050-evk/src/CMakeLists.txt
+++ b/boards/arm/imxrt/imxrt1050-evk/src/CMakeLists.txt
@@ -1,0 +1,74 @@
+# ##############################################################################
+# boards/arm/imxrt/imxrt1050-evk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_boot.c imxrt_flexspi_nor_boot.c imxrt_flexspi_nor_flash.c)
+
+if(CONFIG_IMXRT_SDRAMC)
+  list(APPEND SRCS imxrt_sdram.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS imxrt_buttons.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_IMXRT_LCD)
+  list(APPEND SRCS imxrt_lcd.c)
+endif()
+
+if(CONFIG_MMCSD_SPI)
+  list(APPEND SRCS imxrt_mmcsd_spi.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT1050_EVK_SDRAM)
+  list(APPEND SRCS imxrt_sdram_ini_dcd.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(NOT CONFIG_ARMV7M_DTCM)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+endif()


### PR DESCRIPTION
## Summary

Added CMake build for boards:

imxrt1020-evk
imxrt1050-evk

## Impact

Impact on user: This PR adds imxrt1020-evk and imxrt1050-evk boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
Locally

**imxrt1020-evk**

```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=imxrt1020-evk:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  imxrt1020-evk
--   Config: nsh
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (7.4s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[34/1105] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[39/1105] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[1103/1105] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       99372 B        64 MB      0.15%
            sram:        9736 B       256 KB      3.71%
[1105/1105] Generating nuttx.bin
```

**imxrt1050-evk**
```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=imxrt1050-evk:nsh -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  imxrt1050-evk
--   Config: nsh
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (8.0s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[38/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[40/1101] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[1100/1101] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       94888 B        64 MB      0.14%
            sram:        6588 B       512 KB      1.26%
            itcm:          0 GB       128 KB      0.00%
            dtcm:          0 GB       128 KB      0.00%
[1101/1101] Generating nuttx.hex

```

