### PR TITLE
net/arp: dont learn arp information if interface is noarp

### DIFF
--- a/net/arp/arp_ipin.c
+++ b/net/arp/arp_ipin.c
@@ -83,8 +83,9 @@ void arp_ipin(FAR struct net_driver_s *dev)
    * Ethernet link layer protocol.
    */
 
-  if (dev->d_lltype != NET_LL_ETHERNET &&
-      dev->d_lltype != NET_LL_IEEE80211)
+  if (IFF_IS_NOARP(dev->d_flags) ||
+      (dev->d_lltype != NET_LL_ETHERNET &&
+       dev->d_lltype != NET_LL_IEEE80211))
     {
       return;
     }


### PR DESCRIPTION

## Summary

When the interface turns off the arp learning capability, it should not learn arp from the IP message even if the ARP_IPIN function is enabled.

## Impact

The ARP_IPIN function is invalid for the interface that turns off the arp learning ability.

## Testing

1. Enable the CONFIG_ARP_IPIN compilation option and set up the SIM test environment; 
2. Set the interface NOARP attribute in SIM; 
3. Construct an icmp request message on the host side and send it to the SIM. It is observed that there is no response from the SIM side; 
4. The SIM end enables the interface ARP learning capability and sends the icmp request message from the host again. The host end can receive the icmp reply message.

`
from scapy.all import Ether, IP, ICMP, sendp

SRC_MAC = "fa:b1:d9:6d:a0:d3"
DST_MAC = "42:e1:c4:3f:48:dd"
SRC_IP = "10.0.1.1"
DST_IP = "10.0.1.2"
IFACE = "eth0"

packet = (
    Ether(src=SRC_MAC, dst=DST_MAC) /
    IP(src=SRC_IP, dst=DST_IP) /
    ICMP(type=8, code=0)
)

print("Constructed ICMP Request Packet:")
packet.show()

sendp(packet, iface=IFACE, verbose=1)
print(f"\nICMP request sent from {SRC_IP}({SRC_MAC}) to {DST_IP}({DST_MAC})")
`
