### PR TITLE
arch/arm64: fix create page table err

### DIFF
--- a/arch/arm64/src/common/arm64_mmu.h
+++ b/arch/arm64/src/common/arm64_mmu.h
@@ -156,6 +156,7 @@
 #define TCR_TG0_64K                 (1ULL << 14)
 #define TCR_TG0_16K                 (2ULL << 14)
 #define TCR_EPD1_DISABLE            (1ULL << 23)
+#define TCR_DS                      (1ULL << 59)
 
 #define TCR_AS_SHIFT                36U
 #define TCR_ASID_8                  (0ULL << TCR_AS_SHIFT)
@@ -181,6 +182,7 @@
 #define TCR_PS_BITS_4TB             0x3ULL
 #define TCR_PS_BITS_16TB            0x4ULL
 #define TCR_PS_BITS_256TB           0x5ULL
+#define TCR_PS_BITS_4PB             0x6ULL
 
 #define CTR_EL0_DMINLINE_SHIFT      16
 #define CTR_EL0_DMINLINE_MASK       BIT_MASK(4)


### PR DESCRIPTION
## Summary

fix arm64 platform create page table bug

arm64 pci mmio address space is 512G,
arm64 512G  Block can not be used as lockDescriptors,
So the when PA_BITS !=52  level 0 can not be used as BlockDescriptors,

```
pcie@10000000 {
    #address-cells = <0x03>;
    #size-cells = <0x02>;
    dma-coherent;
    bus-range = <0x00 0xff>;
    interrupt-map = <
      0x00 0x00 0x00 0x01 0x8001 0x00 0x00 0x00 0x03 0x04 
      0x00 0x00 0x00 0x02 0x8001 0x00 0x00 0x00 0x04 0x04 
      0x00 0x00 0x00 0x03 0x8001 0x00 0x00 0x00 0x05 0x04 
      0x00 0x00 0x00 0x04 0x8001 0x00 0x00 0x00 0x06 0x04 
      0x800 0x00 0x00 0x01 0x8001 0x00 0x00 0x00 0x04 0x04 
      0x800 0x00 0x00 0x02 0x8001 0x00 0x00 0x00 0x05 0x04 
      0x800 0x00 0x00 0x03 0x8001 0x00 0x00 0x00 0x06 0x04 
      0x800 0x00 0x00 0x04 0x8001 0x00 0x00 0x00 0x03 0x04 
      0x1000 0x00 0x00 0x01 0x8001 0x00 0x00 0x00 0x05 0x04 
      0x1000 0x00 0x00 0x02 0x8001 0x00 0x00 0x00 0x06 0x04 
      0x1000 0x00 0x00 0x03 0x8001 0x00 0x00 0x00 0x03 0x04 
      0x1000 0x00 0x00 0x04 0x8001 0x00 0x00 0x00 0x04 0x04 
      0x1800 0x00 0x00 0x01 0x8001 0x00 0x00 0x00 0x06 0x04 
      0x1800 0x00 0x00 0x02 0x8001 0x00 0x00 0x00 0x03 0x04 
      0x1800 0x00 0x00 0x03 0x8001 0x00 0x00 0x00 0x04 0x04 
      0x1800 0x00 0x00 0x04 0x8001 0x00 0x00 0x00 0x05 0x04
      >;
    device_type = "pci";
    interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
    compatible = "pci-host-ecam-generic";
    ranges = <
      0x1000000 0x00 0x00       0x00 0x3eff0000 0x00 0x10000 
      0x2000000 0x00 0x10000000 0x00 0x10000000 0x00 0x2eff0000 
      0x3000000 0x80 0x00       0x80 0x00       0x80 0x00
      >;
    #interrupt-cells = <0x01>;
    reg = <0x40 0x10000000 0x00 0x10000000>;
    linux,pci-domain = <0x00>;
    msi-parent = <0x8002>;
  };
```

// 0x3000000 0x80 0x00       0x80 0x00       0x80 0x00
This address space, when create page table,
The original logic,only create one Block,size is 512G,
But arm64 platform, can not use 512G as a BlockDescriptors, Ths biggest Block is 1G,
so ,it need 512 BlockDescriptors,

qemu 9,or qemu 10, The original logic will crash when access that address space,this patch will fix the bug

## Impact

 Impact on arm64 arch

like qemu 9,or qemu 10, pcie 64bit MMIO space, The original logic will crash when access that address space.


## Testing

At qemu 9,or qemu 10, The original logic

