### PR TITLE
drivers/net/mdio: add mdio bus

### DIFF
--- a/Documentation/components/net/index.rst
+++ b/Documentation/components/net/index.rst
@@ -12,6 +12,7 @@ Network Support
   nat.rst
   netdev.rst
   netdriver.rst
+  mdio.rst
   netguardsize.rst
   netlink.rst
   slip.rst

--- a/Documentation/components/net/mdio.rst
+++ b/Documentation/components/net/mdio.rst
@@ -1,0 +1,73 @@
+.. _mdio_bus:
+
+.. include:: /substitutions.rst
+
+=================
+MDIO Bus Driver
+=================
+
+The NuttX MDIO bus driver provides a standardized interface for communicating with Ethernet PHY (Physical Layer) transceivers.
+It employs a classic upper-half/lower-half architecture to abstract hardware-specific logic from the generic MDIO protocol,
+which is currently compliant with Clause 22 of the IEEE 802.3 standard.
+The primary implementation of the upper-half can be found in ``drivers/net/mdio.c``.
+
+Driver Architecture
+===================
+
+The MDIO driver framework serves as an intermediary layer between a network device driver and the physical bus.
+The intended operational model is ``netdev -> phydev -> mdio``, where the network device communicates with a dedicated PHY driver,
+which in turn uses the MDIO bus driver for low-level hardware access.
+Direct interaction between the network device and the MDIO bus is discouraged.
+
+Upper-Half Implementation
+-------------------------
+
+The upper-half driver contains the core logic for the MDIO bus, including bus locking mechanisms to ensure safe transactions.
+It exposes a generic API for managing the bus lifecycle and is capable of handling multiple, independent MDIO bus instances concurrently.
+This abstracts implementation details from both the PHY driver and the underlying hardware-specific code.
+
+Lower-Half Implementation
+-------------------------
+
+A lower-half MDIO driver serves as a thin layer that maps the generic operations defined by the upper-half to hardware-specific register manipulations.
+It is not intended to contain complex logic, but rather to provide a direct translation for bus operations.
+
+Implementing a Lower-Half Driver
+================================
+
+Integrating MDIO support for new hardware requires the implementation of a lower-half driver.
+The contract between the upper and lower halves is defined in ``include/nuttx/net/mdio.h`` and is centered around two key structures.
+
+Key Data Structures
+-------------------
+
+1.  ``struct mdio_ops_s``: A structure containing function pointers that the lower-half driver must implement to perform hardware-level operations.
+    *   ``read``: Performs a Clause 22 MDIO read operation.
+    *   ``write``: Performs a Clause 22 MDIO write operation.
+    *   ``reset``: An optional function to execute a hardware-specific PHY reset.
+
+2.  ``struct mdio_lowerhalf_s``: The container for the lower-half instance, which holds a pointer to the ``mdio_ops_s`` vtable 
+    and an optional private data pointer for the driver's internal state.
+
+Registration and Unregistration
+-------------------------------
+
+The board-level initialization logic is responsible for instantiating the lower-half driver and registering it with the upper-half via the ``mdio_register()`` function.
+Each call to this function with a distinct lower-half driver creates a new, unique bus handle, allowing the system to manage several MDIO buses concurrently.
+
+.. code-block:: c
+
+    FAR struct mdio_dev_s *mdio_register(FAR struct mdio_lowerhalf_s *lower);
+
+This function accepts the lower-half instance and returns an opaque handle (``FAR struct mdio_dev_s *``),
+which is subsequently used by the PHY driver to interact with the bus.
+
+When a bus instance is no longer required, it should be deallocated by calling the ``mdio_unregister()`` function to ensure proper cleanup of resources.
+
+.. code-block:: c
+
+    int mdio_unregister(FAR struct mdio_dev_s *dev);
+
+This function takes the handle returned by ``mdio_register()`` and releases the associated bus instance.
+
+A (mostly) complete reference implementation for a lower-half driver is available in ``arch/arm/src/stm32h7/stm32_mdio.c``.

--- a/arch/arm/src/stm32h7/CMakeLists.txt
+++ b/arch/arm/src/stm32h7/CMakeLists.txt
@@ -181,6 +181,10 @@ if(CONFIG_STM32H7_ETHMAC)
   list(APPEND SRCS stm32_ethernet.c)
 endif()
 
