### PR TITLE
sched/signal: Improve nxsig_wait_irq() for performance enhancement and code duplication reduction

### DIFF
--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -41,6 +41,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* These are special values of si_signo that mean that either the wait was
+ * awakened with a timeout, or the wait was canceled... not the receipt of a
+ * signal.
+ */
+
+#define SIG_CANCEL_TIMEOUT 0xfe
+#define SIG_WAIT_TIMEOUT   0xff
+
 /* The following definition determines the number of signal structures to
  * allocate in a block
  */
@@ -181,9 +189,8 @@ void               nxsig_release(FAR struct task_group_s *group);
 
 /* sig_timedwait.c */
 
-#ifdef CONFIG_CANCELLATION_POINTS
-void nxsig_wait_irq(FAR struct tcb_s *wtcb, int errcode);
-#endif
+void nxsig_wait_irq(FAR struct tcb_s *wtcb, uint8_t signo,
+                    uint8_t code, int errcode);
 
 /* In files of the same name */
 

--- a/sched/task/task_cancelpt.c
+++ b/sched/task/task_cancelpt.c
@@ -162,7 +162,7 @@ bool nxnotify_cancellation(FAR struct tcb_s *tcb)
 
           else if (tcb->task_state == TSTATE_WAIT_SIG)
             {
-              nxsig_wait_irq(tcb, ECANCELED);
+              nxsig_wait_irq(tcb, SIG_CANCEL_TIMEOUT, SI_USER, ECANCELED);
             }
 
 #if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)


### PR DESCRIPTION
## Summary

This PR includes two commits:

**commit 1:** 

        nxsig_wait_irq() is always invoked within an existing critical section,
        and the task state is already verified, similar to nxsem_wait_irq().
        Therefore, the additional critical section protection and task state
        check inside the function are redundant and have been removed.
**commit 2:** 

        Currently, there is duplicated code in nxsig_wait_irq() and nxsig_timeout().
        This patch updates the input parameters of nxsig_wait_irq() so that it can
        be reused in nxsig_timeout(), reducing code duplication and improving
        maintainability.

## Impact

   Update nxsig_wait_irq() implemention  to improve performance, No impact to 
   other nuttx functions.

## Testing

**ostest passed on board a2g-tc397-5v-tft**

<img width="404" height="506" alt="image" src="https://github.com/user-attachments/assets/0d5f2292-c8af-4ea5-b3b9-9f3924df5588" />

