### PR TITLE
net/wireless: fix compile warning issue for wireless

### DIFF
--- a/include/nuttx/wireless/ieee802154/ieee802154_mac.h
+++ b/include/nuttx/wireless/ieee802154/ieee802154_mac.h
@@ -313,34 +313,6 @@ enum ieee802154_status_e
   IEEE802154_STATUS_LIMITREACHED,
 };
 
-static const char *IEEE802154_STATUS_STRING[] =
-{
-  "Success",
-  "Out of capacity",
-  "Denied",
-  "Failure",
-  "Beacon loss",
-  "Channel access failure",
-  "Disable TRX failure",
-  "Failed security check",
-  "Frame too long",
-  "Invalid GTS",
-  "Invalid handle",
-  "Invalid parameter",
-  "No ack",
-  "No beacon",
-  "No data",
-  "No short address",
-  "PAN ID conflict",
-  "Realignment",
-  "Transaction expired",
-  "Transaction overflow",
-  "Tx active",
-  "Unavailable key",
-  "Unsupported attribute",
-  "Limit reached",
-};
-
 /* IEEE 802.15.4 PHY/MAC PIB attributes IDs */
 
 enum ieee802154_attr_e
@@ -1745,6 +1717,12 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
+
+/*****************************************************************************
+ * Public Data
+ *****************************************************************************/
+
+EXTERN FAR const char *g_ieee802154_status_string[];
 
 /*****************************************************************************
  * Public Function Prototypes

--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -48,6 +48,38 @@
 #include <nuttx/wireless/ieee802154/ieee802154_radio.h>
 
 /****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+FAR const char *g_ieee802154_status_string[] =
+{
+  "Success",
+  "Out of capacity",
+  "Denied",
+  "Failure",
+  "Beacon loss",
+  "Channel access failure",
+  "Disable TRX failure",
+  "Failed security check",
+  "Frame too long",
+  "Invalid GTS",
+  "Invalid handle",
+  "Invalid parameter",
+  "No ack",
+  "No beacon",
+  "No data",
+  "No short address",
+  "PAN ID conflict",
+  "Realignment",
+  "Transaction expired",
+  "Transaction overflow",
+  "Tx active",
+  "Unavailable key",
+  "Unsupported attribute",
+  "Limit reached",
+};
+
+/****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
@@ -902,7 +934,7 @@ static void mac802154_txdone_worker(FAR void *arg)
       primitive = (FAR struct ieee802154_primitive_s *)txdesc->conf;
 
       wlinfo("Tx status: %s\n",
-             IEEE802154_STATUS_STRING[txdesc->conf->status]);
+             g_ieee802154_status_string[txdesc->conf->status]);
 
       switch (txdesc->frametype)
         {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
IEEE802154_STATUS_STRING is defined in the .h file, which will generate compilation warning information under some compilers.  Moved the position of the variable to fix this issue.  At the same time, changed the name of the variable to unify the code style.

## Impact

This change has rename `static const char *IEEE802154_STATUS_STRING[]` to `FAR const char *g_ieee802154_status_string[]`.  It will affect wireless/ieee802154/i8sak/*.c in nuttx-apps repository which used this var. So, I submitted another patch to the nuttx apps repository:
[apps pr](https://github.com/apache/nuttx-apps/pull/3269)

## Testing

gcc compiler has no warning infor for `nuttx-apps/wireless/ieee802154/i8sak`, but tasking compiler has warning information.

warnning log: unused variable "IEEE802154_STATUS_STRING"

After the issue is fixed, the warning dispeared, and the results compiled with both compilers are normal.


**_PRs without testing information will not be accepted. We will
request test logs._**