+if(CONFIG_MDIO_BUS)
+  list(APPEND SRCS stm32_mdio.c)
+endif()
+
 if(CONFIG_SENSORS_QENCODER)
   list(APPEND SRCS stm32_qencoder.c)
 endif()

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -187,6 +187,10 @@ ifeq ($(CONFIG_STM32H7_ETHMAC),y)
 CHIP_CSRCS += stm32_ethernet.c
 endif
 
+ifeq ($(CONFIG_MDIO_BUS),y)
+CHIP_CSRCS += stm32_mdio.c
+endif 
+
 ifeq ($(CONFIG_SENSORS_QENCODER),y)
 CHIP_CSRCS += stm32_qencoder.c
 endif

--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -1,0 +1,232 @@
+/****************************************************************************
+ * arch/arm/src/stm32h7/stm32_mdio.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <arm_internal.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_STM32H7_ETHMAC_REGDEBUG
+static uint32_t stm32_getreg(uint32_t addr);
+static void stm32_putreg(uint32_t val, uint32_t addr);
+static void stm32_checksetup(void);
+#else
+#  define stm32_getreg(addr)     getreg32(addr)
+#  define stm32_putreg(val,addr) putreg32(val,addr)
+#  define stm32_checksetup()
+#endif
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/mutex.h>
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <inttypes.h>
+
+#include "stm32_mdio.h"
+#include "hardware/stm32_ethernet.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct stm32_mdio_bus_s
+{
+  struct mdio_lowerhalf_s *lower;
+
+  /* MDIO bus timeout in milliseconds */
+
+  int timeout;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
+                    uint8_t regaddr, uint16_t *value);
+
+static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
+                     uint8_t regaddr, uint16_t value);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+const struct mdio_ops_s g_stm32_mdio_ops =
+{
+  .read  = stm32_c22_read,
+  .write = stm32_c22_write,
+  .reset = NULL,
+};
+
+struct mdio_lowerhalf_s g_stm32_mdio_lowerhalf =
+{
+  .ops = &g_stm32_mdio_ops
+};
+
+struct stm32_mdio_bus_s g_stm32_mdio_bus =
+{
+  .lower = &g_stm32_mdio_lowerhalf,
+  .timeout = 10
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
+                          uint8_t regaddr, uint16_t *value)
+{
+  int to;
+  uint32_t regval;
+
+  int retval = -ETIMEDOUT;
+  struct stm32_mdio_bus_s *priv = (struct stm32_mdio_bus_s *)dev;
+
+  /* Configure the MACMDIOAR register, preserving CSR Clock Range CR[3:0]
+   * bits
+   */
+
+  regval  = stm32_getreg(STM32_ETH_MACMDIOAR);
+  regval &= ETH_MACMDIOAR_CR_MASK;
+
+  /* Set the PHY device address, PHY register address, and set the buy bit.
+   * the ETH_MACMDIOAR_GOC == 3, indicating a read operation.
+   */
+
+  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_PA_SHIFT) &
+            ETH_MACMDIOAR_PA_MASK);
+  regval |= (((uint32_t)regaddr << ETH_MACMDIOAR_RDA_SHIFT) &
+            ETH_MACMDIOAR_RDA_MASK);
+  regval |= ETH_MACMDIOAR_MB | ETH_MACMDIOAR_GOC_READ;
+
+  stm32_putreg(regval, STM32_ETH_MACMDIOAR);
+
+  /* Wait for the transfer to complete */
+
+  for (to = priv->timeout; to >= 0; to--)
+    {
+      if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
+        {
+          *value = (uint16_t)stm32_getreg(STM32_ETH_MACMDIODR);
+          retval = OK;
+          break;
+        }
+
+      up_mdelay(5);
+    }
+
+  if (to <= 0)
+    {
+      ninfo("MII transfer timed out: phydev: %04x regaddr: %04x\n",
+            phydev, regaddr);
+    }
+
+  return retval;
+}
+
+static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
+                           uint8_t regaddr, uint16_t value)
+{
+  int to;
+  uint32_t regval;
+
+  int retval = -ETIMEDOUT;
+  struct stm32_mdio_bus_s *priv = (struct stm32_mdio_bus_s *)dev;
+
+  /* Configure the MACMDIOAR register, preserving CSR Clock Range CR[3:0]
+   * bits
+   */
+
+  regval  = stm32_getreg(STM32_ETH_MACMDIOAR);
+  regval &= ETH_MACMDIOAR_CR_MASK;
+
+  /* Read the existing register value, if clear mask is given */
+
+  /* Set the PHY device address, PHY register address, and set the busy bit.
+   * the ETH_MACMDIOAR_GOC == 1, indicating a write operation.
+   */
+
+  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_PA_SHIFT) &
+            ETH_MACMDIOAR_PA_MASK);
+  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_RDA_SHIFT) &
+            ETH_MACMDIOAR_RDA_MASK);
+  regval |= (ETH_MACMDIOAR_MB | ETH_MACMDIOAR_GOC_WRITE);
+
+  /* Write the value into the MACMDIODR register before setting the new
+   * MACMDIOAR register value.
+   */
+
+  stm32_putreg(value, STM32_ETH_MACMDIODR);
+  stm32_putreg(regval, STM32_ETH_MACMDIOAR);
+
+  /* Wait for the transfer to complete */
+
+  for (to = priv->timeout; to >= 0; to--)
+    {
+      if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
+        {
+          retval = OK;
+          break;
+        }
+
+      up_mdelay(5);
+    }
+
+  if (to <= 0)
+    {
+      ninfo("MII transfer timed out: phydevaddr: %04x phyregaddr: %04x"
+            "value: %04x\n", phydev, regaddr, value);
+    }
+
+  return retval;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_mdio_bus_initialize
+ *
+ * Description:
+ *   Initialize the MDIO bus
+ *
+ * Returned Value:
+ *   Initialized MDIO bus structure or NULL on failure
+ *
+ ****************************************************************************/
+
+struct mdio_bus_s *stm32_mdio_bus_initialize(void)
+{
+  return mdio_register(&g_stm32_mdio_lowerhalf);
+}

