### PR TITLE
libc/lib_mktemp:When the stat() returns ret < 0 and the error is not ENOENT

### DIFF
--- a/libs/libc/stdlib/lib_mktemp.c
+++ b/libs/libc/stdlib/lib_mktemp.c
@@ -237,12 +237,17 @@ FAR char *mktemp(FAR char *path_template)
       /* Attempt to stat the candidate file */
 
       ret = stat(path_template, &buf);
-      if (ret < 0 && get_errno() == ENOENT)
+      if (ret < 0)
         {
           /* We have it... Clear the errno and return the template */
 
-          set_errno(0);
-          return path_template;
+          if (get_errno() == ENOENT)
+            {
+              set_errno(0);
+              return path_template;
+            }
+
+          return NULL;
         }
 
       retries--;


### PR DESCRIPTION
## Summary

bugfix:When the stat() returns ret < 0 and the error is not ENOENT, mkstemp will hang here and keep retrying.

for example:
When:
  path_template:/data/quickapp/cache/ncm_XXXXXX
  xlen is equal to BIG_XS
  retries will be set to UINT32_MAX
then:
  The stat operation fails due to issues with drivers, memory problems,
  or file system operations and continuously returns an error other than ENOENT,
  it will keep retrying, which may cause the watchdog timer to time out.

## Impact

mkstem will not hang and keep retry when stat() failed but not a ENOENT

## Testing

Test passed on qemu-armeabi-v7a-ap
