### PR TITLE
include/net/if.h: Add mechanism for MMD access with SIOCxMIIREG ioctls

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -127,6 +127,17 @@
 #  define IFF_IS_IPv4(f)   (1)
 #endif
 
+/* MDIO Manageable Device (MMD) support with SIOCxMIIREG ioctl commands */
+
+#define MDIO_PHY_ID_C45      0x8000
+#define MDIO_PHY_ID_PRTAD    0x03E0
+#define MDIO_PHY_ID_DEVAD    0x001F
+#define MDIO_PHY_ID_C45_MASK \
+    (MDIO_PHY_ID_C45 | MDIO_PHY_ID_PRTAD | MDIO_PHY_ID_DEVAD)
+
+#define mdio_phy_id_c45(prtad, devad) \
+    ((uint16_t)(MDIO_PHY_ID_C45 | ((prtad) << 5) | (devad)))
+
 /* RFC 2863 operational status */
 
 enum

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/netdev.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2009, 2011-2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007,2009 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2011-2018 Gregory Nutt. All rights reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
@@ -215,6 +216,17 @@
 #  define NETDEV_V6ADDR_ONLINK(dev,addr) \
      (netdev_ipv6_lookup(dev, addr, true) != NULL)
 #endif
+
+/* MDIO Manageable Device (MMD) support with SIOCxMIIREG ioctl commands */
+
+#define mdio_phy_id_is_c45(phy_id) \
+    (((phy_id) & MDIO_PHY_ID_C45) && !((phy_id) & ~MDIO_PHY_ID_C45_MASK))
+
+#define mdio_phy_id_prtad(phy_id) \
+    ((uint16_t)(((phy_id) & MDIO_PHY_ID_PRTAD) >> 5))
+
+#define mdio_phy_id_devad(phy_id) \
+    ((uint16_t)((phy_id) & MDIO_PHY_ID_DEVAD))
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary

This patch adds `mdio_phy_id_c45` macro. This macro allows encoding of additional information needed for MDIO Manageable Device (MMD) access into the `phy_id` field of the `mii_ioctl_data_s` structure. This macro is intended for use by user applications.

This patch also adds macros for decoding the `phy_id` encoded with the `mdio_phy_id_c45` macro. These macros are intended for use by network drivers implementing SIOCxMIIREG commands.

The mechanism is inspired by the approach used in Linux:
https://elixir.bootlin.com/linux/v6.16.3/source/include/uapi/linux/mdio.h#L456-L465
https://elixir.bootlin.com/linux/v6.16.3/source/include/linux/mdio.h#L110-L123

This PR was preceded by discussion in PR https://github.com/apache/nuttx/pull/16911

## Impact

Network drivers now may implement access to MMD registers through ioctl.

## Testing
The testing was performed by a testing application during development of a driver for 10BASE-T1x SPI MAC-PHYs.
A mirrored bit between two registers - one in MII interface, second in an MMD space - was written to. The bit enables / disables the PHY. Same effect was observed when accessing the bit using MII and MMD.