### PR TITLE
arch/arm/stm32h5: Use au_receive_batch in adc_dmaconvcallback

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.h
+++ b/arch/arm/src/stm32h5/stm32_adc.h
@@ -115,22 +115,22 @@
 
 #undef ADC_HAVE_WDG1
 #if defined(CONFIG_STM32H5_ADC1_WDG1) || defined(CONFIG_STM32H5_ADC2_WDG1)
-#  define ADC_HAVE_WDG1
+#  define ADC_HAVE_WDG1 1
 #endif
 
 #undef ADC_HAVE_WDG2
 #if defined(CONFIG_STM32H5_ADC1_WDG2) || defined(CONFIG_STM32H5_ADC2_WDG2)
-#  define ADC_HAVE_WDG2
+#  define ADC_HAVE_WDG2 1
 #endif
 
 #undef ADC_HAVE_WDG3
 #if defined(CONFIG_STM32H5_ADC1_WDG3) || defined(CONFIG_STM32H5_ADC2_WDG3)
-#  define ADC_HAVE_WDG3
+#  define ADC_HAVE_WDG3 1
 #endif
 
 #if defined(ADC_HAVE_WDG1) || defined (ADC_HAVE_WDG2) || \
     defined(ADC_HAVE_WDG3)
-#  define ADC_HAVE_WDG
+#  define ADC_HAVE_WDG 1
 #endif
 /* Timer configuration:  If a timer trigger is specified, then get
  * information about the timer.


### PR DESCRIPTION
## Summary

I reworked the STM32H5 ADC DMA path so it can sustain very high sample rates in circular mode without starving the scheduler.

**DMA/throughput changes**
- I replaced per-sample `au_receive()` calls inside `adc_dmaconvcallback()` with a single `au_receive_batch()` per DMA batch to amortize callback overhead and reduce context switching.
- I channel staging buffer that’s allocated/initialized once in `adc_setup()` and reused across batches. Only used with au_receive_batch. 
- I changed the DMA buffer element type to `uint32_t` to match the `au_receive_batch()` data pointer contract.
- I updated the STM32 GPDMA configuration (e.g., `tr1` data width) to reflect 32-bit transfers from the DMA buffer.
- **Result:** continuous conversions in circular mode now run reliably at the fastest rate I tested (≈5 Msps) without OS lockups, and the callback path consumes significantly less CPU.

**Analog watchdog additions/fixes**
- I fixed the definition and use of guards around ADC Watchdog code. 

## Impact

- **STM32H5 at high rates:** Much lower callback overhead and stable operation at multi-Msps rates in circular DMA mode.
- **Compatibility:** External ADC APIs are unchanged; batching is internal to the driver.  
- **Memory/latency trade-off:** Using a `uint32_t` DMA element increases per-element storage but enables zero-copy batching; overall CPU time per sample drops.

## Testing

**Environment**
- Host: Ubuntu 24.04 (amd64)
- Toolchain: `arm-none-eabi` gcc version 13.3.1 20240614 (Arm GNU Toolchain 13.3.Rel1 (Build arm-13.24))
- Board: ST NUCLEO-H563ZI

**Procedure**
- Built NuttX for `nucleo-h563zi` with ADC enabled and DMA in circular mode.
- Exercised the ADC at multiple rates up to ~5 Msps:
  - Verified stable operation over extended runs; no scheduler stalls or watchdog resets.
  - Confirmed `adc_dmaconvcallback()` issues a single `au_receive_batch()` per DMA half/full transfer and that batches are contiguous and complete.
  - Checked that the channel buffer is initialized once in `adc_setup()` and persists across start/stop cycles.
  - Validated GPDMA `tr1` (data width) matches the `uint32_t` DMA buffer configuration.
- Analog watchdogs:
  - Tested AWD1 and used it to trigger a reset on an advanced timer. Also confirmed operation by setting breakpoints in AWD isr code. 
