### PR TITLE
sched/env_putenv:putenv is kernel function need use kmm_free

### DIFF
--- a/sched/environ/env_putenv.c
+++ b/sched/environ/env_putenv.c
@@ -93,7 +93,7 @@ int putenv(FAR const char *string)
       ret = setenv(pname, pequal + 1, TRUE);
     }
 
-  lib_free(pname);
+  kmm_free(pname);
   return ret;
 
 errout:


### PR DESCRIPTION
## Summary

strdup if use __KERNEL__ defined by nx_strdup
so need kmm_free it

## Impact

noting, just bugfix

## Testing

bugfix
