### PR TITLE
sched/wdog: Fix wd_start() boundary check for WDOG_MAX_DELAY

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -386,7 +386,7 @@ int wd_start(FAR struct wdog_s *wdog, clock_t delay,
 {
   /* Ensure delay is within the range the wdog can handle. */
 
-  if (delay > WDOG_MAX_DELAY)
+  if (delay >= WDOG_MAX_DELAY)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
 ## Summary

The current implementation allows the delay passed to wd_start() to be
equal to WDOG_MAX_DELAY. However, since clock_delay2abstick() internally
increments the delay by one tick, using a delay equal to WDOG_MAX_DELAY
will cause an overflow and make the clock comparison invalid.

This patch fixes the issue by disallowing the delay to be equal to
 WDOG_MAX_DELAY.

Depends on: https://github.com/apache/nuttx-apps/pull/3209.

## Impact

Correct the bug for wd_start implementation, no functional impact to Nuttx

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 f15193ffcc Nov  8 2025 12:27:13 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
[57] ostest: dump_assert_info: Current Version: NuttX  0.0.0 f15193ffcc Nov  8 2025 12:27:13 arm
[57] ostest: dump_assert_info: Assertion failed : at file: /testing/ostest/wdog.c:302 task: ostest process: ostest 0x42100
[57] ostest: up_dump_register: R0: 20002680 R1: 0000012e R2: 00000001  R3: 00000000
[57] ostest: up_dump_register: R4: 00000000 R5: 00000000 R6: 00000000  R7: 00000000
[57] ostest: up_dump_register: R8: 00000000 SB: 00000000 SL: 00000000  FP: 00000000
[57] ostest: up_dump_register: IP: c3500000 SP: 20011688 LR: 0000edb8  PC: 0000edb8
[57] ostest: up_dump_register: CPSR: 600000df
[57] ostest: pthread_completejoin: pid=60 exit_value=0xffffffff
[57] ostest: pthread_completejoin: pid=59 exit_value=0xffffffff
[57] ostest: pthread_completejoin: pid=58 exit_value=0xffffffff
[57] ostest: group_drop: Keep group 0x2000d400 (waiters > 0)
[57] ostest: nxtask_exit: ostest pid=57,TCB=0x20011910
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af10
nsh> 
```
