### PR TITLE
fs/romfs: revert the romfs write feature

### DIFF
--- a/fs/romfs/Kconfig
+++ b/fs/romfs/Kconfig
@@ -27,11 +27,4 @@ config FS_ROMFS_CACHE_FILE_NSECTORS
 	---help---
 		The number of file cache sector
 
-config FS_ROMFS_WRITEABLE
-	bool "Enable write extended feature in romfs"
-	default n
-	depends on FS_ROMFS_CACHE_NODE
-	---help---
-		Enable write extended feature in romfs
-
 endif

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -191,22 +191,12 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
       return ret;
     }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT))
+  ret = romfs_checkmount(rm);
+  if (ret < 0)
     {
-      if (list_is_empty(&rm->rm_sparelist))
-        {
-          ferr("ERROR: RW not enabled, only O_RDONLY supported\n");
-          ret = -EACCES;
-          goto errout_with_lock;
-        }
-
-      nxrmutex_unlock(&rm->rm_lock);
-      nxsem_wait_uninterruptible(&rm->rm_sem);
-      nxrmutex_lock(&rm->rm_lock);
+      ferr("ERROR: romfs_checkmount failed: %d\n", ret);
+      goto errout_with_lock;
     }
-  else
-#endif
 
   /* ROMFS is read-only.  Any attempt to open with any kind of write
    * access is not permitted.
@@ -219,13 +209,6 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
       goto errout_with_lock;
     }
 
-  ret = romfs_checkmount(rm);
-  if (ret < 0)
-    {
-      ferr("ERROR: romfs_checkmount failed: %d\n", ret);
-      goto errout_with_sem;
-    }
-
   /* Locate the directory entry for this path */
 
   ret = romfs_finddirentry(rm, &nodeinfo, relpath);
@@ -233,7 +216,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to find directory directory entry for '%s': %d\n",
            relpath, ret);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* The full path exists -- but is the final component a file
@@ -250,7 +233,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
       ret = -EISDIR;
       ferr("ERROR: '%s' is a directory\n", relpath);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
   else if (!IS_FILE(nodeinfo.rn_next))
     {
@@ -264,7 +247,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
       ret = -ENXIO;
       ferr("ERROR: '%s' is a special file\n", relpath);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Create an instance of the file private data to describe the opened
@@ -277,7 +260,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to allocate private data\n");
       ret = -ENOMEM;
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Initialize the file private data (only need to initialize
@@ -295,7 +278,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed to locate start of file data: %d\n", ret);
       fs_heap_free(rf);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Configure buffering to support access to this file */
@@ -305,34 +288,14 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       ferr("ERROR: Failed configure buffering: %d\n", ret);
       fs_heap_free(rf);
-      goto errout_with_sem;
+      goto errout_with_lock;
     }
 
   /* Attach the private date to the struct file instance */
 
   filep->f_priv = rf;
+
   rm->rm_refs++;
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-
-  /* If the file is only created for read */
-
-  if ((oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT)) == O_CREAT)
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
-
-  nxrmutex_unlock(&rm->rm_lock);
-  return ret;
-
-errout_with_sem:
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (oflags & (O_WRONLY | O_APPEND | O_TRUNC | O_CREAT))
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
 
 errout_with_lock:
   nxrmutex_unlock(&rm->rm_lock);
@@ -369,13 +332,6 @@ static int romfs_close(FAR struct file *filep)
     }
 
   rm->rm_refs--;
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (filep->f_oflags & (O_WRONLY | O_APPEND | O_TRUNC))
-    {
-      nxsem_post(&rm->rm_sem);
-    }
-#endif
-
   nxrmutex_unlock(&rm->rm_lock);
 
   /* Do not check if the mount is healthy.  We must support closing of
@@ -1173,53 +1129,16 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
       goto errout_with_mount;
     }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (data && strstr(data, "rw") && strstr(data, "forceformat"))
-    {
-      ret = romfs_mkfs(rm);
-      if (ret < 0)
-        {
-          ferr("ERROR: romfs_mkfs failed: %d\n", ret);
-          goto errout_with_buffer;
-        }
-    }
-#endif
-
   /* Then complete the mount by getting the ROMFS configuration from
    * the ROMF header
    */
 
-  ret = romfs_fsconfigure(rm, data);
+  ret = romfs_fsconfigure(rm);
   if (ret < 0)
     {
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-      if (data && strstr(data, "rw") && strstr(data, "autoformat"))
-        {
-          ret = romfs_mkfs(rm);
-          if (ret < 0)
-            {
-              ferr("ERROR: romfs_format failed: %d\n", ret);
-              goto errout_with_buffer;
-            }
-
-          ret = romfs_fsconfigure(rm, data);
-          if (ret < 0)
-            {
-              ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
-              goto errout_with_buffer;
-            }
-        }
-      else
-#endif
-        {
-          ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
-          goto errout_with_buffer;
-        }
+      ferr("ERROR: romfs_fsconfigure failed: %d\n", ret);
+      goto errout_with_buffer;
     }
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  nxsem_init(&rm->rm_sem, 0, 1);
-#endif
 
   /* Mounted! */
 
@@ -1227,7 +1146,10 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   return 0;
 
 errout_with_buffer:
-  fs_heap_free(rm->rm_devbuffer);
+  if (!rm->rm_xipbase)
+    {
+      fs_heap_free(rm->rm_buffer);
+    }
 
 errout_with_mount:
   nxrmutex_destroy(&rm->rm_lock);
@@ -1315,14 +1237,13 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
       /* Release the mountpoint private data */
 
-      fs_heap_free(rm->rm_devbuffer);
+      if (!rm->rm_xipbase)
+        {
+          fs_heap_free(rm->rm_buffer);
+        }
 
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
       romfs_freenode(rm->rm_root);
-#endif
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-      nxsem_destroy(&rm->rm_sem);
-      romfs_free_sparelist(&rm->rm_sparelist);
 #endif
       nxrmutex_destroy(&rm->rm_lock);
       fs_heap_free(rm);
@@ -1381,10 +1302,9 @@ static int romfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Everything else follows in units of sectors */
 
