### PR TITLE
{bp-17558} cmake:add missing cflag "-D_FILE_OFFSET_BITS=64" of sim

### DIFF
--- a/arch/sim/src/CMakeLists.txt
+++ b/arch/sim/src/CMakeLists.txt
@@ -30,3 +30,7 @@ if(NOT CONFIG_BUILD_FLAT)
   target_include_directories(arch_interface BEFORE PUBLIC ${CONFIG_ARCH_CHIP}
                                                           common)
 endif()
+
+if(CONFIG_FS_LARGEFILE)
+  target_compile_options(nuttx PRIVATE -D_FILE_OFFSET_BITS=64)
+endif()


### PR DESCRIPTION
## Summary
The -D_FILE_OFFSET_BITS=64 parameter is missing
during the CMake compilation of the sim (simulator) build, which causes incorrect version invocations of interfaces such as hostfs_stat.

## Impact
RELEASE

## Testing
CI