### PR TITLE
net/ioctl: add a socket interface for ioctl

### DIFF
--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -158,10 +158,10 @@ static int bluetooth_setup(FAR struct socket *psock)
    * connection structure, it is unallocated at this point.  It will not
    * actually be initialized until the socket is connected.
    *
-   * SOCK_RAW and SOCK_CTRL are supported
+   * SOCK_RAW is supported
    */
 
-  if (psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_RAW)
     {
       return bluetooth_sockif_alloc(psock);
     }
@@ -210,7 +210,7 @@ static void bluetooth_addref(FAR struct socket *psock)
 {
   FAR struct bluetooth_conn_s *conn;
 
-  DEBUGASSERT(psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL);
+  DEBUGASSERT(psock->s_type == SOCK_RAW);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->bc_crefs > 0 && conn->bc_crefs < 255);
@@ -382,11 +382,10 @@ static int bluetooth_l2cap_bind(FAR struct socket *psock,
 
   /* Bind a PF_BLUETOOTH socket to an network device.
    *
-   * SOCK_RAW and SOCK_CTRL are supported
+   * SOCK_RAW is supported
    */
 
-  if (psock == NULL || psock->s_conn == NULL ||
-      (psock->s_type != SOCK_RAW && psock->s_type != SOCK_CTRL))
+  if (psock == NULL || psock->s_conn == NULL || psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -455,11 +454,10 @@ static int bluetooth_hci_bind(FAR struct socket *psock,
 
   /* Bind a PF_BLUETOOTH socket to an network device.
    *
-   * SOCK_RAW and SOCK_CTRL are supported
+   * SOCK_RAW is supported
    */
 
-  if (psock == NULL || psock->s_conn == NULL ||
-      (psock->s_type != SOCK_RAW && psock->s_type != SOCK_CTRL))
+  if (psock == NULL || psock->s_conn == NULL || psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -627,10 +625,9 @@ static int bluetooth_close(FAR struct socket *psock)
 
   switch (psock->s_type)
     {
-      /* SOCK_RAW and SOCK_CTRL are supported */
+      /* SOCK_RAW is supported */
 
       case SOCK_RAW:
-      case SOCK_CTRL:
         {
           FAR struct bluetooth_conn_s *conn = psock->s_conn;
 

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -200,8 +200,7 @@ static int can_setup(FAR struct socket *psock)
 
   /* Verify the socket type (domain should always be PF_CAN here) */
 
-  if (domain == PF_CAN &&
-      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
+  if (domain == PF_CAN && (type == SOCK_RAW || type == SOCK_DGRAM))
     {
       /* Allocate the CAN socket connection structure and save it in the
        * new socket instance.

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -115,10 +115,10 @@ const struct sock_intf_s g_icmp_sockif =
 
 static int icmp_setup(FAR struct socket *psock)
 {
-  /* SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP are supported */
+  /* SOCK_DGRAM and IPPROTO_ICMP are supported */
 
-  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL ||
-      psock->s_type == SOCK_RAW) && psock->s_proto == IPPROTO_ICMP)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW) &&
+       psock->s_proto == IPPROTO_ICMP)
     {
       /* Allocate the IPPROTO_ICMP socket connection structure and save in
        * the new socket instance.

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -114,10 +114,10 @@ const struct sock_intf_s g_icmpv6_sockif =
 
 static int icmpv6_setup(FAR struct socket *psock)
 {
-  /* SOCK_DGRAM or SOCK_CTRL and IPPROTO_ICMP6 are supported */
+  /* SOCK_DGRAM and IPPROTO_ICMP6 are supported */
 
-  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL ||
-      psock->s_type == SOCK_RAW) && psock->s_proto == IPPROTO_ICMP6)
+  if ((psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW) &&
+       psock->s_proto == IPPROTO_ICMP6)
     {
       /* Allocate the IPPROTO_ICMP6 socket connection structure and save in
        * the new socket instance.

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -148,11 +148,11 @@ static int ieee802154_setup(FAR struct socket *psock)
    * connection structure, it is unallocated at this point.  It will not
    * actually be initialized until the socket is connected.
    *
-   * SOCK_DGRAM and SOCK_CTRL are supported
+   * SOCK_DGRAM is supported
    * (since the MAC header is stripped)
    */
 
-  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_DGRAM)
     {
       return ieee802154_sockif_alloc(psock);
     }
@@ -201,7 +201,7 @@ static void ieee802154_addref(FAR struct socket *psock)
 {
   FAR struct ieee802154_conn_s *conn;
 
-  DEBUGASSERT(psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_CTRL);
+  DEBUGASSERT(psock->s_type == SOCK_DGRAM);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -316,8 +316,7 @@ static int ieee802154_bind(FAR struct socket *psock,
 
   /* Bind a PF_IEEE802154 socket to an network device. */
 
-  if (conn == NULL ||
-      (psock->s_type != SOCK_DGRAM && psock->s_type != SOCK_CTRL))
+  if (conn == NULL || psock->s_type != SOCK_DGRAM)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -502,7 +501,6 @@ static int ieee802154_close(FAR struct socket *psock)
   switch (psock->s_type)
     {
       case SOCK_DGRAM:
-      case SOCK_CTRL:
         {
           FAR struct ieee802154_conn_s *conn = psock->s_conn;
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -298,30 +298,6 @@ static int inet_setup(FAR struct socket *psock)
 #endif
 #endif /* CONFIG_NET_UDP */
 
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-      case SOCK_CTRL:
-#  ifdef NET_TCP_HAVE_STACK
-        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)
-          {
-             /* Allocate and attach the TCP connection structure */
-
-             return inet_tcp_alloc(psock);
-          }
-
-#  endif
-#  ifdef NET_UDP_HAVE_STACK
-        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)
-          {
-             /* Allocate and attach the UDP connection structure */
-
-             return inet_udp_alloc(psock);
-          }
-
-#  endif
-        nerr("ERROR: Unsupported control protocol: %d\n", psock->s_proto);
-        return -EPROTONOSUPPORT;
-#endif /* CONFIG_NET_TCP || CONFIG_NET_UDP */
-
       default:
         nerr("ERROR: Unsupported type: %d\n", psock->s_type);
         return -EPROTONOSUPPORT;
@@ -357,11 +333,6 @@ static sockcaps_t inet_sockcaps(FAR struct socket *psock)
         return SOCKCAP_NONBLOCKING;
 #endif
 
-#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
-      case SOCK_CTRL:
-        return SOCKCAP_NONBLOCKING;
-#endif
-
       default:
         return 0;
     }
@@ -387,9 +358,7 @@ static void inet_addref(FAR struct socket *psock)
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
 
 #ifdef NET_TCP_HAVE_STACK
-  if (psock->s_type == SOCK_STREAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
+  if (psock->s_type == SOCK_STREAM)
     {
       FAR struct tcp_conn_s *conn = psock->s_conn;
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -398,9 +367,7 @@ static void inet_addref(FAR struct socket *psock)
   else
 #endif
 #ifdef NET_UDP_HAVE_STACK
-  if (psock->s_type == SOCK_DGRAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
+  if (psock->s_type == SOCK_DGRAM)
     {
       FAR struct udp_conn_s *conn = psock->s_conn;
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -502,15 +469,6 @@ static int inet_bind(FAR struct socket *psock,
         }
         break;
 #endif /* CONFIG_NET_UDP */
-
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-      case SOCK_CTRL:
-        {
-          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-          ret = -EOPNOTSUPP;
-        }
-        break;
-#endif
 
       default:
         nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
@@ -1414,14 +1372,6 @@ static int inet_connect(FAR struct socket *psock,
         }
 #endif /* CONFIG_NET_UDP */
 
-#if defined(CONFIG_NET_TCP) && defined(CONFIG_NET_UDP)
-      case SOCK_CTRL:
-        {
-          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-          return -EOPNOTSUPP;
-        }
-#endif
-
       default:
         return -EBADF;
     }
@@ -1612,14 +1562,6 @@ static inline int inet_pollsetup(FAR struct socket *psock,
     }
   else
 #endif /* NET_UDP_HAVE_STACK */
-#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
-  if (psock->s_type == SOCK_CTRL)
-    {
-      nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-      return -EOPNOTSUPP;
-    }
-  else
-#endif
     {
       return -ENOSYS;
     }
@@ -1660,14 +1602,6 @@ static inline int inet_pollteardown(FAR struct socket *psock,
     }
   else
 #endif /* NET_UDP_HAVE_STACK */
-#if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
-  if (psock->s_type == SOCK_CTRL)
-    {
-      nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-      return -EOPNOTSUPP;
-    }
-  else
-#endif
     {
       return -ENOSYS;
     }
@@ -1803,15 +1737,6 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
         }
         break;
 #endif /* CONFIG_NET_UDP */
-
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-      case SOCK_CTRL:
-        {
-          nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-          ret = -EOPNOTSUPP;
-        }
-        break;
-#endif
 
       default:
         {
@@ -2011,18 +1936,14 @@ static int inet_ioctl(FAR struct socket *psock, int cmd, unsigned long arg)
     }
 
 #ifdef NET_TCP_HAVE_STACK
-  if (psock->s_type == SOCK_STREAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
+  if (psock->s_type == SOCK_STREAM)
     {
       return tcp_ioctl(psock->s_conn, cmd, arg);
     }
 #endif
 
 #if defined(CONFIG_NET_UDP) && defined(NET_UDP_HAVE_STACK)
-  if (psock->s_type == SOCK_DGRAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
+  if (psock->s_type == SOCK_DGRAM)
     {
       return udp_ioctl(psock->s_conn, cmd, arg);
     }
@@ -2342,15 +2263,6 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
       break;
 #endif /* CONFIG_NET_UDP */
 
-#if defined(CONFIG_NET_TCP) || defined(CONFIG_NET_UDP)
-    case SOCK_CTRL:
-      {
-        nerr("ERROR:  Inappropriate socket type: %d\n", psock->s_type);
-        ret = -EOPNOTSUPP;
-      }
-      break;
-#endif
-
     default:
       {
         nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
@@ -2391,9 +2303,7 @@ int inet_close(FAR struct socket *psock)
    */
 
 #ifdef CONFIG_NET_TCP
-  if (psock->s_type == SOCK_STREAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP)))
+  if (psock->s_type == SOCK_STREAM)
     {
 #ifdef NET_TCP_HAVE_STACK
       FAR struct tcp_conn_s *conn = psock->s_conn;
@@ -2433,9 +2343,7 @@ int inet_close(FAR struct socket *psock)
   else
 #endif /* CONFIG_NET_TCP */
 #ifdef CONFIG_NET_UDP
-  if (psock->s_type == SOCK_DGRAM ||
-      (psock->s_type == SOCK_CTRL &&
-      (psock->s_proto == 0 || psock->s_proto == IPPROTO_UDP)))
+  if (psock->s_type == SOCK_DGRAM)
     {
 #ifdef NET_UDP_HAVE_STACK
       FAR struct udp_conn_s *conn = psock->s_conn;
@@ -2506,8 +2414,8 @@ inet_sockif(sa_family_t family, int type, int protocol)
 #if defined(HAVE_PFINET_SOCKETS) && defined(CONFIG_NET_ICMP_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_CTRL ||
-      type == SOCK_RAW) && protocol == IPPROTO_ICMP)
+  if (family == PF_INET && (type == SOCK_DGRAM || type == SOCK_RAW) &&
+      protocol == IPPROTO_ICMP)
     {
       return &g_icmp_sockif;
     }
@@ -2516,8 +2424,8 @@ inet_sockif(sa_family_t family, int type, int protocol)
 #if defined(HAVE_PFINET6_SOCKETS) && defined(CONFIG_NET_ICMPv6_SOCKET)
   /* PF_INET, ICMP data gram sockets are a special case of raw sockets */
 
-  if (family == PF_INET6 && (type == SOCK_DGRAM || type == SOCK_CTRL ||
-      type == SOCK_RAW) && protocol == IPPROTO_ICMPV6)
+  if (family == PF_INET6 && (type == SOCK_DGRAM || type == SOCK_RAW)
+      && protocol == IPPROTO_ICMPV6)
     {
       return &g_icmpv6_sockif;
     }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -203,17 +203,6 @@ static int local_setup(FAR struct socket *psock)
         return local_sockif_alloc(psock);
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
-      case SOCK_CTRL:
-        if (psock->s_proto == 0 || psock->s_proto == IPPROTO_TCP ||
-            psock->s_proto == IPPROTO_UDP)
-          {
-            /* Allocate and attach the local connection structure */
-
-            return local_sockif_alloc(psock);
-          }
-
-        return -EPROTONOSUPPORT;
-
       default:
         return -EPROTONOSUPPORT;
     }
@@ -306,7 +295,6 @@ static int local_bind(FAR struct socket *psock,
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
 #endif
-      case SOCK_CTRL:
         {
           /* Bind the Unix domain connection structure */
 
@@ -839,12 +827,6 @@ static int local_connect(FAR struct socket *psock,
         break;
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 
-      case SOCK_CTRL:
-        {
-          return -ENOSYS;
-        }
-        break;
-
       default:
         return -EBADF;
     }
@@ -915,7 +897,6 @@ static int local_close(FAR struct socket *psock)
 #ifdef CONFIG_NET_LOCAL_DGRAM
       case SOCK_DGRAM:
 #endif
-      case SOCK_CTRL:
         {
           /* Is this the last reference to the connection structure (there
            * could be more if the socket was dup'ed).
@@ -1176,8 +1157,6 @@ static int local_shutdown(FAR struct socket *psock, int how)
       case SOCK_DGRAM:
         return -EOPNOTSUPP;
 #endif
-      case SOCK_CTRL:
-        return -EOPNOTSUPP;
       default:
         return -EBADF;
     }

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -143,8 +143,7 @@ static int netlink_setup(FAR struct socket *psock)
 
   /* Verify the socket type (domain should always be PF_NETLINK here) */
 
-  if (domain == PF_NETLINK &&
-      (type == SOCK_RAW || type == SOCK_DGRAM || type == SOCK_CTRL))
+  if (domain == PF_NETLINK && (type == SOCK_RAW || type == SOCK_DGRAM))
     {
       /* Allocate the NetLink socket connection structure and save it in the
        * new socket instance.

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -162,11 +162,10 @@ static int pkt_setup(FAR struct socket *psock)
    * connection structure, it is unallocated at this point.  It will not
    * actually be initialized until the socket is connected.
    *
-   * SOCK_RAW and SOCK_CTRL are supported.
+   * SOCK_RAW is supported.
    */
 
-  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW ||
-      psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW)
     {
       return pkt_sockif_alloc(psock);
     }
@@ -215,7 +214,7 @@ static void pkt_addref(FAR struct socket *psock)
 {
   FAR struct pkt_conn_s *conn;
 
-  DEBUGASSERT(psock->s_type == SOCK_RAW || psock->s_type == SOCK_CTRL);
+  DEBUGASSERT(psock->s_type == SOCK_RAW);
 
   conn = psock->s_conn;
   DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
@@ -256,8 +255,7 @@ static int pkt_bind(FAR struct socket *psock,
 
   /* Bind a raw socket to a network device. */
 
-  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW ||
-      psock->s_type == SOCK_CTRL)
+  if (psock->s_type == SOCK_DGRAM || psock->s_type == SOCK_RAW)
     {
       FAR struct pkt_conn_s *conn = psock->s_conn;
       FAR struct net_driver_s *dev;
@@ -351,7 +349,6 @@ static int pkt_close(FAR struct socket *psock)
     {
       case SOCK_DGRAM:
       case SOCK_RAW:
-      case SOCK_CTRL:
         {
           FAR struct pkt_conn_s *conn = psock->s_conn;
 

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -44,6 +44,72 @@
 #include "socket/socket.h"
 
 /****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int ctrl_setup(FAR struct socket *psock);
+static int ctrl_close(FAR struct socket *psock);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct sock_intf_s g_ctrl_sockif =
+{
+  ctrl_setup,       /* si_setup */
+  NULL,             /* si_sockcaps */
+  NULL,             /* si_addref */
+  NULL,             /* si_bind */
+  NULL,             /* si_getsockname */
+  NULL,             /* si_getpeername */
+  NULL,             /* si_listen */
+  NULL,             /* si_connect */
+  NULL,             /* si_accept */
+  NULL,             /* si_poll */
+  NULL,             /* si_sendmsg */
+  NULL,             /* si_recvmsg */
+  ctrl_close        /* si_close */
+};
+
+static struct socket_conn_s g_ctrl_conn;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ctrl_setup
+ *
+ * Description:
+ *   Called for socket() to verify that the provided socket type and
+ *   protocol are usable by this address family.  Perform any family-
+ *   specific socket fields.
+ *
+ *   NOTE:  This is common logic for SOCK_CTRL
+ *
+ * Input Parameters:
+ *   psock    A pointer to a user allocated socket structure to be
+ *            initialized.
+ *   protocol (see sys/socket.h)
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value is
+ *   returned.
+ *
+ ****************************************************************************/
+
+static int ctrl_setup(FAR struct socket *psock)
+{
+  psock->s_conn = &g_ctrl_conn;
+  return 0;
+}
+
+static int ctrl_close(FAR struct socket *psock)
+{
+  return 0;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -74,6 +140,11 @@ net_sockif(sa_family_t family, int type, int protocol)
    * REVISIT:  Should also support PF_UNSPEC which would permit the socket
    * to be used for anything.
    */
+
+  if ((type & SOCK_TYPE_MASK) == SOCK_CTRL)
+    {
+      return &g_ctrl_sockif;
+    }
 
   switch (family)
     {


### PR DESCRIPTION

## Summary

In some scenarios, we only want to configure device related properties through ioctl, and do not want to rely on other protocols, so we abstract a g_ctrl_sockif.

## Impact

When users want to set dev related ioctl, they do not need to rely on other protocols.

## Testing

`
#include <stdio.h>
#include <sys/socket.h>
#include <sys/ioctl.h>
#include <errno.h>
#include <assert.h>
#include <unistd.h>

int main(void)
{
    int sockfd;
    int ret;
    int dummy = 0;

    // Create a control socket
    sockfd = socket(AF_UNSPEC, SOCK_CTRL, 0);
    if (sockfd < 0)
    {
        perror("socket(SOCK_CTRL)");
        printf("Test FAILED: Could not create control socket\n");
        return 1;
    }
    printf("Control socket created: fd=%d\n", sockfd);

    // Try an ioctl operation (should fail with ENOTTY or ENOSYS if not implemented)
    ret = ioctl(sockfd, 0x1234, &dummy);
    if (ret < 0)
    {
        printf("ioctl returned error as expected: %d (%s)\n", errno, strerror(errno));
        // Acceptable: ENOTTY, ENOSYS, or other not supported
    }
    else
    {
        printf("ioctl returned success (unexpected for unimplemented command)\n");
    }

    // Close the control socket
    if (close(sockfd) < 0)
    {
        perror("close");
        printf("Test FAILED: Could not close control socket\n");
        return 1;
    }

    printf("Test PASSED: g_ctrl_sockif setup/close and ioctl behavior checked\n");
    return 0;
}
`
