### PR TITLE
net/tcp: fix tcp conn lock leak when port in use in tcp_selectport

### DIFF
--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -569,6 +569,7 @@ int tcp_selectport(uint8_t domain,
             {
               /* We have looped back, failed. */
 
+              tcp_conn_list_unlock();
               return -EADDRINUSE;
             }
         }
@@ -592,6 +593,7 @@ int tcp_selectport(uint8_t domain,
         {
           /* It is in use... return EADDRINUSE */
 
+          tcp_conn_list_unlock();
           return -EADDRINUSE;
         }
     }


### PR DESCRIPTION


## Summary

fix tcp conn lock leak when port in use in tcp_selectport
## Impact

tcp

## Testing
step1: start iperf server listen 5000
step2: start iperf server listen 5000 again to trigger address in use error
step3: start iperf client, not block in tcp_selectport
```
NuttShell (NSH) NuttX-12.12.0-RC0
MOTD: username=admin password=Administrator
nsh> iperf -s -p 5000 &
iperf [4:100]
nsh>      IP: 10.0.1.2

 mode=tcp-server sip=10.0.1.2:5000,dip=0.0.0.0:5001, interval=3, time=0

nsh> iperf -s -p 5000
     IP: 10.0.1.2

 mode=tcp-server sip=10.0.1.2:5000,dip=0.0.0.0:5001, interval=3, time=0
tcp server bind error, error code: 98, reason: Unknown error 98
iperf exit
nsh>
nsh>
nsh>
nsh> iperf -c 10.0.1.1 -p 5001
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-  20.53 sec 1171980288 Bytes  456.69 Mbits/sec
  20.53-  26.75 sec  382631936 Bytes  492.13 Mbits/sec
  26.75-  54.05 sec 1673445376 Bytes  490.39 Mbits/sec
   0.00-  54.05 sec 4499996672 Bytes  666.05 Mbits/sec
iperf exit

```