### PR TITLE
arch/xtensa/espressif: fix Wi-Fi netpkt copy error

### DIFF
--- a/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
+++ b/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
@@ -1019,7 +1019,7 @@ static int wlan_rx_done(struct esp_wlan_priv_s *priv,
     }
 
   ret = netpkt_copyin(&priv->dev, pkt, buffer, len, 0);
-  if (ret != OK)
+  if (ret < 0)
     {
       wlerr("ERROR: Failed to copy packet\n");
       goto out;


### PR DESCRIPTION
## Summary

- arch/xtensa: fix Wi-Fi netpkt copy error
Fix an issue where netpkt copy would fail due to wrong return checking condition.

Fixes #17113.

## Impact

- Impact on user: Yes. Fixes bug preventing Wi-Fi connection.
- Impact on build: No.
- Impact on hardware: ESP32|S2|S3 only.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: No.

## Testing

### Building
Simply build the wifi defconfig, connect to an AP and ping it.

### Running

- ./tools/configure.sh esp32s3-devkit:wifi
- make and flash

### Results
Connect to a network, obtain an IP address with renew and attempt a ping:

```
wapi psk wlan0 <pass> 3 3
wapi essid wlan0 <ssid> 1
renew wlan0
```

Pings normally:

```
nsh> renew wlan0
nsh> ifconfig
wlan0    Link encap:Ethernet HWaddr 70:b8:f6:12:bf:44 at RUNNING mtu 1500
    inet addr:192.168.0.84 DRaddr:192.168.0.1 Mask:255.255.255.0
nsh> ping -c 1 192.168.0.1
PING 192.168.0.1 56 bytes of data
56 bytes from 192.168.0.1: icmp_seq=0 time=30.0 ms
```
