### PR TITLE
boards/xtensa: fix the issue of undefined symbol reference errors

### DIFF
--- a/boards/xtensa/esp32/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/legacy_sections.ld
@@ -308,15 +308,24 @@ SECTIONS
     /* C++ constructor and destructor tables, properly ordered: */
 
     _sinit = ABSOLUTE(.);
+    __init_array_start = ABSOLUTE(.);
     KEEP (*crtbegin.o(.ctors))
     KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
     _einit = ABSOLUTE(.);
+    __init_array_end = ABSOLUTE(.);
     KEEP (*crtbegin.o(.dtors))
     KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
+
+    /* System init functions registered via ESP_SYSTEM_INIT_FN */
+
+    . = ALIGN(4);
+    _esp_system_init_fn_array_start = ABSOLUTE(.);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.esp_system_init_fn.*)))
+    _esp_system_init_fn_array_end = ABSOLUTE(.);
 
     /* C++ exception handlers table: */
 

--- a/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32s3/common/scripts/legacy_sections.ld
@@ -331,15 +331,24 @@ SECTIONS
     /* C++ constructor and destructor tables, properly ordered: */
 
     _sinit = ABSOLUTE(.);
+    __init_array_start = ABSOLUTE(.);
     KEEP (*crtbegin.o(.ctors))
     KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
+    __init_array_end = ABSOLUTE(.);
     _einit = ABSOLUTE(.);
     KEEP (*crtbegin.o(.dtors))
     KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
+
+    /* System init functions registered via ESP_SYSTEM_INIT_FN */
+
+    . = ALIGN(4);
+    _esp_system_init_fn_array_start = ABSOLUTE(.);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.esp_system_init_fn.*)))
+    _esp_system_init_fn_array_end = ABSOLUTE(.);
 
     /* C++ exception handlers table: */
 


### PR DESCRIPTION
## Summary
boards/xtensa: fix the issue of undefined symbol reference errors occurring during compilation and linking phase when the configuration (CONFIG_ESP32S3_APP_FORMAT_LEGACY=y) is enabled.

```
    undefined reference to _esp_system_init_fn_array_start
    undefined reference to _esp_system_init_fn_array_end
    undefined reference to __init_array_start
    undefined reference to __init_array_end

```
## Impact
New Feature/Change: No
User Impact: No
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing

```
xtensa-esp32-elf-ld: /media/zzq/sda4/work/apache_nuttx/chip_esp32/nuttx/staging/libarch.a(startup.o):(.literal.do_system_init_fn+0x0): undefined reference to `_esp_system_init_fn_array_start'
xtensa-esp32-elf-ld: /media/zzq/sda4/work/apache_nuttx/chip_esp32/nuttx/staging/libarch.a(startup.o):(.literal.do_system_init_fn+0xc): undefined reference to `_esp_system_init_fn_array_end'
xtensa-esp32-elf-ld: /media/zzq/sda4/work/apache_nuttx/chip_esp32/nuttx/staging/libarch.a(startup.o):(.literal.start_cpu0_default+0x0): undefined reference to `__init_array_end'
xtensa-esp32-elf-ld: /media/zzq/sda4/work/apache_nuttx/chip_esp32/nuttx/staging/libarch.a(startup.o):(.literal.start_cpu0_default+0x4): undefined reference to `__init_array_start'
```
After the fix, check that there are no compilation error.

