### PR TITLE
{bp-17049} arch/xtensa: espressif: temperature: Fix incorrect pointer casting

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
@@ -714,7 +714,8 @@ static int esp_temperature_sensor_set_interval(
   struct file *filep,
   uint32_t *period_us)
 {
-  struct esp_temp_priv_s *priv = (struct esp_temp_priv_s *)lower;
+  struct esp_temp_priv_s *priv =
+    container_of(lower, struct esp_temp_priv_s, lower);
 
   if (*period_us < ESP_TEMP_MIN_INTERVAL)
     {
@@ -753,7 +754,8 @@ static int esp_temperature_sensor_activate(
   struct file *filep,
   bool enable)
 {
-  struct esp_temp_priv_s *priv = (struct esp_temp_priv_s *)lower;
+  struct esp_temp_priv_s *priv =
+    container_of(lower, struct esp_temp_priv_s, lower);
 #ifdef CONFIG_ESPRESSIF_TEMP_UORB_POLL
   bool start_thread = false;
 #endif

--- a/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
@@ -713,7 +713,8 @@ static int esp_temperature_sensor_set_interval(
   struct file *filep,
   uint32_t *period_us)
 {
-  struct esp_temp_priv_s *priv = (struct esp_temp_priv_s *)lower;
+  struct esp_temp_priv_s *priv =
+    container_of(lower, struct esp_temp_priv_s, lower);
 
   if (*period_us < ESP_TEMP_MIN_INTERVAL)
     {
@@ -752,7 +753,8 @@ static int esp_temperature_sensor_activate(
   struct file *filep,
   bool enable)
 {
-  struct esp_temp_priv_s *priv = (struct esp_temp_priv_s *)lower;
+  struct esp_temp_priv_s *priv =
+    container_of(lower, struct esp_temp_priv_s, lower);
 #ifdef CONFIG_ESPRESSIF_TEMP_UORB_POLL
   bool start_thread = false;
 #endif


### PR DESCRIPTION
## Summary

    Why change is necessary (fix, update, new feature)? Fix - The temperature sensor driver was using direct pointer casting which could lead to incorrect memory access and potential runtime crashes.
    What functional part of the code is being changed? ESP temperature sensor driver in arch/xtensa/src/common/espressif/esp_temperature_sensor.c.
    How does the change exactly work (what will change and how)? Replaced direct casting of lower half structure pointer with container_of macro to safely derive the private structure pointer, ensuring proper type safety.

## Impact

    Is new feature added? Is existing feature changed? NO - Bug fix only, no functional changes.
    Impact on user (will user need to adapt to change)? NO - Internal implementation change only.
    Impact on build (will build process change)? NO - No build changes required.
    Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES - Only affects ESP temperature sensor driver implementation.
    Impact on documentation (is update required / provided)? NO - Internal code fix, no documentation needed.
    Impact on security (any sort of implications)? NO - Improves memory safety but no security implications.
    Impact on compatibility (backward/forward/interoperability)? NO - Fully backward compatible.
    Anything else to consider or add? This fix prevents potential memory corruption issues in temperature sensor operations.

## Testing

nsh> ls /dev/uorb
/dev/uorb:
 sensor_temp0
nsh> uorb_listener

Monitor objects num:1
object_name:sensor_temp, object_instance:0
sensor_temp(now:44728730000):timestamp:44728730000,temperature:29.000000
sensor_temp(now:44728840000):timestamp:44728840000,temperature:29.000000
sensor_temp(now:44728950000):timestamp:44728950000,temperature:29.000000
sensor_temp(now:44729060000):timestamp:44729060000,temperature:29.000000
sensor_temp(now:44729170000):timestamp:44729170000,temperature:29.000000
sensor_temp(now:44729280000):timestamp:44729280000,temperature:29.000000
sensor_temp(now:44729390000):timestamp:44729390000,temperature:30.000000
sensor_temp(now:44729500000):timestamp:44729500000,temperature:30.000000
sensor_temp(now:44729610000):timestamp:44729610000,temperature:30.000000
sensor_temp(now:44729720000):timestamp:44729720000,temperature:30.000000
sensor_temp(now:44729830000):timestamp:44729830000,temperature:30.000000
sensor_temp(now:44729940000):timestamp:44729940000,temperature:30.000000
sensor_temp(now:44730050000):timestamp:44730050000,temperature:29.000000
sensor_temp(now:44730160000):timestamp:44730160000,temperature:29.000000
sensor_temp(now:44730270000):timestamp:44730270000,temperature:29.000000
sensor_temp(now:44730380000):timestamp:44730380000,temperature:29.000000
sensor_temp(now:44730490000):timestamp:44730490000,temperature:29.000000

