### PR TITLE
mm/iob: update all iob information in the iob_update_pktlen

### DIFF
--- a/mm/iob/iob_update_pktlen.c
+++ b/mm/iob/iob_update_pktlen.c
@@ -138,7 +138,7 @@ int iob_update_pktlen(FAR struct iob_s *iob, unsigned int pktlen,
   /* Update size of each iob */
 
   next = iob;
-  while (next != NULL && pktlen > 0)
+  while (next != NULL && pktlen >= 0)
     {
       if (pktlen + next->io_offset > IOB_BUFSIZE(next))
         {


### PR DESCRIPTION

## Summary

Update io_len to 0 when pktlen is 0. otherwise, io_pktlen and io_len will be inconsistent, cause free check failure.

## Impact

No impact on customer use.

## Testing

`
#include <stdio.h>
#include <nuttx/mm/iob.h>
#include <assert.h>

#define PKTLEN_SMALL  32
#define PKTLEN_LARGE  (CONFIG_IOB_BUFSIZE * 3 + 10)

int main(void)
{
    struct iob_s *iob;
    int ret;
    int count;
    struct iob_s *next;

    // Allocate initial IOB chain for small packet
    iob = iob_alloc(false);
    assert(iob);

    ret = iob_update_pktlen(iob, PKTLEN_SMALL, false);
    printf("Set pktlen to %d, result: %d\n", PKTLEN_SMALL, ret);

    // Count buffers in chain
    count = 0;
    next = iob;
    while (next) {
        count++;
        next = next->io_flink;
    }
    printf("Buffer count after small pktlen: %d\n", count);
    assert(count == 1);

    // Grow packet length to require more buffers
    ret = iob_update_pktlen(iob, PKTLEN_LARGE, false);
    printf("Set pktlen to %d, result: %d\n", PKTLEN_LARGE, ret);

    count = 0;
    next = iob;
    while (next) {
        count++;
        next = next->io_flink;
    }
    printf("Buffer count after large pktlen: %d\n", count);
    assert(count >= 3);

    // Shrink packet length back to small
    ret = iob_update_pktlen(iob, 0, false);
    printf("Set pktlen to %d, result: %d\n", PKTLEN_SMALL, ret);

    count = 0;
    next = iob;
    while (next) {
        count++;
        next = next->io_flink;
    }
    printf("Buffer count after shrink: %d\n", count);
    assert(count == 1);

    iob_free_chain(iob);
    printf("Test PASSED: iob_update_pktlen correctly grows and trims chain\n");
    return 0;
}
`
