### PR TITLE
drivers/pci: Calculate PCI bar size use mask 0xffffffff

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -713,7 +713,7 @@ static void pci_setup_device(FAR struct pci_device_s *dev, int max_bar,
       unsigned int flags;
 
       pci_read_config_dword(dev, base_address_0, &orig0);
-      pci_write_config_dword(dev, base_address_0, 0xfffffffe);
+      pci_write_config_dword(dev, base_address_0, 0xffffffff);
       pci_read_config_dword(dev, base_address_0, &mask);
 
       if (mask == 0 || mask == 0xffffffff)


### PR DESCRIPTION
## Summary

pci: Calculate PCI bar size use mask 0xffffffff

This is the description from the PCIe specification:
5.0-1.0-PUB —PCI Express® Base Specification Revision 5.0 Version 1.0
Decode (I/O or memory) of the appropriate address space is disabled via the Command Register before sizing a
Base Address register. Software saves the original value of the Base Address register, writes a value of all 1's to the
register, then reads it back. Size calculation can be done from the 32 bit value read by first clearing encoding
information bits (bits 1:0 for I/O, bits 3:0 for memory), inverting all 32 bits (logical NOT), then incrementing by 1.
The resultant 32-bit value is the memory/I/O range size decoded by the register. Note that the upper 16 bits of the
result is ignored if the Base Address register is for I/O and bits 31:16 returned zero upon read. The original value in
the Base Address register is restored before re-enabling decode in the Command Register of the Function.
64-bit (memory) Base Address registers can be handled the same, except that the second 32 bit register is
considered an extension of the first (i.e., bits 63:32). Software writes a value of all 1's to both registers, reads them
back, and combines the result into a 64-bit value. Size calculation is done on the 64-bit value.


## Impact

 Impact on pcie driver
Calculate PCI bar size use mask 0xffffffff,According to the PCI Express specification



## Testing
qemu-system-aarch64 -cpu cortex-a53 -nographic -machine virt,virtualization=on,gic-version=3 -chardev stdio,id=con,mux=on -serial chardev:con  -mon chardev=con,mode=readline -object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes -device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb  -kernel  nuttx
NuttShell (NSH) NuttX-12.3.0
qemu-armv8a-ap> [    0.000000] [ 0] [  INFO] [ap] pci_register_rptun_ivshmem_slave_driver: Register ivshmem driver, id=0, cpuname=droid, master=0
[    0.062528] [ 5] [  INFO] [ap] pci_scan_bus: pci_scan_bus for bus 0
[    0.063122] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.063233] [ 5] [  INFO] [ap] pci_scan_bus: 00:00 [1b36:0008]
[    0.063590] [ 5] [  INFO] [ap] pci_setup_device: pbar0 set bad mask
[    0.063631] [ 5] [  INFO] [ap] pci_setup_device: pbar1 set bad mask
[    0.063652] [ 5] [  INFO] [ap] pci_setup_device: pbar2 set bad mask
[    0.063670] [ 5] [  INFO] [ap] pci_setup_device: pbar3 set bad mask
[    0.063688] [ 5] [  INFO] [ap] pci_setup_device: pbar4 set bad mask
[    0.063705] [ 5] [  INFO] [ap] pci_setup_device: pbar5 set bad mask
[    0.064058] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.064085] [ 5] [  INFO] [ap] pci_scan_bus: 00:08 [1af4:1000]
[    0.064189] [ 5] [  INFO] [ap] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.064322] [ 5] [  INFO] [ap] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.064348] [ 5] [  INFO] [ap] pci_setup_device: pbar2 set bad mask
[    0.064369] [ 5] [  INFO] [ap] pci_setup_device: pbar3 set bad mask
[    0.064574] [ 5] [  INFO] [ap] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.064776] [ 5] [  INFO] [ap] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.064803] [ 5] [  INFO] [ap] pci_scan_bus: 00:58 [1af4:1110]
[    0.064830] [ 5] [  INFO] [ap] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.064856] [ 5] [  INFO] [ap] pci_setup_device: pbar1 set bad mask
[    0.064881] [ 5] [  INFO] [ap] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes **// use mask=ffffffff can correctly calculate the size of the BAR.**
[    0.064912] [ 5] [  INFO] [ap] pci_setup_device: pbar4 set bad mask
[    0.064931] [ 5] [  INFO] [ap] pci_setup_device: pbar5 set bad mask
[    0.066208] [ 5] [  INFO] [ap] ivshmem_probe: shmem addr=0x8000400000 size=4194304 reg=0x10001000
[    0.066566] [ 5] [  INFO] [ap] rptun_ivshmem_probe: shmem addr=0x8000400000 size=4194304  **### // use mask=ffffffff can correctly calculate the size of the BAR.**
[    0.067454] [ 5] [  INFO] [ap] rptun_ivshmem_probe: Start the wdog
NuttX  12.3.0 f89c09afff8 Jan 16 2026 14:04:21 arm64 ap
[    0.105200] [12] [  INFO] [ap] dfxd_main:173 dfx daemon init start.
[    0.105668] [12] [  INFO] [ap] dfxd_main:188 No arguments provided, using default configuration.
[    0.106678] [12] [  INFO] [ap] dfx_file_alloc:200 dfx file config - Directory: /data/dfx/log/, Compress: true, Max size: 2097152, Max num: 8
[    0.144930] [22] [  INFO] [ap] adb_hal_run (84): uv_loop exit 0
[    0.640989] [12] [  INFO] [ap] dfx_check_version:407 version mismatch, need to update property
[    0.642466] [12] [ ERROR] [ap] dfx_rmdir_recursive:365 Failed to open directory: /data/dfx/log/, 2
[    0.647151] [12] [  INFO] [ap] logfile_open_for_write:228 Latest log file found: 20260116145519_0_0_0.log, start index: 0
[    0.647573] [12] [  INFO] [ap] logfile_open_for_write:260 Log file /data/dfx/log//20260116145519_0_0_0.log opened for write
[    0.647674] [12] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: log success
[    0.647741] [12] [  INFO] [ap] dfx_channel_register:190 Registered type=logfile;name=log;directory=/data/dfx/log/;compress=1;maxsize=2097152;m8
[    0.647789] [12] [  INFO] [ap] dfx_main_process_arg:128 Registered channel from spec: type=logfile;name=log;directory=/data/dfx/log/;compress=8
[    0.647945] [12] [  INFO] [ap] dfx_file_alloc:200 dfx file config - Directory: /data/dfx/core/, Compress: true, Max size: 131072, Max num: 4
[    0.648563] [12] [  INFO] [ap] dfx_check_version:407 version mismatch, need to update property
[    0.648656] [12] [ ERROR] [ap] dfx_rmdir_recursive:365 Failed to open directory: /data/dfx/core/, 2
[    0.648884] [12] [  INFO] [ap] logfile_open_for_write:228 Latest log file found: 20260116145519_0_0_0.log, start index: 0
[    0.649051] [12] [  INFO] [ap] logfile_open_for_write:260 Log file /data/dfx/core//20260116145519_0_0_0.log opened for write
[    0.649079] [12] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: core success
[    0.649100] [12] [  INFO] [ap] dfx_channel_register:190 Registered type=logfile;name=core;directory=/data/dfx/core/;compress=1;crash=1;maxsize4
[    0.649118] [12] [  INFO] [ap] dfx_main_process_arg:128 Registered channel from spec: type=logfile;name=core;directory=/data/dfx/core/;compres4
[    0.649238] [12] [  INFO] [ap] dfx_file_alloc:200 dfx file config - Directory: /dev/, Compress: false, Max size: 0, Max num: 0
[    0.649386] [12] [  INFO] [ap] dfx_channel_open_internal:130 Channel opened: console success
[    0.649441] [12] [  INFO] [ap] dfx_channel_register:190 Registered type=devfile;name=console;directory=/dev/
[    0.649461] [12] [  INFO] [ap] dfx_main_process_arg:128 Registered channel from spec: type=devfile;name=console;directory=/dev/
[    0.649827] [12] [  INFO] [ap] dfx_device_associate_channel:147 Processing channels list for device: log,core,console
[    0.650087] [12] [  INFO] [ap] dfx_device_associate_channel:163 Device: /dev/kmsg has associated channel: log
[    0.650147] [12] [  INFO] [ap] dfx_device_associate_channel:163 Device: /dev/kmsg has associated channel: core
[    0.650184] [12] [  INFO] [ap] dfx_device_associate_channel:163 Device: /dev/kmsg has associated channel: console
[    0.650443] [12] [  INFO] [ap] dfx_device_register:314 Register device: /dev/kmsg, type: 0, fd: 1853
[    0.650512] [12] [  INFO] [ap] dfx_main_process_arg:119 Registered device from spec: type=log;path=/dev/kmsg;channels=log,core,console
[    0.651074] [12] [  INFO] [ap] dfx_cmd_device_register:376 Command socket server opened: 127.0.0.1:8989, fd: 2110
[    0.651885] [12] [  INFO] [ap] dfx_cmd_device_register:404 Command device registered: fd=2110, path=127.0.0.1:8989
[    0.655482] [12] [  INFO] [ap] dfx_update_version:431 dfx file update property success, version: f89c09afff8 Jan 16 2026 14:04:21
[    0.655592] [12] [  INFO] [ap] dfx_daemon_loop:84 DFX daemon started, entering main event loop

qemu-armv8a-ap> ls
/:
 bin/
 data/
 dev/
 etc/
 host/
 proc/
 tmp/
 var/

**### // use mask=ffffffff can correctly calculate the size of the BAR.**
The  ivshmem size=4194304， pci bus probing resource size is 4194304bytes ，This result is correct.