### PR TITLE
drivers/syslog: let syslog_write() return the maximum bytes writen through a channel

### DIFF
--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -104,6 +104,7 @@ ssize_t syslog_write_foreach(FAR const char *buffer,
   syslog_write_t write;
   syslog_putc_t  putc;
   size_t nwritten = 0;
+  size_t nwritten_max = 0;
   ssize_t ret;
   int i;
 
@@ -205,9 +206,19 @@ ssize_t syslog_write_foreach(FAR const char *buffer,
             }
 #endif
         }
+
+      /* Instead of returning the number of bytes
+       * written to the last channel, returns the maximum
+       * number of bytes written to any existing channel.
+       */
+
+      if (nwritten > nwritten_max)
+        {
+          nwritten_max = nwritten;
+        }
     }
 
-  return nwritten;
+  return nwritten_max;
 }
 
 /****************************************************************************


### PR DESCRIPTION
 In current implementation, when do syslog_write(), there may
 be more than one channel, the syslog will iterate each channel,
 but only return the bytes writen through the last channel, the
 better way should be returning the maximum bytes writen
 through one channel.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Let syslog_write() return the maximum bytes writen through a channel, when have multiple syslog channels

## Impact

Fix syslog_write() return value issue when there are multiple syslog channels

## Testing

**defconfig for fvp-armv8r-aarch32 board**

<img width="718" height="956" alt="image" src="https://github.com/user-attachments/assets/2796f550-49c4-4880-b223-6f9292423e5a" />


**ostest passed**

<img width="1509" height="960" alt="image" src="https://github.com/user-attachments/assets/d72da675-7c39-4b1d-a263-45e2c4cfd185" />

