### PR TITLE
stm32/stm32_usbdev.c: include arch/board/board.h

### DIFF
--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -48,6 +48,7 @@
 #include <nuttx/usb/usbdev_trace.h>
 
 #include <nuttx/irq.h>
+#include <arch/board/board.h>
 
 #include "arm_internal.h"
 #include "stm32.h"


### PR DESCRIPTION
Without this, the compilation would fail for F302 chips.

Source of error:
```
stm32_usbdev.c:3755:20: error: 'GPIO_USB_DP' undeclared (first use in this function); did you mean 'GPIO_USB_DP_0'?
 3755 |   stm32_configgpio(GPIO_USB_DP);
      |                    ^~~~~~~~~~~
      |                    GPIO_USB_DP_0
```

The file expects this definition but is nowhere to be found for STM32F302. The best solution is to put this into the board.h definitions.

## Testing

Tested on a custom STM32F302 board.
