### PR TITLE
drivers/wireless/bluetooth: Aligned Cmake with Make

### DIFF
--- a/drivers/wireless/bluetooth/CMakeLists.txt
+++ b/drivers/wireless/bluetooth/CMakeLists.txt
@@ -42,6 +42,10 @@ if(CONFIG_DRIVERS_BLUETOOTH)
     endif()
   endif()
 
+  if(CONFIG_BLUETOOTH_BRIDGE)
+    list(APPEND SRCS bt_bridge.c)
+  endif()
+
   if(CONFIG_BLUETOOTH_NULL)
     list(APPEND SRCS bt_null.c)
   endif()
@@ -54,8 +58,8 @@ if(CONFIG_DRIVERS_BLUETOOTH)
     list(APPEND SRCS bt_rpmsghci.c)
   endif()
 
-  if(CONFIG_BLUETOOTH_BRIDGE)
-    list(APPEND SRCS bt_bridge.c)
+  if(CONFIG_BLUETOOTH_SLIP)
+    list(APPEND SRCS bt_slip.c)
   endif()
 
   target_sources(drivers PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

Add
- bt slip driver #14224

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally
