### PR TITLE
arch/tricore: remove duplicated local variable in tricore_doirq()

### DIFF
--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -47,7 +47,6 @@
 IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 {
   struct tcb_s *running_task = g_running_tasks[this_cpu()];
-  struct tcb_s *tcb;
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -88,7 +87,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   if (regs != up_current_regs())
     {
-      tcb = this_task();
+      running_task = this_task();
 
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -105,7 +104,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      g_running_tasks[this_cpu()] = running_task;
 
       __mtcr(CPU_PCXI, (uintptr_t)up_current_regs());
       __isync();


### PR DESCRIPTION
  remove duplicated tcb local variable in tricore_doirq()

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

remove the duplicated tcb local variable defined in tricore_doirq()

## Impact

improve  the tricore/arch implementation, no impact to other parts

## Testing

**a2g-tc397-5v-tft tricore board ostest pass**

<img width="636" height="852" alt="image" src="https://github.com/user-attachments/assets/345ba7cb-1470-4e8d-8695-cc54379b3f23" />

