### PR TITLE
arm/rp2311: CMake build for Raspberry Pi RP23xx implemented

### DIFF
--- a/arch/arm/src/rp23xx/CMakeLists.txt
+++ b/arch/arm/src/rp23xx/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ##############################################################################
+# arch/arm/src/rp23xx/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+list(
+  APPEND
+  SRCS
+  rp23xx_idle.c
+  rp23xx_irq.c
+  rp23xx_uart.c
+  rp23xx_serial.c
+  rp23xx_start.c
+  rp23xx_timerisr.c
+  rp23xx_gpio.c
+  rp23xx_pio.c
+  rp23xx_clock.c
+  rp23xx_xosc.c
+  rp23xx_pll.c)
+
+if(CONFIG_SMP)
+  list(APPEND SRCS rp23xx_cpustart.c rp23xx_smpcall.c rp23xx_cpuidlestack.c
+       rp23xx_testset.c)
+endif()
+
+if(CONFIG_ARCH_HAVE_MULTICPU)
+  list(APPEND SRCS rp23xx_cpuindex.c)
+endif()
+
+if(CONFIG_RP23XX_DMAC)
+  list(APPEND SRCS rp23xx_dmac.c)
+endif()
+
+if(CONFIG_RP23XX_SPI)
+  list(APPEND SRCS rp23xx_spi.c)
+endif()
+
+if(CONFIG_RP23XX_PWM)
+  list(APPEND SRCS rp23xx_pwm.c)
+endif()
+
+if(CONFIG_RP23XX_I2C)
+  list(APPEND SRCS rp23xx_i2c.c)
+endif()
+
+if(CONFIG_RP23XX_I2C_SLAVE)
+  list(APPEND SRCS rp23xx_i2c_slave.c)
+endif()
+
+if(CONFIG_RP23XX_I2S)
+  list(APPEND SRCS rp23xx_i2s.c)
+  list(APPEND SRCS rp23xx_i2s_pio.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS rp23xx_usbdev.c)
+endif()
+
+if(CONFIG_WS2812)
+  list(APPEND SRCS rp23xx_ws2812.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS rp23xx_adc.c)
+endif()
+
+if(CONFIG_WATCHDOG)
+  list(APPEND SRCS rp23xx_wdt.c)
+endif()
+
+target_sources(arch PRIVATE ${SRCS})

--- a/boards/arm/rp23xx/common/CMakeLists.txt
+++ b/boards/arm/rp23xx/common/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/arm/rp23xx/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/arm/rp23xx/common/include/rp23xx_common_pico.h
+++ b/boards/arm/rp23xx/common/include/rp23xx_common_pico.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * boards/arm/rp23xx/common/include/rp23xx_common_pico.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP23XX_COMMON_INCLUDE_RP23XX_COMMON_PICO_H
+#define __BOARDS_ARM_RP23XX_COMMON_INCLUDE_RP23XX_COMMON_PICO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rp23xx_dev_gpio_init
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_GPIO
+int rp23xx_dev_gpio_init(void);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_RP23XX_COMMON_INCLUDE_RP23XX_COMMON_PICO_H */

--- a/boards/arm/rp23xx/common/src/CMakeLists.txt
+++ b/boards/arm/rp23xx/common/src/CMakeLists.txt
@@ -1,0 +1,115 @@
+# ##############################################################################
+# boards/arm/rp23xx/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARCH_BOARD_COMMON)
+  set(RP23XXFLAGS -DPICO_RP2040=0 -DPICO_RP2350=1 -DLIB_PICO_BINARY_INFO=0
+                  -DPICO_SECURE=1 -D__ARM_ARCH_6M__=0)
+
+  list(APPEND SRCS rp23xx_common_bringup.c rp23xx_common_initialize.c)
+
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS rp23xx_reset.c)
+  endif()
+
+  if(CONFIG_SPI)
+    list(APPEND SRCS rp23xx_spi.c)
+  endif()
+
+  if(CONFIG_RP23XX_I2C_DRIVER)
+    list(APPEND SRCS rp23xx_i2cdev.c)
+  endif()
+
+  if(CONFIG_RP23XX_PWM)
+    list(APPEND SRCS rp23xx_pwmdev.c)
+  endif()
+
+  if(CONFIG_RP23XX_SPI_DRIVER)
+    list(APPEND SRCS rp23xx_spidev.c)
+  endif()
+
+  if(CONFIG_RP23XX_I2S)
+    list(APPEND SRCS rp23xx_i2sdev.c)
+  endif()
+
+  if(CONFIG_LCD_SSD1306)
+    list(APPEND SRCS rp23xx_ssd1306.c)
+  endif()
+
+  if(CONFIG_LCD_ST7789)
+    list(APPEND SRCS rp23xx_st7789.c)
+  endif()
+
+  if(CONFIG_LCD_ST7735)
+    list(APPEND SRCS rp23xx_st7735.c)
+  endif()
+
+  if(CONFIG_LCD_GC9A01)
+    list(APPEND SRCS rp23xx_gc9a01.c)
+  endif()
+
+  if(CONFIG_USBMSC)
+    list(APPEND SRCS rp23xx_usbmsc.c)
+  endif()
+
+  if(CONFIG_USBDEV_COMPOSITE)
+    list(APPEND SRCS rp23xx_composite.c)
+  endif()
+
+  if(CONFIG_RP23XX_SPISD)
+    list(APPEND SRCS rp23xx_spisd.c)
+  endif()
+
+  if(CONFIG_SENSORS_BMP180)
+    list(APPEND SRCS rp23xx_bmp180.c)
+  endif()
+
+  if(CONFIG_SENSORS_BMP280)
+    list(APPEND SRCS rp23xx_bmp280.c)
+  endif()
+
+  if(CONFIG_SENSORS_INA219)
+    list(APPEND SRCS rp23xx_ina219.c)
+  endif()
+
+  if(CONFIG_ENC28J60)
+    list(APPEND SRCS rp23xx_enc28j60.c)
+  endif()
+
+  if(CONFIG_LCD_BACKPACK)
+    list(APPEND SRCS rp23xx_lcd_backpack.c)
+  endif()
+
+  if(CONFIG_BOARDCTL_UNIQUEID)
+    list(APPEND SRCS rp23xx_uniqueid.c)
+  endif()
+
+  if(CONFIG_NET_W5500)
+    list(APPEND SRCS rp23xx_w5500.c)
+  endif()
+
+  if(CONFIG_SENSORS_MAX6675)
+    list(APPEND SRCS rp23xx_max6675.c)
+  endif()
+
+endif()
+target_sources(board PRIVATE ${SRCS})
+target_compile_options(board PRIVATE ${RP23XXFLAGS})

