### PR TITLE
cmake: Add support for ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,18 @@ if(CONFIG_ARCH_BOARD_COMMON)
     "${NUTTX_DIR}/boards/${CONFIG_ARCH}/${CONFIG_ARCH_CHIP}/common")
 endif()
 
+# Setup ccache ###############################################################
+
+if(CONFIG_CCACHE)
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
+    message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  else()
+    message(STATUS "Could not find ccache, skipping!")
+  endif()
+endif()
+
 # Setup toolchain ############################################################
 
 # This needs to happen before project() when binaries are searched for


### PR DESCRIPTION
- Enable ccache in CMake if CONFIG_CCACHE is set

## Summary

Enable ccache support when building with CMake.
Currently the CONFIG_CCACHE setting is not used when building with CMake.

## Impact

If CONFIG_CCACHE is set and ccache is installed, ccache will be used as compiler wrapper, which will speed up incremental and clean builds.
If CONFIG_CCACHE is set and ccache is **not** found, CMake will fail since the REQUIRED keyword is used.


## Testing
Configure
```
> mkdir build && cd build
> cmake .. -DBOARD_CONFIG=sim:nsh -GNinja
> ninja menuconfig    # <<<  Enable CONFIG_CCACHE
``` 

Build with empty ccache
``` 
> ccache -C -z
> ninja clean
> ninja
> ccache -s
Cacheable calls:    1171 / 1173 (99.83%)
  Hits:                0 / 1171 ( 0.00%)
    Direct:            0
    Preprocessed:      0
  Misses:           1171 / 1171 (100.0%)
Uncacheable calls:     2 / 1173 ( 0.17%)
Local storage:
  Cache size (GiB):  0.0 /  5.0 ( 0.26%)
  Hits:                0 / 1171 ( 0.00%)
  Misses:           1171 / 1171 (100.0%)
```

Build with populated ccache
```
> ccache -z
> ninja clean
> ninja
> ccache -s
Cacheable calls:    1171 / 1173 (99.83%)
  Hits:             1170 / 1171 (99.91%)
    Direct:         1170 / 1170 (100.0%)
    Preprocessed:      0 / 1170 ( 0.00%)
  Misses:              1 / 1171 ( 0.09%)
Uncacheable calls:     2 / 1173 ( 0.17%)
Local storage:
  Cache size (GiB):  0.0 /  5.0 ( 0.26%)
  Hits:             1170 / 1171 (99.91%)
  Misses:              1 / 1171 ( 0.09%)
```
