### PR TITLE
tools/nxtagspkgsfetch.sh: Fetch tags packages for NuttX and Apps.

### DIFF
--- a/Documentation/components/tools/index.rst
+++ b/Documentation/components/tools/index.rst
@@ -851,6 +851,28 @@ This has been tested on the SAMA5D3-Xplained board; see
 `Documentation/platforms/arm/sama5/boards/sama5d3-xplained/README.txt`
 for more information on how to configure the CDC ECM driver for that board.
 
+nxtagspkgsfetch.sh
+------------------
+
+This script downloads all NuttX RTOS and Application snapshot packages
+from the upstream git repository based on the provided git tags list.
+These are NOT official release packages as checksum will differ.
+When launched from the local NuttX git repository clone the script will
+obtain all available tags to be downloaded, otherwise list of tags needs
+to be provided manually (or when just selected tag is required).
+This script uses ``wget`` underneath, make sure this tool is installed.
+Fetch log file is created with a timestamp in name next to the packages.
+
+Having all tags packaged is important for changes comparison
+between specific versions, testing a specific version, compatibility
+checks, searching for a feature introduction timeline, etc.
+
+Usage: ``./nxtagspkgsfetch.sh [download_path] [tags_list_space_separated]``
+
+You can provide optional download path (default ``../../nuttx-packages``)
+and tags list to get packages for (default all tags from local git clone).
+When providing tags you also need to provide download path.
+
 refresh.sh
 ----------
 

