### PR TITLE
bug fix pic:elf do not generate unwind table

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -552,6 +552,11 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS)-fvisibility=hidden -mlong-calls
 
+ifeq ($(CONFIG_UNWINDER_ARM),y)
+  CELFFLAGS += -fno-unwind-tables -fno-asynchronous-unwind-tables
+  CXXELFFLAGS += -fno-unwind-tables -fno-asynchronous-unwind-tables
+endif
+
 ifeq ($(CONFIG_PIC),y)
   CFLAGS += --fixed-r10
   CELFFLAGS += $(PICFLAGS) -mpic-register=r10


### PR DESCRIPTION
## Summary

Nuttx's ELF dynamic loading cannot yet parse ARM exidx, so do not generate it yet.

modlib_read: Read 64 bytes from offset 192665
modlib_symvalue: ERROR: SHN_UNDEF: Exported symbol "__gnu_Unwind_Find_exidx" not found
modlib_relocate: ERROR: Section 2 reloc 12: Failed to get value of symbol[246]: -2
elf_loadbinary: Failed to bind symbols program binary: -2
builtin_loadbinary: Loading file: /pic/hello

## Impact

ELF compilation on ARM

## Testing

mps3-an546 build with pic, load hello elf.
