### PR TITLE
sched_idletask: remove the check for whether tcb is NULL

### DIFF
--- a/sched/sched/sched_idletask.c
+++ b/sched/sched/sched_idletask.c
@@ -60,28 +60,18 @@ bool sched_idletask(void)
 {
   FAR struct tcb_s *rtcb = this_task();
 
-  /* If called early in the initialization sequence, the tasks lists may not
-   * have been initialized and, in that case, rtcb may be NULL.
+  DEBUGASSERT(rtcb);
+
+  /* The IDLE task TCB is distinguishable by a few things:
+   *
+   * (1) It always lies at the end of the task list,
+   * (2) It always has priority zero, and
+   * (3) It should have the TCB_FLAG_CPU_LOCKED flag set.
+   *
+   * In the non-SMP case, the IDLE task will also have PID=0, but that
+   * is not a portable test because there are multiple IDLE tasks with
+   * different PIDs in the SMP configuration.
    */
 
-  DEBUGASSERT(rtcb != NULL || !OSINIT_TASK_READY());
-  if (rtcb != NULL)
-    {
-      /* The IDLE task TCB is distinguishable by a few things:
-       *
-       * (1) It always lies at the end of the task list,
-       * (2) It always has priority zero, and
-       * (3) It should have the TCB_FLAG_CPU_LOCKED flag set.
-       *
-       * In the non-SMP case, the IDLE task will also have PID=0, but that
-       * is not a portable test because there are multiple IDLE tasks with
-       * different PIDs in the SMP configuration.
-       */
-
-      return is_idle_task(rtcb);
-    }
-
-  /* We must be on the IDLE thread if we are early in initialization */
-
-  return true;
+  return is_idle_task(rtcb);
 }


### PR DESCRIPTION
## Summary
We should not call these functions before nx_start; therefore, this_task will not be empty.

## Impact
sched

## Testing
 test in realhardware
target: esp32s3-devkit:smp

nsh> 
nsh> 
nsh> uname -a
NuttX 12.11.0 c7541bc0409 Nov 25 2025 21:59:26 xtensa esp32s3-devkit
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=4

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"