### PR TITLE
{bp-17029} arch: fix stack alignment bug for arm and tricore arch

### DIFF
--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -73,6 +73,9 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
+  uintptr_t top_of_stack;
+  size_t size_of_stack;
+
 #ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
@@ -103,9 +106,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size  =
-      STACK_ALIGN_DOWN((uintptr_t)stack + stack_size) - (uintptr_t)stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
+
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a

--- a/arch/tricore/src/common/tricore_usestack.c
+++ b/arch/tricore/src/common/tricore_usestack.c
@@ -93,26 +93,11 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
+  tcb->stack_base_ptr  = (void *)STACK_ALIGN_UP((uintptr_t)stack);
 
-  /* RISC-V uses a push-down stack: the stack grows toward lower addresses in
-   * memory. The stack pointer register, points to the lowest, valid work
-   * address (the "top" of the stack). Items on the stack are referenced
-   * as positive word offsets from SP.
-   */
-
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-  /* The RISC-V stack must be aligned at 128-bit (16-byte) boundaries.
-   * If necessary top_of_stack must be rounded down to the next boundary.
-   */
-
-  top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
-
-  /* Save the adjusted stack values in the struct tcb_s */
-
-  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size = size_of_stack;
+  top_of_stack = STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_base_ptr;
+  tcb->adj_stack_size  = size_of_stack;
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a


### PR DESCRIPTION
## Summary
   The stack alignment operation in tricore and arm porting
   only aligns the size of the stack, forget to align the start addr
   of the stack, this patch fixes it.

## Impact

RELEASE

## Testing

CI