### PR TITLE
boards/arm/imxrt: CMake added teensy-4.x board

### DIFF
--- a/boards/arm/imxrt/teensy-4.x/CMakeLists.txt
+++ b/boards/arm/imxrt/teensy-4.x/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/imxrt/teensy-4.x/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+if(NOT CONFIG_BUILD_FLAT)
+  add_subdirectory(kernel)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT_USER ${CMAKE_CURRENT_LIST_DIR}/scripts/memory.ld
+                    ${CMAKE_CURRENT_LIST_DIR}/scripts/user-space.ld)
+endif()

--- a/boards/arm/imxrt/teensy-4.x/src/CMakeLists.txt
+++ b/boards/arm/imxrt/teensy-4.x/src/CMakeLists.txt
@@ -1,0 +1,84 @@
+# ##############################################################################
+# boards/arm/imxrt/teensy-4.x/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS imxrt_boot.c imxrt_flexspi_nor_boot.c imxrt_flexspi_nor_flash.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS imxrt_appinit.c imxrt_bringup.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS imxrt_bringup.c)
+endif()
+
+if(CONFIG_BOARDCTL_RESET)
+  list(APPEND SRCS imxrt_reset.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS imxrt_autoleds.c)
+else()
+  list(APPEND SRCS imxrt_userleds.c)
+endif()
+
+if(CONFIG_IMXRT_LPSPI)
+  list(APPEND SRCS imxrt_spi.c)
+endif()
+
+if(CONFIG_IMXRT_LPI2C)
+  list(APPEND SRCS imxrt_i2c.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXCAN)
+  list(APPEND SRCS imxrt_flexcan.c)
+endif()
+
+if(CONFIG_IMXRT_FLEXPWM)
+  list(APPEND SRCS imxrt_flexpwm.c)
+endif()
+
+if(CONFIG_IMXRT_ENET)
+  list(APPEND SRCS imxrt_ethernet.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS imxrt_gpio.c)
+endif()
+
+if(CONFIG_IMXRT_ADC)
+  list(APPEND SRCS imxrt_adc.c)
+endif()
+
+if(CONFIG_LCD_ST7789)
+  list(APPEND SRCS imxrt_st7789.c)
+endif()
+
+if(CONFIG_IMXRT_ENC)
+  list(APPEND SRCS imxrt_enc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_BOOT_RUNFROMFLASH)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+elseif(CONFIG_BOOT_RUNFROMISRAM)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/flash-ocram.ld")
+endif()


### PR DESCRIPTION
## Summary

Added CMake build for teensy-4.x board

## Impact

Impact on user: This PR adds the teensy-4.x board with CMake build.

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally

teensy-4.x

```
D:\nuttximxrt\nuttx>cmake -B build -DBOARD_CONFIG=teensy-4.x:nsh-4.1 -GNinja
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  teensy-4.x
--   Config: nsh-4.1
--   Appdir: D:/nuttximxrt/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (7.6s)
-- Generating done (1.8s)
-- Build files have been written to: D:/nuttximxrt/nuttx/build

D:\nuttximxrt\nuttx>cmake --build build
[28/1111] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_start.c.obj
In file included from D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.h:39,
                 from D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_start.c:45:
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_config.h:166:6: warning: #warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting" [-Wcpp]
  166 | #    warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting"
      |      ^~~~~~~
[34/1111] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_serial.c.obj
In file included from D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_serial.c:59:
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_config.h:166:6: warning: #warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting" [-Wcpp]
  166 | #    warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting"
      |      ^~~~~~~
[36/1111] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_lowputc.c.obj
In file included from D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:37:
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_config.h:166:6: warning: #warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting" [-Wcpp]
  166 | #    warning "No valid CONFIG_[LP]LPUART[n]_SERIAL_CONSOLE Setting"
      |      ^~~~~~~
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c: In function 'imxrt_lpuart_configure':
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_lowputc.c:751:2: warning: #warning missing logic [-Wcpp]
  751 | #warning missing logic
      |  ^~~~~~~
[40/1111] Building C object arch/CMakeFiles/arch.dir/arm/src/imxrt/imxrt_timerisr.c.obj
D:/nuttximxrt/nuttx/arch/arm/src/imxrt/imxrt_timerisr.c:49:2: warning: #warning REVISIT these clock settings [-Wcpp]
   49 | #warning REVISIT these clock settings
      |  ^~~~~~~
[1110/1111] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      103928 B      1984 KB      5.12%
            sram:        9964 B       512 KB      1.90%
            itcm:          0 GB       512 KB      0.00%
            dtcm:          0 GB       512 KB      0.00%
[1111/1111] Generating nuttx.hex
```
