### PR TITLE
arch/crt0.c: revert entry name to `_start`

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -572,7 +572,7 @@ ifneq ($(CONFIG_BUILD_KERNEL),y)
   LDELFFLAGS += $(TOPDIR)$(DELIM)arch$(DELIM)arm$(DELIM)src$(DELIM)crt0.o
 endif
 
-LDELFFLAGS += -e __start -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)elf$(DELIM)gnu-elf.ld)
+LDELFFLAGS += -e _start -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)elf$(DELIM)gnu-elf.ld)
 
 # Zig toolchain
 

--- a/arch/arm/src/common/crt0.c
+++ b/arch/arm/src/common/crt0.c
@@ -141,7 +141,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: __start
+ * Name: _start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -160,7 +160,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void __start(int argc, char *argv[])
+void _start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -288,7 +288,7 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden # --target1-abs
 
-LDELFFLAGS = -r -e __start
+LDELFFLAGS = -r -e _start
 ifneq ($(CONFIG_BUILD_KERNEL),y)
   # Flat build and protected elf entry point use crt0,
   # Kernel build will use apps/import/scripts/crt0

--- a/arch/arm64/src/common/crt0.c
+++ b/arch/arm64/src/common/crt0.c
@@ -148,7 +148,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: __start
+ * Name: _start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -167,7 +167,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void __start(int argc, char *argv[])
+void _start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/risc-v/src/common/crt0.c
+++ b/arch/risc-v/src/common/crt0.c
@@ -145,7 +145,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: __start
+ * Name: _start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -164,7 +164,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void __start(int argc, char *argv[])
+void _start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -258,7 +258,7 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden
 
-LDELFFLAGS = -r -e __start
+LDELFFLAGS = -r -e _start
 ifneq ($(CONFIG_BUILD_KERNEL),y)
   # Flat build and protected elf entry point use crt0,
   # Kernel build will use apps/import/scripts/crt0

--- a/arch/x86_64/src/common/crt0.c
+++ b/arch/x86_64/src/common/crt0.c
@@ -130,7 +130,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: __start
+ * Name: _start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -149,7 +149,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void __start(int argc, char *argv[])
+void _start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/xtensa/src/common/crt0.c
+++ b/arch/xtensa/src/common/crt0.c
@@ -96,7 +96,7 @@ static void exec_dtors(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: __start
+ * Name: _start
  *
  * Description:
  *   This function is the low level entry point into the main thread of
@@ -115,7 +115,7 @@ static void exec_dtors(void)
  *
  ****************************************************************************/
 
-void __start(int argc, char *argv[])
+void _start(int argc, char *argv[])
 {
   int ret;
 

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -232,7 +232,7 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden -mtext-section-literals
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden -mtext-section-literals
 
-LDELFFLAGS = -r -e __start
+LDELFFLAGS = -r -e _start
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)elf$(DELIM)gnu-elf.ld)
 ifneq ($(CONFIG_BUILD_KERNEL),y)
   # Flat build and protected elf entry point use crt0,

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -236,7 +236,7 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden -mtext-section-literals
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden -mtext-section-literals
 
-LDELFFLAGS = -r -e __start
+LDELFFLAGS = -r -e _start
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)elf$(DELIM)gnu-elf.ld)
 ifneq ($(CONFIG_BUILD_KERNEL),y)
   # Flat build and protected elf entry point use crt0,

--- a/tools/toolchain.cmake.export
+++ b/tools/toolchain.cmake.export
@@ -22,8 +22,9 @@ set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
 add_compile_options(-nostdlib)
 add_compile_options(-ffunction-sections -fdata-sections)
 
-# same entry used for all build modes in crt0.c and arch/.../xxx_start.c
-set(ENTRY_NAME "__start")
+# same entry used for all build modes in crt0.c
+
+set(ENTRY_NAME "_start")
 
 set(CMAKE_C_LINK_EXECUTABLE
     "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} -T${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"


### PR DESCRIPTION
## Summary

This reverts original entry name to fix LTO issue/17443 together with https://github.com/apache/nuttx-apps/pull/3235.

## Impact

Issue fix that shouldn't impact existing build processes.

## Testing

- Local checks on Ubuntu 22.04 for:
  - FLAT mode: `qemu-armv7a:nsh`, `rv-virt:nsh`
  - PROTECTED mode: `rv-virt:pnsh`
  - KERNEL mode: `qemu-armv7a:knsh`, `rv-virt:nsbi`
- With help from @pkarashchenko  for  issue/17743 
- CI checks

