### PR TITLE
net/ethernet: fix  compilation issues for inet_sockif.c

### DIFF
--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -762,12 +762,14 @@ static int inet_get_socketlevel_option(FAR struct socket *psock, int option,
               return -EINVAL;
             }
 
+#  ifdef NET_UDP_HAVE_STACK
           if (psock->s_type == SOCK_DGRAM)
             {
               FAR struct udp_conn_s *conn = psock->s_conn;
               *(FAR int *)value = (conn->timestamp != 0);
             }
           else
+#  endif
             {
               return -ENOPROTOOPT;
             }
@@ -1064,6 +1066,7 @@ static int inet_set_socketlevel_option(FAR struct socket *psock, int option,
               return -EINVAL;
             }
 
+#  ifdef NET_UDP_HAVE_STACK
           if (psock->s_type == SOCK_DGRAM)
             {
               net_lock();
@@ -1079,6 +1082,7 @@ static int inet_set_socketlevel_option(FAR struct socket *psock, int option,
               net_unlock();
             }
           else
+#  endif
             {
               return -ENOPROTOOPT;
             }

--- a/net/pkt/Kconfig
+++ b/net/pkt/Kconfig
@@ -9,6 +9,7 @@ config NET_PKT
 	bool "Socket packet socket support"
 	default n
 	select NETDEV_IFINDEX
+	select NET_READAHEAD
 	---help---
 		Enable or disable support for packet sockets.
 


### PR DESCRIPTION
## Summary

When the CONFIG_NET_SOCKOPTS, CONFIG_NET_TIMESTAMP, and CONFIG_NET_UDP_NO_STACK configuration options are enabled and the CONFIG_NET_UDP configuration option is disabled, a compilation error is generated. Modifications have been made to address the aforementioned issues.

`
inet/inet_sockif.c:772:40: error: invalid use of undefined type ‘struct udp_conn_s’
  772 |               *(FAR int *)value = (conn->timestamp != 0);
      |                                        ^~
inet/inet_sockif.c: In function ‘inet_set_socketlevel_option’:
inet/inet_sockif.c:1081:19: error: invalid use of undefined type ‘struct udp_conn_s’
 1081 |               conn->timestamp = (*((FAR int *)value) != 0);
`

## Impact
No modifications have been made to the functionality, so it will not affect the system.

## Testing

As mentioned above, with the above configuration, modifying the code and recompiling, the problem will no longer recur.
