### PR TITLE
risc-v/espressif/twai: Update common source code functions

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_twai.c
+++ b/arch/risc-v/src/common/espressif/esp_twai.c
@@ -55,101 +55,87 @@
 #include "soc/gpio_sig_map.h"
 #include "soc/reg_base.h"
 
-#if defined(CONFIG_ESPRESSIF_TWAI)
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#  if defined(CONFIG_CAN_LOOPBACK) && defined(CONFIG_ESPRESSIF_TWAI_TEST_MODE)
-#   define TX_PIN_ATTR (OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1)
-#   define RX_PIN_ATTR (OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1)
+#if defined(CONFIG_CAN_LOOPBACK) && defined(CONFIG_ESPRESSIF_TWAI_TEST_MODE)
+#  define TX_PIN_ATTR (OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1)
+#  define RX_PIN_ATTR (OUTPUT_FUNCTION_1 | INPUT_FUNCTION_1)
+#else
+#  define TX_PIN_ATTR OUTPUT_FUNCTION_1
+#  define RX_PIN_ATTR INPUT_FUNCTION_1
+#endif
+
+#ifdef CONFIG_ESPRESSIF_TWAI0
+#  ifdef CONFIG_TWAI0_TIMING_100KBITS
+#    define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_100KBITS()
+#  elif CONFIG_TWAI0_TIMING_125KBITS
+#    define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_125KBITS()
+#  elif CONFIG_TWAI0_TIMING_250KBITS
+#    define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_250KBITS()
+#  elif CONFIG_TWAI0_TIMING_500KBITS
+#    define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_500KBITS()
 #  else
-#   define TX_PIN_ATTR OUTPUT_FUNCTION_1
-#   define RX_PIN_ATTR INPUT_FUNCTION_1
+#    define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_800KBITS()
 #  endif
+#endif
 
-#  ifdef CONFIG_ESPRESSIF_TWAI0
-#   ifdef CONFIG_TWAI0_TIMING_100KBITS
-      #define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_100KBITS()
-#   elif CONFIG_TWAI0_TIMING_125KBITS
-      #define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_125KBITS()
-#   elif CONFIG_TWAI0_TIMING_250KBITS
-      #define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_250KBITS()
-#   elif CONFIG_TWAI0_TIMING_500KBITS
-      #define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_500KBITS()
-#   else
-      #define TWAI0_TIMING_CONFIG TWAI_TIMING_CONFIG_800KBITS()
-#   endif
-#  endif
-
-#  ifdef CONFIG_ESPRESSIF_TWAI1
-#   ifdef CONFIG_TWAI1_TIMING_100KBITS
-      #define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_100KBITS()
-#   elif CONFIG_TWAI1_TIMING_125KBITS
-      #define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_125KBITS()
-#   elif CONFIG_TWAI1_TIMING_250KBITS
-      #define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_250KBITS()
-#   elif CONFIG_TWAI1_TIMING_500KBITS
-      #define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_500KBITS()
-#   else
-      #define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_800KBITS()
-#   endif
-#  endif
-
-#  ifdef CONFIG_ARCH_CHIP_ESP32C3_GENERIC
-#    define INT_ENA_REG(hw)       hw->interrupt_enable_reg.val
-#    define PERIPH_TWAI0_MODULE   PERIPH_TWAI_MODULE
-#    define TWAI0_TX_IDX          TWAI_TX_IDX
-#    define TWAI0_RX_IDX          TWAI_RX_IDX
-#    define ETS_TWAI0_INTR_SOURCE ETS_TWAI_INTR_SOURCE
-#    define ESP_IRQ_TWAI0         ESP_IRQ_TWAI
+#ifdef CONFIG_ESPRESSIF_TWAI1
+#  ifdef CONFIG_TWAI1_TIMING_100KBITS
+#    define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_100KBITS()
+#  elif CONFIG_TWAI1_TIMING_125KBITS
+#    define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_125KBITS()
+#  elif CONFIG_TWAI1_TIMING_250KBITS
+#    define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_250KBITS()
+#  elif CONFIG_TWAI1_TIMING_500KBITS
+#    define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_500KBITS()
 #  else
-#    define INT_ENA_REG(hw)       hw->interrupt_enable.val
-#  endif /* CONFIG_ARCH_CHIP_ESP32C3_GENERIC */
+#    define TWAI1_TIMING_CONFIG TWAI_TIMING_CONFIG_800KBITS()
+#  endif
+#endif
 
-#  ifdef CONFIG_ARCH_CHIP_ESP32H2
-#    define TWAI0_TX_IDX          TWAI_TX_IDX
-#    define TWAI0_RX_IDX          TWAI_RX_IDX
-#  endif /* CONFIG_ARCH_CHIP_ESP32H2 */
+#ifdef CONFIG_ARCH_CHIP_ESP32C3_GENERIC
+#  define INT_ENA_REG(hw)       hw->interrupt_enable_reg.val
+#else
+#  define INT_ENA_REG(hw)       hw->interrupt_enable.val
+#endif /* CONFIG_ARCH_CHIP_ESP32C3_GENERIC */
 
 #if !SOC_RCC_IS_INDEPENDENT