```console
/home/lipengfei28/android/qemu-10.0.0/build/qemu-system-aarch64 --version
QEMU emulator version 10.0.0
Copyright (c) 2003-2025 Fabrice Bellard and the QEMU Project developers
 /home/lipengfei28/android/qemu-10.0.0/build/qemu-system-aarch64  -cpu cortex-a53 -nographic -machine virt,virtualization=on,gic-version=3 -nographic -object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes -device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb -kernel nuttx
== smmu_base_class_init 985
== smmuv3_class_init 1996
Reset board on recursive assert:
0x4098fa70: 000000004098fa70 000000000000022d 0000000000000000 0000000000000000 0000000000000001 0000000000000001 00000000409d34b0 0000000000000004
0x4098fab0: 000000000000000f 0000000096000006 0000000000000025 0000000000000000 000000000a200023 3033303478303c5b 0ffffffffffffffe 0000000000000000
0x4098faf0: 00000000ffffffff 0000000000000001 0000000000000000 00000000409d34b0 0000000000000000 00000000406fef18 000000004098fa70 0000000000000001
0x4098fb30: 000000004098e000 000000000000022d 0000000000000008 0000000040958000 00000000000003c0 00000000409c0390 00000000402ff32c 00000000409c0280
0x4098fb70: 00000000402ff32c 00000000600003c5 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fbb0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fbf0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fc30: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fc70: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fcb0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fcf0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fd30: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
0x4098fd70: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
```


 The patch will fix the crash

