### PR TITLE
binfmt/elf: fix issue that the file is not closed after opening

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -107,7 +107,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
   if (ret != 0)
     {
       berr("Failed to initialize to load ELF program binary: %d\n", ret);
-      return ret;
+      goto errout_with_init;
     }
 
   /* Load the program binary */


### PR DESCRIPTION

## Summary

When opening the file succeeds but reading the file fails in modlib_initialize, this will result in the open file not be closed.

## Impact

bug fix

## Testing

When fd check configuration is enabled, executing the `adb shell ls` command 5000 times consecutively results in an error.
If a file is successfully opened in libelf_initialize but reading fails, it will return directly without closing the file, leading to a file descriptor (fd) leak.
```
libelf_initialize
   ...
    _NX_OPEN
   ...
   libelf_read   // if failed, return without close
      return ret;
```
