### PR TITLE
arch/arm/stm32h5: Add missing AWD defines

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.h
+++ b/arch/arm/src/stm32h5/stm32_adc.h
@@ -113,6 +113,25 @@
 #  define ADC2_HAVE_OVERSAMPLE 1
 #endif
 
+#undef ADC_HAVE_WDG1
+#if defined(CONFIG_STM32H5_ADC1_WDG1) || defined(CONFIG_STM32H5_ADC2_WDG1)
+#  define ADC_HAVE_WDG1
+#endif
+
+#undef ADC_HAVE_WDG2
+#if defined(CONFIG_STM32H5_ADC1_WDG2) || defined(CONFIG_STM32H5_ADC2_WDG2)
+#  define ADC_HAVE_WDG2
+#endif
+
+#undef ADC_HAVE_WDG3
+#if defined(CONFIG_STM32H5_ADC1_WDG3) || defined(CONFIG_STM32H5_ADC2_WDG3)
+#  define ADC_HAVE_WDG3
+#endif
+
+#if defined(ADC_HAVE_WDG1) || defined (ADC_HAVE_WDG2) || \
+    defined(ADC_HAVE_WDG3)
+#  define ADC_HAVE_WDG
+#endif
 /* Timer configuration:  If a timer trigger is specified, then get
  * information about the timer.
  */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

I had a previous PR #17007 that added ADC Analog Watchdog functionality to the STM32H5 ADC lower level driver. That PR was missing AWD defines needed by stm32_adc.c. This PR adds those defines. I'm unsure how this was missed, but it probably occurred while moving between branches. 

## Impact

stm32h5 architecture only. More specifically, only the stm32h5 adc driver when a ADC Watchdog is enabled. 

## Testing

Testing is repeated from PR #17007. 

**Host / toolchain**
- x86_64 Linux host; standard NuttX stm32h5 toolchain. (I’ll attach exact toolchain version and logs in a follow-up.)

**Board**
- NUCLEO-H563ZI

**Config**
- ADC1 enabled with two channels configured via the per-channel array:
  - CH3 and CH10, both single-ended, `tsamp = ADC_SMPR_640p5`
- AWD1 enabled for ADC1 with:
  - `low = 0`, `high = 2048`
  - Tested in both “all channels” mode and “single channel” mode (selected channel varied between 3 and 10)

**Procedure**
1. Build and flash NuttX with the above Kconfig. Register `/dev/adc0` via the board init.
2. Start continuous conversions (DMA circular enabled) and run the `adc` example to sanity-check normal operation.
3. Tie both CH3 and CH10 to GND → verified **no** AWD interrupts and ADC continues normally.
4. Tie either CH3 or CH10 to 3.3 V with AWD1 set to “all channels” → ISR fires as expected; conversions continue; AWD1 IRQ is disabled by the ISR.
5. Switch to single-channel AWD1:
   - Select CH3: drive CH3 above the window → ISR fires; drive CH10 above the window → **no** ISR.
   - Select CH10: mirror the above.
6. Re-enable the watchdog interrupt using the driver IOCTL; confirm subsequent out-of-window events retrigger the ISR.
7. DMA circular mode check: stop conversions, call the DMA reset helper, restart conversions → verify buffer alignment and sample sequence remain correct.
