### PR TITLE
drivers/net: setting loopback network driver sending task to the HPWORK queue

### DIFF
--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -239,7 +239,7 @@ static int lo_txavail(FAR struct net_driver_s *dev)
     {
       /* Schedule to serialize the poll on the worker thread. */
 
-      work_queue(LPWORK, &priv->lo_work, lo_txavail_work, priv, 0);
+      work_queue(HPWORK, &priv->lo_work, lo_txavail_work, priv, 0);
     }
 
   return OK;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The loopback network driver sending task is placed in the LPWORK queue, which may result in delayed scheduling when the CPU usage reaches 100%, leading to the timely sending of cached messages from the loopback network driver and causing issues with post waitsem being too late​.we decied to set loopback sending task to the HPWORK queue.

## Impact

loopback

## Testing

It has passed self-testing in true machine(speaker equipment)