### PR TITLE
{bp-17537} mempool:fix bug, Misjudged the condition of interrupt memory release

### DIFF
--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -428,7 +428,6 @@ retry:
 void mempool_release(FAR struct mempool_s *pool, FAR void *blk)
 {
   irqstate_t flags = spin_lock_irqsave(&pool->lock);
-  size_t blocksize = MEMPOOL_REALBLOCKSIZE(pool);
 #if CONFIG_MM_BACKTRACE >= 0
   FAR struct mempool_backtrace_s *buf =
     (FAR struct mempool_backtrace_s *)((FAR char *)blk + pool->blocksize);
@@ -446,10 +445,10 @@ void mempool_release(FAR struct mempool_s *pool, FAR void *blk)
   memset(blk, MM_FREE_MAGIC, pool->blocksize);
 #endif
 
-  if (pool->interruptsize > blocksize)
+  if (pool->ibase)
     {
       if ((FAR char *)blk >= pool->ibase &&
-          (FAR char *)blk < pool->ibase + pool->interruptsize - blocksize)
+          (FAR char *)blk < pool->ibase + pool->interruptsize)
         {
           sq_addlast(blk, &pool->iqueue);
         }


### PR DESCRIPTION
## Summary
We don't need to subtract the block size; we only need to determine if it's within the interrupt memory range.

## Impact
RELEASE

## Testing
CI