### PR TITLE
arch/sim/sim_canchar.c: fix CAN flags decoding for message

### DIFF
--- a/arch/sim/src/sim/sim_canchar.c
+++ b/arch/sim/src/sim/sim_canchar.c
@@ -307,17 +307,17 @@ static void sim_can_work(void *arg)
 
       hdr.ch_id    = frame.can_id & CAN_ERR_MASK;
       hdr.ch_dlc   = can_bytes2dlc(frame.len);
-      hdr.ch_rtr   = frame.can_id & CAN_RTR_FLAG;
+      hdr.ch_rtr   = (bool)(frame.can_id & CAN_RTR_FLAG);
 #ifdef CONFIG_CAN_ERRORS
-      hdr.ch_error = frame.can_id & CAN_ERR_FLAG;
+      hdr.ch_error = (bool)(frame.can_id & CAN_ERR_FLAG);
 #endif
 #ifdef CONFIG_CAN_EXTID
-      hdr.ch_extid = frame.can_id & CAN_EFF_FLAG;
+      hdr.ch_extid = (bool)(frame.can_id & CAN_EFF_FLAG);
 #endif
 #ifdef CONFIG_CAN_FD
-      hdr.ch_edl   = frame.flags & CANFD_FDF;
-      hdr.ch_brs   = frame.flags & CANFD_BRS;
-      hdr.ch_esi   = frame.flags & CANFD_ESI;
+      hdr.ch_edl   = (bool)(frame.flags & CANFD_FDF);
+      hdr.ch_brs   = (bool)(frame.flags & CANFD_BRS);
+      hdr.ch_esi   = (bool)(frame.flags & CANFD_ESI);
 #endif
       hdr.ch_tcf   = 0;
 #ifdef CONFIG_CAN_TIMESTAMP


### PR DESCRIPTION
## Summary
arch/sim/sim_canchar.c: fix CAN flags decoding for message

## Impact
fix broken logic

## Testing

examples/can with loopback mode enabled on SIM:

```
NuttShell (NSH) NuttX-12.10.0
nsh> can
nmsgs: 0
min ID: 1 max ID: 536870911
Bit timing not available: 25
  ID:    1 DLC: 1
  ID:    1 DLC: 1
  ID:    1 DLC: 1 -- OK
  ID:    2 DLC: 2
  ID:    2 DLC: 2
  ID:    2 DLC: 2 -- OK
  ID:    3 DLC: 3
  ID:    3 DLC: 3
  ID:    3 DLC: 3 -- OK
  ID:    4 DLC: 4
  ID:    4 DLC: 4
  ID:    4 DLC: 4 -- OK
  ID:    5 DLC: 5
  ID:    5 DLC: 5
  ID:    5 DLC: 5 -- OK
  ID:    6 DLC: 6
  ID:    6 DLC: 6
  ID:    6 DLC: 6 -- OK
  ID:    7 DLC: 7
  ID:    7 DLC: 7
  ID:    7 DLC: 7 -- OK
  ID:    8 DLC: 8
  ID:    8 DLC: 8
  ID:    8 DLC: 8 -- OK
  ID:    9 DLC: 9
  ID:    9 DLC: 9
  ID:    9 DLC: 9 -- OK

```


