### PR TITLE
CMake: Enable Kconfig generation for external directories

### DIFF
--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -117,6 +117,8 @@ function(nuttx_generate_kconfig)
     nuttx_generate_kconfig
     ONE_VALUE
     MENUDESC
+    MULTI_VALUE
+    EXTERNAL_DIRECTORIES
     REQUIRED
     ARGN
     ${ARGN})
@@ -143,12 +145,21 @@ function(nuttx_generate_kconfig)
     LIST_DIRECTORIES false
     ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/*/CMakeLists.txt)
 
+  if(NOT MENUDESC)
+    set(EXTERNAL_CMAKESCRIPTS)
+    foreach(external_dir ${EXTERNAL_DIRECTORIES})
+      if(EXISTS ${external_dir}/CMakeLists.txt)
+        list(APPEND EXTERNAL_CMAKESCRIPTS "${external_dir}/CMakeLists.txt")
+      endif()
+    endforeach()
+  endif()
+
   # we need to recursively generate the Kconfig menus of multi-level
   # directories.
   #
   # when generating a Kconfig file for the current directory, it should include
   # and invoke all the Kconfig files gathered from its subdirectories.
-  foreach(SUB_CMAKESCRIPT ${SUB_CMAKESCRIPTS})
+  foreach(SUB_CMAKESCRIPT ${SUB_CMAKESCRIPTS} ${EXTERNAL_CMAKESCRIPTS})
     string(REPLACE "CMakeLists.txt" "Kconfig" SUB_KCONFIG ${SUB_CMAKESCRIPT})
     string(REPLACE "/" "_" MENUCONFIG ${SUB_KCONFIG})
     if(WIN32)


### PR DESCRIPTION
## Summary

Currently, nuttx_generate_kconfig() can only parse subdirectories under apps/. 
This patch extends its capability to also parse external directories referenced from the apps tree.

## Impact

Add new capabilites for nuttx_generate_kconfig(), no impact to any nuttx functions

## Testing

1. add tmp directory: 
```
├── nuttx-apps
└── tmp
    ├── CMakeLists.txt
    └── Kconfig
```
2. Update nuttx-apps/CMakeLists.txt: 
`nuttx_generate_kconfig(EXTERNAL_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/../tmp)`

3. Kconfig in tmp directory is included:

```
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_audioutils_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_benchmarks_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_boot_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_canutils_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_crypto_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_examples_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_fsutils_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_games_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_graphics_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_industry_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_interpreters_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_logging_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_lte_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_math_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_mlearning_Kconfig"
source "/home/lixiang/repos/nuttxspace/nuttx-apps/modbus/Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_netutils_Kconfig"
source "/home/lixiang/repos/nuttxspace/nuttx-apps/nshlib/Kconfig"
source "/home/lixiang/repos/nuttxspace/nuttx-apps/platform/Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_sdr_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_system_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_tee_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_testing_Kconfig"
source "/home/lixiang/repos/nuttxspace/nuttx-apps/tools/Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_videoutils_Kconfig"
source "/home/lixiang/repos/nuttxspace/output/nuttx-apps/_home_lixiang_repos_nuttxspace_nuttx-apps_wireless_Kconfig"
source "/home/lixiang/repos/nuttxspace/nuttx-apps/../tmp/Kconfig"
```
