### PR TITLE
net/ethernet: remove no use remove excess code

### DIFF
--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -560,13 +560,11 @@ static int inet_getsockname(FAR struct socket *psock,
 #ifdef CONFIG_NET_IPv4
     case PF_INET:
       return ipv4_getsockname(psock, addr, addrlen);
-      break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
     case PF_INET6:
       return ipv6_getsockname(psock, addr, addrlen);
-      break;
 #endif
 
     default:
@@ -613,13 +611,11 @@ static int inet_getpeername(FAR struct socket *psock,
 #ifdef CONFIG_NET_IPv4
     case PF_INET:
       return ipv4_getpeername(psock, addr, addrlen);
-      break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
     case PF_INET6:
       return ipv6_getpeername(psock, addr, addrlen);
-      break;
 #endif
 
     default:


### PR DESCRIPTION
## Summary

There is some redundant code in the net/inet/inet_stockif. c file, which has caused compilation alarm messages in some compilers. To address the above compilation information, redundant code has been removed.

## Impact

There is no modification function, it will only affect the compilation of alarm information and will not have any other impact.

## Testing

Pass the CI check!
