### PR TITLE
Revert "sched/signal: Unblock task waiting for event when a signal received"

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -43,7 +43,6 @@
 #include "sched/sched.h"
 #include "group/group.h"
 #include "semaphore/semaphore.h"
-#include "event/event.h"
 #include "signal/signal.h"
 #include "mqueue/mqueue.h"
 
@@ -655,17 +654,6 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info,
         {
           nxsem_wait_irq(stcb, EINTR);
         }
-
-#ifdef CONFIG_SCHED_EVENTS
-      /* If the task is blocked waiting for a event, then that task must
-       * be unblocked when a signal is received.
-       */
-
-      else if (stcb->task_state == TSTATE_WAIT_EVENT)
-        {
-          nxevent_wait_irq(stcb, EINTR);
-        }
-#endif
 
 #if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
       /* If the task is blocked waiting on a message queue, then that task


### PR DESCRIPTION
Reverts apache/nuttx#17362

Events are not defined in the POSIX standard, so signals are not required to wake tasks that are in the TSTATE_WAIT_EVENT state.