### PR TITLE
sched: use nxsched_switch_context to unify the calls to nxsched_suspend_scheduler and nxsched_resume_scheduler

### DIFF
--- a/arch/arm/src/arm/arm_doirq.c
+++ b/arch/arm/src/arm/arm_doirq.c
@@ -88,6 +88,8 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -100,15 +102,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
 
       regs = tcb->xcp.regs;
     }

--- a/arch/arm/src/arm/arm_syscall.c
+++ b/arch/arm/src/arm/arm_syscall.c
@@ -92,10 +92,15 @@ uint32_t *arm_syscall(uint32_t *regs)
 
         /* Update scheduler parameters */
 
-        nxsched_resume_scheduler(tcb);
+        nxsched_switch_context(*running_task, tcb);
 
       case SYS_restore_context:
-        nxsched_suspend_scheduler(*running_task);
+
+        /* No context switch occurs in SYS_restore_context, or the
+         * context switch has been completed, so there is no
+         * need to update scheduler parameters.
+         */
+
         *running_task = tcb;
 
         /* Restore the cpu lock */

--- a/arch/arm/src/armv6-m/arm_doirq.c
+++ b/arch/arm/src/armv6-m/arm_doirq.c
@@ -102,10 +102,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   tcb = this_task();
 
-  /* Update scheduler parameters */
+  /* Update scheduler parameters.
+   * The arm-m architecture svc call will trigger an interrupt,
+   * and the actual context switch is executed after doirq is completed,
+   * so only the scheduling information needs to be updated in doirq.
+   */
 
-  nxsched_suspend_scheduler(*running_task);
-  nxsched_resume_scheduler(tcb);
+  nxsched_switch_context(*running_task, tcb);
 
   /* Record the new "running" task when context switch occurred.
    * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/arm/src/armv7-a/arm_doirq.c
+++ b/arch/arm/src/armv7-a/arm_doirq.c
@@ -88,6 +88,8 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -100,15 +102,14 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -270,10 +270,15 @@ uint32_t *arm_syscall(uint32_t *regs)
 
         /* Update scheduler parameters */
 
-        nxsched_resume_scheduler(tcb);
+        nxsched_switch_context(*running_task, tcb);
 
       case SYS_restore_context:
-        nxsched_suspend_scheduler(*running_task);
+
+        /* No context switch occurs in SYS_restore_context, or the
+         * context switch has been completed, so there is no
+         * need to update scheduler parameters.
+         */
+
         *running_task = tcb;
 
         /* Restore the cpu lock */

--- a/arch/arm/src/armv7-m/arm_doirq.c
+++ b/arch/arm/src/armv7-m/arm_doirq.c
@@ -102,10 +102,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   tcb = this_task();
 
-  /* Update scheduler parameters */
+  /* Update scheduler parameters.
+   * The arm-m architecture svc call will trigger an interrupt,
+   * and the actual context switch is executed after doirq is completed,
+   * so only the scheduling information needs to be updated in doirq.
+   */
 
-  nxsched_suspend_scheduler(*running_task);
-  nxsched_resume_scheduler(tcb);
+  nxsched_switch_context(*running_task, tcb);
 
   /* Record the new "running" task when context switch occurred.
    * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/arm/src/armv7-r/arm_doirq.c
+++ b/arch/arm/src/armv7-r/arm_doirq.c
@@ -77,17 +77,18 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -267,10 +267,15 @@ uint32_t *arm_syscall(uint32_t *regs)
 
         /* Update scheduler parameters */
 
-        nxsched_resume_scheduler(tcb);
+        nxsched_switch_context(*running_task, tcb);
 
       case SYS_restore_context:
-        nxsched_suspend_scheduler(*running_task);
+
+        /* No context switch occurs in SYS_restore_context, or the
+         * context switch has been completed, so there is no
+         * need to update scheduler parameters.
+         */
+
         *running_task = tcb;
 
         /* Restore the cpu lock */

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -113,10 +113,13 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   tcb = this_task();
 
-  /* Update scheduler parameters */
+  /* Update scheduler parameters.
+   * The arm-m architecture svc call will trigger an interrupt,
+   * and the actual context switch is executed after doirq is completed,
+   * so only the scheduling information needs to be updated in doirq.
+   */
 
