### PR TITLE
drivers/mtd: add MTDIOC_ISBAD ioctl

### DIFF
--- a/Documentation/components/drivers/special/mtd.rst
+++ b/Documentation/components/drivers/special/mtd.rst
@@ -36,6 +36,7 @@ See include/nuttx/mtd/mtd.h for additional information.
 
    -  ``MTDIOC_GEOMETRY``: Get MTD geometry
    -  ``MTDIOC_BULKERASE``: Erase the entire device
+   -  ``MTDIOC_ISBAD``: Check if a block is bad
 
    is provided via a single ``ioctl`` method (see
    ``include/nuttx/fs/ioctl.h``):

--- a/drivers/mtd/mtd_nand.c
+++ b/drivers/mtd/mtd_nand.c
@@ -837,6 +837,15 @@ static int nand_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ISBAD:
+        {
+          FAR struct mtd_bad_block_s *bad_block =
+                                     (FAR struct mtd_bad_block_s *)arg;
+          bad_block->bad_flag = nand_isbad(dev, bad_block->block_num);
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad command */
         break;

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -85,6 +85,9 @@
                                              * OUT: None
                                              *      Resets the device to the power-on
                                              *      default condition */
+#define MTDIOC_ISBAD        _MTDIOC(0x000e) /* IN: Erase block number
+                                             * OUT: 0=A good block
+                                             *      1=A bad block */
 
 /* Macros to hide implementation */
 
@@ -156,6 +159,14 @@ struct mtd_erase_s
 {
   uint32_t startblock;  /* First block to be erased */
   uint32_t nblocks;     /* Number of blocks to be erased */
+};
+
+/* This structure store the bad block information of a block */
+
+struct mtd_bad_block_s
+{
+  off_t block_num;
+  int bad_flag;
 };
 
 /* This structure defines the interface to a simple memory technology device.


### PR DESCRIPTION
## Summary

This PR adds MTDIOC_ISBAD ioctl support to the NAND MTD driver,
enabling userspace applications to check bad block status through the
standard MTD ioctl interface.
It's related to PR of flashtool: https://github.com/apache/nuttx-apps/pull/3261

## Impact

No impact on existing functionality

## Testing

CI
