### PR TITLE
sched/wdog: fix race condition in wd_gettime()

### DIFF
--- a/sched/wdog/wd_gettime.c
+++ b/sched/wdog/wd_gettime.c
@@ -58,14 +58,21 @@ sclock_t wd_gettime(FAR struct wdog_s *wdog)
   clock_t    expired;
   sclock_t   delay = 0;
 
-  if (wdog && WDOG_ISACTIVE(wdog))
+  if (wdog != NULL)
     {
       flags   = enter_critical_section();
-      expired = wdog->expired;
-      leave_critical_section(flags);
+      if (WDOG_ISACTIVE(wdog))
+        {
+          expired = wdog->expired;
+          leave_critical_section(flags);
 
-      delay   = (sclock_t)(expired - clock_systime_ticks());
-      delay   = delay >= 0 ? delay : 0;
+          delay = (sclock_t)(expired - clock_systime_ticks());
+          delay = delay >= 0 ? delay : 0;
+        }
+      else
+        {
+          leave_critical_section(flags);
+        }
     }
 
   return delay;


### PR DESCRIPTION
## Summary

sched/wdog: fix race condition in wd_gettime()

Move WDOG_ISACTIVE check inside critical section protection to avoid race condition

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, sabre-6quad/smp ostest