### PR TITLE
{bp-17434} select: fix too small timeout will be counted as 0

### DIFF
--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -204,7 +204,7 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
     {
       /* Calculate the timeout in milliseconds */
 
-      msec = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
+      msec = timeout->tv_sec * 1000 + (timeout->tv_usec + 999) / 1000;
     }
   else
     {


### PR DESCRIPTION
## Summary
avoiding timeouts less than 1ms may lead to busyloop

## Impact
RELEASE

## Testing
CI