### PR TITLE
drivers/usbhost: improve usbhost hid kbd

### DIFF
--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -1370,8 +1370,6 @@ static void usbhost_kbd_callback(FAR void *arg, ssize_t nbytes)
 static int usbhost_kbdpoll(int argc, FAR char *argv[])
 {
   FAR struct usbhost_state_s *priv;
-  irqstate_t flags;
-
 #if defined(CONFIG_DEBUG_USB) && defined(CONFIG_DEBUG_INFO)
   unsigned int npolls = 0;
 #endif


### PR DESCRIPTION
## Summary

By passing parameters to the kthread_create process, reduce the global variables and nxmutex lock.

## Impact

improve usbhost hid kbd

## Testing

host： ubuntu 22.04.1
target: sim:usbhost ,  qemu vela

sim usbhost test step:
1.  call usbhost_kbdinit() in sim_usbhost_initialize()
2. modify CONFIG_SIM_USB_VID and CONFIG_SIM_USB_PID  to the keyboard's VID PID
3.  build and run
```
usbhost_registerclass: Registering class:0x40083620 nids:5
usbhost_registerclass: Registering class:0x40083640 nids:1
sim_usbhost_waittask: connected
sim_usbhost_enumerate: Enumerate the device
sim_usbhost_ctrlin: type: 80 req: 06 value: 0100 index: 0000 len: 0012

NuttShell (NSH) NuttX-12.11.0
nsh> usbhost_enumerate: maxpacksetsize: 8 speed: 3
usbhost_devdesc: class:0 subclass:0 protocol:0 vid:046d pid:c31c
sim_usbhost_ctrlin: type: 00 req: 05 value: 0001 index: 0000 len: 0000
sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 0009
usbhost_enumerate: sizeof config data: 59
sim_usbhost_ctrlin: type: 80 req: 06 value: 0200 index: 0000 len: 003b
sim_usbhost_ctrlin: type: 00 req: 09 value: 0001 index: 0000 len: 0000
usbhost_enumerate: Parsing interface: 0
usbhost_configdesc: cfg len:9 total len:59
usbhost_configdesc: class:3 subclass:1 protocol:1
usbhost_findclass: Looking for class:3 subclass:1 protocol:1 vid:046d pid:c31c
usbhost_findclass: Checking class:0x40083640 nids:1
usbhost_idmatch: Compare to class:3 subclass:1 protocol:1 vid:0000 pid:0000
usbhost_classbind: usbhost_findclass: 0x40083640
usbhost_allocclass: Allocated: 0x7b889c864df0
usbhost_classbind: CLASS_CREATE: 0x7b889c864df0
usbhost_cfgdesc: Interface descriptor
usbhost_cfgdesc: HID descriptor
usbhost_cfgdesc: Endpoint descriptor
usbhost_cfgdesc: Interrupt IN EP addr:1 mxpacketsize:8
usbhost_cfgdesc: Interface descriptor
sim_usbhost_epalloc: EP1 DIR=IN FA=00000001 TYPE=3 Interval=10 MaxPacket=8
usbhost_cfgdesc: Found EPOOUT:NO
usbhost_cfgdesc: Endpoints allocated
sim_usbhost_ctrlin: type: 21 req: 0a value: 1900 index: 0000 len: 0000
sim_usbhost_ctrlin: type: 21 req: 0b value: 0000 index: 0000 len: 0000
sim_usbhost_ctrlin: type: 21 req: 09 value: 0200 index: 0000 len: 0001
usbhost_devinit: Start poll task
usbhost_kbdpoll: Started
usbhost_devinit: Register driver
usbhost_classbind: Returning: 0
usbhost_enumerate: Parsing interface: 1
usbhost_configdesc: cfg len:9 total len:59
usbhost_configdesc: class:3 subclass:0 protocol:0
usbhost_findclass: Looking for class:3 subclass:0 protocol:0 vid:046d pid:c31c
usbhost_findclass: Checking class:0x40083640 nids:1
usbhost_idmatch: Compare to class:3 subclass:1 protocol:1 vid:0000 pid:0000
usbhost_findclass: Checking class:0x40083620 nids:5
usbhost_idmatch: Compare to class:2 subclass:0 protocol:0 vid:0000 pid:0000
usbhost_idmatch: Compare to class:2 subclass:2 protocol:0 vid:0000 pid:0000
usbhost_idmatch: Compare to class:2 subclass:2 protocol:1 vid:0000 pid:0000
usbhost_idmatch: Compare to class:255 subclass:0 protocol:0 vid:2c7c pid:0125
usbhost_idmatch: Compare to class:255 subclass:2 protocol:0 vid:2c7c pid:0125
usbhost_classbind: usbhost_findclass: 0
usbhost_classbind: Returning: -22
usbhost_enumerate: ERROR: usbhost_classbind failed -22
usbhost_kbdpoll: Entering poll loop
sim_usbhost_ctrlin: type: a1 req: 01 value: 0100 index: 0000 len: 0008
sim_usbhost_ctrlin: type: a1 req: 01 value: 0100 index: 0000 len: 0008
sim_usbhost_ctrlin: type: a1 req: 01 value: 0100 index: 0000 len: 0008
sim_usbhost_ctrlin: type: a1 req: 01 value: 0100 index: 0000 len: 0008
nsh> 
nsh> 
nsh> cat /dev/kbda &
...
usbhost_extract_keys: Key 0: 04 keycode:a modifier: 00
ausbhost_read: Entry
usbhost_read: Waiting...
usbhost_kbdpoll: Still polling: 1568
...
```


