### PR TITLE
 net/udp: Validate UDP length field against actual packet size

### DIFF
--- a/net/udp/udp_input.c
+++ b/net/udp/udp_input.c
@@ -215,6 +215,7 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
   FAR struct iob_s *iob;
 #endif
   unsigned int udpiplen;
+  unsigned int udpdatalen = dev->d_len - iplen;
 #ifdef CONFIG_NET_UDP_CHECKSUMS
   uint16_t chksum;
 #endif
@@ -231,6 +232,16 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
    */
 
   udp = IPBUF(iplen);
+
+  /* Check the UDP packet length */
+
+  if (udpdatalen < UDP_HDRLEN || ntohs(udp->udplen) != udpdatalen)
+    {
+      nwarn("WARNING: UDP length invalid: hdr=%u actual=%u\n",
+            ntohs(udp->udplen), udpdatalen);
+      dev->d_len = 0;
+      return ret;
+    }
 
   /* Get the size of the IP header and the UDP header */
 


### PR DESCRIPTION

## Summary

According to RFC768 page 2, length feild is the length  in octets  of this user datagram  including  this header  and the data.
So,  Check the length field with the real user data, return error if it failed.

## Impact

Without modification function, it will not have an impact on legitimate messages.

## Testing

Enable the CONFIG_EXAMPLE_UDP compilation option, set up the SIM environment, and run a UDP server on the SIM side.
As a UDP client, the host sends messages to the server, including 5 valid UDP length messages and 5 invalid UDP length messages. It can be seen that the messages with incorrect lengths are discarded by the server, while the messages with correct lengths are received by the server.

`
from scapy.all import Ether, IP, UDP, sendp
import random

SRC_MAC = "fa:b1:d9:6d:a0:d3"
DST_MAC = "42:e1:c4:3f:48:dd"
SRC_IP = "10.0.1.1"
DST_IP = "10.0.1.2"
DST_PORT = 8888
SRC_PORT = random.randint(1024, 65535)
TOTAL_PACKETS = 10
ERROR_PACKETS = 5

def generate_udp_packet(is_normal: bool, data: bytes) -> Ether:
    real_udp_length = 8 + len(data)
    if not is_normal:
        error_offset = random.choice([-1, 1]) * random.randint(5, 10)
        udp_length = real_udp_length + error_offset
        udp_length = max(8, udp_length)
    else:
        udp_length = real_udp_length

    ether = Ether(src=SRC_MAC, dst=DST_MAC)
    ip = IP(src=SRC_IP, dst=DST_IP)
    udp = UDP(
        sport=SRC_PORT, 
        dport=DST_PORT, 
        len=udp_length
    )

    packet = ether / ip / udp / data
    return packet

if __name__ == "__main__":
    for i in range(TOTAL_PACKETS):
        data = f"TestPacket_{i+1}".encode("utf-8")
        is_normal = i >= ERROR_PACKETS
        
        packet = generate_udp_packet(is_normal, data)
        
        sendp(packet, iface="eth0", verbose=1)
        
        real_length = 8 + len(data)
        udp_length = packet[UDP].len
        status = "Normal" if is_normal else "Abnormal"
        print(f"Sending {i+1}th packet | Status: {status} | Actual UDP length: {real_length} | Header length field: {udp_length}")
`