-#define TWAI_RCC_ATOMIC() PERIPH_RCC_ATOMIC()
+#  define TWAI_RCC_ATOMIC() PERIPH_RCC_ATOMIC()
 #else
-#define TWAI_RCC_ATOMIC()
+#  define TWAI_RCC_ATOMIC()
 #endif
 
 #if SOC_PERIPH_CLK_CTRL_SHARED
-#define TWAI_PERI_ATOMIC() PERIPH_RCC_ATOMIC()
+#  define TWAI_PERI_ATOMIC() PERIPH_RCC_ATOMIC()
 #else
-#define TWAI_PERI_ATOMIC()
+#  define TWAI_PERI_ATOMIC()
 #endif
 
 /* Configuration ************************************************************/
 
-#  ifndef CONFIG_CAN_EXTID
-#   define EXTID 0
-#  else
-#   define EXTID 1
-#  endif
+#ifndef CONFIG_CAN_EXTID
+#  define EXTID 0
+#else
+#  define EXTID 1
+#endif
 
-#  ifndef CONFIG_CAN_LOOPBACK
-#   define LOOPBACK 0
-#  else
-#   define LOOPBACK 1
-#  endif
+#ifndef CONFIG_CAN_LOOPBACK
+#  define LOOPBACK 0
+#else
+#  define LOOPBACK 1
+#endif
 
 /* Default values written to various registers on initialization */
 
