### PR TITLE
sched_lock: remove the check for whether tcb is NULL

### DIFF
--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -76,13 +76,13 @@ void sched_lock(void)
        * integer type.
        */
 
-      DEBUGASSERT(rtcb == NULL || rtcb->lockcount < MAX_LOCK_COUNT);
+      DEBUGASSERT(rtcb && rtcb->lockcount < MAX_LOCK_COUNT);
 
       /* A counter is used to support locking. This allows nested lock
        * operations on this thread (on any CPU)
        */
 
-      if (rtcb != NULL && rtcb->lockcount++ == 0)
+      if (rtcb->lockcount++ == 0)
         {
 #if (CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0) || \
     defined(CONFIG_SCHED_INSTRUMENTATION_PREEMPTION)

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -64,13 +64,13 @@ void sched_unlock(void)
 
       /* rtcb may be NULL only during early boot-up phases */
 
-      DEBUGASSERT(rtcb == NULL || rtcb->lockcount > 0);
+      DEBUGASSERT(rtcb && rtcb->lockcount > 0);
 
       /* Check if the lock counter has decremented to zero. If so,
        * then pre-emption has been re-enabled.
        */
 
-      if (rtcb != NULL && rtcb->lockcount == 1)
+      if (rtcb->lockcount == 1)
         {
           irqstate_t flags = enter_critical_section_wo_note();
           FAR struct tcb_s *ptcb;


### PR DESCRIPTION


## Summary

Remove Redundant Checks

## Impact
sched

## Testing
test with ./tools/configure.sh -l qemu-armv8a:nsh

ostest

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7c21000  7c21000
ordblks         7        6
mxordblk  7c06af8  7c10c30
uordblks     c2c0     c2c8
fordblks  7c14d40  7c14d38

user_main: vfork() test
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7c21000  7c21000
ordblks         2        5
mxordblk  7c16fb8  7c12c78
uordblks     a018     c150
fordblks  7c16fe8  7c14eb0
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 