### PR TITLE
net/ethernet: ARP can be configured on interface

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -53,7 +53,7 @@
 #define IFF_IPv6           (1 << 3)  /* Configured for IPv6 packet (vs ARP or IPv4) */
 #define IFF_LOOPBACK       (1 << 5)  /* Is a loopback net */
 #define IFF_POINTOPOINT    (1 << 6)  /* Is point-to-point link */
-#define IFF_NOARP          (1 << 7)  /* ARP is not required for this packet */
+#define IFF_NOARP          (1 << 7)  /* ARP is not required for this interface */
 #define IFF_NAT            (1 << 8)  /* NAT is enabled for this interface */
 #define IFF_SLAVE          (1 << 11) /* Slave of a load balancer. */
 #define IFF_MULTICAST      (1 << 12) /* Supports multicast. */

--- a/net/arp/arp_acd.c
+++ b/net/arp/arp_acd.c
@@ -236,7 +236,7 @@ void arp_acd_update(FAR struct net_driver_s *dev)
 
 void arp_acd_setup(FAR struct net_driver_s *dev)
 {
-  if (dev->d_acd.need_announce == false)
+  if (!dev->d_acd.need_announce || IFF_IS_NOARP(dev->d_flags))
     {
       return;
     }

--- a/net/arp/arp_input.c
+++ b/net/arp/arp_input.c
@@ -196,6 +196,15 @@ void arp_input(FAR struct net_driver_s *dev)
 {
   FAR uint8_t *buf;
 
+  if (IFF_IS_NOARP(dev->d_flags))
+    {
+      /* No arp */
+
+      ninfo("ARP not supported on %s, no receive!\n", dev->d_ifname);
+      dev->d_len = 0;
+      return;
+    }
+
   if (dev->d_iob != NULL)
     {
       buf = dev->d_buf;

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -134,12 +134,6 @@ static uint16_t arp_send_eventhandler(FAR struct net_driver_s *dev,
 
       arp_format(dev, state->snd_ipaddr);
 
-      /* Make sure no ARP request overwrites this ARP request.  This
-       * flag will be cleared in arp_out().
-       */
-
-      IFF_SET_NOARP(dev->d_flags);
-
       /* Don't allow any further call backs. */
 
       arp_send_terminate(dev, state, OK);
@@ -274,6 +268,14 @@ int arp_send(in_addr_t ipaddr)
     {
       /* Yes.. We don't need to send the ARP request */
 
+      return OK;
+    }
+
+  /* No ARP packet if this device do not support ARP */
+
+  if (IFF_IS_NOARP(dev->d_flags))
+    {
+      ninfo("ARP not supported on %s, no send!\n", dev->d_ifname);
       return OK;
     }
 

--- a/net/icmpv6/icmpv6_neighbor.c
+++ b/net/icmpv6/icmpv6_neighbor.c
@@ -259,6 +259,14 @@ int icmpv6_neighbor(FAR struct net_driver_s *dev,
 #endif
     }
 
+  /* No ARP packet if this device do not support ARP */
+
+  if (IFF_IS_NOARP(dev->d_flags))
+    {
+      ninfo("ARP not supported on %s, no send!\n", dev->d_ifname);
+      return -EHOSTUNREACH;
+    }
+
   /* Allocate resources to receive a callback.  This and the following
    * initialization is performed with the network lock because we don't
    * want anything to happen until we are ready.

--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -100,18 +100,6 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
   FAR struct ipv6_hdr_s *ip = IPv6BUF;
   struct neighbor_addr_s laddr;
 
-  /* Skip sending Neighbor Solicitations when the frame to be transmitted was
-   * written into a packet socket.
-   */
-
-  if (IFF_IS_NOARP(dev->d_flags))
-    {
-      /* Clear the indication and let the packet continue on its way. */
-
-      IFF_CLR_NOARP(dev->d_flags);
-      return;
-    }
-
   /* Find the destination IPv6 address in the Neighbor Table and construct
    * the Ethernet header. If the destination IPv6 address isn't on the local
    * network, we use the default router's IPv6 address instead.
@@ -162,6 +150,13 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
       if (neighbor_lookup(ipaddr, &laddr) < 0)
         {
 #ifdef CONFIG_NET_ICMPv6
+          /* No ARP packet if this device do not support ARP */
+
+          if (IFF_IS_NOARP(dev->d_flags))
+            {
+              return;
+            }
+
            ninfo("IPv6 Neighbor solicitation for IPv6\n");
 
           /* The destination address was not in our Neighbor Table, so we

--- a/net/pkt/pkt_sendmsg_unbuffered.c
+++ b/net/pkt/pkt_sendmsg_unbuffered.c
@@ -138,12 +138,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
               ethhdr->type = pstate->addr->sll_protocol;
               dev->d_len += NET_LL_HDRLEN(dev);
             }
-
-          /* Make sure no ARP request overwrites this ARP request.  This
-           * flag will be cleared in arp_out().
-           */
-
-          IFF_SET_NOARP(dev->d_flags);
         }
 
 end_wait:


### PR DESCRIPTION
## Summary
Nuttx use IFF_NOARP as a packet config, this is illogical and no longer in line with user habits.
Referring to the ARP configuration method of Linux, Nuttx has added the ability to configure ARP on interface.

## Impact

Referring to the custom of configuring ARP on Linux interfaces, the 'arp/- app' parameter has been added to the ifconfig command. By default, the interface supports ARP functionality.
When the ARP function of an interface is turned off, the net stack will discard ARP messages received from that interface, and the protocol stack will not send messages to the outside through that interface.


## Testing

When compiling nuttx, open the ping tool for functional testing.

Set up a SIM environment,  sim and host can ping each other successfully.
After using the command 'ifconfig eth0 -arp', the ping between sim and host failed. The packet capture shows that sim cannot process APR request messages or send ARP request messages.
Then use 'ifconfig eth0 arp' to enable arp fuction for eth0， sim and host can ping each other again.

