### PR TITLE
boards/arm/rp23xx/pimoroni-pico-2-plus: fix implicit declaration of function 'board_spisd_initialize'

### DIFF
--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_spisd.h
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_spisd.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_spisd.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP23XX_RASPBERRYPI_PICO_2_INCLUDE_RP23XX_SPISD_H
+#define __BOARDS_ARM_RP23XX_RASPBERRYPI_PICO_2_INCLUDE_RP23XX_SPISD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_spisd_initialize
+ *
+ * Description:
+ *   Initialize the SPI-based SD card.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_RP23XX_SPISD
+int board_spisd_initialize(int minor, int bus);
+#endif
+
+/****************************************************************************
+ * Name: board_spisd_status
+ *
+ * Description:
+ *   Get the status whether SD Card is present or not.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_RP23XX_SPISD
+uint8_t board_spisd_status(struct spi_dev_s *dev, uint32_t devid);
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_ARM_RP23XX_RASPBERRYPI_PICO_2_INCLUDE_RP23XX_SPISD_H */


### PR DESCRIPTION
## Summary

Added missing header file rp23xx_spisd.h

fix
src/rp23xx_common_bringup.c: In function 'rp23xx_common_bringup': Error: src/rp23xx_common_bringup.c:390:9: error: implicit declaration of function 'board_spisd_initialize'; did you mean 'board_spidev_initialize'? [-Werror=implicit-function-declaration]
  390 |   ret = board_spisd_initialize(0, CONFIG_RP23XX_SPISD_SPI_CH);
      |         ^~~~~~~~~~~~~~~~~~~~~~

Linux (arm-06)
https://github.com/apache/nuttx/actions/runs/18284202662/job/52054851120#logs

## Impact

Impact on user: NO

Impact on build: Fix CMake and Make build (audiopack,composite and usbmsc)

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally and GitHub

./tools/configure.sh -l pimoroni-pico-2-plus:audiopack
https://github.com/simbit18/nuttx_test_pr/actions/runs/18287732572/job/52067199643#logs


