### PR TITLE
libs/libc/obstack/lib_obstack_free.c: fix object check within chunk

### DIFF
--- a/libs/libc/obstack/lib_obstack_free.c
+++ b/libs/libc/obstack/lib_obstack_free.c
@@ -53,9 +53,13 @@ void obstack_free(FAR struct obstack *h, FAR void *object)
 
   while (h->chunk)
     {
-      if (object >=
-          (FAR void *)((FAR char *)&h->chunk + sizeof(struct _obstack_chunk))
-          && object < (FAR void *)h->chunk->limit)
+      /* Object has to be after chunk + chunk' header. We can use pointer
+       * arithmetic here as h->chunk + 1 is the same as
+       * (FAR char *)h->chunk + sizeof(struct _obstack_chunk)
+       */
+
+      if (object >= (FAR void *)(h->chunk + 1)
+          && object <= (FAR void *)h->chunk->limit)
         {
           /* The object is in this chunk so just move object base.
            * Note: this keeps the last chunk allocated. This is desirable


### PR DESCRIPTION
## Summary
The original condition incorrectly used `&h->chunk` instead of `h->chunk` in the calculation whether the object is in the chunk. This could lead to the wrong behavior as the first branch gave incorrect result and thus sometimes the entire obstack was freed even though object was not `NULL`.

The commit also simplifies the logic, we can use pointer arithmetic here and just do h->chunk + 1 as it gives the same result as `(FAR char *)h->chunk + sizeof(struct _obstack_chunk)`. This saves unnecessary cast and `sizeof`.

The second branch should be less than or equal, not just less than. This ensures the object is correctly located in the chunk even after previous `obstack_finish` was called.

## Impact

Fixes the undefined behavior of `obstack_free` call.

## Testing

It's pretty hard to reliably reproduce the incorrect behavior as it depends on the address of the pointer to `h->chunk`. The check still might succeed if it is located near the original pointer. Different location however might cause the branch is never triggered and the entire obstack is freed. This issue doesn't occur after the fix as the obstack is located correctly.
