### PR TITLE
arch/xtensa: add non-iram interrupt support for ESP32-S2

### DIFF
--- a/arch/xtensa/include/esp32s2/irq.h
+++ b/arch/xtensa/include/esp32s2/irq.h
@@ -39,6 +39,16 @@
 
 #define ESP32S2_INT_PRIO_DEF        1
 
+/* CPU interrupt flags:
+ *   These flags can be used to specify which interrupt qualities the
+ *   code calling esp32s3_setup_irq needs.
+ */
+
+#define ESP32S2_CPUINT_FLAG_LEVEL   (1 << 0) /* Level-triggered interrupt */
+#define ESP32S2_CPUINT_FLAG_EDGE    (1 << 1) /* Edge-triggered interrupt */
+#define ESP32S2_CPUINT_FLAG_SHARED  (1 << 2) /* Interrupt can be shared between ISRs */
+#define ESP32S2_CPUINT_FLAG_IRAM    (1 << 3) /* ISR can be called if cache is disabled */
+
 /* Interrupt Matrix
  *
  * The Interrupt Matrix embedded in the ESP32-S2 independently allocates

--- a/arch/xtensa/src/esp32s2/esp32s2_irq.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.h
@@ -46,8 +46,8 @@ extern "C"
 
 /* CPU interrupt types. */
 
-#define ESP32S2_CPUINT_LEVEL   0
-#define ESP32S2_CPUINT_EDGE    1
+#define ESP32S2_CPUINT_LEVEL   ESP32S2_CPUINT_FLAG_LEVEL
+#define ESP32S2_CPUINT_EDGE    ESP32S2_CPUINT_FLAG_EDGE
 
 /****************************************************************************
  * Public Functions Prototypes
@@ -81,7 +81,9 @@ int esp32s2_cpuint_initialize(void);
  *   periphid - The peripheral number from irq.h to be assigned to
  *              a CPU interrupt.
  *   priority - Interrupt's priority (1 - 5).
- *   type     - Interrupt's type (level or edge).
+ *   flags    - An ORred mask of the ESP32S3_CPUINT_FLAG_* defines. These
+ *              restrict the choice of interrupts that this routine can
+ *              choose from.
  *
  * Returned Value:
  *   The allocated CPU interrupt on success, a negated errno value on
@@ -89,7 +91,7 @@ int esp32s2_cpuint_initialize(void);
  *
  ****************************************************************************/
 
-int esp32s2_setup_irq(int periphid, int priority, int type);
+int esp32s2_setup_irq(int periphid, int priority, int flags);
 
 /****************************************************************************
  * Name:  esp32s2_teardown_irq
@@ -111,6 +113,86 @@ int esp32s2_setup_irq(int periphid, int priority, int type);
  ****************************************************************************/
 
 void esp32s2_teardown_irq(int periphid, int cpuint);
+
+/****************************************************************************
+ * Name:  esp32s2_irq_noniram_disable
+ *
+ * Description:
+ *   Disable interrupts that aren't specifically marked as running from IRAM
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Input Parameters:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp32s2_irq_noniram_disable(void);
+
+/****************************************************************************
+ * Name:  esp32s2_irq_noniram_enable
+ *
+ * Description:
+ *   Re-enable interrupts disabled by esp32s2_irq_noniram_disable
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Input Parameters:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp32s2_irq_noniram_enable(void);
+
+/****************************************************************************
+ * Name:  esp32s2_irq_noniram_status
+ *
+ * Description:
+ *   Get the current status of non-IRAM interrupts.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   True if non-IRAM interrupts are enabled, false otherwise.
+ *
+ ****************************************************************************/
+
+bool esp32s2_irq_noniram_status(void);
+
+/****************************************************************************
+ * Name:  esp32s2_irq_set_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a IRAM-enabled ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp32s2_irq_set_iram_isr(int irq);
+
+/****************************************************************************
+ * Name:  esp32s2_irq_unset_iram_isr
+ *
+ * Description:
+ *   Set the ISR associated to an IRQ as a non-IRAM ISR.
+ *
+ * Input Parameters:
+ *   irq - The associated IRQ to set
+ *
+ * Returned Value:
+ *   OK on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int esp32s2_irq_unset_iram_isr(int irq);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
@@ -434,6 +434,19 @@ static inline bool IRAM_ATTR esp32s2_ptr_extram(const void *p)
 }
 
 /****************************************************************************
+ * Name: esp32s2_ptr_iram
+ *
+ * Description:
+ *   Check if the pointer is in IRAM
+ *
+ ****************************************************************************/
+
+static inline bool IRAM_ATTR esp32s2_ptr_iram(const void *p)
+{
+  return ((intptr_t)p >= SOC_IRAM_LOW && (intptr_t)p < SOC_IRAM_HIGH);
+}
+
+/****************************************************************************
  * Name: esp32s2_ptr_exec
  *
  * Description:


### PR DESCRIPTION
## Summary

- arch/xtensa: add non-iram interrupt support for ESP32-S2
Adds support for enabling and disabling non-iram interrupts on ESP32-S2.

This change is required to support SPI flash refactor.

## Impact

- Impact on user: No.
- Impact on build: No.
- Impact on hardware: Only ESP32-S2.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: No.

## Testing

Tested internally on CI on all defconfigs.
Example below boots the device on spiflash defconfig and run fstest.

### Building

- ./tools/configure.sh esp32s2-saola-1:spiflash
- Enable CONFIG_TESTING_FSTEST
- make and flash

### Running
Format the partition and reboot:

```
nsh> mksmartfs /dev/smart0
```
Execute fstest:

```
nsh> fstest -n 20 -m /data -o 30
```

### Results
Tests passed.

```
...
Final memory usage:
VARIABLE  BEFORE   AFTER    DELTA
======== ======== ======== ========
arena       42df4    42df4        0
ordblks         1        1        0
mxordblk    3d4a8    3d4a8        0
uordblks     594c     594c        0
fordblks    3d4a8    3d4a8        0
File system tests done... OK: 40, FAILED: 0
nsh> 
```
