### PR TITLE
net/netlink: add RT_TABLE_LOCAL definition for mqttc5 build

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -175,3 +175,5 @@ libs/libc/tre-mem.c
   fs_ep->sems = NULL;
             fs_ep, &fs_ep->sems, queue);
             fs_ep, &fs_ep->sems, &fs_ep->reqq);
+#define RTPROT_RA                        9    /* RDISC/ND router advertisements */
+  /* Followed by one or more ND options */

--- a/include/netpacket/netlink.h
+++ b/include/netpacket/netlink.h
@@ -317,10 +317,11 @@
 
 /* rtm_table.  Routing table identifiers */
 
-#define RT_TABLE_UNSPEC                  0
-                                            /* 1-251: User defined values */
-#define RT_TABLE_MAIN                    254
-#define RT_TABLE_MAX                     0xffffffff
+#define RT_TABLE_UNSPEC       0
+                                 /* 1-251: User defined values */
+#define RT_TABLE_MAIN         254
+#define RT_TABLE_LOCAL        255
+#define RT_TABLE_MAX          0xffffffff
 
 /* rtm_type */
 


### PR DESCRIPTION
## Summary
Just add relevant macro definitions.

## Impact
net/netlink

## Testing
sim:matter
Since no business code was added, only the ability to compile was verified to pass.
