### PR TITLE
risc-v/litex: For vexriscv_smp, match default FDT address set by upstream opensbi.

### DIFF
--- a/Documentation/platforms/risc-v/litex/cores/vexriscv_smp/index.rst
+++ b/Documentation/platforms/risc-v/litex/cores/vexriscv_smp/index.rst
@@ -45,7 +45,7 @@ Create a file, 'boot.json' in the Nuttx root directory, with the following conte
   {
     "romfs.img":   "0x40C00000",
     "nuttx.bin":   "0x40000000",
-    "board.dtb":   "0x41ec0000",
+    "board.dtb":   "0x40EF0000",
     "opensbi.bin": "0x40f00000"
   }
 

--- a/arch/risc-v/src/litex/Kconfig
+++ b/arch/risc-v/src/litex/Kconfig
@@ -20,7 +20,7 @@ config LITEX_COHERENT_DMA
 
 config LITEX_FDT_MEMORY_ADDRESS
 	hex "Location of the FDT in memory"
-	default 0x41ec0000
+	default 0x40EF0000
 
 menu "LITEX Peripheral Support"
 


### PR DESCRIPTION
## Summary

For `vexriscv_smp` cores with FDT support, match the upstream opensbi definitions where the FDT should be mapped to.

The default opensbi `fw_jump.bin` expects to see the FDT in 0x40EF0000 per FW_JUMP_FDT_ADDR in:

0.8 branch: https://github.com/litex-hub/opensbi/blob/a9ce3ada56574fcdb5befae0395f2f3d33134f81/platform/litex/vexriscv/config.mk
1.3.1 branch: https://github.com/litex-hub/opensbi/blob/84c6dc17f7d41c5c02760a5533d7268b57369837/platform/litex/vexriscv/objects.mk

## Impact

Without this, the user must override the configuration in either opensbi or in NuttX to match.

## Testing

I tested with the `arty_a7:knsh` config.