### PR TITLE
boards/x86_64/intel64/qemu-intel64: register TMPFS

### DIFF
--- a/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
+++ b/boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c
@@ -93,6 +93,17 @@ int qemu_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_ONESHOT
   os = oneshot_initialize(ONESHOT_TIMER, 10);
   if (os)


### PR DESCRIPTION
## Summary

register TMPFS for qemu-intel64

## Impact
register `tmp/` when CONFIG_FS_TMPFS is set

## Testing
trivial change, nothing to test

```
NuttShell (NSH) NuttX-12.11.0
nsh> ls
/:
 dev/
 proc/
 tmp/
nsh> 
```