--- a/arch/arm/src/stm32h7/stm32_mdio.h
+++ b/arch/arm/src/stm32h7/stm32_mdio.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * arch/arm/src/stm32h7/stm32_mdio.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H7_STM32_MDIO_H
+#define __ARCH_ARM_SRC_STM32H7_STM32_MDIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/net/mdio.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_mdio_bus_initialize
+ *
+ * Description:
+ *   Initialize the MDIO bus
+ *
+ * Returned Value:
+ *   Initialized MDIO bus structure or NULL on failure
+ *
+ ****************************************************************************/
+
+struct mdio_bus_s *stm32_mdio_bus_initialize(void);
+
+#endif /* __ARCH_ARM_SRC_STM32H7_STM32_MDIO_H */

--- a/drivers/net/CMakeLists.txt
+++ b/drivers/net/CMakeLists.txt
@@ -29,6 +29,10 @@ if(CONFIG_NET)
     list(APPEND SRCS netdev_upperhalf.c)
   endif()
 
+  if(CONFIG_MDIO_BUS)
+    list(APPEND SRCS mdio.c)
+  endif()
+
   if(CONFIG_NET_LOOPBACK)
     list(APPEND SRCS loopback.c)
   endif()

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -68,6 +68,20 @@ config NETDEV_RSS
 		When the hardware supports RSS/aRFS function, provide the
 		hash value and CPU ID to the hardware driver.
 
+menuconfig MDIO_BUS
+	bool "Upper-half MDIO Bus Driver Options"
+	default y
+
+if MDIO_BUS
+
+comment "IEEE 802.3 Ethernet MDIO Clauses Support"
+
+config MDIO_CLAUSE_45
+	bool "MDIO bus supports Clause 45"
+	default n
+
+endif
+
 comment "General Ethernet MAC Driver Options"
 
 config NET_RPMSG_DRV

--- a/drivers/net/Make.defs
+++ b/drivers/net/Make.defs
@@ -30,6 +30,10 @@ ifeq ($(CONFIG_MM_IOB),y)
   CSRCS += netdev_upperhalf.c
 endif
 
+ifeq ($(CONFIG_MDIO_BUS),y)
+  CSRCS += mdio.c
+endif
+
 ifeq ($(CONFIG_NET_LOOPBACK),y)
   CSRCS += loopback.c
 endif

