### PR TITLE
{bp-17462} compiler: redefine float and double when disable float compiling

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -1355,6 +1355,8 @@
 #  undef CONFIG_HAVE_FLOAT
 #  undef CONFIG_HAVE_DOUBLE
 #  undef CONFIG_HAVE_LONG_DOUBLE
+#  define float  int
+#  define double long
 #endif
 
 /* Decorators */


### PR DESCRIPTION
## Summary
Redefine float and double on devices that do not support floating-point. 
float  ==> int
double ==> long

## Impact
RELEASE

## Testing
CI