### PR TITLE
sched/sig_pending: sigpending() should return caller pending signals only

### DIFF
--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -86,13 +86,10 @@ sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
 
   if (stcb == NULL)
     {
-      group = this_task()->group;
-    }
-  else
-    {
-      group = stcb->group;
+      stcb = this_task();
     }
 
+  group = stcb->group;
   DEBUGASSERT(group);
 
   sigemptyset(&sigpendset);
@@ -101,7 +98,7 @@ sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
   for (sigpend = (FAR sigpendq_t *)group->tg_sigpendingq.head;
        (sigpend); sigpend = sigpend->flink)
     {
-      if (stcb == NULL || sigpend->tcb == NULL || stcb == sigpend->tcb)
+      if (sigpend->tcb == NULL || stcb == sigpend->tcb)
         {
           nxsig_addset(&sigpendset, sigpend->info.si_signo);
         }


### PR DESCRIPTION
## Summary

Previously sigpending() returned all pending signals in the group, which is not POSIX compliant. It should return signals pending only for the caller, so a signal send with pthread_kill() intended for another thread should not be returned (it's not pending for a caller).

This fixes the pthread_create.c/test9 test case from PSE52 Open Group Threads Test Suite.

## Impact

POSIX compliance

## Testing

PSE52 test suite.

The test case looks like this:

```
function test():
    setup_signals()       // block signals, set SIGTERM handler

    start thread1
    join thread1

    restore_signals()     // restore original signal mask and handler

------------------------------
thread1 ():
    block all signals
    send SIGTERM to self   // signal becomes pending, pthread_kill(pthread_self(), SIGTERM)

    start thread2
    join thread2           // thread2 checks pending signals (should be none)

    unblock all signals    // pending SIGTERM is delivered
    return

------------------------------
thread2 ():
    get pending signals // sigpending()
    for each signal:
        if signal is pending:
            mark fail      // there should be no pending signals for thread2, NuttX fails here
    return
```