### PR TITLE
drivers/eeprom: Set the bus frequency

### DIFF
--- a/Documentation/components/drivers/character/eeprom.rst
+++ b/Documentation/components/drivers/character/eeprom.rst
@@ -155,7 +155,15 @@ IOCTL Commands
 The full list of ``ioctl()`` commands can be found in
 ``include/nuttx/eeprom/eeprom.h``.
 
--  ``EEPIOC_GEOMETRY``: Get the EEPROM geometry
+- ``EEPIOC_GEOMETRY``
+    *Argument:* ``struct eeprom_geometry_s *``
+
+    Get the EEPROM geometry
+
+- ``EEPIOC_SETSPEED``
+    *Argument:* ``uint32_t``
+
+    Set the SPI/I2C bus frequency
 
 File Systems
 ============

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -24,12 +24,45 @@ if SPI_EE_25XX
 config EE25XX_SPIMODE
 	int "SPI mode (0-3)"
 	default 0
-	depends on SPI_EE_25XX
 
 config EE25XX_FREQUENCY
 	int "SPI EEPROM SCK frequency"
 	default 10000000
-	depends on SPI_EE_25XX
+	---help---
+		Default SPI bus frequency, it can be overwritten at runtime using the
+		EEPIOC_SETSPEED ioctl. See eeprom/eeprom.h.
+
+config EE25XX_START_DELAY
+	int "SPI start delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+	---help---
+		The delay between CS active and first CLK. In ns.
+
+config EE25XX_STOP_DELAY
+	int "SPI stop delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+	---help---
+		The delay between last CLK and CS inactive. In ns.
+
+config EE25XX_CS_DELAY
+	int "SPI CS delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+	---help---
+		The delay between CS inactive and CS active again. In ns.
+
+config EE25XX_IFDELAY
+	int "SPI interface delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 5000
+	---help---
+		The delay between frames. In ns.
 
 endif # SPI_EE_25XX
 
@@ -46,12 +79,13 @@ if I2C_EE_24XX
 config EE24XX_FREQUENCY
 	int "I2C EEPROM frequency (100000 or 400000)"
 	default 100000
-	depends on I2C_EE_24XX
+	---help---
+		Default I2C bus frequency, it can be overwritten at runtime using the
+		EEPIOC_SETSPEED ioctl. See eeprom/eeprom.h.
 
 config AT24CS_UUID
 	bool "Device driver support for Atmel AT24CSxx UUID"
 	default n
-	depends on I2C_EE_24XX
 	---help---
 		The Atmel AT24CSxx family have a 128-bit UUID which appears as
 		another I2C slave whose address is offset from the EEPROM by +8.

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -96,10 +96,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef CONFIG_EE24XX_FREQUENCY
-#  define CONFIG_EE24XX_FREQUENCY 100000
-#endif
-
 #define UUID_SIZE   16
 
 /****************************************************************************
@@ -124,23 +120,23 @@ struct ee24xx_dev_s
 {
   /* Bus management */
 
-  FAR struct i2c_master_s *i2c;      /* I2C device where the EEPROM is attached */
-  uint32_t                 freq;     /* I2C bus speed */
-  uint8_t                  addr;     /* 7-bit unshifted I2C device address */
+  FAR struct i2c_master_s *i2c;  /* I2C device where the EEPROM is attached */
+  uint32_t                 freq; /* I2C bus speed                           */
+  uint8_t                  addr; /* 7-bit unshifted I2C device address      */
 
   /* Driver management */
 
-  mutex_t                  lock;     /* file write access serialization */
-  uint8_t                  refs;     /* Nr of times the device has been opened */
-  bool                     readonly; /* Flags */
+  mutex_t lock;     /* file write access serialization                      */
+  uint8_t refs;     /* Nr of times the device has been opened               */
+  bool    readonly; /* Flags                                                */
 
   /* Expanded from geometry */
 
-  uint32_t                 size;       /* total bytes in device */
-  uint16_t                 pgsize;     /* write block size, in bytes */
-  uint16_t                 addrlen;    /* number of bytes in data addresses */
-  uint16_t                 haddrbits;  /* Number of bits in high address part */
-  uint16_t                 haddrshift; /* bit-shift of high address part */
+  uint32_t size;       /* total bytes in device                             */
+  uint16_t pgsize;     /* write block size, in bytes                        */
+  uint16_t addrlen;    /* number of bytes in data addresses                 */
+  uint16_t haddrbits;  /* Number of bits in high address part               */
+  uint16_t haddrshift; /* bit-shift of high address part                    */
 };
 
 /****************************************************************************
@@ -804,6 +800,17 @@ static int ee24xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
               ret = OK;
             }
+        }
+        break;
+
+      case EEPIOC_SETSPEED:
+        {
+          ret = nxmutex_lock(&eedev->lock);
+          if (ret == OK)
+          {
+            eedev->freq = (uint32_t)arg;
+            nxmutex_unlock(&eedev->lock);
+          }
         }
         break;
 

--- a/include/nuttx/eeprom/eeprom.h
+++ b/include/nuttx/eeprom/eeprom.h
@@ -47,13 +47,20 @@
 /* EEPROM IOCTL Commands ************************************************************/
 
 #define EEPIOC_GEOMETRY     _EEPIOC(0x000)  /* Similar to BIOC_GEOMETRY:
-                                             * Return the geometry of the EEPROM
-                                             * device.
-                                             * IN:  Pointer to writable instance  of
-                                             *      struct eeprom_geometry_s in which
-                                             *      to return the geometry.
-                                             * OUT: Data return in user-provided
-                                             *      buffer. */
+                                             * Return the geometry of the
+                                             * EEPROM device.
+                                             * IN:  Pointer to writable
+                                             *      instance  of struct
+                                             *      eeprom_geometry_s to be
+                                             *      populated
+                                             * OUT: Data return in user-
+                                             *      provided buffer.        */
+
+#define EEPIOC_SETSPEED     _EEPIOC(0x001)  /* Overwrite the SPI/I2C bus speed
+                                             * IN:  Bus speed in Hz
+                                             * OUT: None (ioctl return value
+                                             *      provides success/failure
+                                             *      indication).            */
 
 /************************************************************************************
  * Type Definitions


### PR DESCRIPTION
## Summary

Add EEPIOC_SETSPEED ioctl acting like the MTDIOC_SETSPEED ioctl.  
The default frequency is taken from the Kconfig and can be adjusted at runtime using this ioctl.

The SPI timing configuration parameters from mtd/at25ee have also been copied so that they can be applied to eeprom/spi_xx25xx.

## Impact

If `CONFIG_SPI_DELAY_CONTROL` is set, SPI timing parameters will be explicitly set when communicating with the eeprom/spi_xx25xx device.

As long as the new ioctl command is not used, the EEPROM drivers behaviour is unchanged.

## Testing

Tested on a custom target (STM32F7-based) with a Rhom BR25G256FVT EEPROM (equivalent to a Microchip 25xx256).

Changes to the i2c_xx24xx driver have been compiled only.
