### PR TITLE
drivers/usbhost: Aligned Cmake with Make

### DIFF
--- a/drivers/usbhost/CMakeLists.txt
+++ b/drivers/usbhost/CMakeLists.txt
@@ -75,6 +75,10 @@ if(CONFIG_USBHOST)
     list(APPEND SRCS usbhost_ft232r.c)
   endif()
 
+  if(CONFIG_USBHOST_BTHCI)
+    list(APPEND SRCS usbhost_bthci.c)
+  endif()
+
   if(CONFIG_USBHOST_XHCI_PCI)
     list(APPEND SRCS usbhost_xhci_pci.c usbhost_xhci_trace.c)
   endif()


### PR DESCRIPTION
## Summary

Add:

- Bluetooth HCI Driver #11552

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally