### PR TITLE
docs/config: Wrong term.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2301,7 +2301,7 @@ config DEBUG_RESET_INFO
 endif # DEBUG_RESET
 
 config DEBUG_IPC
-	bool "IPC (Interprocessor communication) Debug Features"
+	bool "IPC (Inter-Process Communication) Debug Features"
 	default n
 	---help---
 		Enable IPC debug features.


### PR DESCRIPTION
Fixes #17225

## Summary

Changed a non-existent term to a technical term which I think was meant to be used.

## Impact

Null

## Testing

- Opened the menuconfig (worked fine)
- Saved defconfig (worked fine)
- Tried compiling (no warning nor error about this change)

## PR verification Self-Check

  * [ ] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.