### PR TITLE
{bp-17050} boards: esp32s3-lckfb-szpi: Remove obsolete device function prototypes

### DIFF
--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
@@ -121,25 +121,6 @@ int board_i2c_init(void);
 #endif
 
 /****************************************************************************
- * Name: board_bmp180_initialize
- *
- * Description:
- *   Initialize and register the BMP180 Pressure Sensor driver.
- *
- * Input Parameters:
- *   devno - The device number, used to build the device path as /dev/pressN
- *   busno - The I2C bus number
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SENSORS_BMP180
-int board_bmp180_initialize(int devno, int busno);
-#endif
-
-/****************************************************************************
  * Name: board_i2sdev_initialize
  *
  * Description:
@@ -161,27 +142,6 @@ int board_bmp180_initialize(int devno, int busno);
 
 #ifdef CONFIG_ESPRESSIF_I2S
 int board_i2sdev_initialize(int port, bool enable_tx, bool enable_rx);
-#endif
-
-/****************************************************************************
- * Name: esp32s3_cs4344_initialize
- *
- * Description:
- *   This function is called by platform-specific, setup logic to configure
- *   and register the CS4344 device.  This function will register the driver
- *   as /dev/audio/pcm[x] where x is determined by the I2S port number.
- *
- * Input Parameters:
- *   port - The I2S port used for the device
- *
- * Returned Value:
- *   Zero is returned on success.  Otherwise, a negated errno value is
- *   returned to indicate the nature of the failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_AUDIO_CS4344
-int esp32s3_cs4344_initialize(int port);
 #endif
 
 #ifdef CONFIG_ESP32S3_OPENETH

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -153,8 +153,7 @@
 int esp32s3_bringup(void)
 {
   int ret;
-#if (defined(CONFIG_ESPRESSIF_I2S0) && !defined(CONFIG_AUDIO_CS4344)) || \
-    defined(CONFIG_ESPRESSIF_I2S1)
+#if defined(CONFIG_ESPRESSIF_I2S0) || defined(CONFIG_ESPRESSIF_I2S1)
   bool i2s_enable_tx;
   bool i2s_enable_rx;
 #endif
@@ -323,30 +322,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_SENSORS_BMP180
-  /* Try to register BMP180 device in I2C0 */
-
-  ret = board_bmp180_initialize(0, ESP32S3_I2C0);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR,
-             "Failed to initialize BMP180 driver for I2C0: %d\n", ret);
-    }
-#endif
-
 #ifdef CONFIG_ESPRESSIF_I2S
-
-#ifdef CONFIG_AUDIO_CS4344
-
-  /* Configure CS4344 audio on I2S0 */
-
-  ret = esp32s3_cs4344_initialize(ESP32S3_I2S0);
-  if (ret != OK)
-    {
-      syslog(LOG_ERR, "Failed to initialize CS4344 audio: %d\n", ret);
-    }
-#else
-
 #ifdef CONFIG_ESPRESSIF_I2S0_TX
   i2s_enable_tx = true;
 #else
@@ -366,7 +342,6 @@ int esp32s3_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize I2S0 driver: %d\n", ret);
     }
-#endif /* CONFIG_AUDIO_CS4344 */
 
 #ifdef CONFIG_ESPRESSIF_I2S1
 


### PR DESCRIPTION
## Summary
Remove function prototypes for BMP180 pressure sensor and CS4344 audio DAC devices that were never actually present on this board configuration. This cleans up the header file by removing declarations for non-existent hardware.

## Impact

RELEASE

## Testing

CI