### PR TITLE
sched/sched: Replace nxsched_alarm_tick_expiration() with nxsched_tick_expiration()

### DIFF
--- a/boards/arm/sam34/sam3u-ek/scripts/memory.ld
+++ b/boards/arm/sam34/sam3u-ek/scripts/memory.ld
@@ -68,8 +68,8 @@ MEMORY
 {
   /* 256Kb FLASH */
 
-  kflash (rx)  : ORIGIN = 0x00080000, LENGTH = 64K
-  uflash (rx)  : ORIGIN = 0x00090000, LENGTH = 64K
+  kflash (rx)  : ORIGIN = 0x00080000, LENGTH = 65K
+  uflash (rx)  : ORIGIN = 0x00090400, LENGTH = 63K
   xflash (rx)  : ORIGIN = 0x000a0000, LENGTH = 128K
 
   /* 32Kb SRAM */

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -51,7 +51,7 @@ static void oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
 
   ONESHOT_TICK_CURRENT(g_oneshot_lower, &now);
 #ifdef CONFIG_SCHED_TICKLESS
-  nxsched_alarm_tick_expiration(now);
+  nxsched_tick_expiration(now);
 #else
   /* Start the next tick first, in order to minimize latency. Ideally
    * the ONESHOT_TICK_START would also return the current tick so that

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2488,8 +2488,8 @@ void nxsched_timer_expiration(void);
 
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
 void nxsched_alarm_expiration(FAR const struct timespec *ts);
-void nxsched_alarm_tick_expiration(clock_t ticks);
 #endif
+void nxsched_tick_expiration(clock_t ticks);
 
 /****************************************************************************
  * Name:  nxsched_get_next_expired

--- a/sched/clock/CMakeLists.txt
+++ b/sched/clock/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
     clock_realtime2absticks.c
     clock_systime_ticks.c
     clock_systime_timespec.c
+    clock_sched_ticks.c
     clock_perf.c)
 
 # Unless a driver with a more accurate version of up_*delay is enabled, always

--- a/sched/clock/Make.defs
+++ b/sched/clock/Make.defs
@@ -21,7 +21,7 @@
 ############################################################################
 
 CSRCS += clock.c clock_initialize.c clock_settime.c clock_gettime.c
-CSRCS += clock_systime_ticks.c clock_systime_timespec.c
+CSRCS += clock_systime_ticks.c clock_systime_timespec.c clock_sched_ticks.c
 CSRCS += clock_perf.c clock_realtime2absticks.c
 
 # Unless a driver with a more accurate version of up_*delay is enabled, always

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -39,6 +39,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* 32-bit mask for 64-bit timer values */
+
+#define TIMER_MASK32 0x00000000ffffffff
+
 /* Configuration ************************************************************/
 
 /* If CONFIG_SYSTEM_TIME64 is selected and the CPU supports long long types,
@@ -77,12 +81,10 @@ extern spinlock_t g_basetime_lock;
 int  clock_basetime(FAR struct timespec *tp);
 
 void clock_initialize(void);
-#if !defined(CONFIG_SCHED_TICKLESS) && \
-    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
-void clock_timer(void);
-#else
-#  define clock_timer()
-#endif
+
+void clock_increase_sched_ticks(clock_t ticks);
+
+clock_t clock_get_sched_ticks(void);
 
 /****************************************************************************
  * perf_init

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -88,10 +88,18 @@ static clock_t clock_process_runtime(FAR struct tcb_s *tcb)
 
 void nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
 {
-  if (clock_id == CLOCK_MONOTONIC || clock_id == CLOCK_BOOTTIME)
+  if (clock_id == CLOCK_MONOTONIC)
     {
       /* The the time elapsed since the timer was initialized at power on
-       * reset.
+       * reset, excluding the time that the system is suspended.
+       */
+
+      clock_ticks2time(tp, clock_get_sched_ticks());
+    }
+  else if (clock_id == CLOCK_BOOTTIME)
+    {
+      /* The the time elapsed since the timer was initialized at power on
+       * reset, including the time that the system is suspended..
        */
 
       clock_systime_timespec(tp);

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -51,10 +51,7 @@
  * Public Data
  ****************************************************************************/
 
-#if !defined(CONFIG_SCHED_TICKLESS) && \
-    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
 volatile clock_t g_system_ticks = INITIAL_SYSTEM_TIMER_TICKS;
-#endif
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
 struct timespec   g_basetime;
@@ -385,29 +382,5 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
       atomic_fetch_add((FAR atomic_t *)&g_system_ticks, diff_ticks);
 #endif
     }
