### PR TITLE
arch/imx9/ethernet: Add a configuration option to use HPWORK queue

### DIFF
--- a/arch/arm64/src/imx9/Kconfig
+++ b/arch/arm64/src/imx9/Kconfig
@@ -1013,6 +1013,15 @@ config IMX9_ENET_USE_OTP_MAC
 	default n
 	depends on IMX9_ENET
 
+config IMX9_ENET_HPWORK
+	bool "Use high priority work queue for ethernet"
+	depends on IMX9_ENET
+	depends on SCHED_HPWORK
+	default n
+	---help---
+		Use high-priority work-queue for ethernet packet handling.
+		Enable if low-latency ethernet packet handling is required.
+
 config IMX9_ENET1_OTP_MAC_ADDR
 	hex "MAC address offset in OCOTP"
 	default 0x4ec


### PR DESCRIPTION
## Summary

Add an option CONFIG_IMX9_ENET_HPWORK to use HPWORK queue for ethernet driver, to reduce delays if more time critical messaging via ethernet is wanted.

## Impact

New configuration option, has no impact if not explicitly enabled for the board, and doesn't affect existing upstream configurations. When enabled, reduces latencies in ethernet packet handling, as it is done in high-priority work queue.

## Testing

Functionality tested in a custom PX4 flight controller system, where Mavlink and uXRCE-DDS protocols are passed between external computer and the IMX9 system over ethernet / UDP. No errors observed. Solves some latency issues with higher rate control over ethernet.
