### PR TITLE
arch/arm/{nrf52|nrf53|nrf91}/i2c: fix I2C bus getting stuck during read

### DIFF
--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -369,47 +369,14 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
           regval = priv->dcnt;
           nrf52_i2c_putreg(priv, NRF52_TWIM_TXDMAXCNT_OFFSET, regval);
 
+          /* Shortcut from LASTTX to STOP */
+
+          nrf52_i2c_putreg(priv, NRF52_TWIM_SHORTS_OFFSET,
+                           TWIM_SHORTS_LASTTX_STOP);
+
           /* Start TX sequence */
 
           nrf52_i2c_putreg(priv, NRF52_TWIM_TASKS_STARTTX_OFFSET, 1);
-
-          /* Wait for last TX event */
-
-#ifdef CONFIG_I2C_POLLED
-          while (nrf52_i2c_getreg(priv,
-                                  NRF52_TWIM_EVENTS_LASTTX_OFFSET) != 1);
-          while (1)
-            {
-              regval = nrf52_i2c_getreg(priv,
-                                        NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
-              if (regval != 0)
-                {
-                  i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-                  ret = -1;
-                  nrf52_i2c_putreg(priv,
-                                  NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
-                  goto errout;
-                }
-
-              if (nrf52_i2c_getreg(priv,
-                                  NRF52_TWIM_EVENTS_LASTTX_OFFSET) == 1)
-                {
-                  break;
-                }
-            }
-
-          /* Clear event */
-
-          nrf52_i2c_putreg(priv, NRF52_TWIM_EVENTS_LASTTX_OFFSET, 0);
-#else
-          nxsem_wait(&priv->sem_isr);
-
-          if (priv->status < 0)
-            {
-              ret = priv->status;
-              goto errout;
-            }
-#endif
         }
       else
         {
@@ -424,46 +391,51 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
           regval = priv->dcnt;
           nrf52_i2c_putreg(priv, NRF52_TWIM_RXDMAXCNT_OFFSET, regval);
 
+          /* Shortcuts from LASTRX to STOP */
+
+          nrf52_i2c_putreg(priv, NRF52_TWIM_SHORTS_OFFSET,
+                           TWIM_SHORTS_LASTRX_STOP);
+
           /* Start RX sequence */
 
           nrf52_i2c_putreg(priv, NRF52_TWIM_TASKS_STARTRX_OFFSET, 1);
+        }
 
-          /* Wait for last RX done */
+      /* Wait for stop event */
 
 #ifdef CONFIG_I2C_POLLED
-        while (1)
-          {
-            regval = nrf52_i2c_getreg(priv,
-                                      NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
-            if (regval != 0)
-              {
-                i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-                ret = -1;
-                nrf52_i2c_putreg(priv,
-                                 NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
-                goto errout;
-              }
-
-            if (nrf52_i2c_getreg(priv,
-                                 NRF52_TWIM_EVENTS_LASTRX_OFFSET) == 1)
-              {
-                break;
-              }
-          }
-
-          /* Clear event */
-
-          nrf52_i2c_putreg(priv, NRF52_TWIM_EVENTS_LASTRX_OFFSET, 0);
-#else
-          nxsem_wait(&priv->sem_isr);
-
-          if (priv->status < 0)
+      while (1)
+        {
+          regval = nrf52_i2c_getreg(priv,
+                                    NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
+          if (regval != 0)
             {
-              ret = priv->status;
+              i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
+              ret = -1;
+              nrf52_i2c_putreg(priv,
+                                NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
               goto errout;
             }
-#endif
+
+          if (nrf52_i2c_getreg(priv,
+                                NRF52_TWIM_EVENTS_STOPPED_OFFSET) == 1)
+            {
+              break;
+            }
         }
+
+      /* Clear event */
+
+      nrf52_i2c_putreg(priv, NRF52_TWIM_EVENTS_STOPPED_OFFSET, 0);
+#else
+      nxsem_wait(&priv->sem_isr);
+
+      if (priv->status < 0)
+        {
+          ret = priv->status;
+          goto errout;
+        }
+#endif
 
       /* Next message */
 
@@ -471,46 +443,6 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
       priv->msgv += 1;
     }
   while (priv->msgc > 0);
-
-  /* TWIM stop */
-
-  nrf52_i2c_putreg(priv, NRF52_TWIM_TASKS_STOP_OFFSET, 1);
-
-  /* Wait for stop event */
-
-#ifdef CONFIG_I2C_POLLED
-  while (1)
-    {
-      regval = nrf52_i2c_getreg(priv,
-                                NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
-      if (regval != 0)
-        {
-          i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-          ret = -1;
-          nrf52_i2c_putreg(priv,
-                           NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
-          goto errout;
-        }
-
-      if (nrf52_i2c_getreg(priv,
-                           NRF52_TWIM_EVENTS_STOPPED_OFFSET) == 1)
-        {
-          break;
-        }
-    }
-
-  /* Clear event */
-
-  nrf52_i2c_putreg(priv, NRF52_TWIM_EVENTS_STOPPED_OFFSET, 0);
-#else
-  nxsem_wait(&priv->sem_isr);
-
-  if (priv->status < 0)
-    {
-      ret = priv->status;
-      goto errout;
-    }
-#endif
 
 errout:
 #ifndef CONFIG_NRF52_I2C_MASTER_DISABLE_NOSTART
@@ -569,10 +501,6 @@ static int nrf52_i2c_isr(int irq, void *context, void *arg)
         {
           i2cinfo("I2C LASTTX\n");
 
-          /* TX done */
-
-          nxsem_post(&priv->sem_isr);
-
           /* Clear event */
 
           nrf52_i2c_putreg(priv, NRF52_TWIM_EVENTS_LASTTX_OFFSET, 0);
@@ -585,10 +513,6 @@ static int nrf52_i2c_isr(int irq, void *context, void *arg)
       if (nrf52_i2c_getreg(priv, NRF52_TWIM_EVENTS_LASTRX_OFFSET) == 1)
         {
           i2cinfo("I2C LASTRX\n");
-
-          /* RX done */
-
-          nxsem_post(&priv->sem_isr);
 
           /* Clear event */
 
@@ -694,8 +618,7 @@ static int nrf52_i2c_init(struct nrf52_i2c_priv_s *priv)
 #ifndef CONFIG_I2C_POLLED
   /* Enable I2C interrupts */
 
-  regval = (TWIM_INT_LASTRX | TWIM_INT_LASTTX | TWIM_INT_STOPPED |
-            TWIM_INT_ERROR);
+  regval = (TWIM_INT_STOPPED | TWIM_INT_ERROR);
   nrf52_i2c_putreg(priv, NRF52_TWIM_INTEN_OFFSET, regval);
 
   /* Attach error and event interrupts to the ISRs */

--- a/arch/arm/src/nrf91/nrf91_i2c.c
+++ b/arch/arm/src/nrf91/nrf91_i2c.c
@@ -419,47 +419,14 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
           regval = priv->dcnt;
           nrf91_i2c_putreg(priv, NRF91_TWIM_TXDMAXCNT_OFFSET, regval);
 
+          /* Shortcut from LASTTX to STOP */
+
+          nrf91_i2c_putreg(priv, NRF91_TWIM_SHORTS_OFFSET,
+                           TWIM_SHORTS_LASTTX_STOP);
+
           /* Start TX sequence */
 
           nrf91_i2c_putreg(priv, NRF91_TWIM_TASKS_STARTTX_OFFSET, 1);
-
-          /* Wait for last TX event */
-
-#ifdef CONFIG_I2C_POLLED
-          while (nrf91_i2c_getreg(priv,
-                                  NRF91_TWIM_EVENTS_LASTTX_OFFSET) != 1);
-          while (1)
-            {
-              regval = nrf91_i2c_getreg(priv,
-                                        NRF91_TWIM_ERRORSRC_OFFSET) & 0x7;
-              if (regval != 0)
-                {
-                  i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-                  ret = -1;
-                  nrf91_i2c_putreg(priv,
-                                  NRF91_TWIM_ERRORSRC_OFFSET, 0x7);
-                  goto errout;
-                }
-
-              if (nrf91_i2c_getreg(priv,
-                                  NRF91_TWIM_EVENTS_LASTTX_OFFSET) == 1)
-                {
-                  break;
-                }
-            }
-
-          /* Clear event */
-
-          nrf91_i2c_putreg(priv, NRF91_TWIM_EVENTS_LASTTX_OFFSET, 0);
-#else
-          nxsem_wait(&priv->sem_isr);
-
-          if (priv->status < 0)
-            {
-              ret = priv->status;
-              goto errout;
-            }
-#endif
         }
       else
         {
@@ -474,46 +441,51 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
           regval = priv->dcnt;
           nrf91_i2c_putreg(priv, NRF91_TWIM_RXDMAXCNT_OFFSET, regval);
 
+          /* Shortcuts from LASTRX to STOP */
+
+          nrf91_i2c_putreg(priv, NRF91_TWIM_SHORTS_OFFSET,
+                           TWIM_SHORTS_LASTRX_STOP);
+
           /* Start RX sequence */
 
           nrf91_i2c_putreg(priv, NRF91_TWIM_TASKS_STARTRX_OFFSET, 1);
+        }
 
-          /* Wait for last RX done */
+      /* Wait for stop event */
 
 #ifdef CONFIG_I2C_POLLED
-        while (1)
-          {
-            regval = nrf91_i2c_getreg(priv,
-                                      NRF91_TWIM_ERRORSRC_OFFSET) & 0x7;
-            if (regval != 0)
-              {
-                i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-                ret = -1;
-                nrf91_i2c_putreg(priv,
-                                 NRF91_TWIM_ERRORSRC_OFFSET, 0x7);
-                goto errout;
-              }
-
-            if (nrf91_i2c_getreg(priv,
-                                 NRF91_TWIM_EVENTS_LASTRX_OFFSET) == 1)
-              {
-                break;
-              }
-          }
-
-          /* Clear event */
-
-          nrf91_i2c_putreg(priv, NRF91_TWIM_EVENTS_LASTRX_OFFSET, 0);
-#else
-          nxsem_wait(&priv->sem_isr);
-
-          if (priv->status < 0)
+      while (1)
+        {
+          regval = nrf91_i2c_getreg(priv,
+                                    NRF91_TWIM_ERRORSRC_OFFSET) & 0x7;
+          if (regval != 0)
             {
-              ret = priv->status;
+              i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
+              ret = -1;
+              nrf91_i2c_putreg(priv,
+                              NRF91_TWIM_ERRORSRC_OFFSET, 0x7);
               goto errout;
             }
-#endif
+
+          if (nrf91_i2c_getreg(priv,
+                              NRF91_TWIM_EVENTS_STOPPED_OFFSET) == 1)
+            {
+              break;
+            }
         }
+
+      /* Clear event */
+
+      nrf91_i2c_putreg(priv, NRF91_TWIM_EVENTS_STOPPED_OFFSET, 0);
+#else
+      nxsem_wait(&priv->sem_isr);
+
+      if (priv->status < 0)
+        {
+          ret = priv->status;
+          goto errout;
+        }
+#endif
 
       /* Next message */
 
@@ -521,46 +493,6 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
       priv->msgv += 1;
     }
   while (priv->msgc > 0);
-
-  /* TWIM stop */
-
-  nrf91_i2c_putreg(priv, NRF91_TWIM_TASKS_STOP_OFFSET, 1);
-
-  /* Wait for stop event */
-
-#ifdef CONFIG_I2C_POLLED
-  while (1)
-    {
-      regval = nrf91_i2c_getreg(priv,
-                                NRF91_TWIM_ERRORSRC_OFFSET) & 0x7;
-      if (regval != 0)
-        {
-          i2cerr("Error SRC: 0x%08" PRIx32 "\n", regval);
-          ret = -1;
-          nrf91_i2c_putreg(priv,
-                           NRF91_TWIM_ERRORSRC_OFFSET, 0x7);
-          goto errout;
-        }
-
-      if (nrf91_i2c_getreg(priv,
-                           NRF91_TWIM_EVENTS_STOPPED_OFFSET) == 1)
-        {
-          break;
-        }
-    }
-
-  /* Clear event */
-
-  nrf91_i2c_putreg(priv, NRF91_TWIM_EVENTS_STOPPED_OFFSET, 0);
-#else
-  nxsem_wait(&priv->sem_isr);
-
-  if (priv->status < 0)
-    {
-      ret = priv->status;
-      goto errout;
-    }
-#endif
 
 errout:
 #ifndef CONFIG_NRF91_I2C_MASTER_DISABLE_NOSTART
@@ -619,10 +551,6 @@ static int nrf91_i2c_isr(int irq, void *context, void *arg)
         {
           i2cinfo("I2C LASTTX\n");
 
-          /* TX done */
-
-          nxsem_post(&priv->sem_isr);
-
           /* Clear event */
 
           nrf91_i2c_putreg(priv, NRF91_TWIM_EVENTS_LASTTX_OFFSET, 0);
@@ -635,10 +563,6 @@ static int nrf91_i2c_isr(int irq, void *context, void *arg)
       if (nrf91_i2c_getreg(priv, NRF91_TWIM_EVENTS_LASTRX_OFFSET) == 1)
         {
           i2cinfo("I2C LASTRX\n");
-
-          /* RX done */
-
-          nxsem_post(&priv->sem_isr);
 
           /* Clear event */
 
@@ -744,8 +668,7 @@ static int nrf91_i2c_init(struct nrf91_i2c_priv_s *priv)
 #ifndef CONFIG_I2C_POLLED
   /* Enable I2C interrupts */
 
-  regval = (TWIM_INT_LASTRX | TWIM_INT_LASTTX | TWIM_INT_STOPPED |
-            TWIM_INT_ERROR);
+  regval = (TWIM_INT_STOPPED | TWIM_INT_ERROR);
   nrf91_i2c_putreg(priv, NRF91_TWIM_INTEN_OFFSET, regval);
 
   /* Attach error and event interrupts to the ISRs */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

During I2C read in interrupt mode, one-too-many byte is read. This can cause the I2C bus getting stuck.

## Impact

NRF52 chips. Likely this issue exists on other Nordic chips like NRF53 ..., since the driver seems to be copied between chips. However, I could not test this.

## Testing

I have tested the fix with a ICM20948 sensor on a nrf52840-dk board and also the LSM6DSL sensor on the xiao-nrf52840 board.
