### PR TITLE
drivers/lpwan: Fix Kconfig SX1276 and SX1262 position

### DIFF
--- a/drivers/wireless/lpwan/Kconfig
+++ b/drivers/wireless/lpwan/Kconfig
@@ -12,13 +12,6 @@ config LPWAN_RN2XX3
 	---help---
 		Enable driver support for the RN2xx3 LoRa radio transceiver family.
 
-config LPWAN_SX127X
-	bool "SX127X Low Power Long Range transceiver support"
-	default n
-	select SPI
-	---help---
-		This options adds driver support for the Samtech SX127X chip.
-
 config LPWAN_SX126X
 	bool "SX126X Low Power Long Range transceiver support"
 	default n
@@ -27,6 +20,13 @@ config LPWAN_SX126X
 		This options adds driver support for the Samtech SX126X chip.
 
 source "drivers/wireless/lpwan/sx126x/Kconfig"
+
+config LPWAN_SX127X
+	bool "SX127X Low Power Long Range transceiver support"
+	default n
+	select SPI
+	---help---
+		This options adds driver support for the Samtech SX127X chip.
 
 if LPWAN_SX127X
 


### PR DESCRIPTION
## Summary

When user was selecting SX1276 the configuration options to this device was appear below SX1262.

## Impact

Improvement

## Testing

Before:
<img width="1384" height="373" alt="kconfig_before_fix" src="https://github.com/user-attachments/assets/b51bd615-0529-4ed7-94ff-2521bda9903c" />

After:
<img width="1384" height="373" alt="kconfig_after_fix" src="https://github.com/user-attachments/assets/c2e39bb6-f0ae-4ecd-9349-504dd6150208" />
