### PR TITLE
arch/xtensa/esp32s3: expose UART RX FIFO controls

### DIFF
--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -1298,6 +1298,24 @@ endmenu # SPI configuration
 menu "UART Configuration"
 	depends on ESP32S3_UART
 
+config ESP32S3_RX_FIFO_THRD
+	int "RX Fifo full threshold"
+	default 120
+	---help---
+		Set how many received bytes must accumulate in the hardware RX FIFO
+		before an RX FIFO full interrupt is generated. The ESP32-S3 UART FIFO
+		can hold 128 bytes, so leaving some headroom here helps prevent overflow
+		while the interrupt handler drains the buffer.
+
+config ESP32S3_RX_FIFO_TOUT
+	int "RX Fifo timeout"
+	default 10
+	---help---
+		Generate an RX timeout interrupt when the UART RX line stays idle for
+		this many bit periods and the FIFO has not reached the full threshold.
+		Lower values move data to the software FIFO sooner; higher values reduce
+		the interrupt rate on continuous transfers.
+
 if ESP32S3_UART0
 
 config ESP32S3_UART0_RS485


### PR DESCRIPTION
### Summary

Resolves the UART RX FIFO overflow reported in issue #17179 by exposing threshold and timeout controls via new CONFIG_ESP32S3_RX_FIFO_THRD and CONFIG_ESP32S3_RX_FIFO_TOUT options.
Updates the ESP32-S3 serial driver to honor those Kconfig values, enabling the RX timeout logic and clearing FIFO overflow interrupts by resetting the hardware buffer.
Provides help text so integrators understand the hardware limits (128-byte FIFO) and the trade-off between latency and interrupt rate when tuning the settings.

### Impact

Behaviour change is limited to ESP32-S3 builds: existing defaults match the previous configuration, while Kconfig now allows board-specific tuning to prevent data loss on high-throughput UART links.
No effect on other architectures or boards; build system and documentation remain unchanged.
Eliminates a class of RX overflow stalls observed when the FIFO filled before the interrupt handler drained it.