### PR TITLE
libc: improve libc dependencies in case of LIBM_NONE

### DIFF
--- a/libs/libc/stdlib/CMakeLists.txt
+++ b/libs/libc/stdlib/CMakeLists.txt
@@ -48,7 +48,6 @@ set(SRCS
     lib_strtoll.c
     lib_strtoul.c
     lib_strtoull.c
-    lib_strtold.c
     lib_checkbase.c
     lib_mktemp.c
     lib_mkstemp.c
@@ -63,6 +62,10 @@ set(SRCS
     lib_wcstombs.c
     lib_arc4random.c
     lib_atexit.c)
+
+if(NOT CONFIG_LIBM_NONE)
+  list(APPEND SRCS lib_strtold.c)
+endif()
 
 if(CONFIG_PSEUDOTERM)
   list(APPEND SRCS lib_ptsname.c lib_ptsnamer.c lib_unlockpt.c lib_openpty.c)

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -26,11 +26,15 @@ CSRCS += lib_abs.c lib_abort.c lib_atof.c lib_atoi.c lib_getprogname.c
 CSRCS += lib_atol.c lib_atoll.c lib_div.c lib_ldiv.c lib_lldiv.c lib_exit.c
 CSRCS += lib_itoa.c lib_labs.c lib_llabs.c lib_realpath.c lib_bsearch.c
 CSRCS += lib_rand.c lib_rand48.c lib_qsort.c lib_srand.c lib_strtol.c
-CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtold.c
-CSRCS += lib_checkbase.c lib_mktemp.c lib_mkstemp.c lib_mkdtemp.c
-CSRCS += lib_aligned_alloc.c lib_posix_memalign.c lib_valloc.c lib_mblen.c
-CSRCS += lib_mbtowc.c lib_wctomb.c lib_mbstowcs.c lib_wcstombs.c lib_atexit.c
+CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_checkbase.c
+CSRCS += lib_mktemp.c lib_mkstemp.c lib_mkdtemp.c lib_aligned_alloc.c
+CSRCS += lib_posix_memalign.c lib_valloc.c lib_mblen.c lib_mbtowc.c
+CSRCS += lib_wctomb.c lib_mbstowcs.c lib_wcstombs.c lib_atexit.c
 CSRCS += lib_reallocarray.c lib_arc4random.c
+
+ifneq ($(CONFIG_LIBM_NONE),y)
+CSRCS += lib_strtold.c
+endif
 
 ifeq ($(CONFIG_PSEUDOTERM),y)
 CSRCS += lib_ptsname.c lib_ptsnamer.c lib_unlockpt.c lib_openpty.c

--- a/libs/libc/stream/lib_libvscanf.c
+++ b/libs/libc/stream/lib_libvscanf.c
@@ -44,6 +44,18 @@
 #  undef CONFIG_LIBC_LONG_LONG
 #endif
 
+#ifdef CONFIG_LIBC_SCANSET
+#  define SCANSET_MODS "["
+#else
+#  define SCANSET_MODS
+#endif
+
+#ifdef CONFIG_LIBC_FLOATINGPOINT
+#  define FLOATINGPOINT_MODS "aAfFeEgG"
+#else
+#  define FLOATINGPOINT_MODS
+#endif
+
 #define MAXLN   128
 
 #define HH_MOD -2
@@ -297,11 +309,10 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
           fmt++;
           for (; fmt_char(fmt); fmt++)
             {
-#ifdef CONFIG_LIBC_SCANSET
-              if (strchr("diboupxXcseEfFgGaAn[%", fmt_char(fmt)))
-#else
-              if (strchr("diboupxXcseEfFgGaAn%", fmt_char(fmt)))
-#endif
+              if (strchr("diboupxXcsn"
+                         FLOATINGPOINT_MODS
+                         SCANSET_MODS
+                         "%", fmt_char(fmt)))
                 {
                   if (fmt_char(fmt) != '%')
                     {
@@ -936,6 +947,7 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
                 }
             }
 
+#ifdef CONFIG_LIBC_FLOATINGPOINT
           /* Process %a, %A, %f, %F, %e, %E, %g, and %G: Floating point
            * conversions.
            */
@@ -976,8 +988,6 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
                     }
 #endif
                 }
-
-#ifdef CONFIG_LIBC_FLOATINGPOINT
 
               /* Skip over any white space before the real string */
 
@@ -1138,8 +1148,8 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
 
                   count++;
                 }
-#endif
             }
+#endif
 
           /* Process %n: Character count */
 


### PR DESCRIPTION
## Summary

Currently the code for `strtof`, `strtod` and `strtold` is in the list of files to compile unconditionally, but when trying to compile kernel with toolchain without `libm` support (`CONFIG_LIBM_NONE =y`) compilation fails because code refers `math.h`

## Impact

Fix build with toolchains that do not have `math.h` (`libm` support) and `CONFIG_LIBM_NONE=y`

## Testing

`same70-qmtech:mcuboot-loader` configuration compiles on MAC with `arm-none-eabi-gcc` installed from `brew`