### PR TITLE
sched/event: move the temporary even_wait variable out of nxevent_tickwait

### DIFF
--- a/Documentation/reference/os/events.rst
+++ b/Documentation/reference/os/events.rst
@@ -116,6 +116,23 @@ Notifier Chain Interfaces
   :param events: Set of events to wait, 0 will indicate wait from any events
   :param eflags: Events flags
 
+
+.. c:function:: nxevent_mask_t nxevent_tickwait_wait(FAR nxevent_t *event, FAR nxevent_wait_t *wait, nxevent_mask_t events, nxevent_flags_t eflags, uint32_t delay);
+
+  Wait for all of the specified events for the specified tick time.
+
+  This routine is functionally identical to nxevent_tickwait, except that the wait object is explicitly provided by the user.
+  In nxevent_tickwait, the wait object is allocated as a temporary variable on the event-wait thread's stack, and the user has no visibility or control over it.
+  Because this object is accessed by both the event-wait thread and the event-post thread, such an arrangement may lead to safety concerns.
+  To address this, the new function allows the user to supply the wait object directly, providing greater control and improving safety.
+
+  :param event: Address of the event object
+  :param wait:  Address of the event wait object
+  :param events: Set of events to wait, 0 will indicate wait from any events
+  :param eflags: Events flags
+  :param delay: Ticks to wait from the start time until the event is posted,
+                If ticks is zero, then this function is equivalent to nxevent_trywait().
+
 .. c:function:: int nxevent_open(FAR nxevent_t **event, FAR const char *name, int oflags, ...)
 
   This function establishes a connection between named event groups and a

--- a/include/nuttx/event.h
+++ b/include/nuttx/event.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/list.h>
+#include <nuttx/semaphore.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -55,8 +56,17 @@
  ****************************************************************************/
 
 typedef struct nxevent_s      nxevent_t;
+typedef struct nxevent_wait_s nxevent_wait_t;
 typedef unsigned long         nxevent_mask_t;
 typedef unsigned long         nxevent_flags_t;
