### PR TITLE
docs/pr-template: Update the testing section of the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,21 @@
 
 ## Testing
 
-*Update this section with details on how did you verify the change,
- what Host was used for build (OS, CPU, compiler, ..), what Target was
- used for verification (arch, board:config, ..), etc. Providing build
- and runtime logs from before and after change is highly appreciated.*
+*This section should provide a detailed description of what you did
+to verify your changes work and do not break existing code.*
 
+*Please provide information about your host machine, the board(s) you
+tested your changes on, and how you tested. Logs should be included.*
 
+*For example, when changing something in the core OS functions, you
+may want to run the OSTest application to verify that there are no
+regressions. Changes to ADC code may warrant running the `adc`
+example. Adding a new uORB driver may require that you run
+`uorb_listener` to verify correct operation.*
+
+*Pure documentation changes can just be tested with `make html`
+(see docs) and verification of the correct format in your
+browser.*
+
+**_PRs without testing information will not be accepted. We will
+request test logs._**


### PR DESCRIPTION
## Summary

This commit updates the pull request template that is auto-populated when GitHub PRs are made. The testing section now includes more detail on what is considered an acceptable level of testing information and a warning that PRs with insufficient testing information will not be accepted.

This comes after witnessing a large number of PRs with either no testing information or testing information that simply says some variation of "tested on `x` board".

## Impact

Ideally this should encourage contributors to provide more detailed testing information in their PRs.

## Testing

Ironically, this PR does not have testing associated with it. I know that GitHub will populate the PR template from this file.