### PR TITLE
documentation: Add HMAC-SHA support for esp32

### DIFF
--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -410,7 +410,7 @@ RSA          No
 RTC          Yes
 SD/MMC       Yes    SPI based SD card driver
 SDIO         No
-SHA          Yes
+SHA          Yes    Also supports HMAC-SHA(1/256) 
 SPI          Yes
 SPIFLASH     Yes
 SPIRAM       Yes


### PR DESCRIPTION
Support for hardware accelerated HMAC-SHA(1/256) for ESP32 was added, this commit updates the documentation to reflect this as well.


