### PR TITLE
net/socket: Fixed network card name does not end with \0 when binding the device issue

### DIFF
--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -203,11 +203,27 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
               break;
             }
 
-          /* No, we are binding a socket to the interface
-           * Find the interface device with this name.
-           */
+          /* Check if the value is already null-terminated */
 
-          dev = netdev_findbyname(value);
+          if (((FAR char *)value)[value_len - 1] != '\0')
+            {
+              char ifname[IFNAMSIZ];
+              socklen_t len = MIN(IFNAMSIZ - 1, value_len);
+
+              /* Copy the data and add null terminator */
+
+              memcpy(ifname, value, len);
+              ifname[len] = '\0';
+
+              dev = netdev_findbyname(ifname);
+            }
+          else
+            {
+              /* Value is already null-terminated, use it directly */
+
+              dev = netdev_findbyname(value);
+            }
+
           if (dev == NULL)
             {
               return -ENODEV;


### PR DESCRIPTION
## Summary

When using usrsock to pass the network interface name, omitting "\0" will cause the host to parse extra characters, resulting in no match for the specified network interface. therefore, the tail section should be inspected during device binding.

## Impact

When binding devices across cores

## Testing

The following code verified that the test was successful.
```
/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, char *argv[])
{
  int fd;
  int ret;
  struct sockaddr_in addr;

  (void)argc;
  (void)argv;

#if !defined(CONFIG_NET) || !defined(CONFIG_NET_SOCKOPTS) || !defined(CONFIG_NET_BINDTODEVICE)
  printf("Need CONFIG_NET + CONFIG_NET_SOCKOPTS + CONFIG_NET_BINDTODEVICE enabled\n");
  return 0;
#else
  /* Create a UDP socket (any socket type that uses inet stack is fine). */
  fd = socket(AF_INET, SOCK_DGRAM, 0);
  if (fd < 0)
    {
      printf("socket() failed: errno=%d\n", errno);
      return 1;
    }

  /* Bind to an ephemeral local port (not strictly required for setsockopt). */
  memset(&addr, 0, sizeof(addr));
  addr.sin_family      = AF_INET;
  addr.sin_port        = htons(0);
  addr.sin_addr.s_addr = htonl(INADDR_ANY);
  (void)bind(fd, (struct sockaddr *)&addr, sizeof(addr));

  /* Case 1: interface name WITH trailing '\0' */
  {
    const char ifname_z[] = "eth0"; /* includes '\0' */
    ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
                     ifname_z, sizeof(ifname_z));
    if (ret == 0)
      {
        printf("BINDTODEVICE(with NUL) OK: \"%s\" len=%zu\n",
               ifname_z, sizeof(ifname_z));
      }
    else
      {
        printf("BINDTODEVICE(with NUL) FAIL: errno=%d\n", errno);
      }
  }

  /* Case 2: interface name WITHOUT trailing '\0' */
  {
    const char ifname_nonul[4] = { 'e', 't', 'h', '0' }; /* no '\0' */
    ret = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
                     ifname_nonul, sizeof(ifname_nonul));
    if (ret == 0)
      {
        printf("BINDTODEVICE(without NUL) OK: \"eth0\" len=%zu\n",
               sizeof(ifname_nonul));
      }
    else
      {
        printf("BINDTODEVICE(without NUL) FAIL: errno=%d\n", errno);
      }
  }

  close(fd);
  return 0;
#endif
}
```
Actual execution result
`nsh> hello
BINDTODEVICE(with NUL) OK: "eth0" len=5
BINDTODEVICE(without NUL) OK: "eth0" len=4`
