### PR TITLE
fs/mmap/fs_msync.c: don't flush changes if MAP_PRIVATE

### DIFF
--- a/fs/mmap/fs_msync.c
+++ b/fs/mmap/fs_msync.c
@@ -78,13 +78,19 @@ int msync(FAR void *start, size_t length, int flags)
       goto out;
     }
 
-  if (entry->msync == NULL)
+  /* Don't synchronize a file if this is private mapping or there is
+   * no msync handler for this file.
+   */
+
+  if (entry->msync && (entry->flags & MAP_PRIVATE) == 0)
+    {
+      ret = entry->msync(entry, start, length, flags);
+    }
+  else
     {
       ret = OK;
-      goto out;
     }
 
-  ret = entry->msync(entry, start, length, flags);
 out:
   mm_map_unlock();
   if (ret < 0)


### PR DESCRIPTION
## Summary

changes should not be flushed to the underlying file if memory mapping is marked as MAP_PRIVATE.

Reference: https://pubs.opengroup.org/onlinepubs/007904975/functions/msync.html

## Impact

POSIX compliance

## Testing

PSE52 test suite
