### PR TITLE
drivers/rpmsg/ping: skip rpmsg ping send if endpoint is not ready

### DIFF
--- a/drivers/rpmsg/rpmsg_ping.c
+++ b/drivers/rpmsg/rpmsg_ping.c
@@ -126,6 +126,11 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept, int len,
   FAR struct rpmsg_ping_msg_s *msg;
   int ret;
 
+  if (!is_rpmsg_ept_ready(ept))
+    {
+      return -ENOTCONN;
+    }
+
   msg = rpmsg_get_tx_payload_buffer(ept, buf_len, true);
   if (!msg)
     {
@@ -162,7 +167,7 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept, int len,
       msg->cookie = (uintptr_t)&sem;
       nxsem_init(&sem, 0, 0);
 
-      ret = rpmsg_send_nocopy(ept, msg, msg->len);
+      ret = rpmsg_sendto_nocopy(ept, msg, msg->len, ept->dest_addr);
       if (ret >= 0)
         {
           nxsem_wait_uninterruptible(&sem);
@@ -172,7 +177,7 @@ static int rpmsg_ping_once(FAR struct rpmsg_endpoint *ept, int len,
     }
   else
     {
-      ret = rpmsg_send_nocopy(ept, msg, msg->len);
+      ret = rpmsg_sendto_nocopy(ept, msg, msg->len, ept->dest_addr);
     }
 
   if (ret < 0)


### PR DESCRIPTION
## Summary

drivers/rpmsg/ping: skip rpmsg ping send if endpoint is not ready

rpmsg ping send blocks for 15 seconds until the ept is ready, which
is not ideal for applications that need to monitor ping status.
In this PR, we will check if the ept is ready to avoid prolonged
blocking in the underlying driver.

Signed-off-by: chao an <anchao.archer@bytedance.com>

## Impact

rpmsg ping ioctl

## Testing

sim/rpproxy with rpmsg ping, qemu-armv8a(ivshmem) with rpmsg ping