### PR TITLE
arch/tricore: allow user defined compiler path

### DIFF
--- a/arch/tricore/src/cmake/ToolchainTasking.cmake
+++ b/arch/tricore/src/cmake/ToolchainTasking.cmake
@@ -35,16 +35,16 @@ endif()
 
 include(${ARCH_SUBDIR})
 
-set(CMAKE_ASM_COMPILER cctc)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}cctc)
 set(CMAKE_C_COMPILER ${CMAKE_ASM_COMPILER})
-set(CMAKE_CXX_COMPILER cctc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}cctc)
 set(CMAKE_STRIP strip --strip-unneeded)
 set(CMAKE_OBJCOPY echo)
 set(CMAKE_OBJDUMP elfdump)
 
-set(CMAKE_LINKER cctc)
-set(CMAKE_LD cctc)
-set(CMAKE_AR artc -r)
+set(CMAKE_LINKER ${TOOLCHAIN_PREFIX}cctc)
+set(CMAKE_LD ${TOOLCHAIN_PREFIX}cctc)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}artc -r)
 set(CMAKE_NM nm)
 set(CMAKE_RANLIB ranlib)
 


### PR DESCRIPTION
      prefix compiler with ${TOOLCHAIN_PREFIX}

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add user defined compiler path prefix to CmakeLists.txt: ${TOOLCHAIN_PREFIX}

## Impact

Tricore arch tasking compiler related update, no impact to other parts

## Testing

**enable tasking compiler on board a2g-tc397-5v-tft **

<img width="549" height="561" alt="image" src="https://github.com/user-attachments/assets/8ae65715-95ae-4508-9821-4a856e897ce8" />

**build passed** 

<img width="645" height="401" alt="image" src="https://github.com/user-attachments/assets/b04eb9b4-b92c-41bb-9174-9d596867198c" />

**ostest passed**

<img width="593" height="550" alt="image" src="https://github.com/user-attachments/assets/8752e13b-f952-4225-b253-81169d27c096" />
