### PR TITLE
sched/wdog: Use list_in_list() to detect active watchdogs

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -39,7 +39,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define WDOG_ISACTIVE(w)   ((w)->func != NULL)
+#define WDOG_ISACTIVE(w)   (list_in_list(&((w)->node)))
 
 /* The maximum delay tick are supposed to be CLOCK_MAX >> 1.
  * However, if there are expired wdog timers in the wdog queue,

--- a/sched/wdog/wd_cancel.c
+++ b/sched/wdog/wd_cancel.c
@@ -86,9 +86,6 @@ int wd_cancel(FAR struct wdog_s *wdog)
 
   list_delete(&wdog->node);
 
-  /* Mark the watchdog inactive */
-
-  wdog->func = NULL;
   spin_unlock_irqrestore(&g_wdspinlock, flags);
 
   if (head)

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -162,7 +162,6 @@ static inline_function void wd_expiration(clock_t ticks)
 
       func = wdog->func;
       arg  = wdog->arg;
-      wdog->func = NULL;
 
       /* Execute the watchdog function */
 
@@ -310,7 +309,6 @@ int wd_start_abstick(FAR struct wdog_s *wdog, clock_t ticks,
     {
       reassess |= list_is_head(&g_wdactivelist, &wdog->node);
       list_delete(&wdog->node);
-      wdog->func = NULL;
     }
 
   reassess |= wd_insert(wdog, ticks, wdentry, arg);
@@ -337,7 +335,6 @@ int wd_start_abstick(FAR struct wdog_s *wdog, clock_t ticks,
   if (WDOG_ISACTIVE(wdog))
     {
       list_delete(&wdog->node);
-      wdog->func = NULL;
     }
 
   wd_insert(wdog, ticks, wdentry, arg);


### PR DESCRIPTION
 ## Summary
        
Use list_in_list() to determine whether a watchdog is active,
eliminating the need to set the watchdog function pointer to NULL
as an indicator of inactivity

## Impact

Improves the watchdog performnce; no functional changes to NuttX.

## Testing

**ostest passed on board a2g-tc397-5v-tft**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 3fbd4c686b Nov  6 2025 19:02:31 tricore a2g-tc397-5v-tft
nsh> 
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```
