### PR TITLE
net/tcp: add TCP_CORK definition

### DIFF
--- a/include/netinet/tcp.h
+++ b/include/netinet/tcp.h
@@ -57,5 +57,6 @@
 #define TCP_KEEPCNT   (__SO_PROTOCOL + 3) /* Number of keepalives before death
                                            * Argument: max retry count */
 #define TCP_MAXSEG    (__SO_PROTOCOL + 4) /* The maximum segment size */
+#define TCP_CORK      (__SO_PROTOCOL + 5) /* Coalescing of small segments */
 
 #endif /* __INCLUDE_NETINET_TCP_H */

--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -204,6 +204,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
 
       case TCP_NODELAY:  /* Avoid coalescing of small segments. */
+      case TCP_CORK:     /* coalescing of small segments. */
         if (*value_len < sizeof(int))
           {
             ret                = -EINVAL;
@@ -214,7 +215,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
 
             /* Always true here since we do not support Nagle. */
 
-            *nodelay           = 1;
+            *nodelay           = option == TCP_NODELAY ? 1 : 0;
             *value_len         = sizeof(int);
             ret                = OK;
           }

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -216,6 +216,7 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
 
       case TCP_NODELAY: /* Avoid coalescing of small segments. */
+      case TCP_CORK:    /* coalescing of small segments. */
         if (value_len != sizeof(int))
           {
             ret = -EDOM;
@@ -224,9 +225,11 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
           {
             int nodelay = *(FAR int *)value;
 
-            if (!nodelay)
+            if ((!nodelay && option == TCP_NODELAY) ||
+                (nodelay && option == TCP_CORK))
               {
-                nerr("ERROR: TCP_NODELAY not supported\n");
+                nerr("ERROR: %s not supported\n",
+                     option == TCP_NODELAY ? "TCP_NODELAY" : "TCP_CORK");
                 ret = -ENOSYS;
               }
           }


### PR DESCRIPTION
## Summary
TCP_CORK and TCP_NODELAY behave almost exactly the opposite, so first provide simple support for TCP_CORK.

## Impact
tcp/setsockopt and getsockopt.

## Testing
sim:matter with below code:
```
#include <nuttx/config.h>
#include <string.h>
#include <stdio.h>
#include <netinet/tcp.h>
#include <sys/socket.h>
#include <netinet/in.h>

int main(int argc, FAR char *argv[])
{
    int fd;
    int res;
    int value = atoi(argv[1]);

    fd = socket(AF_INET, SOCK_STREAM, 0);
    if (fd < 0)
      {
        perror("Failed to open socket");
        return -1;
      }

    res = setsockopt(fd, SOL_TCP, TCP_CORK, &value, sizeof(value));
    if (res < 0)
      {
        perror("Couldn't set TCP_CORK option");
      }
    else
      {
        printf("Successfully set TCP_CORK option\n");
      }

    close(fd);
    return res;
}
```
NuttX log:
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> hello 0
Successfully set TCP_CORK option
nsh> hello 1
tcp_setsockopt: ERROR: TCP_CORK not supported
Couldn't set TCP_CORK option: Error 38
nsh> 
```
