### PR TITLE
boards/arm/stm32l4: CMake added boards Part1

### DIFF
--- a/boards/arm/stm32l4/b-l475e-iot01a/CMakeLists.txt
+++ b/boards/arm/stm32l4/b-l475e-iot01a/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/b-l475e-iot01a/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/b-l475e-iot01a/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/b-l475e-iot01a/src/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# boards/arm/stm32l4/b-l475e-iot01a/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c stm32_timer.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_SPIRIT_NETDEV)
+  list(APPEND SRCS stm32_spirit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32l4/nucleo-l432kc/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l432kc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l432kc/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/nucleo-l432kc/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/CMakeLists.txt
@@ -1,0 +1,106 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l432kc/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS stm32_gpio.c)
+endif()
+
+if(CONFIG_STM32L4_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_STM32L4_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_DAC7571)
+  list(APPEND SRCS stm32_dac7571.c)
+endif()
+
+if(CONFIG_MTD_AT45DB)
+  list(APPEND SRCS stm32_at45db.c)
+endif()
+
+if(CONFIG_SENSORS_INA226)
+  list(APPEND SRCS stm32_ina226.c)
+endif()
+
+if(CONFIG_SENSORS_INA219)
+  list(APPEND SRCS stm32_ina219.c)
+endif()
+
+if(CONFIG_SENSORS_QENCODER)
+  list(APPEND SRCS stm32_qencoder.c)
+endif()
+
+if(CONFIG_PWM)
+  list(APPEND SRCS stm32_pwm.c)
+endif()
+
+if(CONFIG_SENSORS_ZEROCROSS)
+  list(APPEND SRCS stm32_zerocross.c)
+endif()
+
+if(CONFIG_TIMER)
+  list(APPEND SRCS stm32_timer.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+  if(CONFIG_BOARDCTL_IOCTL)
+    list(APPEND SRCS stm32_ioctl.c)
+  endif()
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(CONFIG_NUCLEOL432KC_SPWM)
+  list(APPEND SRCS stm32_spwm.c)
+endif()
+
+if(CONFIG_NUCLEOL432KC_DAC_WGEN)
+  list(APPEND SRCS stm32_dac_wgen.c)
+endif()
+
+if(NOT CONFIG_STM32_ETHMAC)
+  if(CONFIG_NETDEVICES)
+    list(APPEND SRCS stm32_netinit.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/l432kc.ld")

--- a/boards/arm/stm32l4/nucleo-l452re/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l452re/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l452re/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/nucleo-l452re/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l452re/src/CMakeLists.txt
@@ -1,0 +1,50 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l452re/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/l452re-flash.ld")

--- a/boards/arm/stm32l4/nucleo-l496zg/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l496zg/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l496zg/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/nucleo-l496zg/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/nucleo-l496zg/src/CMakeLists.txt
@@ -1,0 +1,78 @@
+# ##############################################################################
+# boards/arm/stm32l4/nucleo-l496zg/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+else()
+  list(APPEND SRCS stm32_userleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinitialize.c)
+  if(CONFIG_BOARDCTL_IOCTL)
+    list(APPEND SRCS stm32_ioctl.c)
+  endif()
+endif()
+
+if(CONFIG_SPI)
+  list(APPEND SRCS stm32_spi.c)
+endif()
+
+if(CONFIG_ADC)
+  list(APPEND SRCS stm32_adc.c)
+  if(CONFIG_STM32L4_DFSDM)
+    list(APPEND SRCS stm32_dfsdm.c)
+  endif()
+endif()
+
+if(CONFIG_DAC)
+  list(APPEND SRCS stm32_dac.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_sdio.c)
+endif()
+
+if(CONFIG_STM32L4_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+if(CONFIG_BOARDCTL_UNIQUEID)
+  list(APPEND SRCS stm32_uid.c)
+endif()
+
+if(NOT CONFIG_STM32_ETHMAC)
+  if(CONFIG_NETDEVICES)
+    list(APPEND SRCS stm32_netinit.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/l496zg-flash.ld")

--- a/boards/arm/stm32l4/steval-stlcs01v1/CMakeLists.txt
+++ b/boards/arm/stm32l4/steval-stlcs01v1/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/steval-stlcs01v1/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/steval-stlcs01v1/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/steval-stlcs01v1/src/CMakeLists.txt
@@ -1,0 +1,39 @@
+# ##############################################################################
+# boards/arm/stm32l4/steval-stlcs01v1/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c)
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_STM32L4_OTGFS)
+  list(APPEND SRCS stm32_usb.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/ld.script")

--- a/boards/arm/stm32l4/stm32l476-mdk/CMakeLists.txt
+++ b/boards/arm/stm32l4/stm32l476-mdk/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32l4/stm32l476-mdk/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32l4/stm32l476-mdk/src/CMakeLists.txt
+++ b/boards/arm/stm32l4/stm32l476-mdk/src/CMakeLists.txt
@@ -1,0 +1,44 @@
+# ##############################################################################
+# boards/arm/stm32l4/stm32l476-mdk/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_spi.c stm32_userleds.c)
+
+if(CONFIG_ARCH_BOARD_STM32L4_CUSTOM_CLOCKCONFIG)
+  list(APPEND SRCS stm32_clockconfig.c)
+endif()
+
+if(CONFIG_ARCH_LEDS)
+  list(APPEND SRCS stm32_autoleds.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+set_property(GLOBAL PROPERTY LD_SCRIPT
+                             "${NUTTX_BOARD_DIR}/scripts/stm32l476-mdk.ld")


### PR DESCRIPTION
## Summary

CMake added boards:

  - b-l475e-iot01a

 -  nucleo-l432kc

 -  nucleo-l452re

 -  nucleo-l496zg

 -  steval-stlcs01v1

 - stm32l476-mdk

## Impact

Impact on user: This PR adds  b-l475e-iot01a

 -  nucleo-l432kc,  nucleo-l452re, nucleo-l496zg, steval-stlcs01v1

 - stm32l476-mdk  boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

Locally


**b-l475e-iot01a**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=b-l475e-iot01a:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/b-l475e-iot01a/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  b-l475e-iot01a
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.7s)
-- Generating done (2.3s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[27/1159] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_rcc.c.obj
In file included from D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_rcc.c:49:
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x5xx_rcc.c: In function 'stm32l4_stdclockconfig':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x5xx_rcc.c:689:2: warning: #warning todo: regulator voltage according to clock freq [-Wcpp]
  689 | #warning todo: regulator voltage according to clock freq
      |  ^~~~~~~
[29/1159] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1157/1159] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      109272 B         1 MB     10.42%
            sram:        6356 B       128 KB      4.85%
[1159/1159] Generating nuttx.bin
```


**nucleo-l432kc**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=nucleo-l432kc:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/nucleo-l432kc/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  nucleo-l432kc
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (10.0s)
-- Generating done (2.7s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[24/1159] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[31/1159] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_rcc.c.obj
In file included from D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_rcc.c:47:
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x3xx_rcc.c: In function 'stm32l4_stdclockconfig':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x3xx_rcc.c:699:2: warning: #warning todo: regulator voltage according to clock freq [-Wcpp]
  699 | #warning todo: regulator voltage according to clock freq
      |  ^~~~~~~
[1157/1159] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      222956 B       256 KB     85.05%
            sram:        9572 B        64 KB     14.61%
[1159/1159] Generating nuttx.bin
```


**nucleo-l452re**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=nucleo-l452re:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/nucleo-l452re/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  nucleo-l452re
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (10.4s)
-- Generating done (2.3s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[25/1204] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[31/1204] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_rcc.c.obj
In file included from D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_rcc.c:47:
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x3xx_rcc.c: In function 'stm32l4_stdclockconfig':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4x3xx_rcc.c:699:2: warning: #warning todo: regulator voltage according to clock freq [-Wcpp]
  699 | #warning todo: regulator voltage according to clock freq
      |  ^~~~~~~
[48/1204] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_dac.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c:283:2: warning: #warning "Missing Logic" [-Wcpp]
  283 | #warning "Missing Logic"
      |  ^~~~~~~
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c: In function 'dac_reset':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c:671:2: warning: #warning "Missing logic" [-Wcpp]
  671 | #warning "Missing logic"
      |  ^~~~~~~
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c: In function 'dac_shutdown':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c:713:2: warning: #warning "Missing logic" [-Wcpp]
  713 | #warning "Missing logic"
      |  ^~~~~~~
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c: In function 'dac_txint':
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_dac.c:731:2: warning: #warning "Missing logic" [-Wcpp]
  731 | #warning "Missing logic"
      |  ^~~~~~~
[1203/1204] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      326500 B       512 KB     62.27%
            sram:       11544 B       160 KB      7.05%
[1204/1204] Generating nuttx.bin
```


**nucleo-l496zg**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=nucleo-l496zg:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/nucleo-l496zg/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  nucleo-l496zg
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (10.3s)
-- Generating done (2.3s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[26/1201] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1200/1201] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      326852 B         1 MB     31.17%
            sram:       13708 B       256 KB      5.23%
[1201/1201] Generating nuttx.bin

```

**steval-stlcs01v1**

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=steval-stlcs01v1:usbnsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/steval-stlcs01v1/configs/usbnsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  steval-stlcs01v1
--   Config: usbnsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.3s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[22/1125] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_allocateheap.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_allocateheap.c:128:4: warning: #warning "CONFIG_MM_REGIONS large enough but I do not know what some of the region(s) are" [-Wcpp]
  128 | #  warning "CONFIG_MM_REGIONS large enough but I do not know what some of the region(s) are"
      |    ^~~~~~~
[25/1125] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1123/1125] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       78864 B         1 MB      7.52%
            sram:        7452 B        96 KB      7.58%
[1125/1125] Generating nuttx.bin
```


**stm32l476-mdk**


```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=stm32l476-mdk:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- Processing includes: D:/nuttxtmp/nuttx/boards/arm/stm32l4/stm32l476-mdk/configs/nsh/defconfig -> D:/nuttxtmp/nuttx/build/.defconfig.processed
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  stm32l476-mdk
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (9.2s)
-- Generating done (2.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[27/1274] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32l4/stm32l4_gpio.c.obj
D:/nuttxtmp/nuttx/arch/arm/src/stm32l4/stm32l4_gpio.c:46:11: note: '#pragma message: CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   46 | #  pragma message "CONFIG_STM32L4_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1272/1274] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      102688 B         1 MB      9.79%
            sram:        7776 B        96 KB      7.91%
           sram2:          0 GB        32 KB      0.00%
[1274/1274] Generating nuttx.bin
```