### PR TITLE
net/tcp/udp: Modify calls of net_iob*alloc calls to be unthrottled for sends, throttled for receives.

### DIFF
--- a/Documentation/components/net/netdriver.rst
+++ b/Documentation/components/net/netdriver.rst
@@ -229,7 +229,8 @@ Here is a guide to do so:
          */
 
         len = receive_data_into(devbuf);
-        netpkt_copyin(dev, pkt, devbuf + sizeof(struct <chip>_rxhead_s), len, 0);
+        netpkt_copyin(dev, pkt, devbuf + sizeof(struct <chip>_rxhead_s), len, 0,
+                      NETPKT_RX);
   #endif
       }
 

--- a/arch/risc-v/src/common/espressif/esp_wlan_netdev.c
+++ b/arch/risc-v/src/common/espressif/esp_wlan_netdev.c
@@ -1018,7 +1018,7 @@ static int wlan_rx_done(struct esp_wlan_priv_s *priv,
       goto out;
     }
 
-  ret = netpkt_copyin(&priv->dev, pkt, buffer, len, 0);
+  ret = netpkt_copyin(&priv->dev, pkt, buffer, len, 0, NETPKT_RX);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to copy packet\n");

--- a/arch/risc-v/src/mpfs/mpfs_can.c
+++ b/arch/risc-v/src/mpfs/mpfs_can.c
@@ -678,7 +678,8 @@ static netpkt_t *mpfs_receive(struct netdev_lowerhalf_s *dev)
           if (pkt != NULL)
             {
               netpkt_copyin(dev, pkt, (uint8_t *)&cf,
-                           sizeof(struct can_frame), 0);
+                            sizeof(struct can_frame), 0,
+                            NETPKT_RX);
             }
 
           ninfo("Received CAN message (ID: 0x%X, DLC: %d) "

--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -181,7 +181,7 @@ static netpkt_t *netdriver_recv(struct netdev_lowerhalf_s *dev)
 #ifdef SIM_NETDEV_RECV_OFFLOAD
       netpkt_setdatalen(dev, pkt, len);
 #else
-      netpkt_copyin(dev, pkt, DEVBUF(dev), len, 0);
+      netpkt_copyin(dev, pkt, DEVBUF(dev), len, 0, NETPKT_RX);
 #endif
     }
 

--- a/arch/xtensa/src/common/espressif/esp_openeth.c
+++ b/arch/xtensa/src/common/espressif/esp_openeth.c
@@ -286,7 +286,7 @@ static netpkt_t *openeth_receive(struct netdev_lowerhalf_s *dev)
           goto err;
         }
 
-      netpkt_copyin(dev, pkt, desc_val.rxpnt, desc_val.len, 0);
+      netpkt_copyin(dev, pkt, desc_val.rxpnt, desc_val.len, 0, NETPKT_RX);
 
       /* Free up the descriptor */
 

--- a/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
+++ b/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
@@ -1018,7 +1018,7 @@ static int wlan_rx_done(struct esp_wlan_priv_s *priv,
       goto out;
     }
 
-  ret = netpkt_copyin(&priv->dev, pkt, buffer, len, 0);
+  ret = netpkt_copyin(&priv->dev, pkt, buffer, len, 0, NETPKT_RX);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to copy packet\n");

--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -1395,7 +1395,7 @@ FAR netpkt_t *netpkt_alloc(FAR struct netdev_lowerhalf_s *dev,
       return NULL;
     }
 
-  pkt = iob_tryalloc(false);
+  pkt = iob_tryalloc(type == NETPKT_RX);
   if (pkt == NULL)
     {
       atomic_fetch_add(&dev->quota[type], 1);
@@ -1446,10 +1446,12 @@ void netpkt_free(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
  ****************************************************************************/
 
 int netpkt_copyin(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
-                  FAR const uint8_t *src, unsigned int len, int offset)
+                  FAR const uint8_t *src, unsigned int len, int offset,
+                  enum netpkt_type_e type)
 {
   return iob_trycopyin(pkt, src, len,
-                       offset - NET_LL_HDRLEN(&dev->netdev), false);
+                       offset - NET_LL_HDRLEN(&dev->netdev),
+                       type == NETPKT_RX);
 }
 
 /****************************************************************************

--- a/drivers/net/oa_tc6/oa_tc6.c
+++ b/drivers/net/oa_tc6/oa_tc6.c
@@ -867,7 +867,8 @@ static void oa_tc6_handle_rx_chunk(FAR struct oa_tc6_driver_s *priv,
         }
 
       netpkt_copyin(&priv->dev, priv->rx_pkt, rxbuf,
-                    rxlen, priv->rx_pkt_idx);
+                    rxlen, priv->rx_pkt_idx,
+                    NETPKT_RX);
       priv->rx_pkt_idx = newlen;
 
       if (oa_tc6_end_valid(footer))

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -998,7 +998,7 @@ static ssize_t tun_write(FAR struct file *filep, FAR const char *buffer,
         {
           net_lock();
           netdev_iob_release(&priv->dev);
-          ret = netdev_iob_prepare(&priv->dev, false, 0);
+          ret = netdev_iob_prepare(&priv->dev, true, 0);
           priv->dev.d_buf = NULL;
           if (ret < 0)
             {

--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -977,7 +977,7 @@ static int cdcncm_packet_handler(FAR struct cdcncm_driver_s *self,
       return ret;
     }
 
-  ret = netpkt_copyin(&self->dev, pkt, dgram, dglen, 0);
+  ret = netpkt_copyin(&self->dev, pkt, dgram, dglen, 0, NETPKT_RX);
   if (ret < 0)
     {
       netpkt_free(&self->dev, pkt, NETPKT_RX);

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -904,7 +904,7 @@ static bool rndis_allocrxreq(FAR struct rndis_dev_s *priv)
 
   /* Prepare buffer to receivce data from usb driver */
 