+
+struct nxevent_wait_s
+{
+  struct list_node        node;    /* Wait node of current task */
+  nxevent_mask_t          expect;  /* Expect events of wait task */
+  nxevent_flags_t         eflags;  /* Event flags of wait task */
+  sem_t                   sem;     /* Wait sem of current task */
+};
 
 struct nxevent_s
 {
@@ -205,6 +215,40 @@ int nxevent_post(FAR nxevent_t *event, nxevent_mask_t events,
 
 nxevent_mask_t nxevent_wait(FAR nxevent_t *event, nxevent_mask_t events,
                             nxevent_flags_t eflags);
+
+/****************************************************************************
+ * Name: nxevent_tickwait_wait
+ *
+ * Description:
+ *   Wait for all of the specified events for the specified tick time.
+ *
+ *   This routine waits on event object event until all of the specified
+ *   events have been delivered to the event object, or the maximum wait time
+ *   timeout has expired. A thread may wait on up to 32 distinctly numbered
+ *   events that are expressed as bits in a single 32-bit word.
+ *
+ * Input Parameters:
+ *   event  - Address of the event object
+ *   wait   - Address of the event wait object
+ *   events - Set of events to wait
+ *          - Set events to 0 will indicate wait from any events
+ *   eflags - Events flags
+ *   delay  - Ticks to wait from the start time until the event is
+ *            posted.  If ticks is zero, then this function is equivalent
+ *            to nxevent_trywait().
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   Return of matching events upon success.
+ *   0 if matching events were not received within the specified time.
+ *
+ ****************************************************************************/
+
+nxevent_mask_t nxevent_tickwait_wait(FAR nxevent_t *event,
+                                     FAR nxevent_wait_t *wait,
+                                     nxevent_mask_t events,
+                                     nxevent_flags_t eflags,
+                                     uint32_t delay);
 
 /****************************************************************************
  * Name: nxevent_tickwait

--- a/sched/event/event.h
+++ b/sched/event/event.h
@@ -39,14 +39,4 @@
  * Public Type Definitions
  ****************************************************************************/
 
-typedef struct nxevent_wait_s nxevent_wait_t;
-
-struct nxevent_wait_s
-{
-  struct list_node        node;    /* Wait node of current task */
-  nxevent_mask_t          expect;  /* Expect events of wait task */
-  nxevent_flags_t         eflags;  /* Event flags of wait task */
-  sem_t                   sem;     /* Wait sem of current task */
-};
-
 #endif /* __SCHED_EVENT_EVENT_H */

--- a/sched/event/event_wait.c
+++ b/sched/event/event_wait.c
@@ -33,7 +33,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxevent_tickwait
+ * Name: nxevent_tickwait_wait
  *
  * Description:
  *   Wait for all of the specified events for the specified tick time.
@@ -45,6 +45,7 @@
  *
  * Input Parameters:
  *   event  - Address of the event object
+ *   wait   - Address of the event wait object
  *   events - Set of events to wait
  *          - Set events to 0 will indicate wait from any events
  *   eflags - Events flags
@@ -59,15 +60,18 @@
  *
  ****************************************************************************/
 
-nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
-                                nxevent_flags_t eflags, uint32_t delay)
+nxevent_mask_t nxevent_tickwait_wait(FAR nxevent_t *event,
+                                     FAR nxevent_wait_t *wait,
+                                     nxevent_mask_t events,
+                                     nxevent_flags_t eflags,
+                                     uint32_t delay)
 {
-  nxevent_wait_t wait;
   irqstate_t flags;
   bool waitany;
   int ret;
 
-  DEBUGASSERT(event != NULL && up_interrupt_context() == false);
+  DEBUGASSERT(event != NULL && wait != NULL &&
+              up_interrupt_context() == false);
 
   waitany = ((eflags & NXEVENT_WAIT_ALL) == 0);
 
@@ -117,31 +121,31 @@ nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
     {
       /* Initialize event wait */
 
-      nxsem_init(&wait.sem, 0, 0);
-      wait.expect = events;
-      wait.eflags = eflags;
+      nxsem_init(&(wait->sem), 0, 0);
+      wait->expect = events;
+      wait->eflags = eflags;
 
-      list_add_tail(&event->list, &wait.node);
+      list_add_tail(&event->list, &(wait->node));
 
       /* Wait for the event */
 
       if (delay == UINT32_MAX)
         {
-          ret = nxsem_wait_uninterruptible(&wait.sem);
+          ret = nxsem_wait_uninterruptible(&(wait->sem));
         }
       else
         {
-          ret = nxsem_tickwait_uninterruptible(&wait.sem, delay);
+          ret = nxsem_tickwait_uninterruptible(&(wait->sem), delay);
         }
 
       /* Destroy local variables */
 
-      nxsem_destroy(&wait.sem);
-      list_delete(&wait.node);
+      nxsem_destroy(&(wait->sem));
+      list_delete(&(wait->node));
 
       if (ret == 0)
         {
-          events = wait.expect;
+          events = wait->expect;
         }
       else
         {
@@ -152,6 +156,41 @@ nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
   leave_critical_section(flags);
 
   return events;
+}
+
+/****************************************************************************
+ * Name: nxevent_tickwait
+ *
+ * Description:
+ *   Wait for all of the specified events for the specified tick time.
+ *
+ *   This routine waits on event object event until all of the specified
+ *   events have been delivered to the event object, or the maximum wait time
+ *   timeout has expired. A thread may wait on up to 32 distinctly numbered
+ *   events that are expressed as bits in a single 32-bit word.
+ *
+ * Input Parameters:
+ *   event  - Address of the event object
+ *   events - Set of events to wait
+ *          - Set events to 0 will indicate wait from any events
+ *   eflags - Events flags
+ *   delay  - Ticks to wait from the start time until the event is
+ *            posted.  If ticks is zero, then this function is equivalent
+ *            to nxevent_trywait().
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   Return of matching events upon success.
+ *   0 if matching events were not received within the specified time.
+ *
+ ****************************************************************************/
+
+nxevent_mask_t nxevent_tickwait(FAR nxevent_t *event, nxevent_mask_t events,
+                                nxevent_flags_t eflags, uint32_t delay)
+{
+  nxevent_wait_t wait;
+
+  return nxevent_tickwait_wait(event, &wait, events, eflags, delay);
 }
 
 /****************************************************************************


### PR DESCRIPTION

 There are cases that user do not want the event wait object to be allocated automatically
 in the stack as a temporary variable in nxevent_tickwait, since multiple threads will
 access the variable, they want to allocate the object as a global variable for safety
 control or easy debug. To solve this problem, this patch updated the nvevent_tickwait
 implementaion to give user the chance to  pass the global wait object to it.

  sched/event/event_wait.c:
    add one more nxevent_wait_t *wait param to nvevent_tickwait.
    nxevent_trywait create a temprary wait variable and then pass it to nxevent_wait_t.
    nxevent_wait create a temprary wait variable and then pass it to nxevent_wait_t.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

There are cases that user do not want the event wait object to be allocated automatically
 in the stack as a temporary variable in nxevent_tickwait, since multiple threads will
 access the variable, they want to allocate the object as a global variable for safety
 control or easy debug. To solve this problem, this patch updated the nvevent_tickwait
 implementaion to give user the chance to  pass the global wait object to it.

## Impact

No impact to nuttx's existing function but let event module to be more easily to use

## Testing

ostest will cover the testing of this update


