### PR TITLE
libc/crc: Add crc8rohcincr for incremental CRC8 ROHC calculation

### DIFF
--- a/include/nuttx/crc8.h
+++ b/include/nuttx/crc8.h
@@ -118,6 +118,12 @@ uint8_t crc8rohcpart(FAR const uint8_t *src, size_t len, uint8_t crc8val);
 
 uint8_t crc8rohc(FAR const uint8_t *src, size_t len);
 
+/****************************************************************************
+ * Name: crc8rohcincr
+ ****************************************************************************/
+
+uint8_t crc8rohcincr(uint8_t data_byte, uint8_t crc8val);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/misc/lib_crc8rohc.c
+++ b/libs/libc/misc/lib_crc8rohc.c
@@ -88,3 +88,12 @@ uint8_t crc8rohc(FAR const uint8_t *src, size_t len)
 {
   return crc8rohcpart(src, len, 0xff);
 }
+
+/****************************************************************************
+ * Name: crc8rohcincr
+ ****************************************************************************/
+
+uint8_t crc8rohcincr(uint8_t data_byte, uint8_t crc8val)
+{
+  return g_crc8_tab[crc8val ^ data_byte];
+}


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The PR aims to add crc8 for incremental. The existing crc8rohcpart() function applies XOR inversions (0xFF)
at the start and end of each call, making it unsuitable for
incremental calculations where intermediate CRC values must be
preserved between calls. Also this PR will solve issues in [PR 3187](https://github.com/apache/nuttx-apps/pull/3187).

## Impact

None.

## Testing

For test, this PR was used in CMUX example.