### PR TITLE
arch/risc-v: add crt0 to LDELFFLAG

### DIFF
--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -143,14 +143,14 @@ $(AOBJS) $(UAOBJS) $(HEAD_OBJ): %$(OBJEXT): %.S
 $(COBJS) $(UCOBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
-crt0$(OBJEXT): %$(OBJEXT): %.c
-	$(call COMPILE, $<, $@)
+$(STARTUP_OBJS): %$(OBJEXT): %.c
+	$(Q) $(CC) $(CELFFLAGS) -c common$(DELIM)crt0.c -o crt0$(OBJEXT)
 
 ifeq ($(CONFIG_BUILD_FLAT),y)
-$(BIN): $(OBJS)
+$(BIN): $(STARTUP_OBJS) $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 else
-$(BIN): $(UOBJS)
+$(BIN): $(STARTUP_OBJS) $(UOBJS)
 	$(call ARCHIVE, $@, $(UOBJS))
 endif
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -445,7 +445,7 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden
 CXXELFFLAGS = $(CXXFLAGS) -fvisibility=hidden
 
-LDELFFLAGS = -e __start
+LDELFFLAGS = -e _start
 
 ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
   LDELFFLAGS += -r
@@ -455,6 +455,13 @@ ifeq ($(CONFIG_ARCH_RV32),y)
   LDELFFLAGS += --oformat elf32-littleriscv
 else
   LDELFFLAGS += --oformat elf64-littleriscv
+endif
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+  # Flat build and protected elf entry point use crt0,
+  # Kernel build will use apps/import/scripts/crt0
+
+  LDELFFLAGS += $(TOPDIR)$(DELIM)arch$(DELIM)risc-v$(DELIM)src$(DELIM)crt0.o
 endif
 
 LDELFFLAGS += -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)


### PR DESCRIPTION
## Summary

fix build riscv elf warning with 
`riscv64-unknown-elf-ld: warning: cannot find entry symbol __start; defaulting to 0000000000000000`

## Impact

noting

## Testing

build maix-bit/elf