--- a/boards/arm/rp23xx/common/src/rp23xx_common_bringup.c
+++ b/boards/arm/rp23xx/common/src/rp23xx_common_bringup.c
@@ -33,7 +33,7 @@
 
 #include <arch/board/board.h>
 
-#include "rp23xx_pico.h"
+#include "rp23xx_common_pico.h"
 #include "rp23xx_common_bringup.h"
 
 #ifdef CONFIG_RP23XX_PWM

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_pico.h
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_pico.h
@@ -46,7 +46,7 @@
 
 int rp23xx_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp23xx_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp23xx/raspberrypi-pico-2/CMakeLists.txt
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/rp23xx/raspberrypi-pico-2/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
+
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/rp23xx/xiao-rp2350/scripts/memmap_copy_to_ram.ld
+ * boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/boards/arm/rp23xx/raspberrypi-pico-2/src/CMakeLists.txt
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/src/CMakeLists.txt
@@ -1,0 +1,57 @@
+# ##############################################################################
+# boards/arm/rp23xx/raspberrypi-pico-2/src/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rp23xx_boardinitialize.c rp23xx_bringup.c)
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp23xx_gpio.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS rp23xx_autoleds.c)
+else()
+  list(APPEND SRCS rp23xx_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS rp23xx_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp23xx_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_BOOT_RUNFROMFLASH)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/memmap_default.ld")
+elseif(CONFIG_BOOT_COPYTORAM)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/memmap_copy_to_ram.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/memmap_no_flash.ld")
+endif()
+
+if(CONFIG_ETC_ROMFS)
+  # TODO: etc/init.d/rc.sysinit etc/init.d/rcS
+endif()

--- a/boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_pico.h
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_pico.h
@@ -46,7 +46,7 @@
 
 int rp23xx_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp23xx_dev_gpio_init(void);
 #endif
 

--- a/boards/arm/rp23xx/xiao-rp2350/src/rp23xx_pico.h
+++ b/boards/arm/rp23xx/xiao-rp2350/src/rp23xx_pico.h
@@ -35,7 +35,7 @@
 
 int rp23xx_bringup(void);
 
-#ifdef CONFIG_DEV_GPIO
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_ARCH_BOARD_COMMON)
 int rp23xx_dev_gpio_init(void);
 #endif
 


### PR DESCRIPTION
## Summary

CMake added board Raspberry Pi Pico 2

fix

```
src/rp23xx_common_bringup.c: In function 'rp23xx_common_bringup':
Error: src/rp23xx_common_bringup.c:652:9: error: implicit declaration of function 'rprp23xx_dev_gpio_init' [-Werror=implicit-function-declaration]
  652 |   ret = rprp23xx_dev_gpio_init();
      |         ^~~~~~~~~~~~~~~~~~~~
```

## Impact

Impact on user: This PR adds Raspberry Pi Pico 2 board with CMake build

Impact on build: This PR Implement CMake build for the Raspberry Pi RP23xx

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally (Linux, and Windows Native)
config -> nsh, usbnsh

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=raspberrypi-pico-2:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp23xx/raspberrypi-pico-2/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  raspberrypi-pico-2
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Skipping OOTCpp project
-- Configuring done (8.5s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1133/1134] Linking C executable nuttx
D:/nx20250410/tools/gcc-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld.exe: warning: nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      146944 B         4 MB      3.50%
             RAM:       13268 B       512 KB      2.53%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
[1134/1134] Running utility command for nuttx_post_build
```
![rp23xx_nsh](https://github.com/user-attachments/assets/c290158b-12a4-4fe7-b9f4-21bf272aa464)

