### PR TITLE
usbhost: cdcacm exit wq after copy all received data

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -17,7 +17,7 @@ Linix 45ZWN24-40           2  0.5 Ohm    0.400 mH  2.34A   24V
 * [#15520](https://github.com/apache/nuttx/pull/15520) drivers/note: fix typo falgs and align local name to irq_mask
 * [#4526](https://github.com/apache/nuttx/pull/4526) Rearch video
 * [#6447](https://github.com/apache/nuttx/pull/6447) bcm43xxx: Remove bcmf_txavail_work and resue bcmf_tx_poll_work
-        ans init
+   ans init
    *   CAF        : Depends on CONFIG_NET_PROMISCUOUS
            * been lost).  If ORE is set along with RXNE then it tells you
   /* GIR bits must be masked! */

--- a/Documentation/platforms/sim/sim/boards/sim/index.rst
+++ b/Documentation/platforms/sim/sim/boards/sim/index.rst
@@ -1859,6 +1859,43 @@ This is a configuration with sim usbhost support.
    Run sim usbhost with root mode, run sim usbdev or plug-in cdcacm usb device.
    Then you can use ``/dev/ttyACM`` to transfer data.
 
+   Here we will demonstrate an example of interaction between sim usbhost and
+   sim usbdev. Build two executable files using the configurations ``sim:usbdev``
+   and ``sim:usbhost`` respectively.
+
+   Run each executable files as root in different terminals.
+   Terminal 1 (run nuttx binary from sim:usbhost):
+
+   .. code:: console
+
+      $ sudo ./nuttx
+
+   Terminal 2  (run nuttx binary from sim:usbdev):
+
+   .. code:: console
+
+      $ sudo ./nuttx
+
+   Then, run CDCACM in usbdev.
+
+   .. code:: console
+
+      nsh> conn 1
+
+   Enter commands to read CDCACM on the usbhost:
+
+   .. code:: console
+
+      nsh> cat /dev/ttyACM0 &
+
+   Enter commands to write CDCACM on the usbdev:
+
+   .. code:: console
+
+      nsh> echo hello > /dev/ttyACM0
+
+   You can see the data on the usbhost: ``hello``.
+
 login
 -----
 

--- a/drivers/usbhost/usbhost_cdcacm.c
+++ b/drivers/usbhost/usbhost_cdcacm.c
@@ -1171,6 +1171,7 @@ static void usbhost_rxdata_work(FAR void *arg)
 
           uart_datareceived(uartdev);
           nxfrd = 0;
+          break;
         }
     }
 


### PR DESCRIPTION
## Summary

cdcacm exit wq after copy all received data

## Impact

Fix issue: When the SIM CDCACM host receives data, the second packet data reception is incorrect.

## Testing

1. Compile usbhost: `./build.sh sim:usbhost -j8`
2. Start usbhost: `sudo nuttx/nuttx`
3. Compile usbdev: `./build.sh sim:usbdev -j8`
4. Start usbdev: `sudo nuttx/nuttx`
5. Enable usbdev as cdcacm:  input `conn 1` 
6. In usbhost, input `cat /dev/ttyACM0 &`
7. In usbdev, input `echo hello > /dev/ttyACM0` multiple times. 
Note that the second `hello` does not display correctly in usbhost.
