### PR TITLE
Fix clang fortify issue

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -127,7 +127,9 @@
                                         } \
                                       while (0)
 
-#    define fortify_va_arg_pack __builtin_va_arg_pack
+#    if !defined(__clang__)
+#      define fortify_va_arg_pack __builtin_va_arg_pack
+#    endif
 #    define fortify_real(fn) __typeof__(fn) __real_##fn __asm__(#fn)
 #    define fortify_function(fn) fortify_real(fn); \
                                  extern __inline__ no_builtin(#fn) \

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -318,6 +318,7 @@ fortify_function(vsprintf) int vsprintf(FAR char *dest,
   return ret;
 }
 
+#ifdef fortify_va_arg_pack
 fortify_function(snprintf) int snprintf(FAR char *buf, size_t size,
                                         FAR const IPTR char *format, ...)
 {
@@ -335,6 +336,7 @@ fortify_function(sprintf) int sprintf(FAR char *buf,
   fortify_assert(ret == -1 || (size_t)ret <= fortify_size(buf, 0));
   return ret;
 }
+#endif
 #endif
 
 #undef EXTERN


### PR DESCRIPTION

## Summary

build configuration `mps3-an547:clang` with arm [clang](https://github.com/arm/arm-toolchain/releases/tag/release-21.1.1-ATfE), and enable config `CONFIG_FORTIFY_SOURCE=3`, 
will meet two errors:

1st error message: `error: compiler version less than 12 does not support dynamic object size`
Reason: the clang compiler has also defined `__GNUC__`, which can't be used to decide the compiler version.
And the version used to decide whether the builtin function `__builtin_dynamic_object_size` exist is not correct.

2nd error: `use of undeclared identifier '__builtin_va_arg_pack'`
Reason: clang does not have builtin function `__builtin_va_arg_pack`

## Impact
clang fortify

## Testing

build configuration `mps3-an547:clang` with config `CONFIG_FORTIFY_SOURCE=3` enabled.


