### PR TITLE
Addresses an issue of multiple invalid loops in the rpmsgfs_mkpath function

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -262,7 +262,7 @@ static void rpmsgfs_mkpath(FAR struct rpmsgfs_mountpt_s *fs,
       int ret;
 
       ret = rpmsgfs_client_stat(fs->handle, fs->fs_root, &buf);
-      if (ret == 0)
+      if (ret <= 0)
         {
           break;
         }


### PR DESCRIPTION
## Summary

This commit addresses an issue of multiple invalid loops in the rpmsgfs_mkpath function under specific cross-system mount scenarios.

Problem Description:
The mount command in the NuttX shell is as follows:

```
mount -t rpmsgfs -o cpu=server,fs=/root/demo/fold /nuttx_fold
```

Running “ls nuttx_fold“ correctly lists the contents of the /root/demo/fold directory on the Linux side. However, if NuttX is compromised by a hacker, the hacker could modify the input parameters of the ls command. Without directory access restrictions implemented on the Linux side, this would allow the hacker to arbitrarily access any directory on the Linux system.

When directory access restrictions are implemented on the Linux side—such as modifying the rpmsgfs driver on the Linux side to return "permission deny" upon detecting unauthorized access—the rpmsgfs_client_stat function in rpmsgfs_mkpath (on the NuttX side) fails to handle this error and continues waiting in the while loop.

## Impact

Only modifies the error handling branch in rpmsgfs_mkpath, with no impact on other functions of the rpmsgfs module.

## Testing

In the Linux shell, create the directory /root/demo/fold, and restrict NuttX from accessing the fold directory itself by configuring the rpmsg_fs driver.
    
In Nuttx shell:

```
mount -t rpmsgfs -o cpu=server,fs=/root/demo/fold /nuttx_fold
ls /nuttx_fold
```
    
Nuttx shell output:
```
proxy> mount -t rpmsgfs -o cpu=server,fs=/root/demo/fold nuttx_fold
proxy> ls
proxy> ls nuttx_fold
nsh: ls: stat failed: 13
```

Signed-off-by: Lijing lijing.ly@bytedance.com
