### PR TITLE
sched/task_recover.c: remove unnecessary header includes

### DIFF
--- a/sched/task/task_recover.c
+++ b/sched/task/task_recover.c
@@ -27,17 +27,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/wdog.h>
 #include <nuttx/sched.h>
-
-#include "semaphore/semaphore.h"
-#include "wdog/wdog.h"
-#include "mqueue/mqueue.h"
-#include "pthread/pthread.h"
-#include "sched/sched.h"
-#include "task/task.h"
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
  The task_recover.c file contained several redundant header
  inclusions. This patch cleans them up to reduce dependencies
  and improve code clarity.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

 Clean up the unnecessary header inlcudes in task_recover.c

## Impact

 Clean up the unnecessary header inlcudes in task_recover.c, no impact to other nuttx functions

## Testing

This patch just removes some unnecessary header includes from task_recover.c and doesn’t change any logic.
If the CI build passes, that should be enough to verify it's good.