### PR TITLE
sim_hostuart.c: add nonblock flags for /dev/console

### DIFF
--- a/include/search.h
+++ b/include/search.h
@@ -45,6 +45,10 @@ struct hsearch_data
   CODE void (*free_entry)(FAR ENTRY *entry);
 };
 
+/* This is the callback type used by hforeach() */
+
+typedef CODE void (*hforeach_t)(FAR ENTRY *entry, FAR void *data);
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -109,6 +113,24 @@ void hdestroy(void);
 FAR ENTRY *hsearch(ENTRY, ACTION);
 
 /****************************************************************************
+ * Name: hforeach
+ *
+ * Description:
+ *   The hforeach() function iterates over the entries in the hashing table
+ *   specified by htab.  The function is called for each entry in the
+ *   table.  The function fn is called with the entry and the data argument.
+ *   The data argument is passed to the function.
+ *
+ *   The hforeach_r() function is the reentrant version of hforeach().
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hforeach(hforeach_t, FAR void *);
+
+/****************************************************************************
  * Name: hcreate_r
  *
  * Description:
@@ -159,5 +181,23 @@ void hdestroy_r(FAR struct hsearch_data *);
  ****************************************************************************/
 
 int hsearch_r(ENTRY, ACTION, FAR ENTRY **, FAR struct hsearch_data *);
+
+/****************************************************************************
+ * Name: hforeach_r
+ *
+ * Description:
+ *   Iterate over the entries in a hash table.
+ *
+ * Input Parameters:
+ *   handle - The function to call for each entry.
+ *   data - The data to pass to the function.
+ *   htab - The hash table to be iterated.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hforeach_r(hforeach_t, FAR void *, FAR struct hsearch_data *);
 
 #endif /* __INCLUDE_SEARCH_H */

--- a/libs/libc/search/hcreate.c
+++ b/libs/libc/search/hcreate.c
@@ -133,3 +133,24 @@ FAR ENTRY *hsearch(ENTRY item, ACTION action)
 
   return retval;
 }
+
+/****************************************************************************
+ * Name: hforeach
+ *
+ * Description:
+ *   The hforeach() function iterates over the entries in the hashing table
+ *   specified by htab. The function is called for each entry in the
+ *   table.  The function fn is called with the entry and the data argument.
+ *   The data argument is passed to the function.
+ *
+ *   The hforeach_r() function is the reentrant version of hforeach().
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hforeach(hforeach_t handle, FAR void *data)
+{
+  hforeach_r(handle, data, &g_htab);
+}

--- a/libs/libc/search/hcreate_r.c
+++ b/libs/libc/search/hcreate_r.c
@@ -287,3 +287,40 @@ int hsearch_r(ENTRY item, ACTION action, FAR ENTRY **retval,
   *retval = &ie->ent;
   return 1;
 }
+
+/****************************************************************************
+ * Name: hforeach_r
+ *
+ * Description:
+ *   Iterate over the entries in a hash table.
+ *
+ * Input Parameters:
+ *   handle - The function to call for each entry.
+ *   data - The data to pass to the function.
+ *   htab - The hash table to be iterated.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void hforeach_r(hforeach_t handle, FAR void *data,
+                FAR struct hsearch_data *htab)
+{
+  FAR struct internal_head *head;
+  FAR struct internal_entry *ie;
+  size_t len;
+
+  for (len = 0; len < htab->htablesize; len++)
+    {
+      head = &htab->htable[len];
+
+      SLIST_FOREACH(ie, head, link)
+        {
+          if (ie != NULL && ie->ent.key != NULL)
+            {
+              handle(&ie->ent, data);
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Summary

This change updates host_uart_start() to configure as non-blocking when running in raw mode. It ensures the host UART polling behavior does not hang on blocking reads, improving responsiveness of input handling in host-simulated environments.

## Impact

Prevents blocking reads on host UART input.

## Testing

sim
