### PR TITLE
sched/signal: Remove shadow definitions to reduce unnecessary API

### DIFF
--- a/Documentation/reference/os/app_vs_os.rst
+++ b/Documentation/reference/os/app_vs_os.rst
@@ -73,13 +73,6 @@ not be used by application logic. Some examples include:
    ``include/nuttx/semaphore.h`` for other internal OS interfaces
    for semaphores).
 
--  ``nxsig_waitinfo()``: functionally
-   equivalent to the standard application interface
-   ``sigwaitinfo()``. However, ``nxsig_waitinfo()`` will not
-   modify the errno value and will not cause a cancellation point
-   (see ``include/nuttx/signal.h`` for other internal OS
-   interfaces for signals).
-
 -  ``nxmq_send()``: functionally equivalent
    to the standard application interface ``mq_send()``. However,
    ``nxmq_send()`` will not modify the errno value and will not

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -195,7 +195,7 @@ static ssize_t signalfd_file_read(FAR struct file *filep,
   siginfo = (FAR struct signalfd_siginfo *)buffer;
   do
     {
-      ret = nxsig_waitinfo(&pendmask, &info);
+      ret = nxsig_timedwait(&pendmask, &info, NULL);
       if (ret < 0)
         {
           goto errout;

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -444,32 +444,6 @@ int nxsig_kill(pid_t pid, int signo);
 int nxsig_tgkill(pid_t pid, pid_t tid, int signo);
 
 /****************************************************************************
- * Name: nxsig_waitinfo
- *
- * Description:
- *   This function is equivalent to nxsig_timedwait with a NULL timeout
- *   parameter.
- *
- *   This is an internal OS interface.  It is functionally equivalent to
- *   sigwaitinfo() except that:
- *
- *   - It is not a cancellation point, and
- *   - It does not modify the errno value.
- *
- * Input Parameters:
- *   set - The pending signal set
- *   info - The returned value
- *
- * Returned Value:
- *   This is an internal OS interface and should not be used by applications.
- *   It follows the NuttX internal error return policy:  Zero (OK) is
- *   returned on success.  A negated errno value is returned on failure.
- *
- ****************************************************************************/
-
-#define nxsig_waitinfo(s,i) nxsig_timedwait(s,i,NULL)
-
-/****************************************************************************
  * Name: nxsig_clockwait
  *
  * Description:

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -386,7 +386,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 
       /* Wait for any death-of-child signal */
 
-      ret = nxsig_waitinfo(&set, info);
+      ret = nxsig_timedwait(&set, info, NULL);
       if (ret < 0)
         {
           errcode = -ret;

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -428,7 +428,7 @@ pid_t nxsched_waitpid(pid_t pid, int *stat_loc, int options)
 
       /* Wait for any death-of-child signal */
 
-      ret = nxsig_waitinfo(&set, &info);
+      ret = nxsig_timedwait(&set, &info, NULL);
       if (ret < 0)
         {
           goto errout;

--- a/sched/signal/sig_pause.c
+++ b/sched/signal/sig_pause.c
@@ -77,11 +77,11 @@ int pause(void)
 
   sigemptyset(&set);
 
-  /* sigtwaitinfo() cannot succeed.  It should always return error EINTR
+  /* nxsig_timedwait() cannot succeed.  It should always return error EINTR
    * meaning that some unblocked signal was caught.
    */
 
-  ret = nxsig_waitinfo(&set, NULL);
+  ret = nxsig_timedwait(&set, NULL, NULL);
   if (ret < 0)
     {
       set_errno(-ret);


### PR DESCRIPTION
## Summary

sched/signal: Remove shadow definitions to reduce unnecessary API

Reduce unnecessary API definitions:

nxsig_waitinfo() -> nxsig_timedwait()

Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

N/A

## Testing

sim/nsh;sabre-6quad/smp ostest