### PR TITLE
note/drivers: Get taskname more safely.

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -2097,11 +2097,11 @@ void sched_note_filter_tag(FAR struct note_filter_named_tag_s *oldf,
  *   len - The length of the buffer
  *
  * Returned Value:
- *   None
+ *   Return name if task name can be retrieved, otherwise "<noname>"
  *
  ****************************************************************************/
 
-void note_get_taskname(pid_t pid, FAR char *buf, size_t len)
+FAR char *note_get_taskname(pid_t pid, FAR char *buf, size_t len)
 {
 #if CONFIG_TASK_NAME_SIZE > 0
   FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
@@ -2109,28 +2109,25 @@ void note_get_taskname(pid_t pid, FAR char *buf, size_t len)
   if (tcb != NULL)
     {
       strlcpy(buf, tcb->name, len);
+      return buf;
     }
-  else
-    {
+
 #  if defined(CONFIG_SCHED_INSTRUMENTATION_SWITCH) && \
       (CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0)
+  else
+    {
       FAR struct note_taskname_info_s *ti = note_find_taskname(pid);
 
       if (ti != NULL)
         {
           strlcpy(buf, ti->name, len);
+          return buf;
         }
-      else
-        {
-          strlcpy(buf, "<noname>", len);
-        }
-#  else
-      strlcpy(buf, "<noname>", len);
-#  endif
     }
-#else
-  strlcpy(buf, "<noname>", len);
+#  endif
 #endif
+
+  return "<noname>";
 }
 
 /****************************************************************************

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -790,11 +790,9 @@ static int noteram_dump_header(FAR struct lib_outstream_s *s,
   int cpu = 0;
 #endif
 
-  note_get_taskname(pid, buf, TASK_NAME_SIZE);
-
   ret = lib_sprintf(s, "%8s-%-3u [%d] %3" PRIu64 ".%09lu: ",
-                    buf, get_pid(pid), cpu,
-                    (uint64_t)ts.tv_sec, ts.tv_nsec);
+                    note_get_taskname(pid, buf, TASK_NAME_SIZE),
+                    get_pid(pid), cpu, (uint64_t)ts.tv_sec, ts.tv_nsec);
 
   return ret;
 }
@@ -830,16 +828,15 @@ static int noteram_dump_sched_switch(FAR struct lib_outstream_s *s,
   current_priority = cctx->current_priority;
   next_priority = cctx->next_priority;
 
-  note_get_taskname(current_pid, current_buf, TASK_NAME_SIZE);
-  note_get_taskname(next_pid, next_buf, TASK_NAME_SIZE);
-
   ret = lib_sprintf(s, "sched_switch: prev_comm=%s prev_pid=%u "
                     "prev_prio=%u prev_state=%c ==> "
                     "next_comm=%s next_pid=%u next_prio=%u\n",
-                    current_buf, get_pid(current_pid),
-                    current_priority, get_task_state(cctx->current_state),
-                    next_buf, get_pid(next_pid),
-                    next_priority);
+                    note_get_taskname(current_pid, current_buf,
+                                      TASK_NAME_SIZE),
+                    get_pid(current_pid), current_priority,
+                    get_task_state(cctx->current_state),
+                    note_get_taskname(next_pid, next_buf, TASK_NAME_SIZE),
+                    get_pid(next_pid), next_priority);
 
   cctx->current_pid = cctx->next_pid;
   cctx->current_priority = cctx->next_priority;
@@ -942,11 +939,11 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SWITCH
     case NOTE_START:
       {
-        note_get_taskname(pid, buf, TASK_NAME_SIZE);
         ret += noteram_dump_header(s, note, ctx);
         ret += lib_sprintf(s, "sched_wakeup_new: comm=%s pid=%d "
                            "target_cpu=%d\n",
-                           buf, get_pid(pid), cpu);
+                           note_get_taskname(pid, buf, TASK_NAME_SIZE),
+                           get_pid(pid), cpu);
       }
       break;
 
@@ -996,11 +993,12 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
              * until leaving the interrupt handler.
              */
 
-            note_get_taskname(cctx->next_pid, buf, TASK_NAME_SIZE);
             ret += noteram_dump_header(s, note, ctx);
             ret += lib_sprintf(s, "sched_waking: comm=%s "
                                "pid=%d target_cpu=%d\n",
-                               buf, get_pid(cctx->next_pid), cpu);
+                               note_get_taskname(cctx->next_pid, buf,
+                                                 TASK_NAME_SIZE),
+                               get_pid(cctx->next_pid), cpu);
             cctx->pendingswitch = true;
           }
       }

--- a/include/nuttx/note/note_driver.h
+++ b/include/nuttx/note/note_driver.h
@@ -191,11 +191,11 @@ int note_initialize(void);
  *   len - The length of the buffer
  *
  * Returned Value:
- *   None
+ *   Return name if task name can be retrieved, otherwise "<noname>"
  *
  ****************************************************************************/
 
-void note_get_taskname(pid_t pid, FAR char *buf, size_t len);
+FAR char *note_get_taskname(pid_t pid, FAR char *buf, size_t len);
 
 /****************************************************************************
  * Name: note_driver_register


### PR DESCRIPTION
## Summary

When tcb may has been released in caller, the return pointer to tcb->name is dangling pointer. So add a buffer in caller, even if tcb is released, buffer is still valid.

## Impact

None

## Testing

build: 
tools/configure.sh qemu-armv7a/nsh 

configs:
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
CONFIG_DRIVERS_NOTE=y
CONFIG_DRIVERS_NOTERAM=y
CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE=256
CONFIG_SCHED_INSTRUMENTATION_DUMP=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_TRACE=y
CONFIG_DRIVERS_NOTECTL=y
CONFIG_SYSTEM_TRACE=y

### ostest pass:
ostest_main: Exiting with status 0

### note driver test pass:
```
nsh> trace start
nsh> trace dump
nsh_main-2   [0]   0.000000000: sched_switch: prev_comm=trace prev_pid=3 prev_prio=255 prev_state=X ==> next_comm=nsh_main next_pid=2 next_prio=100
nsh_main-2   [0]   0.000000000: tracing_mark_write: E|2|trace start
Idle_Task-0   [0]   0.000000000: sched_switch: prev_comm=nsh_main prev_pid=2 prev_prio=100 prev_state=S ==> next_comm=Idle_Task next_pid=0 next_prio=0
nsh_main-2   [0]   0.000000000: sched_switch: prev_comm=Idle_Task prev_pid=0 prev_prio=0 prev_state=R ==> next_comm=nsh_main next_pid=2 next_prio=100
Idle_Task-0   [0]   0.000000000: sched_switch: prev_comm=nsh_main prev_pid=2 prev_prio=100 prev_state=S ==> next_comm=Idle_Task next_pid=0 next_prio=0
nsh_main-2   [0]   0.000000000: sched_switch: prev_comm=Idle_Task prev_pid=0 prev_prio=0 prev_state=R ==> next_comm=nsh_main next_pid=2 next_prio=100
```
### note name test pass:
#### code:
```
FAR void* func(FAR void *arg)
{
  printf("thread exited\n");
  return NULL;
}

int main(int argc, FAR char *argv[])
{
  pthread_t pid;
  char buf[32];

  pthread_create(&pid, NULL, func, NULL);
  sleep(1);
  note_get_taskname(pid, buf, 32);

  printf("pid_name: %s\n", buf);
  return 0;
}
```
#### result:
```
nsh> hello
thread exited
pid_name: hello
```