### PR TITLE
documentation: JPEGResizeTool application

### DIFF
--- a/Documentation/applications/graphics/jpegresizetool/index.rst
+++ b/Documentation/applications/graphics/jpegresizetool/index.rst
@@ -1,0 +1,39 @@
+================
+JPEG Resize Tool
+================
+
+A lightweight utility for resizing JPEG images using parameters from the ``libjpeg`` library.  
+This tool serves both as a simple example of how to use ``libjpeg`` and as a practical scriptable resizer.
+
+Usage
+=====
+
+.. code-block:: bash
+
+   jpegresize <input.jpg> <output.jpg> <scale> <quality>
+
+Arguments
+---------
+
+- **input.jpg** — Path to the input JPEG image.  
+- **output.jpg** — Path to the resized output image.  
+- **scale** — Shrinking denominator. Currently, ``libjpeg`` supports values ``1``, ``2``, ``4``, or ``8``.  
+  For example, a value of ``8`` reduces the image dimensions by a factor of 8.  
+- **quality** — JPEG quality factor from ``0`` to ``100``.  
+  - Above **80%**: compression is nearly unnoticeable.  
+  - Around **20%**: strong compression artifacts appear.
+
+Example
+=======
+
+Shrink an image by 8× with 20% quality:
+
+.. code-block:: bash
+
+   jpegresize /sd/IMAGES/000000a1.jpg /sd/TEMP/THUMBS/000000a1.jpg 8 20
+
+Notes
+=====
+
+- This example assumes ``libjpeg`` is available in your build environment.  
+- The tool is designed for simplicity and small-footprint image processing on embedded systems or automation scripts.

--- a/Documentation/applications/graphics/libjpeg/index.rst
+++ b/Documentation/applications/graphics/libjpeg/index.rst
@@ -1,3 +1,30 @@
-=======================================
-``libjpeg`` libjpeg JPEG image encoding
-=======================================
+==========================================
+``libjpeg`` JPEG image encoding library
+==========================================
+
+``libjpeg`` is an open-source library that provides functionality for encoding and decoding images in the JPEG format.  
+It implements the baseline JPEG standard and is commonly used in image-related applications and utilities.
+
+Including the library
+=====================
+
+To use ``libjpeg`` in a C program, include the main header:
+
+.. code-block:: c
+
+   #include <jpeglib.h>
+
+Configuration
+=============
+
+Support for ``libjpeg`` must be enabled in Kconfig:
+
+  CONFIG_LIBJPEG=y
+
+Example
+=======
+
+NuttX provides an example application that demonstrates how to encode, decode, and resize JPEG images using ``libjpeg``.  
+It can be found under:
+
+``apps/graphics/jpgresizetool``


### PR DESCRIPTION
**This is documentation for the PR at https://github.com/apache/nuttx-apps/pull/3143**

Adds a libjpeg based JPEG resize tool.
Simple resizer that can resize JPEGs using
"jpgresize input.jpg output.jpg scale_denom(1,2,4,8) quality%". Tries to use little memory by scanning per line.