### PR TITLE
fs/mmap/fs_mmap.c: fix errno when fd is not valid

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -279,10 +279,9 @@ FAR void *mmap(FAR void *start, size_t length, int prot, int flags,
   FAR void *mapped = NULL;
   int ret;
 
-  if (fd != -1 && file_get(fd, &filep) < 0)
+  if (fd != -1 && (ret = file_get(fd, &filep)) < 0)
     {
-      ferr("ERROR: fd:%d referred file whose type is not supported\n", fd);
-      ret = -ENODEV;
+      ferr("ERROR: fd:%d referred file is not valid\n", fd);
       goto errout;
     }
 


### PR DESCRIPTION
## Summary

mmap() should return EBADF errno when fd is not valid. We can just return error code from file_get().

Reference: https://pubs.opengroup.org/onlinepubs/000095399/functions/mmap.html

## Impact

POSIX compliance

## Testing

PSE52 test suite
