### PR TITLE
{Bp-16939} sched/signal/sig_dispatch.c: Correct signal dispatch to specific thread

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -725,70 +725,29 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
 int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
 {
 #ifdef HAVE_GROUP_MEMBERS
-  FAR struct tcb_s *stcb;
-  FAR struct task_group_s *group;
-
-  /* Get the TCB associated with the pid */
-
-  stcb = nxsched_get_tcb(pid);
-  if (stcb != NULL)
+  if (!thread)
     {
-      /* The task/thread associated with this PID is still active. Get its
-       * task group.
+      /* Find the group by process PID and call group signal() to send the
+       * signal to the correct group member.
        */
 
-      group = stcb->group;
+      FAR struct task_group_s *group = task_getgroup(pid);
+      if (group != NULL)
+        {
+          return group_signal(group, info);
+        }
     }
   else
+#endif
     {
-      /* The task/thread associated with this PID has exited. In the normal
-       * usage model, the PID should correspond to the PID of the task that
-       * created the task group. Try looking it up.
-       */
+      /* Get the TCB associated with the thread TID */
 
-      group = task_getgroup(pid);
-    }
-
-  /* Did we locate the group? */
-
-  if (group != NULL)
-    {
-      if (thread)
+      FAR struct tcb_s *stcb = nxsched_get_tcb(pid);
+      if (stcb != NULL)
         {
-          /* Before the notification, we should validate the tid. If the
-           * signal is to be delivered to a thread which has exited, it is
-           * just dropped.
-           */
-
-          if (stcb != NULL)
-            {
-              return nxsig_tcbdispatch(stcb, info, false);
-            }
-        }
-      else
-        {
-          /* Yes.. call group_signal() to send the signal to the correct
-           * group member.
-           */
-
-          return group_signal(group, info);
+          return nxsig_tcbdispatch(stcb, info, false);
         }
     }
 
   return -ESRCH;
-
-#else
-  FAR struct tcb_s *stcb;
-
-  /* Get the TCB associated with the pid */
-
-  stcb = nxsched_get_tcb(pid);
-  if (stcb == NULL)
-    {
-      return -ESRCH;
-    }
-
-  return nxsig_tcbdispatch(stcb, info, false);
-
-#endif
 }

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -755,12 +755,12 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
     {
       if (thread)
         {
-          /* Before the notification, we should validate the tid and
-           * and make sure that the notified thread is in same process
-           * with the current thread.
+          /* Before the notification, we should validate the tid. If the
+           * signal is to be delivered to a thread which has exited, it is
+           * just dropped.
            */
 
-          if (stcb != NULL && group == this_task()->group)
+          if (stcb != NULL)
             {
               return nxsig_tcbdispatch(stcb, info, false);
             }


### PR DESCRIPTION
## Summary
Use of this_task() to identify which thread the signal should be delivered to is just wrong. Replace is with stcb.

## Impact
Fixes signal delivery from uart driver (tty), e.g. ctrl-c.

## Testing
Tested on qemu
