### PR TITLE
{bp-17041} include/nuttx/spi/spi_bitbang: Fix incompatible pointer type issue

### DIFF
--- a/include/nuttx/spi/spi_bitbang.h
+++ b/include/nuttx/spi/spi_bitbang.h
@@ -79,7 +79,7 @@ struct spi_bitbang_ops_s
 
 /* This is the type of the function that can exchange one bit */
 
-typedef CODE uint8_t (*bitexchange_t)(uint8_t dataout, uint32_t holdtime);
+typedef CODE uint16_t (*bitexchange_t)(uint16_t dataout, uint32_t holdtime);
 
 /* This structure provides the state of the SPI bit-bang driver */
 


### PR DESCRIPTION
## Summary
This commit fixes the incompatible pointer type issue due to incompatible types of the `bitexchange_t` callback.

## Impact

RELEASE

## Testing

CI