### PR TITLE
arch/xtensa/esp32[-s2|-s3]: Modify the method of downloading the ESP repository

### DIFF
--- a/arch/risc-v/src/common/espressif/Make.defs
+++ b/arch/risc-v/src/common/espressif/Make.defs
@@ -199,7 +199,7 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
+	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty
 endif
 
 ifndef DISABLE_GIT_DEPTH
@@ -209,22 +209,15 @@ endif
 	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
 endif
 
-ifeq ($(STORAGETMP),y)
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CHECK_COMMITSHA, $(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO),$(ESP_HAL_3RDPARTY_VERSION))
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO),$(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO))
-endef
-else
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO))
-endef
-endif
-
 chip/$(ESP_HAL_3RDPARTY_REPO):
-	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
-	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO)
-	$(Q) echo "Espressif HAL for 3rd Party Platforms: ${ESP_HAL_3RDPARTY_VERSION}"
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
+	$(Q) echo "Downloading Espressif HAL for 3rd Party Platforms"
+	$(Q) wget -q -O - $(ESP_HAL_3RDPARTY_URL)/archive/$(ESP_HAL_3RDPARTY_VERSION).tar.gz | tar -xz -C chip/
+	$(Q) mv chip/$(ESP_HAL_3RDPARTY_REPO)-$(ESP_HAL_3RDPARTY_VERSION) chip/$(ESP_HAL_3RDPARTY_REPO)
+ifeq ($(STORAGETMP),y)
+	$(Q) cp -r chip/$(ESP_HAL_3RDPARTY_REPO) $(NXTMPDIR)
+endif
+endif
 	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule --quiet update --init $(GIT_DEPTH_PARAMETER) components/mbedtls/mbedtls
 ifeq ($(CONFIG_ESP_WIRELESS),y)
 	$(Q) echo "Espressif HAL for 3rd Party Platforms: initializing submodules..."
@@ -258,7 +251,20 @@ distclean::
 	$(call DELFILE,../include/chip/gpio_sig_map.h)
 	$(call DELFILE,../include/chip/irq.h)
 	$(call DELFILE,../../../vefuse.bin)
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
 	$(call DELDIR,chip/$(ESP_HAL_3RDPARTY_REPO))
+else
+	$(Q) echo "Espressif HAL for 3rd Party Platforms: uninitializing submodules..."
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/mbedtls/mbedtls
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls
+ifeq ($(CONFIG_ESP_WIRELESS),y)
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32_family components/esp_coex/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_phy/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_wifi/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/bt/controller/lib_esp32c3_family
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_coex/lib
+endif
+endif
 ifeq ($(CONFIG_ESPRESSIF_USE_LP_CORE),y)
 	$(call DELDIR,chip/ulp)
 endif

--- a/arch/risc-v/src/esp32c3-legacy/Make.defs
+++ b/arch/risc-v/src/esp32c3-legacy/Make.defs
@@ -245,25 +245,18 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL	= https://github.com/espressif/esp-hal-3rdparty.git
-endif
-
-ifeq ($(STORAGETMP),y)
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CHECK_COMMITSHA, $(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO),$(ESP_HAL_3RDPARTY_VERSION))
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO),$(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO))
-endef
-else
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO))
-endef
+	ESP_HAL_3RDPARTY_URL	= https://github.com/espressif/esp-hal-3rdparty
 endif
 
 chip/$(ESP_HAL_3RDPARTY_REPO):
-	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
-	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO)
-	$(Q) echo "Espressif HAL for 3rd Party Platforms: ${ESP_HAL_3RDPARTY_VERSION}"
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
+	$(Q) echo "Downloading Espressif HAL for 3rd Party Platforms"
+	$(Q) wget -q -O - $(ESP_HAL_3RDPARTY_URL)/archive/$(ESP_HAL_3RDPARTY_VERSION).tar.gz | tar -xz -C chip/
+	$(Q) mv chip/$(ESP_HAL_3RDPARTY_REPO)-$(ESP_HAL_3RDPARTY_VERSION) chip/$(ESP_HAL_3RDPARTY_REPO)
+ifeq ($(STORAGETMP),y)
+	$(Q) cp -r chip/$(ESP_HAL_3RDPARTY_REPO) $(NXTMPDIR)
+endif
+endif
 
 # Silent preprocessor warnings
 
