### PR TITLE
driver/usbhost: Support obtaining USB3.0 device descriptors

### DIFF
--- a/drivers/usbhost/usbhost_enumerate.c
+++ b/drivers/usbhost/usbhost_enumerate.c
@@ -292,7 +292,7 @@ int usbhost_enumerate(FAR struct usbhost_hubport_s *hport,
   struct usbhost_id_s id;
   size_t maxlen;
   unsigned int cfglen;
-  uint8_t maxpacketsize;
+  uint16_t maxpacketsize;
   uint8_t descsize;
   uint8_t funcaddr = 0;
   FAR uint8_t *buffer = NULL;
@@ -331,7 +331,14 @@ int usbhost_enumerate(FAR struct usbhost_hubport_s *hport,
    *   Data packets following a Setup..."
    */
 
-  if (hport->speed == USB_SPEED_HIGH)
+  if (hport->speed >= USB_SPEED_SUPER)
+    {
+      /* For super-speed, we must use 512 bytes */
+
+      maxpacketsize = 512;
+      descsize      = USB_SIZEOF_DEVDESC;
+    }
+  else if (hport->speed == USB_SPEED_HIGH)
     {
       /* For high-speed, we must use 64 bytes */
 
@@ -370,7 +377,14 @@ int usbhost_enumerate(FAR struct usbhost_hubport_s *hport,
   /* Extract the correct max packetsize from the device descriptor */
 
   maxpacketsize = ((struct usb_devdesc_s *)buffer)->mxpacketsize;
-  uinfo("maxpacksetsize: %d\n", maxpacketsize);
+  if (hport->speed >= USB_SPEED_SUPER && maxpacketsize == 9)
+    {
+      /* For super-speed, we must use 512 bytes */
+
+      maxpacketsize = 512;
+    }
+
+  uinfo("maxpacksetsize: %d speed: %d\n", maxpacketsize, hport->speed);
 
   /* And reconfigure EP0 with the correct maximum packet size */
 


### PR DESCRIPTION

## Summary

usbhost supports USB 3.0 device descriptors.

## Impact

usbhost can analyze usb 3.0 device descriptors.

## Testing

Recognize USB 3.0 flash drives
host: ubuntu 22.04.1
target:  qemu

QEMU acts as a USB host, enabling USB host, XHCI, and MSC.
```
// configuration
CONFIG_DEVICE_TREE=y
CONFIG_PCI=y
CONFIG_PCI_MSIX=y
CONFIG_ARMV7A_GICv2M=y
CONFIG_USBHOST=y
CONFIG_USBHOST_WAITER=y
CONFIG_USBHOST_XHCI_PCI=y
CONFIG_USBHOST_CDCACM=y
CONFIG_USBHOST_HIDKBD=y
CONFIG_USBHOST_HIDMOUSE=y
CONFIG_USBHOST_MSC=y 
CONFIG_FS_FAT=y

// optional
CONFIG_DEBUG_PCI=y
CONFIG_DEBUG_PCI_ERROR=y
CONFIG_DEBUG_PCI_INFO=y
CONFIG_DEBUG_PCI_WARN=y
CONFIG_DEBUG_USB=y
CONFIG_DEBUG_USB_ERROR=y
CONFIG_DEBUG_USB_INFO=y
CONFIG_DEBUG_USB_WARN=y
```
Add support for xhci to the qemu startup options. The vid and pid should be filled in according to the actual device.
```
-device qemu-xhci -device usb-host,vendorid=xxxx,productid=xxxx"
```
start qemu, and then insert a USB 3.0 flash drive.
execute the command `mount usb msc device: mount -t vfat /dev/sda /mnt/flash`. 

