### PR TITLE
documentation: update NTP and NTPC documentation

### DIFF
--- a/Documentation/applications/netutils/ntpclient/index.rst
+++ b/Documentation/applications/netutils/ntpclient/index.rst
@@ -2,5 +2,174 @@
 ``ntpclient`` NTP client
 ========================
 
-This is a fragmentary NTP client. It neither well-tested nor
-mature nor complete at this point in time.
+The NTP (Network Time Protocol) client is a network utility that synchronizes
+the system clock with time servers over the Internet. This implementation
+provides a minimal but functional NTP client for NuttX.
+
+What is NTP?
+============
+
+The Network Time Protocol (NTP) is a networking protocol designed to
+synchronize clocks of computer systems over packet-switched, variable-latency
+data networks. NTP is one of the oldest Internet protocols still in use,
+originally designed by David L. Mills of the University of Delaware.
+
+Key features of NTP:
+
+- **High Precision**: NTP can achieve sub-millisecond accuracy on local area
+  networks and typically 10-100 millisecond accuracy over the Internet
+- **Robust Algorithm**: Uses sophisticated algorithms to filter out network
+  jitter and select the best time sources
+- **Hierarchical Structure**: Uses a stratum system where stratum 0 devices
+  are atomic clocks, stratum 1 servers sync with stratum 0, and so on
+- **Fault Tolerance**: Can handle multiple time sources and automatically
+  switch between them
+
+NTP Protocol Overview
+=====================
+
+NTP uses UDP port 123 and follows a client-server model. The protocol
+exchanges timestamps to calculate:
+
+- **Offset**: The difference between the client's clock and the server's clock
+- **Delay**: The round-trip network delay
+- **Dispersion**: The maximum error due to clock frequency tolerance
+
+The NTP packet format (version 3) includes:
+
+- **Leap Indicator**: Warns of an impending leap second
+- **Version Number**: NTP version (3 in this implementation)
+- **Mode**: Client, server, broadcast, etc.
+- **Stratum**: Clock level (0-15)
+- **Poll Interval**: Maximum interval between successive messages
+- **Precision**: Clock precision
+- **Root Delay/Dispersion**: Total delay and dispersion to the reference clock
+- **Reference Identifier**: Identifies the reference source
+- **Reference Timestamp**: Time when the system clock was last set
+- **Originate Timestamp**: Time when the request departed the client
+- **Receive Timestamp**: Time when the request arrived at the server
+- **Transmit Timestamp**: Time when the reply departed the server
+
+Implementation Details
+======================
+
+The NuttX NTP client implementation consists of several key components:
+
+Source Code Structure
+---------------------
+
+**ntpclient.c** - Main implementation file containing:
+
+- **Daemon Management**: Functions to start, stop, and manage the NTP daemon
+- **Time Synchronization**: Core algorithms for calculating clock offset and delay
+- **Network Communication**: UDP socket handling and NTP packet exchange
+- **Sample Collection**: Gathering multiple time samples for statistical filtering
+
+**ntpv3.h** - NTP version 3 packet format definitions:
+
+- **ntp_datagram_s**: Complete NTP packet structure
+- **ntp_timestamp_s**: 64-bit NTP timestamp format
+- **Protocol Constants**: NTP version, modes, and stratum definitions
+
+Key Functions
+-------------
+
+- **ntpc_start_with_list()**: Starts the NTP daemon with a list of servers
+- **ntpc_start()**: Starts the NTP daemon with default configuration
+- **ntpc_stop()**: Stops the running NTP daemon
+- **ntpc_status()**: Retrieves current synchronization status and samples
+- **ntpc_daemon()**: Main daemon loop that:
+
+  - Connects to configured NTP servers
+  - Sends NTP requests and processes responses
+  - Calculates clock offset and delay
+  - Applies time corrections to the system clock
+  - Continues polling at configured intervals
+
+- **ntpc_get_ntp_sample()**: Performs a single NTP transaction:
+
+  - Creates UDP socket to NTP server
+  - Sends NTP request packet with current timestamp
+  - Receives and validates NTP response
+  - Calculates offset and delay using NTP algorithms
+
+- **ntpc_calculate_offset()**: Implements the NTP clock filter algorithm
+
+  - Uses four timestamps, calculates offset and delay
+  - Applies statistical filtering to reduce jitter
+
+- **ntpc_settime()**: Applies time correction to system clock:
+
+  - Uses calculated offset to adjust system time
+  - Handles both positive and negative time adjustments
+  - Maintains monotonic clock consistency
+
+Configuration Options
+=====================
+
+The NTP client can be configured through Kconfig options:
+
+- **CONFIG_NETUTILS_NTPCLIENT_SERVER**: List of NTP server hostnames
+- **CONFIG_NETUTILS_NTPCLIENT_PORTNO**: NTP server port (default: 123)
+- **CONFIG_NETUTILS_NTPCLIENT_STACKSIZE**: Daemon task stack size
+- **CONFIG_NETUTILS_NTPCLIENT_SERVERPRIO**: Daemon task priority
+- **CONFIG_NETUTILS_NTPCLIENT_STAY_ON**: Keep polling continuously
+- **CONFIG_NETUTILS_NTPCLIENT_POLLDELAYSEC**: Polling interval in seconds
+- **CONFIG_NETUTILS_NTPCLIENT_NUM_SAMPLES**: Number of samples for filtering
+- **CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS**: Network timeout in milliseconds
+
+Usage
+=====
+
+The NTP client is typically used through the system commands:
+
+.. note:: The NTP client functionality requires enabling the :code:`SYSTEM_NTPC` option in your configuration.
+    Make sure to select this option in menuconfig or your Kconfig fragment before building.
+
+- **ntpcstart**: Start the NTP daemon
+- **ntpcstop**: Stop the NTP daemon
+- **ntpcstatus**: Display synchronization status
+
+Example workflow:
+
+1. Configure network connectivity
+2. Start NTP client: ``ntpcstart``
+3. Check status: ``ntpcstatus``
+4. Verify time: ``date`` command
+5. Stop when needed: ``ntpcstop``
+
+The client will automatically:
+- Connect to configured NTP servers
+- Exchange time information
+- Calculate and apply clock corrections
+- Continue periodic synchronization
+
+Limitations
+===========
+
+This is a minimal NTP client implementation with some limitations:
+
+- **No Authentication**: Does not support NTP authentication (MD5/SHA1)
+- **Basic Filtering**: Uses simple statistical filtering, not full NTP algorithms
+- **Single Reference**: Does not implement full NTP reference clock selection
+- **No Leap Seconds**: Does not handle leap second announcements
+- **Limited Error Handling**: Basic error recovery and retry mechanisms
+
+Despite these limitations, the implementation provides sufficient accuracy
+for most embedded applications requiring network time synchronization.
+
+Dependencies
+============
+
+The NTP client requires:
+
+- **CONFIG_NET**: Network support
+- **CONFIG_NET_UDP**: UDP protocol support
+- **CONFIG_NET_SOCKOPTS**: Socket options support
+- **CONFIG_LIBC_NETDB**: DNS resolution (recommended)
+- **CONFIG_HAVE_LONG_LONG**: 64-bit integer support
+
+For best results, ensure:
+- Stable network connectivity
+- Access to reliable NTP servers
+- Sufficient system resources for daemon operation