-  buf->f_blocks  = rm->rm_hwnsectors;
-  buf->f_bfree   = buf->f_blocks -
-                   SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
-  buf->f_bavail  = buf->f_bfree;
+  buf->f_blocks  = SEC_NSECTORS(rm, rm->rm_volsize + SEC_NDXMASK(rm));
+  buf->f_bfree   = 0;
+  buf->f_bavail  = 0;
   buf->f_namelen = NAME_MAX;
 
 errout_with_lock:

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -28,7 +28,6 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/list.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -119,20 +118,6 @@
  * Public Types
  ****************************************************************************/
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-/* This structure represents the spare list.  An instance of this
- * structure is retained as file header and file data size on each mountpoint
- * that is mounted with a romfs filesystem.
- */
-
-struct romfs_sparenode_s
-{
-  struct list_node node;
-  uint32_t start;
-  uint32_t end;
-};
-#endif
-
 /* This structure represents the overall mountpoint state.  An instance of
  * this structure is retained as inode private data on each mountpoint that
  * is mounted with a romfs filesystem.
@@ -156,11 +141,6 @@ struct romfs_mountpt_s
   uint32_t rm_cachesector;        /* Current sector in the rm_buffer */
   FAR uint8_t *rm_xipbase;        /* Base address of directly accessible media */
   FAR uint8_t *rm_buffer;         /* Device sector buffer, allocated if rm_xipbase==0 */
-  FAR uint8_t *rm_devbuffer;      /* Device sector buffer, allocated for write if rm_xipbase != 0 */
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  struct list_node rm_sparelist;  /* The list of spare space */
-  sem_t            rm_sem;        /* The semaphore to assume write safe */
-#endif
 };
 
 /* This structure represents on open file under the mountpoint.  An instance
@@ -186,7 +166,6 @@ struct romfs_nodeinfo_s
   uint32_t rn_next;                        /* Offset of the next file header+flags */
   uint32_t rn_size;                        /* Size (if file) */
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
-  uint32_t rn_origoffset;                  /* Offset of origin file header */
   FAR struct romfs_nodeinfo_s **rn_child;  /* The node array for link to lower level */
   uint16_t rn_count;                       /* The count of node in rn_child level */
   uint8_t  rn_namesize;                    /* The length of name of the entry */
@@ -216,7 +195,7 @@ int  romfs_hwread(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
 int  romfs_filecacheread(FAR struct romfs_mountpt_s *rm,
                          FAR struct romfs_file_s *rf, uint32_t sector);
 int  romfs_hwconfigure(FAR struct romfs_mountpt_s *rm);
-int  romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data);
+int  romfs_fsconfigure(FAR struct romfs_mountpt_s *rm);
 int  romfs_fileconfigure(FAR struct romfs_mountpt_s *rm,
                          FAR struct romfs_file_s *rf);
 int  romfs_checkmount(FAR struct romfs_mountpt_s *rm);
@@ -233,10 +212,6 @@ int  romfs_datastart(FAR struct romfs_mountpt_s *rm,
                      FAR uint32_t *start);
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
 void romfs_freenode(FAR struct romfs_nodeinfo_s *node);
