### PR TITLE
{bp-17513} bugfix/fs:write Bad buf addr should return EINVAL

### DIFF
--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -71,6 +71,11 @@ static ssize_t file_writev_compat(FAR struct file *filep,
           continue;
         }
 
+      if (iov[i].iov_base == NULL)
+        {
+          return -EINVAL;
+        }
+
       /* Sanity check to avoid total length overflow */
 
       if (SSIZE_MAX - ntotal < iov[i].iov_len)


### PR DESCRIPTION
## Summary
return EINVAL if iov_base == NULL

## Impact
RELEASE

## Testing
CI