### PR TITLE
arch/tricore: Place nxsched_switch_context() at the correct location

### DIFF
--- a/arch/tricore/src/common/tricore_switchcontext.c
+++ b/arch/tricore/src/common/tricore_switchcontext.c
@@ -80,10 +80,6 @@ void up_switch_context(struct tcb_s *tcb, struct tcb_s *rtcb)
 
   else
     {
-      /* Update scheduler parameters */
-
-      nxsched_switch_context(rtcb, tcb);
-
       /* Then switch contexts */
 
       tricore_switchcontext(&rtcb->xcp.regs, tcb->xcp.regs);


### PR DESCRIPTION
  The current implementation does not call
  nxsched_switch_context() exactly when a
  task switch occurs.

  This patch fixes the issue by placing the
  call at the correct location.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Place nxsched_switch_context() at the correct location when a
task switch really occurs

## Impact

Tricore arch improvement, no impact to other parts

## Testing

**ostest passed on board a2g-tc397-5v-tft**

<img width="592" height="710" alt="image" src="https://github.com/user-attachments/assets/2bad8f10-db55-4e80-b042-cc4b4fc9f684" />

