### PR TITLE
Documentation: Modify ``do while`` Statement typo

### DIFF
--- a/Documentation/contributing/coding_style.rst
+++ b/Documentation/contributing/coding_style.rst
@@ -2238,7 +2238,7 @@ braces <#braces>`__, `indentation <#indentation>`__, and
 
     do ptr++; while (*ptr != '\0');
 
-.. error:: This is incorrect
+.. tip:: This is correct
 
   .. code-block:: c
 


### PR DESCRIPTION
## Summary
The following should be correct sample:
do
  {
    ready = !notready();
  }
while (!ready);

senddata();

do
  {
    ptr++;
  }
while (*ptr != '\0');

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*


## Impact

None

## Testing

None
