### PR TITLE
boards/arm/kinetis: CMake added NXP TWR-K60N512 and TWR-K64F120M boards

### DIFF
--- a/boards/arm/kinetis/twr-k60n512/CMakeLists.txt
+++ b/boards/arm/kinetis/twr-k60n512/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/twr-k60n512/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/twr-k60n512/src/CMakeLists.txt
+++ b/boards/arm/kinetis/twr-k60n512/src/CMakeLists.txt
@@ -1,0 +1,48 @@
+# ##############################################################################
+# boards/arm/kinetis/twr-k60n512/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k60_boot.c k60_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS k60_leds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS k60_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k60_appinit.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS k60_usbdev.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS k60_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/twr-k60n512.ld")

--- a/boards/arm/kinetis/twr-k64f120m/CMakeLists.txt
+++ b/boards/arm/kinetis/twr-k64f120m/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/twr-k64f120m/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/twr-k64f120m/src/CMakeLists.txt
+++ b/boards/arm/kinetis/twr-k64f120m/src/CMakeLists.txt
@@ -1,0 +1,42 @@
+# ##############################################################################
+# boards/arm/kinetis/twr-k64f120m/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k64_boot.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS k64_leds.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k64_appinit.c)
+endif()
+
+if(CONFIG_KINETIS_SDHC)
+  list(APPEND SRCS k64_sdhc.c)
+  if(CONFIG_FS_AUTOMOUNTER)
+    list(APPEND SRCS k64_automount.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")


### PR DESCRIPTION
## Summary

CMake added boards:

  - NXP TWR-K60N512

 -  NXP TWR-K64F120M
## Impact

Impact on user: This PR adds NXP  TWR-K60N512 and TWR-K64F120M boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally


**TWR-K60N512**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=twr-k60n512:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/twr-k60n512/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  twr-k60n512
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.0s)
-- Generating done (2.5s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1094/1095] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         444 B         1 KB     43.36%
      cfmprotect:          16 B         16 B    100.00%
       progflash:         75 KB       510 KB     14.71%
        datasram:        5732 B       128 KB      4.37%
[1095/1095] Generating nuttx.hex

```

**TWR-K64F120M**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=twr-k64f120m:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/twr-k64f120m/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  twr-k64f120m
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (10.3s)
-- Generating done (2.2s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[52/1118] Building C object arch/CMakeFiles/arch.dir/arm/src/kinetis/kinetis_sdhc.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/kinetis/kinetis_sdhc.c:64:4: warning: #warning "Large Non-DMA transfer may result in RX overrun failures" [-Wcpp]
   64 | #  warning "Large Non-DMA transfer may result in RX overrun failures"
      |    ^~~~~~~
[1117/1118] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         408 B         1 KB     39.84%
      cfmprotect:          16 B         16 B    100.00%
       progflash:      103800 B      1022 KB      9.92%
        datasram:        6364 B       256 KB      2.43%
[1118/1118] Generating nuttx.hex
```