### PR TITLE
boards/arm/rp23xx/pimoroni-pico-2-plus: added ‘rp23xx_spisd.h’ in board.h

### DIFF
--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/include/board.h
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/include/board.h
@@ -30,6 +30,7 @@
 #include "rp23xx_i2cdev.h"
 #include "rp23xx_spidev.h"
 #include "rp23xx_i2sdev.h"
+#include "rp23xx_spisd.h"
 
 #ifndef __ASSEMBLY__
 #  include <stdint.h>


### PR DESCRIPTION
## Summary

Added missing #include ‘rp23xx_spisd.h’ in board.h

 (forgotten in PR #17167)

## Impact

Impact on user: NO

Impact on build: Fix CMake and Make build (audiopack,composite and usbmsc)

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

pimoroni-pico-2-plus:audiopack 
CMake
```
D:\nuttxpico\nuttx>cmake -B build -DBOARD_CONFIG=pimoroni-pico-2-plus:audiopack -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxpico/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/configs/audiopack/defconfig -> D:/nuttxpico/nuttx/build/.defconfig.processed
-- Skipping OOTCpp project
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  pimoroni-pico-2-plus
--   Config: audiopack
--   Appdir: D:/nuttxpico/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Skipping OOTCpp project
-- Configuring done (8.8s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxpico/nuttx/build

D:\nuttxpico\nuttx>cmake --build build
[1182/1183] Linking C executable nuttx
D:/nx20250410/tools/gcc-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld.exe: warning: nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      188300 B        16 MB      1.12%
             RAM:       13676 B       512 KB      2.61%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
[1183/1183] Running utility command for nuttx_post_build
```

Make
```
ubuntu20042@Unuttx:~/nuttxspace/nuttx$ ./tools/configure.sh -l pimoroni-pico-2-plus:audiopack
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/ubuntu20042/nuttxspace/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/ubuntu20042/nuttxspace/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/ubuntu20042/nuttxspace/apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /home/ubuntu20042/nuttxspace/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/include
LN: drivers/platform to /home/ubuntu20042/nuttxspace/nuttx/drivers/dummy
LN: include/arch/chip to /home/ubuntu20042/nuttxspace/nuttx/arch/arm/include/rp23xx
LN: arch/arm/src/chip to /home/ubuntu20042/nuttxspace/nuttx/arch/arm/src/rp23xx
LN: arch/arm/src/board to /home/ubuntu20042/nuttxspace/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/../common
LN: arch/arm/src/board/board to /home/ubuntu20042/nuttxspace/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/src
mkkconfig in /home/ubuntu20042/nuttxspace/apps/examples/sotest
mkkconfig in /home/ubuntu20042/nuttxspace/apps/examples/rust
mkkconfig in /home/ubuntu20042/nuttxspace/apps/examples/mcuboot
mkkconfig in /home/ubuntu20042/nuttxspace/apps/examples/module
mkkconfig in /home/ubuntu20042/nuttxspace/apps/examples
mkkconfig in /home/ubuntu20042/nuttxspace/apps/crypto
mkkconfig in /home/ubuntu20042/nuttxspace/apps/audioutils
mkkconfig in /home/ubuntu20042/nuttxspace/apps/system
mkkconfig in /home/ubuntu20042/nuttxspace/apps/boot
mkkconfig in /home/ubuntu20042/nuttxspace/apps/netutils
mkkconfig in /home/ubuntu20042/nuttxspace/apps/logging
mkkconfig in /home/ubuntu20042/nuttxspace/apps/benchmarks
mkkconfig in /home/ubuntu20042/nuttxspace/apps/database
mkkconfig in /home/ubuntu20042/nuttxspace/apps/math
mkkconfig in /home/ubuntu20042/nuttxspace/apps/interpreters/luamodules
mkkconfig in /home/ubuntu20042/nuttxspace/apps/interpreters
mkkconfig in /home/ubuntu20042/nuttxspace/apps/lte
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/arch
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/cxx
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/mm
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/sched
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/fs
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/drivers
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing/libc
mkkconfig in /home/ubuntu20042/nuttxspace/apps/testing
mkkconfig in /home/ubuntu20042/nuttxspace/apps/mlearning
mkkconfig in /home/ubuntu20042/nuttxspace/apps/graphics
mkkconfig in /home/ubuntu20042/nuttxspace/apps/fsutils
mkkconfig in /home/ubuntu20042/nuttxspace/apps/sdr
mkkconfig in /home/ubuntu20042/nuttxspace/apps/canutils
mkkconfig in /home/ubuntu20042/nuttxspace/apps/inertial
mkkconfig in /home/ubuntu20042/nuttxspace/apps/wireless/ieee802154
mkkconfig in /home/ubuntu20042/nuttxspace/apps/wireless/bluetooth
mkkconfig in /home/ubuntu20042/nuttxspace/apps/wireless
mkkconfig in /home/ubuntu20042/nuttxspace/apps/videoutils
mkkconfig in /home/ubuntu20042/nuttxspace/apps/games
mkkconfig in /home/ubuntu20042/nuttxspace/apps/tee
mkkconfig in /home/ubuntu20042/nuttxspace/apps/industry
mkkconfig in /home/ubuntu20042/nuttxspace/apps
Loaded configuration '.config'
Configuration saved to '.config'
ubuntu20042@Unuttx:~/nuttxspace/nuttx$ make
Create version.h
LN: platform/board to /home/ubuntu20042/nuttxspace/apps/platform/dummy
Register: hello
Register: spi
Register: dd
Register: nsh
Register: sh
Register: nxplayer
Register: ostest
Register: getprime
CPP:  /home/ubuntu20042/nuttxspace/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld-> /home/ubuntu20042/nuttxspace/nuttx/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_defaul
LD: nuttx
arm-none-eabi-ld: warning: /home/ubuntu20042/nuttxspace/nuttx/nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      188288 B        16 MB      1.12%
             RAM:       13676 B       512 KB      2.61%
       SCRATCH_X:          0 GB         4 KB      0.00%
       SCRATCH_Y:          0 GB         4 KB      0.00%
Generating: nuttx.uf2
Done.
```