### PR TITLE
mm: use Kconfig to control sequence number to save memory

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -462,8 +462,10 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
 #if CONFIG_MM_BACKTRACE >= 0
                  "leak: dump all leaked node\n"
                  "pid: dump pid allocated node\n"
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
                  "The current sequence number %lu\n",
                  g_mm_seqno
+#  endif
 #endif
                  );
 

--- a/include/nuttx/mm/mempool.h
+++ b/include/nuttx/mm/mempool.h
@@ -122,7 +122,9 @@ struct mempool_backtrace_s
                        * if there is any out of bounds.
                        */
   pid_t pid;
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
   unsigned long seqno; /* The sequence of memory malloc */
+#  endif
 #  if CONFIG_MM_BACKTRACE > 0
   FAR void *backtrace[CONFIG_MM_BACKTRACE];
 #  endif

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -142,8 +142,12 @@
 #  define MM_DUMP_ALLOC(dump, node) \
     ((node) != NULL && (dump)->pid == PID_MM_ALLOC && \
      (node)->pid != PID_MM_MEMPOOL)
-#  define MM_DUMP_SEQNO(dump, node) \
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+#    define MM_DUMP_SEQNO(dump, node) \
     ((node)->seqno >= (dump)->seqmin && (node)->seqno <= (dump)->seqmax)
+#  else
+#    define MM_DUMP_SEQNO(dump,node)  (true)
+#  endif
 #  define MM_DUMP_ASSIGN(dump, node) \
     ((node) != NULL && (dump)->pid == (node)->pid)
 #  define MM_DUMP_LEAK(dump, node) \
@@ -165,6 +169,12 @@
 #define MM_INIT_MAGIC    0xcc
 #define MM_ALLOC_MAGIC   0xaa
 #define MM_FREE_MAGIC    0x55
+
+#ifdef CONFIG_MM_BACKTRACE_SEQNO
+#  define MM_INCSEQNO(p) ((p)->seqno = g_mm_seqno++)
+#else
+#  define MM_INCSEQNO(p)
+#endif
 
 /****************************************************************************
  * Public Types
@@ -195,7 +205,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if CONFIG_MM_BACKTRACE >= 0
+#ifdef CONFIG_MM_BACKTRACE_SEQNO
 extern unsigned long g_mm_seqno;
 #endif
 

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -138,6 +138,11 @@ config MM_BACKTRACE_DEFAULT
 	default n
 	depends on MM_BACKTRACE > 0
 
+config MM_BACKTRACE_SEQNO
+	bool "Record sequence number in memory block"
+	default y
+	depends on MM_BACKTRACE >= 0
+
 config MM_DUMP_ON_FAILURE
 	bool "Dump heap info on allocation failure"
 	default n

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -107,7 +107,7 @@ static inline void mempool_add_backtrace(FAR struct mempool_s *pool,
   DEBUGASSERT(buf->magic == MEMPOOL_MAGIC_FREE);
   buf->magic = MEMPOOL_MAGIC_ALLOC;
   buf->pid = _SCHED_GETTID();
-  buf->seqno = g_mm_seqno++;
+  MM_INCSEQNO(buf);
 #  if CONFIG_MM_BACKTRACE > 0
   if (pool->procfs.backtrace)
     {
@@ -209,8 +209,15 @@ static void mempool_memdump_callback(FAR struct mempool_s *pool,
       FAR const char *tmp = "";
 #  endif
 
-      syslog(LOG_INFO, "%6d%12zu%9zu%12lu%*p %s\n",
-             buf->pid, blocksize, overhead, buf->seqno,
+      syslog(LOG_INFO, "%6d%12zu%9zu"
+#ifdef CONFIG_MM_BACKTRACE_SEQNO
+             "%12lu"
+#endif
+             "%*p %s\n",
+             buf->pid, blocksize, overhead,
+#ifdef CONFIG_MM_BACKTRACE_SEQNO
+             buf->seqno,
+#endif
              BACKTRACE_PTR_FMT_WIDTH,
              ((FAR char *)buf - pool->blocksize), tmp);
     }

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -78,7 +78,7 @@
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          tmp->pid = _SCHED_GETTID(); \
-         tmp->seqno = g_mm_seqno++; \
+         MM_INCSEQNO(tmp); \
        } \
      while (0)
 #elif CONFIG_MM_BACKTRACE > 0
@@ -102,7 +102,7 @@
            { \
              tmp->backtrace[0] = NULL; \
            } \
-         tmp->seqno = g_mm_seqno++; \
+         MM_INCSEQNO(tmp); \
        } \
      while (0)
 #else
@@ -178,7 +178,9 @@ struct mm_allocnode_s
   mmsize_t size;                            /* Size of this chunk */
 #if CONFIG_MM_BACKTRACE >= 0
   pid_t pid;                                /* The pid for caller */
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
   unsigned long seqno;                      /* The sequence of memory malloc */
