### PR TITLE
arch/tricore: remove redundant and misleading pointer usage in tricore_doirq()

### DIFF
--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -46,7 +46,7 @@
 
 IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 {
-  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+  struct tcb_s *running_task = g_running_tasks[this_cpu()];
   struct tcb_s *tcb;
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -58,9 +58,9 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
   icr.U = __mfcr(CPU_ICR);
   regs = (uintptr_t *)__mfcr(CPU_PCXI);
 
-  if (*running_task != NULL)
+  if (running_task != NULL)
     {
-      (*running_task)->xcp.regs = regs;
+      running_task->xcp.regs = regs;
     }
 
   board_autoled_on(LED_INIRQ);
@@ -117,11 +117,11 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   up_set_current_regs(NULL);
 
-  /* (*running_task)->xcp.regs is about to become invalid
+  /* running_task->xcp.regs is about to become invalid
    * and will be marked as NULL to avoid misusage.
    */
 
-  (*running_task)->xcp.regs = NULL;
+  running_task->xcp.regs = NULL;
   board_autoled_off(LED_INIRQ);
 #endif
 }


### PR DESCRIPTION
 `struct tcb_s **running_task = &g_running_tasks[this_cpu()];`

  was updated to

 `struct tcb_s *running_task = g_running_tasks[this_cpu()];`

```
  if (*running_task != NULL)
    {
     ( *running_task)->xcp.regs = regs;
    }
```

was updated to

```
  if (running_task != NULL)
    {
      running_task->xcp.regs = regs;
    }
```

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Remove redundant and misleading pointer usage in tricore_doirq()

## Impact

Fix typo issue in arch tricore implementation, no impact to other nuttx parts

## Testing

**a2g-tc397-5v-tft board ostest passed**

<img width="586" height="571" alt="image" src="https://github.com/user-attachments/assets/f6dca4d2-773e-40da-aee1-03e09f73e313" />