```console
/home/lipengfei28/android/qemu-10.0.0/build/qemu-system-aarch64  -cpu cortex-a53 -nographic -machine virt,virtualization=on,gic-version=3 -nographic -object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes -device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb -kernel nuttx
== smmu_base_class_init 985
== smmuv3_class_init 1996
nsh: mount: mount failed: 15
nsh: mount: mount failed: 15
nsh: mount: mount failed: 15
nsh: mount: mount failed: 19
not found /data, create tmpfs instead
dfxd [0:255]
kvdbd [0:255]
servicemanager [0:255]
cpcservicemanager [0:255]
adbd [0:255]
telnetd [0:255]

NuttShell (NSH) NuttX-12.3.0
qemu-armv8a-ap>
qemu-armv8a-ap> [    0.000000] [ 0] [  INFO] [ap] pci_register_rptun_ivshmem_slave_driver: Register ivshmem driver, id=0, cpuname=droid, master=0
[    0.064605] [ 5] [  INFO] [ap] pci_scan_bus: pci_scan_bus for bus 0
[    0.065217] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.065328] [ 5] [  INFO] [ap] pci_scan_bus: 00:00 [1b36:0008]
[    0.065694] [ 5] [  INFO] [ap] pci_setup_device: pbar0 set bad mask
[    0.065740] [ 5] [  INFO] [ap] pci_setup_device: pbar1 set bad mask
[    0.065763] [ 5] [  INFO] [ap] pci_setup_device: pbar2 set bad mask
[    0.065783] [ 5] [  INFO] [ap] pci_setup_device: pbar3 set bad mask
[    0.065802] [ 5] [  INFO] [ap] pci_setup_device: pbar4 set bad mask
[    0.065821] [ 5] [  INFO] [ap] pci_setup_device: pbar5 set bad mask
[    0.066164] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.066194] [ 5] [  INFO] [ap] pci_scan_bus: 00:08 [1af4:1000]
[    0.066300] [ 5] [  INFO] [ap] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.066439] [ 5] [  INFO] [ap] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.066468] [ 5] [  INFO] [ap] pci_setup_device: pbar2 set bad mask
[    0.066489] [ 5] [  INFO] [ap] pci_setup_device: pbar3 set bad mask
[    0.066685] [ 5] [  INFO] [ap] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.066918] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.066946] [ 5] [  INFO] [ap] pci_scan_bus: 00:58 [1af4:1110]
[    0.066975] [ 5] [  INFO] [ap] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.067002] [ 5] [  INFO] [ap] pci_setup_device: pbar1 set bad mask
[    0.067029] [ 5] [  INFO] [ap] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.067062] [ 5] [  INFO] [ap] pci_setup_device: pbar4 set bad mask
[    0.067081] [ 5] [  INFO] [ap] pci_setup_device: pbar5 set bad mask
[    0.068460] [ 5] [  INFO] [ap] ivshmem_probe: shmem addr=0x8000400000 size=4194304 reg=0x10001000
[    0.068842] [ 5] [  INFO] [ap] rptun_ivshmem_probe: shmem addr=0x8000400000 size=4194304
[    0.069886] [ 5] [  INFO] [ap] rptun_ivshmem_probe: Start the wdog
NuttX  12.3.0 8d4a442abfd-dirty Nov 28 2025 14:59:54 arm64 ap
[    0.105292] [ 8] [  INFO] [ap] dfxd_main:171 dfx daemon init start.
[    0.105772] [ 8] [  INFO] [ap] dfxd_main:186 No arguments provided, using default configuration.
[    0.106771] [ 8] [  INFO] [ap] dfx_file_alloc:198 dfx file config - Directory: /data/dfx/log/, Compress: true, Max size: 2097152, Max num: 8
[    0.149924] [13] [  INFO] [ap] adb_hal_run (84): uv_loop exit 0
[    0.640462] [ 8] [  INFO] [ap] dfx_check_version:406 version mismatch, need to update property
[    0.641072] [ 8] [ ERROR] [ap] dfx_rmdir_recursive:364 Failed to open directory: /data/dfx/log/, 2
[    0.646272] [ 8] [  INFO] [ap] logfile_open_for_write:226 Latest log file found: 20251128150811_0_0_0.log, start index: 0
[    0.646761] [ 8] [  INFO] [ap] logfile_open_for_write:258 Log file /data/dfx/log//20251128150811_0_0_0.log opened for write
[    0.646836] [ 8] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: log success
[    0.646898] [ 8] [  INFO] [ap] dfx_channel_register:190 Registered type=logfile;name=log;directory=/data/dfx/log/;compress=1;maxsize=2097152;maxnum=8
[    0.646963] [ 8] [  INFO] [ap] dfx_main_process_arg:126 Registered channel from spec: type=logfile;name=log;directory=/data/dfx/log/;compress=1;maxsize=2097152;maxnum=8
[    0.647068] [ 8] [  INFO] [ap] dfx_file_alloc:198 dfx file config - Directory: /data/dfx/core/, Compress: true, Max size: 131072, Max num: 4
[    0.647744] [ 8] [  INFO] [ap] dfx_check_version:406 version mismatch, need to update property
[    0.647840] [ 8] [ ERROR] [ap] dfx_rmdir_recursive:364 Failed to open directory: /data/dfx/core/, 2
[    0.648102] [ 8] [  INFO] [ap] logfile_open_for_write:226 Latest log file found: 20251128150811_0_0_0.log, start index: 0
[    0.648244] [ 8] [  INFO] [ap] logfile_open_for_write:258 Log file /data/dfx/core//20251128150811_0_0_0.log opened for write
[    0.648273] [ 8] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: core success
[    0.648296] [ 8] [  INFO] [ap] dfx_channel_register:190 Registered type=logfile;name=core;directory=/data/dfx/core/;compress=1;crash=1;maxsize=131072;maxnum=4
[    0.648336] [ 8] [  INFO] [ap] dfx_main_process_arg:126 Registered channel from spec: type=logfile;name=core;directory=/data/dfx/core/;compress=1;crash=1;maxsize=131072;maxnum=4
[    0.648440] [ 8] [  INFO] [ap] dfx_file_alloc:198 dfx file config - Directory: /dev/, Compress: false, Max size: 0, Max num: 0
[    0.648596] [ 8] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: console success
[    0.648623] [ 8] [  INFO] [ap] dfx_channel_register:190 Registered type=devfile;name=console;directory=/dev/
[    0.648642] [ 8] [  INFO] [ap] dfx_main_process_arg:126 Registered channel from spec: type=devfile;name=console;directory=/dev/
[    0.649045] [ 8] [  INFO] [ap] dfx_device_associate_channel:142 Processing channels list for device: log,core,console
[    0.649343] [ 8] [  INFO] [ap] dfx_device_associate_channel:158 Device: /dev/kmsg has associated channel: log
[    0.649402] [ 8] [  INFO] [ap] dfx_device_associate_channel:158 Device: /dev/kmsg has associated channel: core
[    0.649432] [ 8] [  INFO] [ap] dfx_device_associate_channel:158 Device: /dev/kmsg has associated channel: console
[    0.649685] [ 8] [  INFO] [ap] dfx_device_register:294 Register device: /dev/kmsg, type: 0, fd: 2104
[    0.649766] [ 8] [  INFO] [ap] dfx_main_process_arg:117 Registered device from spec: type=log;path=/dev/kmsg;channels=log,core,console
[    0.650358] [ 8] [  INFO] [ap] dfx_cmd_device_register:365 Command socket server opened: /tmp/dfx_cmd_socket, fd: 2361
[    0.650475] [ 8] [  INFO] [ap] dfx_cmd_device_register:393 Command device registered: fd=2361, path=cmdqueue
[    0.655333] [ 8] [  INFO] [ap] dfx_update_version:430 dfx file update property success, version: 8d4a442abfd-dirty Nov 28 2025 14:59:54
[    0.655405] [ 8] [  INFO] [ap] dfx_daemon_loop:83 DFX daemon started, entering main event loop

qemu-armv8a-ap> ls
/:
 bin/
 data/
 dev/
 etc/
 host/
 proc/
 tmp/
 var/
qemu-armv8a-ap> pwd
/
```

Result :  no crash occurs.