### PR TITLE
drivers/usbdev: Aligned Cmake with Make

### DIFF
--- a/drivers/usbdev/CMakeLists.txt
+++ b/drivers/usbdev/CMakeLists.txt
@@ -57,6 +57,10 @@ if(CONFIG_USBDEV)
     list(APPEND SRCS adb.c)
   endif()
 
+  if(CONFIG_USBMTP)
+    list(APPEND SRCS mtp.c)
+  endif()
+
   if(CONFIG_NET_CDCECM)
     list(APPEND SRCS cdcecm.c)
   endif()


### PR DESCRIPTION
## Summary

Add:
- media transfer protocol (MTP) #10620

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally