### PR TITLE
{bp-17529} drivers/virtio: Fix DRIVERS_VIRTIO_INPUT configuration dependencies

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -48,7 +48,10 @@ config DRIVERS_VIRTIO_GPU
 
 config DRIVERS_VIRTIO_INPUT
 	bool "Virtio input support"
-	depends on INPUT && INPUT_TOUCHSCREEN && INPUT_KEYBOARD && INPUT_MOUSE
+	depends on INPUT
+	select INPUT_TOUCHSCREEN
+	select INPUT_KEYBOARD
+	select INPUT_MOUSE
 	default n
 
 config DRIVERS_VIRTIO_NET


### PR DESCRIPTION
## Summary
Changed the DRIVERS_VIRTIO_INPUT dependencies from 'depends on' to 'select' for INPUT_TOUCHSCREEN, INPUT_KEYBOARD, and INPUT_MOUSE options. This ensures that when DRIVERS_VIRTIO_INPUT is enabled, all required input subsystems are automatically selected, fixing the issue where mouse device nodes were not being created properly.

## Impact
RELEASE

## Testing
CI