### PR TITLE
arch/xtensa/espressif: Fix efuse build warning for esp32

### DIFF
--- a/arch/xtensa/src/common/espressif/esp_efuse.c
+++ b/arch/xtensa/src/common/espressif/esp_efuse.c
@@ -40,7 +40,7 @@
 
 #ifdef CONFIG_ARCH_CHIP_ESP32
 #include "xtensa.h"
-#include "soc/apb_ctrl_reg.h"
+#include "soc/syscon_reg.h"
 #include "esp_efuse_table.h"
 #endif
 
@@ -352,7 +352,7 @@ uint32_t esp_efuse_hal_chip_revision(void)
                             &minor_chip_version,
                             ESP_EFUSE_WAFER_VERSION_MINOR[0]->bit_count);
 
-  eco_bit2 = (getreg32(APB_CTRL_DATE_REG) & 0x80000000) >> 31;
+  eco_bit2 = (getreg32(SYSCON_DATE_REG) & 0x80000000) >> 31;
   combine_value = (eco_bit2 << 2) | (eco_bit1 << 1) | eco_bit0;
 
   switch (combine_value)


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/xtensa/espressif: Fix efuse build warning for esp32

Fix build warning while building efuse for esp32

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No, just build warning fixed
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

Any config can be used which is based on esp32. `nsh` config used for example and here is the build command:

```
make distclean && ./tools/configure.sh esp32-devkitc:nsh && make -j
``` 

### Running
<!-- Provide how to run the test for each SoC being tested -->

### Results
<!-- Provide tests' results and runtime logs -->

During build process here is logs before this change:

```
CC:  vfs/fs_rmdir.c In file included from common/espressif/esp_efuse.c:43:
.../nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/soc/esp32/register/soc/apb_ctrl_reg.h:9:2: warning: #warning "apb_ctrl_reg is deprecated due to duplicated with syscon_reg, please use syscon_reg instead, they are same" [-Wcpp]
    9 | #warning "apb_ctrl_reg is deprecated due to duplicated with syscon_reg, please use syscon_reg instead, they are same"
      |  ^~~~~~~

```

After this change error dissappeard.