### PR TITLE
nuttx/list: Add `list_prepare_entry()`

### DIFF
--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -286,10 +286,12 @@
 #define list_prepare_entry(entry, list, type, member) \
   ((entry) ? (entry) : list_entry(list, type, member))
 
-#define list_for_every_entry_continue(list, head, type, member)    \
-  for ((list) = list_next_entry(list, type, member); \
-       &(list)->member != (head); \
-       (list) = list_next_entry(list, type, member))
+/* Continue iteration over list */
+
+#define list_for_every_entry_continue(entry, list, type, member) \
+  for ((entry) = list_next_entry(entry, type, member); \
+       &(entry)->member != (list); \
+       (entry) = list_next_entry(entry, type, member))
 
 /* iterates over the list in reverse order, entry should be the container
  * structure type


### PR DESCRIPTION
## Summary
1. Add `list_prepare_entry()` to prepare entry for use in `list_for_every_entry_continue()`.
2. Update the parameter names of the macro `list_for_every_entry_continue()` to maintain consistent naming. Most take the head node (list) as the first parameter, but considering that there is already code using this macro, the parameter order will not be adjusted here.
  The parameter order remains unchanged, so it will _**NOT affect the usage**_. 
    1. list => entry
    2. head => list
 
> The `list_prepare_entry()` references the implementation of Linux. See 
 https://github.com/torvalds/linux/blob/v6.12/include/linux/list.h#L793-L802
## Impact
- include/nuttx/list

## Testing
- Selftest
```C
  struct xxxx_s
  {
    /* ... */

    struct list_node node;
  } *current;

  struct list_node head;

  /* ... */

  current = list_prepare_entry(current, &head, struct xxxx_s, node);
  list_for_every_entry_continue(current, &head, struct xxxx_s, node)
    {
      /* ... */
    }
```
- CI