### PR TITLE
arch/sim: add nonblock flags for /dev/console

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostuart.c
+++ b/arch/sim/src/sim/posix/sim_hostuart.c
@@ -94,6 +94,8 @@ static void restoremode(void)
 
 void host_uart_start(void)
 {
+  int flags;
+
   /* Get the current stdin terminal mode */
 
   host_uninterruptible_no_return(tcgetattr, 0, &g_cooked);
@@ -101,6 +103,12 @@ void host_uart_start(void)
   /* Put stdin into raw mode */
 
   host_uninterruptible_no_return(setrawmode, 0);
+
+  flags = host_uninterruptible(fcntl, 0, F_GETFL, 0);
+  if (flags > 0)
+    {
+      host_uninterruptible_no_return(fcntl, 0, F_SETFL, flags | O_NONBLOCK);
+    }
 
   /* Restore the original terminal mode before exit */
 


### PR DESCRIPTION
## Summary

This change updates host_uart_start() to configure as non-blocking when running in raw mode. It ensures the host UART polling behavior does not hang on blocking reads, improving responsiveness of input handling in host-simulated environments.

## Impact

Prevents blocking reads on host UART input.

## Testing

The task timed out while executing the UORB automated test.

> 2025-08-20 10:23:59 [Nuttx] ap> uorb_listener -b 100000 -r 50 -n 50 sensor_accel0
> 2025-08-20 10:23:59 [Nuttx]
> 2025-08-20 10:23:59 [Nuttx] Mointor objects num:1
> 2025-08-20 10:23:59 [Nuttx] object_name:sensor_accel, object_instance:0
> 2025-08-20 10:23:59 [Nuttx] [   80.659000] [ 9] [ EMERG] [ap] now=80659 , expect=80760
> 2025-08-20 10:24:09 [Nuttx] [   90.722000] [ 0] [ EMERG] [ap] up_alarm_tick_start: expire=80709 now=90722 delta=-10013 ticks
> 2025-08-20 10:24:09 [Nuttx] [   90.734000] [ 0] [ EMERG] [ap] up_alarm_tick_start: expire=90723 now=90734 delta=-11 ticks
> 2025-08-20 10:24:09 [Nuttx] [   90.735000] [ 0] [ EMERG] [ap] up_alarm_tick_start: expire=90735 now=90735 delta=0 ticks

By adding logs, the block was found in host_uart_gets.

> 2025-08-20 15:29:33 [Nuttx] ap> uorb_listener -b 10000 -r50 -n 50 sensor_accelo 2025-08-20 15:29:33 [Nuttx]
> 
> 2025-08-20 15:29:33 [Nuttx] Mointor objects num:1
> 2025-08-20 15:29:33 [Nuttx] object_name:sensor_accel, objectinstance:0 2025-08-20 15:29:33 [Nuttx] [
> 80.636000] [ 9] [EMERG] [ap] nxsig_clockwait, now=80636 , expect=80737
> 2025-08-20 15:29:43 [Nuttx] [90.699000] [0] [ 0] [ EMERG] [ap] [sim[tty_interrupt] rx_cost=10013 ms
> 2025-08-20 15:29:43 [Nuttx] [ 90.699000] [ 0] [ EMERG] [ap] wd_expiration,166, entry = 0x45ab44fd, cost=10013 ms 2025-08-20 15:29:43
> 90.699000] [0] [ EMERG] [ap] up_alarm_tick_start: e\x07
> 2025-08-20 15:29:43 [Nuttx] Broadcast message from systemd-journald@czh-ThinkCentre-M760t (Hed 2025-008-20 15:29:43 CST)
> 2025-08-20 15:29:43 [Nuttx] nuttx[4054247]: **host_uart gets read blocked for 10013 ms (ret=3, fd=0)**
> 2025-08-20 15:29:43 [Nuttx] xpire=80687 now=90699 delta=-10012 ticks
> 2025-08-20 15:29:43 [Nuttx] [190.699000] [0] [ 0] [ EMERG] [ap] [TIMEER] alarm_expire slow! ticks=80686 elapsed=1 next=1 cost=10013 ms

This patch can solve this problem.