### PR TITLE
nuttx/cmake: add cmake disassembly support for GHS compiler

### DIFF
--- a/cmake/nuttx_generate_outputs.cmake
+++ b/cmake/nuttx_generate_outputs.cmake
@@ -52,10 +52,17 @@ function(nuttx_generate_outputs target)
   endif()
 
   if(CONFIG_RAW_DISASSEMBLY)
-    add_custom_command(
-      OUTPUT ${target}.asm
-      COMMAND ${CMAKE_OBJDUMP} -d ${target} > ${target}.asm
-      DEPENDS ${target})
+    if(CONFIG_ARCH_TOOLCHAIN_GHS)
+      add_custom_command(
+        OUTPUT ${target}.asm
+        COMMAND ${CMAKE_OBJDUMP} ${target} -ytext -yl -yp > ${target}.asm
+        DEPENDS ${target})
+    else()
+      add_custom_command(
+        OUTPUT ${target}.asm
+        COMMAND ${CMAKE_OBJDUMP} -d ${target} > ${target}.asm
+        DEPENDS ${target})
+    endif()
     add_custom_target(${target}-asm ALL DEPENDS ${target}.asm)
     file(APPEND ${CMAKE_BINARY_DIR}/nuttx.manifest "${target}.asm\n")
   endif()


### PR DESCRIPTION
 add cmake disassembly support for GHS compiler

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

add cmake disassembly support for GHS compiler

## Impact

add disassembly capability for ghs compiler, no impact to other parts

## Testing

**enable GHS**

<img width="627" height="424" alt="image" src="https://github.com/user-attachments/assets/592a0282-7449-4a2e-a410-513227f89a2c" />

**generated nuttx.sam**

<img width="402" height="518" alt="image" src="https://github.com/user-attachments/assets/a0ae5ee5-79d8-4e83-9a20-f5dccecd9bce" />

