### PR TITLE
ci/docker: add Raspberry Pi picotool and fix GN build

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   nodejs \
   npm \
   unzip \
-  zip
+  zip \
+  python3
 
 RUN mkdir -p /tools
 WORKDIR /tools
@@ -67,8 +68,10 @@ RUN cd nuttx-tools/kconfig-frontends \
 RUN mkdir -p /tools/gn \
   && cd /tools/gn \
   && git clone https://gn.googlesource.com/gn gn \
-  && cd gn && ./build/gen.py \
-  && cd out && ninja
+  && cd gn \
+  && git checkout 5d0a4153b0bcc86c5a23310d5b648a587be3c56d \
+  && python3 build/gen.py \
+  && ninja -C out
 
 # Upgrade nodejs to the stable version we need before install zap
 RUN npm install -g n && n 20.10.0 node && hash -r
@@ -303,6 +306,15 @@ RUN mkdir -p pico-sdk && \
   | tar -C pico-sdk --strip-components 1 -xz
 
 ###############################################################################
+# Build image for tool required by Raspberry Pi picotool builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-raspberrypi-picotool
+# Download the prebuilt Raspberry Pi picotool
+RUN mkdir -p picotool && \
+  curl -s -L "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.2.0-0/picotool-2.2.0-x86_64-lin.tar.gz" \
+  | tar -C picotool --strip-components 1 -xz
+
+###############################################################################
 # Final Docker image used for running CI system.  This includes all toolchains
 # supported by the CI system.
 ###############################################################################
@@ -492,6 +504,10 @@ COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/
 # Raspberry Pi pico-sdk source
 COPY --from=nuttx-toolchain-raspberrypi-pico-sdk /tools/pico-sdk/ pico-sdk/
 ENV PICO_SDK_PATH="/tools/pico-sdk"
+
+# Raspberry Pi picotool
+COPY --from=nuttx-toolchain-raspberrypi-picotool /tools/picotool/ picotool/
+ENV PATH="/tools/picotool:$PATH"
 
 # gn tool
 RUN mkdir -p /tools/gn


### PR DESCRIPTION


## Summary

- Add prebuilt Raspberry Pi picotool

Fix these warnings

```
====================================================================================
Configuration/Tool: adafruit-kb2040/audiopack,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-09-18 13:11:08
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
tools/Unix.mk:556: "picotool not found in $PATH, it will be sourced from pico-sdk"
Warning: building picotool from pico-sdk will skip USB support! See https://github.com/raspberrypi/pico-sdk/issues/1827
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
lib/mbedtls submodule needs to be initialized for bintool hashing/signing
mbedtls not found - no signing/hashing support will be built
PICOTOOL_NO_LIBUSB is set - no USB support will be built
Using precompiled enc_bootloader.elf
  [1/1] Normalize adafruit-kb2040/audiopack
====================================================================================
Configuration/Tool: adafruit-kb2040/smp,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-09-18 13:12:26
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
tools/Unix.mk:556: "picotool not found in $PATH, it will be sourced from pico-sdk"
  [1/1] Normalize adafruit-kb2040/smp
====================================================================================
```

- fix GN build with: git checkout 5d0a4153b0bcc86c5a23310d5b648a587be3c56d

While testing the addition of picotool to our docker image, 
I noticed that GN with the latest commits from September 

https://gn-review.googlesource.com/q/project:gn

fails to build and returns this error:

```
#18 47.55 [60/299] CXX src/gn/command_format.o
#18 49.02 [61/299] CXX src/gn/command_outputs.o
#18 50.90 [62/299] CXX src/gn/ninja_rust_binary_target_writer.o
#18 52.66 [63/299] CXX src/gn/ninja_outputs_writer.o
#18 53.45 [64/299] CXX src/gn/command_path.o
#18 54.38 [65/299] CXX src/gn/command_refs.o
#18 55.44 [66/299] CXX src/gn/config_values.o
#18 56.74 [67/299] CXX src/gn/compile_commands_writer.o
#18 57.34 [68/299] CXX src/gn/commands.o
#18 57.58 [69/299] CXX src/gn/rust_project_writer.o
#18 57.58 FAILED: src/gn/rust_project_writer.o 
#18 57.58 clang++ -MMD -MF src/gn/rust_project_writer.o.d -I../src -I. -DNDEBUG -O3 -fdata-sections -ffunction-sections -Werror -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -pthread -pipe -fno-exceptions -fno-rtti -fdiagnostics-color -Wall -Wextra -Wno-unused-parameter -Wextra-semi -Wundef -std=c++20 -Wrange-loop-analysis -Wextra-semi-stmt -Wno-deprecated-copy -Wno-implicit-fallthrough -Wno-redundant-move -Wno-unused-variable -Wno-format -Wno-strict-aliasing -Wno-cast-function-type -c ../src/gn/rust_project_writer.cc -o src/gn/rust_project_writer.o
#18 57.58 In file included from ../src/gn/rust_project_writer.cc:5:
#18 57.58 In file included from ../src/gn/rust_project_writer.h:8:
#18 57.58 In file included from ../src/gn/err.h:8:
#18 57.58 In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/memory:63:
#18 57.58 In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algobase.h:65:
#18 57.58 In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterator_base_types.h:71:
#18 57.58 /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/iterator_concepts.h:979:13: error: no matching function for call to '__begin'
#18 57.58         = decltype(ranges::__cust_access::__begin(std::declval<_Tp&>()));
#18 57.58                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

For now, as a workaround, I used 
git checkout 5d0a4153b0bcc86c5a23310d5b648a587be3c56d
with a commit that does not cause errors in the build.

https://gn-review.googlesource.com/q/project:gn


## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO


## Testing

 GitHub

```
Version
2279 (5d0a4153b0bc)

Commands (type "gn help <command>" for more help):
  analyze: Analyze which targets are affected by a list of files.
  args: Display or configure arguments declared by the build.
  check: Check header dependencies.
  clean: Cleans the output directory.
  clean_stale: Cleans the stale output files from the output directory.
  desc: Show lots of insightful information about a target or config.
  format: Format .gn files.
  gen: Generate ninja files.
  help: Does what you think.
  ls: List matching targets.
  meta: List target metadata collection results.
  outputs: Which files a source/target make.
  path: Find paths between two targets.
  refs: Find stuff referencing a target or file.
```

```
picotool v2.2.0 (Linux, GNU-11.4.0, Release)
PICOTOOL:
    Tool for interacting with RP-series device(s) in BOOTSEL mode, or with an
    RP-series binary
```

[Linux (arm-06)](https://github.com/simbit18/nuttx-testing-ci/actions/runs/17830909993/job/50695538093#logs)




