### PR TITLE
bugfix/fs:write Bad buf addr should return EINVAL

### DIFF
--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -71,6 +71,11 @@ static ssize_t file_writev_compat(FAR struct file *filep,
           continue;
         }
 
+      if (iov[i].iov_base == NULL)
+        {
+          return -EINVAL;
+        }
+
       /* Sanity check to avoid total length overflow */
 
       if (SSIZE_MAX - ntotal < iov[i].iov_len)


### PR DESCRIPTION

## Summary

This modification is derived from the nx_write interface of the older version, where the legacy nx_write interface includes a check on the buf parameter:

if (buf == NULL)
{
   return -EINVAL;
}

The Linux kernel also enforces checks on the validity of the buf address, yet the POSIX standard does not specify any special requirements for this aspect.

Should we retain this modification?  @acassis  @raiden00pl 

## Impact

Write API logic

## Testing

