### PR TITLE
rp2040,rp23xx,rp23xx-rv: allow up to 32 PIO instructions

### DIFF
--- a/arch/arm/src/rp2040/rp2040_pio.c
+++ b/arch/arm/src/rp2040/rp2040_pio.c
@@ -133,7 +133,7 @@ static void hw_claim_clear(uint8_t *bits, uint32_t bit_index)
 static int _pio_find_offset_for_program(uint32_t pio,
                                         const rp2040_pio_program_t *program)
 {
-  ASSERT(program->length < PIO_INSTRUCTION_COUNT);
+  ASSERT(program->length <= PIO_INSTRUCTION_COUNT);
   uint32_t used_mask = _used_instruction_space[rp2040_pio_get_index(pio)];
   uint32_t program_mask = (1u << program->length) - 1;
 

--- a/arch/arm/src/rp23xx/rp23xx_pio.c
+++ b/arch/arm/src/rp23xx/rp23xx_pio.c
@@ -120,7 +120,7 @@ static void hw_claim_clear(uint8_t *bits, uint32_t bit_index)
 static int _pio_find_offset_for_program(uint32_t pio,
                                         const rp23xx_pio_program_t *program)
 {
-  ASSERT(program->length < PIO_INSTRUCTION_COUNT);
+  ASSERT(program->length <= PIO_INSTRUCTION_COUNT);
   uint32_t used_mask = _used_instruction_space[rp23xx_pio_get_index(pio)];
   uint32_t program_mask = (1u << program->length) - 1;
 

--- a/arch/risc-v/src/rp23xx-rv/rp23xx_pio.c
+++ b/arch/risc-v/src/rp23xx-rv/rp23xx_pio.c
@@ -120,7 +120,7 @@ static void hw_claim_clear(uint8_t *bits, uint32_t bit_index)
 static int _pio_find_offset_for_program(uint32_t pio,
                                         const rp23xx_pio_program_t *program)
 {
-  ASSERT(program->length < PIO_INSTRUCTION_COUNT);
+  ASSERT(program->length <= PIO_INSTRUCTION_COUNT);
   uint32_t used_mask = _used_instruction_space[rp23xx_pio_get_index(pio)];
   uint32_t program_mask = (1u << program->length) - 1;
 


### PR DESCRIPTION
## Summary

Previously only up to 31 PIO instructions were accepted. But the hardware allowed 32 instructions.

Now we accept 32 instructions.

See the corresponding [commit in the pico-sdk repository](https://github.com/raspberrypi/pico-sdk/commit/6f7dc67791dfffc2a22a0f0b59e83fd4da89b408).


## Impact

Calling `rp2040_pio_add_program` with a PIO program containing 32 instructions previously ended in a panic state (`DEBUGPANIC`).

Now 32 instructions are accepted.

## Testing

Uploading my application with 32 PIO instructions previously froze the device (rp2040).

Now uploading 32 PIO instructions succeeds.

No further testing was conducted with rp23xx or rp23xx-rv devices.
But the upstream code (pico-sdk) uses the same `assert` for all three device groups. Thus, the change should be suitable for all platforms.