### PR TITLE
sched/signal: Fix nxsig clockwait() implementation issue

### DIFF
--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -256,7 +256,7 @@ int nxsig_clockwait(int clockid, int flags,
         }
 
         wd_start_abstick(&rtcb->waitdog, expect,
-                          nxsig_timeout, (uintptr_t)rtcb);
+                         nxsig_timeout, (uintptr_t)rtcb);
     }
 
   /* Remove the tcb task from the ready-to-run list. */
@@ -283,7 +283,8 @@ int nxsig_clockwait(int clockid, int flags,
 
   if (rqtp && rmtp && expect)
     {
-      clock_ticks2time(rmtp, expect > stop ? expect - stop : 0);
+      clock_ticks2time(rmtp,
+                       clock_compare(stop, expect) ? expect - stop : 0);
     }
 
   return 0;


### PR DESCRIPTION
## Summary

This PR did three things:

1. Fix remaining time calculation in nxsig_clockwait()

Always compute the expected wake-up time by default, so the remaining
time can be calculated correctly when the flag is TIMER_ABSTIME.

2. Remove redundant wd_cancel() in nxsig_clockwait()

Both the watchdog timeout and signal dispatch paths already cancel
the watchdog timer, so the explicit wd_cancel() call is redundant.

3. Use clock_compare() in nxsig_clockwait()
clock_compare() should be used when comparing clock tick values to
ensure correct handling of tick wrap-around and time ordering.


## Impact

Fix nxsig clockwait() implementation issue, no impact to any existing nuttx functions

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop
nsh> 
nsh> uname -a
NuttX 0.0.0 df2ed8d76f Nov 23 2025 21:49:53 arm fvp-armv8r-aarch32
nsh> 
nsh> ostest

(...)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         7        5
mxordblk  7fe1ee0  7febf08
uordblks     d724     b63c
fordblks  7fec618  7fee700

user_main: vfork() test
[ 4] ostest: arm_fork: fork context [0x2000f6b8]:
[ 4] ostest: arm_fork:   r4:20003860 r5:00000000 r6:00000000 r7:00000000
[ 4] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[ 4] ostest: arm_fork:   r11:00000000 sp:2000f6e0 lr:00055c14
[ 4] ostest: nxtask_setup_fork: Child priority=100 start=0x55c14
[ 4] ostest: nxtask_setup_fork: parent=0x2000d358, returning child=0x2000f790
[ 4] ostest: arm_fork: TCBs: Parent=0x2000d358 Child=0x2000f790
[ 4] ostest: arm_fork: Parent: stackutil:152
[ 4] ostest: arm_fork: Old stack top:2000f778 SP:2000f6e0 FP:00000000
[ 4] ostest: arm_fork: New stack top:20013a80 SP:200139e8 FP:00000000
[ 4] ostest: nxtask_start_fork: Starting Child TCB=0x2000f790
[ 4] ostest: nxtask_activate: ostest pid=85,TCB=0x2000f790
[85] ostest: nxtask_exit: ostest pid=85,TCB=0x2000f790
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         1        5
mxordblk  7ff0880  7febf08
uordblks     94bc     b55c
fordblks  7ff0880  7fee7e0
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d358
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af38
nsh> 
```
