### PR TITLE
libc/localtime: tz_lock/unlock should not touch tcb except FLAT

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -346,7 +346,7 @@ static FAR const char *getnum(FAR const char *strp, FAR int *nump,
 static FAR const char *getsecs(FAR const char *strp,
               FAR int_fast32_t *secsp);
 static FAR const char *getoffset(FAR const char *strp,
-              FAR int_fast32_t *offsetp);
+              FAR int_fast32_t *poffset);
 static FAR const char *getrule(FAR const char *strp,
               FAR struct rule_s *rulep);
 static void gmtload(FAR struct state_s *sp);
@@ -1274,7 +1274,7 @@ static FAR const char *getsecs(FAR const char *strp,
  */
 
 static FAR const char *getoffset(FAR const char *strp,
-                                 FAR int_fast32_t *offsetp)
+                                 FAR int_fast32_t *poffset)
 {
   int neg = FALSE;
 
@@ -1288,7 +1288,7 @@ static FAR const char *getoffset(FAR const char *strp,
       ++strp;
     }
 
-  strp = getsecs(strp, offsetp);
+  strp = getsecs(strp, poffset);
   if (strp == NULL)
     {
       return NULL; /* illegal time */
@@ -1296,7 +1296,7 @@ static FAR const char *getoffset(FAR const char *strp,
 
   if (neg)
     {
-      *offsetp = -*offsetp;
+      *poffset = -*poffset;
     }
 
   return strp;


### PR DESCRIPTION
## Summary
The previous tz_lock not working. #ifndef __KERNEL__ means only usermode will run up_interrupt_context etc.

Causing kernel build report undefined reference 'g_nx_initstate'
Also protect build still ensure no access of kernel objects.

## Impact
The code did not have effect before patch.
After patch, will correctly skip lock when userspace or idle thread.

## Testing
CI test, mps3-knsh

enable CONFIG_LIBC_LOCALTIME in boards/arm/mps/mps3-an547/configs/knsh/defconfig

update apps/examples/hello/hello_main.c 
```C
#include <time.h>

int main(int argc, FAR char *argv[])
{
  tzset();
  printf("Hello, World!!\n");
  return 0;
}
```

error before patch.
```
arm-none-eabi-ld: ~/nuttx/staging//libc.a(lib_localtime.o): in function `tz_lock':
~/nuttx/libs/libc/time/lib_localtime.c:396:(.text.tz_lock+0x12): undefined reference to `sched_idletask'
arm-none-eabi-ld: ~/nuttx/libs/libc/time/lib_localtime.c:403:(.text.tz_lock+0x38): undefined reference to `g_nx_initstate'
arm-none-eabi-ld: ~/nuttx/staging//libc.a(lib_localtime.o): in function `tz_unlock':
~/nuttx/libs/libc/time/lib_localtime.c:408:(.text.tz_unlock+0x12): undefined reference to `sched_idletask'
arm-none-eabi-ld: ~/nuttx/libs/libc/time/lib_localtime.c:415:(.text.tz_unlock+0x38): undefined reference to `g_nx_initstate'
make[1]: *** [Makefile:61: nuttx_user.elf] Error 1
```

fixed after patch. we able to call function tzset in hello.

launch by
```bash
qemu-system-arm -M mps3-an547 -nographic -device loader,file=nuttx -device loader,file=nuttx_user.elf
```