### PR TITLE
net/icmp: check src ip for icmp request message

### DIFF
--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -309,6 +309,21 @@ void icmp_input(FAR struct net_driver_s *dev)
 
   if (icmp->type == ICMP_ECHO_REQUEST)
     {
+      in_addr_t src_ipaddr;
+
+      /* According to RFC1122 section 3.2.2.6， an ICMP Echo Request
+       * which has a broadcast/multicast ip address should be discarded
+       */
+
+      src_ipaddr = net_ip4addr_conv32(ipv4->srcipaddr);
+
+      if (net_ipv4addr_cmp(src_ipaddr, INADDR_BROADCAST) ||
+          IN_MULTICAST(NTOHL(src_ipaddr)))
+        {
+          ninfo("ICMP ECHO request from broadcast/multicast address\n");
+          goto typeerr;
+        }
+
       /* Change the ICMP type */
 
       icmp->type = ICMP_ECHO_REPLY;


### PR DESCRIPTION

## Summary

According to section 3.2.2.6 of RFC1122,  An ICMP Echo Request destined to an IP broadcast or IP multicast address MAY be silently discarded.

## Impact

Check src ip for icmp request message, and drop the request message if src ip is broadcast/multicast.

## Testing

Set up a SIM environment, ping the SIM from the host side, and verify that normal ping can reply.
Then, write a Python script to construct a multicast/broadcast ICMP request message with the source IP address, where SIM does not respond.

`
from scapy.all import Ether, IP, ICMP, sendp

SRC_MAC = "fa:b1:d9:6d:a0:d3"
DST_MAC = "42:e1:c4:3f:48:dd"
SRC_IP = "224.0.0.1"
DST_IP = "10.0.1.2"
INTERFACE = "eth0"

def send_custom_icmp():
    try:
        ether_layer = Ether(src=SRC_MAC, dst=DST_MAC)
        ip_layer = IP(src=SRC_IP, dst=DST_IP, ttl=64)
        icmp_layer = ICMP(type=8, code=0)
        full_packet = ether_layer / ip_layer / icmp_layer

        sendp(full_packet, iface=INTERFACE, verbose=True)
        print("\n✅ ICMP packet sent successfully!")
        print(f"📄 Packet details:")
        print(f"   Source MAC: {SRC_MAC} | Destination MAC: {DST_MAC}")
        print(f"   Source IP: {SRC_IP} (Multicast) | Destination IP: {DST_IP}")

    except PermissionError:
        print("❌ Insufficient permissions! Run the script with administrator/root privileges (e.g., sudo python3 xxx.py)")
    except Exception as e:
        print(f"❌ Failed to send packet: {str(e)}")
        print("💡 Please check: 1. Correct network interface name 2. Valid MAC/IP format 3. Normal network connection")

if __name__ == "__main__":
    send_custom_icmp()
`
