### PR TITLE
{bp-17436} net/netdev: skip mld_devinit if Nic can not support mld

### DIFF
--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -475,7 +475,12 @@ int netdev_register(FAR struct net_driver_s *dev, enum net_lltype_e lltype)
 #ifdef CONFIG_NET_MLD
       /* Configure the device for MLD support */
 
-      mld_devinit(dev);
+      if ((flags & IFF_MULTICAST) != 0)
+        {
+          /* MLD is only supported on multicast capable devices */
+
+          mld_devinit(dev);
+        }
 #endif
 
 #ifdef NET_ICMPv6_HAVE_STACK


### PR DESCRIPTION
## Summary
avoid unnecessary operations

## Impact
RELEASE

## Testing
CI