### PR TITLE
nxgdb: fix remote-register regular expression match

### DIFF
--- a/tools/pynuttx/nxgdb/thread.py
+++ b/tools/pynuttx/nxgdb/thread.py
@@ -65,7 +65,7 @@ class Registers:
 
                 # Name         Nr  Rel Offset    Size  Type            Rmt Nr  g/G Offset
                 match = re.match(
-                    r"\s(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)(?:\s+(\d+)\s+(\d+))?",
+                    r"\s*(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)(?:\s+(\d+)\s+(\d+))?",
                     line,
                 )
                 if not match:


### PR DESCRIPTION

## Summary

The code clearly expects the output of the 'maint print remote-registers' to be indented by white-space character, but at least in my case, it is not. This changes the match to consume any number of white-space characters before it encounters the register name.

## Impact

Fixes the usage of the `thread` gdb command.

## Testing

A part of the output of the `maint print remote-registers` on gdb 16.3 on SAMv7:
```
r0         0    0    0        4     uint32_t        0       0
r1         1    1    4        4     uint32_t        1       4
r2         2    2    8        4     uint32_t        2       8
r3         3    3    12       4     uint32_t        3       12
r4         4    4    16       4     uint32_t        4       16
r5         5    5    20       4     uint32_t        5       20
r6         6    6    24       4     uint32_t        6       24
r7         7    7    28       4     uint32_t        7       28
r8         8    8    32       4     uint32_t        8       32
r9         9    9    36       4     uint32_t        9       36
r10        10   10   40       4     uint32_t        10      40
r11        11   11   44       4     uint32_t        11      44
r12        12   12   48       4     uint32_t        12      48
sp         13   13   52       4     *1              13      52
lr         14   14   56       4     uint32_t        14      56
pc         15   15   60       4     *1              15      60
f0         16   16   64       12    _arm_ext        16      64
```

Without this change none of these lines were matched by the regular expression. After it they are.

Before the change the `info threads` printed theads but `thread 4` for example did not change the context from thread 0 to the requested one.

```
(gdb) info thread
Index Tid  Pid  Thread                Info                                                                             Frame
*0    0    0    Thread 0x20404960     (Name: Idle_Task, State: Running, Priority: 0, Stack: 1008)  0x42d656	up_idle() at common/arm_idle.c:65
 1    1    0    Thread 0x20409638     (Name: hpwork, State: Waiting,Semaphore, Priority: 224, Stack: 4032) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 2    2    2    Thread 0x2040a718     (Name: startup_main, State: Waiting,Semaphore, Priority: 100, Stack: 4056) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 4    4    4    Thread 0x20412048     (Name: broker, State: Waiting,Semaphore, Priority: 100, Stack: 4064) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 5    5    5    Thread 0x20413400     (Name: safetycom, State: Waiting,Semaphore, Priority: 100, Stack: 4056) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 6    6    6    Thread 0x204147b8     (Name: logger, State: Waiting,Semaphore, Priority: 100, Stack: 4064) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 7    7    7    Thread 0x20415b70     (Name: ui, State: Waiting,Signal, Priority: 100, Stack: 8192) 0x446ee8	nxsig_clockwait() at signal/sig_timedwait.c:331
 8    8    4    Thread 0x20411498     (Name: broker, State: Waiting,Semaphore, Priority: 100, Stack: 4080) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 9    9    4    Thread 0x204115f0     (Name: broker, State: Waiting,Signal, Priority: 100, Stack: 4080) 0x446ee8	nxsig_clockwait() at signal/sig_timedwait.c:331
 10   10   4    Thread 0x20411a70     (Name: broker, State: Waiting,Semaphore, Priority: 101, Stack: 4080) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 11   11   5    Thread 0x2041c290     (Name: safetycom, State: Waiting,Semaphore, Priority: 100, Stack: 4080) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
 12   12   7    Thread 0x2042e1f8     (Name: ui, State: Waiting,Semaphore, Priority: 100, Stack: 4080) 0x4234c8	nxsem_wait_slow() at semaphore/sem_wait.c:259
(gdb) thread 8
set $r0=2set $r1=0set $r2=0set $r3=0set $r4=541136024set $r5=541135448set $r6=0set $r7=128set $r8=541135448set $r9=0set $r10=541135440set $r11=68set $r12=0warning: Invalid state, unable to determine sp alias, assuming msp.
set $sp=541167912set $lr=0warning: Invalid state, unable to determine sp alias, assuming msp.
(gdb) set $pc=4338888bnt
Undefined command: "bnt".  Try "help".
(gdb) bt
#0  nxsem_wait_slow (sem=0x20411258) at semaphore/sem_wait.c:259
#1  0x00428c6c in nxsem_wait (sem=<optimized out>) at semaphore/sem_wait.c:201
#2  0x00447ee0 in can_read (filep=0x20411230, buffer=0x204191ec "", buflen=68) at can/can.c:451
#3  can_read (filep=0x20411230, buffer=0x204191ec "", buflen=68) at can/can.c:378
#4  0x00438300 in file_readv_compat (filep=<optimized out>, iov=<optimized out>, iovcnt=<optimized out>) at vfs/fs_read.c:104
#5  file_readv (filep=0x20411230, iov=iov@entry=0x204191c0, iovcnt=iovcnt@entry=1) at vfs/fs_read.c:221
#6  0x00438388 in nx_readv (fd=<optimized out>, iov=iov@entry=0x204191c0, iovcnt=iovcnt@entry=1) at vfs/fs_read.c:304
#7  0x004383b4 in readv (fd=<optimized out>, iov=iov@entry=0x204191c0, iovcnt=iovcnt@entry=1) at vfs/fs_read.c:369
#8  0x004383ee in read (fd=<optimized out>, buf=buf@entry=0x204191ec, nbytes=nbytes@entry=68) at vfs/fs_read.c:403
#9  0x00471e8a in _reader (arg=0x20410cb4) at ../../../../subprojects/shvc/libshvrpc/rpctransport/can.c:207
#10 0x004e3a86 in pthread_startup (entry=<optimized out>, arg=<optimized out>) at pthread/pthread_create.c:61
#11 0x004e6928 in pthread_start () at pthread/pthread_create.c:142
#12 0x00000000 in ?? ()
```

It is still a bit ugly that `thread x` left `set $pc=foo` on the CLI input line, but that is an unrelated cosmetic issue.