-#endif
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-int romfs_mkfs(FAR struct romfs_mountpt_s *rm);
-void romfs_free_sparelist(FAR struct list_node *list);
 #endif
 
 #undef EXTERN

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -397,218 +397,6 @@ static inline int romfs_searchdir(FAR struct romfs_mountpt_s *rm,
   return -ENOENT;
 }
 
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-/****************************************************************************
- * Name: romfs_alloc_sparenode
- *
- * Description:
- *   Allocate the spare node
- *
- ****************************************************************************/
-
-static FAR struct romfs_sparenode_s *
-romfs_alloc_sparenode(uint32_t start, uint32_t end)
-{
-  FAR struct romfs_sparenode_s *node;
-  node = fs_heap_malloc(sizeof(struct romfs_sparenode_s));
-  if (node == NULL)
-    {
-      ferr("romfs_alloc_sparenode: no memory\n");
-      return NULL;
-    }
-
-  node->start = start;
-  node->end = end;
-  return node;
-}
-
-/****************************************************************************
- * Name: romfs_init_sparelist
- *
- * Description:
- *   Init the sparelist
- *
- ****************************************************************************/
-
-static int romfs_init_sparelist(FAR struct romfs_mountpt_s *rm, bool rw)
-{
-  FAR struct romfs_sparenode_s *node;
-
-  list_initialize(&rm->rm_sparelist);
-  if (!rw)
-    {
-      return 0;
-    }
-
-  node = romfs_alloc_sparenode(0, rm->rm_hwsectorsize *
-                               rm->rm_hwnsectors);
-  if (node == NULL)
-    {
-      return -ENOMEM;
-    }
-
-  list_add_head(&rm->rm_sparelist, &node->node);
-  rm->rm_volsize = 0;
-  return 0;
-}
-
-/****************************************************************************
- * Name: romfs_alloc_spareregion
- *
- * Description:
- *   Allocate the spare region
- *
- ****************************************************************************/
-
-static int romfs_alloc_spareregion(FAR struct list_node *list,
-                                   uint32_t start, uint32_t end)
-{
-  FAR struct romfs_sparenode_s *node;
-
-  list_for_every_entry(list, node, struct romfs_sparenode_s, node)
-    {
-      /* Find the node that start ~ end
-       * is in node->start ~ node->end
-       */
-
-      if (start == node->start && end == node->end)
-        {
-          /* Delete the node */
-
-          list_delete(&node->node);
-          fs_heap_free(node);
-          return 0;
-        }
-      else if (start == node->start)
-        {
-          /* Update the node */
-
-          node->start = end;
-          return 0;
-        }
-      else if (end == node->end)
-        {
-          /* Update the node */
-
-          node->end = start;
-          return 0;
-        }
-      else if (start > node->start && end < node->end)
-        {
-          /* Split the node */
-
-          FAR struct romfs_sparenode_s *new;
-          new = romfs_alloc_sparenode(end, node->end);
-          if (new == NULL)
-            {
-              return -ENOMEM;
-            }
-
-          node->end = start;
-          list_add_after(&node->node, &new->node);
-          return 0;
-        }
-    }
-
-  /* Not found */
-
-  ferr("No space for start %" PRIu32 ", end %" PRIu32 "\n", start, end);
-  return -ENOENT;
-}
-
-/****************************************************************************
- * Name: romfs_devmemcpy
- ****************************************************************************/
-
-static void romfs_devmemcpy(FAR struct romfs_mountpt_s *rm,
-                            int ndx, FAR const void *buf, size_t len)
-{
-  memcpy(rm->rm_devbuffer + ndx, buf, len);
-}
-
-/****************************************************************************
- * Name: romfs_devstrcpy
- ****************************************************************************/
-
-static void romfs_devstrcpy(FAR struct romfs_mountpt_s *rm,
-                            int ndx, FAR const char *buf)
-{
-  strcpy((FAR char *)rm->rm_devbuffer + ndx, buf);
-}
-
-/****************************************************************************
- * Name: romfs_devwrite32
- *
- * Description:
- *   Write the big-endian 32-bit value to the mount device buffer
- *
- ****************************************************************************/
-
-static void romfs_devwrite32(FAR struct romfs_mountpt_s *rm,
-                             int ndx, uint32_t value)
-{
-  /* Write the 32-bit value to the specified index in the buffer */
-
-  rm->rm_devbuffer[ndx]     = (uint8_t)(value >> 24) & 0xff;
-  rm->rm_devbuffer[ndx + 1] = (uint8_t)(value >> 16) & 0xff;
-  rm->rm_devbuffer[ndx + 2] = (uint8_t)(value >> 8) & 0xff;
-  rm->rm_devbuffer[ndx + 3] = (uint8_t)(value & 0xff);
-}
-
-/****************************************************************************
- * Name: romfs_hwwrite
- *
- * Description:
- *   Write the specified number of sectors to the block device
- *
- ****************************************************************************/
-
-static int romfs_hwwrite(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
-                         uint32_t sector, unsigned int nsectors)
-{
-  FAR struct inode *inode = rm->rm_blkdriver;
-  ssize_t ret = -ENODEV;
-
-  if (inode->u.i_bops->write)
-    {
-      ret = inode->u.i_bops->write(inode, buffer, sector, nsectors);
-    }
-
-  if (ret == (ssize_t)nsectors)
-    {
-      ret = 0;
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: romfs_devcachewrite
- *
- * Description:
- *   Write the specified sector for specified offset into the sector cache.
- *
- ****************************************************************************/
-
-static int romfs_devcachewrite(FAR struct romfs_mountpt_s *rm,
-                               uint32_t sector)
-{
-  int ret;
-
-  ret = romfs_hwwrite(rm, rm->rm_devbuffer, sector, 1);
-  if (ret >= 0)
-    {
-      rm->rm_cachesector = sector;
-    }
-  else
-    {
-      rm->rm_cachesector = (uint32_t)-1;
-    }
-
-  return ret;
-}
-#endif
-
 /****************************************************************************
  * Name: romfs_cachenode
  *
@@ -619,16 +407,16 @@ static int romfs_devcachewrite(FAR struct romfs_mountpt_s *rm,
 
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
 static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
-                           uint32_t origoffset, uint32_t offset,
-                           uint32_t next, uint32_t size,
-                           FAR const char *name,
+                           uint32_t offset, uint32_t next,
+                           uint32_t size, FAR const char *name,
                            FAR struct romfs_nodeinfo_s **pnodeinfo)
 {
   FAR struct romfs_nodeinfo_s **child;
   FAR struct romfs_nodeinfo_s *nodeinfo;
   char childname[NAME_MAX + 1];
-  uint16_t count = 0;
+  uint32_t linkoffset;
   uint32_t info;
+  uint8_t num = 0;
   size_t nsize;
   int ret;
 
@@ -641,90 +429,72 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
 
   *pnodeinfo              = nodeinfo;
   nodeinfo->rn_offset     = offset;
-  nodeinfo->rn_origoffset = origoffset;
   nodeinfo->rn_next       = next;
   nodeinfo->rn_namesize   = nsize;
   memcpy(nodeinfo->rn_name, name, nsize + 1);
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  if (!list_is_empty(&rm->rm_sparelist))
-    {
-      uint32_t totalsize = ROMFS_ALIGNUP(ROMFS_FHDR_NAME + nsize + 1);
-      if (offset == origoffset)
-        {
-          totalsize += ROMFS_ALIGNUP(size);
-        }
-
-      rm->rm_volsize += totalsize;
-      ret = romfs_alloc_spareregion(&rm->rm_sparelist, origoffset,
-                                    origoffset + totalsize);
-      if (ret < 0)
-        {
-          return ret;
-        }
-    }
-#endif
-
-  if (!IS_DIRECTORY(next) || (strcmp(name, ".") == 0) ||
-      (strcmp(name, "..") == 0))
+  if (!IS_DIRECTORY(next))
     {
       nodeinfo->rn_size = size;
       return 0;
     }
 
-  origoffset = offset;
   child = nodeinfo->rn_child;
 
   do
     {
-      /* Fetch the directory entry at this offset */
+      /* Parse the directory entry at this offset (which may be re-directed
+       * to some other entry if HARLINKED).
+       */
 
-      ret = romfs_parsedirentry(rm, origoffset, &offset, &next, &info,
+      ret = romfs_parsedirentry(rm, offset, &linkoffset, &next, &info,
                                 &size);
       if (ret < 0)
         {
           return ret;
         }
 
-      ret = romfs_parsefilename(rm, origoffset, childname);
+      ret = romfs_parsefilename(rm, offset, childname);
       if (ret < 0)
         {
           return ret;
         }
 
-      if (child == NULL || nodeinfo->rn_count == count - 1)
+      if (strcmp(childname, ".") != 0 && strcmp(childname, "..") != 0)
         {
-          FAR void *tmp;
-
-          tmp = fs_heap_realloc(nodeinfo->rn_child,
-                (count + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
-          if (tmp == NULL)
+          if (child == NULL || nodeinfo->rn_count == num - 1)
             {
-              return -ENOMEM;
+              FAR void *tmp;
+
+              tmp = fs_heap_realloc(nodeinfo->rn_child,
+                    (num + NODEINFO_NINCR) * sizeof(*nodeinfo->rn_child));
+              if (tmp == NULL)
+                {
+                  return -ENOMEM;
+                }
+
+              nodeinfo->rn_child = tmp;
+              memset(nodeinfo->rn_child + num, 0, NODEINFO_NINCR *
+                     sizeof(*nodeinfo->rn_child));
+              num += NODEINFO_NINCR;
             }
 
-          nodeinfo->rn_child = tmp;
-          memset(nodeinfo->rn_child + count, 0, NODEINFO_NINCR *
-                  sizeof(*nodeinfo->rn_child));
-          count += NODEINFO_NINCR;
-        }
+          child = &nodeinfo->rn_child[nodeinfo->rn_count++];
+          if (IS_DIRECTORY(next))
+            {
+              linkoffset = info;
+            }
 
-      child = &nodeinfo->rn_child[nodeinfo->rn_count++];
-      if (IS_DIRECTORY(next))
-        {
-          offset = info;
-        }
-
-      ret = romfs_cachenode(rm, origoffset, offset, next, size,
-                            childname, child);
-      if (ret < 0)
-        {
-          nodeinfo->rn_count--;
-          return ret;
+          ret = romfs_cachenode(rm, linkoffset, next, size,
+                                childname, child);
+          if (ret < 0)
+            {
+              nodeinfo->rn_count--;
+              return ret;
+            }
         }
 
       next &= RFNEXT_OFFSETMASK;
-      origoffset = next;
+      offset = next;
     }
   while (next != 0);
 
@@ -891,16 +661,6 @@ int romfs_hwconfigure(FAR struct romfs_mountpt_s *rm)
   rm->rm_hwnsectors   = geo.geo_nsectors;
   rm->rm_cachesector  = (uint32_t)-1;
 
-  /* Allocate the device cache buffer for normal sector accesses */
-
-  rm->rm_devbuffer = fs_heap_malloc(rm->rm_hwsectorsize);
-  if (!rm->rm_devbuffer)
-    {
-      return -ENOMEM;
-    }
-
-  /* Determine if block driver supports the XIP mode of operation */
-
   if (inode->u.i_bops->ioctl)
     {
       ret = inode->u.i_bops->ioctl(inode, BIOC_XIPBASE,
@@ -917,32 +677,16 @@ int romfs_hwconfigure(FAR struct romfs_mountpt_s *rm)
         }
     }
 
-  /* The device cache buffer for normal sector accesses */
+  /* Allocate the device cache buffer for normal sector accesses */
 
-  rm->rm_buffer = rm->rm_devbuffer;
+  rm->rm_buffer = fs_heap_malloc(rm->rm_hwsectorsize);
+  if (!rm->rm_buffer)
+    {
+      return -ENOMEM;
+    }
+
   return 0;
 }
-
-/****************************************************************************
- * Name: romfs_free_sparelist
- *
- * Description:
- *   Free the sparelist
- *
- ****************************************************************************/
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-void romfs_free_sparelist(FAR struct list_node *list)
-{
-  FAR struct romfs_sparenode_s *node;
-  FAR struct romfs_sparenode_s *tmp;
-
-  list_for_every_entry_safe(list, node, tmp, struct romfs_sparenode_s, node)
-    {
-      list_delete(&node->node);
-      fs_heap_free(node);
-    }
-}
-#endif
 
 /****************************************************************************
  * Name: romfs_fsconfigure
@@ -955,20 +699,19 @@ void romfs_free_sparelist(FAR struct list_node *list)
  *
  ****************************************************************************/
 
-int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data)
+int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm)
 {
   FAR const char *name;
-  int             ret;
-  uint32_t        rootoffset;
+  int16_t         ndx;
 
   /* Then get information about the ROMFS filesystem on the devices managed
    * by this block driver. Read sector zero which contains the volume header.
    */
 
-  ret = romfs_devcacheread(rm, 0);
-  if (ret < 0)
+  ndx = romfs_devcacheread(rm, 0);
+  if (ndx < 0)
     {
-      return ret;
+      return ndx;
     }
 
   /* Verify the magic number at that identifies this as a ROMFS filesystem */
@@ -980,33 +723,22 @@ int romfs_fsconfigure(FAR struct romfs_mountpt_s *rm, FAR const void *data)
 
   /* Then extract the values we need from the header and return success */
 
-  rm->rm_volsize = romfs_devread32(rm, ROMFS_VHDR_SIZE);
+  rm->rm_volsize    = romfs_devread32(rm, ROMFS_VHDR_SIZE);
 
   /* The root directory entry begins right after the header */
 
-  name = (FAR const char *)&rm->rm_buffer[ROMFS_VHDR_VOLNAME];
-  rootoffset = ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME + strlen(name) + 1);
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-  ret = romfs_init_sparelist(rm, data && strstr(data, "rw"));
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
-
+  name              = (FAR const char *)&rm->rm_buffer[ROMFS_VHDR_VOLNAME];
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
-  ret = romfs_cachenode(rm, 0, rootoffset, RFNEXT_DIRECTORY,
-                        0, "", &rm->rm_root);
-  if (ret < 0)
+  ndx               = romfs_cachenode(rm, ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME +
+                                                        strlen(name) + 1),
+                                      RFNEXT_DIRECTORY, 0, "", &rm->rm_root);
+  if (ndx < 0)
     {
-#  ifdef CONFIG_FS_ROMFS_WRITEABLE
-      romfs_free_sparelist(&rm->rm_sparelist);
-#  endif
       romfs_freenode(rm->rm_root);
-      return ret;
+      return ndx;
     }
 #else
