### PR TITLE
fiq: fix some FIQ config in arm64/armv7-r/armv8-r

### DIFF
--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -366,9 +366,10 @@ noinstrument_function static inline_function irqstate_t up_irq_save(void)
   __asm__ __volatile__
     (
       "\tmrs    %0, cpsr\n"
-      "\tcpsid  i\n"
-#if defined(CONFIG_ARMV7R_DECODEFIQ)
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
       "\tcpsid  f\n"
+#else
+      "\tcpsid  i\n"
 #endif
       : "=r" (cpsr)
       :
@@ -387,9 +388,12 @@ static inline_function irqstate_t up_irq_enable(void)
   __asm__ __volatile__
     (
       "\tmrs    %0, cpsr\n"
-      "\tcpsie  i\n"
-#if defined(CONFIG_ARMV7R_DECODEFIQ)
+#if defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+      "\tcpsie  if\n"
+#elif defined(CONFIG_ARCH_TRUSTZONE_SECURE)
       "\tcpsie  f\n"
+#else
+      "\tcpsie  i\n"
 #endif
       : "=r" (cpsr)
       :

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -366,9 +366,10 @@ noinstrument_function static inline_function irqstate_t up_irq_save(void)
   __asm__ __volatile__
     (
       "\tmrs    %0, cpsr\n"
-      "\tcpsid  i\n"
-#if defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+#ifdef CONFIG_ARCH_TRUSTZONE_SECURE
       "\tcpsid  f\n"
+#else
+      "\tcpsid  i\n"
 #endif
       : "=r" (cpsr)
       :
@@ -387,9 +388,12 @@ static inline_function irqstate_t up_irq_enable(void)
   __asm__ __volatile__
     (
       "\tmrs    %0, cpsr\n"
-      "\tcpsie  i\n"
 #if defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+      "\tcpsie  if\n"
+#elif defined(CONFIG_ARCH_TRUSTZONE_SECURE)
       "\tcpsie  f\n"
+#else
+      "\tcpsie  i\n"
 #endif
       : "=r" (cpsr)
       :

--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -332,6 +332,7 @@ config ARCH_CORTEX_R82
 	bool
 	default n
 	select ARCH_ARMV8R
+	select ARCH_HAVE_TRUSTZONE
 	select ARCH_DCACHE
 	select ARCH_ICACHE
 	select ARCH_HAVE_MPU

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -747,6 +747,35 @@ void up_disable_irq(int irq)
 }
 
 /***************************************************************************
+ * Name: up_set_secure_irq
+ *
+ * Description:
+ *   Secure an IRQ
+ *
+ ***************************************************************************/
+
+#if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_HIPRI_INTERRUPT)
+void up_secure_irq(int irq, bool secure)
+{
+  uint32_t mask      = BIT(irq & (GIC_NUM_INTR_PER_REG - 1));
+  uint32_t idx       = irq / GIC_NUM_INTR_PER_REG;
+  unsigned long base = GET_DIST_BASE(irq);
+  unsigned int val   = getreg32(IGROUPR(base, idx));
+
+  if (secure)
+    {
+      val &= (~mask);  /* group 0 fiq */
+    }
+  else
+    {
+      val |= mask;     /* group 1 irq */
+    }
+
+  putreg32(val, IGROUPR(base, idx));
+}
+#endif
+
+/***************************************************************************
  * Name: up_prioritize_irq
  *
  * Description:

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -310,7 +310,7 @@ SECTION_FUNC(text, arm64_fiq_handler)
      * with interrupts disabled
      */
 
-    bl     arm64_decodeirq
+    bl     arm64_decodefiq
 
     mov    sp, x0
     b      arm64_exit_exception


### PR DESCRIPTION

## Summary
1. up_irq_save should not mask fiq if CONFIG_ARCH_HIPRI_INTERRUPT=y
2. up_irq_save should mask fiq if CONFIG_ARCH_TRUSTZONE_SECURE=y
3. up_irq_save should mask irq if CONFIG_ARCH_TRUSTZONE_SECURE=n
4. add up_secure_irq in arm64
5. add ARCH_HAVE_TRUSTZONE support for ARCH_CORTEX_R82

## Impact
arm/arm64 fiq

## Testing
test with ./tools/configure.sh -l qemu-armv8a:nsh

ostest

user_main: vfork() test
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena https://github.com/apache/nuttx/commit/7c210006af5c62e58f253abaa9fc24a05ffb3a99 https://github.com/apache/nuttx/commit/7c210006af5c62e58f253abaa9fc24a05ffb3a99
ordblks 2 5
mxordblk https://github.com/apache/nuttx/commit/7c16fb8424c4a27ccd67b9fdc6235069b6c50d5e https://github.com/apache/nuttx/commit/7c12c78f55321ddc70f92226ffb0be49b6a398e6
uordblks a018 c150
fordblks 7c16fe8 7c14eb0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>