### PR TITLE
arch/sim/can: add loopback support for CAN character dev

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostcan.c
+++ b/arch/sim/src/sim/posix/sim_hostcan.c
@@ -184,3 +184,35 @@ bool host_can_avail(struct sim_can_s *can)
 
   return select(can->fd + 1, &fdset, NULL, NULL, &tv) > 0;
 }
+
+/****************************************************************************
+ * Name: host_can_loopback
+ ****************************************************************************/
+
+int host_can_loopback(struct sim_can_s *can, bool enable)
+{
+  int ret;
+  int tmp;
+
+  /* Receive own messages */
+
+  tmp = 1;
+  ret = setsockopt(can->fd, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS,
+                   &tmp, sizeof(tmp));
+  if (ret < 0)
+    {
+      return -errno;
+    }
+
+  /* Set loopback mode */
+
+  tmp = 1;
+  ret = setsockopt(can->fd, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &tmp,
+                   sizeof(tmp));
+  if (ret < 0)
+    {
+      return -errno;
+    }
+
+  return 0;
+}

--- a/arch/sim/src/sim/sim_canchar.c
+++ b/arch/sim/src/sim/sim_canchar.c
@@ -361,9 +361,17 @@ int sim_canchar_initialize(int devidx, int devno)
   if (ret < 0)
     {
       canerr("host_can_init failed %d\n", ret);
-      kmm_free(priv);
-      return ret;
+      goto errout;
     }
+
+#ifdef CONFIG_CAN_LOOPBACK
+  ret = host_can_loopback(&priv->host, true);
+  if (ret < 0)
+    {
+      canerr("host_can_loopback failed %d\n", ret);
+      goto errout;
+    }
+#endif
 
   /* Initialzie CAN character driver */
 
@@ -377,9 +385,12 @@ int sim_canchar_initialize(int devidx, int devno)
   if (ret < 0)
     {
       canerr("can_register failed %d\n", ret);
-      kmm_free(priv);
-      return ret;
+      goto errout;
     }
 
   return OK;
+
+errout:
+  kmm_free(priv);
+  return ret;
 }

--- a/arch/sim/src/sim/sim_hostcan.h
+++ b/arch/sim/src/sim/sim_hostcan.h
@@ -62,5 +62,6 @@ int host_can_send(struct sim_can_s *can, void *frame, size_t len);
 int host_can_ifup(struct sim_can_s *can);
 int host_can_ifdown(struct sim_can_s *can);
 bool host_can_avail(struct sim_can_s *can);
+int host_can_loopback(struct sim_can_s *can, bool enable);
 
 #endif /* __ARCH_SIM_SRC_SIM_CAN_H */


### PR DESCRIPTION
## Summary
arch/sim/can: add loopback support for CAN character dev

## Impact

new feature

## Testing

examples/can with loopback mode enabled on SIM:

```
NuttShell (NSH) NuttX-12.10.0
nsh> can
nmsgs: 0
min ID: 1 max ID: 536870911
Bit timing not available: 25
  ID:    1 DLC: 1
  ID:    1 DLC: 1
  ID:    1 DLC: 1 -- OK
  ID:    2 DLC: 2
  ID:    2 DLC: 2
  ID:    2 DLC: 2 -- OK
  ID:    3 DLC: 3
  ID:    3 DLC: 3
  ID:    3 DLC: 3 -- OK
  ID:    4 DLC: 4
  ID:    4 DLC: 4
  ID:    4 DLC: 4 -- OK
  ID:    5 DLC: 5
  ID:    5 DLC: 5
  ID:    5 DLC: 5 -- OK
  ID:    6 DLC: 6
  ID:    6 DLC: 6
  ID:    6 DLC: 6 -- OK
  ID:    7 DLC: 7
  ID:    7 DLC: 7
  ID:    7 DLC: 7 -- OK
  ID:    8 DLC: 8
  ID:    8 DLC: 8
  ID:    8 DLC: 8 -- OK
  ID:    9 DLC: 9
  ID:    9 DLC: 9
  ID:    9 DLC: 9 -- OK

```


