### PR TITLE
net/tcp: add kconfig to support retransmission at a fixed time

### DIFF
--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -105,7 +105,21 @@ config NET_TCP_RTO
 	int "RTO of TCP/IP connections"
 	default 3
 	---help---
-		RTO of TCP/IP connections (all tasks)
+		Default retransmission timeout (RTO) of TCP/IP connections (all tasks).
+		In units of half seconds. When the same data packet is retransmitted
+		multiple times due to timeout, the RTO will be doubled. but the maximum
+		RTO is NET_TCP_RTO * 16. When this packet is ACKed, the RTO will be
+		reset to this value. This algorithm helps to reduce network congestion
+		to some extent.
+
+config NET_TCP_FIXED_RTO
+	bool "Use fixed RTO"
+	default n
+	---help---
+		Use fixed RTO for TCP/IP connections (all tasks), i.e. do not use
+		the RTO exponentially increasing algorithm. This is useful for projects
+		that require a fixed RTO value or have restrictions on the maximum
+		retransmission time.
 
 config NET_TCP_MAXRTX
 	int "Maximum retransmitted number of TCP/IP data packet"

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1082,6 +1082,7 @@ found:
         }
 #endif
 
+#ifndef CONFIG_NET_TCP_FIXED_RTO
       /* Do RTT estimation, unless we have done retransmissions. */
 
       if (conn->nrtx == 0)
@@ -1102,6 +1103,7 @@ found:
           conn->sv += m;
           conn->rto = (conn->sa >> 3) + conn->sv;
         }
+#endif
 
       /* Set the acknowledged flag. */
 

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -579,7 +579,9 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
               /* Exponential backoff. */
 
+#ifndef CONFIG_NET_TCP_FIXED_RTO
               conn->rto = TCP_RTO << (conn->nrtx > 4 ? 4: conn->nrtx);
+#endif
               tcp_update_retrantimer(conn, conn->rto);
               conn->nrtx++;
 


### PR DESCRIPTION
## Summary
the maximum retransmission interval allowed for car projects cannot exceed 6 seconds, and allows for fixed retransmission intervals. according to the previous algorithm, the retransmission interval may be 0.5 * 2 ^ 4 = 8 seconds, which does not meet the requirements.

## Impact
retransmission Time Strategy for TCP Network Communication.

## Testing
sim:matter with iperf
test log
```
NuttShell (NSH) NuttX-12.11.0
MOTD: username=admin password=Administrator
nsh> iperf -c 10.0.1.1 -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-   3.08 sec  189693952 Bytes  492.71 Mbits/sec
   3.08-   8.89 sec  359940096 Bytes  495.61 Mbits/sec
   8.89-  11.96 sec  190152704 Bytes  495.51 Mbits/sec
  11.96-  16.11 sec  254279680 Bytes  490.18 Mbits/sec
  16.11-  22.52 sec  388710400 Bytes  485.13 Mbits/sec
  22.52-  25.78 sec  200228864 Bytes  491.36 Mbits/sec
  25.78-  31.58 sec  347570176 Bytes  479.41 Mbits/sec
   0.00-  31.58 sec 1946484736 Bytes  493.09 Mbits/sec
iperf exit
nsh> poweroff
[Inferior 1 (process 3015966) exited normally]
(gdb) q
nuttx$ cat .config | grep DROP
# CONFIG_NET_TCP_DEBUG_DROP_RECV is not set
CONFIG_NET_TCP_DEBUG_DROP_SEND=y
CONFIG_NET_TCP_DEBUG_DROP_SEND_PROBABILITY=50
nuttx$ cat .config | grep FIXED
CONFIG_NET_TCP_FIXED_RTO=y
# CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM is not set
```
