### PR TITLE
{bp-17521} net/socket: Check on the end of the NIC name when binding device

### DIFF
--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -202,11 +202,27 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
               break;
             }
 
-          /* No, we are binding a socket to the interface
-           * Find the interface device with this name.
-           */
+          /* Check if the value is already null-terminated */
 
-          dev = netdev_findbyname(value);
+          if (((FAR char *)value)[value_len - 1] != '\0')
+            {
+              char ifname[IFNAMSIZ];
+              socklen_t len = MIN(IFNAMSIZ - 1, value_len);
+
+              /* Copy the data and add null terminator */
+
+              memcpy(ifname, value, len);
+              ifname[len] = '\0';
+
+              dev = netdev_findbyname(ifname);
+            }
+          else
+            {
+              /* Value is already null-terminated, use it directly */
+
+              dev = netdev_findbyname(value);
+            }
+
           if (dev == NULL)
             {
               return -ENODEV;


### PR DESCRIPTION
## Summary
When using usrsock to pass the network interface name, omitting "\0" will cause the host to parse extra characters. therefore, the tail section should be inspected during device binding.

## Impact
RELEASE

## Testing
CI