@@ -272,4 +265,6 @@ CFLAGS += -Wno-undef -Wno-unused-variable
 include chip/Bootloader.mk
 
 distclean::
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
 	$(call DELDIR,chip/$(ESP_HAL_3RDPARTY_REPO))
+endif

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -227,7 +227,7 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
+	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty
 endif
 
 ifndef DISABLE_GIT_DEPTH
@@ -237,23 +237,16 @@ endif
 	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
 endif
 
-ifeq ($(STORAGETMP),y)
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CHECK_COMMITSHA, $(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO),$(ESP_HAL_3RDPARTY_VERSION))
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO),$(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO))
-endef
-else
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO))
-endef
-endif
-
 chip/$(ESP_HAL_3RDPARTY_REPO):
-	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
-	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO)
-	$(Q) echo "Espressif HAL for 3rd Party Platforms: ${ESP_HAL_3RDPARTY_VERSION}"
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
-
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
+	$(Q) echo "Downloading Espressif HAL for 3rd Party Platforms"
+	$(Q) wget -q -O - $(ESP_HAL_3RDPARTY_URL)/archive/$(ESP_HAL_3RDPARTY_VERSION).tar.gz | tar -xz -C chip/
+	$(Q) mv chip/$(ESP_HAL_3RDPARTY_REPO)-$(ESP_HAL_3RDPARTY_VERSION) chip/$(ESP_HAL_3RDPARTY_REPO)
+ifeq ($(STORAGETMP),y)
+	$(Q) cp -r chip/$(ESP_HAL_3RDPARTY_REPO) $(NXTMPDIR)
+endif
+endif
+	
 # Silent preprocessor warnings
 
 CFLAGS += -Wno-undef -Wno-unused-variable -fno-jump-tables -fno-tree-switch-conversion
@@ -283,7 +276,17 @@ ifeq ($(CONFIG_ESPRESSIF_WIRELESS),y)
 endif
 
 distclean::
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
 	$(call DELDIR,chip/$(ESP_HAL_3RDPARTY_REPO))
+else
+	$(Q) echo "Espressif HAL for 3rd Party Platforms: uninitializing submodules..."
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/mbedtls/mbedtls components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32 components/esp_coex/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_phy/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_wifi/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/bt/controller/lib_esp32
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_coex/lib
+endif
 	$(call DELFILE,../../../vefuse.bin)
 
 INCLUDES += ${INCDIR_PREFIX}$(ARCH_SRCDIR)$(DELIM)common$(DELIM)espressif

--- a/arch/xtensa/src/esp32s2/Make.defs
+++ b/arch/xtensa/src/esp32s2/Make.defs
@@ -137,25 +137,18 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
-endif
-
-ifeq ($(STORAGETMP),y)
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CHECK_COMMITSHA, $(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO),$(ESP_HAL_3RDPARTY_VERSION))
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO),$(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO))
-endef
-else
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO))
-endef
+	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty
 endif
 
 chip/$(ESP_HAL_3RDPARTY_REPO):
-	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
-	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO)
-	$(Q) echo "Espressif HAL for 3rd Party Platforms: ${ESP_HAL_3RDPARTY_VERSION}"
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
+	$(Q) echo "Downloading Espressif HAL for 3rd Party Platforms"
+	$(Q) wget -q -O - $(ESP_HAL_3RDPARTY_URL)/archive/$(ESP_HAL_3RDPARTY_VERSION).tar.gz | tar -xz -C chip/
+	$(Q) mv chip/$(ESP_HAL_3RDPARTY_REPO)-$(ESP_HAL_3RDPARTY_VERSION) chip/$(ESP_HAL_3RDPARTY_REPO)
+ifeq ($(STORAGETMP),y)
+	$(Q) cp -r chip/$(ESP_HAL_3RDPARTY_REPO) $(NXTMPDIR)
+endif
+endif
 
 # Silent preprocessor warnings
 
