### PR TITLE
arch/tricore/tc397: Add UART port pin configuration for TC397

### DIFF
--- a/arch/tricore/src/tc397/chip.h
+++ b/arch/tricore/src/tc397/chip.h
@@ -27,4 +27,7 @@
  * Included Files
  ****************************************************************************/
 
+#define UART_PIN_RX IfxAsclin0_RXA_P14_1_IN     /* UART receive port pin  */
+#define UART_PIN_TX IfxAsclin0_TX_P14_0_OUT     /* UART transmit port pin */
+
 #endif /* __ARCH_TRICORE_SRC_TC397_CHIP_H */

--- a/arch/tricore/src/tc3xx/tc3xx_serial.c
+++ b/arch/tricore/src/tc3xx/tc3xx_serial.c
@@ -45,6 +45,8 @@
 
 #include "Asclin/Asc/IfxAsclin_Asc.h"
 
+#include <chip.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -159,9 +161,6 @@ static char g_uart0txbuffer[CONFIG_UART0_TXBUFSIZE];
 #endif
 
 #ifdef CONFIG_TC3XX_UART0
-
-#define UART_PIN_RX IfxAsclin0_RXA_P14_1_IN     /* UART receive port pin  */
-#define UART_PIN_TX IfxAsclin0_TX_P14_0_OUT     /* UART transmit port pin */
 
 /* Pin configuration */
 


### PR DESCRIPTION
## Summary

Fixed the UART specific pin definitions in the universal serial implementation file. Different chips have different pin definitions, which caused limitations in the universal UART implementation. Therefore, moved the UART pin definitions to specific chip directories.

## Impact

Fix specific definitions in the generic UART module

## Testing

```nsh>
nsh> uname -a
NuttX 0.0.0 5a8f572ad2-dirty Nov 13 2025 19:11:23 tricore a2g-tc397-5v-tft
nsh>
nsh>
nsh> ostest

(...)


user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8c8    1f8c8
uordblks     5e24     553c
fordblks    22fd8    238c0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8c8    1f8c8
uordblks     553c     553c
fordblks    238c0    238c0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24238    1f8c8
uordblks     4bc4     553c
fordblks    24238    238c0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