--- a/Documentation/applications/system/ntpc/index.rst
+++ b/Documentation/applications/system/ntpc/index.rst
@@ -1,3 +1,106 @@
 ============================
 ``ntpc`` NTP Daemon Commands
 ============================
+
+This example demonstrates how to use the NTP client to synchronize system time
+and retrieve the current time and date. It uses the Network Time Protocol (NTP)
+to provide accurate time synchronization.
+
+Description
+-----------
+
+The ntpc example:
+
+- Uses the NTP client library to synchronize system time
+
+- Connects to NTP servers (default: pool.ntp.org)
+
+- Starts the NTP client in the background for continuous synchronization
+
+- Provides commands to check status and stop the NTP client
+
+- Allows management of the NTP client through command line options
+
+Note: This example assumes that network connectivity is already established.
+
+The NTP (Network Time Protocol) is a sophisticated protocol that provides
+high-precision time synchronization and is the standard for network time services.
+
+Configuration
+-------------
+
+This example requires the following NuttX configuration options:
+
+- CONFIG_NET: Enable networking support
+- CONFIG_NET_UDP: Enable UDP support
+- CONFIG_NETUTILS_NTPCLIENT: Enable NTP client support
+- CONFIG_SYSTEM_NTPC: Enable this example
+
+Additional configuration options:
+- CONFIG_NETUTILS_NTPCLIENT_SERVER: NTP server hostname (default: "pool.ntp.org")
+
+Usage
+-----
+
+1. Configure your NuttX build with networking support
+2. Ensure network connectivity is established (e.g., via NSH network commands)
+3. Build and flash the image to your target board
+4. Run the commands:
+   - ``ntpcstart``, ``ntpcstop``, ``ntpcstatus``
+
+**Available Commands:**
+
+- ``ntpcstart`` - Start NTP client in background
+
+- ``ntpcstop`` - Stop the NTP client
+
+- ``ntpcstatus`` - Display NTP client status information
+
+Expected Output
+---------------
+
+**Start NTP client (ntpcstart):**
+::
+
+   Starting NTP client...
+   Using NTP servers: pool.ntp.org
+   NTP client started successfully (task ID: 123)
+   NTP client is now running in the background
+
+**Stop NTP client (ntpcstop):**
+::
+
+   Stopping NTP client...
+   Stopped the NTP daemon
+
+**Show NTP status (ntpcstatus):**
+::
+
+    The number of last samples: 3
+    [0] srv <ip> offset -0.033502142 delay 0.249973549
+    [1] srv <ip> offset -0.020698070 delay 0.029928000
+    [2] srv <ip> offset -0.015448935 delay 0.019815119
+
+**Verify using date command:**
+
+Given network connectivity is available, executing `date` should
+give the proper time and date.
+::
+
+    nsh> ntpcstart
+    Starting NTP client...
+    Using NTP servers: 0.pool.ntp.org;1.pool.ntp.org;2.pool.ntp.org
+    NTP client started successfully (task ID: 10)
+    NTP client is now running in the background
+    nsh> date
+    Fri, Sep 05 18:49:37 2025
+
+Notes
+-----
+
+- This example requires internet connectivity
+- Network must be configured and connected before running this example
+- NTP servers must be accessible (default: pool.ntp.org)
+- UDP port 123 (NTP) must not be blocked by firewalls
+- The example includes error handling for network failures
+- NTP provides more accurate time synchronization than simple time protocols


### PR DESCRIPTION
## Summary

This PR adds documentation for NTP client and daemon which did not exist.

Relates to this [PR](https://github.com/apache/nuttx-apps/pull/3173) on nuttx-apps.

## Impact

- User: No.
- Build: No.
- Documentation: Yes.
- Hardware: No.
- Compatibility: No.

## Testing

NTP is working just fine. Documentation was build successfully locally using `make html`.

Here's some test output:
```
nsh> ifconfig
wlan0	Link encap:Ethernet HWaddr 58:cf:79:07:51:e8 at RUNNING mtu 1500
	inet addr:192.168.0.30 DRaddr:192.168.0.1 Mask:255.255.255.0

nsh> ntpcstart
Starting NTP client...
Using NTP servers: 0.pool.ntp.org;1.pool.ntp.org;2.pool.ntp.org
NTP client started successfully (task ID: 10)
NTP client is now running in the background
nsh> date
Fri, Sep 05 18:49:37 2025
nsh> ntpcstop
Stopping NTP client...
Stopped the NTP daemon
```