### PR TITLE
fs/vfs: fix poll covertify issue about out-of-bound access fds

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -161,25 +161,20 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
       if (fds[i].fd >= 0)
         {
           FAR struct file *filep;
-          int num = i;
 
           ret = file_get(fds[i].fd, &filep);
-          if (ret < 0)
-            {
-              num -= 1;
-            }
-          else
+          if (ret >= 0)
             {
               ret = file_poll(filep, &fds[i], true);
+              if (ret < 0)
+                {
+                  file_put(filep);
+                }
             }
 
           if (ret < 0)
             {
-              if (num >= 0)
-                {
-                  poll_teardown(fds, num, &count);
-                }
-
+              poll_teardown(fds, i, &count);
               fds[i].revents |= POLLERR;
               fds[i].arg = NULL;
               fds[i].cb = NULL;


### PR DESCRIPTION
## Summary

poll: fix covertify issue about out-of-bound access fds
when i is zero and file_get is failed, num is -1,
it's uint32_max for nfds.
so remove num and simplify code logic.

## Impact

fix issue report by covertify tool

## Testing

vela and sim libuv