### PR TITLE
driver/i3c: fix after i3c_bus init without initialization of i3c_device

### DIFF
--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -2241,6 +2241,14 @@ int i3c_master_register(FAR struct i3c_master_controller *master,
 
   master->init_done = true;
 
+  /* The initialization of &struct i3c_device must be completed, otherwise
+   * desc->dev == NULL.
+   */
+
+  i3c_bus_normaluse_lock(&master->bus);
+  i3c_master_register_new_i3c_devs(master);
+  i3c_bus_normaluse_unlock(&master->bus);
+
   /* Expose I3C driver node by the i3c_driver on our I3C Bus, i3c driver id
    * equal to i3c bus id.
    */


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*A crash occurs when sending data through the interface i3c_device_do_priv_xfers, where the struct 'i3c_device * dev' is null. The memory request for 'i3c_device * dev' is in i3c_master_register_new_i3c_devs. In addition to the DAA process for adding new devices, the interface should be called again after init_deone=true.*

## Impact

*NA.*

## Testing

*chip: bes evb*
*dev: LSM6DSR*