-  rm->rm_rootoffset = rootoffset;
+  rm->rm_rootoffset = ROMFS_ALIGNUP(ROMFS_VHDR_VOLNAME + strlen(name) + 1);
 #endif
 
   /* and return success */
@@ -1448,49 +1180,3 @@ int romfs_datastart(FAR struct romfs_mountpt_s *rm,
   return -EINVAL; /* Won't get here */
 #endif
 }
-
-#ifdef CONFIG_FS_ROMFS_WRITEABLE
-
-/****************************************************************************
- * Name: romfs_mkfs
- *
- * Description:
- *   Format the romfs filesystem
- *
- ****************************************************************************/
-
-int romfs_mkfs(FAR struct romfs_mountpt_s *rm)
-{
-  /* Write the magic number at that identifies this as a ROMFS filesystem */
-
-  romfs_devmemcpy(rm, ROMFS_VHDR_ROM1FS, ROMFS_VHDR_MAGIC, ROMFS_VHDR_SIZE);
-
-  /* Init the ROMFS volume size */
-
-  romfs_devwrite32(rm, ROMFS_VHDR_SIZE, 0x60);
-
-  /* Write the volume name */
-
-  romfs_devstrcpy(rm, ROMFS_VHDR_VOLNAME, "romfs");
-
-  /* Write the root node . */
-
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_NEXT, 0x40 | RFNEXT_DIRECTORY);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_INFO, 0x20);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_SIZE, 0);
-  romfs_devwrite32(rm, 0x20 + ROMFS_FHDR_CHKSUM, 0);
-  romfs_devstrcpy(rm, 0x20 + ROMFS_FHDR_NAME, ".");
-
-  /* Write the root node .. */
-
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_NEXT, RFNEXT_HARDLINK);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_INFO, 0x20);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_SIZE, 0);
-  romfs_devwrite32(rm, 0x40 + ROMFS_FHDR_CHKSUM, 0);
-  romfs_devstrcpy(rm, 0x40 + ROMFS_FHDR_NAME, "..");
-
-  /* Write the buffer to sector zero */
-
-  return romfs_devcachewrite(rm, 0);
-}
-#endif


### PR DESCRIPTION
## Summary

The write extension modifications for ROMFS are no longer in use and will be replaced by a fully ROMFS-compatible file system in the future.

## Impact

Revert the write API of romfs which contains several bugs.
Since no mainline board enable writable feature, the impact is very minor.

