### PR TITLE
sched: add stack overflow check on switch context

### DIFF
--- a/Documentation/debugging/stackcheck.rst
+++ b/Documentation/debugging/stackcheck.rst
@@ -6,13 +6,18 @@ Overview
 --------
 
 Currently NuttX supports three types of stack overflow detection:
-    1. Stack Overflow Software Check
-    2. Stack Overflow Hardware Check
-    3. Stack Canary Check
+    1. Stack Overflow Software Check During Function Call
+    2. Stack Overflow Software Check During Context Switching
+    3. Stack Overflow Hardware Check
+    4. Stack Canary Check
 
-The software stack detection includes two implementation ideas:
+The software stack detection during function call includes two implementation ideas:
     1. Implemented by coloring the stack memory
     2. Implemented by comparing the sp and sl registers
+
+The software stack detection during context switching includes two implementation ideas:
+    1. Implemented by coloring the stack memory
+    2. Implemented by checking the bottom memory of the stack and the sp register
 
 Support
 -------
@@ -21,8 +26,8 @@ Software and hardware stack overflow detection implementation,
 currently only implemented on ARM Cortex-M (32-bit) series chips
 Stack Canary Check is available on all platforms
 
-Stack Overflow Software Check
------------------------------
+Stack Overflow Software Check During Function Call
+--------------------------------------------------
 
 1. Memory Coloring Implementation Principle
     1. Before using the stack, Thread will refresh the stack area to 0xdeadbeef
@@ -43,6 +48,16 @@ Stack Overflow Software Check
 
     Usage:
         Enable CONFIG_ARMV8M_STACKCHECK or CONFIG_ARMV7M_STACKCHECK
+
+Stack Overflow Software Check During Context Switching
+------------------------------------------------------
+
+1. Determine by detecting the number of bytes specified at the bottom of the stack.
+2. Check if the sp register is out of bounds.
+
+Usage:
+    Enable CONFIG_STACKCHECK_SOFTWARE
+    You can set the detection length by STACKCHECK_MARGIN
 
 Stack Overflow Hardware Check
 -----------------------------

--- a/Kconfig
+++ b/Kconfig
@@ -2455,6 +2455,25 @@ config STACK_COLORATION
 
 		Only supported by a few architectures.
 
+config STACKCHECK_SOFTWARE
+	bool "Software detection of stack overflow"
+	depends on STACK_COLORATION && DEBUG_ASSERTIONS && SCHED_SUSPENDSCHEDULER
+	---help---
+		When switching contexts, it will detect whether a stack overflow occurs.
+		Two methods are used here.
+		The first is to check the legitimacy of the value of the sp register;
+		the second is to check the specified number of bytes at the bottom of the stack.
+		If either of these two methods fails, an ASSERT will be triggered.
+
+config STACKCHECK_MARGIN
+	int "Stack overflow check size (bytes)"
+	depends on STACKCHECK_SOFTWARE
+	default 16
+	---help---
+		Specifies the number of bytes at the end of the stack to check for overflow.
+		A value of 0 disables additional checking. Increase this value for stricter
+		overflow detection, at the cost of additional overhead.
+
 config STACK_CANARIES
 	bool "Compiler stack canaries"
 	depends on ARCH_HAVE_STACKCHECK

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -200,7 +200,7 @@ void arm_stack_color(void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
   size_t size;
 
@@ -213,7 +213,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
     }
 #endif
 
