### PR TITLE
net/arp: use bufpool to alloc arp send states

### DIFF
--- a/net/arp/Kconfig
+++ b/net/arp/Kconfig
@@ -67,6 +67,47 @@ config ARP_SEND_DELAYMSEC
 		on the network since it is basically the time from when an ARP
 		request is sent until the response is received.
 
+config NET_ARP_PREALLOC_STATES
+	int "Preallocated ARP send states"
+	default 2
+	---help---
+		Number of ARP send states (all tasks).
+
+		This number of connections will be pre-allocated during system boot.
+		If dynamic connections allocation is enabled, more connections may
+		be allocated at a later time, as the system needs them. Else this
+		will be the maximum number of connections available to the system
+		at all times.
+
+		Set to 0 to disable (and rely only on dynamic allocations).
+
+config NET_ARP_ALLOC_STATES
+	int "Dynamic ARP send states allocation"
+	default 1
+	---help---
+		Dynamic memory allocations for ARP send states.
+
+		When set to 0 all dynamic allocations are disabled.
+
+		When set to 1 a new connection will be allocated every time,
+		and it will be free'd when no longer needed.
+
+		Setting this to 2 or more will allocate the connections in
+		batches (with batch size equal to this config). When a
+		connection is no longer needed, it will be returned to the
+		free connections pool, and it will never be deallocated!
+
+config NET_ARP_MAX_STATES
+	int "Maximum number of ARP/IP connections"
+	default 0
+	depends on NET_ARP_ALLOC_STATES > 0
+	---help---
+		If dynamic connections allocation is selected (NET_ARP_ALLOC_STATES > 0)
+		this will limit the number of connections that can be allocated.
+
+		This is useful in case the system is under very heavy load (or
+		under attack), ensuring that the heap will not be exhausted.
+
 endif # NET_ARP_SEND
 
 config NET_ARP_DUMP


### PR DESCRIPTION
## Summary
avoid crashes caused by cross-thread access to stack memory.

## Impact
net/arp

## Testing
sim:matter
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig eth0 10.0.1.2/24
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: ::

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     000c  0012  0000  0015  0000  0007
Dropped      0000  0002  0000  0000  0000  0007
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000
Sent         0000  000b  0000  0000  0000  000b
  Rexmit     ----  ----  0000  ----  ----  ----
nsh> ping -c 3 10.0.1.1
PING 10.0.1.1 56 bytes of data
56 bytes from 10.0.1.1: icmp_seq=0 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=1 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=2 time=0.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 0.000/0.000/0.000/0.000 ms
nsh> 
```