### PR TITLE
net/ipfrag: fix ip fragment assert when iob not enough

### DIFF
--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -361,7 +361,7 @@ int32_t ipv4_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
   uint32_t nfrags;
   uint16_t offset = 0;
   uint16_t hdrlen;
-  FAR struct iob_s *frag;
+  FAR struct iob_s *frag = NULL;
   FAR struct ipv4_hdr_s *ref = NULL;
   struct iob_queue_s fragq =
     {
@@ -379,8 +379,14 @@ int32_t ipv4_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
    */
 
   nfrags = ip_fragout_slice(dev->d_iob, PF_INET, mtu, hdrlen, &fragq);
-  ASSERT(nfrags > 1);
   netdev_iob_clear(dev);
+
+  /* No I/O Buffer is the only cause of failure */
+
+  if (nfrags == 0)
+    {
+      goto fail;
+    }
 
   /* Fill the L3 header into the reserved space */
 

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -570,7 +570,7 @@ int32_t ipv6_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
   uint32_t nfrags;
   uint16_t hdroff;
   uint16_t hdrtype;
-  FAR struct iob_s *frag;
+  FAR struct iob_s *frag = NULL;
   FAR struct ipv6_hdr_s *ref = NULL;
   FAR struct ipv6_fragment_extension_s *fraghdr;
   struct iob_queue_s fragq =
@@ -590,8 +590,14 @@ int32_t ipv6_fragout(FAR struct net_driver_s *dev, uint16_t mtu)
    */
 
   nfrags = ip_fragout_slice(dev->d_iob, PF_INET6, mtu, unfraglen, &fragq);
-  ASSERT(nfrags > 1);
   netdev_iob_clear(dev);
+
+  /* No I/O Buffer is the only cause of failure */
+
+  if (nfrags == 0)
+    {
+      goto fail;
+    }
 
   ipid = ++g_ipv6id;
 


### PR DESCRIPTION
## Summary
insufficient IOB during IP fragment is a normal scenario and should not crash directly. The assert needs to be removed and corresponding error handling needs to be added.

## Impact
net/ipfrag

## Testing
sim:matter with CONFIG_NET_IPFRAG=y
test log
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: ::

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6 CAN
Received     0000  0009  0000  0002  0000  0004  0000
Dropped      0000  0003  0000  0000  0000  0004  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000  ----
Sent         0000  000b  0000  0000  0000  000b  0000
  Rexmit     ----  ----  0000  ----  ----  ----  ----
nsh> ping -c 5 -s 8000 10.0.1.1
PING 10.0.1.1 8000 bytes of data
8000 bytes from 10.0.1.1: icmp_seq=0 time=0.0 ms
8000 bytes from 10.0.1.1: icmp_seq=1 time=0.0 ms
8000 bytes from 10.0.1.1: icmp_seq=2 time=0.0 ms
8000 bytes from 10.0.1.1: icmp_seq=3 time=0.0 ms
8000 bytes from 10.0.1.1: icmp_seq=4 time=0.0 ms
5 packets transmitted, 5 received, 0% packet loss, time 5050 ms
rtt min/avg/max/mdev = 0.000/0.000/0.000/0.000 ms
nsh> 

```