### PR TITLE
fs/procfs: bugfix in heapcheck, avoid '\n' to 0

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -966,12 +966,12 @@ static ssize_t proc_heapcheck_write(FAR struct proc_file_s *procfile,
                                     FAR const char *buffer,
                                     size_t buflen, off_t offset)
 {
-  switch (atoi(buffer))
+  switch (buffer[0])
     {
-      case 0:
+      case '0':
         tcb->flags &= ~TCB_FLAG_HEAP_CHECK;
         break;
-      case 1:
+      case '1':
         tcb->flags |= TCB_FLAG_HEAP_CHECK;
         break;
       default:


### PR DESCRIPTION
## Summary

The lines will end with \n to prevent atoi('\n') from always being 0. It is recommended to check the first byte directly.

## Impact

noting,just bugfix

## Testing

just bugfix

build mps3-an547:nsh with CONFIG_DEBUG_MM CONFIG_MM_BACKTRACE = 0


Before fixing the bug
```
➜ qemu-system-arm -M mps3-an547 -m 2G  -device loader,file=nuttx.hex -gdb tcp::1131 -nographic
ERROR: Failed to mount romfs at /mnt: -22

NuttShell (NSH) NuttX-12.7.2-vela
nsh> cat /proc/0/heapcheck
HeapCheck:  0
nsh> echo 1 > /proc/0/heapcheck
nsh> cat /proc/0/heapcheck
HeapCheck:  0
nsh>
```


After：


```
nsh> cat /proc/0/heapcheck
HeapCheck:  0
nsh> echo 1 > /proc/0/heapcheck
nsh> cat /proc/0/heapcheck
HeapCheck:  1
```