### PR TITLE
xtensa/esp32: Add support for hardware accelerated HMAC-SHA

### DIFF
--- a/arch/xtensa/src/esp32/esp32_crypto.c
+++ b/arch/xtensa/src/esp32/esp32_crypto.c
@@ -95,6 +95,26 @@ const struct auth_hash g_auth_hash_sha2_512_esp32 =
   sha_final
 };
 
+const struct auth_hash g_auth_hash_hmac_sha1_esp32 =
+{
+  CRYPTO_SHA1_HMAC, "HMAC-SHA1",
+  20, 20, 12, sizeof(struct esp32_sha_context_s),
+  HMAC_SHA1_BLOCK_LEN,
+  sha1_init, NULL, NULL,
+  sha_update,
+  sha_final
+};
+
+const struct auth_hash g_auth_hash_hmac_sha256_esp32 =
+{
+  CRYPTO_SHA2_256_HMAC, "HMAC-SHA2-256",
+  32, 32, 16, sizeof(struct esp32_sha_context_s),
+  HMAC_SHA2_256_BLOCK_LEN,
+  sha256_init, NULL, NULL,
+  sha_update,
+  sha_final
+};
+
 struct esp32_crypto_data
 {
   int alg; /* Algorithm */
@@ -288,6 +308,63 @@ static int hash(struct cryptop *crp,
 }
 
 /****************************************************************************
+ * Name: authcompute
+ *
+ * Description:
+ *   Calculate the hash.
+ *
+ ****************************************************************************/
+
+static int authcompute(struct cryptop *crp, struct cryptodesc *crd,
+                       struct esp32_crypto_data *data,
+                       caddr_t buf)
+{
+  unsigned char aalg[AALG_MAX_RESULT_LEN];
+  const struct auth_hash *axf;
+  int err = 0;
+
+  axf = data->hw_axf;
+  err = axf->update(data->hw_ictx, (uint8_t *)buf, crd->crd_len);
+  if (err)
+    {
+      return err;
+    }
+
+  switch (data->alg)
+    {
+      case CRYPTO_SHA1_HMAC:
+      case CRYPTO_SHA2_256_HMAC:
+        if (data->hw_octx == NULL)
+          {
+            return -EINVAL;
+          }
+
+          axf->final(aalg, data->hw_ictx);
+
+          for (int k = 0; k < crd->crd_klen / 8; k++)
+          {
+            crd->crd_key[k] ^= HMAC_OPAD_VAL;
+          }
+
+          axf->update(data->hw_octx, (uint8_t *)crd->crd_key,
+                      crd->crd_klen / 8);
+
+          axf->update(data->hw_octx, hmac_opad_buffer,
+                      axf->blocksize - (crd->crd_klen / 8));
+
+          axf->update(data->hw_octx, aalg, axf->hashsize);
+          axf->final(aalg, data->hw_octx);
+
+        break;
+    }
+
+  /* Inject the authentication data */
+
+  bcopy(aalg, crp->crp_mac, axf->hashsize);
+  return 0;
+}
+
+/****************************************************************************
  * Name: esp32_newsession
  *
  * Description:
@@ -395,6 +472,48 @@ static int esp32_newsession(uint32_t *sid, struct cryptoini *cri)
 
               axf->init(data->hw_ictx);
               data->hw_axf = axf;
+            break;
+          case CRYPTO_SHA1_HMAC:
+            axf = &g_auth_hash_hmac_sha1_esp32;
+            goto common__hmac;
+          case CRYPTO_SHA2_256_HMAC:
+            axf = &g_auth_hash_hmac_sha256_esp32;
+            goto common__hmac;
+          common__hmac:
+            data->hw_ictx = kmm_malloc(axf->ctxsize);
+            if (data->hw_ictx == NULL)
+              {
+                kmm_free(data);
+                return -ENOBUFS;
+              }
+
+            data->hw_octx = kmm_malloc(axf->ctxsize);
+            if (data->hw_octx == NULL)
+              {
+                kmm_free(data->hw_ictx);
+                kmm_free(data);
+                return -ENOBUFS;
+              }
+
+            for (k = 0; k < cri->cri_klen / 8; k++)
+              {
+                cri->cri_key[k] ^= HMAC_IPAD_VAL;
+              }
+
+            axf->init(data->hw_ictx);
+            axf->update(data->hw_ictx, (uint8_t *)cri->cri_key,
+                        cri->cri_klen / 8);
+            axf->update(data->hw_ictx, hmac_ipad_buffer,
+                        axf->blocksize - (cri->cri_klen / 8));
+
+            axf->init(data->hw_octx);
+
+            for (k = 0; k < cri->cri_klen / 8; k++)
+              {
+                cri->cri_key[k] ^= HMAC_IPAD_VAL;
+              }
+
+            data->hw_axf = axf;
             break;
 
           default:
@@ -559,6 +678,14 @@ static int esp32_process(struct cryptop *crp)
               }
 
             break;
+          case CRYPTO_SHA1_HMAC:
+          case CRYPTO_SHA2_256_HMAC:
+            if ((crp->crp_etype = authcompute(crp, crd, data,
+                 crp->crp_buf)) != 0)
+              {
+                return crp->crp_etype;
+              }
+            break;
           default:
             return -EINVAL;
         }
@@ -591,6 +718,8 @@ void hwcr_init(void)
   algs[CRYPTO_SHA2_256] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_384] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_512] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_SHA1_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_SHA2_256_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
 
   esp32_sha_init();
   crypto_register(hwcr_id, algs, esp32_newsession,


### PR DESCRIPTION
## Summary

This add support for using the cryptographic accelerator within the ESP32 for HMAC-SHA operations. The supported algorithms are: SHA1 and SHA512.
The existing support for hardware accelerated HMAC-SHA on ESP32C3 was used as a starting point for the code.

**Modified files:**
arch/xtensa/src/esp32/esp32_crypto.c - handles the HMAC calculations, SHA operations are handed over to already existing implementation

## Impact

Impact on user: this PR adds support for the hardware accelerated HMAC-SHA on ESP32, improving platform support
Impact on build process: none
Impact on hardware: this PR adds support for the hardware accelerated HMAC-SHA on ESP32, improving platform support
Impact on documentation: none
Impact on security: none, since code that uses HMAC-SHA algorithms will continue to use the existing software implementation by default. Otherwise, this implementation has been appropriately tested, see testing section.
Impact on compatibility: none

## Testing

Development was done using ESP32 DevkitC.
Building was done on Ubuntu 24.04 VM.
For testing, I ran the official crypto hmac test: https://github.com/apache/nuttx-apps/blob/master/testing/drivers/crypto/hmac.c, output shown below.
nsh> hmac
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha256 success
hmac sha256 success
hmac sha256 success

The huge block test wasn't ran due to memory constraints.