### PR TITLE
tools/configure.sh: align tools/configure.sh with CmakeLists.txt

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -242,7 +242,8 @@ echo "  Copy files"
 ln -sf ${src_makedefs} ${dest_makedefs} || \
   { echo "Failed to symlink ${src_makedefs}" ; exit 8 ; }
 ${TOPDIR}/tools/process_config.sh -I ${configpath}/../../common/configs \
-  -I ${configpath}/../common -I ${configpath} -o ${dest_config} ${src_config}
+  -I ${configpath}/../common -I ${configpath} -I ${TOPDIR}/../apps -I ${TOPDIR}/../nuttx-apps \
+  -o ${dest_config} ${src_config}
 install -m 644 ${src_config} "${backup_config}" || \
   { echo "Failed to backup ${src_config}" ; exit 10 ; }
 


### PR DESCRIPTION
 Add include patch to configure.sh when processing deconfig file to keep alignment with
 CmakeLists.txt

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Align tools/configure.sh with  CmakeLists.txt when processing the defconfig

## Impact

Built scripts update, improving processing of defconfig,  no impact to other parts

## Testing

N/A


