### PR TITLE
net/tcp: resolve reconnection issues when connection failed due to rejection

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -695,6 +695,19 @@ int tcp_connect(FAR struct tcp_conn_s *conn,
                 FAR const struct sockaddr *addr);
 
 /****************************************************************************
+ * Name: tcp_removeconn
+ *
+ * Description:
+ *   remove the connection from the list of active TCP connections
+ *
+ * Assumptions:
+ *   This function is called from network logic with the network locked.
+ *
+ ****************************************************************************/
+
+void tcp_removeconn(FAR struct tcp_conn_s *conn);
+
+/****************************************************************************
  * Name: psock_tcp_connect
  *
  * Description:

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1489,4 +1489,22 @@ errout_with_lock:
   return ret;
 }
 
+/****************************************************************************
+ * Name: tcp_removeconn
+ *
+ * Description:
+ *   remove the connection from the list of active TCP connections
+ *
+ * Assumptions:
+ *   This function is called from network logic with the network locked.
+ *
+ ****************************************************************************/
+
+void tcp_removeconn(FAR struct tcp_conn_s *conn)
+{
+  net_lock();
+  dq_rem(&conn->sconn.node, &g_active_tcp_connections);
+  net_unlock();
+}
+
 #endif /* CONFIG_NET && CONFIG_NET_TCP */

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -241,6 +241,12 @@ static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
 
       ninfo("Resuming: %d\n", pstate->tc_result);
 
+      if (pstate->tc_result != OK)
+        {
+          tcp_removeconn(conn);
+          conn->tcpstateflags = TCP_ALLOCATED;
+        }
+
       /* Stop further callbacks */
 
       psock_teardown_callbacks(pstate, pstate->tc_result);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

After first connection refused happend,The user use the same connection failed,becasue the tcpstateflags is not TCP_ALLOCATED

## Impact

tcp connect

## Testing
**A TEST case**

```
#include <nuttx/config.h>
#include <stdio.h>
#include <string.h>
#include <stdlib.h>
#include <errno.h>
#include <unistd.h>
#include <arpa/inet.h>
#include <sys/socket.h>
#include <netinet/in.h>
#if defined(CONFIG_NETUTILS_NETLIB)
#include <netutils/netlib.h>
#endif

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

static void test_tcp_rst_reconnect(const char *ifname, uint16_t port)
{
  int fd = -1;
  struct sockaddr_in to;
  int ret;
  struct in_addr dest = {0};

#if defined(CONFIG_NETUTILS_NETLIB)
  if (ifname && ifname[0] != '\0')
    {
      struct in_addr ifaddr;
      if (netlib_get_ipv4addr(ifname, &ifaddr) == 0)
        {
          dest = ifaddr;
          printf("[tcp] iface=%s ip=%s\n", ifname, inet_ntoa(dest));
        }
    }
#endif

  if (dest.s_addr == 0)
    {
      inet_aton("127.0.0.1", &dest);
      printf("[tcp] fallback dest=%s (no ifaddr)\n", inet_ntoa(dest));
    }

  fd = socket(AF_INET, SOCK_STREAM, 0);
  if (fd < 0)
    {
      printf("[tcp] socket() failed errno=%d\n", errno);
      return;
    }

  memset(&to, 0, sizeof(to));
  to.sin_family = AF_INET;
  to.sin_port   = htons(port);
  to.sin_addr   = dest;
  printf("[tcp] connect target=%s:%u\n", inet_ntoa(dest), port);

  /* 1) First connect with no server listening -> expect ECONNREFUSED */
  ret = connect(fd, (struct sockaddr *)&to, sizeof(to));
  printf("[tcp] connect#1 ret=%d errno=%d\n", ret, errno);

  /* 2) Start a local server (bind+listen) in the same thread */
  int ls = socket(AF_INET, SOCK_STREAM, 0);
  if (ls >= 0)
    {
      struct sockaddr_in sa;
      memset(&sa, 0, sizeof(sa));
      sa.sin_family = AF_INET;
      sa.sin_port   = htons(port);
      sa.sin_addr.s_addr = INADDR_ANY;
      if (bind(ls, (struct sockaddr *)&sa, sizeof(sa)) == 0 &&
          listen(ls, 1) == 0)
        {
          printf("[tcp] server: now listening on %u\n", port);
        }
      else
        {
          printf("[tcp] server setup failed errno=%d\n", errno);
        }
    }
  else
    {
      printf("[tcp] listen socket create failed errno=%d\n", errno);
    }

  /* 3) Reuse the SAME client socket to connect again */
  errno = 0;
  ret = connect(fd, (struct sockaddr *)&to, sizeof(to));
  printf("[tcp] connect#2 ret=%d errno=%d\n", ret, errno);
  if (ret == 0)
    {
      printf("[tcp] PASS: reconnect on same socket succeeded.\n");
    }
  else if (errno == EISCONN)
    {
      printf("[tcp] FAIL: got EISCONN (bug reproduced).\n");
    }
  else
    {
      printf("[tcp] INFO: connect#2 failed but not EISCONN.\n");
    }

  if (fd >= 0) close(fd);
}

int main(int argc, FAR char *argv[])
{
  if (argc >= 2 && strcmp(argv[1], "tcp-rst-reconnect-test") == 0)
    {
      const char *ifname = (argc >= 3) ? argv[2] : "";
      uint16_t port = (argc >= 4) ? (uint16_t)atoi(argv[3]) : 34567;
      test_tcp_rst_reconnect(ifname, port);
      return 0;
    }

  printf("Hello, World!!\n\n");
  printf("Usage: hello tcp-rst-reconnect-test [iface] [port]\n");
  return 0;
}
```

**Before the patch**

![img_v3_02t9_fee7b08f-6cf5-453d-b6a1-4058784c9efg](https://github.com/user-attachments/assets/1dec1b78-72ab-463e-889d-03b3066a60e1)

**After the patch**

![img_v3_02t9_235aef47-cdf6-453a-889b-3dc37c4e1cfg](https://github.com/user-attachments/assets/25e4ae1a-5262-409a-bc67-81ec8622cef4)


