### PR TITLE
cmake: correct nuttx_wildcard_sources cmake usage

### DIFF
--- a/cmake/nuttx_extensions.cmake
+++ b/cmake/nuttx_extensions.cmake
@@ -112,7 +112,8 @@ endfunction()
 function(nuttx_wildcard_sources)
   cmake_parse_arguments(ARGS "" "" EXCLUDE ${ARGN})
 
-  file(GLOB SRCS ${ARGN})
+  # `SRCS` just collect all source files instead of EXCLUDE arguments
+  file(GLOB SRCS ${ARGS_UNPARSED_ARGUMENTS})
   if(ARGS_EXCLUDE)
     file(GLOB RM_SRCS ${ARGS_EXCLUDE})
     list(REMOVE_ITEM SRCS ${RM_SRCS})


### PR DESCRIPTION
## Summary

cmake: correct nuttx_wildcard_sources cmake usage

reference:
https://cmake.org/cmake/help/latest/command/cmake_parse_arguments.html

`SRCS` just collect all source files instead of EXCLUDE arguments

## Impact

cmake build with `nuttx_wildcard_sources`

## Testing

add debug message for test
```diff
diff --git a/cmake/nuttx_extensions.cmake b/cmake/nuttx_extensions.cmake
index 9ed430b74a..baa22cf90d 100644

--- a/cmake/nuttx_extensions.cmake
+++ b/cmake/nuttx_extensions.cmake
@@ -116,6 +116,9 @@ endfunction()
 function(nuttx_wildcard_sources)
   cmake_parse_arguments(ARGS "" "" EXCLUDE ${ARGN})

+  message(STATUS "## UNPARSED ARGUMENTS ${ARGS_UNPARSED_ARGUMENTS}")
+  message(STATUS "## ARGN ${ARGN}")
+
   file(GLOB SRCS ${ARGS_UNPARSED_ARGUMENTS})
   if(ARGS_EXCLUDE)
     file(GLOB RM_SRCS ${ARGS_EXCLUDE})
```

cmake build test
```bash
➜  /home/mi/local/mycpp [25-10-15_14:11:41] git:(master) ✗ ls demo
1.c  2.c  3.c
➜  /home/mi/local/mycpp [25-10-15_14:11:57] git:(master) ✗ cmake -S . -B build -G Ninja
>> 14:12:42.161053 INFO    [demo] Time taken: 0ms
-- ## UNPARSED ARGUMENTS aaa/*.c
-- ## ARGN aaa/*.c;EXCLUDE;aaa/3.c
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/mi/local/mycpp/build
➜  /home/mi/local/mycpp [25-10-15_14:12:47] git:(master) ✗
```
