### PR TITLE
icmp/icmp6: Fix some functional errors 

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -230,10 +230,12 @@
 
 /* Protocol-level socket operations. */
 
-#define SOL_IP          IPPROTO_IP   /* See options in include/netinet/ip.h */
-#define SOL_IPV6        IPPROTO_IPV6 /* See options in include/netinet/ip6.h */
-#define SOL_TCP         IPPROTO_TCP  /* See options in include/netinet/tcp.h */
-#define SOL_UDP         IPPROTO_UDP  /* See options in include/netinit/udp.h */
+#define SOL_IP          IPPROTO_IP     /* See options in include/netinet/in.h */
+#define SOL_IPV6        IPPROTO_IPV6   /* See options in include/netinet/in.h */
+#define SOL_TCP         IPPROTO_TCP    /* See options in include/netinet/in.h */
+#define SOL_UDP         IPPROTO_UDP    /* See options in include/netinet/in.h */
+#define SOL_RAW         IPPROTO_RAW    /* See options in include/netinet/in.h */
+#define SOL_ICMPV6      IPPROTO_ICMPV6 /* See options in include/netinet/in.h */
 
 /* Bluetooth-level operations. */
 

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -383,10 +383,10 @@ static int icmp_getsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
   {
-    case IPPROTO_IP:
+    case SOL_IP:
       return ipv4_getsockopt(psock, option, value, value_len);
 
-    case IPPROTO_ICMP:
+    case SOL_RAW:
       return icmp_getsockopt_internal(psock, option, value, value_len);
 
     default:
@@ -486,10 +486,10 @@ static int icmp_setsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
   {
-    case IPPROTO_IP:
+    case SOL_IP:
       return ipv4_setsockopt(psock, option, value, value_len);
 
-    case IPPROTO_ICMP:
+    case SOL_RAW:
       return icmp_setsockopt_internal(psock, option, value, value_len);
 
     default:

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -381,10 +381,10 @@ static int icmpv6_getsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
     {
-      case IPPROTO_IPV6:
+      case SOL_IPV6:
         return ipv6_getsockopt(psock, option, value, value_len);
 
-      case IPPROTO_ICMPV6:
+      case SOL_ICMPV6:
         return icmpv6_getsockopt_internal(psock, option, value, value_len);
 
       default:
@@ -484,10 +484,10 @@ static int icmpv6_setsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
     {
-      case IPPROTO_IPV6:
+      case SOL_IPV6:
         return ipv6_setsockopt(psock, option, value, value_len);
 
-      case IPPROTO_ICMPV6:
+      case SOL_ICMPV6:
         return icmpv6_setsockopt_internal(psock, option, value, value_len);
 
       default:


### PR DESCRIPTION
## Summary
1. fix errno forgot to add a negative sign
2. fix the level parameter type

## Impact
N/A

## Testing
sim:local
can trigger the test program corresponding to the error 
