### PR TITLE
net/netdev: allow stack to send/receive when running

### DIFF
--- a/net/netdev/netdev_default.c
+++ b/net/netdev/netdev_default.c
@@ -66,9 +66,9 @@ FAR struct net_driver_s *netdev_default(void)
   net_lock();
   for (dev = g_netdevices; dev; dev = dev->flink)
     {
-      /* Is the interface in the "up" state? */
+      /* Is the interface in the "running" state? */
 
-      if ((dev->d_flags & IFF_UP) != 0)
+      if (IFF_IS_RUNNING(dev->d_flags) != 0)
         {
           /* Return a reference to the first device that we find in the UP
            * state (but not the loopback device unless it is the only

--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -83,9 +83,9 @@ netdev_prefixlen_findby_lipv4addr(in_addr_t lipaddr, FAR int8_t *prefixlen)
   net_lock();
   for (dev = g_netdevices; dev; dev = dev->flink)
     {
-      /* Is the interface in the "up" state? */
+      /* Is the interface in the "running" state? */
 
-      if ((dev->d_flags & IFF_UP) != 0 &&
+      if (IFF_IS_RUNNING(dev->d_flags) != 0 &&
           !net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
         {
 #ifndef CONFIG_ROUTE_LONGEST_MATCH
@@ -195,9 +195,9 @@ netdev_prefixlen_findby_lipv6addr(const net_ipv6addr_t lipaddr,
 
   for (dev = g_netdevices; dev; dev = dev->flink)
     {
-      /* Is the interface in the "up" state? */
+      /* Is the interface in the "running" state? */
 
-      if ((dev->d_flags & IFF_UP) != 0 && NETDEV_HAS_V6ADDR(dev))
+      if (IFF_IS_RUNNING(dev->d_flags) != 0 && NETDEV_HAS_V6ADDR(dev))
         {
 #ifndef CONFIG_ROUTE_LONGEST_MATCH
           /* Yes.. check for an address match (under the netmask) */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
netdev:when network device is running status,the network protocol stack is allowed to send packet to the network device and to receive from the network device

## Impact

netdev

## Testing
Test in qemu
<img width="860" height="699" alt="image" src="https://github.com/user-attachments/assets/d58a2acf-a7c6-4d94-9da5-941e758e2c3e" />

<img width="655" height="446" alt="image" src="https://github.com/user-attachments/assets/6e2f017b-9c42-41b6-8a4c-0f58afb32e9f" />
