### PR TITLE
sched/wdog: Improve wdog precision

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -137,11 +137,21 @@ static inline_function void wd_expiration(clock_t ticks)
     {
       wdog = list_first_entry(&g_wdactivelist, struct wdog_s, node);
 
-      /* Check if expected time is expired */
+      /* Check if watchdog has expired;
+       * re-evaluate after updating current ticks if needed
+       */
 
-      if (!clock_compare(wdog->expired, ticks))
+      bool expired = clock_compare(wdog->expired, ticks);
+
+      if (!expired)
         {
-          break;
+          ticks = clock_systime_ticks();
+          expired = clock_compare(wdog->expired, ticks);
+
+          if (!expired)
+            {
+              break;
+            }
         }
 
       /* Remove the watchdog from the head of the list */


### PR DESCRIPTION
 ## Summary

    Currently, wd_timer() obtains the current systick from the input parameter,
    and the watchdog processes the list without updating the systick value.
    This is incorrect, as the systick should continue to increase while the watchdog
    is processing callbacks. This patch addresses the issue by retrieving the
    updated systick value after each watchdog node processing.

## Impact

 Improve the precision of wdog, no function change impact

## Testing

**ostest passed on board a2g-tc397-5v-tft**
```

NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 d198aa4b69 Nov  4 2025 20:59:41 tricore a2g-tc397-5v-tft
nsh> 
nsh> oststest

(......)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
