### PR TITLE
com/can: Attempt to release invalid resources when sender is full

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -647,6 +647,21 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
 
       while (TX_FULL(sender))
         {
+          /* The transmit sender is full. In order to resolve the Lower half
+           * interrupt exception, attempt to release invalid unconfirm
+           * messages and trigger can_xmit.
+           */
+
+          if (dev_txempty(dev))
+            {
+              can_send_done(sender);
+
+              if (!TX_FULL(sender))
+                {
+                  break;
+                }
+            }
+
           /* The transmit sender is full  -- non-blocking mode selected? */
 
           if ((filep->f_oflags & O_NONBLOCK) != 0)


### PR DESCRIPTION
## Summary

Due to bus reasons, the can sender may be full. However, after the bus is restored and the hardware has sent the message, in some scenarios, due to hardware bugs, the TXconfirm interrupt is lost, which can lead to packet interruption.
To enhance the robustness of the Nuttx CAN protocol stack and address the potential issues mentioned above. Improved the CAN protocol stack.

## Impact

This modification will not have an impact on normal packet sending, but it will only trigger message sending through can_dend.done when the sender is already full and there is no external data in the driver.


## Testing
Perform functional validation on the development board. Modify the driver layer code so that the first 10 frames of messages sent do not handle TXconfirmation interrupts, and subsequent TXconfirmation interrupts are handled normally, indicating a hardware issue. Before powering on the development board, disconnect the CAN bus connection. There are no CAN messages on the other end device. After the bus connection, CAN messages appear.

```
  int fd;
  int count = 0;
  struct can_msg_s txmsg;

  txmsg.cm_hdr.ch_id = 0x69;
  txmsg.cm_hdr.ch_dlc = 8;
  txmsg.cm_hdr.ch_edl = 1;
  
  
  fd = open("/dev/can0",  O_RDWR | O_NONBLOCK);
  while (1)
    {
        count = (++count)%256;
        txmsg.cm_data[0] = count;
        write(fd, &txmsg, sizeof(struct can_msg_s ));
    }
  close(fd);
```