## Testing

Platform:sim
Host:linux
test: ostest romfs mount cat 

test log:
ap>
ap> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=57

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b59f9 1f4b59f9
uordblks   b4a607   b4a607
fordblks 1f4b59f9 1f4b59f9

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b59f9 1f4b59f9
uordblks   b4a607   b4a607
fordblks 1f4b59f9 1f4b59f9

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b59f9 1f4b59f9
uordblks   b4a607   b4a607
fordblks 1f4b59f9 1f4b59f9
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b59f9 1f4b5a26
uordblks   b4a607   b4a5da
fordblks 1f4b59f9 1f4b5a26
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b5a26 1f4b5c15
uordblks   b4a5da   b4a3eb
fordblks 1f4b5a26 1f4b5c15
tls: Successfully set 0
tls: Successfully set ffffffff
tls: Successfully set 55555555
tls: Successfully set aaaaaaaa

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b5c15 1f4b5c15
uordblks   b4a3eb   b4a3eb
fordblks 1f4b5c15 1f4b5c15

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b5c15 1f4b5c15
uordblks   b4a3eb   b4a3eb
fordblks 1f4b5c15 1f4b5c15

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b5c15 1f4b5c15
uordblks   b4a3eb   b4a3eb
fordblks 1f4b5c15 1f4b5c15

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=58
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started restart_main at PID=58
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b5c15 1f48194c
uordblks   b4a3eb   b7e6b4
fordblks 1f4b5c15 1f48194c

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=73
waitpid_start_child: Started waitpid_main at PID=84
waitpid_start_child: Started waitpid_main at PID=90
waitpid_test: Waiting for PID=73 with waitpid()
waitpid_main: PID 73 Started
waitpid_main: PID 84 Started
waitpid_main: PID 90 Started
waitpid_main: PID 73 exitting with result=14
waitpid_test: PID 73 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=90 with waitpid()
waitpid_main: PID 84 exitting with result=14
waitpid_main: PID 90 exitting with result=14
waitpid_last: PASS: PID 90 waitpid succeeded with stat_loc=0e00

Test waitid(P_PID)
waitpid_start_child: Started waitpid_main at PID=105
waitpid_start_child: Started waitpid_main at PID=116
waitpid_start_child: Started waitpid_main at PID=122
waitpid_test: Waiting for PID=105 with waitid()
waitpid_main: PID 105 Started
waitpid_main: PID 116 Started
waitpid_main: PID 122 Started
waitpid_main: PID 105 exitting with result=14
waitpid_test: waitid PID 105 succeeded with si_status=14
waitpid_last: Waiting for PID=122 with waitpid()
waitpid_main: PID 116 exitting with result=14
waitpid_main: PID 122 exitting with result=14
waitpid_last: PASS: PID 122 waitpid succeeded with stat_loc=0e00

Test waitid(P_ALL)
waitpid_start_child: Started waitpid_main at PID=137
waitpid_start_child: Started waitpid_main at PID=148
waitpid_start_child: Started waitpid_main at PID=154
waitpid_test: Waiting for any child with waitid()
waitpid_main: PID 137 Started
waitpid_main: PID 148 Started
waitpid_main: PID 154 Started
waitpid_main: PID 137 exitting with result=14
waitpid_test: PID 137 waitid succeeded with si_status=14
waitpid_last: Waiting for PID=154 with waitpid()
waitpid_main: PID 148 exitting with result=14
waitpid_main: PID 154 exitting with result=14
waitpid_last: PASS: PID 154 waitpid succeeded with stat_loc=0e00

Test wait()
waitpid_start_child: Started waitpid_main at PID=169
waitpid_start_child: Started waitpid_main at PID=180
waitpid_start_child: Started waitpid_main at PID=186
waitpid_test: Waiting for any child with wait()
waitpid_main: PID 169 Started
waitpid_main: PID 180 Started
waitpid_main: PID 186 Started
waitpid_main: PID 169 exitting with result=14
waitpid_test: PID 169 wait succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=186 with waitpid()
waitpid_main: PID 180 exitting with result=14
waitpid_main: PID 186 exitting with result=14
waitpid_last: PASS: PID 186 waitpid succeeded with stat_loc=0e00

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f48194c 1f41946c
uordblks   b7e6b4   be6b94
fordblks 1f48194c 1f41946c

user_main: wqueue test
wqueue_test: HPWORK
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: HPWORK done
wqueue_test: LPWORK
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: HPWORK done
wqueue_test: test 1
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: test 1 done
wqueue_test: test 2
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: call = 20, expect = 20
wqueue_test: test 2 done

wqueue_test: periodic work and cancel test start...
Testing 5 periodic work
[Pass] Periodic work 0: expected period: 20,     actual period: 20
[Pass] Periodic work 1: expected period: 22,     actual period: 22
[Pass] Periodic work 2: expected period: 24,     actual period: 24
[Pass] Periodic work 3: expected period: 26,     actual period: 26
[Pass] Periodic work 4: expected period: 28,     actual period: 28
cnt_prev: 33, cnt_curr: 33
Passed 5/5
wqueue_test: periodic work and cancel test done

wqueue_test: recursive work test start...
Expect works: 40, actual works: 40
wqueue_test: recursive work test done.

