### PR TITLE
boards/arm/kinetis: CMake added NXP KWIKSTIK-K40 and PJRC Teensy 3.x boards

### DIFF
--- a/boards/arm/kinetis/kwikstik-k40/CMakeLists.txt
+++ b/boards/arm/kinetis/kwikstik-k40/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/kwikstik-k40/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/kwikstik-k40/src/CMakeLists.txt
+++ b/boards/arm/kinetis/kwikstik-k40/src/CMakeLists.txt
@@ -1,0 +1,48 @@
+# ##############################################################################
+# boards/arm/kinetis/kwikstik-k40/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k40_boot.c k40_lcd.c k40_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS k40_leds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS k40_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k40_appinit.c)
+endif()
+
+if(CONFIG_USBDEV)
+  list(APPEND SRCS k40_usbdev.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS k40_usbmsc.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/kwikstik-k40.ld")

--- a/boards/arm/kinetis/teensy-3.x/CMakeLists.txt
+++ b/boards/arm/kinetis/teensy-3.x/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/kinetis/teensy-3.x/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/kinetis/teensy-3.x/src/CMakeLists.txt
+++ b/boards/arm/kinetis/teensy-3.x/src/CMakeLists.txt
@@ -1,0 +1,50 @@
+# ##############################################################################
+# boards/arm/kinetis/teensy-3.x/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS k20_boot.c k20_spi.c k20_i2c.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS k20_autoleds.c)
+else()
+  list(APPEND SRCS k20_userleds.c)
+endif()
+if(CONFIG_KINETIS_USBOTG)
+  list(APPEND SRCS k20_usbdev.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS k20_appinit.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS k20_pwm.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_ARCH_CHIP_MK20DX256VLH7)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/mk20dx128vlh5.ld")
+elseif(CONFIG_ARCH_CHIP_MK20DX128VLH5)
+  set_property(GLOBAL PROPERTY LD_SCRIPT
+                               "${NUTTX_BOARD_DIR}/scripts/mk20dx256vlh7.ld")
+endif()


### PR DESCRIPTION
## Summary

CMake added boards:

  - NXP KWIKSTIK-K40

 -  PJRC Teensy 3.x
 
## Impact

Impact on user: This PR adds NXP KWIKSTIK-K40 and PJRC Teensy 3.x boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally

**Teensy 3.x**
```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=teensy-3.x:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/teensy-3.x/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  teensy-3.x
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.0s)
-- Generating done (2.1s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1089/1091] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         444 B         1 KB     43.36%
      cfmprotect:          16 B         16 B    100.00%
       progflash:       69664 B       126 KB     53.99%
        datasram:        5748 B        16 KB     35.08%
[1091/1091] Generating nuttx.bin

```

**KWIKSTIK-K40**
```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=kwikstik-k40:ostest -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/configs/ostest/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  kwikstik-k40
--   Config: ostest
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.1s)
-- Generating done (2.4s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1001/1047] Building C object boards/CMakeFiles/board.dir/arm/kinetis/kwikstik-k40/src/k40_lcd.c.obj
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c: In function 'board_lcd_initialize':
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c:57:2: warning: #warning "Missing logic" [-Wcpp]
   57 | #warning "Missing logic"
      |  ^~~~~~~
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c: In function 'board_lcd_getdev':
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c:73:2: warning: #warning "Missing logic" [-Wcpp]
   73 | #warning "Missing logic"
      |  ^~~~~~~
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c: In function 'board_lcd_uninitialize':
D:/nuttxtmp/nuttx/boards/arm/kinetis/kwikstik-k40/src/k40_lcd.c:87:2: warning: #warning "Missing logic" [-Wcpp]
   87 | #warning "Missing logic"
      |  ^~~~~~~
[1046/1047] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
       vectflash:         444 B         1 KB     43.36%
      cfmprotect:          16 B         16 B    100.00%
       progflash:       92196 B       254 KB     35.45%
        datasram:        7460 B        64 KB     11.38%
[1047/1047] Generating nuttx.hex
```
