### PR TITLE
boards/esp32s3_lan9250.c: fix some unused variable build warning

### DIFF
--- a/boards/xtensa/esp32s3/common/src/esp32s3_lan9250.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_lan9250.c
@@ -187,8 +187,11 @@ static void lan9250_disable(const struct lan9250_lower_s *lower)
 static int lan9250_getmac(const struct lan9250_lower_s *lower, uint8_t *mac)
 {
   int fd;
-  int i;
   int ret;
+#ifndef CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES_FOUR
+  int i;
+  uint8_t tmp;
+#endif
 
   struct efuse_param_s param;
   struct efuse_desc_s mac_addr =
@@ -228,7 +231,7 @@ static int lan9250_getmac(const struct lan9250_lower_s *lower, uint8_t *mac)
   mac[5] += 3;
 #else
   mac[5] += 1;
-  uint8_t tmp = mac[0];
+  tmp = mac[0];
   for (i = 0; i < 64; i++)
     {
       mac[0] = tmp | 0x02;


### PR DESCRIPTION
## Summary
boards/esp32s3_lan9250.c: fix some unused variable build warning

```
src/esp32s3_lan9250.c: In function 'lan9250_getmac':
src/esp32s3_lan9250.c:190:7: warning: unused variable 'i' [-Wunused-variable]

```
## Impact
New Feature/Change: No
User Impact: No
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
Build based on the configuration defconfig: esp32s3-devkit/eth_lan9250
