### PR TITLE
sched/misc: correct coredump log format

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -759,7 +759,7 @@ static void coredump_dump_dev(pid_t pid)
       return;
     }
 
-  _alert("Finish coredump, write %zu bytes to %s\n",
+  _alert("Finish coredump, write %" PRIdOFF " bytes to %s\n",
          g_devstream.common.nput, CONFIG_BOARD_COREDUMP_DEVPATH);
 }
 #endif


### PR DESCRIPTION
## Summary

sched/misc: correct coredump log format

since it has been replaced with
https://github.com/apache/nuttx/blob/master/sched/misc/coredump.c#L763 
and `nput` map to `off_t`  with 
https://github.com/apache/nuttx/blob/master/include/nuttx/streams.h#L98

align with other prints, reference:
- https://github.com/apache/nuttx/blob/master/drivers/misc/rwbuffer.c#L1121
- https://github.com/apache/nuttx/blob/master/fs/mmap/fs_rammap.c#L84
- https://github.com/apache/nuttx/blob/master/libs/libc/elf/elf_read.c#L85

## Impact

coredump log print

## Testing
Local test with cortex-m55, add more debug log with `syslog(1, "#### %s %d\n", __func__, __LINE__);`
```
[12/31 00:00:20] [12] [ap] #### dump coredump before
[12/31 00:00:20] [12] [ap] #### dump_core_info 782
[12/31 00:00:20] [12] [ap] #### dump_core_info 784
[12/31 00:00:20] [12] [ap] #### coredump_dump 947
[12/31 00:00:20] [12] [ap] #### coredump_dump 954
[12/31 00:00:20] [12] [ap] #### coredump_dump_dev 768
[12/31 00:00:22] [12] [ap] coredump_dump_dev: Finish coredump, write 43970780 bytes to /dev/coredump
[12/31 00:00:22] [12] [ap] #### coredump_dump 959
[12/31 00:00:22] [12] [ap] #### dump_core_info 790
[12/31 00:00:22] [12] [ap] #### dump coredump after
```