### PR TITLE
arm/rp2040: CMake build for Raspberry Pi RP2040 implemented

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,13 @@ if(POLICY CMP0169)
   cmake_policy(SET CMP0169 OLD)
 endif()
 
+# Find Python 3 interpreter
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+if(NOT Python3_Interpreter_FOUND)
+  message(FATAL_ERROR "Did NOT find Python interpreter.")
+endif()
+
 # Basic CMake configuration ##################################################
 
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/arch/arm/src/rp2040/CMakeLists.txt
+++ b/arch/arm/src/rp2040/CMakeLists.txt
@@ -1,0 +1,123 @@
+# ##############################################################################
+# arch/arm/src/rp2040/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+list(
+  APPEND
+  SRCS
+  rp2040_idle.c
+  rp2040_irq.c
+  rp2040_uart.c
+  rp2040_serial.c
+  rp2040_start.c
+  rp2040_timerisr.c
+  rp2040_gpio.c
+  rp2040_pio.c
+  rp2040_clock.c
+  rp2040_xosc.c
+  rp2040_pll.c)
+
+if(CONFIG_SMP)
+  list(APPEND SRCS rp2040_cpustart.c rp2040_smpcall.c rp2040_cpuidlestack.c
+       rp2040_testset.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MULTICPU)
+  list(APPEND SRCS rp2040_cpuindex.c)
+endif()
+
+if(CONFIG_RP2040_DMAC)
+  list(APPEND SRCS rp2040_dmac.c)
+endif()
+
+if(CONFIG_RP2040_SPI)
+  list(APPEND SRCS rp2040_spi.c)
+endif()
+
+if(CONFIG_RP2040_PWM)
+  list(APPEND SRCS rp2040_pwm.c)
+endif()
+
+if(CONFIG_RP2040_I2C)
+  list(APPEND SRCS rp2040_i2c.c)
+endif()
+
+if(CONFIG_RP2040_I2C_SLAVE)
+  list(APPEND SRCS rp2040_i2c_slave.c)
+endif()
+
+if(CONFIG_RP2040_I2S)
+  list(APPEND SRCS rp2040_i2s.c rp2040_i2s_pio.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS rp2040_usbdev.c)
+endif()
+
+if(CONFIG_WS2812)
+  list(APPEND SRCS rp2040_ws2812.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS rp2040_adc.c)
+endif()
+
+if(CONFIG_IEEE80211_INFINEON_CYW43439)
+  list(APPEND SRCS rp2040_cyw43439.c)
+endif()
+
+if(CONFIG_WATCHDOG)
+  list(APPEND SRCS rp2040_wdt.c)
+endif()
+
+if(CONFIG_RP2040_FLASH_FILE_SYSTEM)
+  list(APPEND SRCS rp2040_flash_mtd.c rp2040_flash_initialize.S)
+endif()
+
+if(CONFIG_RP2040_FLASH_BOOT)
+
+  # Set the Pico SDK path using the environment variable
+
+  if(NOT DEFINED ENV{PICO_SDK_PATH})
+    message(
+      FATAL_ERROR
+        "PICO_SDK_PATH environment variable is not set. Please set it to the path of your Pico SDK installation."
+    )
+  else()
+    message(STATUS "PICO_SDK_PATH environment variable is set.")
+
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    include(${CMAKE_CURRENT_SOURCE_DIR}/boot2/rp2040_boot_stage2.cmake)
+
+    set(PATH_CHIP_RP2040 ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/chip)
+    pico_define_boot_stage2(rp2040_boot_stage2 ${PATH_CHIP_RP2040})
+
+    if(EXISTS ${PATH_CHIP_RP2040}/rp2040_boot_stage2.S)
+      list(APPEND SRCS ${PATH_CHIP_RP2040}/rp2040_boot_stage2.S)
+      target_sources(nuttx PRIVATE ${PATH_CHIP_RP2040}/rp2040_boot_stage2.S)
+    else()
+      message(
+        FATAL_ERROR "No rp2040_boot_stage2.S found at ${PATH_CHIP_RP2040}")
+    endif()
+  endif()
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/rp2040/boot2/rp2040_boot_stage2.cmake
+++ b/arch/arm/src/rp2040/boot2/rp2040_boot_stage2.cmake
@@ -1,0 +1,111 @@
+# ##############################################################################
+# arch/arm/src/rp2040/boot2/rp2040_boot_stage2.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# ~~~
+# pico_define_boot_stage2
+#
+# Description: Define a boot stage 2 for the Raspberry Pi rp2040.
+#
+# Parameters:
+#  NAME        : The name of the boot stage 2
+#  path_chip   : The full path of the CMake build /${CONFIG_ARCH}/src/chip
+# ~~~
+
+function(pico_define_boot_stage2 NAME path_chip)
+
+  set(PICO_BOOT_STAGE2_DIR "${PICO_SDK_PATH}/src/rp2040/boot_stage2")
+  set(BOOT2SRC "${PICO_BOOT_STAGE2_DIR}/boot2_${CONFIG_RP2040_FLASH_CHIP}.S")
+
+  set(BOOT2CFLAGSLIST
+      "-T${NUTTX_BOARD_DIR}/scripts/raspberrypi-pico-flash.ld"
+      -DPICO_BOARD=\"pico\" -DPICO_BUILD=1 -DPICO_NO_HARDWARE=0
+      -DPICO_ON_DEVICE=1)
+
+  list(APPEND BOOT2CFLAGSLIST -I${path_chip}/boot2)
+  list(APPEND BOOT2CFLAGSLIST -I${PICO_BOOT_STAGE2_DIR}/asminclude)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2040/hardware_regs/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2_common/hardware_base/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/common/pico_base_headers/include)
+  list(APPEND BOOT2CFLAGSLIST -I${PICO_SDK_PATH}/src/boards/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2040/pico_platform/include)
+
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2_common/pico_platform_common/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2_common/pico_platform_compiler/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2_common/pico_platform_sections/include)
+  list(APPEND BOOT2CFLAGSLIST
+       -I${PICO_SDK_PATH}/src/rp2_common/pico_platform_panic/include)
+  list(APPEND BOOT2CFLAGSLIST -Wl,--no-warn-rwx-segments)
+
+  string(REPLACE ";" " " BOOT2CFLAGS "${BOOT2CFLAGSLIST}")
+
+  set(ORIGINAL_ELF ${path_chip}/${NAME}.elf)
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E touch
+            ${PICO_SDK_PATH}/src/common/pico_base_headers/include/pico/version.h
+  )
+  execute_process(
+    COMMAND
+      ${CMAKE_COMMAND} -E touch
+      ${PICO_SDK_PATH}/src/common/pico_base_headers/include/pico/config_autogen.h
+  )
+
+  set(builtin
+      "${CMAKE_C_COMPILER} -nostdlib ${BOOT2CFLAGS} -o ${ORIGINAL_ELF} ${BOOT2SRC}"
+  )
+
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+    execute_process(COMMAND cmd /c "${builtin}" RESULT_VARIABLE resultVar)
+  else()
+    execute_process(COMMAND sh -c "${builtin}" RESULT_VARIABLE resultVar)
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E remove -f
+            ${PICO_SDK_PATH}/src/common/pico_base_headers/include/pico/version.h
+  )
+  execute_process(
+    COMMAND
+      ${CMAKE_COMMAND} -E remove -f
+      ${PICO_SDK_PATH}/src/common/pico_base_headers/include/pico/config_autogen.h
+  )
+
+  if(resultVar AND NOT resultVar EQUAL 0)
+    message(FATAL_ERROR "Failed: ${resultVar}")
+  else()
+    set(ORIGINAL_BIN ${path_chip}/${NAME}.bin)
+    set(PADDED_CHECKSUMMED_ASM ${path_chip}/${NAME}.S)
+
+    execute_process(COMMAND ${CMAKE_OBJCOPY} -Obinary ${ORIGINAL_ELF}
+                            ${ORIGINAL_BIN})
+    execute_process(
+      COMMAND ${Python3_EXECUTABLE} ${PICO_BOOT_STAGE2_DIR}/pad_checksum -s
+              0xffffffff ${ORIGINAL_BIN} ${PADDED_CHECKSUMMED_ASM})
+  endif()
+endfunction()

