### PR TITLE
net/udp: resolve UDP exit delay due to high CPU usage

### DIFF
--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -162,6 +162,7 @@ struct udp_conn_s
 #ifdef CONFIG_NET_TIMESTAMP
   int timestamp; /* Nonzero when SO_TIMESTAMP is enabled */
 #endif
+  FAR sem_t *txdrain_sem;
 };
 
 /* This structure supports UDP write buffering.  It is simply a container
@@ -849,38 +850,6 @@ int udp_readahead_notifier_setup(worker_t worker,
 #endif
 
 /****************************************************************************
- * Name: udp_writebuffer_notifier_setup
- *
- * Description:
- *   Set up to perform a callback to the worker function when an UDP write
- *   buffer is emptied.  The worker function will execute on the high
- *   priority worker thread.
- *
- * Input Parameters:
- *   worker - The worker function to execute on the low priority work
- *            queue when data is available in the UDP read-ahead buffer.
- *   conn   - The UDP connection where read-ahead data is needed.
- *   arg    - A user-defined argument that will be available to the worker
- *            function when it runs.
- *
- * Returned Value:
- *   > 0   - The notification is in place.  The returned value is a key that
- *           may be used later in a call to udp_notifier_teardown().
- *   == 0  - There is already buffered read-ahead data.  No notification
- *           will be provided.
- *   < 0   - An unexpected error occurred and no notification will occur.
- *           The returned value is a negated errno value that indicates the
- *           nature of the failure.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_UDP_NOTIFIER
-int udp_writebuffer_notifier_setup(worker_t worker,
-                                   FAR struct udp_conn_s *conn,
-                                   FAR void *arg);
-#endif
-
-/****************************************************************************
  * Name: udp_notifier_teardown
  *
  * Description:
@@ -924,31 +893,6 @@ void udp_notifier_teardown(FAR void *key);
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
 void udp_readahead_signal(FAR struct udp_conn_s *conn);
-#endif
-
-/****************************************************************************
- * Name: udp_writebuffer_signal
- *
- * Description:
- *   All buffer Tx data has been sent.  Signal all threads waiting for the
- *   write buffers to become empty.
- *
- *   When write buffer becomes empty, *all* of the workers waiting
- *   for that event data will be executed.  If there are multiple workers
- *   waiting for read-ahead data then only the first to execute will get the
- *   data.  Others will need to call udp_writebuffer_notifier_setup() once
- *   again.
- *
- * Input Parameters:
- *   conn  - The UDP connection where read-ahead data was just buffered.
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-#if defined(CONFIG_NET_UDP_WRITE_BUFFERS) && defined(CONFIG_NET_UDP_NOTIFIER)
-void udp_writebuffer_signal(FAR struct udp_conn_s *conn);
 #endif
 
 /****************************************************************************

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -138,11 +138,14 @@ static void sendto_writebuffer_release(FAR struct udp_conn_s *conn)
           conn->sndcb->event = NULL;
           wrb = NULL;
 
-#ifdef CONFIG_NET_UDP_NOTIFIER
-          /* Notify any waiters that the write buffers have been drained. */
+          if (conn->txdrain_sem != NULL)
+            {
+              /* Notify the txdrain semaphore that the write buffer queue
+               * has been drained.
+               */
 
-          udp_writebuffer_signal(conn);
-#endif
+              nxsem_post(conn->txdrain_sem);
+            }
         }
       else
         {

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -42,35 +42,6 @@
 #if defined(CONFIG_NET_UDP_WRITE_BUFFERS) && defined(CONFIG_NET_UDP_NOTIFIER)
 
 /****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: txdrain_worker
- *
- * Description:
- *   Called with the write buffers have all been sent.
- *
- * Input Parameters:
- *   arg     - The notifier entry.
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-static void txdrain_worker(FAR void *arg)
-{
-  FAR sem_t *waitsem = (FAR sem_t *)arg;
-
-  DEBUGASSERT(waitsem != NULL);
-
-  /* Then just post the semaphore, waking up tcp_txdrain() */
-
-  nxsem_post(waitsem);
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -94,7 +65,7 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
 {
   FAR struct udp_conn_s *conn;
   sem_t waitsem;
-  int ret;
+  int ret = OK;
 
   DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
@@ -111,24 +82,12 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
   /* The following needs to be done with the network stable */
 
   net_lock();
-  ret = udp_writebuffer_notifier_setup(txdrain_worker, conn, &waitsem);
-  if (ret > 0)
+
+  if (!sq_empty(&conn->write_q))
     {
-      int key = ret;
-
-      /* There is pending write data.. wait for it to drain. */
-
-      tls_cleanup_push(tls_get_info(), udp_notifier_teardown, &key);
+      conn->txdrain_sem = &waitsem;
       ret = net_sem_timedwait_uninterruptible(&waitsem, timeout);
-
-      /* Tear down the notifier (in case we timed out or were canceled) */
-
-      if (ret < 0)
-        {
-          udp_notifier_teardown(&key);
-        }
-
-      tls_cleanup_pop(tls_get_info(), 0);
+      conn->txdrain_sem = NULL;
     }
 
   net_unlock();


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

In scenarios where CPU utilization is high, txdrain_worker is not being executed in the LPWORK queue. Therefore, the implementation method of udp_writebuffer_signal is removed, and txdrain_sem is directly set


## Impact

udp

## Testing

It has passed self-testing in true machine(speaker equipment)
