### PR TITLE
sched/task: Provide a task stack overflow check mechanism in task context switch and task exit

### DIFF
--- a/Documentation/debugging/stackcheck.rst
+++ b/Documentation/debugging/stackcheck.rst
@@ -5,24 +5,31 @@ Stack Overflow Check
 Overview
 --------
 
-Currently NuttX supports three types of stack overflow detection:
-    1. Stack Overflow Software Check
-    2. Stack Overflow Hardware Check
-    3. Stack Canary Check
+Currently NuttX supports four types of stack overflow detection:
+    1. Stack Overflow Software Check During Function Call
+    2. Stack Overflow Software Check During Task Context Switch
+    3. Stack Overflow Hardware Check
+    4. Stack Canary Check
 
-The software stack detection includes two implementation ideas:
+The software stack detection during function call includes two implementation ideas:
     1. Implemented by coloring the stack memory
     2. Implemented by comparing the sp and sl registers
+
+The software stack detection during task context switch includes two implementation ideas:
+    1. Implemented by coloring the stack memory
+    2. Implemented by checking stack overflow threshold value during context switch
 
 Support
 -------
 
-Software and hardware stack overflow detection implementation,
-currently only implemented on ARM Cortex-M (32-bit) series chips
-Stack Canary Check is available on all platforms
+Stack overflow software check during function call and stack overflow
+hardware check implementation, currently only implemented on ARM Cortex-M (32-bit)
+series chips. Stack overflow software check during task context switch, currently
+only implemented on ARM Cortex-R52 (32-bit) series chips. Stack Canary Check is available
+on all platforms
 
-Stack Overflow Software Check
------------------------------
+Stack Overflow Software Check During Function Call
+--------------------------------------------------
 
 1. Memory Coloring Implementation Principle
     1. Before using the stack, Thread will refresh the stack area to 0xdeadbeef
@@ -43,6 +50,16 @@ Stack Overflow Software Check
 
     Usage:
         Enable CONFIG_ARMV8M_STACKCHECK or CONFIG_ARMV7M_STACKCHECK
+
+Stack Overflow Software Check During Task Context Switch
+--------------------------------------------------------
+
+1. Before using the stack, Thread will refresh the stack area to 0xdeadbeef
+2. When Thread is running, it will overwrite 0xdeadbeef
+3. During context switching, up_check_tcbstack_overflow() detects 0xdeadbeef to check for stack overflow
+
+Usage:
+    Enable CONFIG_STACK_COLORATION and TASK_STACK_OVERFLOW_CHECK
 
 Stack Overflow Hardware Check
 -----------------------------

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2564,6 +2564,9 @@ void irq_dispatch(int irq, FAR void *context);
 #ifdef CONFIG_STACK_COLORATION
 struct tcb_s;
 size_t up_check_tcbstack(FAR struct tcb_s *tcb);
+#ifdef CONFIG_TASK_STACK_OVERFLOW_CHECK
+bool up_check_tcbstack_overflow(FAR struct tcb_s *tcb);
+#endif
 #if defined(CONFIG_ARCH_INTERRUPTSTACK) && CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(int cpu);
 #endif

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1257,7 +1257,16 @@ void nxsched_resume_scheduler(FAR struct tcb_s *tcb);
 #ifdef CONFIG_SCHED_SUSPENDSCHEDULER
 void nxsched_suspend_scheduler(FAR struct tcb_s *tcb);
 #else
-#  define nxsched_suspend_scheduler(tcb)
+#  ifdef CONFIG_TASK_STACK_OVERFLOW_CHECK
+#    define nxsched_suspend_scheduler(tcb) \
+      do \
+        { \
+            DEBUGASSERT(!up_check_tcbstack_overflow(tcb));\
+        } \
+      while (0)
+#  else
+#    define nxsched_suspend_scheduler(tcb)
+#  endif
 #endif
 
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -2034,3 +2034,25 @@ config CUSTOM_SEMAPHORE_MAXVALUE
 	---help---
 		Enable to support custom max value for semaphores.
 		When this option is enabled, the max value of a semaphore can be set
+
+config TASK_STACK_OVERFLOW_CHECK
+	bool "Task stack overflow check"
+	depends on STACK_COLORATION
+	default n
+	---help---
+		Enable to support task stack overflow check.
+		When this option is enabled, the stack of a task will be checked for
+		overflow when the task is switched out. If a stack overflow is detected,
+		the system will panic.
+
+if TASK_STACK_OVERFLOW_CHECK
+config TASK_STACK_OVERFLOW_CHECK_THRESHOLD
+	int "Stack overflow check threshold"
+	default 16
+	---help---
+		This is the threshold value (in bytes) used to determine if a stack
+		overflow has occurred.  This value should be set to a value that is
+		larger than the worst case stack usage.The stack overflow check will
+		fail if fewer than this number of bytes of unused stack remain after
+		the stack coloration pattern.
+endif

--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -68,6 +68,12 @@ void nxsched_suspend_scheduler(FAR struct tcb_s *tcb)
       return;
     }
 
+#ifdef CONFIG_TASK_STACK_OVERFLOW_CHECK
+  /* Check for stack overflow */
+
+  DEBUGASSERT(!up_check_tcbstack_overflow(tcb));
+#endif
+
 #ifdef CONFIG_SCHED_SPORADIC
   /* Perform sporadic schedule operations */
 


### PR DESCRIPTION
            
   Provide task stack overflow check mechanism in task context switch,
   and add porting on arm arch

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Provide a task stack overflow check mechanism during task context switch.
This method is based on  stack coloration and a threshold value. The stack overflow check will
fail if fewer than the threshold number of bytes of unused stack remain after the stack coloration pattern

## Impact

Add a stack overflow check mechanism to scheduler, this function is default disabled. If it is enabled, 
some performance load will be introduced during task switch.

## Testing

**enable it on board fvp-armv8r-aarch32**
<img width="868" height="624" alt="image" src="https://github.com/user-attachments/assets/f6c072ff-caac-436d-aaba-df752a78c526" />

**ostest passed** 
<img width="787" height="558" alt="image" src="https://github.com/user-attachments/assets/540fac73-960e-445a-8efa-1d67d6e01527" />

**Trigger a stack overflow in hello world demo**

<img width="829" height="761" alt="image" src="https://github.com/user-attachments/assets/21ac36ed-4b0b-4141-9fd7-a24076e12c45" />

**stack overflow detected**
<img width="1010" height="769" alt="image" src="https://github.com/user-attachments/assets/d316fddc-ea8a-4c80-ab35-1e88ba5bc683" />


