### PR TITLE
drivers/i3c: Revert "drivers/i3c: remove extra i3c_dev_register, do_daa has created them"

### DIFF
--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -2240,6 +2240,9 @@ int i3c_master_register(FAR struct i3c_master_controller *master,
    */
 
   master->init_done = true;
+  i3c_bus_normaluse_lock(&master->bus);
+  i3c_master_register_new_i3c_devs(master);
+  i3c_bus_normaluse_unlock(&master->bus);
 
   /* Expose I3C driver node by the i3c_driver on our I3C Bus, i3c driver id
    * equal to i3c bus id.


### PR DESCRIPTION
…aa has created them"

This reverts commit 694750e8af624bbf828420d7096637a63d160963.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*closed driver/i3c: fix after i3c_bus init without initialization of i3c_device #17438, create new PR.*

*Because there is already the same patch, please revert the previous patch.*

*Root cause：A crash occurs when sending data through the interface i3c_device_do_priv_xfers, where the struct 'i3c_device * dev' is null. The memory request for 'i3c_device * dev' is in i3c_master_register_new_i3c_devs. In addition to the DAA process for adding new devices, the interface should be called again after init_deone=true.*

## Impact

*NA.*

## Testing

*chip: bes evb*
*dev: LSM6DSR*
