### PR TITLE
Kconfig: add stack-protector level options

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2469,6 +2469,46 @@ config STACK_CANARIES
 		Enabling this option can result in a significant increase
 		in footprint and an associated decrease in performance.
 
+choice STACK_CANARIES_LEVEL
+    prompt "Stack Canaries Level Configuration"
+    default STACK_PROTECTOR_ALL
+    depends on STACK_CANARIES
+    ---help---
+        Based on the configuration options, configure the stack Canaries Level.
+
+config STACK_PROTECTOR
+    bool "-fstack-protector"
+    ---help---
+        Enable basic stack protection.
+
+config STACK_PROTECTOR_STRONG
+    bool "-fstack-protector-strong"
+    ---help---
+        Using stronger stack protection mechanisms may involve more complex
+        security checks.
+
+config STACK_PROTECTOR_ALL
+    bool "-fstack-protector-all"
+    ---help---
+        Enable stack protection for all functions, including those that are
+        typically not protected.
+
+config STACK_PROTECTOR_EXPLICIT
+    bool "-fstack-protector-explicit"
+    ---help---
+        Enable stack protection only for functions explicitly marked as
+        requiring stack protection.
+
+endchoice # Stack Canaries Level Configuration
+
+config STACK_CANARIES_LEVEL
+    string
+    default "-fstack-protector" if STACK_PROTECTOR
+    default "-fstack-protector-strong" if STACK_PROTECTOR_STRONG
+    default "-fstack-protector-all" if STACK_PROTECTOR_ALL
+    default "-fstack-protector-explicit" if STACK_PROTECTOR_EXPLICIT
+    depends on STACK_CANARIES
+
 config STACK_USAGE
 	bool "Generate stack usage information"
 	---help---

--- a/arch/arm/src/cmake/armclang.cmake
+++ b/arch/arm/src/cmake/armclang.cmake
@@ -107,7 +107,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/arm/src/cmake/clang.cmake
+++ b/arch/arm/src/cmake/clang.cmake
@@ -111,7 +111,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -126,7 +126,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -79,7 +79,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -63,7 +63,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -81,7 +81,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/arch/arm64/src/cmake/clang.cmake
+++ b/arch/arm64/src/cmake/clang.cmake
@@ -57,7 +57,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/arm64/src/cmake/gcc.cmake
+++ b/arch/arm64/src/cmake/gcc.cmake
@@ -83,7 +83,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -156,7 +156,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -72,7 +72,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -103,7 +103,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/tricore/src/cmake/ToolchainGnuc.cmake
+++ b/arch/tricore/src/cmake/ToolchainGnuc.cmake
@@ -83,7 +83,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_COVERAGE_ALL)

--- a/arch/tricore/src/common/ToolchainGnuc.defs
+++ b/arch/tricore/src/common/ToolchainGnuc.defs
@@ -49,7 +49,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -62,7 +62,7 @@ if(CONFIG_FRAME_POINTER)
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 else()
   add_compile_options(-fno-stack-protector)
 endif()

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -91,7 +91,7 @@ ifneq ($(CONFIG_CXX_STANDARD),)
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 else
   ARCHOPTIMIZATION += -fno-stack-protector
 endif

--- a/arch/xtensa/src/cmake/Toolchain.cmake
+++ b/arch/xtensa/src/cmake/Toolchain.cmake
@@ -146,7 +146,7 @@ else()
 endif()
 
 if(CONFIG_STACK_CANARIES)
-  add_compile_options(-fstack-protector-all)
+  add_compile_options(${CONFIG_STACK_CANARIES_LEVEL})
 endif()
 
 if(CONFIG_STACK_USAGE)

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -96,7 +96,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -100,7 +100,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -63,7 +63,7 @@ else
 endif
 
 ifeq ($(CONFIG_STACK_CANARIES),y)
-  ARCHOPTIMIZATION += -fstack-protector-all
+  ARCHOPTIMIZATION += $(patsubst "%",%,$(CONFIG_STACK_CANARIES_LEVEL))
 endif
 
 ifeq ($(CONFIG_STACK_USAGE),y)


### PR DESCRIPTION
## Summary
Kconfig: Add configurable Stack Canaries protection levels.

Support selecting stack overflow protection mechanisms of different strengths according to requirements.
Introduce a configurable stack-protection level for the existing CONFIG_STACK_CANARIES, instead of hard-coding -fstack-protector-all.
Add Kconfig choice STACK_CANARIES_LEVEL four selectable levels:
```
     -fstack-protector
     -fstack-protector-strong
     -fstack-protector-all (default)
     -fstack-protector-explicit
```
## Impact
New Feature/Change: Yes
User Impact:  The default is still  -fstack-protector-all
Build Impact: Add a new Kconfig STACK_CANARIES_LEVEL.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
After modifying STACK_CANARIES_LEVEL, check whether the stack-protector configuration matches during the compilation process for architectures such as Xtensa or ARM64. 

