### PR TITLE
libs/libc/semaphore:  allow nxsem_init to negative value

### DIFF
--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -147,7 +147,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int nxsem_init(FAR sem_t *sem, int pshared, uint32_t value);
+int nxsem_init(FAR sem_t *sem, int pshared, int32_t value);
 
 /****************************************************************************
  * Name: nxsem_destroy

--- a/libs/libc/semaphore/sem_init.c
+++ b/libs/libc/semaphore/sem_init.c
@@ -62,7 +62,7 @@
  *
  ****************************************************************************/
 
-int nxsem_init(FAR sem_t *sem, int pshared, uint32_t value)
+int nxsem_init(FAR sem_t *sem, int pshared, int32_t value)
 {
   UNUSED(pshared);
 


### PR DESCRIPTION
   Allow user to init semaphore value to negative value, this is needed in some use cases

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Update nxsem_init api param type to allow a semaphore to be initialized to a negative value

## Impact

Semaphore can be initialized to a negative value

## Testing

N/A


