### PR TITLE
arch/risc-v/mpfs: Remove strict CAN frame data length check.

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_can.c
+++ b/arch/risc-v/src/mpfs/mpfs_can.c
@@ -731,16 +731,6 @@ static int mpfs_transmit(struct netdev_lowerhalf_s *dev,
       return -EINVAL;
     }
 
-  /* Validate packet size first, like reference driver */
-
-  if (netpkt_getdatalen(dev, pkt) != sizeof(struct can_frame))
-    {
-      nerr("Invalid packet size: %u bytes (expected %zu)\n",
-           netpkt_getdatalen(dev, pkt), sizeof(struct can_frame));
-      netpkt_free(dev, pkt, NETPKT_TX);
-      return -EINVAL;
-    }
-
   /* Get direct pointer to CAN frame data */
 
   struct can_frame *frame =


### PR DESCRIPTION
## Summary

In MSS CAN transmit function, the check of net pkt data len is not neccessary. Since there are cases that the pkt len can exceed the expected 16 bytes of `can_frame` but the pkt is still valid. Such a case is when `CONFIG_NET_CAN_RAW_TX_DEADLINE` is enabled which has pkt len to become 32 bytes due to cmsghdr overhead.

## Impact

arch/risc-v/mpfs/mss_can.c

## Testing

Build Host: Ubuntu 22.04
Target: icicle:hwtest & 3 custom HW designs.

I have a test program called canfd_test which basically sends different types of payload with randomized STD/EXT CAN ID and size. It supports both CANFD and classical CAN test. For this driver, I use only classical CAN test.
On the other side, I use https://www.icpdas.com/en/product/I-7565M-FD to echo back what it receives

