### PR TITLE
{bp-16998} arch/tricore: fix tasking compiler linking error

### DIFF
--- a/arch/tricore/src/cmake/ToolchainTasking.cmake
+++ b/arch/tricore/src/cmake/ToolchainTasking.cmake
@@ -108,6 +108,7 @@ add_compile_options(--branch-target-align)
 # cmake-format: on
 
 add_compile_options(--fp-model=2)
+add_link_options(--no-default-libraries)
 add_link_options(--fp-model=2)
 add_link_options(-lfp_fpu)
 

--- a/arch/tricore/src/common/ToolchainTasking.defs
+++ b/arch/tricore/src/common/ToolchainTasking.defs
@@ -101,6 +101,7 @@ ARCHOPTIMIZATION += --branch-target-align
 #   3                               alias for --fp-model=cflnrSTz (fast-sp)
 
 ARCHOPTIMIZATION += --fp-model=2
+LDFLAGS          += --no-default-libraries
 LDFLAGS          += --fp-model=2
 LDFLAGS          += -lfp_fpu
 


### PR DESCRIPTION
## Summary
  Add "add_link_options(--no-default-libraries)" ToolchainTasking.cmake
  Add "LDFLAGS += --no-default-libraries" in ToolchainTasking.defs

## Impact

RELEASE

## Testing

CI