### PR TITLE
drivers/mtd: Introduce generic mtd partitioning

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -1891,6 +1891,12 @@ config ESP32_STORAGE_MTD_SIZE
 	---help---
 		MTD size in SPI Flash.
 
+mtd_name = ESP32_STORAGE_MTD
+mtd_part_default_sizes = 8,504,512
+mtd_part_default_names = mtd0p0,mtd0p1,mtd0p2
+
+source "drivers/mtd/Kconfig.partition_template"
+
 config ESP32_SPIFLASH_DEBUG
 	bool "Debug SPI Flash"
 	default n

--- a/drivers/mtd/Kconfig.partition_template
+++ b/drivers/mtd/Kconfig.partition_template
@@ -1,0 +1,54 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+# This is a template file to include when partitioning a mtd device.
+# It uses mtd_name, mtd_part_default_sizes and mtd_part_default_names
+# to create CONFIG_{$mtd_name}_PART_SIZES and CONFIG_{mtd_name}_PART_NAMES
+#
+# It can be included in a Kconfig as:
+# mtd_name = ESP32_STORAGE_MTD
+# mtd_part_default_sizes = 8,504,512
+# mtd_part_names = mtd0p0,mtd0p1,mtd0p2
+# source "drivers/mtd/Kconfig.partition_template"
+
+if MTD_PARTITION
+
+config $(mtd_name)_PART
+    bool "Partitioning on $(mtd_name)"
+    default n
+    ---help---
+        Enables partitioning on $(mtd_name)
+
+config $(mtd_name)_PART_SIZES
+    string "$(mtd_name) partition sizes (kB)"
+    default "$(mtd_part_default_sizes)"
+    depends on $(mtd_name)_PART
+    ---help---
+        Partition sizes in kB as comma separated list.
+
+config $(mtd_name)_PART_NAMES
+    string "$(mtd_name) partition names"
+    default "$(mtd_part_default_names)"
+    depends on $(mtd_name)_PART
+    depends on MTD_PARTITION_NAMES
+    ---help---
+        Partition names as comma separated list.
+
+config $(mtd_name)_CONFIG_PART
+	bool "Create application config data partition"
+	default n
+	depends on $(mtd_name)_PART
+	depends on PLATFORM_CONFIGDATA
+	---help---
+		Enables creation of a /dev/config partition.
+
+config $(mtd_name)_CONFIG_PART_NUMBER
+	int "Index number of config partition (in list above)"
+	default 0
+	depends on $(mtd_name)_CONFIG_PART
+	---help---
+		Specifies the index number of the config data partition
+		from the partition list.
+
+endif #MTD_PARTITION


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

While working on partitioning ESP32_STORAGE_MTD I detected that devices create their own method for creating partitions in Kconfig.

To avoid duplicate Kconfig code and to allow standardization on partitions a generic method for creating compile time partitions is proposed. I intend to extend the partitioning approach to allow for (off-image) definition of romfs based /etc, romfs based /bin.

To proposed method could also be used in other places (e.g. logging) to allow more fine tuned setup (e.g. only allow logging for a specific subsystem).

## Impact

The proposal is an opt-in proposal so it should not affect users.

## Testing

At the moment only Kconfig variables are changed, they are not used.

For testing I intend to use the esp32-devkitc.

host machine: Ubuntu 24.04
board: esp32-devkitc