### PR TITLE
Fix newlib multiple definition compiling errors

### DIFF
--- a/libs/libm/newlib/CMakeLists.txt
+++ b/libs/libm/newlib/CMakeLists.txt
@@ -93,11 +93,9 @@ if(CONFIG_LIBM_NEWLIB)
   file(GLOB_RECURSE COMMON_CSRCS ${NEWLIB_DIR}/newlib/libm/common/*.c)
   file(GLOB_RECURSE COMPLEX_CSRCS ${NEWLIB_DIR}/newlib/libm/complex/*.c)
 
-  if(CONFIG_ARCH_X86_64)
-    file(GLOB_RECURSE ARCH_CSRCS ${NEWLIB_DIR}/newlib/libm/fenv/*.c)
-  endif()
+  file(GLOB_RECURSE FENV_CSRCS ${NEWLIB_DIR}/newlib/libm/fenv/*.c)
 
-  set(CSRCS ${COMMON_CSRCS} ${COMPLEX_CSRCS})
+  set(CSRCS ${COMMON_CSRCS} ${COMPLEX_CSRCS} ${FENV_CSRCS})
 
   # aggressive optimisation can replace occurrences of sinl() and cosl() with
   # sincosl(), but sincosl() is missing in newlib which causes error. So let's
@@ -146,7 +144,7 @@ if(CONFIG_LIBM_NEWLIB)
 
   set(INCDIR ${CMAKE_CURRENT_LIST_DIR}/include ${NEWLIB_DIR}/newlib/libm/common)
 
-  if(CONFIG_ARCH_X86_64)
+  if(CONFIG_ARCH_X86_64 OR CONFIG_ARCH_X86)
     list(APPEND INCDIR ${NEWLIB_DIR}/newlib/libc/machine/shared_x86/sys)
   endif()
 

--- a/libs/libm/newlib/Make.defs
+++ b/libs/libm/newlib/Make.defs
@@ -88,12 +88,11 @@ VPATH += :newlib/newlib/newlib/libm/complex
 DEPPATH += --dep-path newlib/newlib/newlib/libm/common
 DEPPATH += --dep-path newlib/newlib/newlib/libm/complex
 
-ifeq ($(CONFIG_ARCH_X86_64),y)
 CSRCS += $(wildcard newlib/newlib/newlib/libm/fenv/*.c)
 VPATH += :newlib/newlib/newlib/libm/fenv
 DEPPATH += --dep-path newlib/newlib/newlib/libm/fenv
 
-
+ifneq ($(CONFIG_ARCH_X86_64)$(CONFIG_ARCH_X86),)
 CFLAGS += ${INCDIR_PREFIX}newlib/newlib/newlib/libc/machine/shared_x86/sys
 endif
 


### PR DESCRIPTION
## Summary

This PR continues the work from https://github.com/apache/nuttx/pull/15022.

While the build system defines a source file inclusion order to prevent common source code from being included alongside architecture-specific implementations, some build environments cannot guarantee this ordering. This can result in multiple definition errors during the linking stage.

The Makefile build with newlib works correctly because it uses VPATH, which gives priority to the first matching path. However, CMake does not utilize per-subdirectory search paths in the same way and requires filename-based filtering to prevent duplicate file inclusions.

This commit series refines the build configuration for the newlib libm component to improve cross-architecture compatibility and resolve potential duplicate file issues.

## Change

### 1. Implements filename-based filtering for libm source lists

Adds filtering logic to exclude duplicate files from source lists.
Ensures architecture-specific files (ARCH_CSRCS) take precedence over files from common or other directories, guaranteeing the correct implementation is selected.

### 2. Expands inclusion of fenv sources and x86 headers

Includes newlib/libm/fenv/*.c (non-functional fallback implementations) for all architectures. These are designed to be overridden by architecture-specific implementations in newlib/libm/machine/ARCH.

Extends the architecture check logic to include shared x86 system headers for both x86 and x86_64 architectures.

## Impact

Prevents common source code from being included alongside architecture-specific implementations in the final library.

Eliminates multiple definition errors during the linking stage.

## Testing

Internal CI testing on ARM Cortex-M55 with the BES platform using newlib.
