### PR TITLE
sched/sched: Fix nxsched_suspend() logic

### DIFF
--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -170,13 +170,12 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
         {
           switch_needed = nxsched_remove_readytorun(tcb);
 
-          if (switch_needed || !nxsched_islocked_tcb(rtcb))
+          if (switch_needed)
             {
 #ifdef CONFIG_SMP
-              switch_needed |= nxsched_deliver_task(cpu, tcb->cpu,
-                                                    SWITCH_HIGHER);
+              nxsched_deliver_task(cpu, tcb->cpu, SWITCH_HIGHER);
 #else
-              switch_needed |= nxsched_merge_pending();
+              nxsched_merge_pending();
 #endif
             }
 


### PR DESCRIPTION
## Summary

nxsched_deliver_task() or nxsched_merge_pending() should only be
called when a context switch is required. This behavior is
independent of whether the current task is locked.

## Impact

Fix nxsched_suspend() logic issue

## Testing

**ostest passed on board a2g-tc397-5v-tft**

```
NuttShell (NSH)
nsh>
nsh>
nsh> uname -a
NuttX 0.0.0 c47bc752f9 Nov 13 2025 10:16:32 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     670c     553c
fordblks    226f0    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