wqueue_test: multiple threads and queues test start
Current thread priority: 150
wqueue_test: delay test
Threads' Priorities:{5} [ 148 149 150 151 152 ]
Work Queues' Priorities:{3} [ 149 150 151 ]
Delays:{20} [ 96 205 188 170 201 67 110 161 383 362 448 467 232 430 64 215 420 207 421 290 ]
Waiting for all works to finish... timeout_cnt:400/2147483647  done
Work[  0] in [0] [    Passed] added at 54869, qtime expected: 54966      actual:54966     ,     delay expected :96     actual:97
Work[  1] in [0] [    Passed] added at 54869, qtime expected: 55075      actual:55075     ,     delay expected :205    actual:206
Work[  2] in [0] [    Passed] added at 54868, qtime expected: 55057      actual:55057     ,     delay expected :188    actual:189
Work[  3] in [0] [    Passed] added at 54867, qtime expected: 55038      actual:55038     ,     delay expected :170    actual:171
Work[  4] in [0] [    Passed] added at 54868, qtime expected: 55070      actual:55070     ,     delay expected :201    actual:202
Work[  5] in [1] [    Passed] added at 54970, qtime expected: 55038      actual:55038     ,     delay expected :67     actual:68
Work[  6] in [1] [    Passed] added at 54970, qtime expected: 55081      actual:55081     ,     delay expected :110    actual:111
Work[  7] in [1] [    Passed] added at 54969, qtime expected: 55131      actual:55131     ,     delay expected :161    actual:162
Work[  8] in [1] [    Passed] added at 54968, qtime expected: 55352      actual:55352     ,     delay expected :383    actual:384
Work[  9] in [1] [    Passed] added at 54969, qtime expected: 55332      actual:55332     ,     delay expected :362    actual:363
Work[ 10] in [2] [    Passed] added at 55071, qtime expected: 55520      actual:55520     ,     delay expected :448    actual:449
Work[ 11] in [2] [    Passed] added at 55071, qtime expected: 55539      actual:55539     ,     delay expected :467    actual:468
Work[ 12] in [2] [    Passed] added at 55070, qtime expected: 55303      actual:55303     ,     delay expected :232    actual:233
Work[ 13] in [2] [    Passed] added at 55069, qtime expected: 55500      actual:55500     ,     delay expected :430    actual:431
Work[ 14] in [2] [    Passed] added at 55070, qtime expected: 55135      actual:55135     ,     delay expected :64     actual:65
Work[ 15] in [0] [    Passed] added at 55172, qtime expected: 55388      actual:55388     ,     delay expected :215    actual:216
Work[ 16] in [0] [    Passed] added at 55172, qtime expected: 55593      actual:55593     ,     delay expected :420    actual:421
Work[ 17] in [0] [    Passed] added at 55171, qtime expected: 55379      actual:55379     ,     delay expected :207    actual:208
Work[ 18] in [0] [    Passed] added at 55170, qtime expected: 55592      actual:55592     ,     delay expected :421    actual:422
Work[ 19] in [0] [    Passed] added at 55171, qtime expected: 55462      actual:55462     ,     delay expected :290    actual:291
wqueue_test: delay test: Total=20, Success=20, Invalid=0, Warning=0, Failed=0, Timeout=0, Unexpected=0
wqueue_test: multiple threads and queues test done

wqueue_test: special delay test start...
wqueue_test: delay test
Threads' Priorities:{1} [ 150 ]
Work Queues' Priorities:{1} [ 150 ]
Delays:{2} [ 18446744073709551615 1 ]
Waiting for all works to finish... timeout_cnt:100/2000  done
Work[  0] in [0] [   Invalid] added at 55694, qtime expected: 0          actual:0         ,     delay expected :18446744073709551615 actual:18446744073709495922
Work[  1] in [0] [    Passed] added at 55795, qtime expected: 55797      actual:55797     ,     delay expected :1      actual:2
wqueue_test: delay test: Total=2, Success=1, Invalid=1, Warning=0, Failed=0, Timeout=0, Unexpected=0
wqueue_test: delay test
Threads' Priorities:{1} [ 150 ]
Work Queues' Priorities:{1} [ 150 ]
Delays:{2} [ 18446744073709551615 4611686018427387903 ]
Waiting for all works to finish... timeout_cnt:2000/2000  timeout
Work[  0] in [0] [   Invalid] added at 56003, qtime expected: 0          actual:0         ,     delay expected :18446744073709551615 actual:18446744073709495613
Work[  1] in [0] [   Timeout] added at 56104, qtime expected: 4611686018427444008 actual:0         ,    delay expected :4611686018427387903 actual:18446744073709495512
wqueue_test: delay test: Total=2, Success=0, Invalid=1, Warning=0, Failed=0, Timeout=1, Unexpected=0
wqueue_test: special delay test done.

wqueue_test: work thread test start...
Thread Num: 10;         Efficiency: 99.95%;          Total time: 10245 ticks,          Execution: 1025 ticks
wqueue_test: work thread test done

wqueue_test: work notifier test start...
start sending notifier signal 1.
notifier_callback: triggered.
test_work1 completed.
start triggering notifier signal 2.
notifier callback2 triggered.
notifier 1 processed success.
notifier 2 processed success.
start sending notifier signal.
notifier callback2 triggered:second notify.
start sending teardown notifier.
notifier successfully torn down on first attempt.
sending second notifier signal.
test completed,work status:teardown
wqueue_test: work notifier test done.

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f41946c 1f4b47b4
uordblks   be6b94   b4b84c
fordblks 1f41946c 1f4b47b4

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b47b4 1f44f504
uordblks   b4b84c   bb0afc
fordblks 1f4b47b4 1f44f504

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the lock
mutex_test: Re-locking
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44f504 1f4b47b4
uordblks   bb0afc   b4b84c
fordblks 1f44f504 1f4b47b4

