### PR TITLE
nuttx/audio: upper half enhancement

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -477,6 +477,7 @@ static int audio_configure(FAR struct file *filep,
       /* INPUT/OUTPUT configure success here */
 
       audio_setstate(upper, AUDIO_STATE_PREPARED);
+      upper->info.type = caps->ac_type;
       upper->info.format = caps->ac_subtype;
       upper->info.channels = caps->ac_channels;
       upper->info.subformat = caps->ac_format.b[0];
@@ -1423,6 +1424,12 @@ static inline void audio_dequeuebuffer(FAR struct audio_upperhalf_s *upper,
   irqstate_t flags;
 
   audinfo("Entry\n");
+
+  if (upper->info.type == AUDIO_TYPE_OUTPUT)
+    {
+      apb->nbytes = 0;
+      memset(apb->samp, 0, apb->nmaxbytes);
+    }
 
   flags = spin_lock_irqsave_nopreempt(&upper->spinlock);
   upper->status->tail++;

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -732,16 +732,12 @@ struct audio_caps_desc_s
 
 struct audio_info_s
 {
-  uint32_t samplerate;   /* Sample Rate of the audio data */
-  uint8_t  channels;     /* Number of channels (1, 2, 5, 7) */
-  uint8_t  format;       /* Audio data format */
-  uint8_t  subformat;    /* Audio subformat
-                          * (maybe should be combined with format?)
-                          */
-
-  /* Codec extra params */
-
-  struct audio_codec_s codec;
+  uint32_t              samplerate; /* Sample Rate of the audio data */
+  uint8_t               channels;   /* Number of channels (1, 2, 5, 7) */
+  uint8_t               format;     /* Audio data format */
+  uint8_t               subformat;  /* Audio subformat */
+  uint8_t               type;       /* device type */
+  struct audio_codec_s  codec;      /* Codec extra params */
 };
 
 /* This structure describes the preferred number and size of


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

We have enhanced the capabilities of the upper driver, mainly including the following features:

1.Support for multiple applications simultaneously using the upper driver for playback/recording;
2.Support for maintaining a ringbuffer in the upper driver for simultaneous access by multiple applications;
3.Lower driver state management and retrieval;
4.Support for poll/mmap;
5.More comprehensive information retrieval via ioctl interfaces.

## Impact

playback/recording, upperhalf driver

## Testing

We have conducted tests on the following platforms:
​​
1. Simulator​​ – Playback / Recording;
2. ​​BES Platform​​ – Playback / Recording;
3. Allwinner Platform​​ – Playback / Recording;

