### PR TITLE
fs/fat: Ignore //... sequences in the file path

### DIFF
--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -362,6 +362,13 @@ static inline int fat_parsesfname(FAR const char **path,
 #ifdef CONFIG_FAT_LCNAMES
           dirinfo->fd_ntflags = ntlcfound & ntlcenable;
 #endif
+          /* Ignore sequences of //... in the filename */
+
+          while (node && *node == '/')
+            {
+              node++;
+            }
+
           *terminator = ch;
           *path       = node;
           return OK;


### PR DESCRIPTION
## Summary

This fixes an issue reported by user arikimari on github.

## Impact

Improvement

## Testing

```
NuttShell (NSH) NuttX-12.10.0
nsh> mkdir /tmp/test1
nsh> mkdir /tmp/test1/test2
nsh> ls /tmp/test1
/tmp/test1:
 test2/
nsh> ls /tmp////test1
/tmp////test1:
 test2/
nsh>
```

close:https://github.com/apache/nuttx/issues/17213
