### PR TITLE
sched: Remove `CONFIG_SCHED_TICKLESS_TICK_ARGUMENT`.

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -107,7 +107,6 @@ config TIMER_ARCH
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TIMEKEEPING
 	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
-	select SCHED_TICKLESS_TICK_ARGUMENT if SCHED_TICKLESS
 	---help---
 		Implement timer arch API on top of timer driver interface.
 
@@ -147,7 +146,6 @@ config ALARM_ARCH
 	select ARCH_HAVE_TIMEKEEPING
 	select SCHED_TICKLESS_ALARM if SCHED_TICKLESS
 	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
-	select SCHED_TICKLESS_TICK_ARGUMENT if SCHED_TICKLESS
 	---help---
 		Implement alarm arch API on top of oneshot driver interface.
 

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -330,6 +330,18 @@ int weak_function up_timer_gettime(struct timespec *ts)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_TICKLESS
+int weak_function up_alarm_cancel(FAR struct timespec *ts)
+{
+  int ret = -EAGAIN;
+
+  if (g_oneshot_lower != NULL)
+    {
+      ret = ONESHOT_CANCEL(g_oneshot_lower, ts);
+    }
+
+  return ret;
+}
+
 int weak_function up_alarm_tick_cancel(FAR clock_t *ticks)
 {
   int ret = -EAGAIN;
@@ -368,7 +380,8 @@ int weak_function up_alarm_tick_cancel(FAR clock_t *ticks)
  *
  ****************************************************************************/
 
-int weak_function up_alarm_start(const struct timespec *ts)
+#ifdef CONFIG_SCHED_TICKLESS
+int weak_function up_alarm_start(FAR const struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -380,7 +393,6 @@ int weak_function up_alarm_start(const struct timespec *ts)
   return ret;
 }
 
-#ifdef CONFIG_SCHED_TICKLESS
 int weak_function up_alarm_tick_start(clock_t ticks)
 {
   int ret = -EAGAIN;

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2002,11 +2002,8 @@ void up_timer_getmask(FAR clock_t *mask);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
-#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_alarm_cancel(FAR struct timespec *ts);
-#  else
 int up_alarm_tick_cancel(FAR clock_t *ticks);
-#  endif
 #endif
 
 /****************************************************************************
@@ -2034,12 +2031,9 @@ int up_alarm_tick_cancel(FAR clock_t *ticks);
  *
  ****************************************************************************/
 
-int up_alarm_start(FAR const struct timespec *ts);
-
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
-#  ifdef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
+int up_alarm_start(FAR const struct timespec *ts);
 int up_alarm_tick_start(clock_t ticks);
-#  endif
 #endif
 
 /****************************************************************************
@@ -2079,11 +2073,8 @@ int up_alarm_tick_start(clock_t ticks);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_ALARM)
-#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_timer_cancel(FAR struct timespec *ts);
-#  else
 int up_timer_tick_cancel(FAR clock_t *ticks);
-#  endif
 #endif
 
 /****************************************************************************
@@ -2111,12 +2102,9 @@ int up_timer_tick_cancel(FAR clock_t *ticks);
  *
  ****************************************************************************/
 
-int up_timer_start(FAR const struct timespec *ts);
-
 #if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_ALARM)
-#  ifdef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
+int up_timer_start(FAR const struct timespec *ts);
 int up_timer_tick_start(clock_t ticks);
-#  endif
 #endif
 
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -73,26 +73,6 @@ config SCHED_TICKLESS
 
 if SCHED_TICKLESS
 
-config SCHED_TICKLESS_TICK_ARGUMENT
-	bool "Scheduler use tick argument"
-	default n
-	---help---
-		Enables use of tick argument in scheduler. If enabled, then the
-		board-specific logic must provide the following functions:
-
-			int up_timer_gettick(FAR clock_t *ticks);
-
-		If SCHED_TICKLESS_ALARM is enabled, then these additional interfaces are
-		expected:
-
-			int up_alarm_tick_cancel(FAR clock_t *ticks);
-			int up_alarm_tick_start(clock_t ticks);
-
-		Otherwise, these additional interfaces are expected:
-
-			int up_timer_tick_cancel(FAR clock_t *ticks);
-			int up_timer_tick_start(clock_t ticks);
-
 config SCHED_TICKLESS_ALARM
 	bool "Tickless alarm"
 	default n


### PR DESCRIPTION
## Summary

This PR is the part IV of https://github.com/apache/nuttx/pull/17556. To support high-precision timer, this PR removed `CONFIG_SCHED_TICKLESS_TICK_ARGUMENT` to simplify kernel configuration and expiration handling.

## Impact

This PR removes `CONFIG_SCHED_TICKLESS_TICK_ARGUMENT`. The `up_alarm/timer_tick_start/cancel` interfaces are now only used as internal OS interfaces, implemented by the `oneshot` or `timer` timer driver abstraction. This change affects NuttX  timer interrupt handling.

## Testing

```bash
➜   qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 8 -bios none -nographic -kernel nuttx

NuttShell (NSH) NuttX-12.11.0
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
...

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fd06e0  1fd06e0
ordblks         1        9
mxordblk  1fcc5f0  1fbbb88
uordblks     40f0     8f98
fordblks  1fcc5f0  1fc7748
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```
