### PR TITLE
arch/arm/stm32f0l0g0: add stm32_flash.c support for CMake

### DIFF
--- a/arch/arm/src/stm32f0l0g0/CMakeLists.txt
+++ b/arch/arm/src/stm32f0l0g0/CMakeLists.txt
@@ -59,6 +59,10 @@ if(CONFIG_BUILD_PROTECTED)
   list(APPEND SRCS stm32_userspace.c)
 endif()
 
+if(CONFIG_STM32F0L0G0_PROGMEM)
+  list(APPEND SRCS stm32_flash.c)
+endif()
+
 if(CONFIG_STM32F0L0G0_GPIOIRQ)
   list(APPEND SRCS stm32_gpioint.c)
 endif()


### PR DESCRIPTION
## Summary

arch/arm/stm32f0l0g0: add stm32_flash.c support for CMake

## Impact

cmake build

## Testing

build PROGMEM with cmake

