### PR TITLE
boards: esp32s3-lckfb-szpi: Remove obsolete device function prototypes

### DIFF
--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
@@ -121,25 +121,6 @@ int board_i2c_init(void);
 #endif
 
 /****************************************************************************
- * Name: board_bmp180_initialize
- *
- * Description:
- *   Initialize and register the BMP180 Pressure Sensor driver.
- *
- * Input Parameters:
- *   devno - The device number, used to build the device path as /dev/pressN
- *   busno - The I2C bus number
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SENSORS_BMP180
-int board_bmp180_initialize(int devno, int busno);
-#endif
-
-/****************************************************************************
  * Name: board_i2sdev_initialize
  *
  * Description:
@@ -161,27 +142,6 @@ int board_bmp180_initialize(int devno, int busno);
 
 #ifdef CONFIG_ESPRESSIF_I2S
 int board_i2sdev_initialize(int port, bool enable_tx, bool enable_rx);
-#endif
-
-/****************************************************************************
- * Name: esp32s3_cs4344_initialize
- *
- * Description:
- *   This function is called by platform-specific, setup logic to configure
- *   and register the CS4344 device.  This function will register the driver
- *   as /dev/audio/pcm[x] where x is determined by the I2S port number.
- *
- * Input Parameters:
- *   port - The I2S port used for the device
- *
- * Returned Value:
- *   Zero is returned on success.  Otherwise, a negated errno value is
- *   returned to indicate the nature of the failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_AUDIO_CS4344
-int esp32s3_cs4344_initialize(int port);
 #endif
 
 #ifdef CONFIG_ESP32S3_OPENETH

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -153,8 +153,7 @@
 int esp32s3_bringup(void)
 {
   int ret;
-#if (defined(CONFIG_ESPRESSIF_I2S0) && !defined(CONFIG_AUDIO_CS4344)) || \
-    defined(CONFIG_ESPRESSIF_I2S1)
+#if defined(CONFIG_ESPRESSIF_I2S0) || defined(CONFIG_ESPRESSIF_I2S1)
   bool i2s_enable_tx;
   bool i2s_enable_rx;
 #endif
@@ -323,30 +322,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_SENSORS_BMP180
-  /* Try to register BMP180 device in I2C0 */
-
-  ret = board_bmp180_initialize(0, ESP32S3_I2C0);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR,
-             "Failed to initialize BMP180 driver for I2C0: %d\n", ret);
-    }
-#endif
-
 #ifdef CONFIG_ESPRESSIF_I2S
-
-#ifdef CONFIG_AUDIO_CS4344
-
-  /* Configure CS4344 audio on I2S0 */
-
-  ret = esp32s3_cs4344_initialize(ESP32S3_I2S0);
-  if (ret != OK)
-    {
-      syslog(LOG_ERR, "Failed to initialize CS4344 audio: %d\n", ret);
-    }
-#else
-
 #ifdef CONFIG_ESPRESSIF_I2S0_TX
   i2s_enable_tx = true;
 #else
@@ -366,7 +342,6 @@ int esp32s3_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize I2S0 driver: %d\n", ret);
     }
-#endif /* CONFIG_AUDIO_CS4344 */
 
 #ifdef CONFIG_ESPRESSIF_I2S1
 


### PR DESCRIPTION
## Summary

  * Why change is necessary (fix, update, new feature)? - Cleanup: Remove obsolete device function prototypes and initialization code that are no longer used or supported.
  * What functional part of the code is being changed? - ESP32S3 LCKFB-SZPI board support code, specifically the board header file and bringup initialization.
  * How does the change exactly work (what will change and how)? - Removes function prototypes for BMP180 pressure sensor and CS4344 audio codec drivers, along with their initialization code from the board bringup process.

## Impact

  * Is new feature added? Is existing feature changed? NO - This is a cleanup removing unused code.
  * Impact on user (will user need to adapt to change)? NO - No functional impact as these devices were not properly initialized.
  * Impact on build (will build process change)? NO - Build process unchanged.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO - Hardware support unchanged, just cleanup of unused initialization.
  * Impact on documentation (is update required / provided)? NO - No documentation impact.
  * Impact on security (any sort of implications)? NO - No security implications.
  * Impact on compatibility (backward/forward/interoperability)? NO - Maintains compatibility.
  * Anything else to consider or add? - This cleanup simplifies the board support code by removing unused device initialization logic.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux, GCC
  * Target(s): ESP32S3, lckfb-szpi-esp32s3 board configuration
  * Verification: Code compiles successfully and board bringup functions properly without the removed obsolete device initializations.
