### PR TITLE
nuttx/list: Add `list_for_every_entry_from()`

### DIFF
--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -274,6 +274,12 @@
       &entry->member != (list); entry = temp, \
       temp = list_container_of(temp->member.next, type, member))
 
+/* Iterate from a given entry node */
+
+#define list_for_every_entry_from(list, cur, type, member) \
+  for (; &(cur)->member != (list); \
+       (cur) = list_next_entry(cur, type, member))
+
 /* Iterate from a given entry node in a safe way */
 
 #define list_for_every_entry_safe_from(list, cur, temp, type, member) \


### PR DESCRIPTION
## Summary
Add `list_for_every_entry_from()`: Iterate over the list of the given type, continuing from the current position.
Referenced `list_for_every_entry_safe_from()`.
## Impact
- nuttx/list

## Testing
- Selftest
```C
struct xxxx_s
{
  /* ... ... */

 struct list_node node;
} *tmp;

list_for_every_entry_from(&head, tmp, struct xxxx_s, node)
{
  /* ... ... */
}
```
- CI