### PR TITLE
boards/arm/rp23xx/pimoroni-pico-2-plus: fix linker scripts 100% RAM usage

### DIFF
--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_copy_to_ram.ld
@@ -256,11 +256,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+    /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld
@@ -269,11 +269,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+    /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_no_flash.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_no_flash.ld
@@ -215,11 +215,10 @@ SECTIONS
         __end__ = .;
         end = __end__;
         KEEP(*(.heap*))
-        /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
-           to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
-        . = ORIGIN(RAM) + LENGTH(RAM);
-        __HeapLimit = .;
     } > RAM
+    /* historically on GCC sbrk was growing past __HeapLimit to __StackLimit, however
+       to be more compatible, we now set __HeapLimit explicitly to where the end of the heap is */
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {


### PR DESCRIPTION


## Summary

Compiling with --print-memory-usage always shows 100% RAM 

bug [raspberrypi/pico-sdk#1871](https://github.com/raspberrypi/pico-sdk/issues/1871)

same as this PR #16253

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

pimoroni-pico-2-plus:nsh

**Before**
```
IN: libs/libc/libc.a -> staging/libc.a 

CPP:  /github/workspace/sources/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld-> /github/workspace/sources/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld.tmp 
LD: nuttx
arm-none-eabi-ld: warning: /github/workspace/sources/nuttx/nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      146964 B        16 MB      0.88%
             RAM:        512 KB       512 KB    100.00%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
Generating: nuttx.uf2
Done.
```

**After**
```
IN: libs/libc/libc.a -> staging/libc.a 

CPP:  /github/workspace/sources/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld-> /github/workspace/sources/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld.tmp 
LD: nuttx
arm-none-eabi-ld: warning: /github/workspace/sources/nuttx/nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      146972 B        16 MB      0.88%
             RAM:       13340 B       512 KB      2.54%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
Generating: nuttx.uf2
Done.
```