### PR TITLE
risc-v/litex: Implement up_flush_dcache_all when CONFIG_ARCH_DCACHE is defined.

### DIFF
--- a/arch/risc-v/src/litex/litex_cache.S
+++ b/arch/risc-v/src/litex/litex_cache.S
@@ -57,6 +57,28 @@ up_invalidate_dcache_all:
 #endif
 
 /****************************************************************************
+ * Name: up_flush_dcache_all
+ *
+ * Description:
+ *   Flush the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_DCACHE
+  .globl  up_flush_dcache_all
+  .type   up_flush_dcache_all, function
+
+up_flush_dcache_all:
+  .word 0x500F
+#endif
+
+/****************************************************************************
  * Name: up_invalidate_icache_all
  *
  * Description:


### PR DESCRIPTION
Implements `up_flush_dcache_all` for litex / vexriscv boards.

This duplicates `up_invalidate_dcache_all` as vexriscv's DBUS cache
does not distinguish between flushing and invalidation.

This was discussed earlier in #17493 and it was felt that this code fix might be better than removing the CONFIG_ARCH_DCACHE definitions.

# Summary

Currently, litex / vexriscv boards do not compile as `up_flush_dcache_all` is not defined.

## Impact

Allows compilation of `arty_a7:nsh`.

## Testing

compilation succeeds with `arty_a7:nsh` builds and runs successfully on a vexriscv linux variant.