### PR TITLE
{bp-17005} arch/arm/armv8-m: stack pointer should be 8-byte aligned in signal co…

### DIFF
--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -119,6 +119,11 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
       tcb->xcp.saved_regs           = tcb->xcp.regs;
 
+      /* Stack pointer should be 8-byte aligned */
+
+      tcb->xcp.regs                 = (void *)STACK_ALIGN_DOWN(
+                                      (uint32_t)tcb->xcp.regs);
+
       /* Duplicate the register context.  These will be
        * restored by the signal trampoline after the signal has been
        * delivered.


### PR DESCRIPTION
## Summary

…ntext

Since the alignment of the signal context is affected by XCPTCONTEXT_SIZE in different Kconfig,  sometimes the stack pointer is not aligned to 8 bytes, this is not what the software and compiler expect, for example,  if va_list() obtains wide data of type long long, the offset will be wrong, So in this commit, we set stack-aligned the base offset so that the correct offset will be set during context restoration.

1. test code:
|            void signal_handler(int signo, siginfo_t *info, void *context) {
|                long long ttt = 1024000;
|                printf("%lld\n", ttt);
|            }
|
|            struct itimerspec its = {   .it_value.tv_sec  = 1,
|                .it_value.tv_nsec = 0,
|                .it_interval.tv_sec  = 1,
|                .it_interval.tv_nsec = 0
|            };
|
|            int main(int argc, FAR char *argv[])
|            {
|                struct sigevent evp;
|                timer_t timer_id;
|
|                memset(&evp, 0, sizeof(evp));
|                evp.sigev_notify          = SIGEV_SIGNAL | SIGEV_THREAD_ID;
|                evp.sigev_signo           = SIGALRM;
|                evp.sigev_notify_thread_id = gettid();
|
|                timer_create(CLOCK_REALTIME, &evp, &timer_id);
|
|
|                struct sigaction sa;
|                memset(&sa, 0, sizeof(sa));
|                sa.sa_sigaction = signal_handler;
|                sa.sa_flags = SA_SIGINFO;
|                sigemptyset(&sa.sa_mask);
|
|                sigaction(SIGALRM, &sa, NULL);
|
|                timer_settime(timer_id, 0, &its, NULL);
|
|                while (1)
|                    sleep(1);
|
|                return 0;
|            }

2. before this change:

|            NuttShell (NSH) NuttX-12.10.0
|            nsh> hello
|            4398046527890440
|            4398046527890472
|            4398046527890504
|            4398046527890536

3. after this change:

|            NuttShell (NSH) NuttX-12.10.0
|            nsh> hello
|            1024000
|            1024000
|            1024000
|            1024000


## Impact
RELEASE

## Testing
CI