### PR TITLE
{bp-17576} boards/leds: remove dependency on leds example for some boards

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
@@ -42,12 +42,6 @@
 #  include <nuttx/leds/userled.h>
 #endif
 
-#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#else
-#  define LED_DRIVER_PATH "/dev/userleds"
-#endif
-
 #include <nuttx/spi/spi_transfer.h>
 
 #include "kinetis_spi.h"
@@ -77,7 +71,7 @@ int k64_bringup(void)
 #ifdef HAVE_LEDS
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/kinetis/freedom-k66f/src/k66_bringup.c
+++ b/boards/arm/kinetis/freedom-k66f/src/k66_bringup.c
@@ -38,12 +38,6 @@
 #  include <nuttx/leds/userled.h>
 #endif
 
-#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#else
-#  define LED_DRIVER_PATH "/dev/userleds"
-#endif
-
 #include <nuttx/spi/spi.h>
 
 #ifdef CONFIG_INPUT_BUTTONS
@@ -77,7 +71,7 @@ int k66_bringup(void)
 #ifdef HAVE_LEDS
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/arduino-nano-33ble-rev2/src/nrf52_bringup.c
@@ -117,7 +117,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/arduino-nano-33ble/src/nrf52_bringup.c
@@ -117,7 +117,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/nrf52-feather/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52-feather/src/nrf52_bringup.c
@@ -74,7 +74,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
@@ -113,7 +113,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/nrf52832-mdk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52832-mdk/src/nrf52_bringup.c
@@ -84,7 +84,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/nrf52832-sparkfun/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52832-sparkfun/src/nrf52_bringup.c
@@ -72,7 +72,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
@@ -164,7 +164,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR,

--- a/boards/arm/nrf52/nrf52840-dongle/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52840-dongle/src/nrf52_bringup.c
@@ -73,7 +73,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf52/xiao-nrf52840/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/xiao-nrf52840/src/nrf52_bringup.c
@@ -75,7 +75,7 @@ int nrf52_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf53/nrf5340-audio-dk/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/nrf5340-audio-dk/src/nrf53_bringup.c
@@ -58,7 +58,7 @@ int nrf53_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
@@ -196,7 +196,7 @@ int nrf53_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/nrf91/nrf9160-dk/src/nrf91_bringup.c
+++ b/boards/arm/nrf91/nrf9160-dk/src/nrf91_bringup.c
@@ -109,7 +109,7 @@ int nrf91_bringup(void)
 #ifdef CONFIG_USERLED
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(CONFIG_EXAMPLES_LEDS_DEVPATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/samv7/pic32czca70-curiosity/src/sam_board.h
+++ b/boards/arm/samv7/pic32czca70-curiosity/src/sam_board.h
@@ -138,14 +138,6 @@
 #  undef HAVE_LED_DRIVER
 #endif
 
-#ifdef HAVE_LED_DRIVER
-#  ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#    define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#  else
-#    define LED_DRIVER_PATH "/dev/userleds"
-#  endif
-#endif
-
 /* Configuration ************************************************************/
 
 /* PIC32CZ CA70 GPIO Pin Definitions ****************************************/

--- a/boards/arm/samv7/pic32czca70-curiosity/src/sam_bringup.c
+++ b/boards/arm/samv7/pic32czca70-curiosity/src/sam_bringup.c
@@ -125,7 +125,7 @@ int sam_bringup(void)
 #ifdef HAVE_LED_DRIVER
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n",

--- a/boards/arm/samv7/samv71-xult/src/sam_bringup.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_bringup.c
@@ -233,7 +233,7 @@ int sam_bringup(void)
 #ifdef HAVE_LED_DRIVER
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n",

--- a/boards/arm/samv7/samv71-xult/src/samv71-xult.h
+++ b/boards/arm/samv7/samv71-xult/src/samv71-xult.h
@@ -341,14 +341,6 @@
 #  undef HAVE_LED_DRIVER
 #endif
 
-#ifdef HAVE_LED_DRIVER
-#  ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#    define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#  else
-#    define LED_DRIVER_PATH "/dev/userleds"
-#  endif
-#endif
-
 /* Check if the MRF24J40 is supported in this configuration */
 
 #ifndef CONFIG_IEEE802154_MRF24J40

--- a/boards/arm/stm32/nucleo-f401re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f401re/src/stm32_bringup.c
@@ -60,12 +60,6 @@
 #  define HAVE_LEDS 1
 #endif
 
-#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#else
-#  define LED_DRIVER_PATH "/dev/userleds"
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -91,7 +85,7 @@ int stm32_bringup(void)
 #ifdef HAVE_LEDS
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);

--- a/boards/arm/stm32/nucleo-f411re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f411re/src/stm32_bringup.c
@@ -60,12 +60,6 @@
 #  define HAVE_LEDS 1
 #endif
 
-#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
-#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
-#else
-#  define LED_DRIVER_PATH "/dev/userleds"
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -91,7 +85,7 @@ int stm32_bringup(void)
 #ifdef HAVE_LEDS
   /* Register the LED driver */
 
-  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);


### PR DESCRIPTION
## Summary
Userled register path shouldn't depend on LED example. This dependency is broken, kernel code should not depend on apps code.

## Impact
RELEASE

## Testing
CI