### PR TITLE
sched/event: give user the explicit control to the wait object

### DIFF
--- a/sched/event/event.h
+++ b/sched/event/event.h
@@ -49,4 +49,57 @@ struct nxevent_wait_s
   sem_t                   sem;     /* Wait sem of current task */
 };
 
+#ifndef __ASSEMBLY__
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxevent_tickwait_core
+ *
+ * Description:
+ *   Core implementation for various nxevent_*wait APIs.
+ *
+ *   This internal function is separated from wrapper APIs to provide
+ *   flexibility in supplying wait object pointers. Avoid using it directly
+ *   unless absolutely necessary. In rare cases where thread stacks are
+ *   strictly isolated, stack-allocated wait objects become inaccessible.
+ *
+ * Input Parameters:
+ *   event     - Address of the event object
+ *   events    - Event set to wait for:
+ *               - 0 indicates waiting for any event
+ *   nxevent_wait_t
+ *             - Per-thread wait object (internal implementation detail)
+ *   eflags    - Event flags
+ *   delay     - Ticks to wait from start time until event posting:
+ *               - 0 ticks behaves identically to nxevent_trywait()
+ *
+ * Returned Value:
+ *   Internal OS interface - not for application use.
+ *   Returns matching event set on success.
+ *   Returns 0 if no matching events occurred within specified time.
+ *
+ ****************************************************************************/
+
+nxevent_mask_t nxevent_tickwait_core(FAR nxevent_t *event,
+                                     nxevent_mask_t events,
+                                     FAR nxevent_wait_t *wait,
+                                     nxevent_flags_t eflags, uint32_t delay);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
 #endif /* __SCHED_EVENT_EVENT_H */


### PR DESCRIPTION
Decouple the API's core logic from the wait object. Let the user provide the wait object, giving them control over its allocation (e.g., heap, stack, or global) and lifetime.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The current API automatically allocates the wait object on the stack, which is incompatible with scenarios where thread stack access is restricted by memory protection mechanisms.
Hence, This change refactors the API to:
- Decouple the core implementation from the wait object management.
- Allow the user to provide the wait object, giving them full control over its allocation strategy (heap, stack, or static) and lifetime.

## Impact

**No Breaking Changes**: The original public API remains unchanged for backward compatibility.
**New API Added**: A interface is introduced for users requiring explicit control over wait object allocation. The legacy functions are now implemented as wrappers around this new core logic.

## Testing

Using the nuttx test suite.