### PR TITLE
arch/arm: Aligned Cmake with Make

### DIFF
--- a/arch/arm/src/armv6-m/CMakeLists.txt
+++ b/arch/arm/src/armv6-m/CMakeLists.txt
@@ -32,8 +32,11 @@ set(SRCS
     arm_svcall.c
     arm_systemreset.c
     arm_tcbinfo.c
-    arm_trigger_irq.c
-    arm_vectors.c)
+    arm_trigger_irq.c)
+
+if(NOT CONFIG_ARCH_HAVE_CUSTOM_VECTORS)
+  list(APPEND SRCS arm_vectors.c)
+endif()
 
 if((DEFINED CONFIG_DEBUG_FEATURES AND CONFIG_DEBUG_FEATURES)
    OR (DEFINED CONFIG_ARM_COREDUMP_REGION AND CONFIG_ARM_COREDUMP_REGION))

--- a/arch/arm/src/armv7-m/CMakeLists.txt
+++ b/arch/arm/src/armv7-m/CMakeLists.txt
@@ -26,7 +26,6 @@ set(SRCS
     arm_exception.S
     arm_saveusercontext.S
     arm_busfault.c
-    arm_dbgmonitor.c
     arm_cache.c
     arm_cpuinfo.c
     arm_doirq.c
@@ -42,8 +41,11 @@ set(SRCS
     arm_tcbinfo.c
     arm_trigger_irq.c
     arm_usagefault.c
-    arm_vectors.c
     arm_dbgmonitor.c)
+
+if(NOT CONFIG_ARCH_HAVE_CUSTOM_VECTORS)
+  list(APPEND SRCS arm_vectors.c)
+endif()
 
 if(CONFIG_ARMV7M_SYSTICK)
   list(APPEND SRCS arm_systick.c)

--- a/arch/arm/src/armv8-m/CMakeLists.txt
+++ b/arch/arm/src/armv8-m/CMakeLists.txt
@@ -42,8 +42,11 @@ set(SRCS
     arm_systemreset.c
     arm_tcbinfo.c
     arm_trigger_irq.c
-    arm_usagefault.c
-    arm_vectors.c)
+    arm_usagefault.c)
+
+if(NOT CONFIG_ARCH_HAVE_CUSTOM_VECTORS)
+  list(APPEND SRCS arm_vectors.c)
+endif()
 
 if(CONFIG_ARMV8M_SYSTICK)
   list(APPEND SRCS arm_systick.c)


### PR DESCRIPTION
## Summary

- use chip specific vectors to allow smpcall update regs apache#14363

## Impact

Impact on user: NO

Impact on build: This PR Aligned Cmake with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally