### PR TITLE
Revert "codespellrc: add ans to ignore words"

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -21,7 +21,6 @@ ignore-words-list =
   afile,
   als,
   ameba,
-  ans,
   ARCHTYPE,
   BU,
   DAA,


### PR DESCRIPTION
Reverts apache/nuttx#16966

The correct solution is here: https://github.com/apache/nuttx-apps/pull/3172/commits/09df4c554397a9a0590ce7df3187884d9e4952fb

Codespell configuration should be per-repository. Sorry for the mess.