### PR TITLE
arp_poll: skip arp_out when arp_send flow

### DIFF
--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -54,6 +54,8 @@
 
 int arp_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 {
+  int bstop = 0;
+
   /* Setup for the ARP callback (most of these do not apply) */
 
   dev->d_appdata = NULL;
@@ -66,7 +68,12 @@ int arp_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
   /* Call back into the driver */
 
-  return devif_poll_out(dev, callback);
+  if (dev->d_len > 0)
+    {
+      bstop = callback(dev);
+    }
+
+  return bstop;
 }
 
 #endif /* CONFIG_NET_ARP_SEND */


### PR DESCRIPTION
## Summary
there is no need to call arp_out again to perform layer 2 header filling in the arp_send process, so we should directly call the driver's callback.

## Impact
net/arp, arp_request

## Testing
sim:matter
test log
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: ::

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6 CAN
Received     0000  0009  0000  0002  0000  0004  0000
Dropped      0000  0003  0000  0000  0000  0004  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000  ----
Sent         0000  000b  0000  0000  0000  000b  0000
  Rexmit     ----  ----  0000  ----  ----  ----  ----
nsh> ping -c 5 10.0.1.1
PING 10.0.1.1 56 bytes of data
56 bytes from 10.0.1.1: icmp_seq=0 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=1 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=2 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=3 time=0.0 ms
56 bytes from 10.0.1.1: icmp_seq=4 time=0.0 ms
5 packets transmitted, 5 received, 0% packet loss, time 5050 ms
rtt min/avg/max/mdev = 0.000/0.000/0.000/0.000 ms
nsh> 

```
