### PR TITLE
style/FAR: remove FAR qualifier

### DIFF
--- a/include/locale.h
+++ b/include/locale.h
@@ -75,20 +75,20 @@ struct lconv
   FAR char *mon_grouping;
   FAR char *positive_sign;
   FAR char *negative_sign;
-  FAR char int_frac_digits;
-  FAR char frac_digits;
-  FAR char p_cs_precedes;
-  FAR char p_sep_by_space;
-  FAR char n_cs_precedes;
-  FAR char n_sep_by_space;
-  FAR char p_sign_posn;
-  FAR char n_sign_posn;
-  FAR char int_n_cs_precedes;
-  FAR char int_n_sep_by_space;
-  FAR char int_n_sign_posn;
-  FAR char int_p_cs_precedes;
-  FAR char int_p_sep_by_space;
-  FAR char int_p_sign_posn;
+  char int_frac_digits;
+  char frac_digits;
+  char p_cs_precedes;
+  char p_sep_by_space;
+  char n_cs_precedes;
+  char n_sep_by_space;
+  char p_sign_posn;
+  char n_sign_posn;
+  char int_n_cs_precedes;
+  char int_n_sep_by_space;
+  char int_n_sign_posn;
+  char int_p_cs_precedes;
+  char int_p_sep_by_space;
+  char int_p_sign_posn;
 };
 
 /* OpenGroup.org:  The locale.h header shall define the locale_t type,

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -436,12 +436,12 @@ void mm_checkcorruption(FAR struct mm_heap_s *heap);
 
 /* Functions contained in umm_checkcorruption.c *****************************/
 
-FAR void umm_checkcorruption(void);
+void umm_checkcorruption(void);
 
 /* Functions contained in kmm_checkcorruption.c *****************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-FAR void kmm_checkcorruption(void);
+void kmm_checkcorruption(void);
 #else
 #define kmm_checkcorruption()  umm_checkcorruption()
 #endif

--- a/include/nuttx/modem/u-blox.h
+++ b/include/nuttx/modem/u-blox.h
@@ -60,7 +60,7 @@
 
 struct ubxmdm_regval
 {
-  FAR char name[3];
+  char name[3];
   bool val;
 };
 

--- a/include/nuttx/net/dns.h
+++ b/include/nuttx/net/dns.h
@@ -180,7 +180,7 @@ begin_packed_struct struct dns_answer_s
 
 typedef CODE int (*dns_callback_t)(FAR void *arg,
                                    FAR struct sockaddr *addr,
-                                   FAR socklen_t addrlen);
+                                   socklen_t addrlen);
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -427,7 +427,7 @@ struct net_driver_s
   /* Remember the outgoing fragments waiting to be sent */
 
 #ifdef CONFIG_NET_IPFRAG
-  FAR struct iob_queue_s d_fragout;
+  struct iob_queue_s d_fragout;
 #endif
 
   /* The d_buf array is used to hold incoming and outgoing packets. The

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -452,7 +452,7 @@ struct pthread_spinlock_s
 #  ifndef __PTHREAD_SPINLOCK_T_DEFINED
 /* It is referenced via this standard type */
 
-typedef FAR struct pthread_spinlock_s pthread_spinlock_t;
+typedef struct pthread_spinlock_s pthread_spinlock_t;
 #    define __PTHREAD_SPINLOCK_T_DEFINED 1
 #  endif
 #endif /* CONFIG_PTHREAD_SPINLOCKS */
@@ -891,7 +891,7 @@ typedef struct pthread_rwlock_s pthread_rwlock_t;
 #ifdef CONFIG_PTHREAD_SPINLOCKS
 #  ifndef __PTHREAD_SPINLOCK_T_DEFINED
 struct pthread_spinlock_s;
-typedef FAR struct pthread_spinlock_s pthread_spinlock_t;
+typedef struct pthread_spinlock_s pthread_spinlock_t;
 #    define __PTHREAD_SPINLOCK_T_DEFINED 1
 #  endif
 #endif /* CONFIG_PTHREAD_SPINLOCKS */

--- a/libs/libc/locale/lib_gettext.c
+++ b/libs/libc/locale/lib_gettext.c
@@ -90,7 +90,7 @@ static mutex_t g_lock = NXMUTEX_INITIALIZER;
 static FAR struct mofile_s *g_mofile;
 
 #ifdef CONFIG_BUILD_KERNEL
