### PR TITLE
sched/sched_lock: remove null pointer check of rtcb

### DIFF
--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -76,7 +76,7 @@ void sched_lock(void)
        * integer type.
        */
 
-      DEBUGASSERT(rtcb && rtcb->lockcount < MAX_LOCK_COUNT);
+      DEBUGASSERT(rtcb->lockcount < MAX_LOCK_COUNT);
 
       /* A counter is used to support locking. This allows nested lock
        * operations on this thread (on any CPU)

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -64,7 +64,7 @@ void sched_unlock(void)
 
       /* rtcb may be NULL only during early boot-up phases */
 
-      DEBUGASSERT(rtcb && rtcb->lockcount > 0);
+      DEBUGASSERT(rtcb->lockcount > 0);
 
       /* Check if the lock counter has decremented to zero. If so,
        * then pre-emption has been re-enabled.


### PR DESCRIPTION
## Summary

Reverts apache/nuttx#17300

sched/sched_lock: remove null pointer check of rtcb

In previous commits to xiaomi, runtime null pointer checks for RTCB were removed.
This could cause `sched_lock/unlock` exceptions when `DEBUG_ASSERTIONS` was disabled.
In this commit, we removed all RTCB checks to improve performance by 1 comparison cycle,
References to null pointers in the RTCB will rely on hardware exception or MPU/MMU protection.


```
| commit d94cb53d6cde6a999d862ae45e1fcd3692675cb4 (HEAD, origin/master, origin/HEAD)
| Author: hujun5 <hujun5@xiaomi.com>
| Date:   Thu Feb 6 15:06:00 2025 +0800
|
|     sched_lock: remove the check for whether tcb is NULL
|
|     Remove Redundant Checks
|
|     Signed-off-by: hujun5 <hujun5@xiaomi.com>
```

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Testing

sim/nsh ostest ; sabre-6quad/smp