### PR TITLE
net/ipv4: Drop a ipv4 packet with total length bigger than the actual transmitted data

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -187,6 +187,8 @@ static int ipv4_in(FAR struct net_driver_s *dev)
 
   /* Get the size of the packet minus the size of link layer header */
 
+  dev->d_len -= NET_LL_HDRLEN(dev);
+
   if (IPv4_HDRLEN > dev->d_len)
     {
       nwarn("WARNING: Packet shorter than IPv4 header\n");
@@ -214,6 +216,9 @@ static int ipv4_in(FAR struct net_driver_s *dev)
     }
   else if (totlen > dev->d_len)
     {
+#ifdef CONFIG_NET_STATISTICS
+      g_netstats.ipv4.drop++;
+#endif
       nwarn("WARNING: IP packet shorter than length in IP header\n");
       goto drop;
     }


### PR DESCRIPTION
## Summary

Drop a ipv4 packet with total length bigger than the actual transmitted data.
Derived from RFC 791 s3.1 p13 Internet Header Format.

## Impact

ipv4

## Testing
```
from scapy.all import *

icmp_pkt = IP(dst="10.0.1.2", len=60) / ICMP()/ "ECU NETWORK VALIDATION TEST"

send(icmp_pkt, verbose=1)

```
test result, no icmp reply:
```
14:12:19.599994 IP truncated-ip - 5 bytes missing! 10.0.1.1 > 10.0.1.2: ICMP echo request, id 0, seq 0, length 40
14:12:31.995797 ARP, Request who-has 10.0.1.2 tell 10.0.1.1, length 28
14:12:31.998049 ARP, Reply 10.0.1.2 is-at 42:e1:c4:3f:48:dd, length 28
```