### PR TITLE
libs/libc/misc: backtrace needs init lock before use

### DIFF
--- a/libs/libc/misc/lib_backtrace.c
+++ b/libs/libc/misc/lib_backtrace.c
@@ -134,6 +134,7 @@ static void backtrace_init(void)
   size_t i;
 
   sq_init(&bp->freelist);
+  spin_lock_init(&bp->lock);
   memset(bp->bucket, -1, sizeof(bp->bucket));
   for (i = 0; i < nitems(bp->pool); i++)
     {


### PR DESCRIPTION

## Summary

need init lock before use

## Impact

lib/backtrace

## Testing

ostest
