### PR TITLE
libs/libc/arm: add back __aeabi_mem* functions

### DIFF
--- a/libs/libc/machine/arm/CMakeLists.txt
+++ b/libs/libc/machine/arm/CMakeLists.txt
@@ -48,6 +48,11 @@ elseif(CONFIG_ARCH_ARMV8R) # All ARMv8-R
   add_subdirectory(armv8-r)
 endif()
 
+list(APPEND SRCS aeabi_memclr.c aeabi_memclr4.c aeabi_memclr8.c)
+list(APPEND SRCS aeabi_memcpy.c aeabi_memcpy4.c aeabi_memcpy8.c)
+list(APPEND SRCS aeabi_memmove.c aeabi_memmove4.c aeabi_memmove8.c)
+list(APPEND SRCS aeabi_memset.c aeabi_memset4.c aeabi_memset8.c)
+
 if(NOT CONFIG_LIBSUPCXX_TOOLCHAIN)
   list(APPEND SRCS arch_atexit.c)
 endif()

--- a/libs/libc/machine/arm/Make.defs
+++ b/libs/libc/machine/arm/Make.defs
@@ -46,6 +46,11 @@ else ifeq ($(CONFIG_ARCH_ARMV8R),y)     # All ARMv8-R
 include $(TOPDIR)/libs/libc/machine/arm/armv8-r/Make.defs
 endif
 
+CSRCS += aeabi_memclr.c aeabi_memclr4.c aeabi_memclr8.c
+CSRCS += aeabi_memcpy.c aeabi_memcpy4.c aeabi_memcpy8.c
+CSRCS += aeabi_memmove.c aeabi_memmove4.c aeabi_memmove8.c
+CSRCS += aeabi_memset.c aeabi_memset4.c aeabi_memset8.c
+
 ifneq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
 CSRCS += arch_atexit.c
 endif

--- a/libs/libc/machine/arm/aeabi_memclr.c
+++ b/libs/libc/machine/arm/aeabi_memclr.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memclr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memclr(void *s, size_t n)
+{
+  memset(s, 0, n);
+}

--- a/libs/libc/machine/arm/aeabi_memclr4.c
+++ b/libs/libc/machine/arm/aeabi_memclr4.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memclr4.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memclr4(void *s, size_t n)
+{
+  memset(s, 0, n);
+}

--- a/libs/libc/machine/arm/aeabi_memclr8.c
+++ b/libs/libc/machine/arm/aeabi_memclr8.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memclr8.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memclr8(void *s, size_t n)
+{
+  memset(s, 0, n);
+}

--- a/libs/libc/machine/arm/aeabi_memcpy.c
+++ b/libs/libc/machine/arm/aeabi_memcpy.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memcpy.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memcpy(void *dest, const void *src, size_t n)
+{
+  memcpy(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memcpy4.c
+++ b/libs/libc/machine/arm/aeabi_memcpy4.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memcpy4.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memcpy4(void *dest, const void *src, size_t n)
+{
+  memcpy(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memcpy8.c
+++ b/libs/libc/machine/arm/aeabi_memcpy8.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memcpy8.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memcpy8(void *dest, const void *src, size_t n)
+{
+  memcpy(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memmove.c
+++ b/libs/libc/machine/arm/aeabi_memmove.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memmove.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memmove(void *dest, const void *src, size_t n)
+{
+  memmove(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memmove4.c
+++ b/libs/libc/machine/arm/aeabi_memmove4.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memmove4.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memmove4(void *dest, const void *src, size_t n)
+{
+  memmove(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memmove8.c
+++ b/libs/libc/machine/arm/aeabi_memmove8.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memmove8.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function
+__aeabi_memmove8(void *dest, const void *src, size_t n)
+{
+  memmove(dest, src, n);
+}

--- a/libs/libc/machine/arm/aeabi_memset.c
+++ b/libs/libc/machine/arm/aeabi_memset.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memset(void *s, size_t n, int c)
+{
+  memset(s, c, n);
+}

--- a/libs/libc/machine/arm/aeabi_memset4.c
+++ b/libs/libc/machine/arm/aeabi_memset4.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memset4.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memset4(void *s, size_t n, int c)
+{
+  memset(s, c, n);
+}

--- a/libs/libc/machine/arm/aeabi_memset8.c
+++ b/libs/libc/machine/arm/aeabi_memset8.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/machine/arm/aeabi_memset8.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void weak_function __aeabi_memset8(void *s, size_t n, int c)
+{
+  memset(s, c, n);
+}


### PR DESCRIPTION
## Summary

Add back `__aeabi_mem*` functions since clang will use them.

How to reproduce the issue:
- prepare clang toolchain, I'm using this one: https://github.com/arm/arm-toolchain/releases/download/release-21.1.1-ATfE/ATfE-21.1.1-Linux-x86_64.tar.xz
- compile `mps3-an547:clang`, with  `CONFIG_BUILTIN_COMPILER_RT` disabled

The error message:
```
ld.lld: error: undefined symbol: __aeabi_memclr
>>> referenced by assert.c:355 (/source/NuttX/nuttx/sched/misc/assert.c:355)
>>>               assert.o:(dump_task) in archive /source/NuttX/nuttx/staging/libsched.a

ld.lld: error: undefined symbol: __aeabi_memclr8
>>> referenced by wdog.c:359 (/source/NuttX/apps/testing/ostest/wdog.c:359)
>>>               wdog.c.source.NuttX.apps.testing.ostest_1.o:(wdog_test) in archive /source/NuttX/nuttx/staging/libapps.a
```

## Impact

libc/arm

## Testing

compile `mps3-an547:clang`, with  `CONFIG_BUILTIN_COMPILER_RT` disabled


