### PR TITLE
board/arm/rp2040: implement "board_boot_image" for bootloader support

### DIFF
--- a/boards/arm/rp2040/common/src/Make.defs
+++ b/boards/arm/rp2040/common/src/Make.defs
@@ -29,6 +29,10 @@ ifeq ($(CONFIG_BOARDCTL_RESET),y)
 CSRCS += rp2040_reset.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_BOOT_IMAGE),y)
+CSRCS += rp2040_boot_image.c
+endif
+
 ifeq ($(CONFIG_SPI),y)
 CSRCS += rp2040_spi.c
 endif

--- a/boards/arm/rp2040/common/src/rp2040_boot_image.c
+++ b/boards/arm/rp2040/common/src/rp2040_boot_image.c
@@ -1,0 +1,166 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/src/rp2040_boot_image.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <stdio.h>
+#include <fcntl.h>
+
+#include <sys/boardctl.h>
+#include <nuttx/irq.h>
+#include <arch/barriers.h>
+
+#include "nvic.h"
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This structure represents the first two entries on NVIC vector table */
+
+struct arm_vector_table
+{
+  uint32_t spr;   /* Stack pointer on reset */
+  uint32_t reset; /* Pointer to reset exception handler */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void cleanup_arm_nvic(void);
+static void systick_disable(void);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  cleanup_arm_nvic
+ *
+ * Description:
+ *   Acknowledge and disable all interrupts in NVIC
+ *
+ * Input Parameters:
+ *   None
+ *
+ *  Returned Value:
+ *    None
+ *
+ ****************************************************************************/
+
+static void cleanup_arm_nvic(void)
+{
+  /* Allow any pending interrupts to be recognized */
+
+  UP_ISB();
+  up_irq_disable();
+
+  /* Disable all interrupts */
+
+  putreg32(0xffffffff, ARMV6M_NVIC_ICER);
+
+  /* Clear all pending interrupts */
+
+  putreg32(0xffffffff, ARMV6M_NVIC_ICPR);
+}
+
+/****************************************************************************
+ * Name:  systick_disable
+ *
+ * Description:
+ *   Disable the SysTick system timer
+ *
+ * Input Parameters:
+ *   None
+ *
+ *  Returned Value:
+ *    None
+ *
+ ****************************************************************************/
+
+static void systick_disable(void)
+{
+  putreg32(0, ARMV6M_SYSTICK_CSR);
+  putreg32(SYSTICK_RVR_MASK, ARMV6M_SYSTICK_RVR);
+  putreg32(0, ARMV6M_SYSTICK_CVR);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_boot_image
+ *
+ * Description:
+ *   This entry point is called by bootloader to jump to application image.
+ *
+ ****************************************************************************/
+
+int board_boot_image(const char *path, uint32_t hdr_size)
+{
+  static struct arm_vector_table vt;
+  struct file file;
+  ssize_t bytes;
+  int ret;
+
+  ret = file_open(&file, path, O_RDONLY | O_CLOEXEC);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to open %s with: %d", path, ret);
+      return ret;
+    }
+
+  bytes = file_pread(&file, &vt, sizeof(vt), hdr_size);
+  if (bytes != sizeof(vt))
+    {
+      syslog(LOG_ERR, "Failed to read ARM vector table: %d", bytes);
+      return bytes < 0 ? bytes : -1;
+    }
+
+  systick_disable();
+
+  cleanup_arm_nvic();
+
+  /* Set main and process stack pointers */
+
+  __asm__ __volatile__(
+                       "\tmsr msp, %0\n"
+                       "\tmsr control, %1\n"
+                       "\tisb\n"
+                       "\tmov pc, %2\n"
+                       :
+                       : "r" (vt.spr), "r" (0), "r" (vt.reset));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

This function is required by the bootloaders (nxboot and mcuboot).

## Impact

Users of rp2040-based boards are now able to integrate one of the bootloaders into their application.

## Testing

I am able to reliably boot into an uploaded firmware (via nxboot).