### PR TITLE
boards/esp32s3: Increase LCD PWM frequency to reduce LCD flicker

### DIFF
--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h
@@ -40,7 +40,7 @@
 #define GPIO_LCD_RST        (-1)
 #define SZPI_LCD_CS_PATH    "/dev/gpio0"
 #define SZPI_LCD_PWM_PATH   "/dev/pwm0"
-#define SZPI_LCD_PWM_FREQ   (100)
+#define SZPI_LCD_PWM_FREQ   (10000)
 #define SZPI_LCD_PWM_DUTY   (0xe666)       /* 0x1 ~ 0xffff */
 
 #define FT5X06_I2C_ADDRESS  (0x38)


### PR DESCRIPTION
## Summary

  * **Why change is necessary**: The original LCD PWM frequency of 100Hz causes visible flicker on the lckfb-szpi ESP32S3 board, resulting in poor user experience and display quality issues.
  * **What functional part of the code is being changed**: Board-specific LCD backlight PWM configuration for the lckfb-szpi ESP32S3 development board.
  * **How does the change exactly work**: The change increases the LCD PWM frequency from 100Hz to 10kHz by modifying the `SZPI_LCD_PWM_FREQ` macro definition. This higher frequency is above the human eye's flicker detection threshold, eliminating visible flicker while maintaining the
same backlight control functionality through PWM duty cycle adjustment.
  * **Related [NuttX Issue](https://github.com/apache/nuttx/issues) reference if applicable**: No specific issue reference provided.
  * **Related NuttX Apps [Issue](https://github.com/apache/nuttx-apps/issues) / [Pull Request](https://github.com/apache/nuttx-apps/pulls) reference if applicable**: Not applicable.

## Impact

  * **Is new feature added? Is existing feature changed?**: NO / YES - Existing LCD backlight control feature is improved by changing PWM frequency parameter.
  * **Impact on user (will user need to adapt to change?)**: NO / YES - Users will experience improved display quality with no visible flicker, but no API or configuration changes required.
  * **Impact on build (will build process change?)**: NO - No build process changes, only a constant value modification.
  * **Impact on hardware (will arch(s) / board(s) / driver(s) change?)**: NO / YES - Only affects lckfb-szpi ESP32S3 board configuration, no driver or architecture changes.
  * **Impact on documentation (is update required / provided?)**: NO - This is a minor configuration optimization that doesn't require documentation updates.
  * **Impact on security (any sort of implications?)**: NO - No security implications.
  * **Impact on compatibility (backward/forward/interoperability?)**: NO - Fully compatible change, only improves visual quality.
  * **Anything else to consider or add?**: The higher PWM frequency may have slightly higher power consumption, but this is negligible compared to the user experience improvement.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * **Build Host(s)**: Linux (Ubuntu 24.04)
  * **Target(s)**: arch: xtensa/esp32s3, board: lckfb-szpi-esp32s3:nsh
  * **Verification steps**:
    1. Build NuttX for lckfb-szpi-esp32s3 board with LCD support enabled
    2. Flash and run on actual hardware
    3 Compare visual quality before and after the change
