### PR TITLE
net/tcp: remove SYN_RCVD state conn by listener created when free listener

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -713,6 +713,17 @@ int tcp_connect(FAR struct tcp_conn_s *conn,
 void tcp_removeconn(FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
+ * Name: tcp_remove_syn_backlog
+ *
+ * Description:
+ *   This function is used to remove the currently SYN_RCVD connection
+ *   created by the listener
+ *
+ ****************************************************************************/
+
+void tcp_remove_syn_backlog(FAR struct tcp_conn_s *listener);
+
+/****************************************************************************
  * Name: tcp_conn_list_lock
  *
  * Description:

--- a/net/tcp/tcp_listen.c
+++ b/net/tcp/tcp_listen.c
@@ -145,6 +145,7 @@ int tcp_unlisten(FAR struct tcp_conn_s *conn)
       if (tcp_listenports[ndx] == conn)
         {
           tcp_listenports[ndx] = NULL;
+          tcp_remove_syn_backlog(conn);
           ret = OK;
           break;
         }


### PR DESCRIPTION
## Summary
after the listener fd is closed, the half-open connections associated
with the listener are not reclaimed. According to the protocol standard,
they should be reclaimed in a timely manner.

## Impact
tcp::listen

## Testing
sim:matter with test code
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <arpa/inet.h>
#include <signal.h>
#include <poll.h>

#define SERVER_IP "10.0.1.2"
#define PORT 7777
#define BUFFER_SIZE 1024

int main(int argc, char *argv[]) {
    int sockfd;
    struct sockaddr_in server_addr;

    if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
        perror("socket creation failed");
        exit(EXIT_FAILURE);
    }

    memset(&server_addr, 0, sizeof(server_addr));
    server_addr.sin_family = AF_INET;
    server_addr.sin_port = htons(PORT);
    if (inet_pton(AF_INET, SERVER_IP, &server_addr.sin_addr) <= 0) {
        perror("invalid address");
        close(sockfd);
        exit(EXIT_FAILURE);
    }

    bind(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
    listen(sockfd, 5);
    sleep(10);
    close(sockfd);

    return 0;
}
```
test log without this patch
```
NuttShell (NSH) NuttX-12.12.0-RC0
MOTD: username=admin password=Administrator
nsh> cat /proc/net/tcp
nsh> hello
nsh> 
nsh> cat /proc/net/tcp
TCP sl  st flg ref tmr uack nrt   txsz   rxsz local_address           remote_address         
     1: 02   0   1   3    1   0      0      0         10.0.1.2:7777           10.0.1.1:60678 
nsh>
```
test log with this patch
```
NuttShell (NSH) NuttX-12.12.0-RC0
MOTD: username=admin password=Administrator
nsh> hello
nsh> 
nsh> cat /proc/net/tcp
nsh> 
```

