### PR TITLE
cmake: Remove unused BUILD_OOTCPP guard from configuration.

### DIFF
--- a/tools/ci/cibuild-oot.sh
+++ b/tools/ci/cibuild-oot.sh
@@ -63,7 +63,7 @@ echo "=== [4/5] Building OOT ==="
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake .. -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" -DBUILD_OOTCPP=ON
+cmake .. -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
 make -j"$(nproc)"
 
 echo "=== [5/5] Verifying Output ==="


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR removes the unused `BUILD_OOTCPP` CMake option from the configuration step:
```
cmake .. -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" -DBUILD_OOTCPP=ON
```
is simplified to:
```
cmake .. -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
```

The `BUILD_OOTCPP` guard is no longer necessary because out-of-tree build logic is now fully supported by the enhanced `nuttx_add_subdirectory()` helper, which provides directory exclusion control via the EXCLUDE argument (introduced in [#17105](https://github.com/apache/nuttx/pull/17105)

## Impact

- Build system: Simplifies configuration by removing an obsolete option.
- Compatibility: No impact on existing builds; the option was unused.
- Developers: Cleaner and more maintainable CMake configuration.

## Testing

- Verified that standard and out-of-tree builds complete successfully without the BUILD_OOTCPP option.
- Confirmed that export and CI workflows continue to function as expected.