### PR TITLE
eeprom/spi_xx25xx: Add IOCTL to set Block Protect

### DIFF
--- a/Documentation/components/drivers/character/eeprom.rst
+++ b/Documentation/components/drivers/character/eeprom.rst
@@ -184,6 +184,17 @@ The full list of ``ioctl()`` commands can be found in
     Erase the full EEPROM, a dedicated command is used if supported by the
     device.
 
+- ``EEPIOC_BLOCKPROTECT``
+    *Argument:* ``uint8_t``
+
+    Set EEPROM's Block Protect bits. For 25AA160-compatible EEPROM with
+    two Block Protect bits in Status Register, the argument may be:
+
+    - ``0`` for no write protect,
+    - ``1`` to set Block Protection 0 bit of Status Register,
+    - ``2`` to set Block Protection 1 bit of Status Register,
+    - ``3`` to set both Block Protection bits 0 and 1.
+
 File Systems
 ============
 

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -964,6 +964,8 @@ static int ee24xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         ret = ee24xx_eraseall(eedev);
         break;
 
+      /* TODO: add "case EEPIOC_BLOCKPROTECT:" */
+
       default:
         ret = -ENOTTY;
     }

--- a/include/nuttx/eeprom/eeprom.h
+++ b/include/nuttx/eeprom/eeprom.h
@@ -84,6 +84,11 @@
                                              *      provides success/failure
                                              *      indication).            */
 
+#define EEPIOC_BLOCKPROTECT _EEPIOC(0x005)  /* Set which memory blocks to
+                                             * protect.
+                                             * IN:  Which blocks as integer.
+                                             * OUT: OK (0) on success.      */
+
 /************************************************************************************
  * Type Definitions
  ************************************************************************************/


### PR DESCRIPTION
## Summary

We need a way to set Block Protect of an EEPROM.

I am happy to discuss other possibilities.

## Impact

EEPROM driver may use ioctl to set Block Protect bits.

## Testing

I wrote a program `foo` to test read/write to the EEPROM:
```
$ tio /dev/ttyUSB0 
[17:16:22.306] tio 3.9
[17:16:22.306] Press ctrl-t q to quit
[17:16:22.323] Connected to /dev/ttyUSB0
__start: Reset status: 00:00

NuttShell (NSH) NuttX-12.11.0
nsh> foo r &
foo [3:100]
nsh> IAI21121AR06,BR07,CR05
J24,J25,J29:2-3

closed with 0
foo w &
foo [4:100]
nsh> written 3
closed with 0

nsh> foo r &
foo [5:100]
nsh> barIAI21121AR06,BR07,CR05
J24,J25,J29:2-3

closed with 0

nsh> foo v &
foo [6:100]
nsh> written 3
closed with 0

nsh> foo r &
foo [7:100]
nsh> IAI21121AR06,BR07,CR05
J24,J25,J29:2-3

closed with 0

nsh> foo 1
ioctl returns 0
closed with 0
nsh> foo r &
foo [9:100]
nsh> IAI21121AR06,BR07,CR05
J24,J25,J29:2-3

closed with 0

nsh> foo w &
foo [10:100]
nsh> written 3
closed with 0

nsh> foo r &
foo [11:100]
nsh> IAI21121AR06,BR07,CR05
J24,J25,J29:2-3

closed with 0
nsh> 
```

the `foo` is compiled from the `main.c` (just test app, not to be included in NuttX):
```
#include <fcntl.h>	/* open */
#include <unistd.h>	/* close, read, write */
#include <stdio.h>	/* printf */
#include <sys/ioctl.h>	/* ioctl */

#include <nuttx/eeprom/eeprom.h>	/* EEPIOC_BLOCKPROTECT */

#define BLEN 100

static void
print_buff(char const *b, size_t len)
{
	while (len--) {
		putchar(*b++);
	}
	putchar('\n');
	putchar('\n');
}

int
main(int argc, char **argv)
{
	int r;
	char b[BLEN];
	int fd = open("/dev/eeprom0", O_RDWR);
	if (-1 == fd) {
		printf("ERROR: Failed to open /dev/eeprom0");
		return 1;
	}

	if (2 == argc) {
		switch (argv[1][0]) {
		case 'a':
			while (0 < (r = read(fd, b, BLEN))) {
				print_buff(b, BLEN);
			}
			break;
		case 'r':
			r = read(fd, b, BLEN);
			print_buff(b, BLEN);
			break;
		case 'w':
			r = write(fd, "bar", 3);
			printf("written %d\n", r);
			break;
		case 'v':
			b[0] = 0x00;
			b[1] = 0x00;
			b[2] = 0x00;
			r = write(fd, b, 3);
			printf("written %d\n", r);
			break;
		case '0':
			r = ioctl(fd, EEPIOC_BLOCKPROTECT, 0);
			printf("ioctl returns %d\n", r);
			break;
		case '1':
			r = ioctl(fd, EEPIOC_BLOCKPROTECT, 3);
			printf("ioctl returns %d\n", r);
			break;
		default:
			printf("just chilling\n");
		}
	}

	r = close(fd);
	printf("closed with %d\n", r);
	return 0;
}
```