### PR TITLE
drivers/syslog: add light-weight, synchronous, unicast and lowlevel console output syslog function

### DIFF
--- a/drivers/syslog/CMakeLists.txt
+++ b/drivers/syslog/CMakeLists.txt
@@ -32,6 +32,12 @@ if(CONFIG_SYSLOG)
     list(APPEND SRCS vsyslog.c)
   endif()
 
+  if(CONFIG_SYSLOG_DEFAULT)
+    if(CONFIG_ARCH_LOWPUTC)
+      list(APPEND SRCS vsyslog_lowout.c)
+    endif()
+  endif()
+
   list(APPEND SRCS syslog_channel.c syslog_write.c syslog_flush.c)
 endif()
 

--- a/drivers/syslog/Make.defs
+++ b/drivers/syslog/Make.defs
@@ -31,6 +31,12 @@ else
   CSRCS += vsyslog.c
 endif
 
+ifeq ($(CONFIG_SYSLOG_DEFAULT),y)
+  ifeq ($(CONFIG_ARCH_LOWPUTC),y)
+    CSRCS += vsyslog_lowout.c
+  endif
+endif
+
 CSRCS += syslog_channel.c syslog_write.c syslog_flush.c
 endif
 

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -230,6 +230,21 @@ void syslog_flush_intbuffer(bool force);
 #endif
 
 /****************************************************************************
+ * Name: nx_vsyslog_lowout
+ *
+ * Description:
+ *   This function is an extension of nx_vsyslog(). It handles the case where
+ *   the user wants to log messages only to the console in a simple,
+ *   synchronous manner for debugging purposes.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SYSLOG_DEFAULT) && \
+    defined(CONFIG_ARCH_LOWPUTC)
+int nx_vsyslog_lowout(FAR const IPTR char *fmt, FAR va_list *ap);
+#endif
+
+/****************************************************************************
  * Name: syslog_write_foreach
  *
  * Description:

--- a/drivers/syslog/vsyslog_lowout.c
+++ b/drivers/syslog/vsyslog_lowout.c
@@ -1,0 +1,76 @@
+/****************************************************************************
+ * drivers/syslog/vsyslog_lowout.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/init.h>
+#include <nuttx/clock.h>
+#include <nuttx/streams.h>
+#include <nuttx/syslog/syslog.h>
+
+#include "syslog.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nx_vsyslog_lowout
+ *
+ * Description:
+ *   This function is an extension of nx_vsyslog(). It handles the case where
+ *   the user wants to log messages only to the console in a simple,
+ *   synchronous manner for debugging purposes.
+ *
+ ****************************************************************************/
+
+int nx_vsyslog_lowout(FAR const IPTR char *fmt, FAR va_list *ap)
+{
+  struct lib_sysloglowoutstream_s stream;
+  int ret = 0;
+
+  /* Wrap the low-level output in a stream object and let lib_vsprintf
+   * do the work.
+   */
+
+  lib_sysloglowoutstream(&stream);
+
+  /* Generate the output */
+
+  ret += lib_vsprintf_internal(&stream.common, fmt, *ap);
+  if (stream.last_ch != '\n')
+    {
+      lib_stream_putc(&stream.common, '\n');
+      ret++;
+    }
+
+  return ret;
+}

