### PR TITLE
tools/checkpatch.sh: fix check for HEAD commit

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -342,7 +342,7 @@ check_msg() {
 check_commit() {
   if [ $message != 0 ]; then
     # check each commit format separately if this is a series of commits
-    if [[ $1 =~  HEAD ]]; then
+    if [[ $1 =~  ..HEAD ]]; then
       for commit in $(git rev-list --no-merges $1); do
         msg=`git show -s --format=%B $commit`
         check_msg <<< "$msg"


### PR DESCRIPTION
## Summary

tools/checkpatch.sh: fix check for HEAD commit:
  `./tools/checkpatch.sh -c -u -m -g HEAD`

In this case, only the last commission needs to be checked.

regression after 93911d52a8db7a8ec283d2b8e386a00a0ccdde09

## Impact

fix regression

## Testing
only the latest commit is checked when we pass HEAD as an argument, which is the correct behavior:
```
$ ./tools/checkpatch.sh -c -u -m -g HEAD                                                                                                                                                                                            
All checks pass.
```
