### PR TITLE
tools/checkpatch.sh: check format for all commits in patch

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -334,15 +334,23 @@ check_msg() {
   fi
 
   if (( $num_lines < $min_num_lines && $signedoffby_found == 1 )); then
-      echo "Missing git commit message."
-      fail=1
+    echo "Missing git commit message"
+    fail=1
   fi
 }
 
 check_commit() {
   if [ $message != 0 ]; then
-    msg=`git show -s --format=%B $1`
-    check_msg <<< "$msg"
+    # check each commit format separately if this is a series of commits
+    if [[ $1 =~  HEAD ]]; then
+      for commit in $(git rev-list --no-merges $1); do
+        msg=`git show -s --format=%B $commit`
+        check_msg <<< "$msg"
+      done
+    else
+      msg=`git show -s --format=%B $1`
+      check_msg <<< "$msg"
+    fi
   fi
   diffs=`git diff $1`
   check_ranges <<< "$diffs"


### PR DESCRIPTION
## Summary

If more than one commit is present in the patch, the commit format must be checked separately for each commit in patch, otherwise not all errors are detected.

## Impact

fix commit format for more than one commit in patch

## Testing

chechpatch.sh used locally and on a nuttx fork on gh: https://github.com/raiden00pl/nuttx/actions/runs/17376518911/job/49323943086?pr=45#step:3:81

