### PR TITLE
net/icmp: Return -ENOPROTOOPT for SOL_SOCKET to avoid misleading logs

### DIFF
--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -383,6 +383,15 @@ static int icmp_getsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
   {
+    case SOL_SOCKET:
+
+      /* Socket-level options are handled by psock_getsockopt()/inet layer.
+       * Return -ENOPROTOOPT so upper layer will fallback to socket-level
+       * handler without emitting misleading ICMP error logs.
+       */
+
+      return -ENOPROTOOPT;
+
     case SOL_IP:
       return ipv4_getsockopt(psock, option, value, value_len);
 
@@ -486,6 +495,15 @@ static int icmp_setsockopt(FAR struct socket *psock, int level, int option,
 {
   switch (level)
   {
+    case SOL_SOCKET:
+
+      /* Socket-level options are handled by psock_setsockopt()/inet layer.
+       * Return -ENOPROTOOPT so upper layer will fallback to socket-level
+       * handler without emitting misleading ICMP error logs.
+       */
+
+      return -ENOPROTOOPT;
+
     case SOL_IP:
       return ipv4_setsockopt(psock, option, value, value_len);
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

When SOL_SOCKET options (e.g., SO_BINDTODEVICE via ping -I) hit ICMP sockets, icmp_{get,set}sockopt logged “Unrecognized ICMP option: 17” before fallback. Handle SOL_SOCKET explicitly by returning -ENOPROTOOPT so psock_* routes to the socket-level handler. Removes noisy logs without changing behavior (invalid devices still return -ENODEV).

## Impact

icmp log 

## Testing
Please verify this PR together with another PR
 https://github.com/apache/nuttx-apps/pull/3263

**After patch**
<img width="613" height="401" alt="image" src="https://github.com/user-attachments/assets/70450953-0a38-4034-b1f2-7e32b6f27d00" />

**Before patch**

<img width="922" height="441" alt="image" src="https://github.com/user-attachments/assets/0185dab7-423b-4c0c-ba93-7dda1f2fce35" />

