### PR TITLE
drivers/sensors: Fix Kconfig

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -267,6 +267,8 @@ config SENSORS_BMI160_SPI
 
 endchoice # BMI160 Interface
 
+if SENSORS_BMI160_I2C
+
 choice
 	prompt "I2C Address"
 	default BMI160_I2C_ADDR_68
@@ -283,6 +285,7 @@ config BMI160_I2C_ADDR_69
 		If SDO pin is pulled to VDDIO, use 0x69
 
 endchoice # I2C Address
+endif # SENSORS_BMI160_I2C
 
 endif # SENSORS_BMI160
 
@@ -320,22 +323,7 @@ config SENSORS_BMI088_SPI
 
 endchoice # BMI088 Interface
 
-choice
-	prompt "I2C Address"
-	default BMI160_I2C_ACC_ADDR_18
-
-config BMI160_I2C_ACC_ADDR_18
-	bool "0x18"
-	---help---
-		Default address.
-		If SDO pin is pulled to GND, use 0x18
-
-config BMI160_I2C_ACC_ADDR_19
-	bool "0x19"
-	---help---
-		If SDO pin is pulled to VDDIO, use 0x19
-
-endchoice # I2C Address
+if SENSORS_BMI088_I2C
 
 choice
 	prompt "I2C Address"
@@ -353,6 +341,8 @@ config BMI088_I2C_GYRO_ADDR_69
 		If SDO pin is pulled to VDDIO, use 0x69
 
 endchoice # I2C Address
+
+endif # SENSORS_BMI088_I2C
 
 endif # SENSORS_BMI088
 


### PR DESCRIPTION
## Summary

As reported by a user in Discord channel selection BMI160 with SPI interface still showing the I2C configuration. This patch fixes it.

## Impact

Improve user experience

## Testing

Not tested yet. TBD
