### PR TITLE
boards/xtensa/esp32s3: Fix esp32s3-devkitc:knsh

### DIFF
--- a/boards/xtensa/esp32s3/common/scripts/kernel-space.ld
+++ b/boards/xtensa/esp32s3/common/scripts/kernel-space.ld
@@ -105,7 +105,6 @@ SECTIONS
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
 
-    esp32s3_userspace.*(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
     *libkarch.a:esp32s3_spiflash.*(.literal .text .literal.* .text.*)
     *libkarch.a:cache_hal.*(.literal .text .literal.* .text.*)
@@ -115,6 +114,20 @@ SECTIONS
     *libkarch.a:xtensa_interruptcontext.*(.literal .text .literal.* .text.*)
     *libkarch.a:xtensa_testset.*(.literal .text .literal.* .text.*)
     *libkarch.a:esp_app_desc.*(.literal .text .literal.* .text.*)
+    *libkarch.a:esp_spiflash.*(.literal .text .literal.* .text.*)
+    *libkarch.a:esp_flash_api.*(.text .text.* .literal .literal.*)
+    *libkarch.a:esp_flash_spi_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_encrypt_hal_iram.*(.text .text.* .literal .literal.*)
+    *libkarch.a:spi_flash_hal_gpspi.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_chip*.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_os_func_noos.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_os_func_app.*(.literal .literal.* .text .text.*)
+    *libkarch.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
+    *libkarch.a:esp_cache.*(.literal .literal.* .text .text.*)
+    *libkarch.a:cache_utils.*(.literal .literal.* .text .text.*)
+    *libkarch.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
 
     *libsched.a:sched_suspendscheduler.*(.literal .text .literal.* .text.*)
     *libsched.a:sched_note.*(.literal .text .literal.* .text.*)
@@ -209,12 +222,27 @@ SECTIONS
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
     *libphy.a:(.rodata  .rodata.*)
-    esp32s3_userspace.*(.rodata  .rodata.*)
     *libkarch.a:esp32s3_spiflash.*(.rodata  .rodata.*)
     *libkarch.a:xtensa_cpupause.*(.rodata  .rodata.*)
     *libkarch.a:xtensa_copystate.*(.rodata  .rodata.*)
     *libkarch.a:xtensa_interruptcontext.*(.rodata  .rodata.*)
     *libkarch.a:xtensa_testset.*(.rodata  .rodata.*)
+    *libkarch.a:esp_spiflash.*(.rodata .rodata.*)
+    *libkarch.a:esp_flash_api.*(.rodata .rodata.*)
+    *libkarch.a:esp_flash_spi_init.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_hal_iram.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_encrypt_hal_iram.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_hal_gpspi.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_chip*.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_wrap.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_os_func_noos.*(.rodata .rodata.*)
+    *libkarch.a:spi_flash_os_func_app.*(.rodata .rodata.*)
+    *libkarch.a:flash_brownout_hook.*(.rodata .rodata.*)
+    *libkarch.a:esp_cache.*(.rodata .rodata.*)
+    *libkarch.a:cache_utils.*(.rodata .rodata.*)
+    *libkarch.a:memspi_host_driver.*(.rodata .rodata.*)
+    *libkarch.a:esp_mmu_map.*(.rodata .rodata.*)
+    *libkarch.a:ext_mem_layout.*(.rodata .rodata.*)
 
     *libsched.a:sched_suspendscheduler.*(.rodata  .rodata.*)
     *libsched.a:sched_thistask.*(.rodata  .rodata.*)
@@ -355,4 +383,25 @@ SECTIONS
 
     . = ALIGN(4);
   } >KDROM
+
+  /*
+   * This section holds RTC data that should have fixed addresses.
+   * The data are not initialized at power-up and are retained during deep sleep.
+   */
+
+  .rtc_reserved (NOLOAD):
+  {
+    . = ALIGN(4);
+    _rtc_reserved_start = ABSOLUTE(.);
+
+    /* New data can only be added here to ensure existing data are not moved.
+     * Because data have adhered to the end of the segment and code is relied
+     * on it.
+     * >> put new data here <<
+     */
+
+    *(.rtc_timer_data_in_rtc_mem .rtc_timer_data_in_rtc_mem.*)
+    KEEP(*(.bootloader_data_rtc_mem .bootloader_data_rtc_mem.*))
+    _rtc_reserved_end = ABSOLUTE(.);
+  } > rtc_reserved_seg
 }

--- a/boards/xtensa/esp32s3/common/scripts/protected_memory.ld
+++ b/boards/xtensa/esp32s3/common/scripts/protected_memory.ld
@@ -73,6 +73,8 @@
 #  define FLASH_SIZE        0x1000000
 #endif
 
