### PR TITLE
arch/arm/src/samv7/Kconfig: allow 0 in MCANx_RXFIFOx_SIZE

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -3681,7 +3681,7 @@ endchoice # MCAN0 RX buffer element size
 config SAMV7_MCAN0_RXFIFO0_SIZE
 	int "MCAN0 RX FIFO0 size"
 	default 8
-	range 1 64
+	range 0 64
 	---help---
 		Number of receive FIFO 0 elements.  Zero disables FIFO 0.
 
@@ -3725,7 +3725,7 @@ endchoice # MCAN0 RX buffer element size
 config SAMV7_MCAN0_RXFIFO1_SIZE
 	int "MCAN0 RX FIFO1 size"
 	default 4
-	range 1 64
+	range 0 64
 	---help---
 		Number of receive FIFO 1 elements for MCAN0.  Zero disables FIFO 1.
 
@@ -3997,7 +3997,7 @@ endchoice # MCAN1 RX buffer element size
 config SAMV7_MCAN1_RXFIFO0_SIZE
 	int "MCAN1 RX FIFO0 size"
 	default 8
-	range 1 64
+	range 0 64
 	---help---
 		Number of receive FIFO 0 elements.  Zero disables FIFO 0.
 
@@ -4041,7 +4041,7 @@ endchoice # MCAN1 RX buffer element size
 config SAMV7_MCAN1_RXFIFO1_SIZE
 	int "MCAN1 RX FIFO1 size"
 	default 4
-	range 1 64
+	range 0 64
 	---help---
 		Number of receive FIFO 1 elements for MCAN1.  Zero disables FIFO 1.
 


### PR DESCRIPTION
## Summary

Zero can be used to disable the FIFO queue. Fix the range to allow to configure this value.

## Impact
Kconfig range only. 0 is now valid option.