--- a/boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_pico.h
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/adafruit-kb2040/src/rp2040_pico.h
+++ b/boards/arm/rp2040/adafruit-kb2040/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_pico.h
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/common/CMakeLists.txt
+++ b/boards/arm/rp2040/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# cmake/nuttx_process_config.cmake
+# boards/arm/rp2040/common/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,27 +20,5 @@
 #
 # ##############################################################################
 
-function(process_config OUTPUT INPUT)
-  set(options)
-  set(oneValueArgs)
-  set(multiValueArgs INCLUDE_PATHS)
-  cmake_parse_arguments(PARSE_ARGV 2 PROCESS_INCLUDES "${options}"
-                        "${oneValueArgs}" "${multiValueArgs}")
-
-  set(include_args "")
-  foreach(path IN LISTS PROCESS_INCLUDES_INCLUDE_PATHS)
-    list(APPEND include_args "${path}")
-  endforeach()
-
-  message(STATUS "Processing includes: ${INPUT} -> ${OUTPUT}")
-  execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/process_config.py
-            ${OUTPUT} ${INPUT} ${include_args}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE out
-    ERROR_VARIABLE err)
-
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "Failed to process includes:\n${err}")
-  endif()
-endfunction()
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/arm/rp2040/common/include/rp2040_common_pico.h
+++ b/boards/arm/rp2040/common/include/rp2040_common_pico.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/include/rp2040_common_pico.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_COMMON_PICO_H
+#define __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_COMMON_PICO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rp2040_dev_gpio_init
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_GPIO
+int rp2040_dev_gpio_init(void);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_COMMON_PICO_H */

