### PR TITLE
arch/tricore: Align Makefile with Cmake for tasking linker script preprocessing

### DIFF
--- a/arch/tricore/src/Makefile
+++ b/arch/tricore/src/Makefile
@@ -105,12 +105,10 @@ else
   LIBRARY_OPT = -l
 endif
 
-ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),y)
-  LDFLAGS += $(addprefix $(SCRIPT_OPT),$(call CONVERT_PATH,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
-else
-  ARCHSCRIPT := $(call CONVERT_PATH,$(ARCHSCRIPT))
-  LDFLAGS += $(addprefix $(SCRIPT_OPT),$(addsuffix .tmp,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
+ARCHSCRIPT := $(call CONVERT_PATH,$(ARCHSCRIPT))
+LDFLAGS += $(addprefix $(SCRIPT_OPT),$(addsuffix .tmp,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
 
+ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),)
   LDSTARTGROUP ?= -Wl,--start-group
   LDENDGROUP   ?= -Wl,--end-group
 endif
@@ -166,16 +164,11 @@ define LINK_ALLSYMS
 	$(Q) $(call DELFILE, allsyms.tmp allsyms$(OBJEXT))
 endef
 
-ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),)
 $(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
-endif
 
-ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),y)
-nuttx$(EXEEXT): $(HEAD_COBJ) board$(DELIM)libboard$(LIBEXT) $(ARCHSCRIPT) $(EXTRA_LIBS)
-else
 nuttx$(EXEEXT): $(HEAD_COBJ) board$(DELIM)libboard$(LIBEXT) $(EXTRA_LIBS) $(addsuffix .tmp,$(ARCHSCRIPT))
-endif
+
 	$(Q) echo "LD: nuttx"
 ifneq ($(CONFIG_ALLSYMS),y)
 	$(Q) $(LD) $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -194,9 +187,7 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)$(DELIM)System.map
 endif
-ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),)
 	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
-endif
 
 # This is part of the top-level export target
 # Note that there may not be a head object if layout is handled

--- a/arch/tricore/src/common/Toolchain.defs
+++ b/arch/tricore/src/common/Toolchain.defs
@@ -25,3 +25,12 @@ ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),y)
 else
   include $(TOPDIR)/arch/tricore/src/common/ToolchainGnuc.defs
 endif
+
+ifeq ($(CONFIG_TRICORE_TOOLCHAIN_TASKING),y)
+  undefine PREPROCESS
+  define PREPROCESS
+    $(ECHO_BEGIN)"CPP: $1->$2 "
+    $(CPP) $(CPPFLAGS) $1 > $2
+    $(ECHO_END)
+  endef
+endif

--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -44,9 +44,12 @@ endif
 
 # Tasking toolchain
 
+TASKING_COMPILER_PATH := $(shell which ctc)
+C_COMPILER_DIR := $(dir $(TASKING_COMPILER_PATH))
+
 CC                = cctc
 CXX               = cctc
-CPP               = cctc $(ARCHOPTIMIZATION)
+CPP               = ctc -E -I$(C_COMPILER_DIR)/../include.lsl
 LD                = cctc
 STRIP             = strip --strip-unneeded
 AR                = artc -r

--- a/boards/tricore/tc397/a2g-tc397-5v-tft/scripts/Lcf_Tasking_Tricore_Tc.lsl
+++ b/boards/tricore/tc397/a2g-tc397-5v-tft/scripts/Lcf_Tasking_Tricore_Tc.lsl
@@ -20,7 +20,7 @@
  *
  ****************************************************************************/
 
-#include "include/nuttx/config.h"
+#include <nuttx/config.h>
 
 #define LCF_CSA0_SIZE 40k
 #define LCF_USTACK0_SIZE CONFIG_IDLETHREAD_STACKSIZE


### PR DESCRIPTION
    Provide linker script preprocessing function porting for
    tasking compiler

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add linker script preprocessing in Makefile scripts for tasking compiler 

## Impact

Tasking compiler Makefile scripts improvement, no impact to other parts

## Testing

**Enable tasking compiler in a2g-tc397-5v-tft board**

<img width="808" height="537" alt="image" src="https://github.com/user-attachments/assets/13596d7c-1758-48c3-83c1-71228a3d5dcd" />

`Build passed using Makefile`

<img width="1460" height="536" alt="image" src="https://github.com/user-attachments/assets/0293591a-934b-4c64-b852-533d1d3f184b" />

`ostest passed `

<img width="672" height="733" alt="image" src="https://github.com/user-attachments/assets/e1278f1e-63e3-42c0-ac8b-099fe9c4f61d" />

