### PR TITLE
arch/arm/rp2040: merge conflicting definitions of `hw_*` functions

### DIFF
--- a/arch/arm/src/rp2040/hardware/rp2040_address_mapped.h
+++ b/arch/arm/src/rp2040/hardware/rp2040_address_mapped.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/hardware/rp2040_address_mapped.h
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_ADDRESS_MAPPED_H
+#define __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_ADDRESS_MAPPED_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define REG_ALIAS_XOR_BITS (0x1u << 12u)
+#define hw_alias_check_addr(addr) ((uintptr_t)(addr))
+#define hw_xor_alias_untyped(addr) ((void *)(REG_ALIAS_XOR_BITS | hw_alias_check_addr(addr)))
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+always_inline_function static void hw_xor_bits(volatile uint32_t *addr,
+  uint32_t mask)
+{
+    *(volatile uint32_t *)hw_xor_alias_untyped((volatile void *)addr) = mask;
+}
+
+always_inline_function static void hw_write_masked(volatile uint32_t *addr,
+  uint32_t values, uint32_t write_mask)
+{
+    hw_xor_bits(addr, (*addr ^ values) & write_mask);
+}
+
+#endif /* __ARCH_ARM_SRC_RP2040_HARDWARE_RP2040_ADDRESS_MAPPED_H */

--- a/arch/arm/src/rp2040/rp2040_gpio.h
+++ b/arch/arm/src/rp2040/rp2040_gpio.h
@@ -34,6 +34,7 @@
 #include <debug.h>
 
 #include "hardware/rp2040_sio.h"
+#include "hardware/rp2040_address_mapped.h"
 #include "hardware/rp2040_io_bank0.h"
 #include "hardware/rp2040_pads_bank0.h"
 
@@ -42,10 +43,6 @@
  ****************************************************************************/
 
 #define RP2040_GPIO_NUM    30       /* Number of GPIO pins */
-
-#define REG_ALIAS_XOR_BITS (0x1u << 12u)
-#define hw_alias_check_addr(addr) ((uintptr_t)(addr))
-#define hw_xor_alias_untyped(addr) ((void *)(REG_ALIAS_XOR_BITS | hw_alias_check_addr(addr)))
 
 /* GPIO function types ******************************************************/
 
@@ -198,17 +195,6 @@ static inline void rp2040_gpio_set_drive_strength(uint32_t gpio,
   modbits_reg32(drive_strength,
                 RP2040_PADS_BANK0_GPIO_DRIVE_MASK,
                 RP2040_PADS_BANK0_GPIO(gpio));
-}
-
-always_inline_function static void hw_xor_bits(uint32_t *addr, uint32_t mask)
-{
-    *(uint32_t *) hw_xor_alias_untyped((volatile void *)addr) = mask;
-}
-
-always_inline_function static void hw_write_masked(uint32_t *addr,
-  uint32_t values, uint32_t write_mask)
-{
-    hw_xor_bits(addr, (*addr ^ values) & write_mask);
 }
 
 /****************************************************************************

--- a/boards/arm/rp2040/common/src/rp2040_uniqueid.c
+++ b/boards/arm/rp2040/common/src/rp2040_uniqueid.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "rp2040_uniqueid.h"
+#include "hardware/rp2040_address_mapped.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -50,11 +51,8 @@
 #define SSI_SR_TFNF_BITS                  0x00000002
 #define SSI_SR_RFNE_BITS                  0x00000008
 #define BOOT2_SIZE_WORDS                  64
-#define REG_ALIAS_XOR_BITS                (0x1u << 12u)
 
 #define ROM_TABLE_CODE(c1, c2)     ((c1) | ((c2) << 8))
-#define hw_alias_check_addr(addr)  ((uintptr_t)(addr))
-#define hw_xor_alias_untyped(addr) ((void *)(REG_ALIAS_XOR_BITS | hw_alias_check_addr(addr)))
 
 /****************************************************************************
  * Private Types
@@ -75,10 +73,6 @@ static inline void __compiler_memory_barrier(void);
 static inline void *rom_hword_as_ptr(uint16_t rom_address);
 static inline uint32_t rom_table_code(uint8_t c1, uint8_t c2);
 static void *rf_lookup(uint32_t code);
-static void hw_xor_bits(io_rw_32 *addr, uint32_t mask);
-static void hw_write_masked(io_rw_32 *addr,
-                            uint32_t values,
-                            uint32_t write_mask);
 static void flash_cs_force (bool high);
 void rp2040_flash_cmd(const uint8_t *txbuf, uint8_t *rxbuf, size_t count);
 
@@ -164,34 +158,6 @@ always_inline_function static void *rf_lookup(uint32_t code)
 }
 
 /****************************************************************************
- * Name: hw_xor_bits
- *
- * Description:
- *   Helper function for flash_cs_force.
- *
- ****************************************************************************/
-
-always_inline_function static void hw_xor_bits(io_rw_32 *addr, uint32_t mask)
-{
-  *(io_rw_32 *) hw_xor_alias_untyped((volatile void *) addr) = mask;
-}
-
-/****************************************************************************
- * Name: hw_write_masked
- *
- * Description:
- *   Helper function for flash_cs_force.
- *
- ****************************************************************************/
-
-always_inline_function static void hw_write_masked(io_rw_32 *addr,
-                                           uint32_t values,
-                                           uint32_t write_mask)
-{
-  hw_xor_bits(addr, (*addr ^ values) & write_mask);
-}
-
-/****************************************************************************
  * Name: flash_cs_force
  *
  * Description:
@@ -208,7 +174,7 @@ static void flash_cs_force (bool high)
   uint32_t field_val = high ?
     QSPI_SS_CTRL_OUTOVER_VALUE_HIGH :
     QSPI_SS_CTRL_OUTOVER_VALUE_LOW;
-  hw_write_masked((io_rw_32 *)QSPI_SS_CTRL,
+  hw_write_masked((volatile uint32_t *)QSPI_SS_CTRL,
     field_val << QSPI_SS_CTRL_OUTOVER_LSB,
     QSPI_SS_CTRL_OUTOVER_BITS
   );


### PR DESCRIPTION
## Summary

The functions `hw_write_masked` and `hw_xor_bits` (as defined in pico-sdk) were defined twice in NuttX.
Additionally these definitions were in conflict (one lacked the `volatile` modifier).

Now these functions and their dependencies are defined in a new header file.
Its name is based on the filename of the original definition in pico-sdk:

```
  src/rp2_common/hardware_base/include/hardware/address_mapped.h
```

## Impact

This change should fix the potential issue of GPIO operations failing due to compiler optimizations caused by the absence of `volatile`.

## Testing

The changes were compile-tested. Previously compilation failed. Since my project does not use these specific functions on the rp2040 board, I cannot prove their correctness.