### PR TITLE
arch/avr: fix MCU type for 64 pin chips.

### DIFF
--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -71,10 +71,10 @@ else ifeq ($(CONFIG_ARCH_CHIP_AVR128DA28),y)
   ARCHCPUFLAGS += -mmcu=avr128da28
   LDFLAGS += -mavrxmega4
 else ifeq ($(CONFIG_ARCH_CHIP_AVR128DA64),y)
-  ARCHCPUFLAGS += -mmcu=avr128da28
+  ARCHCPUFLAGS += -mmcu=avr128da64
   LDFLAGS += -mavrxmega4
 else ifeq ($(CONFIG_ARCH_CHIP_AVR128DB64),y)
-  ARCHCPUFLAGS += -mmcu=avr128da28
+  ARCHCPUFLAGS += -mmcu=avr128db64
   LDFLAGS += -mavrxmega4
 else ifeq ($(CONFIG_ARCH_CHIP_AT90USB646),y)
   ARCHCPUFLAGS += -mmcu=at90usb646


### PR DESCRIPTION
## Summary

PR from kerogit delivered over mailing list.

Toolchain.defs file was treating all supported chips as AVR128DA28, which became apparent while testing changes in USART handling.

## Impact

arch/avr toolchain defines and identification fix.

## Testing

```
nsh> tc74_test
tc74_test [4:100]
nsh> Starting TC74 test
Temperature read: 23
Temperature read: 23
```
