### PR TITLE
sched/signal: Remove un-needed sched_lock()/sched_unlock() in sigsuspend()

### DIFF
--- a/sched/signal/sig_suspend.c
+++ b/sched/signal/sig_suspend.c
@@ -93,7 +93,6 @@ int sigsuspend(FAR const sigset_t *set)
    * can only be eliminated by disabling interrupts!
    */
 
-  sched_lock();  /* Not necessary */
   flags = enter_critical_section();
 
   /* Save a copy of the old sigprocmask and install
@@ -152,7 +151,6 @@ int sigsuspend(FAR const sigset_t *set)
       nxsig_unmask_pendingsignal();
     }
 
-  sched_unlock();
   leave_cancellation_point();
   set_errno(EINTR);
   return ERROR;


### PR DESCRIPTION
 ## Summary

 Remove un-needed sched_lock()/sched_unlock() in sigsuspend() to improve performance

## Impact

sigsuspend() implementation improvment, no impact to other nuttx functions

## Testing

**ostest passed on board fvp-armv8r-aarch32**

<img width="617" height="564" alt="image" src="https://github.com/user-attachments/assets/a2ddd8ca-c182-4d51-8064-101aec9e0db6" />