user_main: recursive mutex test
recursive_mutex_test: Initializing mutex
recursive_mutex_test: Starting thread 1
recursive_mutex_test: Starting thread 2
recursive_mutex_test: Starting thread 3
recursive_mutex_test: Waiting for thread 1
thread_outer[1]: Started
thread_outer[1]: Loop 0
thread_inner[1, 0]: Locking
thread_inner[1, 0]: Locked
thread_outer[2]: Started
thread_outer[2]: Loop 0
thread_inner[2, 0]: Locking
thread_outer[3]: Started
thread_outer[3]: Loop 0
thread_inner[3, 0]: Locking
thread_inner[1, 1]: Locking
thread_inner[1, 1]: Locked
thread_inner[1, 2]: Locking
thread_inner[1, 2]: Locked
thread_inner[1, 2]: Unlocking
thread_inner[1, 2]: Unlocked
thread_inner[1, 1]: Unlocking
thread_inner[1, 1]: Unlocked
thread_inner[1, 0]: Unlocking
thread_inner[1, 0]: Unlocked
thread_inner[2, 0]: Locked
thread_outer[1]: Loop 1
thread_inner[1, 0]: Locking
thread_inner[2, 1]: Locking
thread_inner[2, 1]: Locked
thread_inner[2, 2]: Locking
thread_inner[2, 2]: Locked
thread_inner[2, 2]: Unlocking
thread_inner[2, 2]: Unlocked
thread_inner[2, 1]: Unlocking
thread_inner[2, 1]: Unlocked
thread_inner[2, 0]: Unlocking
thread_inner[2, 0]: Unlocked
thread_inner[3, 0]: Locked
thread_outer[2]: Loop 1
thread_inner[2, 0]: Locking
thread_inner[3, 1]: Locking
thread_inner[3, 1]: Locked
thread_inner[3, 2]: Locking
thread_inner[3, 2]: Locked
thread_inner[3, 2]: Unlocking
thread_inner[3, 2]: Unlocked
thread_inner[3, 1]: Unlocking
thread_inner[3, 1]: Unlocked
thread_inner[3, 0]: Unlocking
thread_inner[3, 0]: Unlocked
thread_inner[1, 0]: Locked
thread_outer[3]: Loop 1
thread_inner[3, 0]: Locking
thread_inner[1, 1]: Locking
thread_inner[1, 1]: Locked
thread_inner[1, 2]: Locking
thread_inner[1, 2]: Locked
thread_inner[1, 2]: Unlocking
thread_inner[1, 2]: Unlocked
thread_inner[1, 1]: Unlocking
thread_inner[1, 1]: Unlocked
thread_inner[1, 0]: Unlocking
thread_inner[1, 0]: Unlocked
thread_inner[2, 0]: Locked
thread_outer[1]: Loop 2
thread_inner[1, 0]: Locking
thread_inner[2, 1]: Locking
thread_inner[2, 1]: Locked
thread_inner[2, 2]: Locking
thread_inner[2, 2]: Locked
thread_inner[2, 2]: Unlocking
thread_inner[2, 2]: Unlocked
thread_inner[2, 1]: Unlocking
thread_inner[2, 1]: Unlocked
thread_inner[2, 0]: Unlocking
thread_inner[2, 0]: Unlocked
thread_inner[3, 0]: Locked
thread_outer[2]: Loop 2
thread_inner[2, 0]: Locking
thread_inner[3, 1]: Locking
thread_inner[3, 1]: Locked
thread_inner[3, 2]: Locking
thread_inner[3, 2]: Locked
thread_inner[3, 2]: Unlocking
thread_inner[3, 2]: Unlocked
thread_inner[3, 1]: Unlocking
thread_inner[3, 1]: Unlocked
thread_inner[3, 0]: Unlocking
thread_inner[3, 0]: Unlocked
thread_inner[1, 0]: Locked
thread_outer[3]: Loop 2
thread_inner[3, 0]: Locking
thread_inner[1, 1]: Locking
thread_inner[1, 1]: Locked
thread_inner[1, 2]: Locking
thread_inner[1, 2]: Locked
thread_inner[1, 2]: Unlocking
thread_inner[1, 2]: Unlocked
thread_inner[1, 1]: Unlocking
thread_inner[1, 1]: Unlocked
thread_inner[1, 0]: Unlocking
thread_inner[1, 0]: Unlocked
thread_inner[2, 0]: Locked
thread_outer[1]: Exiting
thread_inner[2, 1]: Locking
thread_inner[2, 1]: Locked
recursive_mutex_test: Waiting for thread 2
thread_inner[2, 2]: Locking
thread_inner[2, 2]: Locked
thread_inner[2, 2]: Unlocking
thread_inner[2, 2]: Unlocked
thread_inner[2, 1]: Unlocking
thread_inner[2, 1]: Unlocked
thread_inner[2, 0]: Unlocking
thread_inner[2, 0]: Unlocked
thread_inner[3, 0]: Locked
thread_outer[2]: Exiting
thread_inner[3, 1]: Locking
thread_inner[3, 1]: Locked
recursive_mutex_test: Waiting for thread 3
thread_inner[3, 2]: Locking
thread_inner[3, 2]: Locked
thread_inner[3, 2]: Unlocking
thread_inner[3, 2]: Unlocked
thread_inner[3, 1]: Unlocking
thread_inner[3, 1]: Unlocked
thread_inner[3, 0]: Unlocking
thread_inner[3, 0]: Unlocked
thread_outer[3]: Exiting
recursive_mutex_test: Complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b47b4 1f41cbac
uordblks   b4b84c   be3454
fordblks 1f4b47b4 1f41cbac

user_main: pthread-specific data test
Starting thread

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f41cbac 1f481e5c
uordblks   be3454   b7e1a4
fordblks 1f41cbac 1f481e5c

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
sem_cleaner #2
sem_cleaner #1
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
cancel_test: Starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
asynch_waiter: Setting non-cancelable
asynch_waiter: Setting synchronous cancellation type
cancel_test: Canceling thread
cancel_test: Joining
asynch_waiter: Restoring cancelable state
asynch_waiter: Setting cancelable
sem_cleaner #2
sem_cleaner #1
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
sem_cleaner #2
sem_cleaner #1
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
sem_cleaner #2
sem_cleaner #1
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
mqueue_waiter: Waiting to receive a message...
cancel_test: Canceling thread
cancel_test: Joining
mqueue_cleaner... closing message queue
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sig_waiter: Waiting to receive signal...
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481e5c 1f480588
uordblks   b7e1a4   b7fa78
fordblks 1f481e5c 1f480588

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Wake parent start wait mutex
robust_waiter: Exiting with mutex locked
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f480588 1f480588
uordblks   b7fa78   b7fa78
fordblks 1f480588 1f480588

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 160
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 150
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 140
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f480588 1f41cad8
uordblks   b7fa78   be3528
fordblks 1f480588 1f41cad8

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1766477925 sec, 829215922 nsec)
AFTER:  (1766477927 sec, 830112791 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 160
poster_func: Waiting for 10 ms
semtimed_test: Starting poster thread 3
semtimed_test: Set low priority thread to 140
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 10 ms
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1766477927 sec, 834202194 nsec)
AFTER:  (1766477927 sec, 842419575 nsec)
poster_func: Posting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f41cad8 1f44f430
uordblks   be3528   bb0bd0
fordblks 1f41cad8 1f44f430

user_main: Named semaphore test
nsem_test: Create semaphore 1 with value == 0
nsem_test: Starting peer peer
nsem_test: Set peer priority to 160
nsem_peer: Open semaphore 1
nsem_peer: Create semaphore 2 with value == 0
nsem_peer: Post, close, and unlink semaphore 1
nsem_peer: Post and close semaphore 2
nsem_test: Wait on semaphore 1
nsem_test: Close semaphore 1
nsem_test: Open semaphore 2
nsem_test: Wait on semaphore 2
nsem_test: Close and unlink semaphore 2

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44f430 1f481d45
uordblks   bb0bd0   b7e2bb
fordblks 1f44f430 1f481d45

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 160
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 140
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d45 1f44f3ed
uordblks   b7e2bb   bb0c13
fordblks 1f481d45 1f44f3ed

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=1745
pthread_exit_main 1745: Starting pthread_exit_thread
pthread_exit_main 1745: Sleeping for 50 ms
pthread_exit_thread 1746: Sleeping for 100 ms
pthread_exit_main 1745: Calling pthread_exit()
pthread_exit_thread 1746: Still running...
pthread_exit_thread 1746: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44f3ed 1f481d21
uordblks   bb0c13   b7e2df
fordblks 1f44f3ed 1f481d21

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d21 1f481d21
uordblks   b7e2df   b7e2df
fordblks 1f481d21 1f481d21

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d21 1f481d21
uordblks   b7e2df   b7e2df
fordblks 1f481d21 1f481d21

