### PR TITLE
sched/sleep: Add nxsched_nanosleep() API

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1817,6 +1817,28 @@ void nxsched_msleep(unsigned int msec);
 
 void nxsched_sleep(unsigned int sec);
 
+/****************************************************************************
+ * Name: nxsched_nanosleep
+ *
+ * Description:
+ *   Internal nanosleep implementation used by the scheduler.  This function
+ *   converts the requested sleep interval into system ticks, performs a
+ *   tick-based blocking sleep, and optionally returns the remaining time if
+ *   the sleep is interrupted by a signal.
+ *
+ * Input Parameters:
+ *   rqtp - Requested sleep interval (may be NULL)
+ *   rmtp - Remaining time returned when interrupted (optional, may be NULL)
+ *
+ * Returned Value:
+ *   Returns OK (0) on success.  Returns -EINVAL for an invalid timespec
+ *   argument and -EAGAIN for a zero-length timeout, as required by POSIX.
+ *
+ ****************************************************************************/
+
+int nxsched_nanosleep(FAR const struct timespec *rqtp,
+                      FAR struct timespec *rmtp);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary

Introduce the nxsched_nanosleep() API to provide a lightweight nanosecond-level sleep based on nxsched_ticksleep(). This API offers the same functionality as nxsig_nanosleep() but without signal-related overhead, making it suitable for implementing libc sleep() or usleep() when signals are disabled.

## Impact

New api added, no impact to existing nuttx functions

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop
nsh>
nsh> uname -a
NuttX 0.0.0 3e83236063 Nov 23 2025 23:19:00 arm fvp-armv8r-aarch32
nsh> ostest

(...)

user_main: vfork() test
[ 4] ostest: arm_fork: fork context [0x2000f6b8]:
[ 4] ostest: arm_fork:   r4:20003860 r5:00000000 r6:00000000 r7:00000000
[ 4] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[ 4] ostest: arm_fork:   r11:00000000 sp:2000f6e0 lr:00055f04
[ 4] ostest: nxtask_setup_fork: Child priority=100 start=0x55f04
[ 4] ostest: nxtask_setup_fork: parent=0x2000d358, returning child=0x2000f790
[ 4] ostest: arm_fork: TCBs: Parent=0x2000d358 Child=0x2000f790
[ 4] ostest: arm_fork: Parent: stackutil:152
[ 4] ostest: arm_fork: Old stack top:2000f778 SP:2000f6e0 FP:00000000
[ 4] ostest: arm_fork: New stack top:20013a80 SP:200139e8 FP:00000000
[ 4] ostest: nxtask_start_fork: Starting Child TCB=0x2000f790
[ 4] ostest: nxtask_activate: ostest pid=85,TCB=0x2000f790
[85] ostest: nxtask_exit: ostest pid=85,TCB=0x2000f790
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d3c  7ff9d3c
ordblks         1        5
mxordblk  7ff0880  7febf08
uordblks     94bc     b55c
fordblks  7ff0880  7fee7e0
user_main: Exiting
[ 4] ostest: nxtask_exit: ostest pid=4,TCB=0x2000d358
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[ 3] ostest: nxtask_exit: ostest pid=3,TCB=0x2000af38
nsh>
```
