### PR TITLE
arch/xmc4 : add configurable UART RX buffer event trigger threshold

### DIFF
--- a/arch/arm/src/xmc4/Kconfig
+++ b/arch/arm/src/xmc4/Kconfig
@@ -273,6 +273,17 @@ config XMC4_USIC0_CHAN0_RX_BUFFER_SIZE
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
 
+config XMC4_USIC0_CHAN0_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC0_CHAN0_ISUART
+	range 1 XMC4_USIC0_CHAN0_RX_BUFFER_SIZE
+	default XMC4_USIC0_CHAN0_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC0_CHAN0_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC0_CHAN0_RX_BUFFER_SIZE.
+
 endmenu # USIC0 Channel 0 Configuration
 
 
@@ -370,6 +381,17 @@ config XMC4_USIC0_CHAN1_RX_BUFFER_SIZE
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
 
+config XMC4_USIC0_CHAN1_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC0_CHAN1_ISUART
+	range 1 XMC4_USIC0_CHAN1_RX_BUFFER_SIZE
+	default XMC4_USIC0_CHAN1_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC0_CHAN1_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC0_CHAN1_RX_BUFFER_SIZE.
+
 endmenu # USIC0 Channel 1 Configuration
 
 menu "USIC1 Channel 0 Configuration"
@@ -439,6 +461,17 @@ config XMC4_USIC1_CHAN0_RX_BUFFER_SIZE
 		Should be a power of 2 between 2 and 64
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
+
+config XMC4_USIC1_CHAN0_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC1_CHAN0_ISUART
+	range 1 XMC4_USIC1_CHAN0_RX_BUFFER_SIZE
+	default XMC4_USIC1_CHAN0_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC1_CHAN0_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC1_CHAN0_RX_BUFFER_SIZE.
 
 endmenu # USIC1 Channel 0 Configuration
 
@@ -536,6 +569,17 @@ config XMC4_USIC1_CHAN1_RX_BUFFER_SIZE
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
 
+config XMC4_USIC1_CHAN1_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC1_CHAN1_ISUART
+	range 1 XMC4_USIC1_CHAN1_RX_BUFFER_SIZE
+	default XMC4_USIC1_CHAN1_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC1_CHAN1_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC1_CHAN1_RX_BUFFER_SIZE.
+
 endmenu # USIC1 Channel 1 Configuration
 
 menu "USIC2 Channel 0 Configuration"
@@ -605,6 +649,17 @@ config XMC4_USIC2_CHAN0_RX_BUFFER_SIZE
 		Should be a power of 2 between 2 and 64
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
+
+config XMC4_USIC2_CHAN0_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC2_CHAN0_ISUART
+	range 1 XMC4_USIC2_CHAN0_RX_BUFFER_SIZE
+	default XMC4_USIC2_CHAN0_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC2_CHAN0_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC2_CHAN0_RX_BUFFER_SIZE.
 
 endmenu # USIC2 Channel 0 Configuration
 
@@ -700,6 +755,17 @@ config XMC4_USIC2_CHAN1_RX_BUFFER_SIZE
 		Should be a power of 2 between 2 and 64
 		The sum of Rx and Tx buffers sizes of both
 		channels should be inferior to 64
+
+config XMC4_USIC2_CHAN1_RX_BUFFER_LIMIT
+	int "Rx Fifo Buffer Limit"
+	depends on XMC4_USIC2_CHAN1_ISUART
+	range 1 XMC4_USIC2_CHAN1_RX_BUFFER_SIZE
+	default XMC4_USIC2_CHAN1_RX_BUFFER_SIZE
+	---help---
+		Defines the filling level of the Rx buffer that triggers an interruption.
+		By default it is set to XMC4_USIC2_CHAN1_RX_BUFFER_SIZE to limit interrupt rate,
+		but it can be reduced to prevent buffer overflow during reception at high baudrate.
+		Must be set between 1 and XMC4_USIC2_CHAN1_RX_BUFFER_SIZE.
 
 endmenu # USIC2 Channel 1 Configuration
 

--- a/arch/arm/src/xmc4/xmc4_lowputc.c
+++ b/arch/arm/src/xmc4/xmc4_lowputc.c
@@ -187,7 +187,7 @@
 
 #if defined(CONFIG_XMC4_USIC1_CHAN0_ISUART) && defined(CONFIG_XMC4_USIC1_CHAN1_ISUART)
 #if CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE + \
-    CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE > 64 
+    CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE > 64
 #  error The sum of Rx and Tx Buffers sizes should be inferior to 64
 #endif
 #endif
