### PR TITLE
net/vlan: make a judgment before calling fuction

### DIFF
--- a/drivers/net/vlan.c
+++ b/drivers/net/vlan.c
@@ -250,7 +250,10 @@ static void vlan_reclaim(FAR struct netdev_lowerhalf_s *dev)
   FAR struct vlan_device_s      *vlan = (FAR struct vlan_device_s *)dev;
   FAR struct netdev_lowerhalf_s *real = vlan->real;
 
-  real->ops->reclaim(real);
+  if (real->ops->reclaim != NULL)
+    {
+      real->ops->reclaim(real);
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

Without making a judgment before calling the API implemented by the driver layer, there is a potential risk of crashing. 
Make a legality check before calling an uncertain function. 

## Impact
It will enhance the robustness of the system, but will not affect its functionality.

## Testing

Set up Vlan communication environment on the development board, and after modification, Ethernet communication works normally.
