### PR TITLE
nuttx/cmake: improve board specific Toolchain.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,13 +447,11 @@ endif()
 # Setup platform options (this needs to happen after project(), once the
 # toolchain file has been processed)
 
-# Support custom Toolchain options by custom Boards
-if(CONFIG_ARCH_BOARD_CUSTOM)
-  if(EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake
-     AND EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
-    # must be added AFTER ToolchainFile and BEFORE platform
-    include(${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
-  endif()
+# Support board Toolchain options
+if(EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake
+   AND EXISTS ${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
+  # must be added AFTER ToolchainFile and BEFORE platform
+  include(${NUTTX_BOARD_ABS_DIR}/cmake/Toolchain.cmake)
 endif()
 
 include(platform)


### PR DESCRIPTION
     Remove limitation that only custom board can have
     board specific Toolchain.cmake

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Remove limitation that only custom board can have board specific Toolchain.cmake

## Impact

Just give board control of board specific Toolchain.cmake in cmake build system,
No impact to any parts of Nuttx.

## Testing

This is a improvement of cmake build scripts, CI BV stage will verify this change
