### PR TITLE
net/utils/net_bufpool: add lock to struct net_bufpool_s and bufpool_navail

### DIFF
--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -97,6 +97,7 @@
       dynalloc, \
       -(int)(nodesize), \
       SEM_INITIALIZER(NET_BUFPOOL_MAX(prealloc, dynalloc, maxalloc)), \
+      NXRMUTEX_INITIALIZER, \
       { NULL, NULL } \
     };
 
@@ -105,6 +106,9 @@
 #define NET_BUFPOOL_ALLOC(p)        net_bufpool_timedalloc(&p, UINT_MAX)
 #define NET_BUFPOOL_FREE(p,n)       net_bufpool_free(&p, n)
 #define NET_BUFPOOL_TEST(p)         net_bufpool_test(&p)
+#define NET_BUFPOOL_NAVAIL(p)       net_bufpool_navail(&p)
+#define NET_BUFPOLL_LOCK(p)         net_bufpool_lock(&p)
+#define NET_BUFPOLL_UNLOCK(p)       net_bufpool_unlock(&p)
 
 /****************************************************************************
  * Public Types
@@ -132,6 +136,7 @@ struct net_bufpool_s
 
   sem_t      sem;      /* The semaphore for waiting for free buffers */
 
+  rmutex_t   lock;     /* The lock for the pool */
   sq_queue_t freebuffers;
 };
 
@@ -414,6 +419,45 @@ void net_bufpool_free(FAR struct net_bufpool_s *pool, FAR void *node);
  ****************************************************************************/
 
 int net_bufpool_test(FAR struct net_bufpool_s *pool);
+
+/****************************************************************************
+ * Name: net_bufpool_navail
+ *
+ * Description:
+ *   Return the number of available buffers in the buffer pool.
+ *
+ * Assumptions:
+ *   None.
+ *
+ ****************************************************************************/
+
+int net_bufpool_navail(FAR struct net_bufpool_s *pool);
+
+/****************************************************************************
+ * Name: net_bufpool_lock
+ *
+ * Description:
+ *   Use the bufpool lock to protect the node of the buffer pool.
+ *
+ * Input Parameters:
+ *   pool - The lock of pool to be locked.
+ *
+ ****************************************************************************/
+
+void net_bufpool_lock(FAR struct net_bufpool_s *pool);
+
+/****************************************************************************
+ * Name: net_bufpool_unlock
+ *
+ * Description:
+ *   Finish using the bufpool lock to protect the node of the buffer pool.
+ *
+ * Input Parameters:
+ *   pool - The lock of pool to be unlocked.
+ *
+ ****************************************************************************/
+
+void net_bufpool_unlock(FAR struct net_bufpool_s *pool);
 
 /****************************************************************************
  * Name: net_chksum_adjust


### PR DESCRIPTION
## Summary
Add a lock to net_bufpool to simplify the protocol stack code.


## Impact
conn alloc and free process.

## Testing
sim:matter
Verify via iperf TCP/UDP and ping.