+#define RESERVE_RTC_MEM     24
+
 MEMORY
 {
   metadata (RX) :   org = 0x0, len = 0x30
@@ -82,7 +84,7 @@ MEMORY
   /* Instruction RAM */
 
   UIRAM (RWX) :     org = SRAM_IRAM_ORG, len = 16K
-  KIRAM (RWX) :     org = ORIGIN(UIRAM) + LENGTH(UIRAM), len = 48K
+  KIRAM (RWX) :     org = ORIGIN(UIRAM) + LENGTH(UIRAM), len = 64K
 
   /* Flash mapped instruction data. */
 
@@ -115,5 +117,30 @@ MEMORY
 
   KDROM (R)  :      org = 0x3c000020, len = CONFIG_ESP32S3_KERNEL_IMAGE_SIZE - 0x20
   UDROM (R)  :      org = ORIGIN(KDROM) + LENGTH(KDROM) + ORIGIN(ROM), len = FLASH_SIZE - LENGTH(KDROM) - ORIGIN(ROM)
-}
 
+  /* RTC fast memory (executable). Persists over deep sleep. */
+
+  rtc_iram_seg(RWX) :                org = 0x600fe000, len = 0x2000 - RESERVE_RTC_MEM
+
+  /* RTC fast memory (same block as above), viewed from data bus */
+
+  rtc_data_seg(RW)  :                org = 0x600fe000, len = 0x2000 - RESERVE_RTC_MEM
+
+  /* We reduced the size of rtc_iram_seg by RESERVE_RTC_MEM value.
+   * It reserves the amount of RTC fast memory that we use for this memory segment.
+   * This segment is intended for keeping:
+   *   - (lower addr) rtc timer data (s_rtc_timer_retain_mem, see esp_clk.c files).
+   *   - (higher addr) bootloader rtc data (s_bootloader_retain_mem, when a Kconfig option is on).
+   * The aim of this is to keep data that will not be moved around and have a fixed address.
+   */
+
+  rtc_reserved_seg(RW) :             org = 0x600fe000 + 0x2000 - RESERVE_RTC_MEM, len = RESERVE_RTC_MEM
+
+  /* RTC slow memory (data accessible). Persists over deep sleep.
+   * Start of RTC slow memory is reserved for ULP co-processor code + data,
+   * if enabled.
+   */
+
+  rtc_slow_seg(RW)  :    org = 0x50000000 + CONFIG_ESP32S3_ULP_COPROC_RESERVE_MEM,
+                         len = 0x2000 - CONFIG_ESP32S3_ULP_COPROC_RESERVE_MEM
+}


### PR DESCRIPTION
## Summary

* boards/xtensa/esp32s3: Fix esp32s3-devkitc:knsh

This defconfig uses the legacy bootloader (based on ESP-IDF's bootloader) and, due to a recent update on SPI flash support, its initialization was missing data to be moved to the IRAM during the boot process.

## Impact

Impact on user: No.

Impact on build: No.

Impact on hardware: Yes. Fix booting `esp32s3-devkit:knsh` defconfig.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:knsh
```

Enable the ESP-IDF build environment necessary to build the bootloader (tested with `v5.2`):
```
. export.sh
```

Build the bootloader:
```
make bootloader
```

Build and flash NuttX:
```
make flash ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

```
picocom -b 115200 /dev/ttyUSB0
```

### Results

Verify that the device boots as expected:

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fce3818,len:0x1760
load:0x403c9700,len:0x4
load:0x403c9704,len:0xc00
load:0x403cc700,len:0x2e0c
entry 0x403c9908
I (30) boot: ESP-IDF v5.1.4-545-gcd4714dd01 2nd stage bootloader
I (30) boot: compile time Nov 26 2025 14:35:06
I (30) boot: Multicore bootloader
I (34) boot: chip revision: v0.1
I (38) boot.esp32s3: Boot SPI Speed : 40MHz
I (43) boot.esp32s3: SPI Mode       : DIO
I (48) boot.esp32s3: SPI Flash Size : 8MB
I (52) boot: Enabling RNG early entropy source...
I (58) boot: Partition Table:
I (61) boot: ## Label            Usage          Type ST Offset   Length
I (69) boot:  0 factory          factory app      00 00 00010000 00100000
I (76) boot: End of partition table
I (80) esp_image: segment 0: paddr=00010020 vaddr=3c020020 size=01ed4h (  7892) map
I (91) esp_image: segment 1: paddr=00011efc vaddr=3fc95fe0 size=01a34h (  6708) load
I (99) esp_image: segment 2: paddr=00013938 vaddr=40378000 size=062bch ( 25276) load
I (113) esp_image: segment 3: paddr=00019bfc vaddr=00000000 size=0641ch ( 25628) 
I (120) esp_image: segment 4: paddr=00020020 vaddr=42000020 size=137ech ( 79852) map
I (145) boot: Loaded app from partition at offset 0x10000
I (145) boot: Disabling RNG early entropy source...

NuttShell (NSH) NuttX-10.4.0
nsh>
```