### PR TITLE
drivers/sensors/ms56xx: Replace custom curtime with standard function

### DIFF
--- a/drivers/sensors/ms56xx_uorb.c
+++ b/drivers/sensors/ms56xx_uorb.c
@@ -122,8 +122,6 @@ static uint32_t ms56xx_compensate_press(FAR struct ms56xx_dev_s *priv,
                                         uint32_t press, uint32_t dt,
                                         int32_t *temp);
 
-static unsigned long ms56xx_curtime(void);
-
 /* Sensor methods */
 
 static int ms56xx_set_interval(FAR struct sensor_lowerhalf_s *lower,
@@ -151,24 +149,6 @@ static const struct sensor_ops_s g_sensor_ops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: ms56xx_curtime
- *
- * Description: Helper to get current timestamp.
- *
- * Return:
- *   Timestamp in microseconds
- *
- ****************************************************************************/
-
-static unsigned long ms56xx_curtime(void)
-{
-  struct timespec ts;
-
-  clock_systime_timespec(&ts);
-  return 1000000ull * ts.tv_sec + ts.tv_nsec / 1000;
-}
 
 /****************************************************************************
  * Name: ms56xx_sendcmd
@@ -358,7 +338,7 @@ static inline void baro_measure_read(FAR struct ms56xx_dev_s *priv,
   temp = ms56xx_compensate_temp(priv, temp_raw, &deltat);
   press = ms56xx_compensate_press(priv, press, deltat, &temp);
 
-  baro->timestamp = ms56xx_curtime();
+  baro->timestamp = sensor_get_timestamp();
   baro->pressure = press / 100.0f;
   baro->temperature = temp / 100.0f;
 }


### PR DESCRIPTION
## Summary

The custom implementation of obtaining a timestamp for this driver returned an unsigned long, which limited the amount of time the driver could run before roll-over quite significantly (since timestamps are in microseconds). This change standardizes the driver to use the sensor driver implementation for timestamps.

Closes #17030.

## Impact

Impacts only this driver, provides a longer roll-over time for timestamps.

## Testing

Tested on two rocket flights :)

First flight without the change, roll-over occurs:

<img width="1028" height="1234" alt="image" src="https://github.com/user-attachments/assets/d027d3a1-1177-4f77-aee8-4fa352e69ccc" />

This image shows mismatched timestamps, the barometer rolls over every time it reaches the limit of `unsigned long`, and the larger timestamps in the 9024ms range are from a GPS unit.

Second flight after fix was implemented, no roll-over:

<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/54c8f7f2-b30f-44fd-84d0-e2e7f7587a48" />

This has barometer timestamps which match up with the GPS timestamps and exceed the roll-over limit.