@@ -230,7 +230,7 @@
 
 #if defined(CONFIG_XMC4_USIC2_CHAN0_ISUART) && defined(CONFIG_XMC4_USIC2_CHAN1_ISUART)
 #if CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE + \
-    CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE > 64 
+    CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE + CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE > 64
 #  error The sum of Rx and Tx Buffers sizes should be inferior to 64
 #endif
 #endif
@@ -516,7 +516,7 @@ int xmc4_uart_configure(enum usic_channel_e channel,
   regval &= ~(USIC_RBCTR_DPTR_MASK | USIC_RBCTR_LIMIT_MASK |
               USIC_RBCTR_SIZE_MASK);
   regval |= (USIC_RBCTR_DPTR(config->startbufferptr + config->txbuffersize) |
-              USIC_RBCTR_LIMIT(config->rxbuffersize) |
+              USIC_RBCTR_LIMIT(config->rxbufferlimit) |
               USIC_RBCTR_SIZE(config->rxbuffersize) |
              USIC_RBCTR_LOF);
   putreg32(regval, base + XMC4_USIC_RBCTR_OFFSET);

--- a/arch/arm/src/xmc4/xmc4_lowputc.h
+++ b/arch/arm/src/xmc4/xmc4_lowputc.h
@@ -51,6 +51,7 @@ struct uart_config_s
   uint8_t  startbufferptr; /* Hardware Tx buffer start pointer */
   uint8_t  txbuffersize;   /* Hardware Tx Buffer Size */
   uint8_t  rxbuffersize;   /* Hardware Rx Buffer Size */
+  uint8_t  rxbufferlimit;  /* Filling level of Rx Buffer for event trigger */
 };
 
 /****************************************************************************

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -327,6 +327,7 @@ static struct xmc4_dev_s g_uart0priv =
     .startbufferptr = 0,
     .txbuffersize   = CONFIG_XMC4_USIC0_CHAN0_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };
@@ -367,6 +368,7 @@ static struct xmc4_dev_s g_uart1priv =
                     + CONFIG_XMC4_USIC0_CHAN0_RX_BUFFER_SIZE,
     .txbuffersize   = CONFIG_XMC4_USIC0_CHAN1_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC0_CHAN1_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };
@@ -406,6 +408,7 @@ static struct xmc4_dev_s g_uart2priv =
     .startbufferptr = 0,
     .txbuffersize   = CONFIG_XMC4_USIC1_CHAN0_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };
@@ -446,6 +449,7 @@ static struct xmc4_dev_s g_uart3priv =
                     + CONFIG_XMC4_USIC1_CHAN0_RX_BUFFER_SIZE,
     .txbuffersize   = CONFIG_XMC4_USIC1_CHAN1_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC1_CHAN1_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };
@@ -485,6 +489,7 @@ static struct xmc4_dev_s g_uart4priv =
     .startbufferptr = 0,
     .txbuffersize   = CONFIG_XMC4_USIC2_CHAN0_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };
@@ -525,6 +530,7 @@ static struct xmc4_dev_s g_uart5priv =
                     + CONFIG_XMC4_USIC2_CHAN0_RX_BUFFER_SIZE,
     .txbuffersize   = CONFIG_XMC4_USIC2_CHAN1_TX_BUFFER_SIZE,
     .rxbuffersize   = CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_SIZE,
+    .rxbufferlimit  = CONFIG_XMC4_USIC2_CHAN1_RX_BUFFER_LIMIT,
   },
   .lock = SP_UNLOCKED,
 };


### PR DESCRIPTION
## Summary

On XMC4, the USIC peripheral has a FIFO buffer. In UART mode, the FIFO is used to store data at reception.
Until now, the FIFO size was set by user with  XMC4_USICx_CHANy_RX_BUFFER_SIZE. And an interrupt was geenerated when the fifo was full. 
At higher baudrate (ex: 921600), I observed that the interrupt routine wouldn't empty the buffer before the reception of the next byte (too much time spent in the ISR), thus leading to missed bytes.

This PR add the possibility to trigger an interrupt before the buffer is full, the trigger level is set by user in menconfig between 1 and XMC4_USICx_CHANy_RX_BUFFER_SIZE.

## Impact
By default the value is set to XMC4_USICx_CHANy_RX_BUFFER_SIZE, as it is today so no impact on existing boards. 

## Testing
Tested on a XMC4800 custom board.
The UART communication is still working.
I have less occurrences of lost data.