### PR TITLE
tools/ci: Added CMake build for Raspberry Pi Pico on Windows Native

### DIFF
--- a/tools/ci/platforms/windows.ps1
+++ b/tools/ci/platforms/windows.ps1
@@ -223,6 +223,51 @@ function ninja_tool {
   Write-Host ""
 }
 
+function pico_sdk {
+  Write-Host "Check pico-sdk ..." -ForegroundColor Green
+  add_path "$NUTTXTOOLS\pico-sdk"
+  try {
+    if (-not (Test-Path -Path "$NUTTXTOOLS\pico-sdk\pico_sdk_init.cmake")) {
+      Write-Host "Download: pico-sdk package" -ForegroundColor Green
+      # Download the file
+      $basefile = "2.2.0"
+      Set-Location "$NUTTXTOOLS"
+      # Download pico-sdk
+      Invoke-WebRequest -Uri "https://github.com/raspberrypi/pico-sdk/archive/refs/tags/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+      Expand-Archive "$NUTTXTOOLS\$basefile.zip"
+      Move-Item -Path "$basefile\pico-sdk-2.2.0" -Destination "pico-sdk"
+      Remove-Item "$basefile*" -Force
+      # Configuring the PATH environment variable
+      $env:PICO_SDK_PATH = "$NUTTXTOOLS\pico-sdk"
+      Add-Content -Path "$NUTTXTOOLS\env.ps1" -Value "PICO_SDK_PATH=$NUTTXTOOLS\pico-sdk"
+      Write-Host "File downloaded successfully to pico-sdk"
+    }
+  }
+  catch {
+    Write-Error "Failed to download the file: $_"
+  }
+}
+
+function pico_tool {
+  Write-Host "Check picotool ..." -ForegroundColor Green
+  if (run_command("picotool") -ne 0) {
+    add_path "$NUTTXTOOLS\picotool"
+    if ($null -eq (Get-Command picotool -ErrorAction SilentlyContinue)) {
+      Write-Host "Download: picotool package" -ForegroundColor Green
+      # Download the file
+      $basefile = "picotool-2.2.0-x64-win"
+      Set-Location "$NUTTXTOOLS"
+      # Download tool picotool
+      Invoke-WebRequest -Uri "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.2.0-0/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+      Expand-Archive "$NUTTXTOOLS\$basefile.zip"
+      Move-Item -Path "$basefile\picotool" -Destination "picotool"
+      Remove-Item "$basefile*" -Force -Recurse
+    }
+  }
+  picotool version
+  Write-Host ""
+}
+
 function riscv_gcc_toolchain() {
   Write-Host "Check RISCV GCC toolchain ..." -ForegroundColor Green
   add_path "$NUTTXTOOLS\riscv-none-elf-gcc\bin"
@@ -292,7 +337,7 @@ function install_build_tools {
   if (-not (Test-Path -Path "$NUTTXTOOLS\env.ps1")) {
     add_envpath "$NUTTXTOOLS\env.ps1"
   }
-  $install = "arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain riscv_gcc_toolchain cmake_tool kconfig_frontends ninja_tool"
+  $install = "arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain riscv_gcc_toolchain pico_sdk pico_tool cmake_tool kconfig_frontends ninja_tool"
 
   $splitArray = $install.Split(" ")
   $oldpath = Get-Location

--- a/tools/ci/testlist/windows.dat
+++ b/tools/ci/testlist/windows.dat
@@ -6,6 +6,8 @@
 
 /arm/stm32/nucleo-f411re/configs/nsh,CONFIG_ARM_TOOLCHAIN_CLANG
 
+/arm/rp2040/raspberrypi-pico/configs/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
+
 # ARM64
 
 # /arm64/qemu/qemu-armv8a/configs/nsh_smp
@@ -22,5 +24,6 @@
 
 CMake,nucleo-l152re:nsh
 CMake,nucleo-f411re:nsh
+CMake,raspberrypi-pico:nsh
 CMake,rv-virt:nsh
 CMake,sim:windows


### PR DESCRIPTION
## Summary

ci/platforms/windows.ps1 added:

  - pre-built picotool

  - pico-sdk

testlist/windows.dat:

  - Added the entry CMake,raspberrypi-pico:nsh

## Impact

Impact on user: NO

Impact on build: This PR adds Raspberry Pi Pico on Windows native to avoid future breakage.

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
We have run tests on GitHub and locally.

GitHub
[msvc (windows)](https://github.com/simbit18/nuttx-testing-ci/actions/runs/17975040588/job/51126555728#logs)

Locally
cd .\nuttx\tools\ci\

.\cibuild.ps1 -n -i -A -C -N .\testlist\windows.dat

Raspberry Pi pico  -> nsh
![pico](https://github.com/user-attachments/assets/aa2b9b1b-2bc6-4bf1-b6d1-a3f1bdd35673)