-  iob = iob_tryalloc(false);
+  iob = iob_tryalloc(true);
   if (iob == NULL)
     {
       return false;
@@ -1291,7 +1291,7 @@ static inline int rndis_recvpacket(FAR struct rndis_dev_s *priv,
                   iob_trycopyin(priv->rx_req->iob,
                                 &reqbuf[priv->current_rx_datagram_offset],
                                 reqlen - priv->current_rx_datagram_offset,
-                                -NET_LL_HDRLEN(&priv->netdev), false);
+                                -NET_LL_HDRLEN(&priv->netdev), true);
                 }
             }
           else
@@ -1316,7 +1316,7 @@ static inline int rndis_recvpacket(FAR struct rndis_dev_s *priv,
           if ((index + copysize) <= CONFIG_NET_ETH_PKTSIZE)
             {
               iob_trycopyin(priv->rx_req->iob, reqbuf, copysize,
-                            priv->rx_req->iob->io_pktlen, false);
+                            priv->rx_req->iob->io_pktlen, true);
             }
           else
             {

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -369,6 +369,7 @@ void netpkt_free(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
  *   src    - The source buffer
  *   len    - How many bytes to copy
  *   offset - The offset of netpkt to put the data
+ *   type   - Whether used for TX or RX
  *
  * Returned Value:
  *   0:Success; negated errno on failure
@@ -376,7 +377,8 @@ void netpkt_free(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
  ****************************************************************************/
 
 int netpkt_copyin(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt,
-                  FAR const uint8_t *src, unsigned int len, int offset);
+                  FAR const uint8_t *src, unsigned int len, int offset,
+                  enum netpkt_type_e type);
 
 /****************************************************************************
  * Name: netpkt_copyout

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -209,7 +209,7 @@ static int ipv4_in(FAR struct net_driver_s *dev)
   totlen = (ipv4->len[0] << 8) + ipv4->len[1];
   if (totlen < dev->d_len)
     {
-      iob_update_pktlen(dev->d_iob, totlen, false);
+      iob_update_pktlen(dev->d_iob, totlen, true);
       dev->d_len = totlen;
     }
   else if (totlen > dev->d_len)

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -259,7 +259,7 @@ static int ipv6_in(FAR struct net_driver_s *dev)
 
   if (paylen < dev->d_len)
     {
-      iob_update_pktlen(dev->d_iob, paylen, false);
+      iob_update_pktlen(dev->d_iob, paylen, true);
       dev->d_len = paylen;
     }
   else if (paylen > dev->d_len)

--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -350,7 +350,7 @@ int32_t ipv4_fragin(FAR struct net_driver_s *dev)
  *   0 if success or a negative value if fail.
  *
  * Assumptions:
- *   Data length(dev->d_iob->io_pktlen) is grater than the MTU of
+ *   Data length(dev->d_iob->io_pktlen) is greater than the MTU of
  *   current NIC
  *
  ****************************************************************************/

--- a/net/netdev/netdev_input.c
+++ b/net/netdev/netdev_input.c
@@ -74,7 +74,7 @@ int netdev_input(FAR struct net_driver_s *dev,
 
   /* Prepare iob buffer */
 
-  ret = netdev_iob_prepare(dev, false, 0);
+  ret = netdev_iob_prepare(dev, true, 0);
   if (ret != OK)
     {
       return ret;
@@ -82,7 +82,7 @@ int netdev_input(FAR struct net_driver_s *dev,
 
   /* Copy data to iob entry */
 
-  ret = iob_trycopyin(dev->d_iob, buf, dev->d_len, -llhdrlen, false);
+  ret = iob_trycopyin(dev->d_iob, buf, dev->d_len, -llhdrlen, true);
   if (ret == dev->d_len)
     {
       /* Update device buffer to l2 start */

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -62,11 +62,7 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 
   if (dev->d_iob == NULL)
     {
-      dev->d_iob = net_iobtimedalloc(false, timeout);
-      if (dev->d_iob == NULL && throttled)
-        {
-          dev->d_iob = net_iobtimedalloc(true, timeout);
-        }
+      dev->d_iob = net_iobtimedalloc(throttled, timeout);
     }
 
   if (dev->d_iob == NULL)
@@ -75,7 +71,7 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
       return -ENOMEM;
     }
 
-  /* Update l2 gruard size */
+  /* Update l2 guard size */
 
   iob_reserve(dev->d_iob, CONFIG_NET_LL_GUARDSIZE);
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -75,9 +75,9 @@
 #  define TCP_WBIOB(wrb)             ((wrb)->wb_iob)
 #  define TCP_WBCOPYOUT(wrb,dest,n)  (iob_copyout(dest,(wrb)->wb_iob,(n),0))
 #  define TCP_WBCOPYIN(wrb,src,n,off) \
-     (iob_copyin((wrb)->wb_iob,src,(n),(off),true))
+     (iob_copyin((wrb)->wb_iob,src,(n),(off),false))
 #  define TCP_WBTRYCOPYIN(wrb,src,n,off) \
-     (iob_trycopyin((wrb)->wb_iob,src,(n),(off),true))
+     (iob_trycopyin((wrb)->wb_iob,src,(n),(off),false))
 
 #  define TCP_WBTRIM(wrb,n) \
      do { (wrb)->wb_iob = iob_trimhead((wrb)->wb_iob,(n)); } while (0)

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -420,7 +420,7 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
 
               iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
               int ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
-                                          0, iob, 0, false, false);
+                                          0, iob, 0, true, false);
               if (ret < 0)
                 {
                   iob_free_chain(iob);

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1607,7 +1607,8 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
            * we risk a deadlock with other threads competing on IOBs.
            */
 
-          iob = net_iobtimedalloc(true, tcp_send_gettimeout(start, timeout));
+          iob = net_iobtimedalloc(false,
+                                  tcp_send_gettimeout(start, timeout));
           if (iob != NULL)
             {
               iob_free_chain(iob);

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -100,7 +100,7 @@ FAR struct tcp_wrbuffer_s *tcp_wrbuffer_timedalloc(unsigned int timeout)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_iobtimedalloc(true, timeout);
+  wrb->wb_iob = net_iobtimedalloc(false, timeout);
 
   /* Did we get an IOB?  We should always get one except under some really
    * weird error conditions.

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -143,7 +143,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_timedalloc(unsigned int timeout)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_iobtimedalloc(true, timeout);
+  wrb->wb_iob = net_iobtimedalloc(false, timeout);
 
   /* Did we get an IOB?  We should always get one except under some really
    * weird error conditions.


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Addresses this issue: https://github.com/apache/nuttx/issues/17299

The Kconfig option CONFIG_IOB_THROTTLE is used to limit the amount allocated by TCP (and UDP) receives as to not starve sends. This distinction is made via a 'throttle' argument passed to the iob_\*alloc functions, which are wrapped by net_iob\*alloc. Previously the udp/tcp_wrbuffer_write functions incorrectly allocate with throttle=true, effectively making the IOB_THROTTLE option useless.

This patch modifies the calls in udp/tcp_wrbuffer_write to allocate unthrottled.

There were also several locations in the receive path that incorrectly allocated unthrottled.

## Impact

This should not have an effect during normal operation. This change is only in effect when CONFIG_IOB_THROTTLE > 0 and there's high reception load. In that case the system should keep operating and not deadlock on a sendto() call on a blocking socket without timeout.

## Testing

I ran `iperf -s -B 10.0.1.2 -u &` in the simulator target with the other end `iperf -c -b 100M ...` on the host machine while periodically executing `cat /proc/iobinfo` to check the state of the IOB MM. The sim target is compiled with CONFIG_IOB_THROTTLE=128

When compiled from master, I get (worst-case):
```
nsh> cat /proc/iobinfo   3.01-   6.02 sec   29767500 Bytes   79.12 Mbits/sec

    ntotal     nfree     nwait nthrottle
      1024         5         0         0
nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
      1024         5         0         0
nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
      1024         5         0         0
nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
      1024         5         0         0
```
Here you can see that nfree < CONFIG_IOB_THROTTLE(=128) even though only the receive path is exercised.

After the changes the worst-case is:
```
nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
      1024      1024         0       896
nsh> cat /proc/iobinfo   3.01-   6.02 sec   26019000 Bytes   69.15 Mbits/sec

    ntotal     nfree     nwait nthrottle
      1024       134         0         6
nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
      1024       134         0         6
```
So nfree > CONFIG_IOB_THROTTLE.


There are still several places in other drivers that don't respect the throttle parameter e.g. drivers/wireless/ieee802154/xbee/xbee.c:265
