### PR TITLE
fs/fat: Fix wrong alloc used in fat_zero_cluster()

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -509,7 +509,7 @@ static int fat_zero_cluster(FAR struct fat_mountpt_s *fs, int cluster,
   off_t end_sec = sector + DIV_ROUND_UP(end, fs->fs_hwsectorsize);
   int ret;
 
-  buf = fs_heap_malloc(fs->fs_hwsectorsize);
+  buf = fat_io_alloc(fs->fs_hwsectorsize);
   if (!buf)
     {
       return -ENOMEM;
@@ -548,7 +548,7 @@ static int fat_zero_cluster(FAR struct fat_mountpt_s *fs, int cluster,
   ret = OK;
 
 out:
-  fs_heap_free(buf);
+  fat_io_free(buf, fs->fs_hwsectorsize);
 
   return ret;
 }


### PR DESCRIPTION
## Summary

Fat_zero_cluster() use fs_heap_malloc() for buffer that is used to call fat_hwread().
Fat_hwread() must be called with IO buffer that have proper alingment because it might use DMA.

Fix changes fs_heap_malloc() to fat_io_alloc() which uses correct fat_dma_alloc() if CONFIG_FAT_DMAMEMORY is defined.

## Impact

This is a bugfix.
Impacts HW that is build with CONFIG_FAT_DMAMEMORY flag
No impact on build
No impact on documentation

## Testing

Tested with custom imx93 hw that uses DMA for mmcsd/fat32


