### PR TITLE
net/vlan: add some macro for vlan

### DIFF
--- a/Documentation/components/drivers/special/net/vlan.rst
+++ b/Documentation/components/drivers/special/net/vlan.rst
@@ -13,5 +13,81 @@ Vlan Device Drivers
 -  Supporting ADD_VLAN_CMD and DEL_VLAN_CMD of SIOCSIFVLAN.
 -  We add default PCP because some of our apps may not want to set
    PCP manually
+-  ``include/nuttx/net/ethernet.h``. Some definitions for 802.1Q VLAN
+
+   .. code-block:: c
+
+      #define VLAN_PRIO_MASK   0xe000 /* Priority Code Point */
+      #define VLAN_PRIO_SHIFT  13
+      #define VLAN_CFI_MASK    0x1000 /* Canonical Format Indicator / Drop Eligible Indicator */
+      #define VLAN_VID_MASK    0x0fff /* VLAN Identifier */
+      #define VLAN_N_VID       4096
 
 -  **Driver**: ``drivers/net/vlan.c``
+
+Configuration Options
+=====================
+
+``CONFIG_NET_VLAN``
+  Enable 802.1Q VLAN interface support.
+``CONFIG_NET_VLAN_COUNT``
+  Maximum number of VLAN interfaces per physical Ethernet interface.
+
+Usage
+=====
+
+.. code-block:: c
+
+  #include <nuttx/net/vlan.h>
+  #include "netutils/netlib.h"
+
+  /* Create a VLAN interface (eth0.100, VLAN ID 100) */
+
+  FAR const char *ifname = "eth0";
+  uint16_t vlanid = 100;
+  uint8_t priority = 0; /* Default PCP */
+
+  int sockfd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+
+  if (sockfd >= 0)
+   {
+      struct vlan_ioctl_args ifv;
+
+      strncpy(ifv.vlan_devname, ifname, sizeof(ifv.device1));
+      ifv.u.VID  = vlanid;
+      ifv.vlan_qos = priority;
+      ifv.cmd = ADD_VLAN_CMD;
+      if (ioctl(sockfd, SIOCSIFVLAN, (unsigned long)&ifv) < 0)
+        {
+          /* Handle error */
+        }
+      close(sockfd);
+   }
+
+  /* Enable the VLAN interface */
+
+  netdev_ifup("eth0.100");
+
+.. code-block:: c
+
+  #include <nuttx/net/vlan.h>
+  #include "netutils/netlib.h"
+
+  /* Delete a VLAN interface (eth0.100, VLAN ID 100) */
+
+  FAR const char *ifname = "eth0.100";
+
+  int sockfd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+
+  if (sockfd >= 0)
+   {
+      struct vlan_ioctl_args ifv;
+
+      strncpy(ifv.vlan_devname, ifname, sizeof(ifv.device1));
+      ifv.cmd = DEL_VLAN_CMD;
+      if (ioctl(sockfd, SIOCSIFVLAN, (unsigned long)&ifv) < 0)
+        {
+          /* Handle error */
+        }
+      close(sockfd);
+   }

--- a/include/nuttx/net/ethernet.h
+++ b/include/nuttx/net/ethernet.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/ethernet.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2009-2012, 2015 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007, 2009-2012, 2015 Gregory Nutt. All rights
+ *                         reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  * SPDX-FileContributor: Adam Dunkels <adam@dunkels.com>
@@ -62,6 +63,16 @@
  */
 
 #define TPID_8021QVLAN   ETHERTYPE_VLAN
+
+/* These are some control information associated with QVLAN tagged
+ * Ethernet packets.
+ */
+
+#define VLAN_PRIO_MASK   0xe000 /* Priority Code Point */
+#define VLAN_PRIO_SHIFT  13
+#define VLAN_CFI_MASK    0x1000 /* Canonical Format Indicator / Drop Eligible Indicator */
+#define VLAN_VID_MASK    0x0fff /* VLAN Identifier */
+#define VLAN_N_VID       4096
 
 /* These are some of the types associated with QVLAN tagged
  * Ethernet packets.


### PR DESCRIPTION
Refer：
https://github.com/torvalds/linux/blob/v6.8/include/linux/if_vlan.h#L73-L76

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

There are some standard Vlan message operations that require defining macro definitions related to Vlan. Referring to linux code, the following macro definitions have been added.

Refer：
https://github.com/torvalds/linux/blob/v6.8/include/linux/if_vlan.h#L73-L76

## Impact

Adding macro definition information did not affect the Vlan functionality.

## Testing

Set up a SIM environment, add VLAN interface through vconfig in SIM, add VLAN interface in the host side, ping SIM VLAN interface from the host side, and verify that VLAN function is normal.
