### PR TITLE
binfmt: Add a configuration flag to store the module filename

### DIFF
--- a/binfmt/Kconfig
+++ b/binfmt/Kconfig
@@ -89,3 +89,9 @@ config BINFMT_ELF_EXECUTABLE
 		Produce a full linked executable object as output.
 
 endchoice
+
+config BINFMT_STORE_FILENAME
+	bool "Store the binary filename"
+	default n
+	---help---
+		Store the filename of the loaded binary

--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -122,6 +122,12 @@ static int load_absmodule(FAR struct binary_s *bin, FAR const char *filename,
 
           binfo("Successfully loaded module %s\n", filename);
 
+          /* Save the filename of the loaded module */
+
+#ifdef CONFIG_BINFMT_STORE_FILENAME
+          strlcpy(bin->fname, filename, sizeof(bin->fname));
+#endif
+
           /* Save the unload method for use by unload_module */
 
           bin->unload = binfmt->unload;

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -96,6 +96,11 @@ struct binary_s
 
   uint8_t priority;                    /* Task execution priority */
   size_t stacksize;                    /* Size of the stack in bytes (unallocated) */
+
+#ifdef CONFIG_BINFMT_STORE_FILENAME
+  char fname[NAME_MAX];
+#endif
+
 #ifdef CONFIG_SCHED_USER_IDENTITY
   uid_t uid;                           /* File owner user identity */
   gid_t gid;                           /* File owner group user identity */


### PR DESCRIPTION
## Summary

This flag can be used to store the filename of a loaded module or executable in binfmt. The filename is useful for example in debugging. For debugging purpose, gdb or a jtag debugger can be configured to automatically fetch the symbols for the currently executing module.

I have been using this to help in debugging applications in CONFIG_BUILD_KERNEL, autoloading symbols whenever the target is stopped with gdb.

I don't know if there are existing or better ways to achieve the same, if there is a better way or more complete "OS awareness" available for gdb, we can just ignore this.

I am only offering the method here, in case others find it useful as well.

Here is an example script of how such feature can be utilized using gdb:
[smp_autosymbols.py](https://github.com/user-attachments/files/22612431/smp_autosymbols.py)

Usage in gdb:
set $cpu_index = 0 # for smp, set cpu index for each gdb server
set $symbol_path_prefix = "<path_to_symbol_elf_files>"
source /<path_to_script>/smp_autosymbols.py

## Impact

No impact on any existing configurations, just adds the executable name in bin in case the flag is defined in .config.

## Testing

Tested in IMX9 platform, CONFIG_BUILD_KERNEL, SEGGER JLink + GDB.
