### PR TITLE
boards/esp32[c3|c6|h2]: Fix GPIO function used by the button

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-generic/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-generic/index.rst
@@ -153,6 +153,21 @@ You can check that the sensor is working by using the ``bmp180`` application::
     Pressure value = 91526
     Pressure value = 91525
 
+buttons
+-------
+
+This configuration shows the use of the buttons subsystem. It can be used by executing
+the ``buttons`` application and pressing the ``BOOT`` button on the board::
+
+    nsh> buttons
+    buttons_main: Starting the button_daemon
+    buttons_main: button_daemon started
+    button_daemon: Running
+    button_daemon: Opening /dev/buttons
+    button_daemon: Supported BUTTONs 0x01
+    nsh> Sample = 1
+    Sample = 0
+
 coremark
 --------
 

--- a/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitc/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitc/index.rst
@@ -120,6 +120,21 @@ You can check that the sensor is working by using the ``bmp180`` application::
     Pressure value = 91526
     Pressure value = 91525
 
+buttons
+-------
+
+This configuration shows the use of the buttons subsystem. It can be used by executing
+the ``buttons`` application and pressing the ``BOOT`` button on the board::
+
+    nsh> buttons
+    buttons_main: Starting the button_daemon
+    buttons_main: button_daemon started
+    button_daemon: Running
+    button_daemon: Opening /dev/buttons
+    button_daemon: Supported BUTTONs 0x01
+    nsh> Sample = 1
+    Sample = 0
+
 capture
 --------
 

--- a/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitm/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitm/index.rst
@@ -99,6 +99,21 @@ You can check that the sensor is working by using the ``bmp180`` application::
     Pressure value = 91526
     Pressure value = 91525
 
+buttons
+-------
+
+This configuration shows the use of the buttons subsystem. It can be used by executing
+the ``buttons`` application and pressing the ``BOOT`` button on the board::
+
+    nsh> buttons
+    buttons_main: Starting the button_daemon
+    buttons_main: button_daemon started
+    button_daemon: Running
+    button_daemon: Opening /dev/buttons
+    button_daemon: Supported BUTTONs 0x01
+    nsh> Sample = 1
+    Sample = 0
+
 coremark
 --------
 

--- a/Documentation/platforms/risc-v/esp32h2/boards/esp32h2-devkit/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/boards/esp32h2-devkit/index.rst
@@ -119,6 +119,21 @@ You can check that the sensor is working by using the ``bmp180`` application::
     Pressure value = 91526
     Pressure value = 91525
 
+buttons
+-------
+
+This configuration shows the use of the buttons subsystem. It can be used by executing
+the ``buttons`` application and pressing the ``BOOT`` button on the board::
+
+    nsh> buttons
+    buttons_main: Starting the button_daemon
+    buttons_main: button_daemon started
+    button_daemon: Running
+    button_daemon: Opening /dev/buttons
+    button_daemon: Supported BUTTONs 0x01
+    nsh> Sample = 1
+    Sample = 0
+
 coremark
 --------
 

--- a/boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_buttons.c
+++ b/boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_buttons.c
@@ -75,7 +75,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
+  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_2 | PULLUP);
   return 1;
 }
 

--- a/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_buttons.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_buttons.c
@@ -75,7 +75,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
+  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_2 | PULLUP);
   return 1;
 }
 

--- a/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_buttons.c
+++ b/boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_buttons.c
@@ -75,7 +75,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
+  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_2 | PULLUP);
   return 1;
 }
 

--- a/boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_buttons.c
+++ b/boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_buttons.c
@@ -75,7 +75,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
+  esp_configgpio(BUTTON_BOOT, INPUT_FUNCTION_2 | PULLUP);
   return 1;
 }
 


### PR DESCRIPTION
## Summary

* boards/esp32[c3|c6|h2]: Fix GPIO function used by the button
  - Fixes the function to select the GPIO behavior for the pins associated to the board's button.
  - Please note that for [ESP32-C3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf#section.5.12), [ESP32-C6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf#section.7.12) and [ESP32-H2](https://www.espressif.com/sites/default/files/documentation/esp32-h2_technical_reference_manual_en.pdf#section.6.13), the pin `Function 1` corresponds to the GPIO mapping for all pins. That function should be used when selecting the pin function. Please note that the pin function on TRM starts from `0`. On NuttX, on the other hand, it starts from `1`, and the corresponding pin function should be `INPUT_FUNCTION_2` to select `Function 1`.

* Documentation: Add entry for ESP32-[C3|C6|H2]'s `buttons` defconfig
  - Adds an entry on Documentation regarding ESP32-C3, ESP32-C6 and ESP32-H2 boards that implement the `buttons` defconfig

## Impact

Impact on user: Yes. Avoid unintended behavior regarding the on-board button.

Impact on build: No.

Impact on hardware: Yes. Impacts ESP32-C3, ESP32-C6 and ESP32-H2 boards.

Impact on documentation: No. But this PR also provides an entry for the `buttons` defconfig in the respective board.

Impact on security: No.

Impact on compatibility: No.

## Testing

Build the corresponding `buttons` defconfig for the devices and press the `BOOT` button in the board.

### Building

#### ESP32-C3

```
make -j distclean && ./tools/configure.sh esp32c3-generic:buttons && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

#### ESP32-C6

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:buttons && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

#### ESP32-H2

```
make -j distclean && ./tools/configure.sh esp32h2-devkit:buttons && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

### Running

Run the `buttons` application on NSH and press the `BOOT` button.

### Results

```
nsh> buttons
buttons_main: Starting the button_daemon
buttons_main: button_daemon started
button_daemon: Running
button_daemon: Opening /dev/buttons
button_daemon: Supported BUTTONs 0x01
nsh> Sample = 1
Sample = 0
```