--- a/tools/nxtagspkgsfetch.sh
+++ b/tools/nxtagspkgsfetch.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# tools/releasesdownloader.sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# This simple script uses wget to download all git tags release artifacts.
+# At time of 12.10.0 release all rtos and apps downloads take ~4GB in size.
+# Non-existent artifacts (HTTP/404 status) will exist but have zero size.
+# Useful for testing and comparison between releases.
+
+VERSION="20251216"
+TS=`date +%s`
+ARGC=$#
+TAGS=`git tag -l`
+REL_URL_RTOS="https://github.com/apache/nuttx/archive/refs/tags/"
+REL_URL_APPS="https://github.com/apache/nuttx-apps/archive/refs/tags/"
+REL_EXT=".tar.gz"
+REL_OUT="../../nuttx-packages"
+WRKDIR=`pwd`
+WGET_FLAGS="-c -nv --show-progress -a wget-$TS.log --retry-on-http-error=503\
+  --wait=1 --waitretry=60 --keep-badhash"
+
+if [ "$1" != "" ]; then REL_OUT=$1; fi
+if [ $# -ge 2 ]; then
+  TAGS=""
+  while shift && [ -n "$1" ]; do TAGS="$TAGS $1"; done;
+fi
+
+printf "====================================================================\n"
+printf " NuttX RTOS and Apps release packages fetch script version $VERSION\n"
+printf "====================================================================\n\n"
+printf "  Usage: $0 [download_path] [tags_list_space_separated]\n\n"
+printf "  Destination : $REL_OUT.\n"
+printf "     Git tags : `echo $TAGS|tr -d '\n'`.\n\n"
+
+wget --version &>/dev/null || {
+    echo "ERROR: Please install wget to use this script!"; exit 1
+}
+
+if [ $ARGC -lt 2 ]; then printf "NOTE: Using all tags from current nuttx repo clone.\n"; fi
+printf "NOTE: Zero package size = no corresponding tag.\n"
+printf "WARNING: This tool may fetch several GB of data!\n\n"
+printf "Press Return to continue, Ctrl+C to abort.\n"
+read x
+
+if [ ! -d $REL_OUT ]; then printf "Creating: $REL_OUT.\n\n"; mkdir $REL_OUT; fi
+cd $REL_OUT
+    
+set +e
+for TAG in $TAGS; do
+    wget $WGET_FLAGS -O $TAG$REL_EXT $REL_URL_RTOS$TAG$REL_EXT 2>&1
+    wget $WGET_FLAGS -O ${TAG%%-*}-apps-${TAG#*-}$REL_EXT $REL_URL_APPS$TAG$REL_EXT 2>&1
+done
+
+printf "\nDone! Log is at: $REL_OUT/wget-$TS.log.\n"
+
+cd $WKDIR


### PR DESCRIPTION
## Summary

This script downloads all NuttX RTOS and Application snapshot packages from the upstream git repository based on the provided git tags list. These are NOT official release packages as checkum will differ.

When launched from the local NuttX git repository clone the script will obtain all available tags to be downloaded, otherwise list of tags needs to be provided manually (or when just selected tag is required). This script uses ``wget`` underneath, make sure this tool is installed. Fetch log file is created with a timestamp in name next to the packages.

Having all tags packaged is important for changes comparison between specific versions, testing a specific version, compatibility checks, searching for a feature introduction timeline, etc.

Usage: `./nxtagspkgsfetch.sh [download_path] [tags_list_space_separated]`

You can provide optional download path (default `../../nuttx-packages`) and tags list to get packages for (default all tags from local git clone). When providing tags you also need to provide download path.

Documentation update contains new tool description (above).


## Impact

* quick way to obtain packages of all or selected nuttx/nuttx-apps tags.
* useful for testing, comparison, history browse, etc.

## Testing

Developed and tested on `FreeBSD 14.3-RELEASE-p5 amd64`. Script is using `bash, git, wget` for portability.

Launched from outside local git clone:

```
% ./nxtagspkgsfetch.sh packages nuttx-1.0 nuttx-12.11.0
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
====================================================================
 NuttX RTOS and Apps release packages fetch script version 20251216
====================================================================

  Usage: ./nxtagspkgsfetch.sh [download_path] [tags_list_space_separated]

  Destination : packages.
     Git tags : nuttx-1.0 nuttx-12.11.0.

NOTE: Zero package size = no corresponding tag.
WARNING: This tool may fetch several GB of data!

Press Return to continue, Ctrl+C to abort.

Creating: packages.

nuttx-1.0.tar.gz                                    [ <=>                                                                                                   ] 270,50K  --.-KB/s    in 0,1s
nuttx-12.11.0.tar.gz                                [                                    <=>                                                                ] 101,14M  7,27MB/s    in 7,3s
nuttx-apps-12.11.0.tar.gz                           [   <=>                                                                                                 ]   4,19M  7,40MB/s    in 0,6s

Done! Log is at: packages/wget-1765932294.log.

% cat packages/wget-1765932294.log
2025-12-17 01:45:13 URL:https://codeload.github.com/apache/nuttx/tar.gz/refs/tags/nuttx-1.0 [276996] -> "nuttx-1.0.tar.gz" [1]
https://codeload.github.com/apache/nuttx-apps/tar.gz/refs/tags/nuttx-1.0:
2025-12-17 01:45:14 ERROR 404: Not Found.
2025-12-17 01:45:23 URL:https://codeload.github.com/apache/nuttx/tar.gz/refs/tags/nuttx-12.11.0 [106049596] -> "nuttx-12.11.0.tar.gz" [1]
2025-12-17 01:45:25 URL:https://codeload.github.com/apache/nuttx-apps/tar.gz/refs/tags/nuttx-12.11.0 [4394772] -> "nuttx-apps-12.11.0.tar.gz" [1]

% ls -alh packages
total 216272
drwxr-xr-x  2 XXX XXX  320B 17 gru 01:45 .
drwxr-xr-x  3 XXX XXX  128B 17 gru 01:45 ..
-rw-r--r--  1 XXX XXX  271K 17 gru 01:45 nuttx-1.0.tar.gz
-rw-r--r--  1 XXX XXX  101M 17 gru 01:45 nuttx-12.11.0.tar.gz
-rw-r--r--  1 XXX XXX    0B 17 gru 01:45 nuttx-apps-1.0.tar.gz
-rw-r--r--  1 XXX XXX  4,2M 17 gru 01:45 nuttx-apps-12.11.0.tar.gz
-rw-r--r--  1 XXX XXX  527B 17 gru 01:45 wget-1765932294.log
```

Launched from the local git clone:

```
% ./nxtagspkgsfetch.sh
====================================================================
 NuttX RTOS and Apps release packages fetch script version 20251216
====================================================================

  Usage: ./nxtagspkgsfetch.sh [download_path] [tags_list_space_separated]

  Destination : ../../nuttx-packages.
     Git tags : nuttx-1.0 nuttx-1.1 nuttx-1.2 nuttx-10.0.0 nuttx-10.0.0-RC0 nuttx-10.0.1 nuttx-10.1.0 nuttx-10.1.0-RC0 nuttx-10.1.0-RC1 nuttx-10.2.0 nuttx-10.2.0-RC0 nuttx-10.3.0 nuttx-10.3.0-RC0 nuttx-10.3.0-RC1 nuttx-10.3.0-RC2 nuttx-10.3.0-RC3 nuttx-10.3.0-RC4 nuttx-11.0.0 nuttx-11.0.0-RC0 nuttx-11.0.0-RC1 nuttx-11.0.0-RC2 nuttx-12.0.0 nuttx-12.0.0-RC0 nuttx-12.0.0-RC1 nuttx-12.1.0 nuttx-12.1.0-RC0 nuttx-12.10.0 nuttx-12.10.0-RC0 nuttx-12.11.0 nuttx-12.11.0-RC0 nuttx-12.11.0-RC1 nuttx-12.2.0 nuttx-12.2.0-RC0 nuttx-12.2.1 nuttx-12.2.1-RC0 nuttx-12.3.0 nuttx-12.3.0-RC0 nuttx-12.3.0-RC1 nuttx-12.4.0 nuttx-12.4.0-RC0 nuttx-12.5.0 nuttx-12.5.0-RC0 nuttx-12.5.1 nuttx-12.5.1-RC0 nuttx-12.6.0 nuttx-12.6.0-RC0 nuttx-12.6.0-RC1 nuttx-12.7.0 nuttx-12.7.0-RC0 nuttx-12.7.0-RC1 nuttx-12.8.0 nuttx-12.8.0-RC0 nuttx-12.9.0 nuttx-12.9.0-RC0 nuttx-12.9.0-RC1 nuttx-2.1 nuttx-2.2 nuttx-2.3 nuttx-2.4 nuttx-2.5 nuttx-2.6 nuttx-2.7 nuttx-2.8 nuttx-3.0 nuttx-3.1 nuttx-3.10 nuttx-3.11 nuttx-3.12 nuttx-3.13 nuttx-3.14 nuttx-3.15 nuttx-3.16 nuttx-3.17 nuttx-3.18 nuttx-3.19 nuttx-3.2 nuttx-3.3 nuttx-3.4 nuttx-3.5 nuttx-3.6 nuttx-3.6.1 nuttx-3.7 nuttx-3.8 nuttx-3.9 nuttx-4.0 nuttx-4.1 nuttx-4.10 nuttx-4.11 nuttx-4.12 nuttx-4.13 nuttx-4.14 nuttx-4.2 nuttx-4.3 nuttx-4.4 nuttx-4.5 nuttx-4.6 nuttx-4.7 nuttx-4.8 nuttx-4.9 nuttx-5.0 nuttx-5.1 nuttx-5.10 nuttx-5.11 nuttx-5.12 nuttx-5.13 nuttx-5.14 nuttx-5.15 nuttx-5.16 nuttx-5.17 nuttx-5.18 nuttx-5.19 nuttx-5.2 nuttx-5.3 nuttx-5.4 nuttx-5.5 nuttx-5.6 nuttx-5.7 nuttx-5.8 nuttx-5.9 nuttx-6.0 nuttx-6.1 nuttx-6.10 nuttx-6.11 nuttx-6.12 nuttx-6.13 nuttx-6.14 nuttx-6.15 nuttx-6.16 nuttx-6.17 nuttx-6.18 nuttx-6.19 nuttx-6.2 nuttx-6.20 nuttx-6.21 nuttx-6.22 nuttx-6.23 nuttx-6.24 nuttx-6.25 nuttx-6.26 nuttx-6.27 nuttx-6.28 nuttx-6.29 nuttx-6.3 nuttx-6.30 nuttx-6.31 nuttx-6.32 nuttx-6.33 nuttx-6.4 nuttx-6.5 nuttx-6.6 nuttx-6.7 nuttx-6.8 nuttx-6.9 nuttx-7.1 nuttx-7.10 nuttx-7.11 nuttx-7.12 nuttx-7.13 nuttx-7.14 nuttx-7.15 nuttx-7.16 nuttx-7.17 nuttx-7.18 nuttx-7.19 nuttx-7.2 nuttx-7.20 nuttx-7.21 nuttx-7.22 nuttx-7.23 nuttx-7.24 nuttx-7.25 nuttx-7.26 nuttx-7.27 nuttx-7.28 nuttx-7.29 nuttx-7.3 nuttx-7.30 nuttx-7.31 nuttx-7.4 nuttx-7.5 nuttx-7.6 nuttx-7.7 nuttx-7.8 nuttx-7.9 nuttx-8.1 nuttx-8.2 nuttx-9.0.0 nuttx-9.0.0-RC0 nuttx-9.0.0-RC1 nuttx-9.1.0 nuttx-9.1.0-RC0 nuttx-9.1.0-RC1 nuttx-9.1.0-RC2 nuttx-9.1.1 nuttx-9.1.1-RC0.

NOTE: Using all tags from current nuttx repo clone.
NOTE: Zero package size = no corresponding tag.
WARNING: This tool may fetch several GB of data!

Press Return to continue, Ctrl+C to abort.

Creating: ../../nuttx-packages.

nuttx-1.0.tar.gz                                    [ <=>                                                                                                   ] 270,50K  --.-KB/s    in 0,1s
nuttx-1.1.tar.gz                                    [ <=>                                                                                                   ] 275,63K  --.-KB/s    in 0,1s
(..)
nuttx-apps-9.1.0-RC1.tar.gz                         [   <=>                                                                                                 ]   3,54M  6,47MB/s    in 0,5s
nuttx-9.1.0-RC2.tar.gz                              [               <=>                                                                                     ]  22,32M  7,51MB/s    in 3,0s
nuttx-apps-9.1.0-RC2.tar.gz                         [   <=>                                                                                                 ]   3,54M  6,30MB/s    in 0,6s
nuttx-9.1.1.tar.gz                                  [               <=>                                                                                     ]  22,32M  7,36MB/s    in 3,0s
nuttx-apps-9.1.1.tar.gz                             [   <=>                                                                                                 ]   3,54M  6,30MB/s    in 0,6s
nuttx-9.1.1-RC0.tar.gz                              [               <=>                                                                                     ]  22,32M  7,46MB/s    in 3,0s

Done! Log is at: ../../nuttx-packages/wget-1765937260.log.

% ls ../../nuttx-packages
nuttx-1.0.tar.gz		nuttx-3.6.1.tar.gz		nuttx-7.14.tar.gz		nuttx-apps-12.5.1-RC0.tar.gz	nuttx-apps-6.10.tar.gz
nuttx-1.1.tar.gz		nuttx-3.6.tar.gz		nuttx-7.15.tar.gz		nuttx-apps-12.5.1.tar.gz	nuttx-apps-6.11.tar.gz
nuttx-1.2.tar.gz		nuttx-3.7.tar.gz		nuttx-7.16.tar.gz		nuttx-apps-12.6.0-RC0.tar.gz	nuttx-apps-6.12.tar.gz
nuttx-10.0.0-RC0.tar.gz		nuttx-3.8.tar.gz		nuttx-7.17.tar.gz		nuttx-apps-12.6.0-RC1.tar.gz	nuttx-apps-6.13.tar.gz
nuttx-10.0.0.tar.gz		nuttx-3.9.tar.gz		nuttx-7.18.tar.gz		nuttx-apps-12.6.0.tar.gz	nuttx-apps-6.14.tar.gz
nuttx-10.0.1.tar.gz		nuttx-4.0.tar.gz		nuttx-7.19.tar.gz		nuttx-apps-12.7.0-RC0.tar.gz	nuttx-apps-6.15.tar.gz
nuttx-10.1.0-RC0.tar.gz		nuttx-4.1.tar.gz		nuttx-7.2.tar.gz		nuttx-apps-12.7.0-RC1.tar.gz	nuttx-apps-6.16.tar.gz
nuttx-10.1.0-RC1.tar.gz		nuttx-4.10.tar.gz		nuttx-7.20.tar.gz		nuttx-apps-12.7.0.tar.gz	nuttx-apps-6.17.tar.gz
nuttx-10.1.0.tar.gz		nuttx-4.11.tar.gz		nuttx-7.21.tar.gz		nuttx-apps-12.8.0-RC0.tar.gz	nuttx-apps-6.18.tar.gz
nuttx-10.2.0-RC0.tar.gz		nuttx-4.12.tar.gz		nuttx-7.22.tar.gz		nuttx-apps-12.8.0.tar.gz	nuttx-apps-6.19.tar.gz
nuttx-10.2.0.tar.gz		nuttx-4.13.tar.gz		nuttx-7.23.tar.gz		nuttx-apps-12.9.0-RC0.tar.gz	nuttx-apps-6.2.tar.gz
nuttx-10.3.0-RC0.tar.gz		nuttx-4.14.tar.gz		nuttx-7.24.tar.gz		nuttx-apps-12.9.0-RC1.tar.gz	nuttx-apps-6.20.tar.gz
nuttx-10.3.0-RC1.tar.gz		nuttx-4.2.tar.gz		nuttx-7.25.tar.gz		nuttx-apps-12.9.0.tar.gz	nuttx-apps-6.21.tar.gz
nuttx-10.3.0-RC2.tar.gz		nuttx-4.3.tar.gz		nuttx-7.26.tar.gz		nuttx-apps-2.1.tar.gz		nuttx-apps-6.22.tar.gz
nuttx-10.3.0-RC3.tar.gz		nuttx-4.4.tar.gz		nuttx-7.27.tar.gz		nuttx-apps-2.2.tar.gz		nuttx-apps-6.23.tar.gz
nuttx-10.3.0-RC4.tar.gz		nuttx-4.5.tar.gz		nuttx-7.28.tar.gz		nuttx-apps-2.3.tar.gz		nuttx-apps-6.24.tar.gz
nuttx-10.3.0.tar.gz		nuttx-4.6.tar.gz		nuttx-7.29.tar.gz		nuttx-apps-2.4.tar.gz		nuttx-apps-6.25.tar.gz
nuttx-11.0.0-RC0.tar.gz		nuttx-4.7.tar.gz		nuttx-7.3.tar.gz		nuttx-apps-2.5.tar.gz		nuttx-apps-6.26.tar.gz
nuttx-11.0.0-RC1.tar.gz		nuttx-4.8.tar.gz		nuttx-7.30.tar.gz		nuttx-apps-2.6.tar.gz		nuttx-apps-6.27.tar.gz
nuttx-11.0.0-RC2.tar.gz		nuttx-4.9.tar.gz		nuttx-7.31.tar.gz		nuttx-apps-2.7.tar.gz		nuttx-apps-6.28.tar.gz
nuttx-11.0.0.tar.gz		nuttx-5.0.tar.gz		nuttx-7.4.tar.gz		nuttx-apps-2.8.tar.gz		nuttx-apps-6.29.tar.gz
nuttx-12.0.0-RC0.tar.gz		nuttx-5.1.tar.gz		nuttx-7.5.tar.gz		nuttx-apps-3.0.tar.gz		nuttx-apps-6.3.tar.gz
nuttx-12.0.0-RC1.tar.gz		nuttx-5.10.tar.gz		nuttx-7.6.tar.gz		nuttx-apps-3.1.tar.gz		nuttx-apps-6.30.tar.gz
nuttx-12.0.0.tar.gz		nuttx-5.11.tar.gz		nuttx-7.7.tar.gz		nuttx-apps-3.10.tar.gz		nuttx-apps-6.31.tar.gz
nuttx-12.1.0-RC0.tar.gz		nuttx-5.12.tar.gz		nuttx-7.8.tar.gz		nuttx-apps-3.11.tar.gz		nuttx-apps-6.32.tar.gz
nuttx-12.1.0.tar.gz		nuttx-5.13.tar.gz		nuttx-7.9.tar.gz		nuttx-apps-3.12.tar.gz		nuttx-apps-6.33.tar.gz
nuttx-12.10.0-RC0.tar.gz	nuttx-5.14.tar.gz		nuttx-8.1.tar.gz		nuttx-apps-3.13.tar.gz		nuttx-apps-6.4.tar.gz
nuttx-12.10.0.tar.gz		nuttx-5.15.tar.gz		nuttx-8.2.tar.gz		nuttx-apps-3.14.tar.gz		nuttx-apps-6.5.tar.gz
nuttx-12.11.0-RC0.tar.gz	nuttx-5.16.tar.gz		nuttx-9.0.0-RC0.tar.gz		nuttx-apps-3.15.tar.gz		nuttx-apps-6.6.tar.gz
nuttx-12.11.0-RC1.tar.gz	nuttx-5.17.tar.gz		nuttx-9.0.0-RC1.tar.gz		nuttx-apps-3.16.tar.gz		nuttx-apps-6.7.tar.gz
nuttx-12.11.0.tar.gz		nuttx-5.18.tar.gz		nuttx-9.0.0.tar.gz		nuttx-apps-3.17.tar.gz		nuttx-apps-6.8.tar.gz
nuttx-12.2.0-RC0.tar.gz		nuttx-5.19.tar.gz		nuttx-9.1.0-RC0.tar.gz		nuttx-apps-3.18.tar.gz		nuttx-apps-6.9.tar.gz
nuttx-12.2.0.tar.gz		nuttx-5.2.tar.gz		nuttx-9.1.0-RC1.tar.gz		nuttx-apps-3.19.tar.gz		nuttx-apps-7.1.tar.gz
nuttx-12.2.1-RC0.tar.gz		nuttx-5.3.tar.gz		nuttx-9.1.0-RC2.tar.gz		nuttx-apps-3.2.tar.gz		nuttx-apps-7.10.tar.gz
nuttx-12.2.1.tar.gz		nuttx-5.4.tar.gz		nuttx-9.1.0.tar.gz		nuttx-apps-3.3.tar.gz		nuttx-apps-7.11.tar.gz
nuttx-12.3.0-RC0.tar.gz		nuttx-5.5.tar.gz		nuttx-9.1.1-RC0.tar.gz		nuttx-apps-3.4.tar.gz		nuttx-apps-7.12.tar.gz
nuttx-12.3.0-RC1.tar.gz		nuttx-5.6.tar.gz		nuttx-9.1.1.tar.gz		nuttx-apps-3.5.tar.gz		nuttx-apps-7.13.tar.gz
nuttx-12.3.0.tar.gz		nuttx-5.7.tar.gz		nuttx-apps-1.0.tar.gz		nuttx-apps-3.6.1.tar.gz		nuttx-apps-7.14.tar.gz
nuttx-12.4.0-RC0.tar.gz		nuttx-5.8.tar.gz		nuttx-apps-1.1.tar.gz		nuttx-apps-3.6.tar.gz		nuttx-apps-7.15.tar.gz
nuttx-12.4.0.tar.gz		nuttx-5.9.tar.gz		nuttx-apps-1.2.tar.gz		nuttx-apps-3.7.tar.gz		nuttx-apps-7.16.tar.gz
nuttx-12.5.0-RC0.tar.gz		nuttx-6.0.tar.gz		nuttx-apps-10.0.0-RC0.tar.gz	nuttx-apps-3.8.tar.gz		nuttx-apps-7.17.tar.gz
nuttx-12.5.0.tar.gz		nuttx-6.1.tar.gz		nuttx-apps-10.0.0.tar.gz	nuttx-apps-3.9.tar.gz		nuttx-apps-7.18.tar.gz
nuttx-12.5.1-RC0.tar.gz		nuttx-6.10.tar.gz		nuttx-apps-10.0.1.tar.gz	nuttx-apps-4.0.tar.gz		nuttx-apps-7.19.tar.gz
nuttx-12.5.1.tar.gz		nuttx-6.11.tar.gz		nuttx-apps-10.1.0-RC0.tar.gz	nuttx-apps-4.1.tar.gz		nuttx-apps-7.2.tar.gz
nuttx-12.6.0-RC0.tar.gz		nuttx-6.12.tar.gz		nuttx-apps-10.1.0-RC1.tar.gz	nuttx-apps-4.10.tar.gz		nuttx-apps-7.20.tar.gz
nuttx-12.6.0-RC1.tar.gz		nuttx-6.13.tar.gz		nuttx-apps-10.1.0.tar.gz	nuttx-apps-4.11.tar.gz		nuttx-apps-7.21.tar.gz
nuttx-12.6.0.tar.gz		nuttx-6.14.tar.gz		nuttx-apps-10.2.0-RC0.tar.gz	nuttx-apps-4.12.tar.gz		nuttx-apps-7.22.tar.gz
nuttx-12.7.0-RC0.tar.gz		nuttx-6.15.tar.gz		nuttx-apps-10.2.0.tar.gz	nuttx-apps-4.13.tar.gz		nuttx-apps-7.23.tar.gz
nuttx-12.7.0-RC1.tar.gz		nuttx-6.16.tar.gz		nuttx-apps-10.3.0-RC0.tar.gz	nuttx-apps-4.14.tar.gz		nuttx-apps-7.24.tar.gz
nuttx-12.7.0.tar.gz		nuttx-6.17.tar.gz		nuttx-apps-10.3.0-RC1.tar.gz	nuttx-apps-4.2.tar.gz		nuttx-apps-7.25.tar.gz
nuttx-12.8.0-RC0.tar.gz		nuttx-6.18.tar.gz		nuttx-apps-10.3.0-RC2.tar.gz	nuttx-apps-4.3.tar.gz		nuttx-apps-7.26.tar.gz
nuttx-12.8.0.tar.gz		nuttx-6.19.tar.gz		nuttx-apps-10.3.0-RC3.tar.gz	nuttx-apps-4.4.tar.gz		nuttx-apps-7.27.tar.gz
nuttx-12.9.0-RC0.tar.gz		nuttx-6.2.tar.gz		nuttx-apps-10.3.0-RC4.tar.gz	nuttx-apps-4.5.tar.gz		nuttx-apps-7.28.tar.gz
nuttx-12.9.0-RC1.tar.gz		nuttx-6.20.tar.gz		nuttx-apps-10.3.0.tar.gz	nuttx-apps-4.6.tar.gz		nuttx-apps-7.29.tar.gz
nuttx-12.9.0.tar.gz		nuttx-6.21.tar.gz		nuttx-apps-11.0.0-RC0.tar.gz	nuttx-apps-4.7.tar.gz		nuttx-apps-7.3.tar.gz
nuttx-2.1.tar.gz		nuttx-6.22.tar.gz		nuttx-apps-11.0.0-RC1.tar.gz	nuttx-apps-4.8.tar.gz		nuttx-apps-7.30.tar.gz
nuttx-2.2.tar.gz		nuttx-6.23.tar.gz		nuttx-apps-11.0.0-RC2.tar.gz	nuttx-apps-4.9.tar.gz		nuttx-apps-7.31.tar.gz
nuttx-2.3.tar.gz		nuttx-6.24.tar.gz		nuttx-apps-11.0.0.tar.gz	nuttx-apps-5.0.tar.gz		nuttx-apps-7.4.tar.gz
nuttx-2.4.tar.gz		nuttx-6.25.tar.gz		nuttx-apps-12.0.0-RC0.tar.gz	nuttx-apps-5.1.tar.gz		nuttx-apps-7.5.tar.gz
nuttx-2.5.tar.gz		nuttx-6.26.tar.gz		nuttx-apps-12.0.0-RC1.tar.gz	nuttx-apps-5.10.tar.gz		nuttx-apps-7.6.tar.gz
nuttx-2.6.tar.gz		nuttx-6.27.tar.gz		nuttx-apps-12.0.0.tar.gz	nuttx-apps-5.11.tar.gz		nuttx-apps-7.7.tar.gz
nuttx-2.7.tar.gz		nuttx-6.28.tar.gz		nuttx-apps-12.1.0-RC0.tar.gz	nuttx-apps-5.12.tar.gz		nuttx-apps-7.8.tar.gz
nuttx-2.8.tar.gz		nuttx-6.29.tar.gz		nuttx-apps-12.1.0.tar.gz	nuttx-apps-5.13.tar.gz		nuttx-apps-7.9.tar.gz
nuttx-3.0.tar.gz		nuttx-6.3.tar.gz		nuttx-apps-12.10.0-RC0.tar.gz	nuttx-apps-5.14.tar.gz		nuttx-apps-8.1.tar.gz
nuttx-3.1.tar.gz		nuttx-6.30.tar.gz		nuttx-apps-12.10.0.tar.gz	nuttx-apps-5.15.tar.gz		nuttx-apps-8.2.tar.gz
nuttx-3.10.tar.gz		nuttx-6.31.tar.gz		nuttx-apps-12.11.0-RC0.tar.gz	nuttx-apps-5.16.tar.gz		nuttx-apps-9.0.0-RC0.tar.gz
nuttx-3.11.tar.gz		nuttx-6.32.tar.gz		nuttx-apps-12.11.0-RC1.tar.gz	nuttx-apps-5.17.tar.gz		nuttx-apps-9.0.0-RC1.tar.gz
nuttx-3.12.tar.gz		nuttx-6.33.tar.gz		nuttx-apps-12.11.0.tar.gz	nuttx-apps-5.18.tar.gz		nuttx-apps-9.0.0.tar.gz
nuttx-3.13.tar.gz		nuttx-6.4.tar.gz		nuttx-apps-12.2.0-RC0.tar.gz	nuttx-apps-5.19.tar.gz		nuttx-apps-9.1.0-RC0.tar.gz
nuttx-3.14.tar.gz		nuttx-6.5.tar.gz		nuttx-apps-12.2.0.tar.gz	nuttx-apps-5.2.tar.gz		nuttx-apps-9.1.0-RC1.tar.gz
nuttx-3.15.tar.gz		nuttx-6.6.tar.gz		nuttx-apps-12.2.1-RC0.tar.gz	nuttx-apps-5.3.tar.gz		nuttx-apps-9.1.0-RC2.tar.gz
nuttx-3.16.tar.gz		nuttx-6.7.tar.gz		nuttx-apps-12.2.1.tar.gz	nuttx-apps-5.4.tar.gz		nuttx-apps-9.1.0.tar.gz
nuttx-3.17.tar.gz		nuttx-6.8.tar.gz		nuttx-apps-12.3.0-RC0.tar.gz	nuttx-apps-5.5.tar.gz		nuttx-apps-9.1.1-RC0.tar.gz
nuttx-3.18.tar.gz		nuttx-6.9.tar.gz		nuttx-apps-12.3.0-RC1.tar.gz	nuttx-apps-5.6.tar.gz		nuttx-apps-9.1.1.tar.gz
nuttx-3.19.tar.gz		nuttx-7.1.tar.gz		nuttx-apps-12.3.0.tar.gz	nuttx-apps-5.7.tar.gz		wget-1765937260.log
nuttx-3.2.tar.gz		nuttx-7.10.tar.gz		nuttx-apps-12.4.0-RC0.tar.gz	nuttx-apps-5.8.tar.gz		
nuttx-3.3.tar.gz		nuttx-7.11.tar.gz		nuttx-apps-12.4.0.tar.gz	nuttx-apps-5.9.tar.gz
nuttx-3.4.tar.gz		nuttx-7.12.tar.gz		nuttx-apps-12.5.0-RC0.tar.gz	nuttx-apps-6.0.tar.gz
nuttx-3.5.tar.gz		nuttx-7.13.tar.gz		nuttx-apps-12.5.0.tar.gz	nuttx-apps-6.1.tar.gz

% du -h ../../nuttx-packages
4,2G	../../nuttx-packages
```

Documentation build:

```
(Documentation) % gmake html
Removing everything under '_build'...
Running Sphinx v6.2.1
myst v3.0.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
Tags updated
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 1380 source files that are out of date
updating environment: [new config] 1380 added, 0 changed, 0 removed
reading sources... [100%] substitutions
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] substitutions
generating indices... genindex done
writing additional pages... search done
copying images... [100%] _static/images/menuconfig-debug.png
copying downloadable files... [100%] platforms/xtensa/esp32s2/boards/esp32s2-saola-1/tone.wav
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.
```