### PR TITLE
arch/xtensa/esp32s3: fix FSM check to avoid PM deadlocks

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_pm.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_pm.c
@@ -317,7 +317,7 @@ static void IRAM_ATTR esp32s3_suspend_uarts(void)
                   UART_SW_FLOW_CON_EN | UART_FORCE_XOFF);
       do
         {
-          uart_fsm = REG_GET_FIELD(UART_STATUS_REG(i), UART_ST_UTX_OUT);
+          uart_fsm = REG_GET_FIELD(UART_FSM_STATUS_REG(i), UART_ST_UTX_OUT);
         }
       while (!(uart_fsm == UART_FSM_IDLE ||
                uart_fsm == UART_FSM_TX_WAIT_SEND));


### PR DESCRIPTION
This PR fixes a bug in the ESP32-S3 UART driver suspend logic that could
lead to deadlocks when power management (PM) was enabled.

The issue was caused by an incorrect check of the UART FSM status register
during suspend. As a result, the driver could block indefinitely while
waiting for a state transition that never occurred.

Changes include:

- Corrected FSM status register check in suspend path
- Ensures suspend/resume completes reliably under PM

Impact
Build impact: None.
Runtime impact: Prevents potential deadlocks when UARTs are suspended
with PM enabled.
API impact: None.
Area impacted: ESP32-S3 UART driver suspend logic.
