### PR TITLE
drivers/can: iwatermark ioctl to control multiple frame read

### DIFF
--- a/Documentation/components/drivers/character/can.rst
+++ b/Documentation/components/drivers/character/can.rst
@@ -34,8 +34,12 @@ is used to store the timestamp of the CAN message.
 **Usage Note**: When reading from the CAN driver multiple messages
 may be returned, depending on (1) the size the returned can
 messages, and (2) the size of the buffer provided to receive CAN
-messages. *Never assume that a single message will be returned*...
+messages. *Do not assume that a single message will be returned*...
 if you do this, *you will lose CAN data* under conditions where
-your read buffer can hold more than one small message. Below is an
-example about how you should think of the CAN read operation:
+your read buffer can hold more than one small message. This
+behavior can be controlled by using
+``ioctl(fd, CANIOC_SET_IWATERMARK, &(size_t)0)`` that limits the
+last message to be placed at most zero bytes since buffer start
+(thus only one message is provided).
+
 **Examples**: ``drivers/can/mcp2515.c``.

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -193,6 +193,7 @@ static FAR struct can_reader_s *init_can_reader(FAR struct file *filep)
   DEBUGASSERT(reader != NULL);
 
   nxsem_init(&reader->fifo.rx_sem, 0, 0);
+  reader->rxwatermark = SIZE_MAX;
   filep->f_priv = reader;
 
   return reader;
@@ -489,7 +490,7 @@ static ssize_t can_read(FAR struct file *filep, FAR char *buffer,
               fifo->rx_head = 0;
             }
         }
-      while (fifo->rx_head != fifo->rx_tail);
+      while (fifo->rx_head != fifo->rx_tail && ret < reader->rxwatermark);
 
       if (fifo->rx_head != fifo->rx_tail)
         {
@@ -961,6 +962,22 @@ static int can_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               canerr("dev->cd_transv->cts_ops is NULL!");
               ret = -ENOTTY;
             }
+        }
+        break;
+
+      /* Set read watermark */
+
+      case CANIOC_SET_IWATERMARK:
+        {
+          reader->rxwatermark = *(FAR size_t *)arg;
+        }
+        break;
+
+      /* Set read watermark */
+
+      case CANIOC_GET_IWATERMARK:
+        {
+          *(FAR size_t *)arg = reader->rxwatermark;
         }
         break;
 

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -305,6 +305,29 @@
  *                   is returned with the errno variable set to indicate the
  *                   nature of the error.
  *   Dependencies:   None
+ *
+ * CANIOC_SET_IWATERMARK
+ *   Description:    Set read watermark. This watermark limits number of
+ *                   bytes multiple frames can take in read. The frame is not
+ *                   placed to the provided buffer if it would start after
+ *                   the watermark offset (thus value 0 ensures only one
+ *                   frame to be placed into the buffer). The default valued
+ *                   is SIZE_MAX.
+ *
+ *   Argument:       A pointer to an size_t type with watermark value.
+ *   returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
+ *                   is returned with the errno variable set to indicate the
+ *                   nature of the error.
+ *   Dependencies:   None
+ *
+ * CANIOC_GET_IWATERMARK
+ *   Description:    Get read watermark.
+ *
+ *   Argument:       A pointer to an size_t type for watermark value.
+ *   returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
+ *                   is returned with the errno variable set to indicate the
+ *                   nature of the error.
+ *   Dependencies:   None
  */
 
 #define CANIOC_RTR                _CANIOC(1)
@@ -326,9 +349,11 @@
 #define CANIOC_GET_STATE          _CANIOC(17)
 #define CANIOC_SET_TRANSVSTATE    _CANIOC(18)
 #define CANIOC_GET_TRANSVSTATE    _CANIOC(19)
+#define CANIOC_SET_IWATERMARK     _CANIOC(20)
+#define CANIOC_GET_IWATERMARK     _CANIOC(21)
 
 #define CAN_FIRST                 0x0001         /* First common command */
-#define CAN_NCMDS                 19             /* 20 common commands   */
+#define CAN_NCMDS                 21             /* 21 common commands   */
 
 /* User defined ioctl commands are also supported. These will be forwarded
  * by the upper-half CAN driver to the lower-half CAN driver via the
@@ -796,13 +821,15 @@ struct can_ops_s
  *
  *   The elements of 'cd_ops', and 'cd_priv'
  *
- * The common logic will initialize all semaphores.
+ * The common logic will initialize all semaphores and set 'watermark' to
+ * 'SIZE_MAX'.
  */
 
 struct can_reader_s
 {
   struct list_node     list;
   struct can_rxfifo_s  fifo;             /* Describes receive FIFO */
+  size_t               rxwatermark;
   FAR struct pollfd   *cd_fds;
 };
 


### PR DESCRIPTION

## Summary

This adds ioctl to NuttX's CAN that allows control of the read behavior.

## Impact

The old behavior of reading multiple frames with a single read is preserved. The new ioctl just adds the ability to limit it. That includes not only disabilities but also more versatile limitations based on the size, which allows for multiple frames to be read.

## Testing

Tested on a custom SAMv7 board.

```c
  int fd = open("/dev/can0", O_RDWR);
  if (fd < 0) {
    syslog(LOG_ERR, "Failed to open can: %s", strerror(errno));
    return -1;
  }
  size_t iw = SIZE_MAX;
  ioctl(fd, CANIOC_SET_IWATERMARK, &iw);
  while (true) {
    sleep(1); /* Give us some time to use cansend multiple times*/
    struct can_msg_s frame;
    size_t n = read(fd, &frame, sizeof frame);
    syslog(LOG_INFO, "Read %d id%d", n, frame.cm_hdr.ch_id);
  }
```
```
for i in {0..4}; do cansend can0 "00$i##0"; done
```

For `iw == SIZE_MAX`:
```
[1762352028.612600] startup_main: Read 4 id0
[1762352029.613000] startup_main: Read 16 id1
```
for `iw == 0`:
```
[1762352153.185100] startup_main: Read 4 id0
[1762352154.185500] startup_main: Read 4 id1
[1762352155.185900] startup_main: Read 4 id2
[1762352156.186300] startup_main: Read 4 id3
[1762352157.186700] startup_main: Read 4 id4
```
for `iw == 5`:
```
[1762352293.124000] startup_main: Read 4 id0
[1762352294.124400] startup_main: Read 8 id1
[1762352295.124900] startup_main: Read 8 id3
```