### PR TITLE
mm/mempool: fix misjudged condition of interrupt memory release

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -428,7 +428,6 @@ retry:
 void mempool_release(FAR struct mempool_s *pool, FAR void *blk)
 {
   irqstate_t flags = spin_lock_irqsave(&pool->lock);
-  size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
 #if CONFIG_MM_BACKTRACE >= 0
   FAR struct mempool_backtrace_s *buf =
     (FAR struct mempool_backtrace_s *)((FAR char *)blk + pool->blocksize);
@@ -446,10 +445,10 @@ void mempool_release(FAR struct mempool_s *pool, FAR void *blk)
   memset(blk, MM_FREE_MAGIC, pool->blocksize);
 #endif
 
-  if (pool->interruptsize > blocksize)
+  if (pool->ibase)
     {
       if ((FAR char *)blk >= pool->ibase &&
-          (FAR char *)blk < pool->ibase + pool->interruptsize - blocksize)
+          (FAR char *)blk < pool->ibase + pool->interruptsize)
         {
           sq_addlast(blk, &pool->iqueue);
         }


### PR DESCRIPTION
## Summary

mempool bugfix
We don't need to subtract the block size; we only need to determine if it's within the interrupt memory range.

## Impact

mempool

## Testing

ostest with mempool

mps3-an547:nsh with mempoll run heap test and ostest

```
➜ qemu-system-arm -M mps3-an547 -m 2G  -device loader,file=nuttx.hex -gdb tcp::1133 -nographic
ERROR: Failed to mount romfs at /mnt: -22

NuttShell (NSH) NuttX-12.7.2-vela
nsh>
nsh>
nsh>
nsh> ls
/:
 dev/
 proc/
 tmp/
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=4

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        5
mxordblk 7ffffff0 7ffffff0
uordblks     9300     9300
fordblks 801f25d0 801f25d0

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        5
mxordblk 7ffffff0 7ffffff0
uordblks     9300     9300
fordblks 801f25d0 801f25d0

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        5
mxordblk 7ffffff0 7ffffff0
uordblks     9300     9300
fordblks 801f25d0 801f25d0
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        5
mxordblk 7ffffff0 7ffffff0
uordblks     9300     92e0
fordblks 801f25d0 801f25f0
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        5
mxordblk 7ffffff0 7ffffff0
uordblks     92e0     9260
fordblks 801f25f0 801f2670

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        6
mxordblk 7ffffff0 7ffffff0
uordblks     9260     9278
fordblks 801f2670 801f2658

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         6        6
mxordblk 7ffffff0 7ffffff0
uordblks     9278     9278
fordblks 801f2658 801f2658

user_main: FPU test
Starting task FPU#1
fpu_test: Started task FPU#1 at PID=5
FPU#1: pass 1
Starting task FPU#2
fpu_test: Started task FPU#2 at PID=6
FPU#2: pass 1
FPU#1: pass 2
FPU#2: pass 2
FPU#1: pass 3
FPU#2: pass 3
FPU#1: pass 4
FPU#2: pass 4
FPU#1: pass 5
FPU#2: pass 5
FPU#1: pass 6
FPU#2: pass 6
FPU#1: pass 7
FPU#2: pass 7
FPU#1: pass 8
FPU#2: pass 8
FPU#1: pass 9
FPU#2: pass 9
FPU#1: pass 10
FPU#2: pass 10
FPU#1: pass 11
FPU#2: pass 11
FPU#1: pass 12
FPU#2: pass 12
FPU#1: pass 13
FPU#2: pass 13
FPU#1: pass 14
FPU#2: pass 14
FPU#1: pass 15
FPU#2: pass 15
FPU#1: pass 16
FPU#2: pass 16
FPU#1: Succeeded
FPU#2: Succeeded
fpu_test: Returning

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         6        6
mxordblk 7ffffff0 7ffffff0
uordblks     9278     b288
fordblks 801f2658 801f0648

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=7
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started restart_main at PID=7
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         6        6
mxordblk 7ffffff0 7ffffff0
uordblks     b288     b640
fordblks 801f0648 801f0290

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=8
waitpid_start_child: Started waitpid_main at PID=9
waitpid_start_child: Started waitpid_main at PID=10
waitpid_test: Waiting for PID=8 with waitpid()
waitpid_main: PID 8 Started
waitpid_main: PID 9 Started
waitpid_main: PID 10 Started
waitpid_main: PID 8 exitting with result=14
waitpid_test: PID 8 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=10 with waitpid()
waitpid_main: PID 9 exitting with result=14
waitpid_main: PID 10 exitting with result=14
waitpid_last: PASS: PID 10 waitpid succeeded with stat_loc=0e00

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         6        8
mxordblk 7ffffff0 7ffffff0
uordblks     b640     f650
fordblks 801f0290 801ec280

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
                Thread1 Thread2
        Moved Loops     32      32
        Moved Errors    0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        7
mxordblk 7ffffff0 7ffffff0
uordblks     f650     b2e0
fordblks 801ec280 801f05f0

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     b2e0     a2d8
fordblks 801f05f0 801f15f8

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     a2d8     b2d8
fordblks 801f15f8 801f05f8

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     b2d8     b2d8
fordblks 801f05f8 801f05f8

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 128
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     b2d8     c2e8
fordblks 801f05f8 801ef5e8

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1682380845 sec, 988993000 nsec)
AFTER:  (1682380847 sec, 990016000 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1682380847 sec, 991152000 nsec)
AFTER:  (1682380848 sec, 992023000 nsec)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     c2e8     a2d8
fordblks 801ef5e8 801f15f8

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        8
mxordblk 7ffffff0 7ffffff0
uordblks     a2d8     a2d8
fordblks 801f15f8 801f15f8

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=31
pthread_exit_main 31: Starting pthread_exit_thread
pthread_exit_main 31: Sleeping for 5 seconds
pthread_exit_thread 37: Sleeping for 10 second
pthread_exit_main 31: Calling pthread_exit()
pthread_exit_thread 37: Still running...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        7
mxordblk 7ffffff0 7ffffff0
uordblks     a2d8     c3c0
fordblks 801f15f8 801ef510

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 37: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        8
mxordblk 7ffffff0 7ffffff0
uordblks     c3c0     a2e8
fordblks 801ef510 801f15e8

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        7
mxordblk 7ffffff0 7ffffff0
uordblks     a2e8     92e0
fordblks 801f15e8 801f25f0

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        7
mxordblk 7ffffff0 7ffffff0
uordblks     92e0     a2e8
fordblks 801f25f0 801f15e8

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         7        8
mxordblk 7ffffff0 7ffffff0
uordblks     a2e8     d368
fordblks 801f15e8 801ee568

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     d368     b360
fordblks 801ee568 801f0570

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     b360     b360
fordblks 801f0570 801f0570

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=54
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=54 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     b360     b370
fordblks 801f0570 801f0560

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=55
signest_test: Starting interfering task at priority 102
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=56
signest_test: Simple case:
  Total signalled 1240  Odd=620 Even=620
  Total handled   1240  Odd=620 Even=620
  Total nested    0    Odd=0   Even=0
signest_test: With task locking
  Total signalled 2480  Odd=1240 Even=1240
  Total handled   2480  Odd=1240 Even=1240
  Total nested    0    Odd=0   Even=0
signest_test: With intefering thread
  Total signalled 3720  Odd=1860 Even=1860
  Total handled   3720  Odd=1860 Even=1860
  Total nested    0    Odd=0   Even=0
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     b370     b3d0
fordblks 801f0560 801f0500

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741819
wdtest_recursive 1000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
wdog_test end...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     b3d0     d3e8
fordblks 801f0500 801ee4e8

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=4
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=5
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     d3e8     d3e8
fordblks 801ee4e8 801ee4e8

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
         First get_primes_thread: 61
rr_test: Starting second get_primes_thread
         Second get_primes_thread: 62
rr_test: Waiting for threads to complete -- this should take awhile
         If RR scheduling is working, they should start and complete at
         about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        8
mxordblk 7ffffff0 7ffffff0
uordblks     d3e8     b3d8
fordblks 801ee4e8 801f04f8

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_func: Thread 3 done
barrier_test: Thread 0 completed with result=0
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_test: Thread 3 completed with result=0
barrier_func: Thread 4 done
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         8        9
mxordblk 7ffffff0 7ffffff0
uordblks     b3d8     a3d0
fordblks 801f04f8 801f1500

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         9        9
mxordblk 7ffffff0 7ffffff0
uordblks     a3d0     a3d0
fordblks 801f1500 801f1500

user_main: vfork() test
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena    801fb8d0 801fb8d0
ordblks         5        8
mxordblk 7ffffff0 7ffffff0
uordblks     9300     b3d0
fordblks 801f25d0 801f0500
user_main: Exiting
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
nsh> heap
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 8
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28448
       Total non-inuse space             = 2149534128
(0)Allocating 5024 bytes
(0)Memory allocated at 0x100ef88
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 8
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 33464
       Total non-inuse space             = 2149529112
(1)Allocating 124336 bytes
(1)Memory allocated at 0x1017fd8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 8
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 157792
       Total non-inuse space             = 2149404784
(2)Allocating 5704 bytes
(2)Memory allocated at 0x1010320
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 8
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 163488
       Total non-inuse space             = 2149399088
(3)Allocating 80 bytes
(3)Memory allocated at 0x1037f60
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 163592
       Total non-inuse space             = 2149398984
(4)Allocating 2760 bytes
(4)Memory allocated at 0x1016360
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 166344
       Total non-inuse space             = 2149396232
(5)Allocating 16 bytes
(5)Memory allocated at 0x100cdd0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 166360
       Total non-inuse space             = 2149396216
(6)Allocating 616 bytes
(6)Memory allocated at 0x1036580
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 166968
       Total non-inuse space             = 2149395608
(7)Allocating 40 bytes
(7)Memory allocated at 0x100a390
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 167000
       Total non-inuse space             = 2149395576
(8)Allocating 1544 bytes
(8)Memory allocated at 0x10367e0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 168544
       Total non-inuse space             = 2149394032
(9)Allocating 976 bytes
(9)Memory allocated at 0x1011960
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 169512
       Total non-inuse space             = 2149393064
(10)Allocating 69192 bytes
(10)Memory allocated at 0x1037fb8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 238696
       Total non-inuse space             = 2149323880
(11)Allocating 912 bytes
(11)Memory allocated at 0x1011d28
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 239608
       Total non-inuse space             = 2149322968
(12)Allocating 6760 bytes
(12)Memory allocated at 0x1048df8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 246368
       Total non-inuse space             = 2149316208
(13)Allocating 1656 bytes
(13)Memory allocated at 0x10120b8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 248024
       Total non-inuse space             = 2149314552
(14)Allocating 1032 bytes
(14)Memory allocated at 0x1012730
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 249056
       Total non-inuse space             = 2149313520
(15)Allocating 16 bytes
(15)Memory allocated at 0x100cdc0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 249072
       Total non-inuse space             = 2149313504
(16)Allocating 208 bytes
(16)Memory allocated at 0x100ede0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 249280
       Total non-inuse space             = 2149313296
(17)Allocating 488 bytes
(17)Memory allocated at 0x1036de8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 249768
       Total non-inuse space             = 2149312808
(18)Allocating 2024 bytes
(18)Memory allocated at 0x104a860
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 251784
       Total non-inuse space             = 2149310792
(19)Allocating 2600 bytes
(19)Memory allocated at 0x104b040
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 254384
       Total non-inuse space             = 2149308192
(20)Allocating 232 bytes
(20)Memory allocated at 0x10141d0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 254608
       Total non-inuse space             = 2149307968
(21)Allocating 984 bytes
(21)Memory allocated at 0x1012b38
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 255584
       Total non-inuse space             = 2149306992
(22)Allocating 80 bytes
(22)Memory allocated at 0x1037f10
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 255664
       Total non-inuse space             = 2149306912
(23)Allocating 864 bytes
(23)Memory allocated at 0x104ba68
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 256520
       Total non-inuse space             = 2149306056
(24)Allocating 10264 bytes
(24)Memory allocated at 0x104bdc0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 266784
       Total non-inuse space             = 2149295792
(25)Allocating 24 bytes
(25)Memory allocated at 0x100cdb0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 266800
       Total non-inuse space             = 2149295776
(26)Allocating 656 bytes
(26)Memory allocated at 0x104e5d8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 267456
       Total non-inuse space             = 2149295120
(27)Allocating 9944 bytes
(27)Memory allocated at 0x104e868
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 277392
       Total non-inuse space             = 2149285184
(28)Allocating 4744 bytes
(28)Memory allocated at 0x1050f38
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 282128
       Total non-inuse space             = 2149280448
(29)Allocating 784 bytes
(29)Memory allocated at 0x10521b8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 282912
       Total non-inuse space             = 2149279664
(30)Allocating 120 bytes
(30)Memory allocated at 0x1017e80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 283024
       Total non-inuse space             = 2149279552
(31)Allocating 81656 bytes
(31)Memory allocated at 0x10524c8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 364680
       Total non-inuse space             = 2149197896
(0)Re-allocating at 0x1011960 from 962 to 963 bytes
(0)Memory re-allocated at 0x1011960
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 364680
       Total non-inuse space             = 2149197896
(1)Re-allocating at 0x1036de8 from 480 to 4346 bytes
(1)Memory re-allocated at 0x10663c0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 368544
       Total non-inuse space             = 2149194032
(2)Re-allocating at 0x1037f10 from 68 to 592 bytes
(2)Memory re-allocated at 0x10674c0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 9
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 369064
       Total non-inuse space             = 2149193512
(3)Re-allocating at 0x10524c8 from 81647 to 4734 bytes
(3)Memory re-allocated at 0x10524c8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 10
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 292152
       Total non-inuse space             = 2149270424
(4)Re-allocating at 0x1012b38 from 969 to 812 bytes
(4)Memory re-allocated at 0x1012b38
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 10
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 291992
       Total non-inuse space             = 2149270584
(5)Re-allocating at 0x1017fd8 from 124321 to 6 bytes
(5)Memory re-allocated at 0x100cda0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 11
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 167680
       Total non-inuse space             = 2149394896
(6)Re-allocating at 0x100ede0 from 194 to 30421 bytes
(6)Memory re-allocated at 0x1053750
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 11
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 197904
       Total non-inuse space             = 2149364672
(7)Re-allocating at 0x104bdc0 from 10254 to 511 bytes
(7)Memory re-allocated at 0x104bdc0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 12
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 188160
       Total non-inuse space             = 2149374416
(8)Re-allocating at 0x100ef88 from 5011 to 9172 bytes
(8)Memory re-allocated at 0x104bfc8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 192320
       Total non-inuse space             = 2149370256
(9)Re-allocating at 0x1036580 from 601 to 42 bytes
(9)Memory re-allocated at 0x1009c40
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 191760
       Total non-inuse space             = 2149370816
(10)Re-allocating at 0x1012730 from 1024 to 18 bytes
(10)Memory re-allocated at 0x100a370
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 190760
       Total non-inuse space             = 2149371816
(11)Re-allocating at 0x1050f38 from 4732 to 8663 bytes
(11)Memory re-allocated at 0x105ae30
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 194696
       Total non-inuse space             = 2149367880
(12)Re-allocating at 0x104b040 from 2590 to 1666 bytes
(12)Memory re-allocated at 0x104b040
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 193768
       Total non-inuse space             = 2149368808
(13)Re-allocating at 0x104ba68 from 852 to 5040 bytes
(13)Memory re-allocated at 0x105d010
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 197960
       Total non-inuse space             = 2149364616
(14)Re-allocating at 0x1017e80 from 111 to 11666 bytes
(14)Memory re-allocated at 0x105e3c8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 209520
       Total non-inuse space             = 2149353056
(15)Re-allocating at 0x104e5d8 from 646 to 59139 bytes
(15)Memory re-allocated at 0x1017fd8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 268008
       Total non-inuse space             = 2149294568
(16)Re-allocating at 0x100cdc0 from 3 to 1412 bytes
(16)Memory re-allocated at 0x104b6c8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 269408
       Total non-inuse space             = 2149293168
(17)Re-allocating at 0x100a390 from 28 to 91255 bytes
(17)Memory re-allocated at 0x1067718
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 360640
       Total non-inuse space             = 2149201936
(18)Re-allocating at 0x10120b8 from 1646 to 221 bytes
(18)Memory re-allocated at 0x1014390
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 359208
       Total non-inuse space             = 2149203368
(19)Re-allocating at 0x1037f60 from 70 to 416 bytes
(19)Memory re-allocated at 0x1016e20
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 359552
       Total non-inuse space             = 2149203024
(20)Re-allocating at 0x10141d0 from 222 to 9374 bytes
(20)Memory re-allocated at 0x1061160
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 368712
       Total non-inuse space             = 2149193864
(21)Re-allocating at 0x100cdd0 from 7 to 4 bytes
(21)Memory re-allocated at 0x100cd90
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 368712
       Total non-inuse space             = 2149193864
(22)Re-allocating at 0x1010320 from 5692 to 123 bytes
(22)Memory re-allocated at 0x1027f10
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 363168
       Total non-inuse space             = 2149199408
(23)Re-allocating at 0x1037fb8 from 69179 to 7830 bytes
(23)Memory re-allocated at 0x1037fb8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 301824
       Total non-inuse space             = 2149260752
(24)Re-allocating at 0x1016360 from 2746 to 1990 bytes
(24)Memory re-allocated at 0x1016360
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 301072
       Total non-inuse space             = 2149261504
(25)Re-allocating at 0x1011d28 from 901 to 28 bytes
(25)Memory re-allocated at 0x100a350
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 300192
       Total non-inuse space             = 2149262384
(26)Re-allocating at 0x104a860 from 2011 to 229 bytes
(26)Memory re-allocated at 0x1028e20
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 298440
       Total non-inuse space             = 2149264136
(27)Re-allocating at 0x10521b8 from 776 to 4088 bytes
(27)Memory re-allocated at 0x10514c8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 301752
       Total non-inuse space             = 2149260824
(28)Re-allocating at 0x100cdb0 from 12 to 3088 bytes
(28)Memory re-allocated at 0x1011d28
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 304832
       Total non-inuse space             = 2149257744
(29)Re-allocating at 0x10367e0 from 1536 to 168 bytes
(29)Memory re-allocated at 0x1029f30
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 303488
       Total non-inuse space             = 2149259088
(30)Re-allocating at 0x1048df8 from 6750 to 11 bytes
(30)Memory re-allocated at 0x100cd80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 296744
       Total non-inuse space             = 2149265832
(31)Re-allocating at 0x104e868 from 9932 to 3723 bytes
(31)Memory re-allocated at 0x104e868
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 290536
       Total non-inuse space             = 2149272040
(0)Releasing memory at 0x1061160 (size=9374 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 281152
       Total non-inuse space             = 2149281424
(1)Releasing memory at 0x1067718 (size=91255 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 189888
       Total non-inuse space             = 2149372688
(2)Releasing memory at 0x1027f10 (size=123 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 189760
       Total non-inuse space             = 2149372816
(3)Releasing memory at 0x100a350 (size=28 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 189728
       Total non-inuse space             = 2149372848
(4)Releasing memory at 0x1037fb8 (size=7830 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 181888
       Total non-inuse space             = 2149380688
(5)Releasing memory at 0x10524c8 (size=4734 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 177144
       Total non-inuse space             = 2149385432
(6)Releasing memory at 0x1012b38 (size=812 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 176328
       Total non-inuse space             = 2149386248
(7)Releasing memory at 0x100cda0 (size=6 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 176312
       Total non-inuse space             = 2149386264
(8)Releasing memory at 0x10674c0 (size=592 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 175712
       Total non-inuse space             = 2149386864
(9)Releasing memory at 0x1028e20 (size=229 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 175472
       Total non-inuse space             = 2149387104
(10)Releasing memory at 0x104bdc0 (size=511 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 174952
       Total non-inuse space             = 2149387624
(11)Releasing memory at 0x104bfc8 (size=9172 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 165776
       Total non-inuse space             = 2149396800
(12)Releasing memory at 0x1014390 (size=221 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 165552
       Total non-inuse space             = 2149397024
(13)Releasing memory at 0x104b6c8 (size=1412 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 164136
       Total non-inuse space             = 2149398440
(14)Releasing memory at 0x1053750 (size=30421 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 133704
       Total non-inuse space             = 2149428872
(15)Releasing memory at 0x1011d28 (size=3088 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 130608
       Total non-inuse space             = 2149431968
(16)Releasing memory at 0x100cd90 (size=4 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 130592
       Total non-inuse space             = 2149431984
(17)Releasing memory at 0x100cd80 (size=11 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 130576
       Total non-inuse space             = 2149432000
(18)Releasing memory at 0x10663c0 (size=4346 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 126224
       Total non-inuse space             = 2149436352
(19)Releasing memory at 0x1029f30 (size=168 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 126048
       Total non-inuse space             = 2149436528
(20)Releasing memory at 0x100a370 (size=18 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 126016
       Total non-inuse space             = 2149436560
(21)Releasing memory at 0x1016e20 (size=416 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 125592
       Total non-inuse space             = 2149436984
(22)Releasing memory at 0x1009c40 (size=42 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 125544
       Total non-inuse space             = 2149437032
(23)Releasing memory at 0x1017fd8 (size=59139 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 66400
       Total non-inuse space             = 2149496176
(24)Releasing memory at 0x1016360 (size=1990 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 64400
       Total non-inuse space             = 2149498176
(25)Releasing memory at 0x105d010 (size=5040 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 59352
       Total non-inuse space             = 2149503224
(26)Releasing memory at 0x1011960 (size=963 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 58384
       Total non-inuse space             = 2149504192
(27)Releasing memory at 0x104b040 (size=1666 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 56712
       Total non-inuse space             = 2149505864
(28)Releasing memory at 0x105ae30 (size=8663 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 48040
       Total non-inuse space             = 2149514536
(29)Releasing memory at 0x104e868 (size=3723 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 44312
       Total non-inuse space             = 2149518264
(30)Releasing memory at 0x10514c8 (size=4088 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 40216
       Total non-inuse space             = 2149522360
(31)Releasing memory at 0x105e3c8 (size=11666 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 12
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28544
       Total non-inuse space             = 2149534032
(0)Allocating 962 bytes aligned to 0x00000080
(0)Memory allocated at 0x1016380
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29512
       Total non-inuse space             = 2149533064
(1)Allocating 480 bytes aligned to 0x00000800
(1)Memory allocated at 0x100f000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30000
       Total non-inuse space             = 2149532576
(2)Allocating 68 bytes aligned to 0x00020000
(2)Memory allocated at 0x1040000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30072
       Total non-inuse space             = 2149532504
(3)Allocating 81647 bytes aligned to 0x00002000
(3)Memory allocated at 0x1042000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 111728
       Total non-inuse space             = 2149450848
(4)Allocating 969 bytes aligned to 0x00000020
(4)Memory allocated at 0x1016760
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 112704
       Total non-inuse space             = 2149449872
(5)Allocating 124321 bytes aligned to 0x00008000
(5)Memory allocated at 0x1058000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 237032
       Total non-inuse space             = 2149325544
(6)Allocating 194 bytes aligned to 0x00004000
(6)Memory allocated at 0x102c000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 237232
       Total non-inuse space             = 2149325344
(7)Allocating 10254 bytes aligned to 0x00040000
(7)Memory allocated at 0x1080000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 247496
       Total non-inuse space             = 2149315080
(8)Allocating 5011 bytes aligned to 0x00000200
(8)Memory allocated at 0x1040200
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 252512
       Total non-inuse space             = 2149310064
(9)Allocating 601 bytes aligned to 0x00001000
(9)Memory allocated at 0x1010000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 22
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 253120
       Total non-inuse space             = 2149309456
(10)Allocating 1024 bytes aligned to 0x00010000
(10)Memory allocated at 0x1090000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 23
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 254152
       Total non-inuse space             = 2149308424
(11)Allocating 4732 bytes aligned to 0x00000008
(11)Memory allocated at 0x1029fe8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 23
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 258888
       Total non-inuse space             = 2149303688
(12)Allocating 2590 bytes aligned to 0x00000040
(12)Memory allocated at 0x102b280
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 24
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 261488
       Total non-inuse space             = 2149301088
(13)Allocating 852 bytes aligned to 0x00000400
(13)Memory allocated at 0x100f400
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 25
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 262344
       Total non-inuse space             = 2149300232
(14)Allocating 111 bytes aligned to 0x00000010
(14)Memory allocated at 0x1027e90
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 25
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 262472
       Total non-inuse space             = 2149300104
(15)Allocating 646 bytes aligned to 0x00000004
(15)Memory allocated at 0x102bca8
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 25
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 263128
       Total non-inuse space             = 2149299448
(0)Allocating 3 bytes aligned to 0x00000080
(0)Memory allocated at 0x1013c00
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 25
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 263272
       Total non-inuse space             = 2149299304
(1)Allocating 28 bytes aligned to 0x00000800
(1)Memory allocated at 0x1056000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 26
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 263304
       Total non-inuse space             = 2149299272
(2)Allocating 1646 bytes aligned to 0x00020000
(2)Memory allocated at 0x10a0000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 27
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 264960
       Total non-inuse space             = 2149297616
(3)Allocating 70 bytes aligned to 0x00002000
(3)Memory allocated at 0x1038000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 28
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 265040
       Total non-inuse space             = 2149297536
(4)Allocating 222 bytes aligned to 0x00000020
(4)Memory allocated at 0x1039e20
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 29
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 265320
       Total non-inuse space             = 2149297256
(5)Allocating 7 bytes aligned to 0x00008000
(5)Memory allocated at 0x10a8000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 30
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 265336
       Total non-inuse space             = 2149297240
(6)Allocating 5692 bytes aligned to 0x00004000
(6)Memory allocated at 0x1078000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 31
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 271032
       Total non-inuse space             = 2149291544
(7)Allocating 69179 bytes aligned to 0x00040000
(7)Memory allocated at 0x10c0000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 32
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 340216
       Total non-inuse space             = 2149222360
(8)Allocating 2746 bytes aligned to 0x00000200
(8)Memory allocated at 0x1038200
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 33
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 342968
       Total non-inuse space             = 2149219608
(9)Allocating 901 bytes aligned to 0x00001000
(9)Memory allocated at 0x1011000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 34
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 343880
       Total non-inuse space             = 2149218696
(10)Allocating 2011 bytes aligned to 0x00010000
(10)Memory allocated at 0x10e0000
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 35
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 345896
       Total non-inuse space             = 2149216680
(11)Allocating 776 bytes aligned to 0x00000008
(11)Memory allocated at 0x1038cc0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 35
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 346680
       Total non-inuse space             = 2149215896
(12)Allocating 12 bytes aligned to 0x00000040
(12)Memory allocated at 0x1037ec0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 35
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 346760
       Total non-inuse space             = 2149215816
(13)Allocating 1536 bytes aligned to 0x00000400
(13)Memory allocated at 0x1076800
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 36
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 348304
       Total non-inuse space             = 2149214272
(14)Allocating 6750 bytes aligned to 0x00000010
(14)Memory allocated at 0x1011390
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 36
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 355064
       Total non-inuse space             = 2149207512
(15)Allocating 9932 bytes aligned to 0x00000004
(15)Memory allocated at 0x1039f18
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 36
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 365000
       Total non-inuse space             = 2149197576
(0)Releasing memory at 0x1040200 (size=5011 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 35
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 359984
       Total non-inuse space             = 2149202592
(1)Releasing memory at 0x1058000 (size=124321 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 34
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 235656
       Total non-inuse space             = 2149326920
(2)Releasing memory at 0x1078000 (size=5692 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 33
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 229960
       Total non-inuse space             = 2149332616
(3)Releasing memory at 0x1038000 (size=70 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 32
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 229880
       Total non-inuse space             = 2149332696
(4)Releasing memory at 0x1038200 (size=2746 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 32
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 227128
       Total non-inuse space             = 2149335448
(5)Releasing memory at 0x10a8000 (size=7 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 31
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 227112
       Total non-inuse space             = 2149335464
(6)Releasing memory at 0x1010000 (size=601 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 30
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 226504
       Total non-inuse space             = 2149336072
(7)Releasing memory at 0x1056000 (size=28 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 29
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 226472
       Total non-inuse space             = 2149336104
(8)Releasing memory at 0x1076800 (size=1536 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 28
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 224928
       Total non-inuse space             = 2149337648
(9)Releasing memory at 0x1016380 (size=962 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 27
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 223960
       Total non-inuse space             = 2149338616
(10)Releasing memory at 0x10c0000 (size=69179 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 26
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 154776
       Total non-inuse space             = 2149407800
(11)Releasing memory at 0x1011000 (size=901 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 26
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 153864
       Total non-inuse space             = 2149408712
(12)Releasing memory at 0x1011390 (size=6750 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 25
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 147104
       Total non-inuse space             = 2149415472
(13)Releasing memory at 0x10a0000 (size=1646 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 24
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 145448
       Total non-inuse space             = 2149417128
(14)Releasing memory at 0x1090000 (size=1024 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 23
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 144416
       Total non-inuse space             = 2149418160
(15)Releasing memory at 0x1013c00 (size=3 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 23
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 144272
       Total non-inuse space             = 2149418304
(16)Releasing memory at 0x102c000 (size=194 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 22
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 144072
       Total non-inuse space             = 2149418504
(17)Releasing memory at 0x100f000 (size=480 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 21
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 143584
       Total non-inuse space             = 2149418992
(18)Releasing memory at 0x10e0000 (size=2011 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 141568
       Total non-inuse space             = 2149421008
(19)Releasing memory at 0x102b280 (size=2590 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 138968
       Total non-inuse space             = 2149423608
(20)Releasing memory at 0x1039e20 (size=222 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 20
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 138712
       Total non-inuse space             = 2149423864
(21)Releasing memory at 0x1016760 (size=969 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 19
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 137736
       Total non-inuse space             = 2149424840
(22)Releasing memory at 0x1040000 (size=68 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 18
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 137664
       Total non-inuse space             = 2149424912
(23)Releasing memory at 0x100f400 (size=852 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 17
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 136808
       Total non-inuse space             = 2149425768
(24)Releasing memory at 0x1080000 (size=10254 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 126544
       Total non-inuse space             = 2149436032
(25)Releasing memory at 0x1037ec0 (size=12 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 16
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 126464
       Total non-inuse space             = 2149436112
(26)Releasing memory at 0x102bca8 (size=646 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 125808
       Total non-inuse space             = 2149436768
(27)Releasing memory at 0x1039f18 (size=9932 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 115872
       Total non-inuse space             = 2149446704
(28)Releasing memory at 0x1029fe8 (size=4732 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 111136
       Total non-inuse space             = 2149451440
(29)Releasing memory at 0x1038cc0 (size=776 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 110352
       Total non-inuse space             = 2149452224
(30)Releasing memory at 0x1027e90 (size=111 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 110224
       Total non-inuse space             = 2149452352
(31)Releasing memory at 0x1042000 (size=81647 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28568
       Total non-inuse space             = 2149534008
(0)Allocating 3 bytes aligned to 0x00000001
(0)Memory allocated at 0x100cd70
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28584
       Total non-inuse space             = 2149533992
(1)Allocating 20 bytes aligned to 0x00000002
(1)Memory allocated at 0x100a330
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28616
       Total non-inuse space             = 2149533960
(2)Allocating 13 bytes aligned to 0x00000004
(2)Memory allocated at 0x100a310
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28648
       Total non-inuse space             = 2149533928
(3)Allocating 24 bytes aligned to 0x00000008
(3)Memory allocated at 0x100a2f0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28680
       Total non-inuse space             = 2149533896
(4)Allocating 31 bytes aligned to 0x00000010
(4)Memory allocated at 0x1009c10
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28728
       Total non-inuse space             = 2149533848
(5)Allocating 12 bytes aligned to 0x00000020
(5)Memory allocated at 0x1009be0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 13
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28776
       Total non-inuse space             = 2149533800
(6)Allocating 28 bytes aligned to 0x00000040
(6)Memory allocated at 0x100ff80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28896
       Total non-inuse space             = 2149533680
(7)Allocating 5 bytes aligned to 0x00000080
(7)Memory allocated at 0x1013b80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29040
       Total non-inuse space             = 2149533536
(8)Allocating 21 bytes aligned to 0x00000001
(8)Memory allocated at 0x100a2d0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29072
       Total non-inuse space             = 2149533504
(9)Allocating 8 bytes aligned to 0x00000002
(9)Memory allocated at 0x100cd60
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29088
       Total non-inuse space             = 2149533488
(10)Allocating 1 bytes aligned to 0x00000004
(10)Memory allocated at 0x100cd50
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29104
       Total non-inuse space             = 2149533472
(11)Allocating 17 bytes aligned to 0x00000008
(11)Memory allocated at 0x100a2b0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29136
       Total non-inuse space             = 2149533440
(12)Allocating 29 bytes aligned to 0x00000010
(12)Memory allocated at 0x1009bb0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29184
       Total non-inuse space             = 2149533392
(13)Allocating 16 bytes aligned to 0x00000020
(13)Memory allocated at 0x1009b80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29232
       Total non-inuse space             = 2149533344
(14)Allocating 6 bytes aligned to 0x00000040
(14)Memory allocated at 0x1037e80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 14
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29312
       Total non-inuse space             = 2149533264
(15)Allocating 25 bytes aligned to 0x00000080
(15)Memory allocated at 0x1010f80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29496
       Total non-inuse space             = 2149533080
(0)Allocating 11 bytes aligned to 0x00000001
(0)Memory allocated at 0x100cd40
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29512
       Total non-inuse space             = 2149533064
(1)Allocating 18 bytes aligned to 0x00000002
(1)Memory allocated at 0x100a290
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29544
       Total non-inuse space             = 2149533032
(2)Allocating 26 bytes aligned to 0x00000004
(2)Memory allocated at 0x100a270
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29576
       Total non-inuse space             = 2149533000
(3)Allocating 32 bytes aligned to 0x00000008
(3)Memory allocated at 0x1009b50
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29624
       Total non-inuse space             = 2149532952
(4)Allocating 9 bytes aligned to 0x00000010
(4)Memory allocated at 0x100a250
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29656
       Total non-inuse space             = 2149532920
(5)Allocating 30 bytes aligned to 0x00000020
(5)Memory allocated at 0x1006ea0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29720
       Total non-inuse space             = 2149532856
(6)Allocating 4 bytes aligned to 0x00000040
(6)Memory allocated at 0x1037e40
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29800
       Total non-inuse space             = 2149532776
(7)Allocating 27 bytes aligned to 0x00000080
(7)Memory allocated at 0x1010e80
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29960
       Total non-inuse space             = 2149532616
(8)Allocating 10 bytes aligned to 0x00000001
(8)Memory allocated at 0x100cd30
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29976
       Total non-inuse space             = 2149532600
(9)Allocating 19 bytes aligned to 0x00000002
(9)Memory allocated at 0x100a230
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30008
       Total non-inuse space             = 2149532568
(10)Allocating 23 bytes aligned to 0x00000004
(10)Memory allocated at 0x100a210
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30040
       Total non-inuse space             = 2149532536
(11)Allocating 14 bytes aligned to 0x00000008
(11)Memory allocated at 0x100a1f0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30072
       Total non-inuse space             = 2149532504
(12)Allocating 2 bytes aligned to 0x00000010
(12)Memory allocated at 0x100a1d0
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30104
       Total non-inuse space             = 2149532472
(13)Allocating 22 bytes aligned to 0x00000020
(13)Memory allocated at 0x1006e60
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30168
       Total non-inuse space             = 2149532408
(14)Allocating 15 bytes aligned to 0x00000040
(14)Memory allocated at 0x1037e00
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30248
       Total non-inuse space             = 2149532328
(15)Allocating 7 bytes aligned to 0x00000080
(15)Memory allocated at 0x1013b00
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30392
       Total non-inuse space             = 2149532184
(0)Releasing memory at 0x100a2d0 (size=21 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30360
       Total non-inuse space             = 2149532216
(1)Releasing memory at 0x1009be0 (size=12 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30312
       Total non-inuse space             = 2149532264
(2)Releasing memory at 0x1037e40 (size=4 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30232
       Total non-inuse space             = 2149532344
(3)Releasing memory at 0x1009b50 (size=32 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30184
       Total non-inuse space             = 2149532392
(4)Releasing memory at 0x100cd30 (size=10 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30168
       Total non-inuse space             = 2149532408
(5)Releasing memory at 0x1006ea0 (size=30 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30104
       Total non-inuse space             = 2149532472
(6)Releasing memory at 0x100cd60 (size=8 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30088
       Total non-inuse space             = 2149532488
(7)Releasing memory at 0x100a290 (size=18 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 30056
       Total non-inuse space             = 2149532520
(8)Releasing memory at 0x1006e60 (size=22 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29992
       Total non-inuse space             = 2149532584
(9)Releasing memory at 0x100cd70 (size=3 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29976
       Total non-inuse space             = 2149532600
(10)Releasing memory at 0x1010e80 (size=27 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29816
       Total non-inuse space             = 2149532760
(11)Releasing memory at 0x100a230 (size=19 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29784
       Total non-inuse space             = 2149532792
(12)Releasing memory at 0x1037e00 (size=15 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29704
       Total non-inuse space             = 2149532872
(13)Releasing memory at 0x100a270 (size=26 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29672
       Total non-inuse space             = 2149532904
(14)Releasing memory at 0x100cd50 (size=1 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29656
       Total non-inuse space             = 2149532920
(15)Releasing memory at 0x100cd40 (size=11 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29640
       Total non-inuse space             = 2149532936
(16)Releasing memory at 0x100ff80 (size=28 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29544
       Total non-inuse space             = 2149533032
(17)Releasing memory at 0x100a330 (size=20 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29512
       Total non-inuse space             = 2149533064
(18)Releasing memory at 0x100a210 (size=23 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29480
       Total non-inuse space             = 2149533096
(19)Releasing memory at 0x1009bb0 (size=29 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29432
       Total non-inuse space             = 2149533144
(20)Releasing memory at 0x100a250 (size=9 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29400
       Total non-inuse space             = 2149533176
(21)Releasing memory at 0x1009c10 (size=31 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29352
       Total non-inuse space             = 2149533224
(22)Releasing memory at 0x100a310 (size=13 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29320
       Total non-inuse space             = 2149533256
(23)Releasing memory at 0x1009b80 (size=16 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29272
       Total non-inuse space             = 2149533304
(24)Releasing memory at 0x1013b80 (size=5 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29128
       Total non-inuse space             = 2149533448
(25)Releasing memory at 0x100a1d0 (size=2 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 29096
       Total non-inuse space             = 2149533480
(26)Releasing memory at 0x1010f80 (size=25 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28936
       Total non-inuse space             = 2149533640
(27)Releasing memory at 0x1013b00 (size=7 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28792
       Total non-inuse space             = 2149533784
(28)Releasing memory at 0x100a2b0 (size=17 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28760
       Total non-inuse space             = 2149533816
(29)Releasing memory at 0x100a1f0 (size=14 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28728
       Total non-inuse space             = 2149533848
(30)Releasing memory at 0x1037e80 (size=6 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28648
       Total non-inuse space             = 2149533928
(31)Releasing memory at 0x100a2f0 (size=24 bytes)
     mallinfo:
       Total space allocated from system = 2149562576
       Number of non-inuse chunks        = 15
       Largest non-inuse chunk           = 2147483632
       Total allocated space             = 28616
       Total non-inuse space             = 2149533960
TEST COMPLETE
nsh>
```
