### PR TITLE
video/fb: add FBIOGET_PANINFOCNT ioctl

### DIFF
--- a/Documentation/components/nxgraphics/framebuffer_char_driver.rst
+++ b/Documentation/components/nxgraphics/framebuffer_char_driver.rst
@@ -249,7 +249,7 @@ IOCTL Commands
   in the framebuffer. Some hardware requires that there be 
   such a notification when a change is made to the 
   framebuffer (see, for example, the discussion of LCD drivers 
-  below). This IOTCL command is if ``CONFIG_NX_UPDATE=y`` is 
+  below). This IOCTL command is if ``CONFIG_NX_UPDATE=y`` is 
   defined. It takes a pointer to a read-only instance of 
   ``struct nxgl_rect_s`` that describes the region to be updated:
 
@@ -260,6 +260,9 @@ IOCTL Commands
         struct nxgl_point_s pt1; /* Upper, left-hand corner */
         struct nxgl_point_s pt2; /* Lower, right-hand corner */
     };
+
+* ``FBIOGET_PANINFOCNT``. Retrieves the current number of pan info 
+  structures. This IOCTL command requires the overlay index as a parameter.
 
 ``mmap()``
 ==========

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1308,6 +1308,12 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case FBIOGET_PANINFOCNT:
+        {
+          ret = fb_paninfo_count(fb->vtable, (int)arg);
+        }
+        break;
+
       default:
         if (fb->vtable->ioctl != NULL)
           {

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -321,6 +321,9 @@
 #define FBIOGET_FSCREENINFO   _FBIOC(0x001c)  /* Get video fix info */
                                               /* Argument: writable struct
                                                *           fb_fix_screeninfo */
+#define FBIOGET_PANINFOCNT    _FBIOC(0x001d)  /* Get pan info count */
+                                              /* Argument: read-only
+                                               *           unsigned long */
 
 #define FB_TYPE_PACKED_PIXELS        0      /* Packed Pixels */
 #define FB_TYPE_PLANES               1      /* Non interleaved planes */


### PR DESCRIPTION
## Summary

Add a new ioctl to get the count of paninfo

The framebuffer is usually in high-speed RAM. Getting the paninfo count can help us get the idle state of the framebuffer so that we can temporarily use this memory.

## Impact

Add new ioctl without affecting old devices

## Testing

Build Host: Ubuntu 22.04
Target: sim:lvgl_fb

test case
```c
  int fd = open("/dev/fb0", O_RDWR);
  struct fb_planeinfo_s pinfo = { 0 };
  int ret = 0;

  ret = ioctl(fd, FBIOGET_PANINFOCNT, FB_NO_OVERLAY);
  syslog(0, "FBIOGET_PANINFOCNT ret=%d\n", ret);

  ioctl(fd, FBIOPAN_DISPLAY, &pinfo);

  ret = ioctl(fd, FBIOGET_PANINFOCNT, FB_NO_OVERLAY);
  syslog(0, "FBIOGET_PANINFOCNT ret=%d\n", ret);

  ioctl(fd, FBIOPAN_DISPLAY, &pinfo);

  ret = ioctl(fd, FBIOGET_PANINFOCNT, FB_NO_OVERLAY);
  syslog(0, "FBIOGET_PANINFOCNT ret=%d\n", ret);

  ioctl(fd, FBIOPAN_CLEAR, FB_NO_OVERLAY);

  ret = ioctl(fd, FBIOGET_PANINFOCNT, FB_NO_OVERLAY);
  syslog(0, "FBIOGET_PANINFOCNT ret=%d\n", ret);

  close(fd);
```

test result
```c
FBIOGET_PANINFOCNT ret=0
FBIOGET_PANINFOCNT ret=1
FBIOGET_PANINFOCNT ret=2
FBIOGET_PANINFOCNT ret=0
```