--- a/drivers/syslog/vsyslog_rfc5424.c
+++ b/drivers/syslog/vsyslog_rfc5424.c
@@ -66,23 +66,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: nx_vsyslog
- *
- * Description:
- *   nx_vsyslog() handles the system logging system calls. It is functionally
- *   equivalent to vsyslog() except that (1) the per-process priority
- *   filtering has already been performed and the va_list parameter is
- *   passed by reference.  That is because the va_list is a structure in
- *   some compilers and passing of structures in the NuttX sycalls does
- *   not work.
- *
- ****************************************************************************/
-
-int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
+static inline int
+nx_vsyslog_rawstream(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 {
   struct lib_syslograwstream_s stream;
   int ret = 0;
@@ -234,5 +222,40 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   /* Flush and destroy the syslog stream buffer */
 
   lib_syslograwstream_close(&stream);
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nx_vsyslog
+ *
+ * Description:
+ *   nx_vsyslog() handles the system logging system calls. It is functionally
+ *   equivalent to vsyslog() except that (1) the per-process priority
+ *   filtering has already been performed and the va_list parameter is
+ *   passed by reference.  That is because the va_list is a structure in
+ *   some compilers and passing of structures in the NuttX sycalls does
+ *   not work.
+ *
+ ****************************************************************************/
+
+int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
+{
+  int ret = 0;
+
+  if (priority == LOG_LOWOUT)
+    {
+#if defined(CONFIG_SYSLOG_DEFAULT) && defined(CONFIG_ARCH_LOWPUTC)
+      ret = nx_vsyslog_lowout(fmt, ap);
+#endif
+    }
+  else
+    {
+      ret = nx_vsyslog_rawstream(priority, fmt, ap);
+    }
+
   return ret;
 }

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -282,6 +282,14 @@ struct lib_syslograwstream_s
   int last_ch;
 };
 
+#if defined(CONFIG_SYSLOG_DEFAULT) && defined(CONFIG_ARCH_LOWPUTC)
+struct lib_sysloglowoutstream_s
+{
+  struct lib_outstream_s common;
+  int last_ch;
+};
+#endif
+
 /* LZF compressed stream pipeline */
 
 #ifdef CONFIG_LIBC_LZF
@@ -605,6 +613,27 @@ void lib_syslogstream(FAR struct lib_syslogstream_s *stream, int priority);
  ****************************************************************************/
 
 void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream);
+
+#ifdef CONFIG_SYSLOG_DEFAULT
+
+/****************************************************************************
+ * Name: lib_sysloglowoutstream
+ *
+ * Description:
+ *   Initializes a stream for use with the configured syslog interface.
+ *   Only accessible from with the OS SYSLOG logic.
+ *
+ * Input Parameters:
+ *   stream - User allocated, uninitialized instance of struct
+ *            lib_sysloglowoutstream_s to be initialized.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_sysloglowoutstream(FAR struct lib_sysloglowoutstream_s *stream);
+#endif
 
 /****************************************************************************
  * Name: lib_syslograwstream_close

--- a/include/syslog.h
+++ b/include/syslog.h
@@ -121,6 +121,10 @@
 #define LOG_INFO      6  /* Informational message */
 #define LOG_DEBUG     7  /* Debug-level message */
 
+#define LOG_LOWOUT    8  /* Log to console straightly
+                          * for debugging
+                          */
+
 /* Used with setlogmask() */
 
 #define LOG_MASK(p)   (1 << (p))

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -50,6 +50,10 @@ list(
   lib_libvsprintf.c
   lib_ultoa_invert.c)
 
+if(CONFIG_SYSLOG_DEFAULT AND CONFIG_ARCH_LOWPUTC)
+  list(APPEND SRCS lib_sysloglowoutstream.c)
+endif()
+
 if(CONFIG_LIBC_FLOATINGPOINT)
   list(APPEND SRCS lib_dtoa_engine.c lib_dtoa_data.c)
 endif()

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -33,6 +33,12 @@ CSRCS += lib_hexdumpstream.c lib_base64outstream.c lib_mtdsostream.c
 CSRCS += lib_fileinstream.c lib_fileoutstream.c lib_libbsprintf.c
 CSRCS += lib_libvscanf.c lib_libvsprintf.c lib_ultoa_invert.c
 
+ifeq ($(CONFIG_SYSLOG_DEFAULT),y)
+  ifeq ($(CONFIG_ARCH_LOWPUTC),y)
+    CSRCS += lib_sysloglowoutstream.c
+  endif
+endif
+
 ifeq ($(CONFIG_LIBC_FLOATINGPOINT),y)
 CSRCS += lib_dtoa_engine.c lib_dtoa_data.c
 endif

--- a/libs/libc/stream/lib_sysloglowoutstream.c
+++ b/libs/libc/stream/lib_sysloglowoutstream.c
@@ -1,0 +1,115 @@
+/****************************************************************************
+ * libs/libc/stream/lib_sysloglowoutstream.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <syslog.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/streams.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sysloglowoutstream_putc
+ ****************************************************************************/
+
+static void
+sysloglowoutstream_putc(FAR struct lib_outstream_s *self, int ch)
+{
+  FAR struct lib_sysloglowoutstream_s *stream = (FAR void *)self;
+
+  DEBUGASSERT(stream != NULL);
+
+  stream->last_ch = ch;
+
+  up_putc(ch);
+
+  self->nput++;
+}
+
+/****************************************************************************
+ * Name: sysloglowoutstream_puts
+ ****************************************************************************/
+
+static ssize_t sysloglowoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buff, size_t len)
+{
+  FAR struct lib_sysloglowoutstream_s *stream = (FAR void *)self;
+
+  DEBUGASSERT(stream != NULL);
+
+  ssize_t nput = 0;
+
+  if (len <= 0)
+    {
+      return 0;
+    }
+
+  stream->last_ch = ((FAR const char *)buff)[len - 1];
+
+  while (len-- > 0)
+    {
+      up_putc(((FAR const char *)buff)[nput++]);
+    }
+
+  return nput;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_sysloglowoutstream
+ *
+ * Description:
+ *   Initializes syslog stream
+ *
+ * Input Parameters:
+ *   stream   - User allocated, uninitialized instance of struct
+ *              lib_outstream_s to be initialized.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+void lib_sysloglowoutstream(FAR struct lib_sysloglowoutstream_s *stream)
+{
+  DEBUGASSERT(stream != NULL);
+
+  /* Initialize the common fields */
+
+  stream->common.nput  = 0;
+  stream->common.putc  = sysloglowoutstream_putc;
+  stream->common.puts  = sysloglowoutstream_puts;
+  stream->common.flush = lib_noflush;
+  stream->last_ch      = '\0';
+}

--- a/libs/libc/syslog/lib_syslog.c
+++ b/libs/libc/syslog/lib_syslog.c
@@ -54,7 +54,8 @@ void vsyslog(int priority, FAR const IPTR char *fmt, va_list ap)
 {
   /* Check if this priority is enabled */
 
-  if ((g_syslog_mask & LOG_MASK(LOG_PRI(priority))) != 0)
+  if (((g_syslog_mask & LOG_MASK(LOG_PRI(priority))) != 0) ||
+      (priority == LOG_LOWOUT))
     {
       /* Yes.. Perform the nx_vsyslog system call.
        *


### PR DESCRIPTION
  Introduce a new `LOG_LOWPUT` priority level in syslog to provide
  a lightweight printing function especially for early-stage/interrupt/exception debugging.
  This priority is designed to be simple and fast, with the following
  characteristics:

     1. No buffering in either task or interrupt context
     2. No spinlock or critical section protection
        (users must ensure protection themselves if needed)
     3. Output directed only to `up_putc()`
     4. Only performs formatted output of the provided input string

## Summary

Add a new syslog function to meet below requirements:
   1. uinicast(log to serial)
   2. synchronous
   3. light-weight (no buffering, no spinlock, no flushing)
   4. work at anytime(after earlyserialint() is completed),
   5. work at anywhere(task, interrupt, crash context, interrut nest task, crash nest interrup ....)

## Impact

A new syslog function was added, no impact to other parts 

## Testing

Insert test code 

<img width="906" height="504" alt="image" src="https://github.com/user-attachments/assets/7fae5d1a-accb-4f0a-9959-f7b0e31cda33" />

log success on fvp-armv8r-aarch32
<img width="986" height="135" alt="image" src="https://github.com/user-attachments/assets/a78dccf3-8800-4b04-bd59-cce2d05f6635" />

ostest passed on fvp-armv8r-aarch32

<img width="857" height="878" alt="image" src="https://github.com/user-attachments/assets/dc241860-61a5-45fd-8055-3344fbb023f5" />
