### PR TITLE
boards/arm/kinetis: CMake added NXP Freedom-K28F and Freedom-K66F boards

### DIFF
--- a/boards/arm/kinetis/freedom-k28f/CMakeLists.txt
+++ b/boards/arm/kinetis/freedom-k28f/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/freedom-k28f/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/freedom-k28f/src/CMakeLists.txt
+++ b/boards/arm/kinetis/freedom-k28f/src/CMakeLists.txt
@@ -1,0 +1,62 @@
+# ##############################################################################
+# boards/arm/kinetis/freedom-k28f/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k28_boot.c k28_bringup.c k28_spi.c k28_i2c.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k28_appinit.c)
+endif()
+
+# If the RGB driver is not enabled, then treat the RGB as 3 LEDs
+
+if(NOT CONFIG_RGBLED)
+  if(CONFIG_ARCH_LEDS)
+    list(APPEND SRCS k28_autoleds.c)
+  else()
+    list(APPEND SRCS k28_userleds.c)
+  endif()
+endif()
+
+if(CONFIG_KINETIS_SDHC)
+  list(APPEND SRCS k28_sdhc.c)
+  if(CONFIG_FS_AUTOMOUNTER)
+    list(APPEND SRCS k28_automount.c)
+  endif()
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS k28_pwm.c)
+endif()
+
+if(CONFIG_KINETIS_USBOTG)
+  list(APPEND SRCS k28_usbdev.c)
+endif()
+
+if(CONFIG_KINETIS_USBHS)
+  if(CONFIG_USBHOST)
+    list(APPEND SRCS k28_usbhshost.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/kinetis/freedom-k66f/CMakeLists.txt
+++ b/boards/arm/kinetis/freedom-k66f/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/freedom-k66f/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/freedom-k66f/src/CMakeLists.txt
+++ b/boards/arm/kinetis/freedom-k66f/src/CMakeLists.txt
@@ -1,0 +1,73 @@
+# ##############################################################################
+# boards/arm/kinetis/freedom-k66f/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k66_boot.c k66_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS k66_autoleds.c)
+else()
+  list(APPEND SRCS k66_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS k66_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k66_appinit.c k66_bringup.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS k66_reset.c)
+  endif()
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  list(APPEND SRCS k66_bringup.c)
+endif()
+
+if(CONFIG_KINETIS_SDHC)
+  list(APPEND SRCS k66_sdhc.c)
+  if(CONFIG_FS_AUTOMOUNTER)
+    list(APPEND SRCS k66_automount.c)
+  endif()
+endif()
+
+if(CONFIG_KINETIS_RTC)
+  list(APPEND SRCS k66_rtc.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS k66_usbdev.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS k66_usbmsc.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS k66_pwm.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS k66_uid.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")


### PR DESCRIPTION
## Summary

 Added CMake build for boards::

  - NXP Freedom-K28F

 -  NXP Freedom-K66F


## Impact

Impact on user: This PR adds NXP Freedom-K28F and Freedom-K66F boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
Locally

**NXP Freedom-K28F**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=freedom-k28f:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/freedom-k28f/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  freedom-k28f
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (8.8s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1105/1107] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         492 B         1 KB     48.05%
      cfmprotect:          16 B         16 B    100.00%
       progflash:       84584 B      1022 KB      8.08%
             tcm:          0 GB       512 KB      0.00%
           ocram:        5852 B       512 KB      1.12%
[1107/1107] Generating nuttx.bin
```


**NXP Freedom-K66F**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=freedom-k66f:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/freedom-k66f/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  freedom-k66f
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (10.2s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[48/1177] Building C object arch/CMakeFiles/arch.dir/arm/src/kinetis/kinetis_sdhc.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/kinetis/kinetis_sdhc.c:64:4: warning: #warning "Large Non-DMA transfer may result in RX overrun failures" [-Wcpp]
   64 | #  warning "Large Non-DMA transfer may result in RX overrun failures"
      |    ^~~~~~~
[1099/1177] Building C object boards/CMakeFiles/board.dir/arm/kinetis/freedom-k66f/src/k66_spi.c.obj
D:/nuttxtmp/nuttx/boards/arm/kinetis/freedom-k66f/src/k66_spi.c: In function 'kinetis_spi1status':
D:/nuttxtmp/nuttx/boards/arm/kinetis/freedom-k66f/src/k66_spi.c:125:3: warning: #warning "Missing logic" [-Wcpp]
  125 | # warning "Missing logic"
      |   ^~~~~~~
[1176/1177] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         464 B         1 KB     45.31%
      cfmprotect:          16 B         16 B    100.00%
       progflash:      138868 B    2096112 B      6.63%
        datasram:       11604 B       256 KB      4.43%
[1177/1177] Generating nuttx.bin
```