### PR TITLE
boards/nucleo-h743zi: register TMPFS

### DIFF
--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_bringup.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_bringup.c
@@ -274,6 +274,17 @@ int stm32_bringup(void)
     }
 #endif /* CONFIG_FS_PROCFS */
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_STM32_ROMFS
   /* Mount the romfs partition */
 


### PR DESCRIPTION
## Summary

register TMPFS for nucleo-h743zi

## Impact
register `tmp/` when CONFIG_FS_TMPFS is set

## Testing
trivial change, nothing to test

```
NuttShell (NSH) NuttX-12.11.0
nsh> ls
/:
 dev/
 proc/
 tmp/
nsh> 
```
