### PR TITLE
nuttx/cmake: Remove redundant logic in CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,24 +270,21 @@ if(CONFIG_ARCH_BOARD_CUSTOM)
                          ABSOLUTE BASE_DIR ${NUTTX_DIR})
 else()
   set(NUTTX_BOARD_ABS_DIR ${NUTTX_BOARD_DIR})
-  file(TOUCH ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
 endif()
 
 # check if board custom dir points to NuttX upstream board. This is useful when
 # an out-of-tree configuration uses an upstream board directory
 string(FIND "${CONFIG_ARCH_BOARD_CUSTOM_DIR}" "boards/" IS_NUTTX_BOARD)
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
-  # link dummy/Kconfig only if this is not upstream board otherwise the same
-  # Kconfig file is included twice which cause CMake warnings
-  if(CONFIG_ARCH_BOARD_CUSTOM
-     AND EXISTS ${NUTTX_BOARD_ABS_DIR}/Kconfig
-     AND NOT (IS_NUTTX_BOARD EQUAL 0))
-    nuttx_create_symlink(${NUTTX_BOARD_ABS_DIR}/Kconfig
-                         ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
-  else()
-    file(TOUCH ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
-  endif()
+# link dummy/Kconfig only if this is not upstream board otherwise the same
+# Kconfig file is included twice which cause CMake warnings
+if(CONFIG_ARCH_BOARD_CUSTOM
+   AND EXISTS ${NUTTX_BOARD_ABS_DIR}/Kconfig
+   AND NOT (IS_NUTTX_BOARD EQUAL 0))
+  nuttx_create_symlink(${NUTTX_BOARD_ABS_DIR}/Kconfig
+                       ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
+else()
+  file(TOUCH ${CMAKE_BINARY_DIR}/boards/dummy/Kconfig)
 endif()
 
 # board platform driver
@@ -318,13 +315,11 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/arch/dummy)
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/arch/dummy)
 endif()
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/arch/dummy/Kconfig)
-  if(CONFIG_ARCH_CHIP_CUSTOM AND EXISTS ${NUTTX_CHIP_ABS_DIR}/Kconfig)
-    nuttx_create_symlink(${NUTTX_CHIP_ABS_DIR}/Kconfig
-                         ${CMAKE_BINARY_DIR}/arch/dummy/Kconfig)
-  else()
-    file(TOUCH ${CMAKE_BINARY_DIR}/arch/dummy/Kconfig)
-  endif()
+if(CONFIG_ARCH_CHIP_CUSTOM AND EXISTS ${NUTTX_CHIP_ABS_DIR}/Kconfig)
+  nuttx_create_symlink(${NUTTX_CHIP_ABS_DIR}/Kconfig
+                       ${CMAKE_BINARY_DIR}/arch/dummy/Kconfig)
+else()
+  file(TOUCH ${CMAKE_BINARY_DIR}/arch/dummy/Kconfig)
 endif()
 
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH})


### PR DESCRIPTION
    Simplify the CMake scripts by removing redundant logic to
    improve code readability and maintainability.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

    Simplify the CMake scripts by removing redundant logic to
    improve code readability and maintainability.

## Impact

   Cmake scripts improvement, will improve build system efficiency

## Testing

This is build system improvement, CI will verify this update is OK
