### PR TITLE
{bp-17548} procfs/heapcheck:fix bug,aviod '\n' to 0

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -966,12 +966,12 @@ static ssize_t proc_heapcheck_write(FAR struct proc_file_s *procfile,
                                     FAR const char *buffer,
                                     size_t buflen, off_t offset)
 {
-  switch (atoi(buffer))
+  switch (buffer[0])
     {
-      case 0:
+      case '0':
         tcb->flags &= ~TCB_FLAG_HEAP_CHECK;
         break;
-      case 1:
+      case '1':
         tcb->flags |= TCB_FLAG_HEAP_CHECK;
         break;
       default:


### PR DESCRIPTION
## Summary
The lines will end with \n to prevent atoi('\n') from always being 0. It is recommended to check the first byte directly.

## Impact
RELEASE

## Testing
CI