### PR TITLE
sched/signal: use list_waitingforsignal() to access g_waitingforsignal

### DIFF
--- a/sched/sched/sched_sleep.c
+++ b/sched/sched/sched_sleep.c
@@ -131,7 +131,7 @@ void nxsched_ticksleep(unsigned int ticks)
   /* Add the task to the specified blocked task list */
 
   rtcb->task_state = TSTATE_WAIT_SIG;
-  dq_addlast((FAR dq_entry_t *)rtcb, &g_waitingforsignal);
+  dq_addlast((FAR dq_entry_t *)rtcb, list_waitingforsignal());
 
   /* Now, perform the context switch if one is needed */
 

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -320,7 +320,7 @@ int nxsig_clockwait(int clockid, int flags,
   /* Add the task to the specified blocked task list */
 
   rtcb->task_state = TSTATE_WAIT_SIG;
-  dq_addlast((FAR dq_entry_t *)rtcb, &g_waitingforsignal);
+  dq_addlast((FAR dq_entry_t *)rtcb, list_waitingforsignal());
 
   /* Now, perform the context switch if one is needed */
 


### PR DESCRIPTION
    Replace direct access to the g_waitingforsignal list with the
    NuttX-defined macro list_waitingforsignal() to improve code
    consistency and maintainability.

## Summary

    Replace direct access to the g_waitingforsignal list with the
    NuttX-defined macro list_waitingforsignal() to improve code
    consistency and maintainability

## Impact
    Nuttx sched signal module code improvement, no impact to other parts

## Testing

**ostest passed on board a2g-tc397-5v-tft**
<img width="716" height="745" alt="image" src="https://github.com/user-attachments/assets/b5f25a4b-a26b-4e42-8330-39f38cffb55a" />