### PR TITLE
netdev_upperhalf: add direct rx mode

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -1394,6 +1394,9 @@ int netdev_lower_register(FAR struct netdev_lowerhalf_s *dev,
       case NETDEV_RX_WORK:
         extra_size = sizeof(struct work_s);
         break;
+      case NETDEV_RX_DIRECT:
+        extra_size = 0; /* No extra size needed for direct mode */
+        break;
       case NETDEV_RX_THREAD:
         extra_size = sizeof(struct netdev_thread_s);
         cpu = 1;
@@ -1574,7 +1577,14 @@ void netdev_lower_rxready(FAR struct netdev_lowerhalf_s *dev)
    * in eth_input.
    */
 
-  netdev_upper_queue_work(&dev->netdev);
+  if (dev->rxtype == NETDEV_RX_DIRECT)
+    {
+      netdev_upper_rxpoll_work(dev->netdev.d_private);
+    }
+  else
+    {
+      netdev_upper_queue_work(&dev->netdev);
+    }
 }
 
 /****************************************************************************
@@ -1594,7 +1604,15 @@ void netdev_lower_txdone(FAR struct netdev_lowerhalf_s *dev)
   FAR struct netdev_upperhalf_s *upper = dev->netdev.d_private;
   netdev_upper_vlan_foreach(upper, netdev_lower_txdone);
 #endif
-  netdev_upper_queue_work(&dev->netdev);
+  if (dev->rxtype == NETDEV_RX_DIRECT)
+    {
+      netdev_upper_txavail_work(dev->netdev.d_private);
+    }
+  else
+    {
+      netdev_upper_queue_work(&dev->netdev);
+    }
+
   NETDEV_TXDONE(&dev->netdev);
 }
 

--- a/include/nuttx/net/netdev_lowerhalf.h
+++ b/include/nuttx/net/netdev_lowerhalf.h
@@ -90,6 +90,7 @@ enum netpkt_type_e
 enum netdev_rx_e
 {
   NETDEV_RX_WORK,      /* Use work queue thread */
+  NETDEV_RX_DIRECT,    /* Directly based on the current thread */
   NETDEV_RX_THREAD,    /* Upper half dedicated thread */
   NETDEV_RX_THREAD_RSS /* RSS mode, upper half thread */
 };


### PR DESCRIPTION
## Summary
Avoid packet processing delays caused by task switching, to support those applications that are extremely time-sensitive.
Has a very obvious positive effect on CAN communication.

## Impact
lowerhalf net device driver.
If the network card does not call netdev_lower_rxready during an interrupt, rxtype can be configured as NETDEV_RX_DIRECT, which will reduce one thread context switch in the packet reception process, thereby reducing latency and CPU load.

## Testing
sim:matter with ping and iperf
change in nuttx/arch/sim/src/sim/sim_netdriver.c
```
diff --git a/arch/sim/src/sim/sim_netdriver.c b/arch/sim/src/sim/sim_netdriver.c
index de298f81edb..87dfd78342f 100644
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -99,6 +99,8 @@
 struct sim_netdev_s
 {
   struct netdev_lowerhalf_s dev;
+  struct work_s rxworker;
+  struct work_s txworker;
   uint8_t buf[SIM_NETDEV_BUFSIZE]; /* Used when packet buffer is fragmented */
 };
 #endif
@@ -220,18 +222,30 @@ static int netdriver_ifdown(struct netdev_lowerhalf_s *dev)
   return OK;
 }
 
-static void netdriver_txdone_interrupt(void *priv)
+static void netdriver_txdone_handle(void *priv)
 {
   struct netdev_lowerhalf_s *dev = (struct netdev_lowerhalf_s *)priv;
   netdev_lower_txdone(dev);
 }
 
-static void netdriver_rxready_interrupt(void *priv)
+static void netdriver_txdone_interrupt(void *priv)
+{
+  struct sim_netdev_s *dev = (struct sim_netdev_s *)priv;
+  work_queue(HPWORK, &dev->txworker, netdriver_txdone_handle, priv, 0);
+}
+
+static void netdriver_rxready_handle(void *priv)
 {
   struct netdev_lowerhalf_s *dev = (struct netdev_lowerhalf_s *)priv;
   netdev_lower_rxready(dev);
 }
 
+static void netdriver_rxready_interrupt(void *priv)
+{
+  struct sim_netdev_s *dev = (struct sim_netdev_s *)priv;
+  work_queue(HPWORK, &dev->rxworker, netdriver_rxready_handle, priv, 0);
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -256,6 +270,7 @@ int sim_netdriver_init(void)
       dev->quota[NETPKT_TX] = 1;
       dev->quota[NETPKT_RX] = 1;
       dev->ops              = &g_ops;
+      dev->rxtype           = NETDEV_RX_DIRECT;
 
 #if CONFIG_SIM_WIFIDEV_NUMBER != 0
       if (devidx < CONFIG_SIM_WIFIDEV_NUMBER)
```
test log
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig eth0 10.0.1.2/24
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: ::

nsh> ping -c 3 10.0.1.1
PING 10.0.1.1 56 bytes of data
56 bytes from 10.0.1.1: icmp_seq=0 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=1 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=2 time=0.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 0.000/0.000/0.000/0.000 ms
nsh> iperf -c 10.0.1.1
ERROR: access IP is 0x00
nsh> iperf -c 10.0.1.1 -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-   7.35 sec  450871296 Bytes  490.74 Mbits/sec
   7.35-  11.27 sec  233832448 Bytes  477.21 Mbits/sec
  11.27-  15.01 sec  226230272 Bytes  483.92 Mbits/sec
  15.01-  20.07 sec  305397760 Bytes  482.84 Mbits/sec
  20.07-  23.30 sec  198524928 Bytes  491.70 Mbits/sec
  23.30-  26.75 sec  210583552 Bytes  488.31 Mbits/sec
  26.75-  30.20 sec  206946304 Bytes  479.88 Mbits/sec
   0.00-  30.20 sec 2012200960 Bytes  533.03 Mbits/sec
iperf exit
nsh> iperf -s -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-server sip=10.0.1.2:5001,dip=0.0.0.0:5001, interval=3, time=0
accept: 10.0.1.1:36692

           Interval         Transfer         Bandwidth

   0.00-   3.24 sec  238423900 Bytes  588.70 Mbits/sec
   3.24-   7.78 sec  370243184 Bytes  652.41 Mbits/sec
closed by the peer: 10.0.1.1:36692
iperf exit
nsh> 
```