--- a/drivers/net/mdio.c
+++ b/drivers/net/mdio.c
@@ -1,0 +1,253 @@
+/****************************************************************************
+ * drivers/net/mdio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
+#include <nuttx/net/mdio.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Private Defines
+ ****************************************************************************/
+
+#define MDIO_READ(d,a,r,v) d->lower->ops->read(d->lower, a, r, v);
+
+#define MDIO_WRITE(d,a,r,v) d->lower->ops->write(d->lower, a, r, v);
+
+#define MDIO_RESET(d,a) d->lower->ops->reset(d->lower, a);
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This is the opaque handle used by application code to access the
+ * MDIO bus.
+ */
+
+struct mdio_bus_s
+{
+  /* Pointer to the lower-half driver's state */
+
+  FAR struct mdio_lowerhalf_s *lower;
+
+  /* For exclusive access to the bus */
+
+  mutex_t lock;
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mdio_register
+ *
+ * Description:
+ *   Register a new MDIO bus instance.
+ *
+ * Input Parameters:
+ *   lower - An instance of the lower-half MDIO driver, with the ops vtable
+ *           as the first member.
+ *
+ * Returned Value:
+ *   A non-NULL handle on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct mdio_bus_s *mdio_register(FAR struct mdio_lowerhalf_s *lower)
+{
+  FAR struct mdio_bus_s *dev;
+
+  /* Allocate the upper-half MDIO driver state structure */
+
+  dev = (FAR struct mdio_bus_s *)kmm_zalloc(sizeof(struct mdio_bus_s));
+  if (dev != NULL)
+    {
+      /* Initialize the upper-half driver state */
+
+      nxmutex_init(&dev->lock);
+      dev->lower = lower;
+    }
+  else
+    {
+      nerr("ERROR: Failed to allocate MDIO device structure\n");
+    }
+
+  return dev;
+}
+
+/****************************************************************************
+ * Name: mdio_unregister
+ *
+ * Description:
+ *   Unregister an MDIO bus instance.
+ *
+ * Input Parameters:
+ *   dev - The MDIO bus handle returned by mdio_register.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_unregister(FAR struct mdio_bus_s *dev)
+{
+  DEBUGASSERT(dev != NULL);
+
+  nxmutex_destroy(&dev->lock);
+  kmm_free(dev);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: mdio_read
+ *
+ * Description:
+ *   Read a 16-bit value from a PHY register on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31).
+ *   regaddr - The PHY register address (0-31).
+ *   value   - A pointer to the location to store the read value.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_read(FAR struct mdio_bus_s *dev, uint8_t phyaddr, uint8_t regaddr,
+              FAR uint16_t *value)
+{
+  int ret;
+
+  DEBUGASSERT(dev != NULL && dev->lower != NULL);
+  DEBUGASSERT(dev->lower->ops->read != NULL);
+
+  /* Take the mutex */
+
+  ret = nxmutex_lock(&dev->lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Call the lowerhalf driver's read method */
+
+  ret = MDIO_READ(dev, phyaddr, regaddr, value);
+
+  /* Release the mutex */
+
+  nxmutex_unlock(&dev->lock);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: mdio_write
+ *
+ * Description:
+ *   Write a 16-bit value to a PHY register on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31).
+ *   regaddr - The PHY register address (0-31).
+ *   value   - The value to write.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_write(FAR struct mdio_bus_s *dev, uint8_t phyaddr, uint8_t regaddr,
+               uint16_t value)
+{
+  int ret;
+
+  DEBUGASSERT(dev != NULL && dev->lower != NULL);
+  DEBUGASSERT(dev->lower->ops->write != NULL);
+
+  /* Take the mutex */
+
+  ret = nxmutex_lock(&dev->lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Call the lowerhalf driver's write method */
+
+  ret = MDIO_WRITE(dev, phyaddr, regaddr, value);
+
+  /* Release the mutex */
+
+  nxmutex_unlock(&dev->lock);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: mdio_reset
+ *
+ * Description:
+ *   Reset a PHY on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31) to reset.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_reset(FAR struct mdio_bus_s *dev, uint8_t phyaddr)
+{
+  int ret = -ENOSYS;
+
+  DEBUGASSERT(dev != NULL && dev->lower != NULL);
+
+  /* Check if the reset method is provided by the lower-half */
+
+  if (dev->lower->ops->reset)
+    {
+      /* Take the mutex */
+
+      ret = nxmutex_lock(&dev->lock);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      /* Call the lowerhalf driver's reset method */
+
+      ret = MDIO_RESET(dev, phyaddr);
+
+      /* Release the mutex */
+
+      nxmutex_unlock(&dev->lock);
+    }
+
+  return ret;
+}

--- a/include/nuttx/net/mdio.h
+++ b/include/nuttx/net/mdio.h
@@ -1,0 +1,192 @@
+/****************************************************************************
+ * include/nuttx/net/mdio.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_NET_MDIO_H
+#define __INCLUDE_NUTTX_NET_MDIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+#include <stdint.h>
+#include <nuttx/mutex.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Forward references */
+
+struct mdio_bus_s;
+struct mdio_lowerhalf_s;
+
+/* This structure defines the interface for the MDIO lower-half driver.
+ * These methods are called by the upper-half MDIO driver.
+ */
+
+struct mdio_ops_s
+{
+  /* Clause 22 MDIO Read. The first argument is a reference to the
+   * lower-half driver's private state.
+   */
+
+  int (*read)(FAR struct mdio_lowerhalf_s *lower, uint8_t phyaddr,
+              uint8_t regaddr, FAR uint16_t *value);
+
+  /* Clause 22 MDIO Write */
+
+  int (*write)(FAR struct mdio_lowerhalf_s *lower, uint8_t phyaddr,
+               uint8_t regaddr, uint16_t value);
+
+  #ifdef CONFIG_MDIO_CLAUSE_45
+  #endif
+
+  /* PHY Reset. Optional. */
+
+  int (*reset)(FAR struct mdio_lowerhalf_s *lower, uint8_t phyaddr);
+};
+
+/* This structure defines the state of the MDIO lower-half driver.
+ * The chip-specific MDIO driver must allocate and initialize one instance
+ * of this structure.
+ */
+
+struct mdio_lowerhalf_s
+{
+  /* The vtable of MDIO lower-half operations.
+   * This must be the first field.
+   */
+
+  FAR const struct mdio_ops_s *ops;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: mdio_register
+ *
+ * Description:
+ *   Register a new MDIO bus instance.
+ *
+ * Input Parameters:
+ *   lower - An instance of the lower-half MDIO driver, with the ops vtable
+ *           as the first member.
+ *
+ * Returned Value:
+ *   A non-NULL handle on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct mdio_bus_s *mdio_register(FAR struct mdio_lowerhalf_s *lower);
+
+/****************************************************************************
+ * Name: mdio_unregister
+ *
+ * Description:
+ *   Unregister an MDIO bus instance.
+ *
+ * Input Parameters:
+ *   dev - The MDIO bus handle returned by mdio_register.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_unregister(FAR struct mdio_bus_s *dev);
+
+/****************************************************************************
+ * Name: mdio_read
+ *
+ * Description:
+ *   Read a 16-bit value from a PHY register on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31).
+ *   regaddr - The PHY register address (0-31).
+ *   value   - A pointer to the location to store the read value.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_read(FAR struct mdio_bus_s *dev, uint8_t phyaddr, uint8_t regaddr,
+              FAR uint16_t *value);
+
+/****************************************************************************
+ * Name: mdio_write
+ *
+ * Description:
+ *   Write a 16-bit value to a PHY register on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31).
+ *   regaddr - The PHY register address (0-31).
+ *   value   - The value to write.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_write(FAR struct mdio_bus_s *dev, uint8_t phyaddr, uint8_t regaddr,
+               uint16_t value);
+
+/****************************************************************************
+ * Name: mdio_reset
+ *
+ * Description:
+ *   Reset a PHY on the MDIO bus.
+ *
+ * Input Parameters:
+ *   dev     - The MDIO bus handle.
+ *   phyaddr - The PHY address (0-31) to reset.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int mdio_reset(FAR struct mdio_bus_s *dev, uint8_t phyaddr);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_NET_MDIO_H */


### PR DESCRIPTION
## Summary

Currently the mdio communication is part of the monolithic 'full netdevs'.
This commit serves as an way to add modularity for the netdevs drivers.
A new upperhalf/lowerhalf mdio device comes with this commit that manages the data transfer ofer mdio interface.

It resembles the upperhalf/lowerhalf approach of the netdevs or i2c bitbang.

It is still in the draft because there are still code style issues, but I ask you to review this PR nevertheless
 
## Impact

A new upperhalf mdio bus is now added as a set of **include/nuttx/net/mdio.h** and **drivers/net/mdio.c** files
which "sets" the available mdio commands (read, write, reset). Acts as the bus "controller". It block the bus during the transaction and calls the apropriate lowerhalf function.

A new lowerhalf mdio bus for the stm32h7 mcu family was added which implements the actual mdio transfers.

A new Kconfig option was added MDIO_BUS in the drivers/net directory

## Testing

This PR have low impact over the nuttx codebase. The new files are included to the build system based on the
CONFIG_MDIO_BUS
Currently, only stm32h7 has the new mdio bus.
