### PR TITLE
nuttx/can: in trunk support to Send message cancel mechanism.

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -128,11 +128,28 @@ config CAN_TXREADY
 		no longer full.  can_txready() will then awaken the
 		can_write() logic and the hang condition is avoided.
 
-config CAN_TXPRIORITY
+config CAN_STRICT_TX_PRIORITY
 	bool "Prioritize sending based on canid"
 	default n
 	---help---
-		Prioritize sending based on canid.
+		Enable strict transmit priority ordering based on CAN ID.
+
+		When the hardware transmit buffers (not a hardware FIFO) are
+		full and there are frames pending in the software tx_pending list,
+		the cancel ability is taken effect. this feature may cancel
+		the msg with the largest CAN ID in the mailbox.
+
+		Specifically, the driver may cancel the transmission of the
+		lowest-priority frame(the msg with the largest CAN ID) currently
+		stored in a hardware transmit buffer, reinsert that frame back
+		into the software pending list, and replace it with a
+		higher-priority pending frame.
+
+		This feature requires that the CAN controller hardware supports
+		cancellation (abort) of buffered transmissions.
+
+		Do not enable this option if the lower-half driver uses a hardware
+		FIFO to store transmit frames.
 
 choice
 	prompt "TX Ready Work Queue"

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -396,6 +396,7 @@
 #define dev_send(dev,m)           (dev)->cd_ops->co_send(dev,m)
 #define dev_txready(dev)          (dev)->cd_ops->co_txready(dev)
 #define dev_txempty(dev)          (dev)->cd_ops->co_txempty(dev)
+#define dev_cancel(dev,m)         (dev)->cd_ops->co_cancel(dev,m)
 
 /* CAN message support ******************************************************/
 
@@ -677,7 +678,7 @@ struct can_rxfifo_s
   struct can_msg_s rx_buffer[CONFIG_CAN_RXFIFOSIZE];
 };
 
-#ifdef CONFIG_CAN_TXPRIORITY
+#ifdef CONFIG_CAN_STRICT_TX_PRIORITY
 struct can_msg_node_s
 {
   struct list_node  list;
@@ -688,7 +689,7 @@ struct can_msg_node_s
 struct can_txcache_s
 {
   sem_t             tx_sem;             /* Counting semaphore */
-#ifdef CONFIG_CAN_TXPRIORITY
+#ifdef CONFIG_CAN_STRICT_TX_PRIORITY
   /* tx_buffer   - Buffer of CAN message. And this buffer is managed by
    *               tx_free/tx_pending/tx_sending
    * tx_free     - Link all buffer node in the initial step
@@ -815,6 +816,9 @@ struct can_ops_s
    */
 
   CODE bool (*co_txempty)(FAR struct can_dev_s *dev);
+
+  CODE bool (*co_cancel)(FAR struct can_dev_s *dev,
+                         FAR struct can_msg_s *msg);
 };
 
 /* This is the device structure used by the driver.  The caller of

--- a/include/nuttx/can/can_sender.h
+++ b/include/nuttx/can/can_sender.h
@@ -46,7 +46,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_CAN_TXPRIORITY
+#ifdef CONFIG_CAN_STRICT_TX_PRIORITY
 
 /* There are three linked lists to manage TX buffer:
  * tx_free     - can_write function get a tx_free node, write message, then
@@ -145,7 +145,7 @@
                                                 % CONFIG_CAN_TXFIFOSIZE; \
     }) \
 
-#endif  /* CONFIG_CAN_TXPRIORITY */
+#endif  /* CONFIG_CAN_STRICT_TX_PRIORITY */
 
 /****************************************************************************
  * Public Function Prototypes
@@ -234,6 +234,34 @@ void can_revert_msg(FAR struct can_txcache_s *cd_sender,
  ****************************************************************************/
 
 void can_send_done(FAR struct can_txcache_s *cd_sender);
+
+/****************************************************************************
+ * Name: can_txneed_cancel
+ *
+ * Description:
+ *   Compare the msgID between tx_sending and tx_pending's head when
+ *   dev_txready return false and tx_pending is not empty, preserve the node
+ *   with largest msgID in tx_sending into *callbackmsg_node. return true if
+ *   the msgID in tx_pending's head < the smallest msgID in tx_sending.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_CAN_STRICT_TX_PRIORITY
+bool can_txneed_cancel(FAR struct can_txcache_s *cd_sender);
+#endif
+
+/****************************************************************************
+ * Name: can_cancel_mbmsg
+ *
+ * Description:
+ *   cancel the msg with the largest msgID in the mailbox and
+ *   return true if success.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_CAN_STRICT_TX_PRIORITY
+bool can_cancel_mbmsg(FAR struct can_dev_s *dev);
+#endif
 
 #endif /* CONFIG_CAN */
 #endif /* __INCLUDE_NUTTX_CAN_SENDER_H */


### PR DESCRIPTION
add the logic about  "cancel mechanism" of sending can/canfd message based priority list.

## Summary
This PR is intended to resolve the CAN message priority inversion issue that can occur during CAN frame transmission.
It fundamentally addresses the problem of CAN message priority inversion, thereby avoiding communication latency or errors caused by priority inversion.

The solution manages CAN message transmission by introducing a **cancel mechanism** combined with a linked list, along with **predefined cancel conditions** (can_txneed_cancel), to control and reorder CAN frame transmission as needed.

## Impact
If users want to use this scheme, they only need to enable CONFIG_CAN_TXCANCEL.
This scheme does not affect the build process, security, or compatibility.

A new dev_cancel interface is introduced, which is used to cancel the transmission of CAN messages that are already queued in the CAN driver’s hardware transmit buffer.

## Testing
This scheme has been applied in an automotive basic-software project and has undergone long-term testing and validation; it does not break existing code.
The scheme also ran stably on development boards based on the Cortex-M7 architecture.

**Test procedure:**

1. Enable CONFIG_CAN_TXCANCEL.
2. Configure the CAN driver to use only one hardware transmit buffer.
3. Disconnect the CAN bus.
4. Using the cansend utility, first send a low-priority CAN message (ID 0x222). After confirming that this message has been placed into the hardware transmit buffer, send a high-priority CAN message (ID 0x111).
5. Reconnect the CAN bus.

**Observed behavior:** 
the high-priority message (ID 0x111) appears on the bus first, followed by the low-priority message (ID 0x222).

<img width="726" height="378" alt="github_PR_1" src="https://github.com/user-attachments/assets/4b9f91d3-1220-406c-b9ba-2294892be10d" />
<img width="1230" height="824" alt="github_PR_2" src="https://github.com/user-attachments/assets/f005e105-3b75-4a95-a7b8-8bd737f6792e" />
<img width="716" height="360" alt="github_PR_3" src="https://github.com/user-attachments/assets/081aef0c-b20e-4a99-9d82-327ad9c435c7" />

