### PR TITLE
drivers/usbdev: fix cdcecm netdev can not enter running state

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1047,6 +1047,7 @@ error:
 static int cdcecm_setinterface(FAR struct cdcecm_driver_s *self,
                                uint16_t interface, uint16_t altsetting)
 {
+  netdev_carrier_on(&self->dev);
   uinfo("interface: %hu, altsetting: %hu\n", interface, altsetting);
   return OK;
 }


### PR DESCRIPTION
## Summary
When the setinterface interface is called, it indicates that the underlying USB link has been successfully established. At this point, the status of the network card needs to be updated to RUNNING by calling the netdev_carrier_on interface. It is similar to the logic after a Wi-Fi network card is connected to a hotspot. Otherwise, an incorrect network card status may cause packets to fail to be successfully sent.

## Impact
Fixed the issue where the network card status did not enter "running" after the CDCECM usb connection was established.

## Testing
sim:usbdev
Establish a cdcecm network card connection with HOST Linux and send/receive packets.

NuttX:
```
NuttShell (NSH) NuttX-12.11.0
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 00:00:00:00:00:00 at RUNNING mtu 1504
        inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
        inet6 addr: fe80::200:ff:fe00:0/64
        inet6 DRaddr: ::

        RX: Received Fragment Errors   Bytes
            00000000 00000000 00000000 0
            IPv4     IPv6     ARP      Dropped
            00000000 00000000 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes
            0000000b 00000000 00000000 00000000 362
        Total Errors: 00000000

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     0000  0000  0000  0000  0000  0000
Dropped      0000  0000  0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000
Sent         0000  000b  0000  0000  0000  000b
  Rexmit     ----  ----  0000  ----  ----  ----
nsh>
nsh> conn 1
conn_main: Performing architecture-specific initialization
conn_main: Exiting
nsh>
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 00:00:00:00:00:00 at RUNNING mtu 1504
        inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
        inet6 addr: fe80::200:ff:fe00:0/64
        inet6 DRaddr: ::

        RX: Received Fragment Errors   Bytes
            00000000 00000000 00000000 0
            IPv4     IPv6     ARP      Dropped
            00000000 00000000 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes
            0000000b 00000000 00000000 00000000 362
        Total Errors: 00000000

eth1    Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at RUNNING mtu 1504
        inet addr:0.0.0.0 DRaddr:0.0.0.0 Mask:0.0.0.0
        inet6 addr: ::/0
        inet6 DRaddr: ::

        RX: Received Fragment Errors   Bytes
            00000000 00000000 00000000 0
            IPv4     IPv6     ARP      Dropped
            00000002 00000008 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes
            00000000 00000000 00000000 00000000 0
        Total Errors: 00000000

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     0002  0008  0000  0002  0000  0000
Dropped      0000  0008  0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000
Sent         0000  000b  0000  0000  0000  000b
  Rexmit     ----  ----  0000  ----  ----  ----
nsh>
nsh> ifconfig eth1 10.0.0.1/24
nsh> ping -c 2 10.0.0.2
PING 10.0.0.2 56 bytes of data
ERROR: sendto failed at seqno 0: 101
ERROR: sendto failed at seqno 1: 101
2 packets transmitted, 0 received, 100% packet loss, time 2020 ms
nsh>
```
Linux
```
[ 4249.641591] cdc_ether 3-1:1.2 usb0: register 'cdc_ether' at usb-dummy_hcd.0-1, CDC Ethernet Device, 02:00:00:11:22:33
[ 4249.659334] cdc_ether 3-1:1.2 enx020000112233: renamed from usb0
sudo ifconfig enx020000112233 10.0.0.2/24
```
NuttX:
```
nsh>
nsh> ping -c 2 10.0.0.2
PING 10.0.0.2 56 bytes of data
56 bytes from 10.0.0.2: icmp_seq=0 time=10.0 ms
56 bytes from 10.0.0.2: icmp_seq=1 time=20.0 ms
2 packets transmitted, 2 received, 0% packet loss, time 2020 ms
rtt min/avg/max/mdev = 10.000/15.000/20.000/5.000 ms
nsh>
```