### PR TITLE
sched/signal: Initialize signal action pool during init phase

### DIFF
--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -62,11 +62,6 @@
 
 static spinlock_t g_sigaction_spin;
 
-#if CONFIG_SIG_PREALLOC_ACTIONS > 0
-static sigactq_t  g_sigactions[CONFIG_SIG_PREALLOC_ACTIONS];
-static bool       g_sigactions_used = false;
-#endif
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -85,23 +80,6 @@ static void nxsig_alloc_actionblock(void)
   FAR sigactq_t *sigact;
   irqstate_t flags;
   int i;
-
-  /* Use pre-allocated instances only once */
-
-#if CONFIG_SIG_PREALLOC_ACTIONS > 0
-  flags = spin_lock_irqsave(&g_sigaction_spin);
-  if (!g_sigactions_used)
-    {
-      for (i = 0; i < CONFIG_SIG_PREALLOC_ACTIONS; i++)
-        {
-          sq_addlast((FAR sq_entry_t *)(g_sigactions + i), &g_sigfreeaction);
-        }
-
-      g_sigactions_used = true;
-    }
-
-  spin_unlock_irqrestore(&g_sigaction_spin, flags);
-#endif
 
   /* Allocate a block of signal actions */
 

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -116,6 +116,12 @@ typedef struct sigq_s sigq_t;
  * Public Data
  ****************************************************************************/
 
+/* The g_sigactions data structure a pool of pre-allocated signal action
+ * structures buffers structures.
+ */
+
+extern  sigactq_t  g_sigactions[CONFIG_SIG_PREALLOC_ACTIONS];
+
 /* The g_sigfreeaction data structure is a list of available signal action
  * structures.
  */


### PR DESCRIPTION
## Summary

Initialize the signal action pool during the signal initialization phase to 
improve performance and reduce footprint.

## Impact

Improved the signal implementation, no impact to existing nuttx functions

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop
nsh> 
nsh> uname -a
NuttX 0.0.0 f0e0f5219c Nov 23 2025 16:13:04 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d44  7ff9d44
ordblks         7        5
mxordblk  7fe1ee8  7febf10
uordblks     d724     b63c
fordblks  7fec620  7fee708

user_main: vfork() test
[ 4] ostest: arm_fork: fork context [0x2000f6b0]:
[ 4] ostest: arm_fork:   r4:20003858 r5:00000000 r6:00000000 r7:00000000
[ 4] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[ 4] ostest: arm_fork:   r11:00000000 sp:2000f6d8 lr:00055bec
[ 4] ostest: nxtask_setup_fork: Child priority=100 start=0x55bec
[ 4] ostest: nxtask_setup_fork: parent=0x2000d350, returning child=0x2000f788
[ 4] ostest: arm_fork: TCBs: Parent=0x2000d350 Child=0x2000f788
[ 4] ostest: arm_fork: Parent: stackutil:152
[ 4] ostest: arm_fork: Old stack top:2000f770 SP:2000f6d8 FP:00000000
[ 4] ostest: arm_fork: New stack top:20013a78 SP:200139e0 FP:00000000
[ 4] ostest: nxtask_start_fork: Starting Child TCB=0x2000f788
[ 4] ostest: nxtask_activate: ostest pid=85,TCB=0x2000f788
[85] ostest: nxtask_exit: ostest pid=85,TCB=0x2000f788
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d44  7ff9d44
ordblks         1        5
mxordblk  7ff0888  7febf10
uordblks     94bc     b55c
fordblks  7ff0888  7fee7e8
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d350
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af30
nsh>
```