-  size = arm_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+  size = arm_stack_check(tcb->stack_base_ptr, check_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -210,7 +210,7 @@ void arm64_stack_color(void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
   size_t size;
 
@@ -223,7 +223,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
     }
 #endif
 
-  size = arm64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+  size = arm64_stack_check(tcb->stack_base_ptr, check_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/avr/src/avr/avr_checkstack.c
+++ b/arch/avr/src/avr/avr_checkstack.c
@@ -144,10 +144,9 @@ size_t avr_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(FAR struct tcb_s *tcb, size_t check_size)
 {
-  return avr_stack_check((uintptr_t)tcb->stack_base_ptr,
-                                    tcb->adj_stack_size);
+  return avr_stack_check((uintptr_t)tcb->stack_base_ptr, check_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/ceva/src/common/ceva_checkstack.c
+++ b/arch/ceva/src/common/ceva_checkstack.c
@@ -139,10 +139,9 @@ size_t ceva_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
-  return ceva_stack_check((uintptr_t)tcb->stack_alloc_ptr,
-                          tcb->adj_stack_size);
+  return ceva_stack_check((uintptr_t)tcb->stack_alloc_ptr, check_size);
 }
 
 size_t up_check_intstack(int cpu)

--- a/arch/or1k/src/common/or1k_checkstack.c
+++ b/arch/or1k/src/common/or1k_checkstack.c
@@ -115,10 +115,9 @@ size_t or1k_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
-  return or1k_stack_check((uintptr_t)tcb->stack_base_ptr,
-                                     tcb->adj_stack_size);
+  return or1k_stack_check((uintptr_t)tcb->stack_base_ptr, check_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -156,7 +156,7 @@ size_t riscv_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
   size_t size;
 
@@ -169,8 +169,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
     }
 #endif
 
-  size = riscv_stack_check((uintptr_t)tcb->stack_base_ptr,
-                                      tcb->adj_stack_size);
+  size = riscv_stack_check((uintptr_t)tcb->stack_base_ptr, check_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/sim/src/sim/sim_checkstack.c
+++ b/arch/sim/src/sim/sim_checkstack.c
@@ -154,8 +154,7 @@ size_t sim_stack_check(void *alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
-  return sim_stack_check((void *)(uintptr_t)tcb->stack_base_ptr,
-                                            tcb->adj_stack_size);
+  return sim_stack_check((void *)(uintptr_t)tcb->stack_base_ptr, check_size);
 }

--- a/arch/sparc/src/common/sparc_checkstack.c
+++ b/arch/sparc/src/common/sparc_checkstack.c
@@ -200,9 +200,9 @@ void sparc_stack_color(void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
-  return sparc_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+  return sparc_stack_check(tcb->stack_base_ptr, check_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7

--- a/arch/tricore/src/common/tricore_checkstack.c
+++ b/arch/tricore/src/common/tricore_checkstack.c
@@ -117,7 +117,7 @@ size_t tricore_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
   size_t size;
 
@@ -130,8 +130,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
     }
 #endif
 
-  size = tricore_stack_check((uintptr_t)tcb->stack_base_ptr,
-                                      tcb->adj_stack_size);
+  size = tricore_stack_check((uintptr_t)tcb->stack_base_ptr, check_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/x86_64/src/intel64/intel64_checkstack.c
+++ b/arch/x86_64/src/intel64/intel64_checkstack.c
@@ -154,7 +154,7 @@ void x86_64_stack_color(void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
   size_t size;
 
@@ -167,7 +167,7 @@ size_t up_check_tcbstack(struct tcb_s *tcb)
     }
 #endif
 
-  size = x86_64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
+  size = x86_64_stack_check(tcb->stack_base_ptr, check_size);
 
 #ifdef CONFIG_ARCH_ADDRENV
   if (tcb->addrenv_own != NULL)

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -158,10 +158,9 @@ size_t xtensa_stack_check(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb, size_t check_size)
 {
-  return xtensa_stack_check((uintptr_t)tcb->stack_base_ptr,
-                                       tcb->adj_stack_size);
+  return xtensa_stack_check((uintptr_t)tcb->stack_base_ptr, check_size);
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1054,8 +1054,10 @@ static ssize_t proc_stack(FAR struct proc_file_s *procfile,
 
   /* Show the stack size */
 
-  linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%ld\n",
-                               "StackUsed:", (long)up_check_tcbstack(tcb));
+  linesize = procfs_snprintf(
+      procfile->line, STATUS_LINELEN, "%-12s%zu\n",
+      "StackUsed:", up_check_tcbstack(tcb, tcb->adj_stack_size));
+
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2563,7 +2563,7 @@ void irq_dispatch(int irq, FAR void *context);
 
 #ifdef CONFIG_STACK_COLORATION
 struct tcb_s;
-size_t up_check_tcbstack(FAR struct tcb_s *tcb);
+size_t up_check_tcbstack(FAR struct tcb_s *tcb, size_t check_size);
 #if defined(CONFIG_ARCH_INTERRUPTSTACK) && CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(int cpu);
 #endif

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -335,7 +335,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
                      tcbstack_base,
                      tcbstack_size,
 #ifdef CONFIG_STACK_COLORATION
-                     up_check_tcbstack(rtcb)
+                     up_check_tcbstack(rtcb, rtcb->adj_stack_size)
 #else
                      0
 #endif
@@ -376,7 +376,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 #endif
 
 #ifdef CONFIG_STACK_COLORATION
-  stack_used = up_check_tcbstack(tcb);
+  stack_used = up_check_tcbstack(tcb, tcb->adj_stack_size);
   if (tcb->adj_stack_size > 0 && stack_used > 0)
     {
       /* Use fixed-point math with one decimal place */
@@ -431,7 +431,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
          , tcb->stack_base_ptr
          , tcb->adj_stack_size
 #ifdef CONFIG_STACK_COLORATION
-         , up_check_tcbstack(tcb)
+         , up_check_tcbstack(tcb, tcb->adj_stack_size)
          , stack_filled / 10, stack_filled % 10
          , (stack_filled >= 10 * 80 ? '!' : ' ')
 #endif

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -411,7 +411,7 @@ static void elf_emit_tcb_stack(FAR struct elf_dumpinfo_s *cinfo,
 #ifdef CONFIG_STACK_COLORATION
       else
         {
-          len = up_check_tcbstack(tcb);
+          len = up_check_tcbstack(tcb, tcb->adj_stack_size);
           buf = (uintptr_t)tcb->stack_base_ptr +
                            (tcb->adj_stack_size - len);
         }
@@ -576,7 +576,7 @@ static void elf_emit_tcb_phdr(FAR struct elf_dumpinfo_s *cinfo,
 #ifdef CONFIG_STACK_COLORATION
       else
         {
-          phdr->p_filesz = up_check_tcbstack(tcb);
+          phdr->p_filesz = up_check_tcbstack(tcb, tcb->adj_stack_size);
           phdr->p_vaddr  = (uintptr_t)tcb->stack_base_ptr +
                            (tcb->adj_stack_size - phdr->p_filesz);
         }

--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -68,6 +68,22 @@ void nxsched_suspend_scheduler(FAR struct tcb_s *tcb)
       return;
     }
 
+#ifdef CONFIG_STACKCHECK_SOFTWARE
+  if (tcb->xcp.regs)
+    {
+      uintptr_t sp = up_getusrsp(tcb->xcp.regs);
+      uintptr_t top = (uintptr_t)tcb->stack_base_ptr + tcb->adj_stack_size;
+      uintptr_t bottom = (uintptr_t)tcb->stack_base_ptr;
+      DEBUGASSERT(sp > bottom && sp <= top);
+    }
+
+#if CONFIG_STACKCHECK_MARGIN > 0
+    DEBUGASSERT(up_check_tcbstack(tcb) <=
+                tcb->adj_stack_size - CONFIG_STACKCHECK_MARGIN);
+#endif
+
+#endif
+
 #ifdef CONFIG_SCHED_SPORADIC
   /* Perform sporadic schedule operations */
 

--- a/sched/sched/sched_suspendscheduler.c
+++ b/sched/sched/sched_suspendscheduler.c
@@ -78,8 +78,7 @@ void nxsched_suspend_scheduler(FAR struct tcb_s *tcb)
     }
 
 #if CONFIG_STACKCHECK_MARGIN > 0
-    DEBUGASSERT(up_check_tcbstack(tcb) <=
-                tcb->adj_stack_size - CONFIG_STACKCHECK_MARGIN);
+    DEBUGASSERT(up_check_tcbstack(tcb, CONFIG_STACKCHECK_MARGIN) == 0);
 #endif
 
 #endif


### PR DESCRIPTION
## Summary

I add a software method for stack overflow detection, which will detect the sp register and the bottom stack memory of the thread.

## Impact

Add stack overflow detection on context switching. If enable `STACKCHECK_SOFTWARE`, this check will be turned on. By default, the bottom 16 bytes of the stack will be checked. This parameter can be configured through `STACKCHECK_MARGIN`

## Testing

```c
#include <pthread.h>
#include <sched.h>
#include <stdint.h>
#include <stdio.h>
#include <sys/types.h>
#include <unistd.h>

#define STACK_SIZE (8192)

static unsigned char stack[STACK_SIZE];

void *thread_func(void *arg) {
  puts("haha");
  return NULL;
}

int main(int argc, char *argv[]) {
  pthread_t thread;
  pthread_attr_t attr;
  uint32_t stack_color = 0xdeadbeef;

  pthread_attr_init(&attr);
  pthread_attr_setstack(&attr, stack, STACK_SIZE);
  printf("stack: %p\n", stack);

  if (pthread_create(&thread, &attr, thread_func, NULL) != 0) {
    perror("pthread_create");
    return 1;
  }

  const uintptr_t stack_bottom_align = ((uintptr_t)stack);
  uint32_t *start = (uint32_t *)stack_bottom_align;
  const uint32_t *end = (uint32_t *)(stack + STACK_SIZE - sizeof(uint32_t));
  int found = 0;

  for (; start <= end; ++start) {
    if (*start == stack_color) {
      *start = 0xabcdabcd;
      printf("fetch the stack color: %p\n", start);
      found = 1;
      break;
    }
  }

  pthread_join(thread, NULL);
  if (!found) {
    fprintf(stderr, "stack color not found\n");
  }

  pthread_attr_destroy(&attr);

  return 0;
}
```

```bash
$ qemu-system-arm -cpu cortex-a7 -nographic -machine virt -kernel build/nuttx -s 

NuttShell (NSH) NuttX-12.10.0
nsh> stack_canarytest
stack: 0x400053b8
fetch the stack color: 0x400053c8
haha
dump_assert_info: Current Version: NuttX  12.10.0 0d62d83134-dirty Sep 22 2025 19:37:18 arm
dump_assert_info: Assertion failed : at file: /sched/sched/sched_suspendscheduler.c:78 task: stack_canarytest process: Kernel 0x19a6c
up_dump_register: R0: 400035f0 R1: 00000001 R2: 00000000  R3: 00000001
up_dump_register: R4: 4000df38 R5: 4000df38 R6: 400035f0  R7: 00000000
up_dump_register: R8: 00039479 SB: 40002e94 SL: 00000006  FP: 0000004e
up_dump_register: IP: 00007ffe SP: 40007268 LR: 00005fcc  PC: 00005fcc
...
```