-  nxsched_suspend_scheduler(*running_task);
-  nxsched_resume_scheduler(tcb);
+  nxsched_switch_context(*running_task, tcb);
 
   /* Record the new "running" task when context switch occurred.
    * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/arm/src/armv8-r/arm_doirq.c
+++ b/arch/arm/src/armv8-r/arm_doirq.c
@@ -78,17 +78,18 @@ uint32_t *arm_doirq(int irq, uint32_t *regs)
 
   if (regs != tcb->xcp.regs)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -159,7 +159,7 @@ static void dispatch_syscall(void)
 uint32_t *arm_syscall(uint32_t *regs)
 {
   int cpu = this_cpu();
-  struct tcb_s *running_task = g_running_tasks[cpu];
+  struct tcb_s **running_task = &g_running_tasks[cpu];
   struct tcb_s *tcb = this_task();
   uint32_t cmd;
 #ifdef CONFIG_BUILD_PROTECTED
@@ -180,13 +180,13 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   cmd = regs[REG_R0];
 
-  /* if cmd == SYS_restore_context running_task->xcp.regs is valid
+  /* if cmd == SYS_restore_context (*running_task)->xcp.regs is valid
    * should not be overwritten
    */
 
   if (cmd != SYS_restore_context)
     {
-      running_task->xcp.regs = regs;
+      (*running_task)->xcp.regs = regs;
     }
 
   /* The SVCall software interrupt is called with R0 = system call command
@@ -267,12 +267,16 @@ uint32_t *arm_syscall(uint32_t *regs)
 
         /* Update scheduler parameters */
 
-        nxsched_resume_scheduler(tcb);
+        nxsched_switch_context(*running_task, tcb);
 
       case SYS_restore_context:
-        nxsched_suspend_scheduler(running_task);
-        running_task = tcb;
-        g_running_tasks[cpu] = running_task;
+        /* No context switch occurs in SYS_restore_context, or the
+         * context switch has been completed, so there is no
+         * need to update scheduler parameters.
+         */
+
+        *running_task = tcb;
+        g_running_tasks[cpu] = *running_task;
 
         /* Restore the cpu lock */
 
@@ -554,11 +558,11 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   up_set_interrupt_context(false);
 
-  /* running_task->xcp.regs is about to become invalid
+  /* (*running_task)->xcp.regs is about to become invalid
    * and will be marked as NULL to avoid misusage.
    */
 
-  running_task->xcp.regs = NULL;
+  (*running_task)->xcp.regs = NULL;
 
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the

--- a/arch/arm64/src/common/arm64_doirq.c
+++ b/arch/arm64/src/common/arm64_doirq.c
@@ -85,6 +85,8 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 
   if (regs != tcb->xcp.regs)
     {
+      struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
       /* need to do a context switch */
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -99,15 +101,14 @@ uint64_t *arm64_doirq(int irq, uint64_t * regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[this_cpu()]);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
       regs = tcb->xcp.regs;
     }
 

