### PR TITLE
arch/arm/src/stm32f0l0g0: don't compile stm32_pwr.c for STM32C0

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_pwr.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_pwr.c
@@ -33,7 +33,7 @@
 
 #if defined(CONFIG_STM32F0L0G0_STM32G0)
 #  include "stm32g0_pwr.c"
-#else
+#elif defined(CONFIG_STM32F0L0G0_STM32F0) || defined(CONFIG_STM32F0L0G0_STM32L0)
 #  include "stm32f0l0_pwr.c"
 #endif
 


### PR DESCRIPTION
## Summary

PWR is not supported for STM32C0 yet.
This fix build error when CONFIG_STM32F0L0G0_PWR=y which is required to access backup registers (we need enable PWR clock for this).

## Impact

fix build error for stm32c0

## Testing

compile stm32c0 code with CONFIG_STM32F0L0G0_PWR=y, backup registers works as expected
