### PR TITLE
timers/oneshot: Fix converted tv_nsec > NSEC_PER_SEC.

### DIFF
--- a/include/nuttx/timers/clkcnt.h
+++ b/include/nuttx/timers/clkcnt.h
@@ -84,7 +84,7 @@ void clkcnt_best_multshift(uint32_t freq, uint32_t scale,
 {
   uint32_t logfreq = log2floor(freq);
 
-  /* Be careful of the round-nearest behavior here.
+  /* Do not use the round-nearest behavior here.
    * It may lead to the converted result is larger than the
    * integer division.
    * In rare cases, this can cause the converted tick to be greater
@@ -103,7 +103,7 @@ void clkcnt_best_multshift(uint32_t freq, uint32_t scale,
    * affecting the accuracy of time compensation.
    */
 
-  *mult  = (((uint64_t)scale << logfreq) + (freq >> 1)) / freq;
+  *mult  = ((uint64_t)scale << logfreq) / freq;
   *shift = logfreq;
 }
 


### PR DESCRIPTION
## Summary

In rare case, the round-nearest behavior in function `clkcnt_best_multshift` may result in converted `tv_nsec >= NSEC_PER_SEC`. This commit fixed the issue.

## Impact

This commit will affect all architectures using the `CONFIG_ONESHOT_COUNT`, including ARMv7a/ARMv7r/ARMv8a/ARMv8r/Intel64/RISC-V/sim/goldfish/tricore.

## Testing

Tested on `rv-virt:smp`, ostest passed.
