### PR TITLE
risc-v/litex: For vexriscv_smp, explicitly document requirement for C ISA ext.

### DIFF
--- a/Documentation/platforms/risc-v/litex/boards/arty_a7/index.rst
+++ b/Documentation/platforms/risc-v/litex/boards/arty_a7/index.rst
@@ -58,11 +58,16 @@ You will need to download the tool-chain for this board:
 
    $ curl https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz
 
-Flashing
+vexriscv
 ========
 
+This section is for the vexriscv softcore fpga gateware.
+
+Flashing
+--------
+
 1. Follow the instructions on https://github.com/enjoy-digital/litex to build
-   the vexriscv softcore fpga gateware and flash to Arty A7 board:
+   the vexriscv and flash to Arty A7 board:
 
 .. code:: console
 
@@ -86,7 +91,7 @@ Flashing
    You should then see the NSH prompt.
 
 Configurations
-==============
+--------------
 
 You can configure NuttX for this board using:
 
@@ -97,6 +102,23 @@ You can configure NuttX for this board using:
 Where ``<config>`` is the name of one of the configurations listed below.
 
 nsh
----
+^^^
 
 A simple configuration with the NSH shell.
+
+
+VexRISCV_SMP
+============
+
+This section is for the VexRISCV_SMP softcore fpga gateware.
+
+1. For VexRISCV_SMP cores on an Arty A7, you can follow the instructions on
+   https://github.com/enjoy-digital/litex to build the vexriscv_smp softcore fpga gateware:
+
+.. code:: console
+
+   $ cd litex-boards/litex_boards/targets
+   $ ./digilent_arty.py --with-ethernet --with-sdcard --uart-baudrate 1000000 --cpu-type=vexriscv_smp --cpu-variant=linux --with-rvc --cpu-count 8 --build --load --flash
+
+
+Please consult the VexRISCV_SMP core documentation for more information about setting up a two-pass build.

--- a/Documentation/platforms/risc-v/litex/cores/vexriscv_smp/index.rst
+++ b/Documentation/platforms/risc-v/litex/cores/vexriscv_smp/index.rst
@@ -6,6 +6,12 @@ The vexrisc_smp core supports a two-pass build, producing the kernel (nuttx.bin)
 compiled into the apps/bin directory. In the standard configuration, the applications are loaded to the FPGA in a RAMdisk. 
 Although, for custom boards this could be extended to loading from SDCards, flash, or other mediums.
 
+Configuration
+-------------
+
+For VexRISCV_SMP cores, the gateware requires the `--with-rvc` configuration to enable compressed
+instructions.  Please consult the appropriate board documentation for flashing gateware.
+
 Building
 --------
 


### PR DESCRIPTION
## Summary

For `vexriscv_smp` cores, the gateware must be flashed with the C ISA extension to enable compressed instructions.  Otherwise, the NuttX image will not start after the OpenSBI handoff.  By default, the C ISA extension is not enabled for `vexriscv_smp` cores.  For litex generators, passing `--with-rvc` will enable the C ISA extension.

An alternative could be to remove `select ARCH_RV_ISA_C` from `config LITEX_CORE_VEXRISCV_SMP` in `arch/risc-v/Kconfig`; but, I think it's more straightforward to update the documentation in this instance.  (I have tested that disabling this option does allow it to work with more traditional configs.)

## Impact

One other note is that the bundled Verilog in litex-hub/pythondata-cpu-vexriscv_smp does not contain already generated `--with-rvc` options, so the user must have the full `sbt` toolchain to run the SpinalHDL process to emit the appropriate Verilog following the instructions for Litex.

## Testing

I tested with `arty_a7:knsh` with a `vexriscv_smp` core that has `--with-rvc` setting and support C ISA extension.