-static FAR char g_domain[NAME_MAX];
+static char g_domain[NAME_MAX];
 #endif
 
 /****************************************************************************

--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -843,7 +843,7 @@ static void dns_query_error(FAR const char *prompt, int ret,
  ****************************************************************************/
 
 static int dns_query_callback(FAR void *arg, FAR struct sockaddr *addr,
-                              FAR socklen_t addrlen)
+                              socklen_t addrlen)
 {
   FAR struct dns_query_data_s *qdata = arg;
   FAR struct dns_query_s      *query = &qdata->query;

--- a/libs/libc/netdb/lib_getaddrinfo.c
+++ b/libs/libc/netdb/lib_getaddrinfo.c
@@ -139,7 +139,7 @@ int getaddrinfo(FAR const char *hostname, FAR const char *servname,
   int proto = 0;
   int socktype = 0;
   FAR char *hostbuffer;
-  FAR struct hostent_s host;
+  struct hostent_s host;
   FAR struct ai_s *ai;
   FAR struct ai_s *prev_ai = NULL;
   const int valid_flags = AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST |

--- a/libs/libc/netdb/lib_parsehostfile.c
+++ b/libs/libc/netdb/lib_parsehostfile.c
@@ -255,7 +255,7 @@ ssize_t parse_hostfile(FAR FILE *stream, FAR struct hostent_s *host,
                        FAR char *buf, size_t buflen)
 {
   FAR struct hostent_info_s *info;
-  FAR char addrstring[48];
+  char addrstring[48];
   FAR char *ptr;
   FAR char *start;
   socklen_t addrlen;

--- a/libs/libc/unistd/lib_getoptvars.c
+++ b/libs/libc/unistd/lib_getoptvars.c
@@ -38,7 +38,7 @@
  * access to process-specific global data is needed.
  */
 
-FAR struct getopt_s g_getopt_vars =
+struct getopt_s g_getopt_vars =
 {
   NULL,
   0,

--- a/libs/libc/userfs/lib_userfs.c
+++ b/libs/libc/userfs/lib_userfs.c
@@ -987,7 +987,7 @@ int userfs_run(FAR const char *mountpt,
                FAR void *volinfo, size_t mxwrite)
 {
   FAR struct userfs_info_s *info;
-  FAR struct userfs_config_s config;
+  struct userfs_config_s config;
   struct sockaddr_in server;
   unsigned int iolen;
   socklen_t addrlen;

--- a/libs/libnx/nxfonts/nxfonts_cache.c
+++ b/libs/libnx/nxfonts/nxfonts_cache.c
@@ -384,7 +384,7 @@ static inline void nxf_fillglyph(FAR struct nxfonts_fcache_s *priv,
   if (priv->bpp == 24)
     {
       FAR uint32_t *ptr = (FAR uint32_t *)glyph->bitmap;
-      FAR uint32_t pixel[3];
+      uint32_t pixel[3];
 
       /* Get two 32-bit values for alternating 32 representations */
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -91,7 +91,7 @@ config SCHED_TICKLESS_TICK_ARGUMENT
 		Otherwise, these additional interfaces are expected:
 
 			int up_timer_tick_cancel(FAR clock_t *ticks);
-			int up_timer_tick_start(FAR clock_t ticks);
+			int up_timer_tick_start(clock_t ticks);
 
 config SCHED_TICKLESS_ALARM
 	bool "Tickless alarm"

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -197,7 +197,7 @@ extern enum task_deliver_e g_delivertasks[CONFIG_SMP_NCPUS];
 
 /* This is the list of idle tasks */
 
-extern FAR struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
+extern struct tcb_s g_idletcb[CONFIG_SMP_NCPUS];
 
 #endif
 

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -220,7 +220,7 @@ pid_t nxsched_waitpid(pid_t pid, int *stat_loc, int options)
   FAR struct child_status_s *child = NULL;
   bool retains;
 #endif
-  FAR struct siginfo info;
+  struct siginfo info;
   irqstate_t flags;
   sigset_t set;
   int ret;


### PR DESCRIPTION
## Summary

style/FAR: remove FAR qualifier

N/A, remove FAR qualifier from non-pointer types

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

nsh/sim, ostest, ci-check