### PR TITLE
libc/unistd: Replace pipe() macro with proper function implementation

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -394,7 +394,7 @@ FAR void *sbrk(intptr_t incr);
 
 /* Special devices */
 
-#define pipe(fd) pipe2(fd, 0)
+int     pipe(int pipefd[2]);
 int     pipe2(int pipefd[2], int flags);
 
 /* Schedule an alarm */

--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -192,6 +192,7 @@
 "ntohs","arpa/inet.h","","uint16_t","uint16_t"
 "opendir","dirent.h","","FAR DIR *","FAR const char *"
 "perror","stdio.h","defined(CONFIG_FILE_STREAM)","void","FAR const char *"
+"pipe","unistd.h","defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0","int","int [2]|FAR int *"
 "posix_fallocate","fcntl.h","","int","int","off_t","off_t"
 "posix_memalign","stdlib.h","","int","FAR void **","size_t","size_t"
 "preadv","sys/uio.h","","ssize_t","int","FAR const struct iovec *","int","off_t"

--- a/libs/libc/unistd/CMakeLists.txt
+++ b/libs/libc/unistd/CMakeLists.txt
@@ -105,4 +105,8 @@ if(CONFIG_CRYPTO)
   list(APPEND SRCS lib_crypt.c lib_crypt_r.c)
 endif()
 
+if(CONFIG_PIPES)
+  list(APPEND SRCS lib_pipe.c)
+endif()
+
 target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -60,6 +60,10 @@ ifeq ($(CONFIG_CRYPTO),y)
 CSRCS += lib_crypt.c lib_crypt_r.c
 endif
 
+ifeq ($(CONFIG_PIPES),y)
+CSRCS += lib_pipe.c
+endif
+
 # Add the unistd directory to the build
 
 DEPPATH += --dep-path unistd

--- a/libs/libc/unistd/lib_pipe.c
+++ b/libs/libc/unistd/lib_pipe.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_pipe.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <unistd.h>
+
+#if CONFIG_DEV_PIPE_SIZE > 0
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pipe
+ *
+ * Description:
+ *   pipe() creates a pair of file descriptors, pointing to a pipe inode,
+ *   and places them in the array pointed to by 'fd'. fd[0] is for reading,
+ *   fd[1] is for writing.
+ *
+ * Input Parameters:
+ *   fd[2] - The user provided array in which to catch the pipe file
+ *   descriptors
+ *
+ * Returned Value:
+ *   0 is returned on success; -1 (ERROR) is returned on a failure
+ *   with the errno value set appropriately.
+ *
+ ****************************************************************************/
+
+int pipe(int fd[2])
+{
+  return pipe2(fd, 0);
+}
+
+#endif /* CONFIG_DEV_PIPE_SIZE > 0 */


### PR DESCRIPTION
## Summary

Replace the pipe() macro definition with a proper function implementation to improve POSIX compliance and debugging capabilities. The new pipe() function serves as a wrapper around pipe2() with flags set to 0.

Changes include:
- Convert pipe() from macro to function declaration in unistd.h
- Add lib_pipe.c implementation file with proper function documentation
- Update build system files (CMakeLists.txt and Make.defs) to include the new source file when CONFIG_PIPES is enabled
- Add pipe() entry to libc.csv for symbol tracking

This change allows for better debugging, proper symbol resolution, and follows NuttX coding standards for library function implementations.

## Impact

* **Is new feature added? Is existing feature changed?** 
  NO - This is a refactoring change. The functionality remains identical; only the implementation approach changes from macro to function.
* **Impact on user (will user need to adapt to change)?** 
  NO - The API signature and behavior remain exactly the same. User code calling `pipe()` will continue to work without modification.
* **Impact on build (will build process change)?** 
  YES (minor) - An additional source file (`lib_pipe.c`) is now compiled when `CONFIG_PIPES` is enabled. Build time impact is negligible (single small source file). No configuration changes required.
* **Impact on hardware (will arch(s) / board(s) / driver(s) change)?** 
  NO - This change is purely in the C library layer and does not affect any architecture-specific code, board configurations, or drivers.
* **Impact on documentation (is update required / provided)?** 
  NO - The user-facing API documentation remains valid. This is an internal implementation change.
* **Impact on security (any sort of implications)?** 
  NO - The security properties remain identical. The function wrapper performs the same operation as the previous macro.
* **Impact on compatibility (backward/forward/interoperability)?** 
  YES (improvement) - Improves binary compatibility and debugging compatibility. Debuggers and profiling tools will now properly resolve the `pipe()` symbol. Stack traces will show `pipe()` in call stacks instead of expanded macro code.

## Testing

pipe relative tests (ltp & pipe example)
