### PR TITLE
{bp-17458} binfmt/elf: fix issue of file not closing after being opened.

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -107,7 +107,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
   if (ret != 0)
     {
       berr("Failed to initialize to load ELF program binary: %d\n", ret);
-      return ret;
+      goto errout_with_init;
     }
 
   /* Load the program binary */


### PR DESCRIPTION
## Summary
When opening the file succeeds but reading the file fails in modlib_initialize, this will result in the open file not be closed.

## Impact
RELEASE

## Testing
CI