### PR TITLE
LICENSE: update NuttX-PublicDomain SPDX identifier

### DIFF
--- a/crypto/cast.c
+++ b/crypto/cast.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/cast.c
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * CAST-128 in C
  * Written by Steve Reid <sreid@sea-to-sky.net>

--- a/crypto/castsb.h
+++ b/crypto/castsb.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/castsb.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * CAST-128 in C
  * Written by Steve Reid <sreid@sea-to-sky.net>

--- a/crypto/chacha_private.h
+++ b/crypto/chacha_private.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/chacha_private.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * D. J. Bernstein
  * Public domain.

--- a/crypto/md5.c
+++ b/crypto/md5.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/md5.c
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest. This code was

--- a/crypto/poly1305.c
+++ b/crypto/poly1305.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/poly1305.c
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * Public Domain poly1305 from Andrew Moon
  *

--- a/crypto/rijndael.c
+++ b/crypto/rijndael.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/rijndael.c
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  * SPDX-FileContributor: Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
  * SPDX-FileContributor: Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
  * SPDX-FileContributor: Paulo Barreto <paulo.barreto@terra.com.br>

--- a/crypto/sha1.c
+++ b/crypto/sha1.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * crypto/sha1.c
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * By Steve Reid <steve@edmweb.com>
  * 100% Public Domain

--- a/include/crypto/cast.h
+++ b/include/crypto/cast.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/crypto/cast.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * Written by Steve Reid <sreid@sea-to-sky.net>
  * 100% Public Domain - no warranty

--- a/include/crypto/md5.h
+++ b/include/crypto/md5.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/crypto/md5.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.  This code was

--- a/include/crypto/poly1305.h
+++ b/include/crypto/poly1305.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/crypto/poly1305.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * Public Domain poly1305 from Andrew Moon
  *

--- a/include/crypto/rijndael.h
+++ b/include/crypto/rijndael.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/crypto/rijndael.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * SPDX-FileContributor: Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
  * SPDX-FileContributor: Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>

--- a/include/crypto/sha1.h
+++ b/include/crypto/sha1.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/crypto/sha1.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * By Steve Reid <steve@edmweb.com>
  * 100% Public Domain

--- a/include/search.h
+++ b/include/search.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/search.h
  *
- * SPDX-License-Identifier: NuttX-PublicDomain
+ * SPDX-License-Identifier: LicenseRef-NuttX-PublicDomain
  *
  * Written by J.T. Conklin <jtc@netbsd.org>
  * Public domain.


### PR DESCRIPTION
## Summary
According to the feedback from SPDX community we should use LicenseRef-NuttX-PublicDomain because NuttX-PublicDomain is not a valid SPDX id, so it will fail tests for SPDX spec compliance.

## Impact
LICENSE

## Testing
CI