### PR TITLE
arch/arm,riscv/rp23xx: Silence "LOAD segment with RWX permissions" linker warnings

### DIFF
--- a/arch/arm/src/rp23xx/Make.defs
+++ b/arch/arm/src/rp23xx/Make.defs
@@ -23,6 +23,7 @@
 include armv8-m/Make.defs
 
 CFLAGS += -Wno-array-bounds
+LDFLAGS += --no-warn-rwx-segments
 
 CHIP_CSRCS += rp23xx_idle.c
 CHIP_CSRCS += rp23xx_irq.c

--- a/arch/risc-v/src/rp23xx-rv/Make.defs
+++ b/arch/risc-v/src/rp23xx-rv/Make.defs
@@ -27,6 +27,7 @@ include common/Make.defs
 HEAD_ASRC = rp23xx_head.S
 
 CFLAGS += -Wno-array-bounds
+LDFLAGS += --no-warn-rwx-segments
 
 CHIP_CSRCS += rp23xx_idle.c
 CHIP_CSRCS += rp23xx_irq.c


### PR DESCRIPTION
## Summary

Setting the "--no-warn-rwx-segments" linker option

Port of https://github.com/apache/nuttx/pull/16886 

## Impact

No more rwx warnings while linking


