### PR TITLE
sched/task: move lock to mhead scope

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -661,6 +661,7 @@ struct tcb_s
 
 #if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
   FAR struct pthread_mutex_s *mhead;     /* List of mutexes held by thread  */
+  spinlock_t mhead_lock;
 #endif
 
   /* CPU load monitoring support ********************************************/
@@ -715,10 +716,6 @@ struct tcb_s
   size_t caller_deepest;
   size_t level_deepest;
   size_t level;
-#endif
-
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  spinlock_t mutex_lock;
 #endif
 };
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -444,8 +444,8 @@ static void idle_group_initialize(void)
 
       nxtask_joininit(tcb);
 
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-      spin_lock_init(&tcb->mutex_lock);
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+      spin_lock_init(&tcb->mhead_lock);
 #endif
 
 #ifdef CONFIG_SMP

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -223,7 +223,7 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   nxtask_joininit(&ptcb->cmn);
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  spin_lock_init(&ptcb->cmn.mutex_lock);
+  spin_lock_init(&ptcb->cmn.mhead_lock);
 #endif
 
   /* Bind the parent's group to the new TCB (we have not yet joined the

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -65,10 +65,10 @@ static void pthread_mutex_add(FAR struct pthread_mutex_s *mutex)
 
   /* Add the mutex to the list of mutexes held by this pthread */
 
-  flags        = spin_lock_irqsave(&rtcb->mutex_lock);
+  flags        = spin_lock_irqsave(&rtcb->mhead_lock);
   mutex->flink = rtcb->mhead;
   rtcb->mhead  = mutex;
-  spin_unlock_irqrestore(&rtcb->mutex_lock, flags);
+  spin_unlock_irqrestore(&rtcb->mhead_lock, flags);
 }
 
 /****************************************************************************
@@ -92,7 +92,7 @@ static void pthread_mutex_remove(FAR struct pthread_mutex_s *mutex)
   FAR struct pthread_mutex_s *prev;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave(&rtcb->mutex_lock);
+  flags = spin_lock_irqsave(&rtcb->mhead_lock);
 
   /* Remove the mutex from the list of mutexes held by this task */
 
@@ -118,7 +118,7 @@ static void pthread_mutex_remove(FAR struct pthread_mutex_s *mutex)
     }
 
   mutex->flink = NULL;
-  spin_unlock_irqrestore(&rtcb->mutex_lock, flags);
+  spin_unlock_irqrestore(&rtcb->mhead_lock, flags);
 }
 
 /****************************************************************************
@@ -372,7 +372,7 @@ void pthread_mutex_inconsistent(FAR struct tcb_s *tcb)
 
   DEBUGASSERT(tcb != NULL);
 
-  flags = spin_lock_irqsave(&tcb->mutex_lock);
+  flags = spin_lock_irqsave(&tcb->mhead_lock);
 
   /* Remove and process each mutex held by this task */
 
@@ -390,5 +390,5 @@ void pthread_mutex_inconsistent(FAR struct tcb_s *tcb)
       mutex_unlock(&mutex->mutex);
     }
 
-  spin_unlock_irqrestore(&tcb->mutex_lock, flags);
+  spin_unlock_irqrestore(&tcb->mhead_lock, flags);
 }

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -164,8 +164,8 @@ FAR struct task_tcb_s *nxtask_setup_fork(start_t retaddr)
 
   nxtask_joininit(&child->cmn);
 
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  spin_lock_init(&child->cmn.mutex_lock);
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+  spin_lock_init(&child->cmn.mhead_lock);
 #endif
 
   /* Allocate a new task group with the same privileges as the parent */

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -126,8 +126,8 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   nxtask_joininit(&tcb->cmn);
 #endif
 
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  spin_lock_init(&tcb->cmn.mutex_lock);
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+  spin_lock_init(&tcb->cmn.mhead_lock);
 #endif
 
   /* Duplicate the parent tasks environment */


### PR DESCRIPTION
## Summary

sched/task: move lock to mhead scope

1. rename mutex_lock to mhead_lock to declare purpose of lock
2. move lock to mhead scope

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, sabre-6quad/smp ostest