### PR TITLE
 arch/arm: Solving the ghs compiler not recognizing 0b prefix representing binary

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -61,6 +61,7 @@ endif()
 
 add_link_options(-entry=__start)
 add_compile_options(--no_commons -Wall -Wshadow -Wundef -nostdlib)
+add_compile_options(--option=305)
 
 if(CONFIG_DEBUG_CUSTOMOPT)
   add_compile_options(${CONFIG_DEBUG_OPTLEVEL})


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

To resolve the issue where the GHS compiler fails to recognize the "0b" prefix for binary literals, it is important to note that without specific compiler options, macros like 0b0001 will result in compilation errors. This problem occurs because the GHS compiler does not inherently support the "0b" prefix for binary representation.

## Impact

Solving the ghs compiler not recognizing "0b" prefix representing binary.

## Testing
ostest passed on board a2g-tc397-5v-tft
```nsh>
nsh> uname -a
NuttX 0.0.0 5a8f572ad2-dirty Nov  8 2025 21:44:04 tricore a2g-tc397-5v-tft
nsh>
nsh>
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```