### PR TITLE
{bp-17441} drivers/can/can.c: fix broken O_NONBLOCK

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -518,7 +518,7 @@ return_with_irqdisabled:
 
   /* ret can be more than buflen due to roundup, so return at most buflen */
 
-  return ret ? MIN(ret, buflen) : -EMSGSIZE;
+  return ret ? MIN(ret, (ssize_t)buflen) : -EMSGSIZE;
 }
 
 /****************************************************************************
@@ -744,7 +744,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
    * can be more due to roundup.
    */
 
-  ret = MIN(nsent, buflen);
+  ret = MIN(nsent, (ssize_t)buflen);
 
 return_with_irqdisabled:
   leave_critical_section(flags);


### PR DESCRIPTION
## Summary
O_NONBLOCK open mode was broken since
https://github.com/apache/nuttx/pull/17360

MIN() comapres signed value (int) with unsigned value (size_t) which causes an unexpected return value when ret is negative

## Impact
RELEASE

## Testing
CI