### PR TITLE
docs/applications/nsh: Add documentation for NSH_BUILTIN_AS_COMMAND

### DIFF
--- a/Documentation/applications/nsh/builtin.rst
+++ b/Documentation/applications/nsh/builtin.rst
@@ -16,6 +16,8 @@ Built-in application support is enabled with these configuration option:
   -  ``CONFIG_BUILTIN``: Enable NuttX support for builtin applications.
   -  ``CONFIG_NSH_BUILTIN_APPS``: Enable NSH support for builtin
      applications.
+  -  ``CONFIG_NSH_BUILTIN_AS_COMMAND``: Enable NSH run builtin applications
+     directly without creating a separate thread (optional).
 
 When these configuration options are set, you will also be able to see
 the built-in applications if you enter "nsh> help". They will appear at

--- a/Documentation/applications/nsh/config.rst
+++ b/Documentation/applications/nsh/config.rst
@@ -193,6 +193,13 @@ Configuration                        Description
                                      more information). This required ``CONFIG_BUILTIN`` to enable
                                      NuttX support for "builtin" applications.
 
+ ``CONFIG_NSH_BUILTIN_AS_COMMAND``   If enabled, then "builtin" applications will be executed directly
+                                     from the NSH command line without creating a separate thread. The
+                                     advantage is simpler and faster execution. The disadvantage is that
+                                     background execution is not supported. This required ``CONFIG_BUILTIN``
+                                     and ``CONFIG_NSH_BUILTIN_APPS`` to enable NuttX support for "builtin"
+                                     applications.
+
  ``CONFIG_NSH_FILEIOSIZE``           Size of a static I/O buffer used for file access (ignored if there
                                      is no file system). Default is 1024.
 

--- a/Documentation/applications/nsh/running_apps.rst
+++ b/Documentation/applications/nsh/running_apps.rst
@@ -35,7 +35,9 @@ There are currently be three ways to execute applications from NSH:
    This functionality depends on these configuration settings:
 
      * ``CONFIG_BUILTIN=y`` Enables NuttX support for builtin applications, and
-     * ``CONFIG_NSH_BUILTIN_APPS=y`` Enables NSH support for builtin applications
+     * ``CONFIG_NSH_BUILTIN_APPS=y`` Enables NSH support for builtin applications, and
+     * ``CONFIG_NSH_BUILTIN_AS_COMMAND``: Enable NSH run builtin applications directly
+       without creating a separate thread (optional).
 
    In additional to other configuration needed by NSH.
 


### PR DESCRIPTION
This patch adds the description for NSH_BUILTIN_AS_COMMAND including its advantage and disadvantage. NSH_BUILTIN_AS_COMMAND is an optional configuration in nsh. It allows nsh builtin apps to run directly like nsh command without creating a thread. This is done in pull request https://github.com/apache/nuttx-apps/pull/3168

## Summary

Add the description documentation for NSH_BUILTIN_AS_COMMAND.

## Impact

Provide description, advantages and disadvantages for NSH_BUILTIN_AS_COMMAND. Make users easier to use.

## Testing

N/A. No impact over the codebase.
