### PR TITLE
Documentation: add '-f' description for umount command

### DIFF
--- a/Documentation/applications/nsh/commands.rst
+++ b/Documentation/applications/nsh/commands.rst
@@ -1725,11 +1725,17 @@ reads as zero bytes.
 
 **Command Syntax**::
 
-  umount <dir-path>
+  umount [-f] <dir-path>
 
 **Synopsis**. Un-mount the file system at mount point ``<dir-path>``.
 The ``umount`` command can only be used to un-mount volumes previously
 mounted using :ref:`mount <cmdmount>` command.
+
+**Options**
+
+======  ======================================================
+``-f``  Force unmounting of the filesystem even if it is busy.
+======  ======================================================
 
 **Example**::
 


### PR DESCRIPTION
## Summary

This change updates the umount documentation to include a  
description of the -f (force) option.
This documentation change relates to:
https://github.com/apache/nuttx-apps/pull/3240

## Impact

This change affects documentation only.
It improves clarity for users by accurately describing the behavior
and implications of the -f option in the umount command.

## Testing

N/A
