### PR TITLE
risc-v/litex: For vexriscv, point docs at linux CPU variant instead of secure.

### DIFF
--- a/Documentation/platforms/risc-v/litex/boards/arty_a7/README.txt
+++ b/Documentation/platforms/risc-v/litex/boards/arty_a7/README.txt
@@ -6,7 +6,7 @@
    and flash to arty_a7 board
 
   $ cd litex-boards/litex_boards/targets
-  $ ./digilent_arty.py --with-ethernet --with-sdcard --uart-baudrate 1000000 --cpu-type=vexriscv --cpu-variant=secure --build --load --flash
+  $ ./digilent_arty.py --with-ethernet --with-sdcard --uart-baudrate 1000000 --cpu-type=vexriscv --cpu-variant=linux --build --load --flash
 
 3. Configure and build NuttX
 

--- a/Documentation/platforms/risc-v/litex/boards/arty_a7/index.rst
+++ b/Documentation/platforms/risc-v/litex/boards/arty_a7/index.rst
@@ -67,7 +67,7 @@ Flashing
 .. code:: console
 
    $ cd litex-boards/litex_boards/targets
-   $ ./digilent_arty.py --with-ethernet --with-sdcard --uart-baudrate 1000000 --cpu-type=vexriscv --cpu-variant=secure --build --load --flash
+   $ ./digilent_arty.py --with-ethernet --with-sdcard --uart-baudrate 1000000 --cpu-type=vexriscv --cpu-variant=linux --build --load --flash
 
 
 2. Next, set up a TFTP server on your host machine, copy ``nuttx.bin`` to your

--- a/Documentation/platforms/risc-v/litex/cores/vexriscv/index.rst
+++ b/Documentation/platforms/risc-v/litex/cores/vexriscv/index.rst
@@ -4,6 +4,15 @@ Vexriscv Core
 
 The vexriscv core only supports standard "Flat builds", consisting of a single binary.
 
+Configuration
+-------------
+
+For vexriscv, the linux CPU variant is required.  Please consult the appropriate board
+documentation for flashing gateware.
+
+If you use the secure CPU variant, you may encounter a kernel panic on startup - please see
+https://github.com/apache/nuttx/pull/17494 for an example.
+
 Building
 --------
 


### PR DESCRIPTION
## Summary

The secure CPU variant of vexriscv immediately panics after bring up with `arty_a7:nsh` build.

However, the linux CPU variant of the vexriscv core does work successfully.

I have not been successful in identifying exactly why the secure variant is unsuccessful, but from testing various gateware configurations, the linux variant does work.

## Impact

Immediately after boot of a `arty_a7:nsh` config, the NuttX kernel panics with:

```
--============= Liftoff! ===============--
Current Version: NuttX  12.11.0 ec9dabc3f8-dirty Dec 12 2025 10:00:48 risc-v
Assertion failed panic: at file: :0 task: Idle_Task process: Kernel 0x40000dd8
EPC: 400015e0
A0: 408024f0 A1: 00000000 A2: 40013048 A3: 00000000
A4: 00000007 A5: 00000007 A6: 00000000 A7: 0000004c
T0: 408021b0 T1: 40001178 T2: 0000007f T3: 0000007a
T4: 00000074 T5: 00000009 T6: 0000002a
S0: 40802000 S1: 408022b0 S2: 40803000 S3: 00000000
S4: 00000000 S5: 40013048 S6: 00000000 S7: 40803000
S8: 00000002 S9: 00000000 S10: 00000000 S11: 00000000
SP: 40802078 FP: 40802000 TP: 00000000 RA: 400015e0
IRQ Stack:
  base: 0x408001b0
  size: 00008192
    sp: 0x40802078
0x40802058: 00000000 00000000 40802078 00002000 40803000 408022b0 40802078 4000172c
0x40802078: 00000000 00000000 00000000 00000000 00000000 00000000 408022b0 408024f0
0x40802098: 40013048 00000000 00000000 7474754e 00000058 00000000 00000000 00000000
0x408020b8: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
0x408020d8: 2e323100 302e3131 00000000 00000000 00000000 63650000 62616439 38663363
0x408020f8: 7269642d 44207974 31206365 30322032 31203532 30303a30 0038343a 00000000
0x40802118: 00000000 00000000 73697200 00762d63 00000000 00000000 00000000 00000000
0x40802138: 00000000 00000000 100001e0 00000002 00000003 00000001 408022b0 00000000
0x40802158: 00000002 40803000 40803000 40005bd0 00000000 00000000 00000000 4000119c
0x40802178: 00000000 00000000 00000000 40000464 00000000 00000000 00000000 4080487c
0x40802198: 00000002 40006054 408021b0 400001d4 408047f8 40006054 00000000 00000000
ERROR: Stack pointer 4080487c is not within the stack
User Stack:
  base: 0
  size: 00000000
0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
   PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
  ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x408001b0      8192      8192   100.0%!   irq

```

## Testing

When flashing a gateware with the `linux` variant of `vexriscv`, NuttX works as expected.