### PR TITLE
arch/arm: use cfi to debug syscall

### DIFF
--- a/arch/arm/src/armv6-m/CMakeLists.txt
+++ b/arch/arm/src/armv6-m/CMakeLists.txt
@@ -44,4 +44,8 @@ if(CONFIG_ARCH_RAMVECTORS)
   list(APPEND SRCS arm_ramvec_initialize.c arm_ramvec_attach.c)
 endif()
 
+if(CONFIG_LIB_SYSCALL)
+  list(APPEND SRCS arm_dispatch_syscall.S)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/armv6-m/Make.defs
+++ b/arch/arm/src/armv6-m/Make.defs
@@ -42,3 +42,7 @@ endif
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
   CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c
 endif
+
+ifeq ($(CONFIG_LIB_SYSCALL),y)
+  CMN_ASRCS += arm_dispatch_syscall.S
+endif

--- a/arch/arm/src/armv6-m/arm_dispatch_syscall.S
+++ b/arch/arm/src/armv6-m/arm_dispatch_syscall.S
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * arch/arm/src/armv6-m/arm_dispatch_syscall.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <syscall.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl		arm_dispatch_syscall
+
+	.syntax		unified
+	.thumb
+	.file		"arm_dispatch_syscall.S"
+
+/****************************************************************************
+ * .text
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dispatch_syscall
+ *
+ * Description:
+ *   Call the stub function corresponding to the system call.  NOTE the non-
+ *   standard parameter passing:
+ *
+ *     R0 = SYS_ call number
+ *     R1 = parm0
+ *     R2 = parm1
+ *     R3 = parm2
+ *     R4 = parm3
+ *     R5 = parm4
+ *     R6 = parm5
+ *
+ *   The values of R4-R5 may be preserved in the proxy called by the user
+ *   code if they are used (but otherwise will not be).
+ *
+ *   Register usage:
+ *
+ *     R0 - Need not be preserved.
+ *     R1-R3 - Need to be preserved until the stub is called.  The values of
+ *       R0 and R1 returned by the stub must be preserved.
+ *     R4-R11 must be preserved to support the expectations of the user-space
+ *       callee.  R4-R6 may have been preserved by the proxy, but don't know
+ *       for sure.
+ *     R12 - Need not be preserved
+ *     R13 - (stack pointer)
+ *     R14 - Need not be preserved
+ *     R15 - (PC)
+ *
+ ****************************************************************************/
+
+	.text
+	.thumb_func
+	.type	arm_dispatch_syscall, function
+arm_dispatch_syscall:
+	sub sp, sp, #32                            /* Create a stack frame to hold 3 parms */
+	str r4, [sp, #0]                           /* Move parameter 4 (if any) into position */
+	str r5, [sp, #4]                           /* Move parameter 5 (if any) into position */
+	str r6, [sp, #8]                           /* Move parameter 6 (if any) into position */
+	str ip, [sp, #12]                          /* Save ip is pc backup */
+	.cfi_offset pc, 12
+	ldr r4, =g_stublookup                      /* R4=The base of the stub lookup table */
+	lsl r0, r0, #2                             /* R0=Offset of the stub for this syscall */
+	ldr r4, [r4, r0]                           /* R4=Address of the stub for this syscall */
+	blx r4                                     /* Call the stub (modifies lr) */
+	add sp, sp, #32                            /* Destroy the stack frame */
+	mov r2, r0                                 /* R2=Save return value in R2 */
+	mov r0, SYS_syscall_return                 /* R0=SYS_syscall_return */
+	svc SYS_syscall                            /* Return from the SYSCALL */
+	.size	arm_dispatch_syscall, .-arm_dispatch_syscall
+	.end

--- a/arch/arm/src/armv7-m/CMakeLists.txt
+++ b/arch/arm/src/armv7-m/CMakeLists.txt
@@ -73,4 +73,8 @@ if(CONFIG_ARM_COREDUMP_REGION)
   list(APPEND SRCS arm_dumpnvic.c)
 endif()
 
+if(CONFIG_LIB_SYSCALL)
+  list(APPEND SRCS arm_dispatch_syscall.S)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/armv7-m/Make.defs
+++ b/arch/arm/src/armv7-m/Make.defs
@@ -65,3 +65,7 @@ endif
 ifeq ($(CONFIG_ARM_COREDUMP_REGION),y)
   CMN_CSRCS += arm_dumpnvic.c
 endif
+
+ifeq ($(CONFIG_LIB_SYSCALL),y)
+  CMN_ASRCS += arm_dispatch_syscall.S
+endif

--- a/arch/arm/src/armv7-m/arm_dispatch_syscall.S
+++ b/arch/arm/src/armv7-m/arm_dispatch_syscall.S
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * arch/arm/src/armv7-m/arm_dispatch_syscall.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <syscall.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl		arm_dispatch_syscall
+
+	.syntax		unified
+	.thumb
+	.file		"arm_dispatch_syscall.S"
+
+/****************************************************************************
+ * .text
+ ****************************************************************************/
+
+/****************************************************************************
+ *   Call the stub function corresponding to the system call.  NOTE the non-
+ *   standard parameter passing:
+ *
+ *     R0 = SYS_ call number
+ *     R1 = parm0
+ *     R2 = parm1
+ *     R3 = parm2
+ *     R4 = parm3
+ *     R5 = parm4
+ *     R6 = parm5
+ *
+ *   The values of R4-R5 may be preserved in the proxy called by the user
+ *   code if they are used (but otherwise will not be).
+ *
+ *   Register usage:
+ *
+ *     R0 - Need not be preserved.
+ *     R1-R3 - Need to be preserved until the stub is called.  The values of
+ *       R0 and R1 returned by the stub must be preserved.
+ *     R4-R11 must be preserved to support the expectations of the user-space
+ *       callee.  R4-R6 may have been preserved by the proxy, but don't know
+ *       for sure.
+ *     R12 - Need not be preserved
+ *     R13 - (stack pointer)
+ *     R14 - Need not be preserved
+ *     R15 - (PC)
+ *
+ ****************************************************************************/
+
+	.text
+	.thumb_func
+	.type	arm_dispatch_syscall, function
+arm_dispatch_syscall:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
+	mov r11, sp
+	.cfi_register sp, r11
+	sub	sp, sp, #32
+	str	r4, [sp, #0]
+	.cfi_offset r4, 0
+	str	r5, [sp, #4]
+	.cfi_offset r5, 4
+	str	r6, [sp, #8]
+	.cfi_offset r6, 8
+	str	lr, [sp, #12]
+	.cfi_offset lr, 12
+	str	ip, [sp, #16]
+	.cfi_offset pc, 16
+	ldr	ip, =g_stublookup
+	ldr	ip, [ip, r0, lsl #2]
+	blx	ip
+	ldr	lr, [sp, #12]
+	add	sp, sp, #32
+	mov	r2, r0
+	mov	r0, SYS_syscall_return
+	svc	SYS_syscall
+	.cfi_endproc
+	.size	arm_dispatch_syscall, .-arm_dispatch_syscall
+	.end

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -48,72 +48,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- *   Call the stub function corresponding to the system call.  NOTE the non-
- *   standard parameter passing:
- *
- *     R0 = SYS_ call number
- *     R1 = parm0
- *     R2 = parm1
- *     R3 = parm2
- *     R4 = parm3
- *     R5 = parm4
- *     R6 = parm5
- *
- *   The values of R4-R5 may be preserved in the proxy called by the user
- *   code if they are used (but otherwise will not be).
- *
- *   Register usage:
- *
- *     R0 - Need not be preserved.
- *     R1-R3 - Need to be preserved until the stub is called.  The values of
- *       R0 and R1 returned by the stub must be preserved.
- *     R4-R11 must be preserved to support the expectations of the user-space
- *       callee.  R4-R6 may have been preserved by the proxy, but don't know
- *       for sure.
- *     R12 - Need not be preserved
- *     R13 - (stack pointer)
- *     R14 - Need not be preserved
- *     R15 - (PC)
- *
- ****************************************************************************/
-
-#ifdef CONFIG_LIB_SYSCALL
-static void dispatch_syscall(void) naked_function;
-static void dispatch_syscall(void)
-{
-  __asm__ __volatile__
-    (
-      /* Create a stack frame to hold 3 parameters + LR and SP adjustment
-       * value.  Also, Ensure 8 bytes alignment. We use IP as a scratch.
-       *
-       * NOTE: new_SP = (orig_SP - 20) & ~7
-       *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
-       */
-
-      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
-      " sub ip, ip, #20\n"
-      " and ip, ip, #7\n"
-      " add ip, ip, #20\n"
-      " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
-      " blx ip\n"                                     /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"                          /* Restore lr */
-      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"                             /* Restore SP */
-      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
-      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
-    );
-}
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -201,7 +135,7 @@ int arm_svcall(int irq, void *context, void *arg)
           regs[REG_CONTROL]    = rtcb->xcp.syscall[index].ctrlreturn;
           rtcb->xcp.nsyscalls  = index;
 
-          /* The return value must be in R0-R1.  dispatch_syscall()
+          /* The return value must be in R0-R1.  arm_dispatch_syscall()
            * temporarily moved the value for R0 into R2.
            */
 
@@ -389,14 +323,20 @@ int arm_svcall(int irq, void *context, void *arg)
 
           DEBUGASSERT(index < CONFIG_SYS_NNEST);
 
-          /* Setup to return to dispatch_syscall in privileged mode. */
+          /* Use ip to create a debug frame.
+           * we can use gdb backtrace from syscall to user space.
+           */
+
+          regs[REG_IP] = regs[REG_PC];
+
+          /* Setup to return to arm_dispatch_syscall in privileged mode. */
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_PC];
           rtcb->xcp.syscall[index].excreturn  = regs[REG_EXC_RETURN];
           rtcb->xcp.syscall[index].ctrlreturn = regs[REG_CONTROL];
           rtcb->xcp.nsyscalls  = index + 1;
 
-          regs[REG_PC]         = (uint32_t)dispatch_syscall & ~1;
+          regs[REG_PC]         = (uint32_t)arm_dispatch_syscall & ~1;
           regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
 
           /* Return privileged mode */

--- a/arch/arm/src/armv8-m/CMakeLists.txt
+++ b/arch/arm/src/armv8-m/CMakeLists.txt
@@ -77,4 +77,8 @@ if(CONFIG_ARM_COREDUMP_REGION)
   list(APPEND SRCS arm_dumpnvic.c)
 endif()
 
+if(CONFIG_LIB_SYSCALL)
+  list(APPEND SRCS arm_dispatch_syscall.S)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/armv8-m/Make.defs
+++ b/arch/arm/src/armv8-m/Make.defs
@@ -70,3 +70,7 @@ endif
 ifeq ($(CONFIG_ARM_COREDUMP_REGION),y)
   CMN_CSRCS += arm_dumpnvic.c
 endif
+
+ifeq ($(CONFIG_LIB_SYSCALL),y)
+  CMN_ASRCS += arm_dispatch_syscall.S
+endif

--- a/arch/arm/src/armv8-m/arm_dispatch_syscall.S
+++ b/arch/arm/src/armv8-m/arm_dispatch_syscall.S
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * arch/arm/src/armv8-m/arm_dispatch_syscall.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <syscall.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl		arm_dispatch_syscall
+
+	.syntax		unified
+	.thumb
+	.file		"arm_dispatch_syscall.S"
+
+/****************************************************************************
+ * .text
+ ****************************************************************************/
+
+/****************************************************************************
+ *   Call the stub function corresponding to the system call.  NOTE the non-
+ *   standard parameter passing:
+ *
+ *     R0 = SYS_ call number
+ *     R1 = parm0
+ *     R2 = parm1
+ *     R3 = parm2
+ *     R4 = parm3
+ *     R5 = parm4
+ *     R6 = parm5
+ *
+ *   The values of R4-R5 may be preserved in the proxy called by the user
+ *   code if they are used (but otherwise will not be).
+ *
+ *   Register usage:
+ *
+ *     R0 - Need not be preserved.
+ *     R1-R3 - Need to be preserved until the stub is called.  The values of
+ *       R0 and R1 returned by the stub must be preserved.
+ *     R4-R11 must be preserved to support the expectations of the user-space
+ *       callee.  R4-R6 may have been preserved by the proxy, but don't know
+ *       for sure.
+ *     R12 - Need not be preserved
+ *     R13 - (stack pointer)
+ *     R14 - Need not be preserved
+ *     R15 - (PC)
+ *
+ ****************************************************************************/
+
+	.text
+	.thumb_func
+	.type	arm_dispatch_syscall, function
+arm_dispatch_syscall:
+	.cfi_sections	.debug_frame
+	.cfi_startproc
+	sub	sp, sp, #32
+	.cfi_def_cfa sp, 0
+	str	r4, [sp, #0]
+	.cfi_offset r4, 0
+	str	r5, [sp, #4]
+	.cfi_offset r5, 4
+	str	r6, [sp, #8]
+	.cfi_offset r6, 8
+	str	lr, [sp, #12]
+	.cfi_offset lr, 12
+	str	ip, [sp, #16]
+	.cfi_offset pc, 16
+	ldr	ip, =g_stublookup
+	ldr	ip, [ip, r0, lsl #2]
+	blx	ip
+	ldr	lr, [sp, #12]
+	add	sp, sp, #32
+	mov	r2, r0
+	mov	r0, SYS_syscall_return
+	svc	SYS_syscall
+	.cfi_endproc
+	.size	arm_dispatch_syscall, .-arm_dispatch_syscall
+	.end

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -48,72 +48,6 @@
  ****************************************************************************/
 
 /****************************************************************************
- *   Call the stub function corresponding to the system call.  NOTE the non-
- *   standard parameter passing:
- *
- *     R0 = SYS_ call number
- *     R1 = parm0
- *     R2 = parm1
- *     R3 = parm2
- *     R4 = parm3
- *     R5 = parm4
- *     R6 = parm5
- *
- *   The values of R4-R5 may be preserved in the proxy called by the user
- *   code if they are used (but otherwise will not be).
- *
- *   Register usage:
- *
- *     R0 - Need not be preserved.
- *     R1-R3 - Need to be preserved until the stub is called.  The values of
- *       R0 and R1 returned by the stub must be preserved.
- *     R4-R11 must be preserved to support the expectations of the user-space
- *       callee.  R4-R6 may have been preserved by the proxy, but don't know
- *       for sure.
- *     R12 - Need not be preserved
- *     R13 - (stack pointer)
- *     R14 - Need not be preserved
- *     R15 - (PC)
- *
- ****************************************************************************/
-
-#ifdef CONFIG_LIB_SYSCALL
-static void dispatch_syscall(void) naked_function;
-static void dispatch_syscall(void)
-{
-  __asm__ __volatile__
-    (
-      /* Create a stack frame to hold 3 parameters + LR and SP adjustment
-       * value.  Also, Ensure 8 bytes alignment. We use IP as a scratch.
-       *
-       * NOTE: new_SP = (orig_SP - 20) & ~7
-       *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
-       */
-
-      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
-      " sub ip, ip, #20\n"
-      " and ip, ip, #7\n"
-      " add ip, ip, #20\n"
-      " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
-      " blx ip\n"                                     /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"                          /* Restore lr */
-      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"                             /* Restore SP */
-      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
-      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
-    );
-}
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -201,7 +135,7 @@ int arm_svcall(int irq, void *context, void *arg)
           regs[REG_CONTROL]    = rtcb->xcp.syscall[index].ctrlreturn;
           rtcb->xcp.nsyscalls  = index;
 
-          /* The return value must be in R0-R1.  dispatch_syscall()
+          /* The return value must be in R0-R1.  arm_dispatch_syscall()
            * temporarily moved the value for R0 into R2.
            */
 
@@ -389,14 +323,20 @@ int arm_svcall(int irq, void *context, void *arg)
 
           DEBUGASSERT(index < CONFIG_SYS_NNEST);
 
-          /* Setup to return to dispatch_syscall in privileged mode. */
+          /* Use ip to create a debug frame.
+           * we can use gdb backtrace from syscall to user space.
+           */
+
+          regs[REG_IP] = regs[REG_PC];
+
+          /* Setup to return to arm_dispatch_syscall in privileged mode. */
 
           rtcb->xcp.syscall[index].sysreturn  = regs[REG_PC];
           rtcb->xcp.syscall[index].excreturn  = regs[REG_EXC_RETURN];
           rtcb->xcp.syscall[index].ctrlreturn = regs[REG_CONTROL];
           rtcb->xcp.nsyscalls  = index + 1;
 
-          regs[REG_PC]         = (uint32_t)dispatch_syscall & ~1;
+          regs[REG_PC]         = (uint32_t)arm_dispatch_syscall & ~1;
           regs[REG_EXC_RETURN] = EXC_RETURN_THREAD;
 
           /* Return privileged mode */

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -328,6 +328,10 @@ EXTERN const void *__vector_table[];
 EXTERN const void * const _vectors[];
 #endif
 
+#ifdef CONFIG_LIB_SYSCALL
+void arm_dispatch_syscall(void);
+#endif
+
 /* Exception Handlers */
 
 int  arm_svcall(int irq, void *context, void *arg);


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This is a debug feature that allows gdb to use the backtrace command to trace back from the kernel to the user.

gdb nuttx -ex "add-symbol-file nuttx_user"

## Impact

nothing, just for debug protect build

## Testing

armv8m:use ip save pc
armv7m:use ip save pc, r11 save sp

nsh_main backtrace before:
```
0  nxsem_wait_slow (sem=0x10001e0 <g_uart0port+32>) at semaphore/sem_wait.c:202
1  0x0000882c in nxsem_wait (sem=0x10001e0 <g_uart0port+32>) at semaphore/sem_wait.c:270
2  0x0000e7e2 in uart_read (filep=0x608037d4, buffer=0x60c013eb " h\024\300`", buflen=1)
   at serial/serial.c:1203
3  0x0001aad4 in file_readv_compat (filep=0x608037d4, uio=0x60c01344) at vfs/fs_read.c:81
4  0x0001abae in file_readv (filep=0x608037d4, uio=0x60c01344) at vfs/fs_read.c:165
5  0x0001ac2e in nx_readv (fd=0, iov=0x60c01388, iovcnt=1) at vfs/fs_read.c:256
6  0x0001ac84 in readv (fd=0, iov=0x60c01388, iovcnt=1) at vfs/fs_read.c:318
7  0x0001acca in read (fd=0, buf=0x60c013eb, nbytes=1) at vfs/fs_read.c:352
8  0x000100ea in STUB_read (nbr=56, parm1=0, parm2=1623200747, parm3=1) at stubs/STUB_read.c:9
9  0x000014d2 in dispatch_syscall () at armv8-m/arm_svcall.c:82
```

nsh_main backtrace after:

```
0  nxsem_wait_slow (sem=0x10001f0 <g_uart0port+32>) at semaphore/sem_wait.c:202
1  0x000088c0 in nxsem_wait (sem=0x10001f0 <g_uart0port+32>) at semaphore/sem_wait.c:270
2  0x0000e882 in uart_read (filep=0x6080380c, buffer=0x60c013eb " h\024\300`", buflen=1)
   at serial/serial.c:1203
3  0x0001ab74 in file_readv_compat (filep=0x6080380c, uio=0x60c01344) at vfs/fs_read.c:81
4  0x0001ac4e in file_readv (filep=0x6080380c, uio=0x60c01344) at vfs/fs_read.c:165
5  0x0001acce in nx_readv (fd=0, iov=0x60c01388, iovcnt=1) at vfs/fs_read.c:256
6  0x0001ad24 in readv (fd=0, iov=0x60c01388, iovcnt=1) at vfs/fs_read.c:318
7  0x0001ad6a in read (fd=0, buf=0x60c013eb, nbytes=1) at vfs/fs_read.c:352
8  0x0001018a in STUB_read (nbr=56, parm1=0, parm2=1623200747, parm3=1) at stubs/STUB_read.c:9
9  0x00001ece in dispatch_syscall () at armv8-m/arm_dispatch_syscall.S:111
10 0x2000a874 in read (parm1=0, parm2=0x60c013eb, parm3=1) at proxies/PROXY_read.c:9
11 0x20001152 in readline_getc (vtbl=0x60c01468) at readline_fd.c:73
12 0x20003994 in readline_common (vtbl=0x60c01468, buf=0x60c017f8 "\n", buflen=80)
   at readline_common.c:513
13 0x200012ec in readline_fd (buf=0x60c017f8 "\n", buflen=80, infd=0, outfd=1) at readline_fd.c:236
14 0x200010a8 in nsh_session (pstate=0x60c01540, login=1, argc=1, argv=0x60c00548)
   at nsh_session.c:229
15 0x20000eb0 in nsh_consolemain (argc=1, argv=0x60c00548) at nsh_consolemain.c:75
16 0x20000e4c in nsh_main (argc=1, argv=0x60c00548) at nsh_main.c:74
17 0x20000062 in nxtask_startup (entrypt=0x20000e11 <nsh_main>, argc=1, argv=0x60c00548)
   at sched/task_startup.c:72
18 0x00009ac4 in nxtask_start () at task/task_start.c:106
19 0x60c00548 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```