+#  endif
 #  if CONFIG_MM_BACKTRACE > 0
   FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
 #  endif

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -66,8 +66,15 @@ static void memdump_allocnode(FAR struct mm_allocnode_s *node)
          nodesize, overhead, BACKTRACE_PTR_FMT_WIDTH,
          (FAR const char *)node + MM_SIZEOF_ALLOCNODE);
 #elif CONFIG_MM_BACKTRACE == 0
-  syslog(LOG_INFO, "%6d%12zu%9zu%12lu%*p\n",
-         node->pid, nodesize, overhead, node->seqno,
+  syslog(LOG_INFO, "%6d%12zu%9zu"
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+         "%12lu"
+#  endif
+         "%*p\n",
+         node->pid, nodesize, overhead,
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+         node->seqno,
+#  endif
          BACKTRACE_PTR_FMT_WIDTH,
          (FAR const char *)node + MM_SIZEOF_ALLOCNODE);
 #else
@@ -76,8 +83,15 @@ static void memdump_allocnode(FAR struct mm_allocnode_s *node)
   backtrace_format(buf, sizeof(buf), node->backtrace,
                    CONFIG_MM_BACKTRACE);
 
-  syslog(LOG_INFO, "%6d%12zu%9zu%12lu%*p %s\n",
-         node->pid, nodesize, overhead, node->seqno,
+  syslog(LOG_INFO, "%6d%12zu%9zu"
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+         "%12lu%"
+#  endif
+         "*p %s\n",
+         node->pid, nodesize, overhead,
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+         node->seqno,
+#  endif
          BACKTRACE_PTR_FMT_WIDTH,
          (FAR const char *)node + MM_SIZEOF_ALLOCNODE, buf);
 #endif
@@ -293,8 +307,15 @@ void mm_memdump(FAR struct mm_heap_s *heap,
                    BACKTRACE_PTR_FMT_WIDTH,
                    "Address");
 #else
-  syslog(LOG_INFO, "%6s%12s%9s%12s%*s %s\n", "PID", "Size", "Overhead",
-                   "Sequence", BACKTRACE_PTR_FMT_WIDTH,
+  syslog(LOG_INFO, "%6s%12s%9s"
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+                   "%12s"
+#  endif
+                   "%*s %s\n", "PID", "Size", "Overhead",
+#  ifdef CONFIG_MM_BACKTRACE_SEQNO
+                   "Sequence",
+#  endif
+                    BACKTRACE_PTR_FMT_WIDTH,
                    "Address", "Backtrace");
 #endif
 

--- a/mm/umm_heap/umm_memdump.c
+++ b/mm/umm_heap/umm_memdump.c
@@ -33,7 +33,7 @@
  * Public data
  ****************************************************************************/
 
-#if CONFIG_MM_BACKTRACE >= 0
+#ifdef CONFIG_MM_BACKTRACE_SEQNO
 unsigned long g_mm_seqno;
 #endif
 


### PR DESCRIPTION
## Summary

Add Kconfig to control sequence number to save memory

## Impact

use Kconfig to save memory

## Testing

ostest and mm

build
./tools/configure.sh mps3-an547:nsh

use config 
CONFIG_MM_BACKTRACE=0
CONFIG_MM_BACKTRACE_SEQNO=y

```
qemu-system-arm -M mps3-an547 -m 2G  -device loader,file=nuttx.hex -gdb tcp::1129 -nographic

NuttShell (NSH) NuttX-12.7.2-vela
nsh>
nsh>
nsh> free
      total       used       free    maxused    maxfree  nused  nfree name
 2149562732      12700 2149550032      13200 2147483616     30      2 Umem
nsh> QEMU: Terminated

```


use config 
CONFIG_MM_BACKTRACE=0
\# CONFIG_MM_BACKTRACE_SEQNO is not set

```
qemu-system-arm -M mps3-an547 -m 2G  -device loader,file=nuttx.hex -gdb tcp::1129 -nographic

NuttShell (NSH) NuttX-12.7.2-vela
nsh>
nsh>
nsh>
nsh> free
      total       used       free    maxused    maxfree  nused  nfree name
 2149562732      12580 2149550152      13080 2147483624     30      2 Umem
nsh>

```

used memory less.