--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -187,10 +187,6 @@ uint64_t *arm64_syscall(uint64_t *regs)
     {
       case SYS_restore_context:
 
-        /* Update scheduler parameters */
-
-        nxsched_resume_scheduler(tcb);
-
         /* Restore the cpu lock */
 
         restore_critical_section(tcb, cpu);
@@ -203,8 +199,7 @@ uint64_t *arm64_syscall(uint64_t *regs)
 
         /* Update scheduler parameters */
 
-        nxsched_suspend_scheduler(*running_task);
-        nxsched_resume_scheduler(tcb);
+        nxsched_switch_context(*running_task, tcb);
         *running_task = tcb;
 
         /* Restore the cpu lock */

--- a/arch/avr/src/avr/avr_doirq.c
+++ b/arch/avr/src/avr/avr_doirq.c
@@ -96,12 +96,18 @@ uint8_t *avr_doirq(uint8_t irq, uint8_t *regs)
 
   if (regs != up_current_regs())
     {
+      struct tcb_s *tcb = this_task();
+
+      /* Update scheduler parameters */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      *running_task = this_task();
+      *running_task = tcb;
     }
 
   regs = up_current_regs();   /* Cast removes volatile attribute */

--- a/arch/avr/src/avr/avr_switchcontext.c
+++ b/arch/avr/src/avr/avr_switchcontext.c
@@ -56,10 +56,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -69,10 +65,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       avr_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts */
 
@@ -85,7 +77,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/avr/src/avr32/avr_doirq.c
+++ b/arch/avr/src/avr32/avr_doirq.c
@@ -109,6 +109,10 @@ uint32_t *avr_doirq(int irq, uint32_t *regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/avr/src/avr32/avr_switchcontext.c
+++ b/arch/avr/src/avr32/avr_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -71,10 +67,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       avr_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any new address environment needed by
        * the new thread will be instantiated before the return from
@@ -99,7 +91,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/avr/src/common/avr_exit.c
+++ b/arch/avr/src/common/avr_exit.c
@@ -69,7 +69,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/ceva/src/common/ceva_doirq.c
+++ b/arch/ceva/src/common/ceva_doirq.c
@@ -87,17 +87,18 @@ uint32_t *ceva_doirq(int irq, uint32_t *regs)
 
       if (regs != up_current_regs())
         {
+          struct tcb_s *tcb = this_task();
+
           /* Update scheduler parameters */
 
-          nxsched_suspend_scheduler(*running_task);
-          nxsched_resume_scheduler(this_task());
+          nxsched_switch_context(*running_task, tcb);
 
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.
            */
 
-          g_running_tasks[this_cpu()] = this_task();
+          *running_task = tcb;
           regs = up_current_regs();
         }
 

--- a/arch/ceva/src/common/ceva_switchcontext.c
+++ b/arch/ceva/src/common/ceva_switchcontext.c
@@ -90,6 +90,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else
     {
+      /* Update scheduler parameters */
+
+      nxsched_switch_context(rtcb, tcb);
+
       /* Switch context to the context of the task at the head of the
        * ready to run list.
        */

--- a/arch/hc/src/common/hc_doirq.c
+++ b/arch/hc/src/common/hc_doirq.c
@@ -109,6 +109,10 @@ uint8_t *hc_doirq(int irq, uint8_t *regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/hc/src/common/hc_exit.c
+++ b/arch/hc/src/common/hc_exit.c
@@ -68,7 +68,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/hc/src/common/hc_switchcontext.c
+++ b/arch/hc/src/common/hc_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -71,10 +67,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       hc_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -102,7 +94,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/mips/src/mips32/mips_doirq.c
+++ b/arch/mips/src/mips32/mips_doirq.c
@@ -118,12 +118,16 @@ uint32_t *mips_doirq(int irq, uint32_t *regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/mips/src/mips32/mips_switchcontext.c
+++ b/arch/mips/src/mips32/mips_switchcontext.c
@@ -59,10 +59,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -72,10 +68,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       mips_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -90,7 +82,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Then switch contexts */
 

--- a/arch/misoc/src/lm32/lm32_doirq.c
+++ b/arch/misoc/src/lm32/lm32_doirq.c
@@ -103,6 +103,10 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/misoc/src/lm32/lm32_switchcontext.c
+++ b/arch/misoc/src/lm32/lm32_switchcontext.c
@@ -59,10 +59,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -72,10 +68,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       misoc_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -90,7 +82,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Then switch contexts */
 

--- a/arch/misoc/src/minerva/minerva_doirq.c
+++ b/arch/misoc/src/minerva/minerva_doirq.c
@@ -102,12 +102,16 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/misoc/src/minerva/minerva_switchcontext.c
+++ b/arch/misoc/src/minerva/minerva_switchcontext.c
@@ -59,10 +59,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -72,10 +68,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       misoc_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment changes
        * will be made when the interrupt returns.
@@ -90,7 +82,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Then switch contexts */
 

--- a/arch/or1k/src/common/or1k_doirq.c
+++ b/arch/or1k/src/common/or1k_doirq.c
@@ -78,6 +78,10 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs)
 
   if (regs != up_current_regs())
     {
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/or1k/src/common/or1k_exit.c
+++ b/arch/or1k/src/common/or1k_exit.c
@@ -70,7 +70,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/or1k/src/common/or1k_switchcontext.c
+++ b/arch/or1k/src/common/or1k_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
 #if 0  /* REVISIT */
@@ -75,10 +71,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       or1k_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -106,7 +98,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/renesas/src/common/renesas_doirq.c
+++ b/arch/renesas/src/common/renesas_doirq.c
@@ -112,6 +112,10 @@ uint32_t *renesas_doirq(int irq, uint32_t * regs)
           addrenv_switch(tcb);
 #endif
 
+          /* Update scheduler parameters. */
+
+          nxsched_switch_context(*running_task, tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/renesas/src/common/renesas_exit.c
+++ b/arch/renesas/src/common/renesas_exit.c
@@ -68,7 +68,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/renesas/src/common/renesas_switchcontext.c
+++ b/arch/renesas/src/common/renesas_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -71,10 +67,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       renesas_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -102,7 +94,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -128,12 +128,7 @@ uintreg_t *riscv_doirq(int irq, uintreg_t *regs)
 
       /* Update scheduler parameters */
 
-      if (!restore_context)
-        {
-          nxsched_suspend_scheduler(*running_task);
-        }
-
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/risc-v/src/common/riscv_switchcontext.c
+++ b/arch/risc-v/src/common/riscv_switchcontext.c
@@ -80,6 +80,10 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else
     {
+      /* Update scheduler parameters */
+
+      nxsched_switch_context(rtcb, tcb);
+
       /* Then switch contexts */
 
       riscv_switchcontext();

--- a/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
+++ b/arch/risc-v/src/common/supervisor/riscv_perform_syscall.c
@@ -73,10 +73,8 @@ void *riscv_perform_syscall(uintreg_t *regs)
 
       if (!restore_context)
         {
-          nxsched_suspend_scheduler(*running_task);
+          nxsched_switch_context(*running_task, tcb);
         }
-
-      nxsched_resume_scheduler(tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.

--- a/arch/sim/src/sim/sim_doirq.c
+++ b/arch/sim/src/sim/sim_doirq.c
@@ -83,12 +83,18 @@ void *sim_doirq(int irq, void *context)
 
       if (regs != up_current_regs())
         {
+          struct tcb_s *tcb = this_task();
+
+          /* Update scheduler parameters. */
+
+          nxsched_switch_context(*running_task, tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.
            */
 
-          *running_task = this_task();
+          *running_task = tcb;
         }
 
       regs = up_current_regs();

--- a/arch/sim/src/sim/sim_exit.c
+++ b/arch/sim/src/sim/sim_exit.c
@@ -69,7 +69,6 @@ void up_exit(int status)
    * NOTE: the API also adjusts the global IRQ control for SMP
    */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
   /* Restore the cpu lock */

--- a/arch/sim/src/sim/sim_switchcontext.c
+++ b/arch/sim/src/sim/sim_switchcontext.c
@@ -60,10 +60,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   sinfo("Unblocking TCB=%p\n", tcb);
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_interrupt_context())
@@ -73,10 +69,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       sim_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Restore the cpu lock */
 
@@ -101,7 +93,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Restore the cpu lock */
 

--- a/arch/sparc/src/common/sparc_exit.c
+++ b/arch/sparc/src/common/sparc_exit.c
@@ -58,10 +58,6 @@ void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   (void)nxtask_exit();

--- a/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_doirq.c
@@ -113,12 +113,16 @@ uint32_t *sparc_doirq(int irq, uint32_t *regs)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters. */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = tcb;
+      *running_task = tcb;
     }
 
   /* If a context switch occurred while processing the interrupt then

--- a/arch/sparc/src/sparc_v8/sparc_v8_switchcontext.c
+++ b/arch/sparc/src/sparc_v8/sparc_v8_switchcontext.c
@@ -59,10 +59,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -72,10 +68,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       sparc_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -90,7 +82,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Then switch contexts */
 

--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -99,6 +99,10 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
       addrenv_switch(tcb);
 #endif
 
+      /* Update scheduler parameters */
+
+      nxsched_switch_context(*running_task, tcb);
+
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.

--- a/arch/tricore/src/common/tricore_switchcontext.c
+++ b/arch/tricore/src/common/tricore_switchcontext.c
@@ -59,10 +59,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -72,10 +68,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       tricore_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -90,7 +82,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Then switch contexts */
 

--- a/arch/x86/src/common/x86_exit.c
+++ b/arch/x86/src/common/x86_exit.c
@@ -71,7 +71,6 @@ void up_exit(int status)
    * NOTE: the API also adjusts the global IRQ control for SMP
    */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/x86/src/common/x86_switchcontext.c
+++ b/arch/x86/src/common/x86_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (up_current_regs())
@@ -71,10 +67,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
        */
 
       x86_savestate(rtcb->xcp.regs);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then switch contexts.  Any necessary address environment
        * changes will be made when the interrupt returns.
@@ -102,7 +94,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 #endif
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/x86/src/qemu/qemu_handlers.c
+++ b/arch/x86/src/qemu/qemu_handlers.c
@@ -125,8 +125,7 @@ static uint32_t *common_handler(int irq, uint32_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(*running_task);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/x86_64/src/common/x86_64_exit.c
+++ b/arch/x86_64/src/common/x86_64_exit.c
@@ -70,7 +70,6 @@ void up_exit(int status)
    * NOTE: the API also adjusts the global IRQ control for SMP
    */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
   /* Context switch, rearrange MMU */

--- a/arch/x86_64/src/common/x86_64_switchcontext.c
+++ b/arch/x86_64/src/common/x86_64_switchcontext.c
@@ -84,6 +84,7 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else if (!up_saveusercontext(rtcb->xcp.regs))
     {
+      struct tcb_s **running_task;
       cpu = this_cpu();
 
       x86_64_restore_auxstate(tcb);
@@ -104,14 +105,15 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(g_running_tasks[cpu]);
-      nxsched_resume_scheduler(current_task(cpu));
+      running_task = &g_running_tasks[cpu];
+      tcb = current_task(cpu);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task.  g_running_tasks[] is only used by
        * assertion logic for reporting crashes.
        */
 
-      g_running_tasks[cpu] = current_task(cpu);
+      *running_task = tcb;
 
       /* Then switch contexts */
 

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -106,8 +106,7 @@ static uint64_t *common_handler(int irq, uint64_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(*running_task);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -97,8 +97,7 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
       /* Update scheduler parameters */
 
-      nxsched_suspend_scheduler(*running_task);
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(*running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting

--- a/arch/z16/src/common/z16_doirq.c
+++ b/arch/z16/src/common/z16_doirq.c
@@ -92,12 +92,18 @@ FAR chipreg_t *z16_doirq(int irq, FAR chipreg_t *regs)
 
       if (regs != up_current_regs())
         {
+          struct tcb_s *tcb = this_task();
+
+          /* Update scheduler parameters. */
+
+          nxsched_switch_context(*running_task, tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.
            */
 
-          *running_task = this_task();
+          *running_task = tcb;
         }
 
       /* Restore the previous value of g_current_regs.  NULL would indicate

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -69,7 +69,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
   /* Then switch contexts */

--- a/arch/z16/src/common/z16_switchcontext.c
+++ b/arch/z16/src/common/z16_switchcontext.c
@@ -58,10 +58,6 @@
 
 void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (IN_INTERRUPT)
@@ -71,10 +67,6 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
        */
 
       SAVE_IRQCONTEXT(rtcb);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then setup so that the context will be performed on exit
        * from the interrupt.
@@ -93,7 +85,7 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
     {
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/arch/z80/src/common/z80_doirq.c
+++ b/arch/z80/src/common/z80_doirq.c
@@ -95,6 +95,10 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
           addrenv_switch(tcb);
 #endif
 
+          /* Update scheduler parameters */
+
+          nxsched_switch_context(*running_task, tcb);
+
           /* Record the new "running" task when context switch occurred.
            * g_running_tasks[] is only used by assertion logic for reporting
            * crashes.

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -71,7 +71,6 @@ void up_exit(int status)
 
   /* Adjusts time slice for SCHED_RR & SCHED_SPORADIC cases */
 
-  nxsched_resume_scheduler(tcb);
   g_running_tasks[this_cpu()] = tcb;
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/z80/src/common/z80_switchcontext.c
+++ b/arch/z80/src/common/z80_switchcontext.c
@@ -60,10 +60,6 @@
 
 void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
 {
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(rtcb);
-
   /* Are we in an interrupt handler? */
 
   if (IN_INTERRUPT())
@@ -73,10 +69,6 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
        */
 
       SAVE_IRQCONTEXT(rtcb);
-
-      /* Update scheduler parameters */
-
-      nxsched_resume_scheduler(tcb);
 
       /* Then setup so that the context will be performed on exit
        * from the interrupt.  Any necessary address environment
@@ -103,9 +95,10 @@ void up_switch_context(FAR struct tcb_s *tcb, FAR struct tcb_s *rtcb)
 
       addrenv_switch(tcb);
 #endif
+
       /* Update scheduler parameters */
 
-      nxsched_resume_scheduler(tcb);
+      nxsched_switch_context(rtcb, tcb);
 
       /* Record the new "running" task */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1261,6 +1261,27 @@ void nxsched_suspend_scheduler(FAR struct tcb_s *tcb);
 #endif
 
 /****************************************************************************
+ * Name: nxsched_switch_context
+ *
+ * Description:
+ *   This function is used to switch context between two tasks.
+ *
+ * Input Parameters:
+ *   from - The TCB of the task to be suspended.
+ *   to   - The TCB of the task to be resumed.
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+
+static inline void nxsched_switch_context(FAR struct tcb_s *from,
+                                          FAR struct tcb_s *to)
+{
+  nxsched_suspend_scheduler(from);
+  nxsched_resume_scheduler(to);
+}
+
+/****************************************************************************
  * Name: nxsched_get_param
  *
  * Description:


### PR DESCRIPTION
## Summary

Add nxsched_switch_context to unify the nxsched_resume_scheduler and nxsched_suspend_scheduler.

## Impact

Change the calling logic of `nxsched_suspend_scheduler` and `nxsched_resume_scheduler`, and the context switch will have a unified entry point.

This patchset doesn't change the behavior, but simplify the interaction between arch and sched

## Testing

run the `ostest` with the qemu-armv7a:nsh configuration and no error found.