### PR TITLE
net/bufpool: fix typo

### DIFF
--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -86,7 +86,7 @@ FAR struct can_conn_s *can_alloc(void)
 
   /* The free list is protected by a a mutex. */
 
-  NET_BUFPOLL_LOCK(g_can_connections);
+  NET_BUFPOOL_LOCK(g_can_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_can_connections);
   if (conn != NULL)
@@ -114,7 +114,7 @@ FAR struct can_conn_s *can_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_can_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_can_connections);
+  NET_BUFPOOL_UNLOCK(g_can_connections);
   return conn;
 }
 
@@ -133,7 +133,7 @@ void can_free(FAR struct can_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
-  NET_BUFPOLL_LOCK(g_can_connections);
+  NET_BUFPOOL_LOCK(g_can_connections);
 
   /* Remove the connection from the active list */
 
@@ -164,7 +164,7 @@ void can_free(FAR struct can_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_can_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_can_connections);
+  NET_BUFPOOL_UNLOCK(g_can_connections);
 }
 
 /****************************************************************************

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -87,7 +87,7 @@ FAR struct icmp_conn_s *icmp_alloc(void)
 
   /* The free list is protected by a mutex. */
 
-  NET_BUFPOLL_LOCK(g_icmp_connections);
+  NET_BUFPOOL_LOCK(g_icmp_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_icmp_connections);
   if (conn != NULL)
@@ -97,7 +97,7 @@ FAR struct icmp_conn_s *icmp_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_icmp_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_icmp_connections);
+  NET_BUFPOOL_UNLOCK(g_icmp_connections);
 
   return conn;
 }
@@ -119,7 +119,7 @@ void icmp_free(FAR struct icmp_conn_s *conn)
 
   /* Take the mutex (perhaps waiting) */
 
-  NET_BUFPOLL_LOCK(g_icmp_connections);
+  NET_BUFPOOL_LOCK(g_icmp_connections);
 
   /* Is this the last reference on the connection?  It might not be if the
    * socket was cloned.
@@ -142,7 +142,7 @@ void icmp_free(FAR struct icmp_conn_s *conn)
       NET_BUFPOOL_FREE(g_icmp_connections, conn);
     }
 
-  NET_BUFPOLL_UNLOCK(g_icmp_connections);
+  NET_BUFPOOL_UNLOCK(g_icmp_connections);
 }
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -88,7 +88,7 @@ FAR struct icmpv6_conn_s *icmpv6_alloc(void)
 
   /* The free list is protected by a mutex. */
 
-  NET_BUFPOLL_LOCK(g_icmpv6_connections);
+  NET_BUFPOOL_LOCK(g_icmpv6_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_icmpv6_connections);
   if (conn != NULL)
@@ -98,7 +98,7 @@ FAR struct icmpv6_conn_s *icmpv6_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_icmpv6_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_icmpv6_connections);
+  NET_BUFPOOL_UNLOCK(g_icmpv6_connections);
 
   return conn;
 }
@@ -120,7 +120,7 @@ void icmpv6_free(FAR struct icmpv6_conn_s *conn)
 
   /* Take the mutex (perhaps waiting) */
 
-  NET_BUFPOLL_LOCK(g_icmpv6_connections);
+  NET_BUFPOOL_LOCK(g_icmpv6_connections);
 
   /* Remove the connection from the active list */
 
@@ -130,7 +130,7 @@ void icmpv6_free(FAR struct icmpv6_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_icmpv6_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_icmpv6_connections);
+  NET_BUFPOOL_UNLOCK(g_icmpv6_connections);
 }
 
 /****************************************************************************

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -153,7 +153,7 @@ FAR struct netlink_conn_s *netlink_alloc(void)
 
   /* The free list is protected by a mutex. */
 
-  NET_BUFPOLL_LOCK(g_netlink_connections);
+  NET_BUFPOOL_LOCK(g_netlink_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_netlink_connections);
   if (conn != NULL)
@@ -163,7 +163,7 @@ FAR struct netlink_conn_s *netlink_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_netlink_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_netlink_connections);
+  NET_BUFPOOL_UNLOCK(g_netlink_connections);
   return conn;
 }
 