-}
-#endif
-
-/****************************************************************************
- * Name: clock_timer
- *
- * Description:
- *   This function must be called once every time the real time clock
- *   interrupt occurs.  The interval of this clock interrupt must be
- *   USEC_PER_TICK
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_SCHED_TICKLESS) && \
-    !defined(CONFIG_ALARM_ARCH) && !defined(CONFIG_TIMER_ARCH)
-void clock_timer(void)
-{
-  /* Increment the per-tick system counter */
-
-#ifdef CONFIG_SYSTEM_TIME64
-  atomic64_fetch_add((FAR atomic64_t *)&g_system_ticks, 1);
-#else
-  atomic_fetch_add((FAR atomic_t *)&g_system_ticks, 1);
-#endif
 }
 #endif

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -376,11 +376,7 @@ void clock_resynchronize(FAR struct timespec *rtc_diff)
       clock_t diff_ticks = SEC2TICK(rtc_diff->tv_sec) +
                            NSEC2TICK(rtc_diff->tv_nsec);
 
-#ifdef CONFIG_SYSTEM_TIME64
-      atomic64_fetch_add((FAR atomic64_t *)&g_system_ticks, diff_ticks);
-#else
-      atomic_fetch_add((FAR atomic_t *)&g_system_ticks, diff_ticks);
-#endif
+      clock_increase_sched_ticks(diff_ticks);
     }
 }
 #endif

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -88,31 +88,7 @@ clock_t clock_systime_ticks(void)
 
   up_timer_gettick(&ticks);
   return ticks;
-#elif defined(CONFIG_SYSTEM_TIME64)
-  clock_t sample;
-  clock_t verify;
-
-  /* 64-bit accesses are not atomic on most architectures.  The following
-   * loop samples the 64-bit timer twice and loops in the rare event that
-   * there was 32-bit rollover between samples.
-   *
-   * If there is no 32-bit rollover, then:
-   *
-   *  - The MS 32-bits of each sample will be the same, and
-   *  - The LS 32-bits of the second sample will be greater than or equal
-   *    to the LS 32-bits for the first sample.
-   */
-
-  do
-    {
-      verify = g_system_ticks;
-      sample = g_system_ticks;
-    }
-  while ((sample &  TIMER_MASK32)  < (verify &  TIMER_MASK32) ||
-         (sample & ~TIMER_MASK32) != (verify & ~TIMER_MASK32));
-
-  return sample;
 #else
-  return g_system_ticks;
+  return clock_get_sched_ticks();
 #endif
 }

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -81,6 +81,6 @@ void clock_systime_timespec(FAR struct timespec *ts)
       defined(CONFIG_SCHED_TICKLESS)
   up_timer_gettime(ts);
 #else
-  clock_ticks2time(ts, g_system_ticks);
+  clock_ticks2time(ts, clock_get_sched_ticks());
 #endif
 }

--- a/sched/sched/sched_processtimer.c
+++ b/sched/sched/sched_processtimer.c
@@ -184,7 +184,7 @@ void nxsched_process_timer(void)
 
   /* Increment the system time (if in the link) */
 
-  clock_timer();
+  clock_increase_sched_ticks(1);
 
   /* Check if the currently executing task has exceeded its
    * timeslice.

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -480,6 +480,8 @@ void nxsched_alarm_tick_expiration(clock_t ticks)
 
   elapsed = ticks - update_time_tick(ticks);
 
+  clock_increase_sched_ticks(elapsed);
+
   /* Process the timer ticks and set up the next interval (or not) */
 
   nexttime = nxsched_timer_process(ticks, elapsed, false);
@@ -527,6 +529,8 @@ void nxsched_timer_expiration(void)
   up_timer_gettick(&ticks);
   update_time_tick(ticks);
   elapsed = atomic_read(&g_timer_interval);
+
+  clock_increase_sched_ticks(elapsed);
 
   /* Process the timer ticks and set up the next interval (or not) */
 


### PR DESCRIPTION

    Introduce a new function nxsched_tick_expiration() to replace
    nxsched_alarm_tick_expiration(). The new function provides a
    common implementation that can be shared by both the alarm
    and timer architectures.

    This change reduces code duplication and provides a unified
    function that can be directly reused.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

  Improve nuttx kernel tickless implementation,

## Impact

    Improve nuttx kernel tickless implementation,
    No impact to user interface
    No impact to other nuttx functions

## Testing

**ostest passed on board a2g-tc397-5v-tft**

<img width="623" height="742" alt="image" src="https://github.com/user-attachments/assets/0d0641e6-81f5-4d6d-a50c-1e4b3310305a" />

