### PR TITLE
add userled support to freedom-k64f

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/freedom-k64f.h
+++ b/boards/arm/kinetis/freedom-k64f/src/freedom-k64f.h
@@ -45,6 +45,11 @@
 #define HAVE_AUTOMOUNTER 1
 #define HAVE_USBDEV      1
 
+#undef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
+#  define HAVE_LEDS 1
+#endif
+
 #if defined(CONFIG_KINETIS_RTC)
 #define HAVE_RTC_DRIVER  1
 #endif

--- a/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
@@ -38,6 +38,16 @@
 #  include "kinetis_alarm.h"
 #endif
 
+#ifdef CONFIG_USERLED
+#  include <nuttx/leds/userled.h>
+#endif
+
+#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
+#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
+#else
+#  define LED_DRIVER_PATH "/dev/userleds"
+#endif
+
 #include "freedom-k64f.h"
 
 #if defined(CONFIG_BOARDCTL) || defined(CONFIG_BOARD_LATE_INITIALIZE)
@@ -59,6 +69,17 @@ int k64_bringup(void)
   int ret;
 #ifdef HAVE_RTC_DRIVER
   struct rtc_lowerhalf_s *lower;
+#endif
+
+#ifdef HAVE_LEDS
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+      return ret;
+    }
 #endif
 
 #ifdef HAVE_PROC


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR adds *user LED support for the NXP Freedom-K64F board*.
The implementation integrates the on-board LEDs with the NuttX userled driver interface, making them accessible under /dev/userleds.

This allows applications (such as the leds example app) to interact with the user LEDs in a standardized way. The change brings the Freedom-K64F in line with other boards that already support the userled subsystem.

## Impact

- Users: Can now control the K64F board’s on-board LEDs via /dev/userleds.
- Applications: The leds example works out-of-the-box on this board.
- Compatibility: No changes to existing APIs or drivers; this only extends functionality for the K64F board.
- Build system: No impact unless the Freedom-K64F board is selected.
- Documentation: New functionality matches existing userled driver docs, so no additional docs are required.

## Testing

Testing was performed on an NXP Freedom-K64F board using the leds example app.
Steps:
1. Built NuttX with the leds example enabled.
2. Booted the board and confirmed /dev/userleds was created.
3. Ran the leds example app to exercise the user LED driver.

NSH shell output (excerpt):
```
NuttShell (NSH) NuttX-12.11.0-RC1
nsh> ls /dev
/dev:
 console
 null
 pwm0
 ttyS0
 userleds
 zero
nsh> leds
leds_main: Starting the led_daemon
leds_main: led_daemon started

led_daemon (pid# 4): Running
led_daemon: Opening /dev/userleds
led_daemon: Supported LEDs 0x07
led_daemon: LED set 0x01
led_daemon: LED set 0x02
led_daemon: LED set 0x03
...
led_daemon: LED set 0x00
```

The leds app successfully cycled through all supported LED states, verifying correct integration of the driver. (pretty colors on the board :))