### PR TITLE
arch/tricore: Fix tricore arch build error 

### DIFF
--- a/arch/tricore/src/common/tricore_doirq.c
+++ b/arch/tricore/src/common/tricore_doirq.c
@@ -47,6 +47,7 @@
 IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 {
   struct tcb_s *running_task = g_running_tasks[this_cpu()];
+  struct tcb_s *tcb;
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -87,7 +88,7 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
   if (regs != up_current_regs())
     {
-      running_task = this_task();
+      tcb = this_task();
 
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
@@ -101,14 +102,14 @@ IFX_INTERRUPT_INTERNAL(tricore_doirq, 0, 255)
 
       /* Update scheduler parameters */
 
-      nxsched_switch_context(*running_task, tcb);
+      nxsched_switch_context(running_task, tcb);
 
       /* Record the new "running" task when context switch occurred.
        * g_running_tasks[] is only used by assertion logic for reporting
        * crashes.
        */
 
-      g_running_tasks[this_cpu()] = running_task;
+      g_running_tasks[this_cpu()] = tcb;
 
       __mtcr(CPU_PCXI, (uintptr_t)up_current_regs());
       __isync();


### PR DESCRIPTION
  Fix the tircore arch build error introduced by [PR17060](https://github.com/apache/nuttx/pull/17060)

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

It looks like the tricore arch related board is not in CI, so the build issue 
was not checked

This patch fixed the build error.

## Impact

Fixed build error introduced by new PR merged

## Testing

**Before this PR**

![img_v3_02qg_88e1b451-0dbf-4196-bdd6-3f135a050ceg](https://github.com/user-attachments/assets/158a9ead-94d0-474d-b841-1923158ddbcd)

**After this PR**

![img_v3_02qg_c006c3b1-d195-4dce-b00f-2a5a9dfdd8fg](https://github.com/user-attachments/assets/54113f7e-30e7-4547-a81d-4fe159e7b8ce)

**Ostest Passed**

<img width="590" height="714" alt="image" src="https://github.com/user-attachments/assets/951ec1e5-4291-4bfd-a923-75d91a960c2a" />

