### PR TITLE
include/string.h: mark memset and memcpy as used_code

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -100,10 +100,10 @@ FAR void  *memrchr(FAR const void *s, int c, size_t n);
 FAR void  *rawmemchr(FAR const void *s, int c);
 FAR void  *memccpy(FAR void *s1, FAR const void *s2, int c, size_t n);
 int        memcmp(FAR const void *s1, FAR const void *s2, size_t n);
-FAR void  *memcpy(FAR void *dest, FAR const void *src, size_t n);
+FAR void  *memcpy(FAR void *dest, FAR const void *src, size_t n) used_code;
 FAR void  *mempcpy(FAR void *dest, FAR const void *src, size_t n);
 FAR void  *memmove(FAR void *dest, FAR const void *src, size_t count);
-FAR void  *memset(FAR void *s, int c, size_t n);
+FAR void  *memset(FAR void *s, int c, size_t n) used_code;
 FAR void  *memmem(FAR const void *haystack, size_t haystacklen,
                   FAR const void *needle, size_t needlelen);
 


### PR DESCRIPTION
## Summary

Mark memset and memcpy as used_code to fix issues with GCC LTO and CMake which throws many "undefined reference to memset" errors.
used_code force the compiler to emit the memset symbol under LTO.

Example error for libcxxabi:

```
/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: /tmp/ccFKUV08.ltrans1.ltrans.o: in function `__dynamic_cast.constprop.0':
external/nuttx/libs/libxx/libcxxabi/libcxxabi/src/private_typeinfo.cpp:655:(.text.__dynamic_cast.constprop.0+0x20): undefined reference to `memset'
/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: external/nuttx/libs/libxx/libcxxabi/libcxxabi/src/private_typeinfo.cpp:736:(.text.__dynamic_cast.constprop.0+0x4e): undefined reference to `memset'
/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: /tmp/ccFKUV08.ltrans1.ltrans.o: in function `__cxxabiv1::__class_type_info::can_catch(__cxxabiv1::__shim_type_info const*, void*&) const':
external/nuttx/libs/libxx/libcxxabi/libcxxabi/src/private_typeinfo.cpp:236:(.text._ZNK10__cxxabiv117__class_type_info9can_catchEPKNS_16__shim_type_infoERPv+0x28): undefined reference to `memset'
/usr/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: /tmp/ccFKUV08.ltrans1.ltrans.o: in function `__cxxabiv1::__pointer_type_info::can_catch(__cxxabiv1::__shim_type_info const*, void*&) const':
external/nuttx/libs/libxx/libcxxabi/libcxxabi/src/private_typeinfo.cpp:434:(.text._ZNK10__cxxabiv119__pointer_type_info9can_catchEPKNS_16__shim_type_infoERPv+0x12c): undefined reference to `memset'

```

## Impact
fix LTO compilation

## Testing
local build with LTO enabled