### PR TITLE
net/pkt: Fixed error handling for unsupported types

### DIFF
--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -474,7 +474,7 @@ ssize_t pkt_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   if (psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
-      ret = -ENOSYS;
+      return -ENOSYS;
     }
 
   /* Perform the packet recvfrom() operation */


### PR DESCRIPTION
## Summary

Currently, only SOCK_DGRAM and SOCK_RAW are supported packet socket types. If a packet socket is not of one of these two types at the time of creation, socket creation will fail. Since the packet socket type will not be modified throughout the socket's lifecycle, this branch will not be executed under normal circumstances.

The check here is a defensive protection mechanism to prevent memory corruption or other similar situations. In such abnormal scenarios, execution should not continue, therefore a return should be made here.

## Impact

Scenario of receiving a PKT socket of type non-SOCK_RAW(This will only happen under abnormal circumstances.)

## Testing

As mentioned above, this part of the code is normally untestable.
