### PR TITLE
net/pkt: fix DHCP transmission failure by updating d_sndlen/d_len lengths

### DIFF
--- a/net/pkt/pkt_sendmsg_buffered.c
+++ b/net/pkt/pkt_sendmsg_buffered.c
@@ -143,7 +143,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
        * window size.
        */
 
-      dev->d_sndlen = iob->io_pktlen;
+      dev->d_sndlen = iob->io_pktlen + NET_LL_HDRLEN(dev);
+      dev->d_len = dev->d_sndlen;
       ninfo("wrb=%p sndlen=%d\n", iob, dev->d_sndlen);
 
       if (write_q_len > 1)


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

on some device, the wifi driver uses dev->d_len as the length of the sent packet. However, due to the lack of update in d_len, the sent packet is not considered a normal packet and is not processed by the other end

## Impact

dev->d_sndlen & dev->d_len update

## Testing

It has passed self-testing in true machine(wearable devices)