@@ -184,7 +184,7 @@ void netlink_free(FAR struct netlink_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
-  NET_BUFPOLL_LOCK(g_netlink_connections);
+  NET_BUFPOOL_LOCK(g_netlink_connections);
 
   /* Remove the connection from the active list */
 
@@ -201,7 +201,7 @@ void netlink_free(FAR struct netlink_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_netlink_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_netlink_connections);
+  NET_BUFPOOL_UNLOCK(g_netlink_connections);
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -93,7 +93,7 @@ FAR struct pkt_conn_s *pkt_alloc(void)
 
   /* The free list is protected by a mutex. */
 
-  NET_BUFPOLL_LOCK(g_pkt_connections);
+  NET_BUFPOOL_LOCK(g_pkt_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_pkt_connections);
   if (conn)
@@ -103,7 +103,7 @@ FAR struct pkt_conn_s *pkt_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_pkt_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_pkt_connections);
+  NET_BUFPOOL_UNLOCK(g_pkt_connections);
   return conn;
 }
 
@@ -122,7 +122,7 @@ void pkt_free(FAR struct pkt_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
-  NET_BUFPOLL_LOCK(g_pkt_connections);
+  NET_BUFPOOL_LOCK(g_pkt_connections);
 
   /* Remove the connection from the active list */
 
@@ -138,7 +138,7 @@ void pkt_free(FAR struct pkt_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_pkt_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_pkt_connections);
+  NET_BUFPOOL_UNLOCK(g_pkt_connections);
 }
 
 /****************************************************************************

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -552,7 +552,7 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 
   /* The free list is protected by a mutex. */
 
-  NET_BUFPOLL_LOCK(g_udp_connections);
+  NET_BUFPOOL_LOCK(g_udp_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_udp_connections);
 
@@ -585,7 +585,7 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
       dq_addlast(&conn->sconn.node, &g_active_udp_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_udp_connections);
+  NET_BUFPOOL_UNLOCK(g_udp_connections);
   return conn;
 }
 
@@ -608,7 +608,7 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
-  NET_BUFPOLL_LOCK(g_udp_connections);
+  NET_BUFPOOL_LOCK(g_udp_connections);
   conn->lport = 0;
 
   /* Remove the connection from the active list */
@@ -644,7 +644,7 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_udp_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_udp_connections);
+  NET_BUFPOOL_UNLOCK(g_udp_connections);
 }
 
 /****************************************************************************

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -87,7 +87,7 @@ FAR struct usrsock_conn_s *usrsock_alloc(void)
 
   /* The free list is protected by a a mutex. */
 
-  NET_BUFPOLL_LOCK(g_usrsock_connections);
+  NET_BUFPOOL_LOCK(g_usrsock_connections);
 
   conn = NET_BUFPOOL_TRYALLOC(g_usrsock_connections);
   if (conn)
@@ -103,7 +103,7 @@ FAR struct usrsock_conn_s *usrsock_alloc(void)
       dq_addlast(&conn->sconn.node, &g_active_usrsock_connections);
     }
 
-  NET_BUFPOLL_UNLOCK(g_usrsock_connections);
+  NET_BUFPOOL_UNLOCK(g_usrsock_connections);
   return conn;
 }
 
@@ -122,7 +122,7 @@ void usrsock_free(FAR struct usrsock_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
-  NET_BUFPOLL_LOCK(g_usrsock_connections);
+  NET_BUFPOOL_LOCK(g_usrsock_connections);
 
   /* Remove the connection from the active list */
 
@@ -136,7 +136,7 @@ void usrsock_free(FAR struct usrsock_conn_s *conn)
 
   NET_BUFPOOL_FREE(g_usrsock_connections, conn);
 
-  NET_BUFPOLL_UNLOCK(g_usrsock_connections);
+  NET_BUFPOOL_UNLOCK(g_usrsock_connections);
 }
 
 /****************************************************************************

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -107,8 +107,8 @@
 #define NET_BUFPOOL_FREE(p,n)       net_bufpool_free(&p, n)
 #define NET_BUFPOOL_TEST(p)         net_bufpool_test(&p)
 #define NET_BUFPOOL_NAVAIL(p)       net_bufpool_navail(&p)
-#define NET_BUFPOLL_LOCK(p)         net_bufpool_lock(&p)
-#define NET_BUFPOLL_UNLOCK(p)       net_bufpool_unlock(&p)
+#define NET_BUFPOOL_LOCK(p)         net_bufpool_lock(&p)
+#define NET_BUFPOOL_UNLOCK(p)       net_bufpool_unlock(&p)
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary
A previous spelling mistake has been detected. fix it

## Impact
net

## Testing
sim:matter
Since the logical code was not modified, only the compilation was verified.
```
nuttx$ make -j12
Create version.h
LN: platform/board to /home/zhhyu/source/upstream/apps/platform/dummy
Register: iperf
Register: gpio
Register: hello
Register: dd
Register: ping6
Register: nsh
Register: sh
Register: ping
Register: dumpstack
CP:  /home/zhhyu/source/upstream/nuttx/include/nuttx/config.h
LD:  nuttx
Pac SIM with dynamic libs..
'/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
```