### PR TITLE
cmake:add lib_psa_set/getstackaddr file to CMakeLists.txt

### DIFF
--- a/libs/libc/spawn/CMakeLists.txt
+++ b/libs/libc/spawn/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SRCS
     lib_psa_destroy.c)
 
 if(NOT CONFIG_BUILD_KERNEL)
-  list(APPEND SRCS lib_psa_getstacksize.c lib_psa_setstacksize.c)
+  list(APPEND SRCS lib_psa_getstackaddr.c lib_psa_setstackaddr.c)
 endif()
 
 if(CONFIG_DEBUG_FEATURES)


### PR DESCRIPTION
## Summary

CMake forgot to compile these two files, so add them.

## Impact

nothing,just add file to cmake

## Testing

ci build
