### PR TITLE
arch/tricore: Allow Make to gen .srec and .hex for tasking compiler

### DIFF
--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -108,8 +108,16 @@ LDFLAGS          += --no-default-libraries
 LDFLAGS          += --fp-model=2
 LDFLAGS          += -lfp_fpu
 
-LDFLAGS          += --hex-format=s -Wl-OtxYcL -Wl-mcrfiklsmnoduq
+LDFLAGS          += -Wl-OtxYcL -Wl-mcrfiklsmnoduq
 LDFLAGS          += -lrt
+
+ifeq ($(CONFIG_INTELHEX_BINARY),y)
+  LDFLAGS        += -Wl-o${TOPDIR}/nuttx.hex:IHEX:4 --hex-format=s
+endif
+
+ifeq ($(CONFIG_MOTOROLA_SREC),y)
+  LDFLAGS        += -Wl-o${TOPDIR}/nuttx.srec:SREC:4
+endif
 
 # ctc W500: ["stdio/lib_libvsprintf.c" 884/29] expression without effect
 # ctc W507: ["mm_heap/mm_malloc.c" 238/64] variable "nodesize" is possibly uninitialized


### PR DESCRIPTION
  Allow Make to gen .srec and .hex for tasking compiler

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Allow Make to generate .srec and .hex for tasking compiler

## Impact

Make scripts improvement for tricore arch and tasking compiler, no impact
to other nuttx parts

## Testing

**enable srec and hex file generation and tasking compiler**

<img width="701" height="511" alt="image" src="https://github.com/user-attachments/assets/787a18ec-e57e-433e-809e-aa54c0b59823" />

**build success**
<img width="304" height="853" alt="image" src="https://github.com/user-attachments/assets/061b6a7b-d2bf-4fa2-b2c0-c091f0458a59" />