-#  define DRIVER_DEFAULT_INTERRUPTS   0xe7  /* Exclude data overrun (bit[3]) and brp_div (bit[4]) */
+#define DRIVER_DEFAULT_INTERRUPTS   0xe7  /* Exclude data overrun (bit[3]) and brp_div (bit[4]) */
 
 struct esp_twai_dev_s
 {
   /* Device configuration */
 
   uint8_t port;                   /* TWAI port number */
-  uint8_t periph;                 /* Peripheral ID */
-  uint8_t irq;                    /* IRQ associated with this TWAI */
   int8_t cpuint;                  /* CPU interrupt assigned to this TWAI */
   twai_hal_context_t ctx;         /* Context struct of common layer */
   twai_timing_config_t t_config;  /* Timing struct of common layer */
@@ -199,8 +185,6 @@ static const struct can_ops_s g_twaiops =
 static struct esp_twai_dev_s g_twai0priv =
 {
   .port             = 0,
-  .periph           = ETS_TWAI0_INTR_SOURCE,
-  .irq              = ESP_IRQ_TWAI0,
   .cpuint           = -ENOMEM,
   .t_config         = TWAI0_TIMING_CONFIG,
 };
@@ -216,8 +200,6 @@ static struct can_dev_s g_twai0dev =
 static struct esp_twai_dev_s g_twai1priv =
 {
   .port             = 1,
-  .periph           = ETS_TWAI1_INTR_SOURCE,
-  .irq              = ESP_IRQ_TWAI1,
   .cpuint           = -ENOMEM,
   .t_config         = TWAI1_TIMING_CONFIG,
 };
@@ -323,6 +305,7 @@ static int esp_twai_setup(struct can_dev_s *dev)
   struct esp_twai_dev_s *priv = (struct esp_twai_dev_s *)dev->cd_priv;
   irqstate_t flags;
   int ret = OK;
+  int irq;
 
   caninfo("TWAI%" PRIu8 "\n", priv->port);
 
@@ -332,14 +315,16 @@ static int esp_twai_setup(struct can_dev_s *dev)
 
   twai_ll_get_and_clear_intrs(priv->ctx.dev); /* clear latched interrupts */
 
+  irq = twai_controller_periph_signals.controllers[priv->port].irq_id;
+
   if (priv->cpuint != -ENOMEM)
     {
       /* Disable the provided CPU Interrupt to configure it. */
 
-      up_disable_irq(priv->irq);
+      up_disable_irq(ESP_SOURCE2IRQ(irq));
     }
 
-  priv->cpuint = esp_setup_irq(priv->periph,
+  priv->cpuint = esp_setup_irq(irq,
                                ESP_IRQ_PRIORITY_DEFAULT,
                                ESP_IRQ_TRIGGER_LEVEL);
   if (priv->cpuint < 0)
@@ -352,12 +337,12 @@ static int esp_twai_setup(struct can_dev_s *dev)
       return ret;
     }
 
-  ret = irq_attach(priv->irq, esp_twai_interrupt, dev);
+  ret = irq_attach(ESP_SOURCE2IRQ(irq), esp_twai_interrupt, dev);
   if (ret != OK)
     {
       /* Failed to attach IRQ, so CPU interrupt must be freed. */
 
-      esp_teardown_irq(priv->periph, priv->cpuint);
+      esp_teardown_irq(irq, priv->cpuint);
       priv->cpuint = -ENOMEM;
       leave_critical_section(flags);
 
@@ -366,7 +351,7 @@ static int esp_twai_setup(struct can_dev_s *dev)
 
   /* Enable the CPU interrupt that is linked to the TWAI device. */
 
-  up_enable_irq(priv->irq);
+  up_enable_irq(ESP_SOURCE2IRQ(irq));
 
   leave_critical_section(flags);
 
@@ -398,17 +383,21 @@ static void esp_twai_shutdown(struct can_dev_s *dev)
 
   if (priv->cpuint != -ENOMEM)
     {
+      int irq;
+
+      irq = twai_controller_periph_signals.controllers[priv->port].irq_id;
+
       /* Disable cpu interrupt */
 
-      up_disable_irq(priv->irq);
+      up_disable_irq(ESP_SOURCE2IRQ(irq));
 
       /* Dissociate the IRQ from the ISR */
 
-      irq_detach(priv->irq);
+      irq_detach(ESP_SOURCE2IRQ(irq));
 
       /* Free cpu interrupt that is attached to this peripheral */
 
-      esp_teardown_irq(priv->periph, priv->cpuint);
+      esp_teardown_irq(irq, priv->cpuint);
       priv->cpuint = -ENOMEM;
     }
 }
@@ -825,20 +814,16 @@ struct can_dev_s *esp_twaiinitialize(int port)
 #ifdef CONFIG_ESPRESSIF_TWAI0
   if (port == 0)
     {
-      /* Enable power to the TWAI module and
-       * Enable clocking to the TWAI module
-       */
-
-      periph_module_reset(PERIPH_TWAI0_MODULE);
-      periph_module_enable(PERIPH_TWAI0_MODULE);
+      int tx_sig = twai_controller_periph_signals.controllers[0].tx_sig;
+      int rx_sig = twai_controller_periph_signals.controllers[0].rx_sig;
 
       /* Configure CAN GPIO pins */
 
-      esp_gpio_matrix_out(CONFIG_ESPRESSIF_TWAI0_TXPIN, TWAI0_TX_IDX, 0, 0);
+      esp_gpio_matrix_out(CONFIG_ESPRESSIF_TWAI0_TXPIN, tx_sig, 0, 0);
       esp_configgpio(CONFIG_ESPRESSIF_TWAI0_TXPIN, TX_PIN_ATTR);
 
+      esp_gpio_matrix_in(CONFIG_ESPRESSIF_TWAI0_RXPIN, rx_sig, 0);
       esp_configgpio(CONFIG_ESPRESSIF_TWAI0_RXPIN, RX_PIN_ATTR);
-      esp_gpio_matrix_in(CONFIG_ESPRESSIF_TWAI0_RXPIN, TWAI0_RX_IDX, 0);
 
       dev = &g_twai0dev;
     }
@@ -848,20 +833,16 @@ struct can_dev_s *esp_twaiinitialize(int port)
 #ifdef CONFIG_ESPRESSIF_TWAI1
   if (port == 1)
     {
-      /* Enable power to the TWAI module and
-       * Enable clocking to the TWAI module
-       */
-
-      periph_module_reset(PERIPH_TWAI1_MODULE);
-      periph_module_enable(PERIPH_TWAI1_MODULE);
+      int tx_sig = twai_controller_periph_signals.controllers[1].tx_sig;
+      int rx_sig = twai_controller_periph_signals.controllers[1].rx_sig;
 
       /* Configure CAN GPIO pins */
 
-      esp_gpio_matrix_out(CONFIG_ESPRESSIF_TWAI1_TXPIN, TWAI1_TX_IDX, 0, 0);
+      esp_gpio_matrix_out(CONFIG_ESPRESSIF_TWAI1_TXPIN, tx_sig, 0, 0);
       esp_configgpio(CONFIG_ESPRESSIF_TWAI1_TXPIN, TX_PIN_ATTR);
 
+      esp_gpio_matrix_in(CONFIG_ESPRESSIF_TWAI1_RXPIN, rx_sig, 0);
       esp_configgpio(CONFIG_ESPRESSIF_TWAI1_RXPIN, RX_PIN_ATTR);
-      esp_gpio_matrix_in(CONFIG_ESPRESSIF_TWAI1_RXPIN, TWAI1_RX_IDX, 0);
 
       dev = &g_twai1dev;
     }
@@ -882,4 +863,3 @@ struct can_dev_s *esp_twaiinitialize(int port)
 
   return dev;
 }
-#endif /* CONFIG_ESPRESSIF_TWAI */

