### PR TITLE
sched/signal: Fix nxsig_ismember() return value behavior

### DIFF
--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -149,7 +149,7 @@ static int signalfd_file_close(FAR struct file *filep)
 
   for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
     {
-      if (nxsig_ismember(&dev->sigmask, signo))
+      if (nxsig_ismember(&dev->sigmask, signo) == 1)
         {
           signal(signo, SIG_DFL);
         }
@@ -379,7 +379,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
       dev = filep->f_priv;
       for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
         {
-          if (nxsig_ismember(&dev->sigmask, signo))
+          if (nxsig_ismember(&dev->sigmask, signo) == 1)
             {
               signal(signo, SIG_DFL);
             }
@@ -394,7 +394,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
   act.sa_user = dev;
   for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
     {
-      if (nxsig_ismember(&dev->sigmask, signo))
+      if (nxsig_ismember(&dev->sigmask, signo) == 1)
         {
           nxsig_action(signo, &act, NULL, false);
         }

--- a/libs/libc/signal/sig_ismember.c
+++ b/libs/libc/signal/sig_ismember.c
@@ -68,7 +68,7 @@ int nxsig_ismember(FAR const sigset_t *set, int signo)
     {
       /* Check if the signal is in the set */
 
-      return ((set->_elem[_SIGSET_NDX(signo)] & _SIGNO2SET(signo)) != 0);
+      return (set->_elem[_SIGSET_NDX(signo)] & _SIGNO2SET(signo)) ? 1 : 0;
     }
 }
 

--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -127,7 +127,7 @@ static int group_signal_handler(pid_t pid, FAR void *arg)
 
   /* Is this signal unblocked on this thread? */
 
-  if (!nxsig_ismember(&tcb->sigprocmask, info->siginfo->si_signo) &&
+  if ((nxsig_ismember(&tcb->sigprocmask, info->siginfo->si_signo) != 1) &&
       !info->ptcb && tcb != info->atcb)
     {
       /* Yes.. remember this TCB if we have not encountered any

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -550,7 +550,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
 
       if (stcb->task_state == TSTATE_WAIT_SIG &&
           (masked == 0 ||
-           nxsig_ismember(&stcb->sigwaitmask, info->si_signo)))
+           (nxsig_ismember(&stcb->sigwaitmask, info->si_signo) == 1)))
         {
           if (stcb->sigunbinfo != NULL)
             {

--- a/sched/signal/sig_lowest.c
+++ b/sched/signal/sig_lowest.c
@@ -50,7 +50,7 @@ int nxsig_lowest(sigset_t *set)
 
   for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
     {
-      if (nxsig_ismember(set, signo))
+      if (nxsig_ismember(set, signo) == 1)
         {
           return signo;
         }

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -413,7 +413,7 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
            * that we were waiting for?
            */
 
-          if (nxsig_ismember(set, rtcb->sigunbinfo->si_signo))
+          if (nxsig_ismember(set, rtcb->sigunbinfo->si_signo) == 1)
             {
               /* Yes.. the return value is the number of the signal that
                * awakened us.


### PR DESCRIPTION
## Summary

nxsig_ismember() has a return type of int, but the current implementation returns a boolean value, which is incorrect.
All callers should determine membership by checking whether the return value is 1 or 0, which is also consistent with the POSIX sigismember() API.


## Impact

Fix issue of nxsig_ismember implementation, no impact to any other Nuttx functions

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop
nsh> uname -a
NuttX 0.0.0 1827748fbb Nov 21 2025 15:51:41 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         7        5
mxordblk  7fe1ee0  7febf08
uordblks     d724     b63c
fordblks  7fec618  7fee700

user_main: vfork() test
[ 4] ostest: arm_fork: fork context [0x2000f6b8]:
[ 4] ostest: arm_fork:   r4:20003860 r5:00000000 r6:00000000 r7:00000000
[ 4] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[ 4] ostest: arm_fork:   r11:00000000 sp:2000f6e0 lr:00055c04
[ 4] ostest: nxtask_setup_fork: Child priority=100 start=0x55c04
[ 4] ostest: nxtask_setup_fork: parent=0x2000d358, returning child=0x2000f790
[ 4] ostest: arm_fork: TCBs: Parent=0x2000d358 Child=0x2000f790
[ 4] ostest: arm_fork: Parent: stackutil:152
[ 4] ostest: arm_fork: Old stack top:2000f778 SP:2000f6e0 FP:00000000
[ 4] ostest: arm_fork: New stack top:20013a80 SP:200139e8 FP:00000000
[ 4] ostest: nxtask_start_fork: Starting Child TCB=0x2000f790
[ 4] ostest: nxtask_activate: ostest pid=85,TCB=0x2000f790
[85] ostest: nxtask_exit: ostest pid=85,TCB=0x2000f790
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         1        5
mxordblk  7ff0880  7febf08
uordblks     94bc     b55c
fordblks  7ff0880  7fee7e0
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d358
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af38
nsh> 
```