--- a/boards/arm/rp2040/common/src/CMakeLists.txt
+++ b/boards/arm/rp2040/common/src/CMakeLists.txt
@@ -1,0 +1,120 @@
+# ##############################################################################
+# boards/arm/rp2040/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARCH_BOARD_COMMON)
+
+  list(APPEND SRCS rp2040_common_bringup.c rp2040_common_initialize.c)
+
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS rp2040_reset.c)
+  endif()
+
+  if(CONFIG_SPI)
+    list(APPEND SRCS rp2040_spi.c)
+  endif()
+
+  if(CONFIG_RP2040_I2C_DRIVER)
+    list(APPEND SRCS rp2040_i2cdev.c)
+  endif()
+
+  if(CONFIG_RP2040_PWM)
+    list(APPEND SRCS rp2040_pwmdev.c)
+  endif()
+
+  if(CONFIG_RP2040_SPI_DRIVER)
+    list(APPEND SRCS rp2040_spidev.c)
+  endif()
+
+  if(CONFIG_RP2040_I2S)
+    list(APPEND SRCS rp2040_i2sdev.c)
+  endif()
+
+  if(CONFIG_LCD_SSD1306)
+    list(APPEND SRCS rp2040_ssd1306.c)
+  endif()
+
+  if(CONFIG_LCD_ST7789)
+    list(APPEND SRCS rp2040_st7789.c)
+  endif()
+
+  if(CONFIG_LCD_ST7735)
+    list(APPEND SRCS rp2040_st7735.c)
+  endif()
+
+  if(CONFIG_LCD_GC9A01)
+    list(APPEND SRCS rp2040_gc9a01.c)
+  endif()
+
+  if(CONFIG_USBMSC)
+    list(APPEND SRCS rp2040_usbmsc.c)
+  endif()
+
+  if(CONFIG_USBDEV_COMPOSITE)
+    list(APPEND SRCS rp2040_composite.c)
+  endif()
+
+  if(CONFIG_RP2040_SPISD)
+    list(APPEND SRCS rp2040_spisd.c)
+  endif()
+
+  if(CONFIG_SENSORS_BMP180)
+    list(APPEND SRCS rp2040_bmp180.c)
+  endif()
+
+  if(CONFIG_SENSORS_BMP280)
+    list(APPEND SRCS rp2040_bmp280.c)
+  endif()
+
+  if(CONFIG_SENSORS_INA219)
+    list(APPEND SRCS rp2040_ina219.c)
+  endif()
+
+  if(CONFIG_ENC28J60)
+    list(APPEND SRCS rp2040_enc28j60.c)
+  endif()
+
+  if(CONFIG_LCD_BACKPACK)
+    list(APPEND SRCS rp2040_lcd_backpack.c)
+  endif()
+
+  if(CONFIG_BOARDCTL_UNIQUEID)
+    list(APPEND SRCS rp2040_uniqueid.c)
+  endif()
+
+  if(CONFIG_NET_W5500)
+    list(APPEND SRCS rp2040_w5500.c)
+  endif()
+
+  if(CONFIG_SENSORS_MAX6675)
+    list(APPEND SRCS rp2040_max6675.c)
+  endif()
+
+  if(CONFIG_SENSORS_TMP112)
+    list(APPEND SRCS rp2040_tmp112.c)
+  endif()
+
+  if(CONFIG_ADC_ADS7046)
+    list(APPEND SRCS rp2040_ads7046.c)
+  endif()
+
+endif()
+target_sources(board PRIVATE ${SRCS})

--- a/boards/arm/rp2040/common/src/rp2040_common_bringup.c
+++ b/boards/arm/rp2040/common/src/rp2040_common_bringup.c
@@ -36,7 +36,7 @@
 
 #include <arch/board/board.h>
 
-#include "rp2040_pico.h"
+#include "rp2040_common_pico.h"
 #include "rp2040_common_bringup.h"
 
 #ifdef CONFIG_LCD_BACKPACK

