### PR TITLE
fs/fat: Ignore multiple consecutive slashes in long file names

### DIFF
--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -607,6 +607,13 @@ static inline int fat_parselfname(FAR const char **path,
 
           dirinfo->fd_lfname[ndx] = '\0';
 
+          /* Ignore sequences of //... in the filename */
+
+          while (node && *node == '/')
+            {
+              node++;
+            }
+
           /* Return the remaining sub-string and the terminating character. */
 
           *terminator = (char)ch;


### PR DESCRIPTION

## Summary

Fix https://github.com/apache/nuttx/pull/17233 for issue https://github.com/apache/nuttx/issues/17213 was not complete. The same fix is needed for long file names.

## Impact

Impacts parsing of fat file paths on all platforms.

## Testing

Tested on IMX93 HW, by copying file. Before the fix:

```
nsh> ls
/fs/microsd:
 log/
nsh> cp /fs/microsd/log/2104-02-06///06_36_24.ulg .
nsh: cp: open_rdfd failed: Invalid argument
nsh>
```

After this fix:

```
nsh> ls
/fs/microsd:
 log/
nsh> cp /fs/microsd/log/2104-02-06///06_36_24.ulg .
nsh> ls
/fs/microsd:
 log/
 06_36_24.ulg
nsh>
```

@arikimari , @acassis Can you please have a look, thanks!
