### PR TITLE
mld: free all mld group when netdev unregister

### DIFF
--- a/net/mld/mld.h
+++ b/net/mld/mld.h
@@ -331,6 +331,16 @@ void mld_grpfree(FAR struct net_driver_s *dev,
                  FAR struct mld_group_s *group);
 
 /****************************************************************************
+ * Name:  mld_grpfree_all
+ *
+ * Description:
+ *   Release all previously allocated groups for a device.
+ *
+ ****************************************************************************/
+
+void mld_grpfree_all(FAR struct net_driver_s *dev);
+
+/****************************************************************************
  * Name:  mld_new_pollcycle
  *
  * Description:

--- a/net/mld/mld_group.c
+++ b/net/mld/mld_group.c
@@ -285,4 +285,29 @@ void mld_new_pollcycle(FAR struct net_driver_s *dev)
 }
 #endif
 
+/****************************************************************************
+ * Name:  mld_grpfree_all
+ *
+ * Description:
+ *   Release all previously allocated groups for a device.
+ *
+ * Assumptions:
+ *   The network is locked.
+ *
+ ****************************************************************************/
+
+void mld_grpfree_all(FAR struct net_driver_s *dev)
+{
+  FAR struct mld_group_s *group =
+                         (FAR struct mld_group_s *)dev->d_mld.grplist.head;
+  FAR struct mld_group_s *next;
+
+  while (group != NULL)
+    {
+      next = group->next;
+      mld_grpfree(dev, group);
+      group = next;
+    }
+}
+
 #endif /* CONFIG_NET_MLD */

--- a/net/netdev/netdev_unregister.c
+++ b/net/netdev/netdev_unregister.c
@@ -37,6 +37,7 @@
 #include <net/ethernet.h>
 #include <nuttx/net/netdev.h>
 
+#include "mld/mld.h"
 #include "utils/utils.h"
 #include "netdev/netdev.h"
 
@@ -150,6 +151,16 @@ int netdev_unregister(FAR struct net_driver_s *dev)
 #ifdef CONFIG_NETDEV_IFINDEX
       free_ifindex(dev->d_ifindex);
 #endif
+
+#ifdef CONFIG_NET_MLD
+      if ((dev->d_flags & IFF_MULTICAST) != 0)
+        {
+          /* MLD is only supported on multicast capable devices */
+
+          mld_grpfree_all(dev);
+        }
+#endif
+
       net_unlock();
 
 #if CONFIG_NETDEV_STATISTICS_LOG_PERIOD > 0


### PR DESCRIPTION
## Summary
otherwise, if the mld timers are not cancelled, an illegal address will be accessed after timeout. to avoid this scenario, when the network card is unregistered, all MLD timers must be attempted to be synchronously cancelled.

## Impact
network device.
## Testing
sim:matter with code change:
```
nuttx$ git diff arch/sim/src/sim/sim_netdriver.c
diff --git a/arch/sim/src/sim/sim_netdriver.c b/arch/sim/src/sim/sim_netdriver.c
index 4dfef8da682..a983ed3bf4b 100644
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -272,6 +272,15 @@ static void sim_netdev_interrupt(wdparm_t arg)
                 sim_netdev_interrupt, arg);
 }
 
+static struct work_s g_work;
+static void sim_netdev_unregister_work(void *work)
+{
+  struct netdev_lowerhalf_s *dev = work;
+
+  netdev_lower_unregister(dev);
+  memset(dev, 0, sizeof(struct netdev_lowerhalf_s));
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -310,8 +319,9 @@ int sim_netdriver_init(void)
 
       netdev_lower_register(dev, devidx < CONFIG_SIM_WIFIDEV_NUMBER ?
                                  NET_LL_IEEE80211 : NET_LL_ETHERNET);
-      wd_start(&g_sim_dev[devidx].wdog, 0,
-               sim_netdev_interrupt, (wdparm_t)&g_sim_dev[devidx]);
+      // wd_start(&g_sim_dev[devidx].wdog, 0,
+      //          sim_netdev_interrupt, (wdparm_t)&g_sim_dev[devidx]);
+      work_queue(HPWORK, &g_work, sim_netdev_unregister_work, &g_sim_dev[devidx].dev, 50);
     }
 
   return OK;
```
log without this patch
```
(gdb) r
Starting program: /home/zhhyu/source/upstream/nuttx/nuttx 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> 
Program received signal SIGSEGV, Segmentation fault.
0x0000000040007b4e in wd_insert (wdog=0x7ffff3d33b80, expired=53, wdentry=0x4009df88 <sim_bthcisock_interrupt>, arg=140737284092720) at wdog/wd_start.c:192
192	      if (!clock_compare(curr->expired, expired))
(gdb) 
```
log with this patch
```
(gdb) r
Starting program: /home/zhhyu/source/upstream/nuttx/nuttx 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig
             IPv4  IPv6   TCP   UDP  ICMP ICMPv6 CAN
Received     0000  0003  0000  0000  0000  0000  0000
Dropped      0000  0003  0000  0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000  ----
Sent         0000  000b  0000  0000  0000  000b  0000
  Rexmit     ----  ----  0000  ----  ----  ----  ----
nsh> 
```