### PR TITLE
Revert "sched_idletask: remove the check for whether tcb is NULL"

### DIFF
--- a/sched/sched/sched_idletask.c
+++ b/sched/sched/sched_idletask.c
@@ -60,18 +60,28 @@ bool sched_idletask(void)
 {
   FAR struct tcb_s *rtcb = this_task();
 
-  DEBUGASSERT(rtcb);
-
-  /* The IDLE task TCB is distinguishable by a few things:
-   *
-   * (1) It always lies at the end of the task list,
-   * (2) It always has priority zero, and
-   * (3) It should have the TCB_FLAG_CPU_LOCKED flag set.
-   *
-   * In the non-SMP case, the IDLE task will also have PID=0, but that
-   * is not a portable test because there are multiple IDLE tasks with
-   * different PIDs in the SMP configuration.
+  /* If called early in the initialization sequence, the tasks lists may not
+   * have been initialized and, in that case, rtcb may be NULL.
    */
 
-  return is_idle_task(rtcb);
+  DEBUGASSERT(rtcb != NULL || !OSINIT_TASK_READY());
+  if (rtcb != NULL)
+    {
+      /* The IDLE task TCB is distinguishable by a few things:
+       *
+       * (1) It always lies at the end of the task list,
+       * (2) It always has priority zero, and
+       * (3) It should have the TCB_FLAG_CPU_LOCKED flag set.
+       *
+       * In the non-SMP case, the IDLE task will also have PID=0, but that
+       * is not a portable test because there are multiple IDLE tasks with
+       * different PIDs in the SMP configuration.
+       */
+
+      return is_idle_task(rtcb);
+    }
+
+  /* We must be on the IDLE thread if we are early in initialization */
+
+  return true;
 }


### PR DESCRIPTION
## Summary

This reverts commit 8f91054b1d3f88d528c5327340de41d4f63c4262.
which cause  https://github.com/apache/nuttx/issues/17384

## Impact
sched

## Testing
qemu-system-xtensa -nographic -machine esp32 -drive file=nuttx.merged.bin,if=mtd,format=raw -s
Adding SPI flash device
ets Jul 29 2019 12:21:46

rst:0x1 (POWERON_RESET),boot:0x12 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3ffb2030,len:7472
load:0x40080000,len:33052
entry 0x40082b84
*** Booting NuttX ***
I (663) boot: chip revision: v0.0
I (665) boot.esp32: SPI Speed      : 40MHz
I (665) boot.esp32: SPI Mode       : DIO
I (665) boot.esp32: SPI Flash Size : 4MB
I (668) boot: Enabling RNG early entropy source...
dram: lma 0x00001020 vma 0x3ffb2030 len 0x1d30   (7472)
iram: lma 0x00002d58 vma 0x40080000 len 0x811c   (33052)
padd: lma 0x0000ae88 vma 0x00000000 len 0x5170   (20848)
imap: lma 0x00010000 vma 0x400e0000 len 0x142c4  (82628)
padd: lma 0x000242cc vma 0x00000000 len 0xbd2c   (48428)
dmap: lma 0x00030000 vma 0x3f410000 len 0x3dc8   (15816)
total segments stored 6
ABI (502) cpu_start: Pro cpu start user code
I (503) cpu_start: cpu freq: 240000000 Hz
I (508) spi_flash: detected chip: gd
I (510) spi_flash: flash io: dio
D__esp32_start: ESP32 chip revision is v0.0
WARNING: NuttX supports ESP32 chip revision >= v3.0 (chip is v0.0).
Ignoring this error and continuing because `ESP32_IGNORE_CHIP_REVISION_CHECK` is set...
THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!

NuttShell (NSH) NuttX-12.11.0
nsh> 
nsh> 
nsh> 