### PR TITLE
cmake/stm32h7: Add LTDC support to CMakeLists.txt

### DIFF
--- a/arch/arm/src/stm32h7/CMakeLists.txt
+++ b/arch/arm/src/stm32h7/CMakeLists.txt
@@ -150,6 +150,10 @@ if(CONFIG_CAPTURE)
   list(APPEND SRCS stm32_capture_lowerhalf.c)
 endif()
 
+if(CONFIG_STM32H7_LTDC)
+  list(APPEND SRCS stm32_ltdc.c)
+endif()
+
 if(CONFIG_USBDEV)
   list(APPEND SRCS stm32_otgdev.c)
 endif()


### PR DESCRIPTION
## Summary

This PR adds conditional compilation support for the STM32H7 LTDC (LCD-TFT Display Controller) driver in the CMake build system. Specifically, it includes stm32_ltdc.c in the source list (SRCS) when CONFIG_STM32H7_LTDC is enabled in the NuttX configuration.

## Impact

The LTDC driver for STM32H7 is already implemented in the codebase, but it was not being built via CMake due to missing inclusion in CMakeLists.txt. This change ensures that the driver can be compiled and linked properly when the configuration option is selected, enabling display support for STM32H7-based boards without build errors. This aligns with ongoing efforts to improve STM32H7 peripheral support in NuttX.

## Testing

Tested on host: Linux Mint 22.2 Zara base: Ubuntu 24.04 noble, with CMake version 3.28.3 and arm-none-eabi-gcc (15:13.2.rel1-2) 13.2.1 20231009 toolchain. 
Tested build with CMake for the STM32H7 target, using the stm32h750b-dk:lvgl configuration.

Build logs before changes:

```
❯ cmake -B ../build -DBOARD_CONFIG=stm32h750b-dk:lvgl -GNinja
-- Found Python3: /home/user/nuttxspace/.env/bin/python3 (found version "3.12.3") found components: Interpreter
-- Processing includes: /home/user/nuttxspace/nuttx/boards/arm/stm32h7/stm32h750b-dk/configs/lvgl/defconfig → /home/user/nuttxspace/build/.defconfig.processed
-- Initializing NuttX
  Select HOST_LINUX=y
--   CMake:  3.28.3
--   Ninja:  1.11.1
--   Board:  stm32h750b-dk
--   Config: lvgl
--   Appdir: /home/user/nuttxspace/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/arm-none-eabi-gcc
-- Configuring done (4.6s)
-- Generating done (0.2s)
-- Build files have been written to: /home/user/nuttxspace/build

❯ cmake --build ../build
[1814/1817] Linking CXX executable nuttx
FAILED: nuttx
: && /usr/bin/arm-none-eabi-g++  --specs=nosys.specs   -Wl,--print-memory-usage -Wl,--entry=__start -nostdlib -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map @CMakeFiles/nuttx.rsp -o nuttx  && :
/usr/lib/gcc/arm-none-eabi/13.2.1/../../../arm-none-eabi/bin/ld: boards/libboard.a(stm32_lcd.c.obj): in function `up_fbinitialize':
stm32_lcd.c:(.text.up_fbinitialize+0x26): undefined reference to `stm32_ltdcinitialize'
/usr/lib/gcc/arm-none-eabi/13.2.1/../../../arm-none-eabi/bin/ld: boards/libboard.a(stm32_lcd.c.obj): in function `up_fbgetvplane':
stm32_lcd.c:(.text.up_fbgetvplane+0x2): undefined reference to `stm32_ltdcgetvplane'
Memory region         Used Size  Region Size  %age Used
            itcm:           0 B        64 KB      0.00%
           flash:      465004 B         2 MB     22.17%
           dtcm1:           0 B        64 KB      0.00%
           dtcm2:           0 B        64 KB      0.00%
            sram:       13500 B       512 KB      2.57%
           sram1:           0 B       128 KB      0.00%
           sram2:           0 B       128 KB      0.00%
           sram3:           0 B        32 KB      0.00%
           sram4:           0 B        64 KB      0.00%
           bbram:           0 B         4 KB      0.00%
           sdram:           0 B         8 MB      0.00%
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

Build logs after changes:

```
❯ cmake -B ../build -DBOARD_CONFIG=stm32h750b-dk:lvgl -GNinja
-- Found Python3: /home/user/nuttxspace/.env/bin/python3 (found version "3.12.3") found components: Interpreter 
-- Processing includes: /home/user/nuttxspace/nuttx/boards/arm/stm32h7/stm32h750b-dk/configs/lvgl/defconfig → /home/user/nuttxspace/build/.defconfig.processed
-- Initializing NuttX
  Select HOST_LINUX=y
--   CMake:  3.28.3
--   Ninja:  1.11.1
--   Board:  stm32h750b-dk
--   Config: lvgl
--   Appdir: /home/user/nuttxspace/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/arm-none-eabi-gcc
-- Configuring done (2.6s)
-- Generating done (0.2s)
-- Build files have been written to: /home/user/nuttxspace/build
❯ cmake --build ../build
[1815/1818] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
            itcm:           0 B        64 KB      0.00%
           flash:      465752 B         2 MB     22.21%
           dtcm1:           0 B        64 KB      0.00%
           dtcm2:           0 B        64 KB      0.00%
            sram:       13632 B       512 KB      2.60%
           sram1:           0 B       128 KB      0.00%
           sram2:           0 B       128 KB      0.00%
           sram3:           0 B        32 KB      0.00%
           sram4:           0 B        64 KB      0.00%
           bbram:           0 B         4 KB      0.00%
           sdram:           0 B         8 MB      0.00%
[1818/1818] Generating System.map
```
