### PR TITLE
tools/ci/testlist: skip the build of <board>:cxxtest

### DIFF
--- a/tools/ci/testlist/arm-12.dat
+++ b/tools/ci/testlist/arm-12.dat
@@ -6,3 +6,6 @@
 /arm/stm32/stm32vldiscovery,CONFIG_ARM_TOOLCHAIN_CLANG
 
 /arm/stm32/viewtool-stm32f107,CONFIG_ARM_TOOLCHAIN_CLANG
+
+# cURL error 60 SSL certificate expired
+-stm32f4discovery:cxxtest

--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -1,6 +1,9 @@
 /sim/*/*/*/c[j-z]*
 /sim/*/*/*/[d-n]*
 
+# cURL error 60 SSL certificate expired
+-sim:cxxtest
+
 # macOS doesn't have V4L2
 -Darwin,sim:nxcamera
 


### PR DESCRIPTION
## Summary

Problems downloading the uClibc++-0.2.5.tar.bz2 package

```
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
make[1]: *** [uClibc++/Make.defs:28: uClibc++-0.2.5.tar.bz2] Error 60
make[1]: Target 'context' not remade because of errors.
make: *** [tools/Unix.mk:458: libs/libxx/.context] Error 2
```

net::ERR_CERT_DATE_INVALID
Subject: cxx.uclibc.org

Issuer: R10

Expires on: 27 set 2025

This blocks the jobs:

- arm-12
- sim-02

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub

```
====================================================================================
Skipping: stm32f4discovery/cxxtest,CONFIG_ARM_TOOLCHAIN_GNU_EABI
Configuration/Tool: stm32f4discovery/cxxtest,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2025-09-28 13:16:12
------------------------------------------------------------------------------------
  Cleaning...
  Skipping: stm32f4discovery/cxxtest,CONFIG_ARM_TOOLCHAIN_GNU_EABI
====================================================================================
```


```
====================================================================================
Skipping: sim/cxxtest
Configuration/Tool: sim/cxxtest
2025-09-28 12:57:18
------------------------------------------------------------------------------------
  Cleaning...
  Skipping: sim/cxxtest
====================================================================================
```
