### PR TITLE
boards/arm/rp23xx: CMake added Pimoroni Pico Plus 2 board

### DIFF
--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/CMakeLists.txt
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# boards/arm/rp23xx/pimoroni-pico-2-plus/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+
+add_custom_target(
+  nuttx_post_build
+  DEPENDS nuttx
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")
+
+# The uf2 command to convert ELF/BIN to UF2
+add_custom_command(
+  TARGET nuttx_post_build
+  POST_BUILD
+  COMMAND picotool ARGS uf2 convert --quiet -t elf nuttx nuttx.uf2
+  COMMAND_EXPAND_LISTS
+  COMMAND ${CMAKE_COMMAND} -E echo "nuttx.uf2" >>
+          ${CMAKE_BINARY_DIR}/nuttx.manifest
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Regenerate nuttx.uf2")

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/src/CMakeLists.txt
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/src/CMakeLists.txt
@@ -1,0 +1,55 @@
+# ##############################################################################
+# boards/arm/rp23xx/pimoroni-pico-2-plus/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS rp23xx_boardinitialize.c rp23xx_bringup.c)
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS rp23xx_gpio.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS rp23xx_autoleds.c)
+else()
+  list(APPEND SRCS rp23xx_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS rp23xx_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS rp23xx_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_BOOT_RUNFROMFLASH)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/memmap_default.ld")
+elseif(CONFIG_BOOT_COPYTORAM)
+  set_property(
+    GLOBAL PROPERTY LD_SCRIPT
+                    "${NUTTX_BOARD_DIR}/scripts/memmap_copy_to_ram.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/memmap_no_flash.ld")
+endif()


### PR DESCRIPTION
## Summary

Added CMake build for Pimoroni Pico Plus 2

#17155

## Impact

Impact on user: This PR adds the Pimoroni Pico Plus 2 board with CMake build.

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

pimoroni-pico-2-plus:nsh

```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=pimoroni-pico-2-plus:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/configs/nsh/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  pimoroni-pico-2-plus
--   Config: nsh
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Skipping OOTCpp project
-- Configuring done (8.3s)
-- Generating done (1.9s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1133/1134] Linking C executable nuttx
D:/nx20250410/tools/gcc-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld.exe: warning: nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      146944 B        16 MB      0.88%
             RAM:        512 KB       512 KB    100.00%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
[1134/1134] Running utility command for nuttx_post_build
```