### PR TITLE
sched/printk: add nxprintk() to support syncronous printf function for kernel debug

### DIFF
--- a/include/nuttx/printk.h
+++ b/include/nuttx/printk.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ * include/nuttx/printk.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_PRINTK_H
+#define __INCLUDE_NUTTX_PRINTK_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxprintk
+ *
+ * Description:
+ *   This routine provides low-level, internal formatted output similar to
+ *   printf().  The output is sent to the system console using up_putc().
+ *
+ * Input Parameters:
+ *   fmt - The printf-style format string
+ *   ... - The variable argument list providing values referenced in fmt
+ *
+ * Returned Value:
+ *   This is an internal OS interface, not available to applications.
+ *   The return value is the number of characters actually printed.
+ *
+ ****************************************************************************/
+
+int nxprintk(const char *fmt, ...);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __INCLUDE_NUTTX_EVENT_H */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -2034,3 +2034,17 @@ config CUSTOM_SEMAPHORE_MAXVALUE
 	---help---
 		Enable to support custom max value for semaphores.
 		When this option is enabled, the max value of a semaphore can be set
+
+config SCHED_HAVE_PRINTK
+	bool "Support nxprink() function"
+	default y
+	---help---
+		Enable to support nxprintk() function as synchronous printing function
+
+if SCHED_HAVE_PRINTK
+config PRINTK_BUFFER_MAXLEN
+	int "Maximum allowed buffer length for a single printk call"
+	default 64
+	---help---
+		Define maximum allowed buffer length for a single printk call
+endif #SCHED_HAVE_PRINTK

--- a/sched/printk/CMakeLists.txt
+++ b/sched/printk/CMakeLists.txt
@@ -1,0 +1,29 @@
+# ##############################################################################
+# sched/printk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# Add printk-related files to the build
+set(CSRCS)
+if(CONFIG_SCHED_HAVE_PRINTK)
+  list(APPEND CSRCS printk.c)
+endif()
+
+target_sources(sched PRIVATE ${CSRCS})

--- a/sched/printk/Make.defs
+++ b/sched/printk/Make.defs
@@ -1,0 +1,32 @@
+############################################################################
+# sched/printk/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Add printk-related files to the build
+
+ifeq ($(CONFIG_SCHED_HAVE_PRINTK),y)
+  CSRCS += printk.c
+endif
+
+# Include printk build support
+
+DEPPATH += --dep-path printk
+VPATH += :printk

--- a/sched/printk/printk.c
+++ b/sched/printk/printk.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * sched/printk/printk.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "printk.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxprintk
+ *
+ * Description:
+ *   This routine provides low-level, internal formatted output similar to
+ *   printf().  The output is sent to the system console using up_putc().
+ *
+ * Input Parameters:
+ *   fmt - The printf-style format string
+ *   ... - The variable argument list providing values referenced in fmt
+ *
+ * Returned Value:
+ *   This is an internal OS interface, not available to applications.
+ *   The return value is the number of characters actually printed.
+ *
+ ****************************************************************************/
+
+int nxprintk(const char *fmt, ...)
+{
+  va_list ap;
+  char buf[CONFIG_PRINTK_BUFFER_MAXLEN];
+  int len;
+  char *p;
+
+  va_start(ap, fmt);
+  len = vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+
+  if (len < 0)
+    {
+      return 0;
+    }
+
+  if (len >= sizeof(buf))
+    {
+      len = sizeof(buf) - 1;
+    }
+
+  for (p = buf; *p; p++)
+    {
+      if (*p == '\n')
+        {
+          up_putc('\r');
+        }
+
+      up_putc(*p);
+    }
+
+  return len;
+}

--- a/sched/printk/printk.h
+++ b/sched/printk/printk.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * sched/printk/printk.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __SCHED_PRINTK_PRINTK_H
+#define __SCHED_PRINTK_PRINTK_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include <nuttx/printk.h>
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+#endif /* __SCHED_PRINTK_PRINTK_H */


### PR DESCRIPTION
   The syncronous printf function is needed in some cases
   during kernel debug, so provide nxprintk() here。

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Provide a new function nxprintk() for syncronous printf function intended to be used for kernel debug. 

## Impact

Provide a new function, no impact to any other nuttx parts.

## Testing

N/A.