user_main: pthread_cleanup test
pthread_cleanup: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d21 1f481d21
uordblks   b7e2df   b7e2df
fordblks 1f481d21 1f481d21

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 202
thread_waiter: Taking mutex
thread_waiter: Starting 1 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d21 1f481d21
uordblks   b7e2df   b7e2df
fordblks 1f481d21 1f481d21

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 160
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 140
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
mqueue_test: sig_handler
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated
mqueue_test: receiver mqd_t left open

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f481d21 1f4b4573
uordblks   b7e2df   b4ba8d
fordblks 1f481d21 1f4b4573

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b4573 1f48041b
uordblks   b4ba8d   b7fbe5
fordblks 1f4b4573 1f48041b

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f48041b 1f48041b
uordblks   b7fbe5   b7fbe5
fordblks 1f48041b 1f48041b

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Unmasking SIGCHLD
sighand_test: Registering SIGCHLD handler
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=1764
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=1764 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f48041b 1f4803f7
uordblks   b7fbe5   b7fc09
fordblks 1f48041b 1f4803f7

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 151
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=1765
signest_test: Starting interfering task at priority 152
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=1766
signest_test: Simple case:
  Total signalled 1180  Odd=580 Even=600
  Total handled   1180  Odd=580 Even=600
  Total nested    0    Odd=0   Even=0
signest_test: With task locking
  Total signalled 2360  Odd=1160 Even=1200
  Total handled   2360  Odd=1160 Even=1200
  Total nested    0    Odd=0   Even=0
signest_test: With intefering thread
  Total signalled 3540  Odd=1740 Even=1800
  Total handled   3540  Odd=1740 Even=1800
  Total nested    0    Odd=0   Even=0
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4803f7 1f47faf3
uordblks   b7fc09   b8050d
fordblks 1f4803f7 1f47faf3

user_main: spinlock test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f47faf3 1f4b3c4b
uordblks   b8050d   b4c3b5
fordblks 1f47faf3 1f4b3c4b

user_main: signal action test
suspend_test: Starting victim task
suspend_test: Started victim_main pid=1767
suspend_test:  Is the victim saying anything?
victim_main: Victim started
suspend_test: Signaling pid=1767 with SIGSTOP
suspend_test:  Is the victim still jabbering?
suspend_test: Signaling pid=1767 with SIGCONT
suspend_test:  The victim should continue the rant.
victim_main: Wasting time
suspend_test: Signaling pid=1767 with SIGKILL
suspend_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b3c4b 1f4b3c4b
uordblks   b4c3b5   b4c3b5
fordblks 1f4b3c4b 1f4b3c4b

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 4611686018427387902
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 4611686018427387902
wdtest_recursive 1000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
wdog_test end...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b3c4b 1f44e99b
uordblks   b4c3b5   bb1665
fordblks 1f4b3c4b 1f44e99b

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0x45a1a1ae oact.sa_flags=0 oact.sa_mask=2aaaaaaaaaa2a8aa
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44e99b 1f4b3c7f
uordblks   bb1665   b4c381
fordblks 1f44e99b 1f4b3c7f

user_main: SIGEV_THREAD timer test
sigev_thread_test: Initializing semaphore to 0
sigev_thread_test: Creating timer
sigev_thread_test: Starting timer
sigev_thread_test: Waiting on semaphore
sigev_thread_callback: Received value 42
sigev_thread_test: Awakened with no error!
sigev_thread_test: g_value_received=42
sigev_thread_test: Deleting timer
sigev_thread_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b3c7f 1f4b3c7f
uordblks   b4c381   b4c381
fordblks 1f4b3c7f 1f4b3c7f

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_func: Thread 0 done
barrier_test: Thread 0 completed with result=0
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_test: Thread 3 completed with result=0
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b3c7f 1f44e9cf
uordblks   b4c381   bb1631
fordblks 1f4b3c7f 1f44e9cf

user_main: setjmp test
setjmp_test: Initializing jmp_buf
setjmp_test: Try jump
setjmp_test: About to jump, longjmp with ret val: 123
setjmp_test: Jump succeed
setjmp_test: Try jump
setjmp_test: About to jump, longjmp with ret val: 0
setjmp_test: Jump succeed

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44e9cf 1f44e9cf
uordblks   bb1631   bb1631
fordblks 1f44e9cf 1f44e9cf

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 147
sched_lock: Set lowpri_thread priority to 147
sched_lock: Starting highpri_thread at 148
sched_lock: Set highpri_thread priority to 148
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 147
sched_lock: Set lowpri_thread priority to 147
sched_lock: Starting highpri_thread at 148
sched_lock: Set highpri_thread priority to 148
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f44e9cf 1f4b3c7f
uordblks   bb1631   b4c381
fordblks 1f44e9cf 1f4b3c7f

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    20000000 20000000
ordblks         1        1
mxordblk 1f4b59f9 1f4b3c7f
uordblks   b4a607   b4c381
fordblks 1f4b59f9 1f4b3c7f
user_main: Exiting
ostest_main: Exiting with status 0
ap>
ap>
ap>
ap> mount
  /bin type binfs
  /etc type romfs
  /proc type procfs
  /tmp type tmpfs
ap> ls /etc/
/etc:
 build.prop
 charger_parameters.json
 dbus-1/
 init.d/
 media/
 mobile-broadband-provider-info/
 ofono/
 ssl/
 wifi/
 zoneinfo/
ap> cat /etc/build.prop
ro.build.codename=DEV
ro.build.version.release=12.0.0
ro.product.model=Simulator-Vela
ro.product.device=Simulator-Vela
ro.product.name=Simulator-Vela
ro.product.brand=xiaomi
ro.product.manufacturer=xiaomi
ro.product.board=Simulator
ap> romfs
Mounting ROMFS filesystem at target=/usr/local/share with source=/dev/ram10
Traversing directory: /usr/local/share
  DIRECTORY: /usr/local/share/adir/
Traversing directory: /usr/local/share/adir
  FILE: /usr/local/share/adir/anotherfile.txt/
  DIRECTORY: /usr/local/share/adir/subdir/
Traversing directory: /usr/local/share/adir/subdir
  FILE: /usr/local/share/adir/subdir/subdirfile.txt/
Continuing directory: /usr/local/share/adir
  FILE: /usr/local/share/adir/yafile.txt/
Continuing directory: /usr/local/share
  FILE: /usr/local/share/afile.txt/
  FILE: /usr/local/share/hfile/
PASSED

