### PR TITLE
workflows/build.yml: fix fatal: write error: No space left on device

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,16 @@ jobs:
 
     steps:
 
+      - name: Show Disk Space
+        run: df -h
+
+      - name: Free Disk Space (Ubuntu)
+        run: |
+          sudo rm -rf /usr/local/lib/android
+
+      - name: After CLEAN-UP Disk Space
+        run: df -h
+
       - name: Download Source Artifact
         uses: actions/download-artifact@v6
         with:
@@ -193,6 +203,10 @@ jobs:
                 ( sleep 7200 ; echo Killing pytest after timeout... ; pkill -f pytest )&
                 ./cibuild.sh -c -A -N -R -S testlist/${{matrix.boards}}.dat
             fi
+
+      - name: Post-build Disk Space
+        if: always()
+        run: df -h
 
       - uses: actions/upload-artifact@v5
         if: ${{ always() }}


### PR DESCRIPTION
## Summary

Fixed error verified in this PR https://github.com/apache/nuttx/pull/17423

added to the workflow:

- Show Disk Space

- Free Disk Space (Ubuntu) 
  Only Android runtime removed

- Post-build Disk Space

We can now monitor disk space.

## Impact

Impact on user: NO

Impact on build: This PR fix fatal: write error: No space left on device

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Github

https://github.com/simbit18/nuttx-testing-ci/actions/runs/19925458380/job/57124175655
