### PR TITLE
net/igmp: mod check of IGMP_SCHEDMSG from assert to error log

### DIFF
--- a/net/igmp/igmp_msg.c
+++ b/net/igmp/igmp_msg.c
@@ -77,8 +77,14 @@ int igmp_schedmsg(FAR struct igmp_group_s *group, uint8_t msgid)
 {
   FAR struct net_driver_s *dev;
 
-  DEBUGASSERT(group != NULL && !IS_SCHEDMSG(group->flags));
+  DEBUGASSERT(group != NULL);
   DEBUGASSERT(group->ifindex > 0);
+
+  if (IS_SCHEDMSG(group->flags))
+    {
+      nerr("ERROR: The group %u is busy\n", group->ifindex);
+      return -EBUSY;
+    }
 
   /* Get the device instance associated with the interface index of the
    * group


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Setting group->flags to IGMP_SCHEDMSG is a possible outcome, not unacceptable. If it occurs, an error log message will be reported

## Impact

igmp

## Testing
code in igmp_msg.c
```
#ifdef CONFIG_NET_IGMP_TESTMODE
static struct igmp_group_s g_test_group;

/****************************************************************************
 * Name: igmp_test_schedmsg_busy
 * Description:
 *   Schedule once without presetting SCHEDMSG. This should return OK and
 *   leave SCHEDMSG set internally by igmp_schedmsg.
 */
int igmp_test_schedmsg_busy(uint8_t ifindex)
{
  g_test_group.ifindex = ifindex;
  g_test_group.flags   = 0;  
  g_test_group.msgid   = 0;
  return igmp_schedmsg(&g_test_group, IGMPv2_MEMBERSHIP_REPORT);
}

/****************************************************************************
 * Name: igmp_test_schedmsg_conflict
 * Description:
 *   Call igmp_schedmsg again on the same group to hit the busy-path.
 */
int igmp_test_schedmsg_conflict(uint8_t ifindex)
{
  if (g_test_group.ifindex != ifindex)
    {
      g_test_group.ifindex = ifindex;
    }
  return igmp_schedmsg(&g_test_group, IGMPv2_MEMBERSHIP_REPORT);
}
#endif /* CONFIG_NET_IGMP_TESTMODE */

#if defined(CONFIG_NET_IGMP) && defined(CONFIG_NET_IGMP_TESTMODE)
#include <nuttx/net/igmp.h>

```
code in hello_main.c
```
static void test_igmp_schedmsg(void)
{
  int r1 = igmp_test_schedmsg_busy(1);
  printf("igmp_test_schedmsg_busy ret=%d (expect 0)\n", r1);
  int r2 = igmp_test_schedmsg_conflict(1);
  printf("igmp_test_schedmsg_conflict ret=%d (expect -EBUSY)\n", r2);
}
#endif

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n\n");

  /* Run the IGMP schedmsg test */
  test_igmp_schedmsg();

  return 0;
}
```
test result:
<img width="783" height="189" alt="image" src="https://github.com/user-attachments/assets/80ac4d35-08f3-48ec-a23d-1356a26f676d" />
