### PR TITLE
sched/signal: Unblock task waiting for event when a signal received

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -43,6 +43,7 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "semaphore/semaphore.h"
+#include "event/event.h"
 #include "signal/signal.h"
 #include "mqueue/mqueue.h"
 
@@ -654,6 +655,17 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
         {
           nxsem_wait_irq(stcb, EINTR);
         }
+
+#ifdef CONFIG_SCHED_EVENTS
+      /* If the task is blocked waiting for a event, then that task must
+       * be unblocked when a signal is received.
+       */
+
+      else if (stcb->task_state == TSTATE_WAIT_EVENT)
+        {
+          nxevent_wait_irq(stcb, EINTR);
+        }
+#endif
 
 #if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
       /* If the task is blocked waiting on a message queue, then that task


### PR DESCRIPTION
## Summary

 If the task is blocked waiting for a event, then that task must
 be unblocked when a signal is received.

## Impact

Fix signal dispatch issue, no impact to other nuttx functions.

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop

nsh> uname -a
NuttX 0.0.0 78d7e29638 Nov 22 2025 15:49:02 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

user_main: nxevent test
[ 4] ostest: nxtask_activate: ostest pid=86,TCB=0x20011988
[86] ostest: nx_pthread_exit: exit_value=0
[86] ostest: pthread_completejoin: pid=86 exit_value=0
[86] ostest: nxtask_exit: ostest pid=86,TCB=0x20011988
[ 4] ostest: pthread_destroyjoin: pjoin=0x20011a70
[ 4] ostest: pthread_join: Returning 0
[ 4] ostest: nxtask_activate: ostest pid=87,TCB=0x20011988
[ 4] ostest: nxtask_activate: ostest pid=88,TCB=0x20011ac8
[87] ostest: nx_pthread_exit: exit_value=0
[87] ostest: pthread_completejoin: pid=87 exit_value=0
[87] ostest: nxtask_exit: ostest pid=87,TCB=0x20011988
[88] ostest: nx_pthread_exit: exit_value=0
[88] ostest: pthread_completejoin: pid=88 exit_value=0
[88] ostest: nxtask_exit: ostest pid=88,TCB=0x20011ac8
[ 4] ostest: pthread_destroyjoin: pjoin=0x20011a70
[ 4] ostest: pthread_join: Returning 0
[ 4] ostest: pthread_destroyjoin: pjoin=0x20011a80
[ 4] ostest: pthread_join: Returning 0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d1c  7ff9d1c
ordblks         5        5
mxordblk  7febeb8  7febeb8
uordblks     b664     b664
fordblks  7fee6b8  7fee6b8

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d1c  7ff9d1c
ordblks         1        5
mxordblk  7ff0840  7febeb8
uordblks     94dc     b664
fordblks  7ff0840  7fee6b8
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d390
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af68
nsh>
```
