### PR TITLE
sched/signal: Old signal action need save sa_user

### DIFF
--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -294,6 +294,7 @@ int nxsig_action(int signo, FAR const struct sigaction *act,
           oact->sa_handler = sigact->act.sa_handler;
           oact->sa_mask    = sigact->act.sa_mask;
           oact->sa_flags   = sigact->act.sa_flags;
+          oact->sa_user    = sigact->act.sa_user;
         }
       else
         {


### PR DESCRIPTION
## Summary
Old signal action need save `sa_user`.
For example, set sigaction after create signalfd, the `sa_sigaction` was restored but `sa_user` not, causing `signalfd_action()` get the wild private data.
```
# create signalfd,
xxxx_main -> signalfd -> nxsig_action

# set sigaction
nsh_telnetstart -> nsh_parse -> nsh_parse_command -> nsh_execute -> nsh_builtin -> sigaction -> nxsig_action
```
## Impact
- sched/signal

## Testing
1. Selftest with signalfd OK.
2. CI


