### PR TITLE
{bp-17577} boards/nucleo-c0xxx: fix leds handling

### DIFF
--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/src/nucleo-c071rb.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/src/nucleo-c071rb.h
@@ -45,7 +45,7 @@
  */
 
 #define GPIO_LD1        (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_MEDIUM | \
-                         GPIO_OUTPUT_SET | GPIO_PORTA | GPIO_PIN5)
+                         GPIO_OUTPUT_CLEAR | GPIO_PORTA | GPIO_PIN5)
 #define GPIO_LD2        (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_MEDIUM | \
                          GPIO_OUTPUT_SET | GPIO_PORTC | GPIO_PIN9)
 

--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_autoleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_autoleds.c
@@ -50,8 +50,9 @@
 
 void board_autoled_initialize(void)
 {
-  /* Configure LD2 GPIO for output */
+  /* Configure LD1 and LD2 GPIO for output */
 
+  stm32_configgpio(GPIO_LD1);
   stm32_configgpio(GPIO_LD2);
 }
 
@@ -61,7 +62,12 @@ void board_autoled_initialize(void)
 
 void board_autoled_on(int led)
 {
-  if (led == 1)
+  if (led == BOARD_LED1)
+    {
+      stm32_gpiowrite(GPIO_LD1, true);
+    }
+
+  if (led == BOARD_LED2)
     {
       stm32_gpiowrite(GPIO_LD2, false);
     }
@@ -73,7 +79,12 @@ void board_autoled_on(int led)
 
 void board_autoled_off(int led)
 {
-  if (led == 1)
+  if (led == BOARD_LED1)
+    {
+      stm32_gpiowrite(GPIO_LD1, false);
+    }
+
+  if (led == BOARD_LED2)
     {
       stm32_gpiowrite(GPIO_LD2, true);
     }

--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_bringup.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_bringup.c
@@ -78,7 +78,7 @@ int stm32_bringup(void)
   stm32_iwdginitialize("/dev/watchdog0", STM32_LSI_FREQUENCY);
 #endif
 
-#ifdef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
   /* Register the LED driver */
 
   ret = userled_lower_initialize(LED_DRIVER_PATH);

--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_userleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/src/stm32_userleds.c
@@ -120,8 +120,9 @@ static int led_pm_prepare(struct pm_callback_s *cb, int domain,
 
 uint32_t board_userled_initialize(void)
 {
-  /* Configure LD2 GPIO for output */
+  /* Configure LD1 and LD2 GPIO for output */
 
+  stm32_configgpio(GPIO_LD1);
   stm32_configgpio(GPIO_LD2);
   return BOARD_NLEDS;
 }
@@ -132,9 +133,14 @@ uint32_t board_userled_initialize(void)
 
 void board_userled(int led, bool ledon)
 {
-  if (led == BOARD_LD2)
+  if (led == BOARD_LED1)
     {
-      stm32_gpiowrite(GPIO_LD2, ledon);
+      stm32_gpiowrite(GPIO_LD1, ledon);
+    }
+
+  if (led == BOARD_LED2)
+    {
+      stm32_gpiowrite(GPIO_LD2, !ledon);
     }
 }
 
@@ -144,7 +150,8 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
-  stm32_gpiowrite(GPIO_LD2, (ledset & BOARD_LD2_BIT) != 0);
+  stm32_gpiowrite(GPIO_LD1, (ledset & BOARD_LED1_BIT) != 0);
+  stm32_gpiowrite(GPIO_LD2, (ledset & BOARD_LED2_BIT) == 0);
 }
 
 /****************************************************************************

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/src/nucleo-c092rc.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/src/nucleo-c092rc.h
@@ -45,7 +45,7 @@
  */
 
 #define GPIO_LD1        (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_MEDIUM | \
-                         GPIO_OUTPUT_SET | GPIO_PORTA | GPIO_PIN5)
+                         GPIO_OUTPUT_CLEAR | GPIO_PORTA | GPIO_PIN5)
 #define GPIO_LD2        (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_MEDIUM | \
                          GPIO_OUTPUT_SET | GPIO_PORTC | GPIO_PIN9)
 

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_autoleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_autoleds.c
@@ -50,8 +50,9 @@
 
 void board_autoled_initialize(void)
 {
-  /* Configure LD2 GPIO for output */
+  /* Configure LD1 and LD2 GPIO for output */
 
+  stm32_configgpio(GPIO_LD1);
   stm32_configgpio(GPIO_LD2);
 }
 
@@ -61,7 +62,12 @@ void board_autoled_initialize(void)
 
 void board_autoled_on(int led)
 {
-  if (led == 1)
+  if (led == BOARD_LED1)
+    {
+      stm32_gpiowrite(GPIO_LD1, true);
+    }
+
+  if (led == BOARD_LED2)
     {
       stm32_gpiowrite(GPIO_LD2, false);
     }
@@ -73,7 +79,12 @@ void board_autoled_on(int led)
 
 void board_autoled_off(int led)
 {
-  if (led == 1)
+  if (led == BOARD_LED1)
+    {
+      stm32_gpiowrite(GPIO_LD1, false);
+    }
+
+  if (led == BOARD_LED2)
     {
       stm32_gpiowrite(GPIO_LD2, true);
     }

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_bringup.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_bringup.c
@@ -78,7 +78,7 @@ int stm32_bringup(void)
   stm32_iwdginitialize("/dev/watchdog0", STM32_LSI_FREQUENCY);
 #endif
 
-#ifdef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
   /* Register the LED driver */
 
   ret = userled_lower_initialize(LED_DRIVER_PATH);

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_userleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/src/stm32_userleds.c
@@ -120,8 +120,9 @@ static int led_pm_prepare(struct pm_callback_s *cb, int domain,
 
 uint32_t board_userled_initialize(void)
 {
-  /* Configure LD2 GPIO for output */
+  /* Configure LD1 and LD2 GPIO for output */
 
+  stm32_configgpio(GPIO_LD1);
   stm32_configgpio(GPIO_LD2);
   return BOARD_NLEDS;
 }
@@ -132,9 +133,14 @@ uint32_t board_userled_initialize(void)
 
 void board_userled(int led, bool ledon)
 {
-  if (led == BOARD_LD2)
+  if (led == BOARD_LED1)
     {
-      stm32_gpiowrite(GPIO_LD2, ledon);
+      stm32_gpiowrite(GPIO_LD1, ledon);
+    }
+
+  if (led == BOARD_LED2)
+    {
+      stm32_gpiowrite(GPIO_LD2, !ledon);
     }
 }
 
@@ -144,7 +150,8 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
-  stm32_gpiowrite(GPIO_LD2, (ledset & BOARD_LD2_BIT) != 0);
+  stm32_gpiowrite(GPIO_LD1, (ledset & BOARD_LED1_BIT) != 0);
+  stm32_gpiowrite(GPIO_LD2, (ledset & BOARD_LED2_BIT) == 0);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix LED handling for nucleo-c092rc and nucleo-c071rb. These boards have two LEDs but one is activated with HIGH the other is activated with LOW.

Also fix userled registration.

## Impact
RELEASE

## Testing
CI