### PR TITLE
net/tcp: add net_lock in cleanup and update callback pointer type

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -442,7 +442,7 @@ struct tcp_backlog_s
 struct tcp_callback_s
 {
   FAR struct tcp_conn_s *tc_conn;
-  FAR struct devif_callback_s *tc_cb;
+  FAR struct devif_callback_s **tc_cb;
   FAR sem_t *tc_sem;
 };
 

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -437,8 +437,10 @@ void tcp_callback_cleanup(FAR void *arg)
 {
   FAR struct tcp_callback_s *cb = (FAR struct tcp_callback_s *)arg;
 
+  net_lock();
   nerr("ERROR: pthread is being canceled, need to cleanup cb\n");
-  tcp_callback_free(cb->tc_conn, cb->tc_cb);
+  tcp_callback_free(cb->tc_conn, *(cb->tc_cb));
   nxsem_destroy(cb->tc_sem);
+  net_unlock();
 }
 #endif /* NET_TCP_HAVE_STACK */

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -369,7 +369,7 @@ int psock_tcp_connect(FAR struct socket *psock,
                */
 
               info.tc_conn = conn;
-              info.tc_cb = state.tc_cb;
+              info.tc_cb = &state.tc_cb;
               info.tc_sem = &state.tc_sem;
               tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -803,7 +803,7 @@ static ssize_t tcp_recvfrom_one(FAR struct tcp_conn_s *conn, FAR void *buf,
            */
 
           info.tc_conn = conn;
-          info.tc_cb   = state.ir_cb;
+          info.tc_cb   = &state.ir_cb;
           info.tc_sem  = &state.ir_sem;
           tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1465,7 +1465,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
            */
 
           info.tc_conn = conn;
-          info.tc_cb   = conn->sndcb;
+          info.tc_cb   = &conn->sndcb;
           info.tc_sem  = &conn->snd_sem;
           tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -611,7 +611,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
                */
 
               info.tc_conn = conn;
-              info.tc_cb   = state.snd_cb;
+              info.tc_cb   = &state.snd_cb;
               info.tc_sem  = &state.snd_sem;
               tls_cleanup_push(tls_get_info(), tcp_callback_cleanup, &info);
 


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. Add net_lock protection in tcp_callback_cleanup function
2. Change devif_callback_s member of tcp_callback_s to two-dimensional pointer

## Impact

tcp

## Testing

It has passed self-testing in true machine(wearable devices)
