### PR TITLE
arch/xtensa/esp32[-|-s3]: Fix exception issue when pm active

### DIFF
--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -167,6 +167,18 @@ static void esp32_idlepm(void)
   static enum pm_state_e oldstate = PM_NORMAL;
   enum pm_state_e newstate;
   int ret;
+  int count;
+
+  count = pm_staycount(PM_IDLE_DOMAIN, PM_NORMAL);
+  if (oldstate != PM_NORMAL && count == 0)
+    {
+      pm_stay(PM_IDLE_DOMAIN, PM_NORMAL);
+
+      /* Keep working in normal stage */
+
+      pm_changestate(PM_IDLE_DOMAIN, PM_NORMAL);
+      newstate = PM_NORMAL;
+    }
 
   /* Decide, which power saving level can be obtained */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_idle.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_idle.c
@@ -90,6 +90,18 @@ static void up_idlepm(void)
   static enum pm_state_e oldstate = PM_NORMAL;
   enum pm_state_e newstate;
   int ret;
+  int count;
+
+  count = pm_staycount(PM_IDLE_DOMAIN, PM_NORMAL);
+  if (oldstate != PM_NORMAL && count == 0)
+    {
+      pm_stay(PM_IDLE_DOMAIN, PM_NORMAL);
+
+      /* Keep working in normal stage */
+
+      pm_changestate(PM_IDLE_DOMAIN, PM_NORMAL);
+      newstate = PM_NORMAL;
+    }
 
   /* Decide, which power saving level can be obtained */
 


### PR DESCRIPTION
## Summary

This PR fixes exception issue which is happening PM_NORMAL state count value. When DEBUG_ASSERTIONS and PM enabled, system raises an exception after recovering back from light sleep (PM_STANDBY mode).  

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/xtensa/esp32[-|-s3]: Fix exception issue when pm active

Fix exception issue when PM and DEBUG_ASSERTIONS enabled for esp32 and esp32s3

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, exception bug when DEBUG_ASSERTIONS enabled with PM on esp32 and esp32s3 fixed
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->

To reproduce the issue this command used:

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:pm && kconfig-tweak -e DEBUG_FEATURES && kconfig-tweak -e DEBUG_ASSERTIONS && make olddefconfig -s -j && make ESPTOOL_BINDIR=./ -s -j && make download ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BAUD=921600 ESPTOOL_BINDIR=./
``` 

### Running
<!-- Provide how to run the test for each SoC being tested -->

To have exception this commands applied:

```
nsh> pmconfig relax normal
nsh> pmconfig relax normal
nsh> pmconfig relax idle
```

### Results
<!-- Provide tests' results and runtime logs -->

After this commands, device should get into light-sleep mode and after some time [this exception](https://github.com/apache/nuttx/blob/master/drivers/power/pm/pm_activity.c#L407) was getting triggered. It should not happen again with this MR.