### PR TITLE
codespellrc: add ans to ignore words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -21,6 +21,7 @@ ignore-words-list =
   afile,
   als,
   ameba,
+  ans,
   ARCHTYPE,
   BU,
   DAA,


### PR DESCRIPTION


## Summary
- codespellrc: add ans to ignore words
ans is short for "Alert Notification Service" used in NimBLE.

## Impact

fix CI error: https://github.com/apache/nuttx-apps/actions/runs/17407545043/job/49415895823?pr=3172

## Testing

CI


