### PR TITLE
boards/avr/avrdx/breadxavr: Adds TC74 Thermal Sensor to the board config.

### DIFF
--- a/Documentation/platforms/avr/avrdx/boards/breadxavr/index.rst
+++ b/Documentation/platforms/avr/avrdx/boards/breadxavr/index.rst
@@ -63,6 +63,24 @@ expectation that requires pressed button to read as logical 1 and depressed
 button as logical 0 while allowing the board to operate without external
 components (internal pull-ups are used.)
 
+I\ :sup:`2`\ C temperature sensor TC74Ax
+----------------------------------------
+
+The board has readymade configuration for TC74Ax temperature sensor
+from Microchip.
+
+To enable it, it is needed to:
+
+  - enable :menuselection:`Device Drivers --> I2C Driver Support`
+  - enable :menuselection:`System Type --> AVR DA/DB Peripheral Selections --> Enable TWI (I2C) driver for interface 0`
+  - enable :menuselection:`Device Drivers --> Sensor Device Support --> Microchip TC74Ax Digital Thermal Sensor`
+  - configure the driver for requested mode of operation with regards
+    to multimaster and power management
+  - enable :menuselection:`Board Selection --> Enable initializing I2C TC74Ax sensor`
+  - configure variant of the connected sensor
+
+The sensor is made available as ``/dev/tc74ax``. Further information regarding usage of the sensor is available in its driver's documentation: :doc:`/components/drivers/special/sensors/tc74ax`
+
 Compile & Flash
 ===============
 

--- a/boards/avr/avrdx/breadxavr/Kconfig
+++ b/boards/avr/avrdx/breadxavr/Kconfig
@@ -13,4 +13,26 @@ config BREADXAVR_BUTTONS_DRIVER
 		If set, button driver registered as /dev/buttons
 		for PORT A and PORT C (pins 2 and 3 for both ports.)
 
+config BREADXAVR_TC74AX_SENSOR
+	bool "Enable initializing I2C TC74Ax sensor"
+	depends on AVR_TWI0 && SENSORS_TC74AX
+	select BOARD_LATE_INITIALIZE
+	default n
+	---help---
+		If set, the board will register driver for Microchip TC74Ax
+		thermal sensor.
+
+if BREADXAVR_TC74AX_SENSOR
+
+config BREADXAVR_TC74AX_SENSOR_VARIANT
+	int "TC74Ax variant"
+	default 0
+	range 0 7
+	---help---
+		Select specific part used on your (bread)board. Number chosen
+		here corresponds to the "x" in the part name (and also to I2C
+		address of the sensor.)
+
+endif
+
 endif

--- a/boards/avr/avrdx/breadxavr/src/avrdx_init.c
+++ b/boards/avr/avrdx/breadxavr/src/avrdx_init.c
@@ -32,10 +32,15 @@
 #  include <nuttx/input/buttons.h>
 #endif
 
+#ifdef CONFIG_BREADXAVR_TC74AX_SENSOR
+#  include <nuttx/sensors/tc74ax.h>
+#endif
+
 #include <assert.h>
 #include <avr/io.h>
 
 #include "avrdx_gpio.h"
+#include "avrdx_twi.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -92,3 +97,50 @@ void board_early_initialize(void)
 }
 
 #endif /* CONFIG_BOARD_EARLY_INITIALIZE */
+
+/****************************************************************************
+ * Name: board_late_initialize
+ *
+ * Description:
+ *  Function called by the OS when BOARD_LATE_INITIALIZE is set.
+ *  Called after up_initialize, OS has been initialized at this point
+ *  and it is okay to initialize drivers. Running in special kernel
+ *  thread so waiting is allowed. Executed just before application code.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARD_LATE_INITIALIZE
+void board_late_initialize(void)
+{
+#  ifdef CONFIG_BREADXAVR_TC74AX_SENSOR
+  FAR struct i2c_master_s *i2c;
+#  endif
+  int ret = OK;
+
+#  ifdef CONFIG_BREADXAVR_TC74AX_SENSOR
+
+#    if  (CONFIG_BREADXAVR_TC74AX_SENSOR_VARIANT < 0) || \
+         (CONFIG_BREADXAVR_TC74AX_SENSOR_VARIANT > 7)
+#      error Incorrect setting of variant, Kconfig should not allow this
+#    endif
+
+  i2c = avrdx_initialize_twi(0);
+  if (i2c)
+    {
+      ret = tc74ax_register("/dev/tc74ax",
+                            i2c,
+                            72 + CONFIG_BREADXAVR_TC74AX_SENSOR_VARIANT);
+      if (ret != OK)
+        {
+          PANIC();
+        }
+    }
+  else
+    {
+      PANIC();
+    }
+
+#  endif /* ifdef CONFIG_BREADXAVR_TC74AX_SENSOR */
+}
+
+#endif /* CONFIG_BOARD_LATE_INITIALIZE */


### PR DESCRIPTION
## Summary

PR delivered by kerogit over mailing list.

TC74 Tiny Serial Digital Thermal Sensor from Microchip is added to AVR Dx BreadBoard + board Documentation update.

Depends-on: #17403, #17404, #17404, #17405

## Impact

boards/avr/avrdx/breadxavr: Added support for TC74 thermal sensor.

## Testing

The driver was tested on AVR128DA28 chip using simple application that read the temperature from it and also switched it to/from standby state.

```
nsh> tc74_test
tc74_test [4:100]
nsh> Starting TC74 test
Temperature read: 23
Temperature read: 23
```