### PR TITLE
{bp-17433} drivers/usbdev/cdcecm.c: fix cdcecm netdev can not enter running state

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1047,6 +1047,7 @@ error:
 static int cdcecm_setinterface(FAR struct cdcecm_driver_s *self,
                                uint16_t interface, uint16_t altsetting)
 {
+  netdev_carrier_on(&self->dev);
   uinfo("interface: %hu, altsetting: %hu\n", interface, altsetting);
   return OK;
 }


### PR DESCRIPTION
## Summary
When the setinterface interface is called, it indicates that the underlying USB link has been successfully established. At this point, the status of the network card needs to be updated to RUNNING by calling the netdev_carrier_on interface. It is similar to the logic after a Wi-Fi network card is connected to a hotspot. Otherwise, an incorrect network card status may cause packets to fail to be successfully sent.

## Impact
RELEASE

## Testing
CI