@@ -184,5 +177,16 @@ ifeq ($(CONFIG_ESPRESSIF_WIRELESS),y)
 endif
 
 distclean::
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
 	$(call DELDIR,chip/$(ESP_HAL_3RDPARTY_REPO))
+else
+	$(Q) echo "Espressif HAL for 3rd Party Platforms: uninitializing submodules..."
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/mbedtls/mbedtls
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls
+ifeq ($(CONFIG_ESP32_WIRELESS),y)
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/esp_phy/lib components/esp_wifi/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_phy/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_wifi/lib
+endif
+endif
 	$(call DELFILE,../../../vefuse.bin)

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -211,7 +211,7 @@ ifndef ESP_HAL_3RDPARTY_VERSION
 endif
 
 ifndef ESP_HAL_3RDPARTY_URL
-	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git
+	ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty
 endif
 
 ifndef DISABLE_GIT_DEPTH
@@ -221,22 +221,15 @@ endif
 	GIT_DEPTH_PARAMETER = --depth=$(GIT_DEPTH)
 endif
 
-ifeq ($(STORAGETMP),y)
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CHECK_COMMITSHA, $(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO),$(ESP_HAL_3RDPARTY_VERSION))
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO),$(NXTMPDIR)/$(ESP_HAL_3RDPARTY_REPO))
-endef
-else
-define CLONE_ESP_HAL_3RDPARTY_REPO
-	$(call CLONE, $(ESP_HAL_3RDPARTY_URL),chip/$(ESP_HAL_3RDPARTY_REPO))
-endef
-endif
-
 chip/$(ESP_HAL_3RDPARTY_REPO):
-	$(Q) echo "Cloning Espressif HAL for 3rd Party Platforms"
-	$(Q) $(call CLONE_ESP_HAL_3RDPARTY_REPO)
-	$(Q) echo "Espressif HAL for 3rd Party Platforms: ${ESP_HAL_3RDPARTY_VERSION}"
-	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) checkout --quiet $(ESP_HAL_3RDPARTY_VERSION)
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
+	$(Q) echo "Downloading Espressif HAL for 3rd Party Platforms"
+	$(Q) wget -q -O - $(ESP_HAL_3RDPARTY_URL)/archive/$(ESP_HAL_3RDPARTY_VERSION).tar.gz | tar -xz -C chip/
+	$(Q) mv chip/$(ESP_HAL_3RDPARTY_REPO)-$(ESP_HAL_3RDPARTY_VERSION) chip/$(ESP_HAL_3RDPARTY_REPO)
+ifeq ($(STORAGETMP),y)
+	$(Q) cp -r chip/$(ESP_HAL_3RDPARTY_REPO) $(NXTMPDIR)
+endif
+endif
 
 # Silent preprocessor warnings
 
@@ -270,5 +263,18 @@ ifeq ($(CONFIG_ESPRESSIF_WIRELESS),y)
 endif
 
 distclean::
+ifeq ($(wildcard chip/$(ESP_HAL_3RDPARTY_REPO)/.git),)
 	$(call DELDIR,chip/$(ESP_HAL_3RDPARTY_REPO))
+else
+	$(Q) echo "Espressif HAL for 3rd Party Platforms: uninitializing submodules..."
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/mbedtls/mbedtls
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/mbedtls/mbedtls
+ifeq ($(CONFIG_ESPRESSIF_WIRELESS),y)
+	$(Q) git -C chip/$(ESP_HAL_3RDPARTY_REPO) submodule deinit -f components/esp_phy/lib components/esp_wifi/lib components/bt/controller/lib_esp32_family components/esp_coex/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_phy/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_wifi/lib
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/bt/controller/lib_esp32c3_family
+	$(Q) rm -rf chip/$(ESP_HAL_3RDPARTY_REPO)/components/esp_coex/lib
+endif
+endif
 	$(call DELFILE,../../../vefuse.bin)


### PR DESCRIPTION
Directly downloading the Git repository is inconvenient for local debugging. Change it to the same approach as other components, that is downloading the compressed package.

Also, add handling for cases where the Git repository has already been downloaded.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
