### PR TITLE
sched: remove csection in event

### DIFF
--- a/include/nuttx/event.h
+++ b/include/nuttx/event.h
@@ -31,6 +31,7 @@
 
 #include <nuttx/list.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -70,8 +71,9 @@ struct nxevent_wait_s
 
 struct nxevent_s
 {
-  struct list_node         list;    /* Waiting list of nxevent_wait_t */
-  volatile nxevent_mask_t  events;  /* Pending Events */
+  struct list_node         list;   /* Waiting list of nxevent_wait_t */
+  volatile nxevent_mask_t  events; /* Pending Events */
+  spinlock_t               lock;   /* Spinlock */
 };
 
 #ifdef CONFIG_FS_NAMED_EVENTS

--- a/sched/event/event_init.c
+++ b/sched/event/event_init.c
@@ -49,5 +49,6 @@
 void nxevent_init(FAR nxevent_t *event, nxevent_mask_t events)
 {
   event->events = events;
+  spin_lock_init(&event->lock);
   list_initialize(&event->list);
 }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
sched: remove csection in event

## Impact

We hope to replace the large lock with a small lock to improve concurrency performance.

## Testing
ostest