--- a/arch/risc-v/src/esp32c3/hal_esp32c3.mk
+++ b/arch/risc-v/src/esp32c3/hal_esp32c3.mk
@@ -196,6 +196,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)i2s_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)timer_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)twai_periph.c
 
 ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)bootloader_banner_wrap.c

--- a/arch/risc-v/src/esp32c6/hal_esp32c6.mk
+++ b/arch/risc-v/src/esp32c6/hal_esp32c6.mk
@@ -217,6 +217,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)rtc_io_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)timer_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)twai_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)${CHIP_SERIES}$(DELIM)uart_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)ulp$(DELIM)lp_core$(DELIM)lp_core_i2c.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)ulp$(DELIM)lp_core$(DELIM)lp_core.c

--- a/arch/risc-v/src/esp32h2/hal_esp32h2.mk
+++ b/arch/risc-v/src/esp32h2/hal_esp32h2.mk
@@ -198,6 +198,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)mcpwm_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)timer_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)twai_periph.c
 
 ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)bootloader_banner_wrap.c


### PR DESCRIPTION
## Summary

* risc-v/espressif/twai: Update common source code functions

Updates the common source code for the twai peripheral used by Espressif's RISC-Vs SoCs. This enables newer SoCs to be supported in the future while maintaining backwards compatibility.

## Impact

Impact on user: No.

Impact on build: No.

Impact on hardware: Not yet: newer Espressif SoCs can be supported on NuttX following this change.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No. It's totally backwards compatible.

## Testing

Testing can be performed using any of the `twai` defconfig available for any of Espressif's RISC-V-based devices (ESP32-C3, ESP32-C6, or ESP32-H2). The behavior of the twai didn't change, and this PR's results are the same of the results before it. This can be verified:

### Building

#### ESP32-C3

```
make -j distclean && ./tools/configure.sh esp32c3-generic:twai && kconfig-tweak -e DEBUG_ASSERTIONS && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e CAN_LOOPBACK && kconfig-tweak -e ESPRESSIF_TWAI_TEST_MODE && kconfig-tweak --set-val ESPRESSIF_TWAI0_TXPIN 8 && kconfig-tweak --set-val ESPRESSIF_TWAI0_RXPIN 8 && make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

#### ESP32-C6

##### TWAI0

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:twai && kconfig-tweak -e DEBUG_ASSERTIONS && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e CAN_LOOPBACK && kconfig-tweak -e ESPRESSIF_TWAI_TEST_MODE && kconfig-tweak --set-val ESPRESSIF_TWAI0_TXPIN 8 && kconfig-tweak --set-val ESPRESSIF_TWAI0_RXPIN 8 && make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

##### TWAI1

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:twai && kconfig-tweak -e DEBUG_ASSERTIONS && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e CAN_LOOPBACK && kconfig-tweak -e ESPRESSIF_TWAI_TEST_MODE && kconfig-tweak -d ESPRESSIF_TWAI0 && kconfig-tweak -e ESPRESSIF_TWAI1 && kconfig-tweak --set-val ESPRESSIF_TWAI1_TXPIN 8 && kconfig-tweak --set-val ESPRESSIF_TWAI1_RXPIN 8 && kconfig-tweak --set-str EXAMPLES_CAN_DEVPATH "/dev/can1" && make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0  && picocom -b 115200 /dev/ttyUSB0
```

#### ESP32-H2

```
make -j distclean && ./tools/configure.sh esp32h2-devkit:twai && kconfig-tweak -e DEBUG_ASSERTIONS && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e CAN_LOOPBACK && kconfig-tweak -e ESPRESSIF_TWAI_TEST_MODE && kconfig-tweak --set-val ESPRESSIF_TWAI0_TXPIN 8 && kconfig-tweak --set-val ESPRESSIF_TWAI0_RXPIN 8 && make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

### Running

Run the `can` application and expect it to exit with success code:

```
nsh> can -n 5 -b 5
```

### Results

```
nsh> can -n 5 -b 5
nmsgs: 5
min ID: 1 max ID: 5
Bit timing:
   Baud: 727272
  TSEG1: 16
  TSEG2: 5
    SJW: 4
  ID:    1 DLC: 1
  ID:    1 DLC: 1
  ID:    1 DLC: 1 -- OK
  ID:    2 DLC: 2
  ID:    2 DLC: 2
  ID:    2 DLC: 2 -- OK
  ID:    3 DLC: 3
  ID:    3 DLC: 3
  ID:    3 DLC: 3 -- OK
  ID:    4 DLC: 4
  ID:    4 DLC: 4
  ID:    4 DLC: 4 -- OK
  ID:    5 DLC: 5
  ID:    5 DLC: 5
  ID:    5 DLC: 5 -- OK
Terminating!
nsh> echo $?
0
```