### PR TITLE
driver/note: make SIZEOF_NOTE_START return the right size

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -117,9 +117,9 @@ struct note_startalloc_s
 };
 
 #if CONFIG_TASK_NAME_SIZE > 0
-#  define SIZEOF_NOTE_START(n) (sizeof(struct note_start_s) + (n) - 1)
+#  define SIZEOF_NOTE_START(n) (sizeof(struct note_common_s) + (n))
 #else
-#  define SIZEOF_NOTE_START(n) (sizeof(struct note_start_s))
+#  define SIZEOF_NOTE_START(n) (sizeof(struct note_common_s))
 #endif
 
 #if CONFIG_DRIVERS_NOTE_TASKNAME_BUFSIZE > 0

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -324,16 +324,6 @@ struct note_common_s
   clock_t nc_systime;          /* Time when note was buffered */
 };
 
-/* This is the specific form of the NOTE_START note */
-
-struct note_start_s
-{
-  struct note_common_s nst_cmn; /* Common note parameters */
-#if CONFIG_TASK_NAME_SIZE > 0
-  char    nst_name[1];          /* Start of the name of the thread/task */
-#endif
-};
-
 /* This is the specific form of the NOTE_STOP note */
 
 struct note_stop_s


### PR DESCRIPTION
## Summary

The value returned by sizeof(struct note_start_s) is larger than the actual memory footprint of struct note_start_s.

This causes the length calculated in sched_note_start to be larger than the actual memory size,which further leads to out-of-bounds reads in note_common.

## Impact

 fix out-of-bounds reads bug in note_common

## Testing

* 1 sim with driver note and fs_test  enable 
* 2 use a long name command can reproduce such as:

ap> vela_fs_multi_thread_read_test testPath=/data dataLen=100

=================================================================
==2708389==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xe64f2380 at pc 0x43fe06f1 bp 0xe64f21e8 sp 0xe64f21d8
READ of size 1 at 0xe64f2380 thread T0
    #0 0x43fe06f0 in memcpy ../../nuttx/libs/libc/string/lib_bsdmemcpy.c:89
    #1 0x443f84b7 in noteram_add ../../nuttx/drivers/note/noteram_driver.c:1002
    #2 0x443ededa in sched_note_start ../../nuttx/drivers/note/note_driver.c:755
    #3 0x441778b8 in nxtask_activate ../../nuttx/sched/task/task_activate.c:86
    #4 0x4569b0c0 in exec_module ../../nuttx/binfmt/binfmt_execmodule.c:380
    #5 0x456984a3 in exec_internal ../../nuttx/binfmt/binfmt_exec.c:137
    #6 0x45698564 in exec_spawn ../../nuttx/binfmt/binfmt_exec.c:205
    #7 0x4463f77d in nxposix_spawn_exec ../../nuttx/sched/task/task_posixspawn.c:109
    #8 0x4463f987 in posix_spawn ../../nuttx/sched/task/task_posixspawn.c:223
    #9 0x4421f45d in nsh_fileapp ../../apps/nshlib/nsh_fileapps.c:229
    #10 0x4420a65a in nsh_execute ../../apps/nshlib/nsh_parse.c:551
    #11 0x4421b934 in nsh_parse_command ../../apps/nshlib/nsh_parse.c:2890
    #12 0x4421c66d in nsh_parse ../../apps/nshlib/nsh_parse.c:3000
    #13 0x4421de42 in nsh_session ../../apps/nshlib/nsh_session.c:246
    #14 0x441e32a9 in nsh_consolemain ../../apps/nshlib/nsh_consolemain.c:75
    #15 0x441a63c2 in nsh_main ../../apps/system/nsh/nsh_main.c:74
    #16 0x445e84b5 in nxtask_startup ../../nuttx/libs/libc/sched/task_startup.c:66
    #17 0x44177d2c in nxtask_start ../../nuttx/sched/task/task_start.c:107
    #18 0x443c679c in pre_start ../../nuttx/arch/sim/src/sim/sim_initialstate.c:59

0xe64f2380 is located 203648 bytes inside of 206872-byte region [0xe64c0800,0xe64f3018)
allocated by thread T0 here:
    #0 0xeaa51f3f in __interceptor_posix_memalign ../../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x43cc1bfa in host_memalign ../../nuttx/arch/sim/src/sim/posix/sim_hostmemory.c:156
    #2 0x43cc1d6d in host_realloc ../../nuttx/arch/sim/src/sim/posix/sim_hostmemory.c:181
    #3 0x43e4d13d in reallocate ../../nuttx/arch/sim/src/sim/sim_ummheap.c:390
    #4 0x43e4d4a8 in malloc ../../nuttx/arch/sim/src/sim/sim_ummheap.c:486
    #5 0x443c75ca in up_create_stack ../../nuttx/arch/sim/src/sim/sim_createstack.c:120
    #6 0x441731db in task_setup ../../nuttx/sched/task/task_init.c:111
    #7 0x44173cf4 in nxtask_init ../../nuttx/sched/task/task_init.c:282
    #8 0x4417b694 in nxtask_spawn_create ../../nuttx/sched/task/task_spawn.c:107
    #9 0x4417b9c1 in nxtask_spawn_exec ../../nuttx/sched/task/task_spawn.c:216
    #10 0x4417bcab in task_spawn ../../nuttx/sched/task/task_spawn.c:318
    #11 0x44147b16 in nx_start_application ../../nuttx/sched/init/nx_bringup.c:359
    #12 0x44147c1e in nx_start_task ../../nuttx/sched/init/nx_bringup.c:414
    #13 0x44177d0d in nxtask_start ../../nuttx/sched/task/task_start.c:101
    #14 0x443c679c in pre_start ../../nuttx/arch/sim/src/sim/sim_initialstate.c:59

SUMMARY: AddressSanitizer: stack-buffer-overflow ../../nuttx/libs/libc/string/lib_bsdmemcpy.c:89 in memcpy
Shadow bytes around the buggy address:
  0xe64f2100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2300: 00 00 00 00 f1 f1 f1 f1 f1 f1 00 00 00 00 00 00
=>0xe64f2380:[f3]f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0xe64f2600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2708389==ABORTING
Aborted (core dumped)

3 This patch fixes the out-of-bounds memory issue.

ap> vela_fs_multi_thread_read_test testPath=/data dataLen=100
[   66.898406] [11] [  INFO] [ap] Creating threads...
[   66.899319] [11] [  INFO] [ap] Joining threads...
ap> [   66.934001] [11] [  INFO] [ap] TEST PASS!


