### PR TITLE
schec/clock: remove return value of clock_systime_timespec()

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cisif.c
+++ b/arch/arm/src/cxd56xx/cxd56_cisif.c
@@ -286,10 +286,7 @@ static uint64_t cisif_get_msec_time(void)
 {
   struct timespec tp;
 
-  if (clock_systime_timespec(&tp) < 0)
-    {
-      return 0;
-    }
+  clock_systime_timespec(&tp);
 
   return (((uint64_t)tp.tv_sec) * 1000 + tp.tv_nsec / 1000000);
 }

--- a/arch/arm/src/cxd56xx/cxd56_nxaudio.c
+++ b/arch/arm/src/cxd56xx/cxd56_nxaudio.c
@@ -2094,15 +2094,10 @@ static int cxd56_power_on_micbias(struct cxd56_dev_s *dev)
 
   /* Set mic boot time */
 
-  if (clock_systime_timespec(&start) < 0)
-    {
-      dev->mic_boot_start = 0x0ull;
-    }
-  else
-    {
-      dev->mic_boot_start = (uint64_t)start.tv_sec * 1000 +
-                            (uint64_t)start.tv_nsec / 1000000;
-    }
+  clock_systime_timespec(&start);
+
+  dev->mic_boot_start = (uint64_t)start.tv_sec * 1000 +
+                        (uint64_t)start.tv_nsec / 1000000;
 
   return OK;
 }
@@ -2953,16 +2948,16 @@ static int cxd56_start(struct audio_lowerhalf_s *lower)
       if (priv->mic_boot_start != 0x0ull)
         {
           struct timespec end;
-          if (clock_systime_timespec(&end) == 0)
-            {
-              uint64_t time = (uint64_t)end.tv_sec * 1000 +
-                              (uint64_t)end.tv_nsec / 1000000 -
-                               priv->mic_boot_start;
 
-              if (time < CXD56_MIC_BOOT_WAIT)
-                {
-                  nxsig_usleep((CXD56_MIC_BOOT_WAIT - time) * 1000);
-                }
+          clock_systime_timespec(&end);
+
+          uint64_t time = (uint64_t)end.tv_sec * 1000 +
+                          (uint64_t)end.tv_nsec / 1000000 -
+                           priv->mic_boot_start;
+
+          if (time < CXD56_MIC_BOOT_WAIT)
+            {
+              nxsig_usleep((CXD56_MIC_BOOT_WAIT - time) * 1000);
             }
         }
     }

--- a/boards/arm/cxd56xx/drivers/audio/cxd56_audio_analog.c
+++ b/boards/arm/cxd56xx/drivers/audio/cxd56_audio_analog.c
@@ -64,12 +64,7 @@ static void clear_mic_boot_time(void)
 static void set_mic_boot_time(void)
 {
   struct timespec start;
-  if (clock_systime_timespec(&start) < 0)
-    {
-      g_mic_boot_start_time = 0x0ull;
-      return;
-    }
-
+  clock_systime_timespec(&start);
   g_mic_boot_start_time = (uint64_t)start.tv_sec * 1000 +
                           (uint64_t)start.tv_nsec / 1000000;
 }
@@ -79,11 +74,7 @@ static void wait_mic_boot_finish(void)
   if (g_mic_boot_start_time != 0x0ull)
     {
       struct timespec end;
-      if (clock_systime_timespec(&end) < 0)
-        {
-          return;
-        }
-
+      clock_systime_timespec(&end);
       uint64_t time = (uint64_t)end.tv_sec * 1000 +
                       (uint64_t)end.tv_nsec / 1000000 -
                        g_mic_boot_start_time;

--- a/drivers/sensors/sht4x_uorb.c
+++ b/drivers/sensors/sht4x_uorb.c
@@ -835,14 +835,7 @@ int sht4x_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
   priv->addr = addr;
   priv->precision = SHT4X_PREC_HIGH;
   priv->interval = 1000000; /* 1s interval */
-  err = clock_systime_timespec(&priv->last_heat);
-
-  if (err < 0)
-    {
-      snerr("ERROR: Failed to get timespec: %d\n", err);
-      kmm_free(priv);
-      return err;
-    }
+  clock_systime_timespec(&priv->last_heat);
 
   /* Allow heat immediately after registration since in theory the sensor has
    * never had its heater activated yet.

--- a/drivers/video/isx019.c
+++ b/drivers/video/isx019.c
@@ -1230,11 +1230,7 @@ static bool try_repeat(int sec, int usec, FAR isx019_dev_t *priv,
   struct timespec now;
   struct timespec delta;
 
-  ret = clock_systime_timespec(&start);
-  if (ret < 0)
-    {
-      return false;
-    }
+  clock_systime_timespec(&start);
 
   while (1)
     {
@@ -1245,12 +1241,7 @@ static bool try_repeat(int sec, int usec, FAR isx019_dev_t *priv,
         }
       else
         {
-          ret = clock_systime_timespec(&now);
-          if (ret < 0)
-            {
-              return false;
-            }
-
+          clock_systime_timespec(&now);
           clock_timespec_subtract(&now, &start, &delta);
           if ((delta.tv_sec > sec) ||
               ((delta.tv_sec == sec) &&

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -731,13 +731,13 @@ clock_t clock_systime_ticks(void);
  *   ts - Location to return the time
  *
  * Returned Value:
- *   OK (0) on success; a negated errno value on failure.
+ *   None
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-int clock_systime_timespec(FAR struct timespec *ts);
+void clock_systime_timespec(FAR struct timespec *ts);
 
 /****************************************************************************
  * Name:  clock_cpuload

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -52,14 +52,13 @@
  *   ts - Location to return the time
  *
  * Returned Value:
- *   Current version almost always returns OK. Currently errors are
- *   possible with CONFIG_RTC_HIRES only.
+ *   None
  *
  * Assumptions:
  *
  ****************************************************************************/
 
-int clock_systime_timespec(FAR struct timespec *ts)
+void clock_systime_timespec(FAR struct timespec *ts)
 {
 #ifdef CONFIG_RTC_HIRES
   if (g_rtc_enabled)
@@ -84,6 +83,4 @@ int clock_systime_timespec(FAR struct timespec *ts)
 #else
   clock_ticks2time(ts, g_system_ticks);
 #endif
-  return 0;
 }
-


### PR DESCRIPTION

## Summary

schec/clock: remove return value of clock_systime_timespec()

clock_systime_timespec() always returns 0, so there is no need to
check the return value in the caller code, let us remove the return
value directly.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, sabre-6quad/smp   ostest