### PR TITLE
net: Check listening connections when selecting ports

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -171,7 +171,17 @@ static FAR struct tcp_conn_s *
         }
     }
 
-  return NULL;
+/* Check if this port number is in use by any listen TCP connection.
+ * Since tcp_findlistener only uses laddr internally, and laddr offset is
+ * 0 in the ip_binding_u union, ipaddr can be passed in through directly.
+ */
+
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+  return tcp_findlistener((FAR union ip_binding_u *)ipaddr,
+                          portno, domain);
+#else
+  return tcp_findlistener((FAR union ip_binding_u *)ipaddr, portno);
+#endif
 }
 
 /****************************************************************************

--- a/net/tcp/tcp_listen.c
+++ b/net/tcp/tcp_listen.c
@@ -111,7 +111,8 @@ FAR struct tcp_conn_s *tcp_findlistener(FAR union ip_binding_u *uaddr,
           if (domain == PF_INET6)
 #  endif
             {
-              if (net_ipv6addr_cmp(conn->u.ipv6.laddr, uaddr->ipv6.laddr) ||
+              if (net_ipv6addr_cmp(uaddr->ipv6.laddr, g_ipv6_unspecaddr) ||
+                  net_ipv6addr_cmp(conn->u.ipv6.laddr, uaddr->ipv6.laddr) ||
                   net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
                 {
                   /* Yes.. we found a listener on this port */
@@ -126,7 +127,8 @@ FAR struct tcp_conn_s *tcp_findlistener(FAR union ip_binding_u *uaddr,
           if (domain == PF_INET)
 #  endif
             {
-              if (net_ipv4addr_cmp(conn->u.ipv4.laddr, uaddr->ipv4.laddr) ||
+              if (net_ipv4addr_cmp(uaddr->ipv4.laddr, INADDR_ANY) ||
+                  net_ipv4addr_cmp(conn->u.ipv4.laddr, uaddr->ipv4.laddr) ||
                   net_ipv4addr_cmp(conn->u.ipv4.laddr, INADDR_ANY))
                 {
                   /* Yes.. we found a listener on this port */


### PR DESCRIPTION
## Summary

Added check for port number on listen queue, should not use the port number that is being used for listening.

## Impact

Port allocation during TCP connection establishment

## Testing

It has passed self-testing in sim & qemu-goldfish-armeabi-v7a-ap
