### PR TITLE
arch: fix alignment bug for archs that need stack alignment

### DIFF
--- a/arch/arm64/src/common/arm64_usestack.c
+++ b/arch/arm64/src/common/arm64_usestack.c
@@ -84,6 +84,9 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
+  uintptr_t top_of_stack;
+  size_t size_of_stack;
+
 #ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
@@ -115,9 +118,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size  =
-         STACK_ALIGN_DOWN((uintptr_t)stack + stack_size) - (uintptr_t)stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/avr/src/avr32/avr_usestack.c
+++ b/arch/avr/src/avr32/avr_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,28 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
 #endif
-
-  /* The AVR32 uses a push-down stack:  the stack grows
-   * toward loweraddresses in memory.  The stack pointer
-   * register, points to the lowest, valid work address
-   * (the "top" of the stack).  Items on the stack are
-   * referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The AVR32 stack must be aligned at word (4 byte)
-   * boundaries. If necessary top_of_stack must be rounded
-   * down to the next boundary
-   */
-
-  top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/ceva/src/common/ceva_usestack.c
+++ b/arch/ceva/src/common/ceva_usestack.c
@@ -91,26 +91,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* The CEVA uses a push-down stack:  the stack grows toward lower addresses
-   * in memory.  The stack pointer register, points to the lowest, valid
-   * work address (the "top" of the stack).  Items on the stack are
-   * referenced as positive word offsets from sp.
-   */
-
-  /* The CEVA stack must be aligned to 4-byte alignment.
-   * If necessary size_of_stack must be rounded down to the next
-   * boundary
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a recognizable

--- a/arch/hc/src/common/hc_usestack.c
+++ b/arch/hc/src/common/hc_usestack.c
@@ -92,6 +92,11 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -100,28 +105,6 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* The CPU12 uses a push-down stack: the stack grows
-   * toward lower addresses in memory. Because the CPU12 stack
-   * operates as a decrement then store stack, the value assigned
-   * to the initial stack pointer is one more than the last valid
-   * stack address.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The CPU12 stack should be aligned at half-word (2 byte)
-   * boundaries. If necessary top_of_stack must be rounded
-   * down to the next boundary
-   */
-
-  top_of_stack &= ~1;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,34 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* MIPS uses a push-down stack:  the stack grows toward loweraddresses in
-   * memory.  The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack).  Items on the stack are referenced
-   * as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The MIPS stack must be aligned at word (4 byte) or double word (8 byte)
-   * boundaries. If necessary top_of_stack must be rounded down to the
-   * next boundary
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-
-  /* The size of the stack in bytes is then the difference between
-   * the top and the bottom of the stack (+4 because if the top
-   * is the same as the bottom, then the size is one 32-bit element).
-   * The size need not be aligned.
-   */
-
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/misoc/src/lm32/lm32_usestack.c
+++ b/arch/misoc/src/lm32/lm32_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,28 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* LM32 uses a push-down stack:  the stack grows toward lower
-   * addresses in memory.  The stack pointer register points to the
-   * lowest, valid working address (the "top" of the stack).  Items on
-   * the stack are referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The LM32 stack must be aligned at word (4 byte) boundaries; for
-   * floating point use, the stack must be aligned to 8-byte addresses.
-   * If necessary top_of_stack must be rounded down to the next
-   * boundary to meet these alignment requirements.
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/misoc/src/minerva/minerva_usestack.c
+++ b/arch/misoc/src/minerva/minerva_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,28 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* MINERVA uses a push-down stack: the stack grows toward lower
-   * addresses in memory.  The stack pointer register points to the
-   * lowest, valid working address (the "top" of the stack).  Items on
-   * the stack are referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The MINERVA stack must be aligned at word (4 byte) boundaries; for
-   * floating point use, the stack must be aligned to 8-byte addresses.
-   * If necessary top_of_stack must be rounded down to the next boundary
-   * to meet these alignment requirements.
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/or1k/src/common/or1k_usestack.c
+++ b/arch/or1k/src/common/or1k_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,15 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/renesas/src/common/renesas_usestack.c
+++ b/arch/renesas/src/common/renesas_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,26 +106,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* The SH family uses a push-down stack:  the stack grows toward lower
-   * addresses in memory.  The stack pointer register, points to the
-   * lowest, valid work address (the "top" of the stack).  Items on the
-   * stack are referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The SH stack must be aligned at word (4 byte) boundaries. If necessary
-   * top_of_stack must be rounded down to the next boundary
-   */
-
-  top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -93,26 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* RISC-V uses a push-down stack: the stack grows toward lower addresses in
-   * memory. The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack). Items on the stack are referenced
-   * as positive word offsets from SP.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The RISC-V stack must be aligned at 128-bit (16-byte) boundaries.
-   * If necessary top_of_stack must be rounded down to the next boundary.
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/sim/src/sim/sim_usestack.c
+++ b/arch/sim/src/sim/sim_usestack.c
@@ -92,15 +92,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/sparc/src/common/sparc_usestack.c
+++ b/arch/sparc/src/common/sparc_usestack.c
@@ -85,27 +85,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* sparc uses a push-down stack:  the stack grows toward loweraddresses in
-   * memory.  The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack).  Items on the stack are referenced
-   * as positive word offsets from sp.
-   */
-
-  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The sparc stack must be aligned at word (4 byte) or double word (8 byte)
-   * boundaries. If necessary top_of_stack must be rounded down to the
-   * next boundary
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/x86/src/i486/i486_usestack.c
+++ b/arch/x86/src/i486/i486_usestack.c
@@ -93,34 +93,15 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* If stack debug is enabled, then fill the stack with a recognizable value
-   * that we can use later to test for high water marks.
-   */
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* The i486 uses a push-down stack:  the stack grows toward loweraddresses
-   * in memory.  The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack).  Items on the stack are referenced as
-   * positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The i486 stack must be aligned at word (4 byte) boundaries. If necessary
-   * top_of_stack must be rounded down to the next boundary
-   */
-
-  top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/x86_64/src/intel64/intel64_usestack.c
+++ b/arch/x86_64/src/intel64/intel64_usestack.c
@@ -93,29 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* The intel64 uses a push-down stack:  the stack grows toward lower
-   * addresses in memory.  The stack pointer register, points to the lowest,
-   * valid work address (the "top" of the stack).  Items on the stack are
-   * referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The intel64 stack must be aligned at word (16 byte) boundaries. If
-   * necessary top_of_stack must be rounded down to the next boundary.
-   * We intentionally align at 8 byte boundary (look at up_stack_frame()),
-   * because at task_start, only frame pointer will be pushed, not
-   * instruction pointer.
-   */
-
-  top_of_stack &= ~0x0f;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -93,26 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* XTENSA uses a push-down stack:  the stack grows toward loweraddresses in
-   * memory.  The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack).  Items on the stack are referenced
-   * as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The XTENSA stack must be aligned at 16 bytes boundaries. If necessary
-   * top_of_stack must be rounded down to the next boundary.
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/z16/src/common/z16_usestack.c
+++ b/arch/z16/src/common/z16_usestack.c
@@ -93,6 +93,11 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -101,26 +106,6 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* The ZNEO uses a push-down stack:  the stack grows toward lower
-   * addresses in memory.  The stack pointer register, points to the
-   * lowest, valid work address (the "top" of the stack).  Items on
-   * the stack are referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* Align the stack to word (4 byte) boundaries.  This is probably
-   * a greater alignment than is required.
-   */
-
-  top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -92,6 +92,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
   /* If stack debug is enabled, then fill the stack with a recognizable value
    * that we can use later to test for high water marks.
@@ -100,26 +105,6 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 #ifdef CONFIG_STACK_COLORATION
   memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
-
-  /* The Z80 uses a push-down stack:  the stack grows toward lower
-   * addresses in memory.  The stack pointer register, points to the
-   * lowest, valid work address (the "top" of the stack).  Items on
-   * the stack are* referenced as positive word offsets from sp.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The Z80 stack does not need to be aligned.  Here is is aligned at
-   * word (4 byte) boundary.
-   */
-
-  top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
 
   return OK;
 }


### PR DESCRIPTION
 These archs only align the size of the stack, forgeting to do the
 stack start addr alignment, this patch fixes it.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This patch fixes the stack alignment bug for all archs that need
do stack addr alignment

## Impact

This patch fixed bugs in the arch level, on impact on other parts

## Testing

This patch fixes the alignment bugs for all arches, there is no way to do the test for
all archs...., I will resort to the CI to verify that this fix is OK.
