### PR TITLE
cmake: pass exclusion list to nuttx_add_subdirectory

### DIFF
--- a/cmake/nuttx_add_subdirectory.cmake
+++ b/cmake/nuttx_add_subdirectory.cmake
@@ -21,6 +21,14 @@
 # ##############################################################################
 
 function(nuttx_add_subdirectory)
+  # Parse arguments: EXCLUDE can be a list of directories
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs EXCLUDE)
+  cmake_parse_arguments(NUTTX "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
+
+  # Find all subdirs that have a CMakeLists.txt
   file(
     GLOB subdir
     LIST_DIRECTORIES false
@@ -29,6 +37,14 @@ function(nuttx_add_subdirectory)
 
   foreach(dir ${subdir})
     get_filename_component(dir ${dir} DIRECTORY)
+
+    # Skip excluded directories
+    list(FIND NUTTX_EXCLUDE ${dir} _skip_index)
+    if(_skip_index GREATER -1)
+      message(STATUS "nuttx_add_subdirectory: Skipping ${dir}")
+      continue()
+    endif()
+
     add_subdirectory(${dir})
   endforeach()
 endfunction()


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Closes: #17074.

This PR extends the nuttx_add_subdirectory() CMake helper to support excluding specific directories from being added to the build.

Previously, nuttx_add_subdirectory() added all available subdirectories, which could be undesirable in cases where certain apps or components should be skipped.

With this change, developers can now pass an EXCLUDE argument to specify directories that should not be included.

Example usage:
```
nuttx_add_subdirectory(EXCLUDE dir_to_ignore)
```

This improves flexibility in project configurations, particularly in out-of-tree builds and when fine-grained control of the build process is needed.

## Impact

- Build system: Adds the ability to ignore directories when invoking nuttx_add_subdirectory(). No impact on existing builds unless the new EXCLUDE argument is explicitly used.

- Compatibility: Maintains backward compatibility with current nuttx_add_subdirectory() usage.

- Users: Developers gain more control over which directories are included in builds.

## Testing

Tested with this PR: https://github.com/apache/nuttx-apps/pull/3186



