### PR TITLE
.editorconfig: fix character encoding property specification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-encoding = utf-8
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
## Summary
The property should be named `charset`, not `encoding`, according to editorconfig documentation.

https://editorconfig.org/#supported-properties

## Impact
None on the code, fixes editorconfig formatting.
