### PR TITLE
net/ipv4: Send ICMP Destination Unreachable for unknown protocol

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -443,7 +443,12 @@ static int ipv4_in(FAR struct net_driver_s *dev)
 #endif
 
         nwarn("WARNING: Unrecognized IP protocol\n");
+#if defined(CONFIG_NET_ICMP) && !defined(CONFIG_NET_ICMP_NO_STACK)
+        icmp_reply(dev, ICMP_DEST_UNREACHABLE, ICMP_PROT_UNREACH);
+        goto done;
+#else
         goto drop;
+#endif
     }
 
 #ifdef CONFIG_NET_IPFILTER
@@ -451,7 +456,8 @@ static int ipv4_in(FAR struct net_driver_s *dev)
 #endif
 
 #if defined(CONFIG_NET_IPFORWARD) || defined(CONFIG_NET_IPFILTER) || \
-    (defined(CONFIG_NET_BROADCAST) && defined(NET_UDP_HAVE_STACK))
+    (defined(CONFIG_NET_BROADCAST) && defined(NET_UDP_HAVE_STACK)) || \
+    defined(CONFIG_NET_ICMP) && !defined(CONFIG_NET_ICMP_NO_STACK)
 done:
 #endif
 


### PR DESCRIPTION
## Summary

According RFC1122 3.2.2.1, A host SHOULD generate Destination Unreachable messages with code: 2(Protocol Unreachable), when the designated transport protocol is not supported.

## Impact

ipv4
## Testing

```
from scapy.all import *

icmp_pkt = IP(dst="10.0.1.2", len=21, proto=143) / "E"

send(icmp_pkt, verbose=1)

```

test result:
```
13:38:31.958568 IP 10.0.1.1 > 10.0.1.2: [Ethernet requires IPv6] (invalid)
13:38:31.959701 IP 10.0.1.2 > 10.0.1.1: ICMP 10.0.1.2 protocol 143 unreachable, length 29
```
