### PR TITLE
drivers/usbhost_hub: Add support to Multiple TT HS HUB

### DIFF
--- a/drivers/usbhost/usbhost_hub.c
+++ b/drivers/usbhost/usbhost_hub.c
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <sys/param.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
@@ -184,7 +185,7 @@ static int usbhost_disconnected(FAR struct usbhost_class_s *hubclass);
  * used to associate the USB host hub class to a connected USB hub.
  */
 
-static const struct usbhost_id_s g_id[2] =
+static const struct usbhost_id_s g_id[] =
 {
   {
       USB_CLASS_HUB,  /* base         */
@@ -196,7 +197,14 @@ static const struct usbhost_id_s g_id[2] =
   {
       USB_CLASS_HUB,  /* base         */
       0,              /* subclass     */
-      1,              /* proto HS hub */
+      1,              /* proto Single TT HS hub */
+      0,              /* vid          */
+      0               /* pid          */
+  },
+  {
+      USB_CLASS_HUB,  /* base         */
+      0,              /* subclass     */
+      2,              /* proto Multiple TT HS hub */
       0,              /* vid          */
       0               /* pid          */
   }
@@ -208,7 +216,7 @@ static struct usbhost_registry_s g_hub =
 {
   NULL,                   /* flink    */
   usbhost_create,         /* create   */
-  2,                      /* nids     */
+  nitems(g_id),           /* nids     */
   g_id                    /* id[]     */
 };
 


### PR DESCRIPTION
## Summary

This PR adds support to USB HUB Multi TT (Transaction Translator).
This is the case for USB2517 USB HUB. Also improved the driver to avoid mistakes: initially I changed g_id[3], but the in register there is another field where we need to pass this size again. So it is better to use ARRAY_SIZE() macro to avoid mistakes.

## Impact

Users will be able to use the USB HUBs Multi-TT like USB2517.

## Testing

imxrt1050-evk:

usbhost_classbind: usbhost_findclass: 0x202000f8                                  
usbhost_classbind: CLASS_CREATE: 0x20208f70                                       
usbhost_cfgdesc: Interface descriptor                                             
usbhost_cfgdesc: Endpoint descriptor                                              
usbhost_cfgdesc: Interrupt IN EP:usbhost_cfgdesc:  addr=1 interval=12 mxpacketsiz1
usbhost_cfgdesc: Endpoint allocated                                               
usbhost_hubdesc: Read hub descriptor                                              
usbhost_hubdesc: Hub Descriptor:                                                  
usbhost_hubdesc:   bDescLength:         9                                         
usbhost_hubdesc:   bDescriptorType:     0x29                                      
usbhost_hubdesc:   bNbrPorts:           7                                         
usbhost_hubdesc:   wHubCharacteristics: 0x0089                                    
usbhost_hubdesc:     lpsm:              1                                         
usbhost_hubdesc:     compounddev:       FALSE                                     
usbhost_hubdesc:     ocmode:            1                                         
usbhost_hubdesc:     indicator:         TRUE                                      
usbhost_hubdesc:   bPwrOn2PwrGood:      50                                        
usbhost_hubdesc:     pwrondelay:        100                                       
usbhost_hubdesc:   bHubContrCurrent:    1                                         
usbhost_hubdesc:   DeviceRemovable:     0                                         
usbhost_hubdesc:   PortPwrCtrlMask:     255                                       
usbhost_classbind: Returning: 0  