--- a/boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_pico.h
+++ b/boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_pico.h
+++ b/boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/raspberrypi-pico/CMakeLists.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# cmake/nuttx_process_config.cmake
+# boards/arm/rp2040/raspberrypi-pico/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,27 +20,21 @@
 #
 # ##############################################################################
 
-function(process_config OUTPUT INPUT)
-  set(options)
-  set(oneValueArgs)
-  set(multiValueArgs INCLUDE_PATHS)
-  cmake_parse_arguments(PARSE_ARGV 2 PROCESS_INCLUDES "${options}"
-                        "${oneValueArgs}" "${multiValueArgs}")
+add_subdirectory(src)
 
-  set(include_args "")
-  foreach(path IN LISTS PROCESS_INCLUDES_INCLUDE_PATHS)
-    list(APPEND include_args "${path}")
-  endforeach()
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
 
-  message(STATUS "Processing includes: ${INPUT} -> ${OUTPUT}")
-  execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/process_config.py
-            ${OUTPUT} ${INPUT} ${include_args}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE out
-    ERROR_VARIABLE err)
-
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "Failed to process includes:\n${err}")
-  endif()
-endfunction()
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp2040/raspberrypi-pico/src/CMakeLists.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# cmake/nuttx_process_config.cmake
+# boards/arm/rp2040/raspberrypi-pico/src/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,27 +20,34 @@
 #
 # ##############################################################################
 
-function(process_config OUTPUT INPUT)
-  set(options)
-  set(oneValueArgs)
-  set(multiValueArgs INCLUDE_PATHS)
-  cmake_parse_arguments(PARSE_ARGV 2 PROCESS_INCLUDES "${options}"
-                        "${oneValueArgs}" "${multiValueArgs}")
+set(SRCS rp2040_boardinitialize.c rp2040_bringup.c)
 
-  set(include_args "")
-  foreach(path IN LISTS PROCESS_INCLUDES_INCLUDE_PATHS)
-    list(APPEND include_args "${path}")
-  endforeach()
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp2040_gpio.c)
+endif()
 
-  message(STATUS "Processing includes: ${INPUT} -> ${OUTPUT}")
-  execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/process_config.py
-            ${OUTPUT} ${INPUT} ${include_args}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE out
-    ERROR_VARIABLE err)
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS rp2040_autoleds.c)
+else()
+  list(APPEND SRCS rp2040_userleds.c)
+endif()
 
-  if(NOT result EQUAL 0)
-    message(FATAL_ERROR "Failed to process includes:\n${err}")
-  endif()
-endfunction()
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS rp2040_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp2040_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_RP2040_FLASH_BOOT)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/raspberrypi-pico-flash.ld")
+else()
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/raspberrypi-pico-sram.ld")
+endif()

--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_pico.h
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_pico.h
@@ -48,7 +48,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_pico.h
+++ b/boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_pico.h
@@ -37,7 +37,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/w5500-evb-pico/src/rp2040_pico.h
+++ b/boards/arm/rp2040/w5500-evb-pico/src/rp2040_pico.h
@@ -48,7 +48,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_pico.h
+++ b/boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_pico.h
@@ -31,7 +31,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_pico.h
+++ b/boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_pico.h
@@ -29,7 +29,7 @@
 
 int rp2040_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp2040_dev_gpio_init(void);
 #endif
 

--- a/tools/ci/testlist/arm-06.dat
+++ b/tools/ci/testlist/arm-06.dat
@@ -1,1 +1,5 @@
 /arm/r*,CONFIG_ARM_TOOLCHAIN_GNU_EABI
+
+# Boards build by CMake
+
+CMake,raspberrypi-pico:bmp280


### PR DESCRIPTION
## Summary

- CMake added board Raspberry Pi Pico

- Added the entry:

     CMake,raspberrypi-pico:bmp280

   to the file arm-06.dat.

- Moved the search for the Python 3 interpreter to the root CMakefile to avoid unnecessary repetition.

## Impact

Impact on user: This PR adds Raspberry Pi Pico board with CMake build

Impact on build: This PR Implement CMake build for the Raspberry Pi RP2040

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO
## Testing

Locally (Linux, Msys2 and Windows Native) and on GitHub
config -> nsh, nshusb and bmp280

Locally

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=raspberrypi-pico:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp2040/raspberrypi-pico/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  raspberrypi-pico
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- PICO_SDK_PATH environment variable is set.
-- Configuring done (9.4s)
-- Generating done (2.4s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1121/1122] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        152 KB         2 MB      7.42%
            sram:        8272 B       264 KB      3.06%
[1122/1122] Running utility command for nuttx_post_build

```


![rp2040_nsh](https://github.com/user-attachments/assets/96f0eaf9-16e4-4e1b-999e-317ba814a7e2)

