### PR TITLE
arch/tricore: remove magic number in tricore_checkstack.c

### DIFF
--- a/arch/tricore/src/common/tricore_checkstack.c
+++ b/arch/tricore/src/common/tricore_checkstack.c
@@ -79,8 +79,8 @@ size_t tricore_stack_check(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-  start = (alloc + 3) & ~3;
-  end   = (alloc + size) & ~3;
+  start = STACK_ALIGN_UP((uintptr_t)alloc);
+  end   = STACK_ALIGN_DOWN((uintptr_t)alloc + size);
 
   /* Get the adjusted size based on the top and bottom of the stack */
 


### PR DESCRIPTION
  before:
  |   start = (alloc + 3) & ~3;
  |   end   = (alloc + size) & ~3;
  after:
  |   start = STACK_ALIGN_UP((uintptr_t)alloc);
  |   end   = STACK_ALIGN_DOWN((uintptr_t)alloc + size);

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

tricore arch code implemention optimization

## Impact

tricore arch code optimization，no impact to other nuttx parts

## Testing

**ostest passed on a2g-tc397-5v-tft board:**

<img width="403" height="521" alt="image" src="https://github.com/user-attachments/assets/1ed90a49-888a-4b6e-baa2-a4a50da30cef" />
