### PR TITLE
{bp-17540} rtc_time:set zero rtc_time struct

### DIFF
--- a/drivers/timers/arch_rtc.c
+++ b/drivers/timers/arch_rtc.c
@@ -125,7 +125,10 @@ int weak_function up_rtc_gettime(FAR struct timespec *tp)
 
   if (g_rtc_lower != NULL)
     {
-      struct rtc_time rtctime;
+      struct rtc_time rtctime =
+        {
+          0
+        };
 
       ret = g_rtc_lower->ops->rdtime(g_rtc_lower, &rtctime);
       if (ret == 0)

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -654,7 +654,10 @@ static int rpmsg_rtc_server_ept_cb(FAR struct rpmsg_endpoint *ept,
     case RPMSG_RTC_GET:
       {
         FAR struct rpmsg_rtc_get_s *msg = data;
-        struct rtc_time rtctime;
+        struct rtc_time rtctime =
+          {
+            0
+          };
 
         header->result = rpmsg_rtc_server_rdtime(priv, &rtctime);
 
@@ -666,7 +669,11 @@ static int rpmsg_rtc_server_ept_cb(FAR struct rpmsg_endpoint *ept,
     case RPMSG_RTC_SET:
       {
         FAR struct rpmsg_rtc_set_s *msg = data;
-        struct rtc_time rtctime;
+        struct rtc_time rtctime =
+          {
+            0
+          };
+
         time_t time = msg->sec;
 
         gmtime_r(&time, (FAR struct tm *)&rtctime);
@@ -737,8 +744,11 @@ static void rpmsg_rtc_server_ns_bind(FAR struct rpmsg_device *rdev,
   FAR struct rpmsg_rtc_server_s *server = priv;
   FAR struct rpmsg_rtc_client_s *client;
   struct rpmsg_rtc_set_s msg;
-  struct rtc_time rtctime;
   irqstate_t flags;
+  struct rtc_time rtctime =
+    {
+      0
+    };
 
   client = kmm_zalloc(sizeof(*client));
   if (client == NULL)


### PR DESCRIPTION
## Summary
timegm set struct tm, not set nsec, so rtc_time->nsec will be a random value, so set it zero.

## Impact
RELEASE

## Testing
CI