### PR TITLE
fs/mmap/fs_mmap.c: add missing NULL pointer

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -68,6 +68,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
      prot,
      flags,
      { NULL }, /* priv.p */
+     NULL,     /* msync */
      NULL      /* munmap */
     };
 


### PR DESCRIPTION
## Summary
add missing NULL pointer for msync to match `struct mm_map_entry_s` definition

## Impact

pure cosmetic change

## Testing

CI
