### PR TITLE
libs/libc: Fix Kconfig issue for ARMv8-R assembly implementations of memcpy and memset

### DIFF
--- a/libs/libc/machine/arm/armv8-r/Kconfig
+++ b/libs/libc/machine/arm/armv8-r/Kconfig
@@ -8,9 +8,9 @@ config ARMV8R_STRING_FUNCTION
 	default n
 	depends on ARCH_TOOLCHAIN_GNU
 	select ARMV8R_MEMCHR
-	select ARMV8R_MEMCPY
+	select ARMV8R_MEMCPY if ARM_NEON
 	select ARMV8R_MEMMOVE
-	select ARMV8R_MEMSET
+	select ARMV8R_MEMSET if ARM_NEON
 	select ARMV8R_STRCMP
 	select ARMV8R_STRLEN
 
@@ -19,6 +19,7 @@ config ARMV8R_MEMCHR
 	default n
 	select LIBC_ARCH_MEMCHR
 	depends on ARCH_TOOLCHAIN_GNU
+	depends on ARM_NEON
 	---help---
 		Enable optimized ARMv8-R specific memchr() library function
 


### PR DESCRIPTION
 ## Summary

Fix an issue on ARMv8-R where NEON is not supported.
When NEON is disabled, the assembly-optimized implementations
of memset and memcpy should not be used, **since the assembly code
relies on NEON instructions**.

## Impact

 Fix armv8-r arch related issue, no impact to other nuttx functions

## Testing

**ostest passed on board  fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 52b8808582 Nov  7 2025 16:45:04 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         7        5
mxordblk  7fe1f10  7febf38
uordblks     b60c     b60c
fordblks  7fee730  7fee730

user_main: vfork() test
[ 4] ostest: arm_fork: fork context [0x2000f690]:
[ 4] ostest: arm_fork:   r4:20003860 r5:00000000 r6:00000000 r7:00000000
[ 4] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[ 4] ostest: arm_fork:   r11:00000000 sp:2000f6b8 lr:00055c9c
[ 4] ostest: nxtask_setup_fork: Child priority=100 start=0x55c9c
[ 4] ostest: nxtask_setup_fork: parent=0x2000d330, returning child=0x2000f768
[ 4] ostest: arm_fork: TCBs: Parent=0x2000d330 Child=0x2000f768
[ 4] ostest: arm_fork: Parent: stackutil:152
[ 4] ostest: arm_fork: Old stack top:2000f750 SP:2000f6b8 FP:00000000
[ 4] ostest: arm_fork: New stack top:20013a50 SP:200139b8 FP:00000000
[ 4] ostest: nxtask_start_fork: Starting Child TCB=0x2000f768
[ 4] ostest: nxtask_activate: ostest pid=85,TCB=0x2000f768
[85] ostest: nxtask_exit: ostest pid=85,TCB=0x2000f768
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         1        5
mxordblk  7ff08a8  7febf38
uordblks     9494     b52c
fordblks  7ff08a8  7fee810
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d330
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af10
nsh>
```

**ostest passed on board a2g-tc397-5v-tft**

```
NuttShell (NSH)
nsh> 
nsh> uname -a 
NuttX 0.0.0 52b8808582-dirty Nov  7 2025 16:47:22 tricore a2g-tc397-5v-tft
nsh> 
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     5e24     553c
fordblks    22fd8    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```


