### PR TITLE
net/ethernet: change struct ifreq to consistent with Linux

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -240,7 +240,6 @@ struct can_ioctl_state_s
 struct lifreq
 {
   char                         lifr_name[IFNAMSIZ];  /* Network device name (e.g. "eth0") */
-  int16_t                      lifr_ifindex;         /* Interface index */
   union
   {
     struct sockaddr_storage    lifru_addr;           /* IP Address */
@@ -249,6 +248,7 @@ struct lifreq
     struct sockaddr_storage    lifru_netmask;        /* Netmask */
     struct sockaddr            lifru_hwaddr;         /* MAC address */
     int                        lifru_count;          /* Number of devices */
+    int                        lifru_ivalue;         /* Value for ifindex/metric/bandwidth and so on */
     int                        lifru_mtu;            /* MTU size */
     uint32_t                   lifru_flags;          /* Interface flags */
     struct mii_ioctl_notify_s  llfru_mii_notify;     /* PHY event notification */
@@ -264,6 +264,10 @@ struct lifreq
 #define lifr_broadaddr        lifr_ifru.lifru_broadaddr        /* Broadcast address */
 #define lifr_netmask          lifr_ifru.lifru_netmask          /* Interface net mask */
 #define lifr_hwaddr           lifr_ifru.lifru_hwaddr           /* MAC address */
+#define lifr_ifindex          lifr_ifru.lifru_ivalue           /* Interface index */
+#define lifr_metric           lifr_ifru.lifru_ivalue           /* metric */
+#define lifr_bandwidth        lifr_ifru.lifru_ivalue           /* link bandwidth */
+#define lifr_qlen             lifr_ifru.lifru_ivalue           /* Queue length */
 #define lifr_mtu              lifr_ifru.lifru_mtu              /* MTU */
 #define lifr_count            lifr_ifru.lifru_count            /* Number of devices */
 #define lifr_flags            lifr_ifru.lifru_flags            /* interface flags */
@@ -294,7 +298,6 @@ struct lifconf
 struct ifreq
 {
   char                         ifr_name[IFNAMSIZ];  /* Network device name (e.g. "eth0") */
-  int16_t                      ifr_ifindex;         /* Interface index */
   union
   {
     struct sockaddr            ifru_addr;           /* IP Address */
@@ -303,6 +306,7 @@ struct ifreq
     struct sockaddr            ifru_netmask;        /* Netmask */
     struct sockaddr            ifru_hwaddr;         /* MAC address */
     int                        ifru_count;          /* Number of devices */
+    int                        ifru_ivalue;         /* Value for ifindex/metric/bandwidth and so on */
     int                        ifru_mtu;            /* MTU size */
     uint32_t                   ifru_flags;          /* Interface flags */
     struct mii_ioctl_notify_s  ifru_mii_notify;     /* PHY event notification */
@@ -319,6 +323,10 @@ struct ifreq
 #define ifr_broadaddr         ifr_ifru.ifru_broadaddr        /* Broadcast address */
 #define ifr_netmask           ifr_ifru.ifru_netmask          /* Interface net mask */
 #define ifr_hwaddr            ifr_ifru.ifru_hwaddr           /* MAC address */
+#define ifr_ifindex           ifr_ifru.ifru_ivalue           /* Interface index */
+#define ifr_metric            ifr_ifru.ifru_ivalue           /* metric */
+#define ifr_bandwidth         ifr_ifru.ifru_ivalue           /* link bandwidth */
+#define ifr_qlen              ifr_ifru.ifru_ivalue           /* Queue length */
 #define ifr_mtu               ifr_ifru.ifru_mtu              /* MTU */
 #define ifr_count             ifr_ifru.ifru_count            /* Number of devices */
 #define ifr_flags             ifr_ifru.ifru_flags            /* interface flags */


### PR DESCRIPTION
## Summary

There is a compile warning information: 
`ctc W597: ["/home/mi/code/dev-system/nuttx/libs/libc/net/lib_getifaddrs.c" 215/21] alignment of automatic object limited to 4`

In order to fix compilation issue, the struct ifreq structure is modified.

## Impact

There is no impact for user. 

## Testing

`
#include <stdio.h>
#include <string.h>
#include <sys/ioctl.h>
#include <net/if.h>
#include <unistd.h>
#include <errno.h>
#include <fcntl.h>

int main(void)
{
  int sockfd;
  struct ifreq ifr;
  unsigned int idx;
  char name[IFNAMSIZ] = "eth0";
  char namebuf[IFNAMSIZ];

  sockfd = socket(AF_INET, SOCK_DGRAM, 0);
  if (sockfd < 0) {
      perror("socket");
      return 1;
  }

  memset(&ifr, 0, sizeof(ifr));
  strncpy(ifr.ifr_name, name, IFNAMSIZ-1);

  if (ioctl(sockfd, SIOCGIFINDEX, &ifr) < 0) {
      perror("ioctl SIOCGIFINDEX");
      close(sockfd);
      return 1;
  }
  idx = ifr.ifr_ifindex;
  printf("Interface %s has index %u\n", name, idx);

  if (if_indextoname(idx, namebuf) == NULL) {
      perror("if_indextoname");
      close(sockfd);
      return 1;
  }
  printf("Index %u corresponds to interface %s\n", idx, namebuf);

  if (strncmp(name, namebuf, IFNAMSIZ) == 0) {
      printf("Test PASSED: ifr_ifindex works as expected.\n");
  } else {
      printf("Test FAILED: name mismatch.\n");
  }

  close(sockfd);
  return 0;
}
`

Result of test:
`
nsh> hello
Interface eth0 has index 1
Index 1 corresponds to interface eth0
Test PASSED: ifr_ifindex works as expected.
`
