### PR TITLE
net/devif: fix poll issue when ifdown

### DIFF
--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -286,7 +286,7 @@ FAR struct devif_callback_s *
    * to de-allocate connection callbacks reliably on NETDEV_DOWN event.
    */
 
-  if (dev && !(netdev_verify(dev) && (dev->d_flags & IFF_UP) != 0))
+  if (dev && !netdev_verify(dev))
     {
       net_unlock();
       return NULL;


### PR DESCRIPTION
## Summary

When the interface bound to the socket is in the down state, polling the socket will return an error message, which in some cases will cause a busy loop.
The function call stack is roughly as follows: poll->pkt_pollsetup->pkt_callback_alloc->devif_callback_alloc. Then return NULL if interface is down.
To fix this problem, we modified the error judgment condition in devif_callback_alloc.

## Impact

No impact on functions

## Testing

Set up a sim environment, start the sim and ifdown eth0, then start the poll program, and repeat that the poll is always in the busy loop. After the current patch is marked, the problem is fixed.

`
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/socket.h>
#include <sys/types.h>
#include <sys/poll.h>
#include <netpacket/packet.h>
#include <net/if.h>
#include <errno.h>
#include <arpa/inet.h>

#define TEST_DATA "Hello, PKT poll!"
#define PKT_IFNAME "eth0" // 使用eth0接口

#ifndef ETH_P_ALL
#define ETH_P_ALL 0x0003
#endif

int main(void)
{
    int sockfd;
    struct sockaddr_ll addr;
    struct pollfd pfd;
    char buf[128];
    int ret;

    sockfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
    if (sockfd < 0) {
        perror("socket");
        return 1;
    }

    memset(&addr, 0, sizeof(addr));
    addr.sll_family = AF_PACKET;
    addr.sll_protocol = htons(ETH_P_ALL);
    addr.sll_ifindex = if_nametoindex(PKT_IFNAME);
    if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
        perror("bind");
        close(sockfd);
        return 1;
    }


    pfd.fd = sockfd;
    pfd.events = POLLIN;

    printf("Waiting for data with poll...\n");

    while (1)
    {
      ret = poll(&pfd, 1, 3000); 
      if (ret < 0) {
          perror("poll");
          close(sockfd);
          return 1;
      } else if (ret == 0) {
          printf("poll timeout, no data received\n");
          close(sockfd);
          return 1;
      }

      if (pfd.revents & POLLIN) {
          ret = recv(sockfd, buf, sizeof(buf) - 1, 0);
          if (ret < 0) {
              perror("recv");
          } else {
              buf[ret] = '\0';
              printf("Received data: %s\n", buf);
          }
      } else {
          printf("Unexpected poll revents: 0x%x\n", pfd.revents);
      }
    }
    

    close(sockfd);
    return 0;
}
`