### PR TITLE
{bp-17501} drivers/battery: fix race condition in event handling

### DIFF
--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -474,18 +474,18 @@ int battery_charger_changed(FAR struct battery_charger_dev_s *dev,
 
   /* Event happen too early? */
 
+  ret = nxmutex_lock(&dev->batlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (list_is_clear(&dev->flist))
     {
       /* Yes, record it and return directly */
 
       dev->mask |= mask;
-      return 0;
-    }
-
-  ret = nxmutex_lock(&dev->batlock);
-  if (ret < 0)
-    {
-      return ret;
+      goto out;
     }
 
   dev->mask |= mask;
@@ -495,6 +495,7 @@ int battery_charger_changed(FAR struct battery_charger_dev_s *dev,
       battery_charger_notify(priv, mask);
     }
 
+out:
   nxmutex_unlock(&dev->batlock);
   return OK;
 }

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -434,18 +434,18 @@ int battery_gauge_changed(FAR struct battery_gauge_dev_s *dev,
 
   /* Event happen too early? */
 
+  ret = nxmutex_lock(&dev->batlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (list_is_clear(&dev->flist))
     {
       /* Yes, record it and return directly */
 
       dev->mask |= mask;
-      return 0;
-    }
-
-  ret = nxmutex_lock(&dev->batlock);
-  if (ret < 0)
-    {
-      return ret;
+      goto out;
     }
 
   dev->mask |= mask;
@@ -455,6 +455,7 @@ int battery_gauge_changed(FAR struct battery_gauge_dev_s *dev,
       battery_gauge_notify(priv, mask);
     }
 
+out:
   nxmutex_unlock(&dev->batlock);
   return OK;
 }

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -499,18 +499,18 @@ int battery_monitor_changed(FAR struct battery_monitor_dev_s *dev,
 
   /* Event happen too early? */
 
+  ret = nxmutex_lock(&dev->batlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (list_is_clear(&dev->flist))
     {
       /* Yes, record it and return directly */
 
       dev->mask |= mask;
-      return 0;
-    }
-
-  ret = nxmutex_lock(&dev->batlock);
-  if (ret < 0)
-    {
-      return ret;
+      goto out;
     }
 
   dev->mask |= mask;
@@ -520,6 +520,7 @@ int battery_monitor_changed(FAR struct battery_monitor_dev_s *dev,
       battery_monitor_notify(priv, mask);
     }
 
+out:
   nxmutex_unlock(&dev->batlock);
   return OK;
 }


### PR DESCRIPTION
## Summary
Move mutex lock before checking flist to prevent race condition where events could be lost when occurring simultaneously with service opening.

## Impact
RELEASE

## Testing
CI