### PR TITLE
risc-v/espressif/uart: Update common source code functions

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_usbserial.c
+++ b/arch/risc-v/src/common/espressif/esp_usbserial.c
@@ -106,8 +106,8 @@ static char g_txbuffer[ESP_USBCDC_BUFFERSIZE];
 
 static struct esp_priv_s g_usbserial_priv =
 {
-  .source = USB_SERIAL_JTAG_INTR_SOURCE,
-  .irq    = ESP_IRQ_USB_SERIAL_JTAG,
+  .source = ETS_USB_SERIAL_JTAG_INTR_SOURCE,
+  .irq    = ESP_SOURCE2IRQ(ETS_USB_SERIAL_JTAG_INTR_SOURCE),
   .cpuint = -ENOMEM,
 };
 
@@ -167,23 +167,23 @@ uart_dev_t g_uart_usbserial =
 static int esp_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
-  uint32_t tx_mask = USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT_ST;
-  uint32_t rx_mask = USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT_INT_ST;
   uint32_t int_status = usb_serial_jtag_ll_get_intsts_mask();
 
   /* Send buffer has room and can accept new data. */
 
-  if ((int_status & tx_mask) != 0)
+  if ((int_status & USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY) != 0)
     {
-      usb_serial_jtag_ll_clr_intsts_mask(tx_mask);
+      usb_serial_jtag_ll_clr_intsts_mask(
+        USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
       uart_xmitchars(dev);
     }
 
   /* Data from the host are available to read. */
 
-  if ((int_status & rx_mask) != 0)
+  if ((int_status & USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT) != 0)
     {
-      usb_serial_jtag_ll_clr_intsts_mask(rx_mask);
+      usb_serial_jtag_ll_clr_intsts_mask(
+        USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT);
       uart_recvchars(dev);
     }
 
@@ -230,12 +230,12 @@ static void esp_txint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
       usb_serial_jtag_ll_ena_intr_mask(
-        USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT_ENA);
+        USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
     }
   else
     {
       usb_serial_jtag_ll_disable_intr_mask(
-        USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT_ENA);
+        USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
     }
 }
 
@@ -252,12 +252,12 @@ static void esp_rxint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
       usb_serial_jtag_ll_ena_intr_mask(
-        USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT_INT_ENA);
+        USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT);
     }
   else
     {
       usb_serial_jtag_ll_disable_intr_mask(
-        USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT_INT_ENA);
+        USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT);
     }
 }
 

--- a/arch/risc-v/src/esp32c3/hal_esp32c3.mk
+++ b/arch/risc-v/src/esp32c3/hal_esp32c3.mk
@@ -197,6 +197,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)timer_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)twai_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)${CHIP_SERIES}$(DELIM)uart_periph.c
 
 ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)bootloader_banner_wrap.c
@@ -217,7 +218,6 @@ ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)bootloader_sha.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)${CHIP_SERIES}$(DELIM)bootloader_soc.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)flash_encrypt.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)${CHIP_SERIES}$(DELIM)uart_periph.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_uart.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_sys.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_spiflash.c

--- a/arch/risc-v/src/esp32h2/hal_esp32h2.mk
+++ b/arch/risc-v/src/esp32h2/hal_esp32h2.mk
@@ -199,6 +199,7 @@ CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)temperature_sensor_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)timer_periph.c
 CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)twai_periph.c
+CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)$(CHIP_SERIES)$(DELIM)uart_periph.c
 
 ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)nuttx$(DELIM)src$(DELIM)bootloader_banner_wrap.c
@@ -219,7 +220,6 @@ ifeq ($(CONFIG_ESPRESSIF_SIMPLE_BOOT),y)
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)${CHIP_SERIES}$(DELIM)bootloader_soc.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)flash_encrypt.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)bootloader_support$(DELIM)src$(DELIM)bootloader_sha.c
-  CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)soc$(DELIM)${CHIP_SERIES}$(DELIM)uart_periph.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_uart.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_sys.c
   CHIP_CSRCS += chip$(DELIM)$(ESP_HAL_3RDPARTY_REPO)$(DELIM)components$(DELIM)esp_rom$(DELIM)patches$(DELIM)esp_rom_spiflash.c


### PR DESCRIPTION
## Summary

* risc-v/espressif/uart: Update common source code functions
  - Updates the common source code for the UART peripheral used by Espressif's RISC-Vs SoCs. This enables newer SoCs to be supported in the future while maintaining backwards compatibility.

## Impact

Impact on user: No.

Impact on build: No.

Impact on hardware: Not yet: newer Espressif SoCs can be supported on NuttX following this change.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No. It's totally backwards compatible.

## Testing

Testing can be performed using any of the `nsh` or `usbconsole` defconfigs available for any of Espressif's RISC-V-based devices (ESP32-C3, ESP32-C6, or ESP32-H2). The behavior of the UART-related peripherals didn't change, and this PR's results are the same of the results before it. This can be verified:

### Building

#### ESP32-C3

##### `nsh`

```
make -j distclean && ./tools/configure.sh esp32c3-generic:nsh && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

##### `usbconsole`

```
make -j distclean && ./tools/configure.sh esp32c3-generic:usbconsole && make flash ESPTOOL_PORT=/dev/ttyACM0 && picocom -b 115200 /dev/ttyACM0
```

#### ESP32-C6

##### `nsh`

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:nsh && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

##### `usbconsole`

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:usbconsole && make flash ESPTOOL_PORT=/dev/ttyACM0 && picocom -b 115200 /dev/ttyACM0
```

#### ESP32-H2

##### `nsh`

```
make -j distclean && ./tools/configure.sh esp32h2-devkit:nsh && make flash ESPTOOL_PORT=/dev/ttyUSB0 && picocom -b 115200 /dev/ttyUSB0
```

##### `usbconsole`

```
make -j distclean && ./tools/configure.sh esp32h2-devkit:usbconsole && make flash ESPTOOL_PORT=/dev/ttyACM0 && picocom -b 115200 /dev/ttyACM0
```

### Running

Just check for the proper boot with `nsh`.

### Results

Device booting properly:

```
ESP-ROM:esp32c6-20220919
Build:Sep 19 2022
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x40800000,len:0x4620
load:0x40804620,len:0x840
SHA-256 comparison failed:
Calculated: cf880d2574dbbce0efb8c367c2ad01953ddeb6487982414181460af34b263e3a
Expected: 0000000060b10000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x408042f0
pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
*** Booting NuttX ***
dram: lma 0x00000020 vma 0x40800000 len 0x4620   (17952)
dram: lma 0x00004648 vma 0x40804620 len 0x840    (2112)
padd: lma 0x00004e98 vma 0x00000000 len 0xb160   (45408)
imap: lma 0x00010000 vma 0x42020000 len 0xaf80   (44928)
padd: lma 0x0001af88 vma 0x00000000 len 0x5070   (20592)
imap: lma 0x00020000 vma 0x42000000 len 0x1d820  (120864)
total segments stored 6

NuttShell (NSH) NuttX-10.4.0
nsh> 
```