### PR TITLE
arch/tricore: fix tricore_doirq function local var "regs" not initialized issue

### DIFF
--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -55,13 +55,13 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
   Ifx_CPU_ICR icr;
   uintptr_t *regs;
 
+  icr.U = __mfcr(CPU_ICR);
+  regs = (uintptr_t *)__mfcr(CPU_PCXI);
+
   if (*running_task != NULL)
     {
       (*running_task)->xcp.regs = regs;
     }
-
-  icr.U = __mfcr(CPU_ICR);
-  regs = (uintptr_t *)__mfcr(CPU_PCXI);
 
   board_autoled_on(LED_INIRQ);
 


### PR DESCRIPTION
 In tricore_doirq, local variable regs is firstly used without initiazlied, this is a bug

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

 In tricore_doirq, local variable regs is firstly used without initiazlied, this is a bug

```
  uintptr_t *regs;

  if (*running_task != NULL)
    {
      (*running_task)->xcp.regs = regs;
    }

```

## Impact

Only fix the bug in arch tricore porting, no impact to other parts

## Testing

**ostest pass:**

<img width="586" height="546" alt="image" src="https://github.com/user-attachments/assets/68737dc3-9656-4e43-b55d-18e87bb1de72" />

