### PR TITLE
drivers/usbmisc: Aligned Cmake with Make

### DIFF
--- a/drivers/usbmisc/CMakeLists.txt
+++ b/drivers/usbmisc/CMakeLists.txt
@@ -37,5 +37,9 @@ if(CONFIG_USBMISC)
     list(APPEND SRCS fusb303.c)
   endif()
 
+  if(CONFIG_STUSB4500)
+    list(APPEND SRCS stusb4500.c)
+  endif()
+
   target_sources(drivers PRIVATE ${SRCS})
 endif()


### PR DESCRIPTION
## Summary

Add:
- ST standalone USB PD sink controller #14895

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally