### PR TITLE
{bp-17485} sched/misc: correct coredump log format

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -759,7 +759,7 @@ static void coredump_dump_dev(pid_t pid)
       return;
     }
 
-  _alert("Finish coredump, write %zu bytes to %s\n",
+  _alert("Finish coredump, write %" PRIdOFF " bytes to %s\n",
          g_devstream.common.nput, CONFIG_BOARD_COREDUMP_DEVPATH);
 }
 #endif


### PR DESCRIPTION
## Summary
since it has been replaced with
https://github.com/apache/nuttx/blob/master/sched/misc/coredump.c#L763 and `nput` map to `off_t` https://github.com/apache/nuttx/blob/master/include/nuttx/streams.h#L98

align with other prints, reference:
- https://github.com/apache/nuttx/blob/master/drivers/misc/rwbuffer.c#L1121
- https://github.com/apache/nuttx/blob/master/fs/mmap/fs_rammap.c#L84
- https://github.com/apache/nuttx/blob/master/libs/libc/elf/elf_read.c#L85

## Impact
RELEASE

## Testing
CI