### PR TITLE
arch/x86_64: fix syscall type mismatch

### DIFF
--- a/arch/x86_64/include/syscall.h
+++ b/arch/x86_64/include/syscall.h
@@ -175,7 +175,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
   __asm__ volatile
   (
-    "movq %1, %%rax\n"
+    "movl %1, %%eax\n"
     "movq %2, %%rdi\n"
     "movq %3, %%rsi\n"
     "movq %4, %%rdx\n"


### PR DESCRIPTION
## Summary

x86_64:fix syscall type mismatch

/home/ajh/work/vela_system/nuttx/include/arch/syscall.h:181: Error: operand type mismatch for `movq'

`rax`: Used in 64-bit mode, suitable for storing 64 bits of data.

`eax`: In 64-bit mode, typically used for operating on 32-bit data. When writing to `eax`, the high 32 bits of `rax` are automatically cleared to zero.

`nbr` is an unsigned int, is 32-bi

## Impact

nothing, just bug fix

## Testing

x64 ostest
