### PR TITLE
arch/x86_64: fix bootup problem in SMP

### DIFF
--- a/arch/x86_64/src/intel64/intel64_cpu.c
+++ b/arch/x86_64/src/intel64/intel64_cpu.c
@@ -366,14 +366,7 @@ bool x86_64_cpu_ready_get(uint8_t cpu)
 
 uint8_t x86_64_cpu_count_get(void)
 {
-  irqstate_t flags;
-  uint8_t count;
-
-  flags = spin_lock_irqsave(&g_ap_boot);
-  count = g_cpu_count;
-  spin_unlock_irqrestore(&g_ap_boot, flags);
-
-  return count;
+  return g_cpu_count;
 }
 
 /****************************************************************************
@@ -424,11 +417,5 @@ void x86_64_cpu_priv_set(uint8_t cpu)
   /* Mask applied to RFLAGS when making a syscall */
 
   write_msr(MSR_FMASK, X86_64_RFLAGS_IF | X86_64_RFLAGS_DF);
-#endif
-
-#ifdef CONFIG_SMP
-  /* Attach TLB shootdown handler */
-
-  irq_attach(SMP_IPI_TLBSHOOTDOWN_IRQ, x86_64_tlb_handler, NULL);
 #endif
 }

--- a/arch/x86_64/src/intel64/intel64_cpustart.c
+++ b/arch/x86_64/src/intel64/intel64_cpustart.c
@@ -154,6 +154,7 @@ void x86_64_ap_boot(void)
 
   tcb = current_task(cpu);
   UNUSED(tcb);
+  up_update_task(tcb);
 
 #ifdef CONFIG_SCHED_THREAD_LOCAL
   /* Make sure that FS_BASE is not null */
@@ -211,8 +212,6 @@ void x86_64_ap_boot(void)
 
   x86_64_hwdebug_init();
 #endif
-
-  up_update_task(tcb);
 
   /* Then transfer control to the IDLE task */
 

--- a/arch/x86_64/src/intel64/intel64_irq.c
+++ b/arch/x86_64/src/intel64/intel64_irq.c
@@ -544,6 +544,12 @@ void up_irqinitialize(void)
   irq_attach(ISR13, x86_64_fault_panic_isr, NULL);
   irq_attach(ISR14, x86_64_fault_panic_isr, NULL);
   irq_attach(ISR16, x86_64_fault_kill_isr, NULL);
+
+#ifdef CONFIG_SMP
+  /* Attach TLB shootdown handler */
+
+  irq_attach(SMP_IPI_TLBSHOOTDOWN_IRQ, x86_64_tlb_handler, NULL);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
We need to initialize the per - CPU registers as early as possible.

In the previous implementation,spin_lock_irqsave would call sched_lock, and we need to ensure that this_task is not null.Therefore, I moved the initialization of this_task earlier.

## Impact
x86_64

## Testing

qemu-intel64:nsh and add config
CONFIG_SMP=y
CONFIG_ARCH_INTERRUPTSTACK=4194304

qemu-system-x86_64 -enable-kvm -cpu host -smp 4 -m 1G -kernel ./nuttx -nographic -serial mon:stdio -s
SeaBIOS (version 1.16.3-debian-1.16.3-2)


iPXE (https://ipxe.org) 00:03.0 CA00 PCI2.10 PnP PMM+3EFCAD00+3EF0AD00 CA00
                                                                               


Booting from ROM..
NuttShell (NSH) NuttX-12.11.0
nsh> uname -a
NuttX 12.11.0 7eb3a9d5676-dirty Nov 26 2025 11:49:12 x86_64 qemu-intel64
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=6

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     b681000  b681000
ordblks         1        1
mxordblk  aa7e4a8  aa7e4a8
