### PR TITLE
arch/tricore: Fix build errors in tricore architecture

### DIFF
--- a/arch/tricore/src/common/tricore_systimer.c
+++ b/arch/tricore/src/common/tricore_systimer.c
@@ -49,6 +49,8 @@
  * 40 CPU cycles (100ns at 400Mhz) ~ 10 timer cycles (for 100 Mhz timer).
  */
 
+#define IFX_CFG_CPU_CLOCK_FREQUENCY 100000000
+
 #define TRICORE_SYSTIMER_MIN_DELAY \
   (40ull * SCU_FREQUENCY / IFX_CFG_CPU_CLOCK_FREQUENCY)
 
@@ -65,6 +67,7 @@ struct tricore_systimer_lowerhalf_s
 {
   struct oneshot_lowerhalf_s lower;
   volatile void             *tbase;
+  spinlock_t                lock;
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fix build errors in the Tricore architecture caused by the missing `lock` member in `struct tricore_systimer_lowerhalf_s`, as well as the missing definition of the `IFX_CFG_CPU_CLOCK_FREQUENCY` macro.

## Impact

Fix build errors in tricore arch, no impact to any other nuttx functions

## Testing

**ostest passed on board a2g-tc397-5v-tft**

```
NuttShell (NSH)
nsh>
nsh> uname -a
NuttX 0.0.0 b6b9f172ba Dec  1 2025 20:38:25 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f8a8    1f8a8
uordblks     555c     555c
fordblks    238a0    238a0

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f8a8    1f8a8
uordblks     555c     555c
fordblks    238a0    238a0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24220    1f8a8
uordblks     4bdc     555c
fordblks    24220    238a0
user_main: Exiting
ostest_main: Exiting with status 0
nsh>

```

