### PR TITLE
fs/tmpfs: fix memoryleak of tmpfs_opendir

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -2047,14 +2047,18 @@ static int tmpfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
     {
       tdir->tf_tdo   = tdo;
       tdir->tf_index = tdo->tdo_nentries;
-
+      *dir = &tdir->tf_base;
       tmpfs_unlock_directory(tdo);
     }
 
   /* Release the lock on the file system and return the result */
 
   tmpfs_unlock(fs);
-  *dir = &tdir->tf_base;
+  if (ret < 0)
+    {
+      fs_heap_free(tdir);
+    }
+
   return ret;
 }
 


### PR DESCRIPTION
## Summary

fix the memory leak in tmpfs_opendir

## Impact

fix memory leak 

## Testing

sim on linux
<img width="1495" height="630" alt="image" src="https://github.com/user-attachments/assets/1e566b44-bbd4-4198-bc41-dcd351ccef7b" />

We identified that tmpfs would cause a memory leak when opening a non-existent directory (dir), and this leak no longer occurs after the fix.  @linguini1 

![adb4224f-2304-40c6-8873-29a3d6510ff2](https://github.com/user-attachments/assets/6b6df1c0-16f2-4a23-b291-f61a55433bf2)
