### PR TITLE
espressif: improve esp-hal-3rdparty handling

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -635,7 +635,7 @@ define CLONE
 		if [ ! -d $3 ]; then \
 			git clone --quiet $1 $3; \
 		fi; \
-		cp -fr $3 $2; \
+		$(DIRLINK) $3 $2; \
 	fi
 	$(ECHO_END)
 endef


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Reduce the downloads of esp-hal-3rdparty when using nxtmpdir to store esp-hal-3rdparty and speedup compilation after `make distclean`.

Any new `make distclean` and configure for a different espressif device no longer requires the downloading of modules or patching.

## Impact

Impact on build process: reduced compilation time,
Impact on hardware: none,
Impact on documentation: none,
Impact on security: none,
Impact on compatibility: none,

## Testing

Usage:
```
~/nuttxspace/nuttx/make distclean
~/nuttxspace/nuttx/./tools/configure.sh -l -S esp32-devkitc:nsh
~/nuttxspace/nuttx/make flash -j 8 ESPTOOL_PORT=/dev/ttyUSB0
~/nuttxspace/nuttx/picocom /dev/ttyUSB0 --baud 115200
```
Result:
```
load:0x40080000,len:30516
entry 0x40082880
*** Booting NuttX ***
dram: lma 0x00001020 vma 0x3ffb2020 len 0xe30    (3632)
iram: lma 0x00001e58 vma 0x40080000 len 0x7734   (30516)
padd: lma 0x00009598 vma 0x00000000 len 0x6a60   (27232)
imap: lma 0x00010000 vma 0x400e0000 len 0x11e50  (73296)
padd: lma 0x00021e58 vma 0x00000000 len 0xe1a0   (57760)
dmap: lma 0x00030000 vma 0x3f410000 len 0x2d3c   (11580)
total segments stored 6
WARNING: NuttX supports ESP32 chip revision >= v3.0 (chip is v1.0).
Ignoring this error and continuing because `ESP32_IGNORE_CHIP_REVISION_CHECK` is set...
THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!

NuttShell (NSH) NuttX-12.8.0
nsh> uname -a
NuttX 12.8.0 edf89ddedd-dirty Dec 22 2025 09:21:37 xtensa esp32-devkitc
nsh>
Terminating...
```

@tmedicci, @fdcavalcanti, @simbit18 