### PR TITLE
boards/xtensa/esp32s3: Refactor ES8311 initialization to use I2C handle

### DIFF
--- a/boards/xtensa/esp32s3/common/src/esp32s3_es8311.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_es8311.c
@@ -65,7 +65,7 @@ static struct es8311_lower_s g_es8311_lower[2];
  *   as /dev/audio/pcm[x] where x is determined by the I2S port number.
  *
  * Input Parameters:
- *   i2c_port  - The I2C port used for the device
+ *   i2c       - The I2C handle used for the device
  *   i2c_addr  - The I2C address used by the device
  *   i2c_freq  - The I2C frequency used for the device
  *   i2s_port  - The I2S port used for the device
@@ -76,17 +76,16 @@ static struct es8311_lower_s g_es8311_lower[2];
  *
  ****************************************************************************/
 
-int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
-                            int i2s_port)
+int esp32s3_es8311_initialize(struct i2c_master_s *i2c, uint8_t i2c_addr,
+                              int i2c_freq, int i2s_port)
 {
   struct audio_lowerhalf_s *es8311;
   struct i2s_dev_s *i2s;
-  struct i2c_master_s *i2c;
   static bool initialized = false;
   int ret;
 
-  audinfo("i2c_port %d, i2c_addr %d, i2c_freq %d\n",
-          i2c_port, i2c_addr, i2c_freq);
+  audinfo("i2c_addr %d, i2c_freq %d\n",
+           i2c_addr, i2c_freq);
 
   /* Have we already initialized? Since we never uninitialize we must
    * prevent multiple initializations. This is necessary, for example,
@@ -107,10 +106,9 @@ int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
           goto errout;
         }
 
-      i2c = esp32s3_i2cbus_initialize(i2c_port);
       if (i2c == NULL)
         {
-          auderr("ERROR: Failed to initialize I2C%d\n", i2c_port);
+          auderr("ERROR: I2C handle is NULL\n");
           ret = -ENODEV;
           goto errout;
         }

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 #include <stdint.h>
+#include <nuttx/i2c/i2c_master.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -100,7 +101,7 @@ int board_spiflash_init(void);
  *   as /dev/audio/pcm[x] where x is determined by the I2S port number.
  *
  * Input Parameters:
- *   i2c_port  - The I2C port used for the device
+ *   i2c       - The I2C handle used for the device
  *   i2c_addr  - The I2C address used by the device
  *   i2c_freq  - The I2C frequency used for the device
  *   i2s_port  - The I2S port used for the device
@@ -112,8 +113,8 @@ int board_spiflash_init(void);
  ****************************************************************************/
 
 #ifdef CONFIG_AUDIO_ES8311
-int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
-                            int i2s_port);
+int esp32s3_es8311_initialize(struct i2c_master_s *i2c, uint8_t i2c_addr,
+                              int i2c_freq, int i2s_port);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3-lcd-ev.h
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3-lcd-ev.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 #include <stdint.h>
+#include <nuttx/i2c/i2c_master.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -207,7 +208,7 @@ int board_ioexpander_initialize(void);
  *   as /dev/audio/pcm[x] where x is determined by the I2S port number.
  *
  * Input Parameters:
- *   i2c_port  - The I2C port used for the device
+ *   i2c       - The I2C handle used for the device
  *   i2c_addr  - The I2C address used by the device
  *   i2c_freq  - The I2C frequency used for the device
  *   i2s_port  - The I2S port used for the device
@@ -219,8 +220,8 @@ int board_ioexpander_initialize(void);
  ****************************************************************************/
 
 #ifdef CONFIG_AUDIO_ES8311
-int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
-                              int i2s_port);
+int esp32s3_es8311_initialize(struct i2c_master_s *i2c, uint8_t i2c_addr,
+                              int i2c_freq, int i2s_port);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
@@ -111,11 +111,14 @@
 
 int esp32s3_bringup(void)
 {
-  int ret;
+  int ret = OK;
 #if (defined(CONFIG_ESPRESSIF_I2S0) && !defined(CONFIG_AUDIO_CS4344) && \
      !defined(CONFIG_AUDIO_ES8311)) || defined(CONFIG_ESPRESSIF_I2S1)
   bool i2s_enable_tx;
   bool i2s_enable_rx;
+#endif
+#ifdef CONFIG_AUDIO_ES8311
+  struct i2c_master_s *i2c;
 #endif
 
 #if defined(CONFIG_ESPRESSIF_EFUSE)
@@ -195,8 +198,22 @@ int esp32s3_bringup(void)
   esp32s3_configgpio(SPEAKER_ENABLE_GPIO, OUTPUT);
   esp32s3_gpiowrite(SPEAKER_ENABLE_GPIO, true);
 
-  ret = esp32s3_es8311_initialize(ESP32S3_I2C0, ES8311_I2C_ADDR,
-                                  ES8311_I2C_FREQ, ESP32S3_I2S0);
+  i2c = esp32s3_i2cbus_initialize(ESP32S3_I2C0);
+  if (i2c == NULL)
+    {
+      syslog(LOG_ERR, "Failed to initialize I2C%d\n", ESP32S3_I2C0);
+      ret = -ENODEV;
+    }
+  else
+    {
+      ret = esp32s3_es8311_initialize(i2c, ES8311_I2C_ADDR,
+                                      ES8311_I2C_FREQ, ESP32S3_I2S0);
+      if (ret != OK)
+        {
+          syslog(LOG_ERR, "Failed to initialize ES8311 audio: %d\n", ret);
+        }
+    }
+
   if (ret != OK)
     {
       syslog(LOG_ERR, "Failed to initialize ES8311 audio: %d\n", ret);


### PR DESCRIPTION
## Summary

  * **Why change is necessary**: The original ES8311 initialization function accepted an I2C port number and handled I2C bus initialization internally. This created tight coupling between the audio codec driver and I2C bus management, limiting flexibility for
different board implementations.
  * **What functional part of the code is being changed**: ESP32S3 ES8311 audio codec initialization in boards/xtensa/esp32s3/common/src/esp32s3_es8311.c and corresponding board bringup code for esp32s3-korvo-2 and esp32s3-lcd-ev boards.
  * **How does the change exactly work**: Refactored esp32s3_es8311_initialize() function to accept an I2C handle instead of port number, moving I2C bus initialization responsibility to the board bringup code. This provides better separation of concerns and
allows boards to manage I2C initialization according to their specific requirements.
  * **Related NuttX Issue reference**: N/A (internal refactoring improvement)
  * **Related NuttX Apps Issue/PR reference**: N/A

## Impact

  * **Is new feature added? Is existing feature changed?**: NO - This is a refactoring that maintains existing functionality while improving architecture.
  * **Impact on user**: NO - Existing functionality is preserved, API change is internal to board initialization code.
  * **Impact on build**: NO - Build process remains unchanged.
  * **Impact on hardware**: NO - Same hardware support maintained.
  * **Impact on documentation**: NO - Internal implementation change only.
  * **Impact on security**: NO - No security implications.
  * **Impact on compatibility**: NO - Backward compatibility maintained for existing functionality.
  * **Anything else to consider**: This change improves code maintainability and follows better software engineering practices by separating concerns.

## Testing

CI and local build