### PR TITLE
mm/iob: limit the alignment length of IOB to no less than sizeof(uinptr_t)

### DIFF
--- a/drivers/usrsock/usrsock_rpmsg.c
+++ b/drivers/usrsock/usrsock_rpmsg.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <nuttx/net/dns.h>
+#include <nuttx/net/net.h>
 #include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/usrsock/usrsock_rpmsg.h>

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/param.h>
 
 #ifdef CONFIG_IOB_NOTIFIER
 #  include <nuttx/wqueue.h>
@@ -74,9 +75,7 @@
 
 /* Default config of alignment and head padding size */
 
-#if !defined(CONFIG_IOB_ALIGNMENT)
-#  define CONFIG_IOB_ALIGNMENT      1
-#endif
+#define IOB_ALIGNMENT    MAX(CONFIG_IOB_ALIGNMENT, sizeof(uintptr_t))
 
 /* IOB helpers */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -46,7 +46,6 @@
 #include <nuttx/queue.h>
 #include <nuttx/wdog.h>
 #include <nuttx/fs/fs.h>
-#include <nuttx/net/net.h>
 #include <nuttx/mm/map.h>
 #include <nuttx/tls.h>
 #include <nuttx/spinlock_type.h>

--- a/mm/iob/iob_alloc.c
+++ b/mm/iob/iob_alloc.c
@@ -335,9 +335,9 @@ FAR struct iob_s *iob_alloc_dynamic(uint16_t size)
   FAR struct iob_s *iob;
   size_t alignsize;
 
-  alignsize = ALIGN_UP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT) + size;
+  alignsize = ALIGN_UP(sizeof(struct iob_s), IOB_ALIGNMENT) + size;
 
-  iob = kmm_memalign(CONFIG_IOB_ALIGNMENT, alignsize);
+  iob = kmm_memalign(IOB_ALIGNMENT, alignsize);
   if (iob)
     {
       iob->io_flink   = NULL;             /* Not in a chain */
@@ -347,7 +347,7 @@ FAR struct iob_s *iob_alloc_dynamic(uint16_t size)
       iob->io_pktlen  = 0;                /* Total length of the packet */
       iob->io_free    = iob_free_dynamic; /* Customer free callback */
       iob->io_data    = (FAR uint8_t *)ALIGN_UP((uintptr_t)(iob + 1),
-                                                CONFIG_IOB_ALIGNMENT);
+                                                IOB_ALIGNMENT);
     }
 
   return iob;
@@ -432,7 +432,7 @@ FAR struct iob_s *iob_init_with_data(FAR void *data, uint16_t size,
   iob->io_pktlen  = 0;       /* Total length of the packet */
   iob->io_free    = free_cb; /* Customer free callback */
   iob->io_data    = (FAR uint8_t *)ALIGN_UP((uintptr_t)(iob + 1),
-                                            CONFIG_IOB_ALIGNMENT);
+                                            IOB_ALIGNMENT);
   iob->io_bufsize = ((FAR uint8_t *)data + size) - iob->io_data;
 
   return iob;

--- a/mm/iob/iob_free.c
+++ b/mm/iob/iob_free.c
@@ -122,7 +122,7 @@ FAR struct iob_s *iob_free(FAR struct iob_s *iob)
   if (iob->io_free != NULL)
     {
       FAR uint8_t *io_data = (FAR uint8_t *)ALIGN_UP((uintptr_t)(iob + 1),
-                                                     CONFIG_IOB_ALIGNMENT);
+                                                     IOB_ALIGNMENT);
       if (iob->io_data == io_data)
         {
           iob->io_free(iob);

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -41,13 +41,13 @@
 
 #ifdef CONFIG_IOB_ALLOC
 #  define IOB_ALIGN_SIZE  ALIGN_UP(sizeof(struct iob_s) + CONFIG_IOB_BUFSIZE, \
-                                   CONFIG_IOB_ALIGNMENT)
+                                   IOB_ALIGNMENT)
 #else
-#  define IOB_ALIGN_SIZE  ALIGN_UP(sizeof(struct iob_s), CONFIG_IOB_ALIGNMENT)
+#  define IOB_ALIGN_SIZE  ALIGN_UP(sizeof(struct iob_s), IOB_ALIGNMENT)
 #endif
 
 #define IOB_BUFFER_SIZE   (IOB_ALIGN_SIZE * CONFIG_IOB_NBUFFERS + \
-                           CONFIG_IOB_ALIGNMENT - 1)
+                           IOB_ALIGNMENT - 1)
 
 /****************************************************************************
  * Private Data
@@ -55,7 +55,7 @@
 
 /* Following raw buffer will be divided into iob_s instances, the initial
  * procedure will ensure that the member io_data of each iob_s is aligned
- * to the CONFIG_IOB_ALIGNMENT memory boundary.
+ * to the IOB_ALIGNMENT memory boundary.
  */
 
 #ifdef IOB_SECTION
@@ -135,11 +135,11 @@ void iob_initialize(void)
   uintptr_t buf;
 
   /* Get a start address which plus offsetof(struct iob_s, io_data) is
-   * aligned to the CONFIG_IOB_ALIGNMENT memory boundary
+   * aligned to the IOB_ALIGNMENT memory boundary
    */
 
   buf = ALIGN_UP((uintptr_t)g_iob_buffer + offsetof(struct iob_s, io_data),
-                 CONFIG_IOB_ALIGNMENT) - offsetof(struct iob_s, io_data);
+                 IOB_ALIGNMENT) - offsetof(struct iob_s, io_data);
 
   /* Get I/O buffer instance from the start address and add each I/O buffer
    * to the free list


### PR DESCRIPTION
## Summary
avoid crashes caused by four-byte alignment issues.

## Impact
mm/iob and net

## Testing
sim:matter with ping and iperf
test log:
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig eth0 10.0.1.2/24
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: ::

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6 CAN
Received     0010  0012  0000  0019  0000  0006  0000
Dropped      0000  0003  0000  0000  0000  0006  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000  ----
Sent         0000  000b  0000  0000  0000  000b  0000
  Rexmit     ----  ----  0000  ----  ----  ----  ----
nsh> ping -c 3 10.0.1.1
PING 10.0.1.1 56 bytes of data
56 bytes from 10.0.1.1: icmp_seq=0 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=1 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=2 time=0.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 0.000/0.000/0.000/0.000 ms
nsh> iperf -c 10.0.1.1 -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-   3.18 sec  207699968 Bytes  522.52 Mbits/sec
   3.18-   7.50 sec  281968640 Bytes  522.16 Mbits/sec
   7.50-  11.30 sec  249856000 Bytes  526.01 Mbits/sec
  11.30-  17.96 sec  438517760 Bytes  526.75 Mbits/sec
  17.96-  32.37 sec  940507136 Bytes  522.14 Mbits/sec
   0.00-  32.37 sec 2297282560 Bytes  567.76 Mbits/sec
iperf exit
nsh> iperf -s -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-server sip=10.0.1.2:5001,dip=0.0.0.0:5001, interval=3, time=0
accept: 10.0.1.1:57610

           Interval         Transfer         Bandwidth

   0.00-   3.22 sec  247189740 Bytes  614.14 Mbits/sec
   3.22-   6.36 sec  230052200 Bytes  586.12 Mbits/sec
   6.36-   9.77 sec  267815100 Bytes  628.31 Mbits/sec
closed by the peer: 10.0.1.1:57610
iperf exit
nsh> 
```