### PR TITLE
drivers/timers/capture: fix typo in capture.h

### DIFF
--- a/Documentation/components/drivers/character/timers/capture.rst
+++ b/Documentation/components/drivers/character/timers/capture.rst
@@ -24,7 +24,7 @@ Supported ``ioctl`` Commands
 
    **Argument:** ``int8_t *`` (pointer to duty cycle percentage).
 
-.. c:macro:: CAPIOC_FREQUENCE
+.. c:macro:: CAPIOC_FREQUENCY
 
    Get the pulse frequency from the capture unit.
 
@@ -153,7 +153,7 @@ frequency:
           return 1;
         }
 
-      if (ioctl(fd, CAPIOC_FREQUENCE, (unsigned long)&frequency) < 0)
+      if (ioctl(fd, CAPIOC_FREQUENCY, (unsigned long)&frequency) < 0)
         {
           perror("Failed to get frequency");
           close(fd);
@@ -229,7 +229,7 @@ Here is an example using signal notifications for event-driven capture
       sleep(2);
 
       /* Get frequency and duty cycle */
-      ioctl(fd, CAPIOC_FREQUENCE, (unsigned long)&frequency);
+      ioctl(fd, CAPIOC_FREQUENCY, (unsigned long)&frequency);
       ioctl(fd, CAPIOC_DUTYCYCLE, (unsigned long)&duty);
 
       printf("Captured %d edges\n", edge_count);
@@ -276,7 +276,7 @@ The fake capture driver can be used for testing without hardware
       sleep(1);
 
       /* Read values (should be 10Hz, 50% duty) */
-      ioctl(fd, CAPIOC_FREQUENCE, (unsigned long)&frequency);
+      ioctl(fd, CAPIOC_FREQUENCY, (unsigned long)&frequency);
       ioctl(fd, CAPIOC_DUTYCYCLE, (unsigned long)&duty);
 
       printf("Fake Capture - Frequency: %u Hz, Duty: %u%%\n",
@@ -294,7 +294,7 @@ Notes
 
 * The actual set of supported ``ioctl`` commands may vary depending on
   the hardware and driver implementation.
-* The ``CAPIOC_FREQUENCE`` macro name is preserved for compatibility,
+* The ``CAPIOC_FREQUENCY`` macro name is preserved for compatibility,
   even though "frequency" is the correct English spelling.
 * Always check return values from ``ioctl()`` calls for error handling.
 * **Important:** In debug builds of NuttX, calling an unsupported

--- a/drivers/timers/capture.c
+++ b/drivers/timers/capture.c
@@ -364,11 +364,11 @@ static int cap_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* CAPIOC_FREQUENCE - Get the pulse frequency from the capture.
+      /* CAPIOC_FREQUENCY - Get the pulse frequency from the capture.
        * Argument: int32_t pointer to the location to return the frequency.
        */
 
-      case CAPIOC_FREQUENCE:
+      case CAPIOC_FREQUENCY:
         {
           FAR uint32_t *ptr = (FAR uint32_t *)((uintptr_t)arg);
           DEBUGASSERT(ptr);

--- a/include/nuttx/timers/capture.h
+++ b/include/nuttx/timers/capture.h
@@ -48,14 +48,14 @@
 
 #define CAPIOC_DUTYCYCLE _CAPIOC(1)
 
-/* Command:     CAPIOC_FREQUENCE
+/* Command:     CAPIOC_FREQUENCY
  * Description: Get the pulse frequency from the capture.
  * Arguments:   int32_t pointer to the location to return the frequency.
  * Return:      Zero (OK) on success.  Minus one will be returned on failure
  *              with the errno value set appropriately.
  */
 
-#define CAPIOC_FREQUENCE _CAPIOC(2)
+#define CAPIOC_FREQUENCY _CAPIOC(2)
 
 /* Command:     CAPIOC_EDGES
  * Description: Get the pwm edges from the capture.


### PR DESCRIPTION
## Summary

This commit fixes a typo in the capture.h header file (fix #16835).

Change: CAPIOC_FREQUENCE -> CAPIOC_FREQUENCY

Added a compiler warning of the deprecation to the capture.h file.

Updated capture driver and documentation.

## Impact

Now shows a compiler warning when using the capture driver. Old spelling is aliased to the new spelling. Should be removed in future releases. 

## Testing

Built config capture on Ubuntu.