```
canfd_test --classic-only --filter-test can0


>>>>> SOCKETCAN TEST <<<<<

SocketCAN opened


=> Classical CAN test

==> Current bitrate 100 Kbps
===> Current EXT CAN ID 0x13110060
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0x8d 0xbf 0xf8 0xba
====> transmit CAN frame with payload size 4, payload 0x8d 0xbf 0xf8 0xba
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0x96 0x4e 0xda 0x54
====> transmit CAN frame with payload size 4, payload 0x96 0x4e 0xda 0x54
====> transmit CAN frame with payload size 8, payload 0x1a 0x16 0x4b 0xa1 0xb7 0x8e 0xcb 0xb8
===> Current STD CAN ID 0x0000041a
====> transmit CAN frame with payload size 8, payload 0x1a 0x16 0x4b 0xa1 0xb7 0x8e 0xcb 0xb8
====> transmit CAN frame with payload size 3, payload 0x9e 0xdd 0xbc
====> transmit CAN frame with payload size 7, payload 0x22 0xa5 0x2d 0x3c 0x8b 0x87 0x4e
====> transmit CAN frame with payload size 7, payload 0x22 0xa5 0x2d 0x3c 0x8b 0x87 0x4e
====> transmit CAN frame with payload size 3, payload 0xa6 0x6d 0x9e
====> transmit CAN frame with payload size 7, payload 0x2a 0x34 0x0e 0xd6 0x5f 0x80 0xd1
====> transmit CAN frame with payload size 7, payload 0x2a 0x34 0x0e 0xd6 0x5f 0x80 0xd1
====> transmit CAN frame with payload size 2, payload 0xae 0xfc
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 2, payload 0xae 0xfc
====> transmit CAN frame with payload size 6, payload 0x32 0xc4 0xf0 0x70 0x34 0x79
====> transmit CAN frame with payload size 2, payload 0xb6 0x8b
====> transmit CAN frame with payload size 2, payload 0xb6 0x8b
====> transmit CAN frame with payload size 6, payload 0x3a 0x53 0xd2 0x0b 0x08 0x71
====> transmit CAN frame with payload size 1, payload 0xbe
====> transmit CAN frame with payload size 1, payload 0xbe
====> transmit CAN frame with payload size 5, payload 0x42 0xe2 0xb4 0xa5 0xdc
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 5, payload 0x42 0xe2 0xb4 0xa5 0xdc
====> transmit CAN frame with payload size 1, payload 0xc6
====> transmit CAN frame with payload size 5, payload 0x4a 0x71 0x96 0x3f 0xb1
====> transmit CAN frame with payload size 5, payload 0x4a 0x71 0x96 0x3f 0xb1
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0x53 0x01 0x77 0xda
====> transmit CAN frame with payload size 8, payload 0xd7 0xc8 0xe8 0x27 0x6f 0xd8 0x24 0xf5

==> Current bitrate 250 Kbps
===> Current EXT CAN ID 0x13110060
====> transmit CAN frame with payload size 4, payload 0x5b 0x90 0x59 0x74
====> transmit CAN frame with payload size 8, payload 0xdf 0x57 0xca 0xc1 0x43 0xd0 0xa7 0x74
====> transmit CAN frame with payload size 8, payload 0xdf 0x57 0xca 0xc1 0x43 0xd0 0xa7 0x74
====> transmit CAN frame with payload size 3, payload 0x63 0x1f 0x3b
====> transmit CAN frame with payload size 7, payload 0xe7 0xe7 0xac 0x5c 0x17 0xc9 0x2a
====> transmit CAN frame with payload size 7, payload 0xe7 0xe7 0xac 0x5c 0x17 0xc9 0x2a
====> transmit CAN frame with payload size 3, payload 0x6b 0xae 0x1d
====> transmit CAN frame with payload size 3, payload 0x6b 0xae 0x1d
===> Current STD CAN ID 0x0000041a
====> transmit CAN frame with payload size 7, payload 0xef 0x76 0x8e 0xf6 0xec 0xc2 0xad
====> transmit CAN frame with payload size 2, payload 0x73 0x3e
====> transmit CAN frame with payload size 2, payload 0x73 0x3e
====> transmit CAN frame with payload size 6, payload 0xf7 0x05 0x70 0x90 0xc0 0xbb
====> transmit CAN frame with payload size 6, payload 0xf7 0x05 0x70 0x90 0xc0 0xbb
====> transmit CAN frame with payload size 2, payload 0x7b 0xcd
====> transmit CAN frame with payload size 6, payload 0xff 0x94 0x51 0x2b 0x94 0xb3
====> transmit CAN frame with payload size 6, payload 0xff 0x94 0x51 0x2b 0x94 0xb3
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 1, payload 0x84
====> transmit CAN frame with payload size 1, payload 0x84
====> transmit CAN frame with payload size 5, payload 0x08 0x24 0x33 0xc5 0x68
====> transmit CAN frame with payload size 1, payload 0x8c
====> transmit CAN frame with payload size 1, payload 0x8c
====> transmit CAN frame with payload size 5, payload 0x10 0xb3 0x15 0x5f 0x3d
====> transmit CAN frame with payload size 5, payload 0x10 0xb3 0x15 0x5f 0x3d
====> transmit CAN frame with payload size 0, payload
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 4, payload 0x18 0x42 0xf7 0xfa
====> transmit CAN frame with payload size 4, payload 0x18 0x42 0xf7 0xfa
====> transmit CAN frame with payload size 8, payload 0x9c 0x0a 0x68 0x47 0xfb 0x1a 0x00 0xb1
====> transmit CAN frame with payload size 8, payload 0x9c 0x0a 0x68 0x47 0xfb 0x1a 0x00 0xb1
====> transmit CAN frame with payload size 4, payload 0x20 0xd1 0xd9 0x94
====> transmit CAN frame with payload size 8, payload 0xa4 0x99 0x49 0xe1 0xcf 0x13 0x83 0x31
====> transmit CAN frame with payload size 8, payload 0xa4 0x99 0x49 0xe1 0xcf 0x13 0x83 0x31
====> transmit CAN frame with payload size 3, payload 0x28 0x61 0xba

==> Current bitrate 500 Kbps
===> Current EXT CAN ID 0x13110060
====> transmit CAN frame with payload size 3, payload 0x30 0xf0 0x9c
====> transmit CAN frame with payload size 3, payload 0x30 0xf0 0x9c
====> transmit CAN frame with payload size 7, payload 0xb4 0xb8 0x0d 0x16 0x78 0x04 0x8a
====> transmit CAN frame with payload size 7, payload 0xb4 0xb8 0x0d 0x16 0x78 0x04 0x8a
====> transmit CAN frame with payload size 2, payload 0x39 0x7f
====> transmit CAN frame with payload size 6, payload 0xbd 0x47 0xef 0xb0 0x4c 0xfd
====> transmit CAN frame with payload size 6, payload 0xbd 0x47 0xef 0xb0 0x4c 0xfd
====> transmit CAN frame with payload size 2, payload 0x41 0x0e
===> Current STD CAN ID 0x0000041a
====> transmit CAN frame with payload size 2, payload 0x41 0x0e
====> transmit CAN frame with payload size 6, payload 0xc5 0xd6 0xd1 0x4b 0x20 0xf5
====> transmit CAN frame with payload size 1, payload 0x49
====> transmit CAN frame with payload size 1, payload 0x49
====> transmit CAN frame with payload size 5, payload 0xcd 0x65 0xb2 0xe5 0xf5
====> transmit CAN frame with payload size 5, payload 0xcd 0x65 0xb2 0xe5 0xf5
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 5, payload 0xd5 0xf5 0x94 0x7f 0xc9
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 5, payload 0xd5 0xf5 0x94 0x7f 0xc9
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0xdd 0x84 0x76 0x1a
====> transmit CAN frame with payload size 8, payload 0x61 0x4b 0xe7 0x67 0x87 0x5c 0xdc 0x6e
====> transmit CAN frame with payload size 8, payload 0x61 0x4b 0xe7 0x67 0x87 0x5c 0xdc 0x6e
====> transmit CAN frame with payload size 4, payload 0xe5 0x13 0x58 0xb4
====> transmit CAN frame with payload size 4, payload 0xe5 0x13 0x58 0xb4
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 8, payload 0x69 0xdb 0xc9 0x01 0x5b 0x55 0x5f 0xee
====> transmit CAN frame with payload size 3, payload 0xed 0xa2 0x3a
====> transmit CAN frame with payload size 3, payload 0xed 0xa2 0x3a
====> transmit CAN frame with payload size 7, payload 0x72 0x6a 0xab 0x9b 0x30 0x4d 0xe3
====> transmit CAN frame with payload size 3, payload 0xf6 0x32 0x1b
====> transmit CAN frame with payload size 3, payload 0xf6 0x32 0x1b
====> transmit CAN frame with payload size 7, payload 0x7a 0xf9 0x8c 0x36 0x04 0x46 0x66
====> transmit CAN frame with payload size 7, payload 0x7a 0xf9 0x8c 0x36 0x04 0x46 0x66

==> Current bitrate 1000 Kbps
===> Current EXT CAN ID 0x13110060
====> transmit CAN frame with payload size 6, payload 0x82 0x88 0x6e 0xd0 0xd8 0x3f
====> transmit CAN frame with payload size 1, payload 0x06
====> transmit CAN frame with payload size 1, payload 0x06
====> transmit CAN frame with payload size 6, payload 0x8a 0x18 0x50 0x6a 0xac 0x37
====> transmit CAN frame with payload size 6, payload 0x8a 0x18 0x50 0x6a 0xac 0x37
====> transmit CAN frame with payload size 1, payload 0x0e
====> transmit CAN frame with payload size 5, payload 0x92 0xa7 0x32 0x05 0x81
====> transmit CAN frame with payload size 5, payload 0x92 0xa7 0x32 0x05 0x81
===> Current STD CAN ID 0x0000041a
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 5, payload 0x9a 0x36 0x14 0x9f 0x55
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0xa2 0xc5 0xf5 0x39
====> transmit CAN frame with payload size 4, payload 0xa2 0xc5 0xf5 0x39
====> transmit CAN frame with payload size 8, payload 0x27 0x8d 0x66 0x87 0x13 0x9e 0xb8 0x2a
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 4, payload 0xab 0x55 0xd7 0xd4
====> transmit CAN frame with payload size 4, payload 0xab 0x55 0xd7 0xd4
====> transmit CAN frame with payload size 8, payload 0x2f 0x1c 0x48 0x21 0xe8 0x97 0x3b 0xaa
====> transmit CAN frame with payload size 8, payload 0x2f 0x1c 0x48 0x21 0xe8 0x97 0x3b 0xaa
====> transmit CAN frame with payload size 3, payload 0xb3 0xe4 0xb9
====> transmit CAN frame with payload size 7, payload 0x37 0xac 0x2a 0xbb 0xbc 0x8f 0xbf
====> transmit CAN frame with payload size 7, payload 0x37 0xac 0x2a 0xbb 0xbc 0x8f 0xbf
====> transmit CAN frame with payload size 2, payload 0xbb 0x73
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 2, payload 0xbb 0x73
====> transmit CAN frame with payload size 7, payload 0x3f 0x3b 0x0c 0x56 0x90 0x88 0x42
====> transmit CAN frame with payload size 2, payload 0xc3 0x02
====> transmit CAN frame with payload size 2, payload 0xc3 0x02
====> transmit CAN frame with payload size 6, payload 0x47 0xca 0xed 0xf0 0x64 0x81
====> transmit CAN frame with payload size 1, payload 0xcb
====> transmit CAN frame with payload size 1, payload 0xcb
====> transmit CAN frame with payload size 6, payload 0x4f 0x59 0xcf 0x8a 0x39 0x79

______________________________________________________


=> CAN ID filtering test (Classical CAN). 1st and 2nd ID are in acceptance range and 3rd is out of range 
Range filter configured
Mask filter configured

==> Current bitrate 500 Kbps
===> Current EXT CAN ID 0x0000041a
====> transmit CAN frame with payload size 1, payload 0xd3
====> transmit CAN frame with payload size 5, payload 0x57 0xe9 0xb1 0x25 0x0d
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 0, payload
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 5, payload 0x60 0x78 0x93 0xbf 0xe1
====> transmit CAN frame with payload size 5, payload 0x60 0x78 0x93 0xbf 0xe1
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0x68 0x07 0x75 0x59
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 4, payload 0x68 0x07 0x75 0x59
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 2, payload 0x88 0x44
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 0, payload
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 7, payload 0xc9 0xbe 0x0a 0x95 0xa8 0x0c 0xfa
Nothing received due to filtering. OK

==> Current bitrate 1000 Kbps
===> Current EXT CAN ID 0x0000041a
====> transmit CAN frame with payload size 0, payload
====> transmit CAN frame with payload size 4, payload 0xf2 0x8a 0x73 0x99
====> transmit CAN frame with payload size 8, payload 0x76 0x52 0xe4 0xe6 0xb8 0x64 0x4d 0x60
====> transmit CAN frame with payload size 8, payload 0x76 0x52 0xe4 0xe6 0xb8 0x64 0x4d 0x60
===> Current STD CAN ID 0x00000221
====> transmit CAN frame with payload size 3, payload 0xfa 0x1a 0x55
====> transmit CAN frame with payload size 3, payload 0xfa 0x1a 0x55
====> transmit CAN frame with payload size 8, payload 0x7e 0xe1 0xc6 0x81 0x8c 0x5d 0xd0 0xe0
====> transmit CAN frame with payload size 3, payload 0x03 0xa9 0x37
===> Current STD CAN ID 0x00000232
====> transmit CAN frame with payload size 3, payload 0x03 0xa9 0x37
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 1, payload 0x23
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 8, payload 0x44 0x23 0x45 0xa0 0x18 0x9f 0xac 0x9c
Nothing received due to filtering. OK
====> transmit CAN frame with payload size 5, payload 0x64 0x60 0xcc 0x0a 0x69
Nothing received due to filtering. OK
Filters cleared

______________________________________________________

TEST RESULT: 152 passed, 0 failed
```