### PR TITLE
sched/task: remove the check for whether tcb is NULL

### DIFF
--- a/sched/task/task_getpid.c
+++ b/sched/task/task_getpid.c
@@ -67,7 +67,8 @@ pid_t nxsched_getpid(void)
    */
 
   rtcb = this_task();
-  if (rtcb != NULL)
+  DEBUGASSERT(rtcb);
+  if (rtcb->group != NULL)
     {
       /* Yes.. Return the Process ID */
 

--- a/sched/task/task_getppid.c
+++ b/sched/task/task_getppid.c
@@ -77,7 +77,8 @@ pid_t nxsched_getppid(void)
    */
 
   rtcb = this_task();
-  if (rtcb != NULL)
+  DEBUGASSERT(rtcb);
+  if (rtcb->group != NULL)
     {
       /* Check if the task is actually running */
 


### PR DESCRIPTION
## Summary

sched/task: remove the check for whether tcb is NULL

We should not call these functions before nx_start; therefore, this_task will not be empty. If these functions are called (before nx_start), the correct value cannot be obtained either.

## Impact

sched

This is a very minor optimization, primarily focused on performance.For example, in the ARM64 compilation of nxsched_gettid, there were 27 instructions before the modification and 20 instructions after the modification.

## Testing

test with ./tools/configure.sh -l qemu-armv8a:nsh_smp

ostest
End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b94000  7b94000
ordblks        10        9
mxordblk  7b61118  7b65150
uordblks    1a588    1a590
fordblks  7b79a78  7b79a70

user_main: vfork() test
vfork_test: Child 95 ran successfully

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b94000  7b94000
ordblks         2        9
mxordblk  7b81e58  7b65150
uordblks    12180    1a410
fordblks  7b81e80  7b79bf0
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 




I also test in realhardware 
target: esp32s3-devkit:smp

nsh> 
nsh> uname -a
NuttX 12.11.0 c85db15d7b1 Nov 21 2025 20:16:56 xtensa esp32s3-devkit
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=4

user_main: Begin argument test