### PR TITLE
fs/mmap/fs_munmap.c: return error if len is 0

### DIFF
--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -55,6 +55,11 @@ static int file_munmap_(FAR void *start, size_t length,
   FAR struct mm_map_s *mm = get_current_mm();
   int ret = OK;
 
+  if (length == 0)
+    {
+      return -EINVAL;
+    }
+
   /* Iterate through all the mappings and call the underlying
    * unmap for every mapping where "start" lies
    * break loop on any errors.


### PR DESCRIPTION
## Summary

munmap() shall return ERROR with errno = EINVAL if len is 0

reference: https://pubs.opengroup.org/onlinepubs/000095399/functions/munmap.html

## Impact

POSIX compliance

## Testing

CI
