### PR TITLE
arch/tricore: fix tasking compiler linking error

### DIFF
--- a/arch/tricore/src/cmake/ToolchainTasking.cmake
+++ b/arch/tricore/src/cmake/ToolchainTasking.cmake
@@ -108,6 +108,7 @@ add_compile_options(--branch-target-align)
 # cmake-format: on
 
 add_compile_options(--fp-model=2)
+add_link_options(--no-default-libraries)
 add_link_options(--fp-model=2)
 add_link_options(-lfp_fpu)
 

--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -101,6 +101,7 @@ ARCHOPTIMIZATION += --branch-target-align
 #   3                               alias for --fp-model=cflnrSTz (fast-sp)
 
 ARCHOPTIMIZATION += --fp-model=2
+LDFLAGS          += --no-default-libraries
 LDFLAGS          += --fp-model=2
 LDFLAGS          += -lfp_fpu
 


### PR DESCRIPTION
  Add "add_link_options(--no-default-libraries)" ToolchainTasking.cmake
  Add "LDFLAGS += --no-default-libraries" in ToolchainTasking.defs

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Update tasking compiler linker option to avoid linking compiler lib in default

## Impact

tricore arch compiling issue fix, no impact to other parts

## Testing

**enable tasking compiler on board a2g-tc397-5v-tft **

<img width="549" height="561" alt="image" src="https://github.com/user-attachments/assets/d35b9cfe-d01a-4ead-a070-7a1a03d80b56" />

**before this fix patch**

<img width="864" height="266" alt="image" src="https://github.com/user-attachments/assets/c980b690-caee-4f72-a651-2b1fe3d484a6" />

**after this fix patch**

<img width="645" height="401" alt="image" src="https://github.com/user-attachments/assets/8bd44479-6c11-4eab-998a-2d4f560be4b5" />

**ostest passed**
<img width="593" height="550" alt="image" src="https://github.com/user-attachments/assets/61be2f36-a28a-46fd-9e5b-8f52a0fb8d82" />

