### PR TITLE
boards/arm/rp2040: CMake added Adafruit boards

### DIFF
--- a/boards/arm/rp2040/adafruit-feather-rp2040/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-feather-rp2040/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
+
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp2040/adafruit-feather-rp2040/src/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-feather-rp2040/src/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-feather-rp2040/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rp2040_boardinitialize.c rp2040_bringup.c)
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp2040_gpio.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp2040_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_RP2040_FLASH_BOOT)
+  set_property(
+    GLOBAL
+    PROPERTY LD_SCRIPT
+             "${NUTTX_BOARD_DIR}/scripts/adafruit-feather-rp2040-flash.ld")
+else()
+  set_property(
+    GLOBAL
+    PROPERTY LD_SCRIPT
+             "${NUTTX_BOARD_DIR}/scripts/adafruit-feather-rp2040-sram.ld")
+endif()

--- a/boards/arm/rp2040/adafruit-kb2040/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-kb2040/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-kb2040/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
+
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp2040/adafruit-kb2040/src/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-kb2040/src/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-kb2040/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rp2040_boardinitialize.c rp2040_bringup.c)
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp2040_gpio.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp2040_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_RP2040_FLASH_BOOT)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/adafruit-kb2040-flash.ld")
+else()
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/adafruit-kb2040-sram.ld")
+endif()

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-qt-py-rp2040/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
+
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp2040/adafruit-qt-py-rp2040/src/CMakeLists.txt
+++ b/boards/arm/rp2040/adafruit-qt-py-rp2040/src/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# boards/arm/rp2040/adafruit-qt-py-rp2040/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rp2040_boardinitialize.c rp2040_bringup.c)
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp2040_gpio.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp2040_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_RP2040_FLASH_BOOT)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/adafruit-qt-py-rp2040-flash.ld")
+else()
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/adafruit-qt-py-rp2040-sram.ld")
+endif()


### PR DESCRIPTION
## Summary

Added CMake build for:

-  adafruit-feather-rp2040
-  adafruit-kb2040
-  adafruit-qt-py-rp2040

## Impact

Impact on user: This PR adds the Adafruit boards with CMake build.

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally

adafruit-feather-rp2040:nsh

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=adafruit-feather-rp2040:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp2040/adafruit-feather-rp2040/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  adafruit-feather-rp2040
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- PICO_SDK_PATH environment variable is set.
-- Skipping OOTCpp project
-- Configuring done (9.1s)
-- Generating done (1.9s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1123/1124] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        152 KB         8 MB      1.86%
            sram:        8460 B       264 KB      3.13%
[1124/1124] Running utility command for nuttx_post_build

```
adafruit-kb2040:nsh

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=adafruit-kb2040:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp2040/adafruit-kb2040/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  adafruit-kb2040
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- PICO_SDK_PATH environment variable is set.
-- Skipping OOTCpp project
-- Configuring done (8.5s)
-- Generating done (1.9s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1123/1124] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        152 KB         8 MB      1.86%
            sram:        8460 B       264 KB      3.13%
[1124/1124] Running utility command for nuttx_post_build

```

adafruit-qt-py-rp2040:nsh

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=adafruit-qt-py-rp2040:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp2040/adafruit-qt-py-rp2040/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  adafruit-qt-py-rp2040
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- PICO_SDK_PATH environment variable is set.
-- Skipping OOTCpp project
-- Configuring done (8.7s)
-- Generating done (1.9s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1123/1124] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        152 KB         8 MB      1.86%
            sram:        8460 B       264 KB      3.13%
[1124/1124] Running utility command for nuttx_post_build
```