### PR TITLE
drivers/mtd/w25: support custom SPI transfers delay

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -1352,6 +1352,38 @@ config W25_SPIFREQUENCY
 	int "W25 SPI Frequency"
 	default 20000000
 
+config W25_START_DELAY
+	int "W25 SPI start delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 0
+	---help---
+		The delay between CS active and first CLK. In ns.
+
+config W25_STOP_DELAY
+	int "W25 SPI stop delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 0
+	---help---
+		The delay between last CLK and CS inactive. In ns.
+
+config W25_CS_DELAY
+	int "W25 SPI chip select delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 0
+	---help---
+		The delay between CS inactive and CS active again. In ns.
+
+config W25_IFDELAY
+	int "W25 SPI frames delay"
+	depends on SPI_DELAY_CONTROL
+	range 0 1000000
+	default 0
+	---help---
+		The delay between consecutive frames. In ns.
+
 config W25_READONLY
 	bool "W25 Read-Only FLASH"
 	default n

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -354,6 +354,11 @@ static void w25_lock(FAR struct spi_dev_s *spi)
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);
   SPI_SETFREQUENCY(spi, CONFIG_W25_SPIFREQUENCY);
+#ifdef CONFIG_SPI_DELAY_CONTROL
+  SPI_SETDELAY(spi, CONFIG_W25_START_DELAY,
+               CONFIG_W25_STOP_DELAY, CONFIG_W25_CS_DELAY,
+               CONFIG_W25_IFDELAY);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This commit adds `SPI_SETDELAY` interface if `CONFIG_SPI_DELAY_CONTROL` option is set. This allows to set custom delay between SPI transfers, chip selects and so on.

Default values are set to 0. W25 SPI NOR flash works with them and I haven't found any other values in the datasheet.

## Impact

None on current implementation unless `CONFIG_SPI_DELAY_CONTROL` is set. Implementation with the option enabled will
set delays to zero if target platform supports the interface.

## Testing

Tested on a custom SAMv7 board. Flash had SmartFS partition and three partitions for NXboot. The update and confirmation process was significantly slower because of default large delay between consecutive transfers. The speed is as expected with the delays set to zero.