### PR TITLE
net/tcp: fix conn->work use after free in worker queue list

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -647,6 +647,7 @@ static inline int devif_poll_tcp_connections(FAR struct net_driver_s *dev,
 
   /* Traverse all of the active TCP connections and perform the poll action */
 
+  tcp_conn_list_lock();
   while (!bstop && (conn = tcp_nextconn(conn)))
     {
       /* Skip TCP connections that are bound to other polling devices */
@@ -667,6 +668,7 @@ static inline int devif_poll_tcp_connections(FAR struct net_driver_s *dev,
         }
     }
 
+  tcp_conn_list_unlock();
   return bstop;
 }
 #else

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -818,10 +818,6 @@ void tcp_free(FAR struct tcp_conn_s *conn)
       return;
     }
 
-  /* Cancel tcp timer */
-
-  tcp_stop_timer(conn);
-
   /* Make sure monitor is stopped. */
 
   conn_dev_lock(&conn->sconn, conn->dev);
@@ -851,6 +847,10 @@ void tcp_free(FAR struct tcp_conn_s *conn)
       dq_rem(&conn->sconn.node, &g_active_tcp_connections);
       tcp_conn_list_unlock();
     }
+
+  /* Cancel tcp timer */
+
+  tcp_stop_timer(conn);
 
   nxrmutex_destroy(&conn->sconn.s_lock);
   tcp_free_rx_buffers(conn);


### PR DESCRIPTION

## Summary

in multi-core cpu, tcp_free and tcp_timer_expiry->tcp_timer will work in parallel, after tcp_free call work_cancle, tcp->timer will call tcp_update_timer to re-add work to worker queue, then tcp_free free conn, in this condition, it will result use after free.

## Impact

tcp

## Testing
Check the normal TCP process ok
```
NuttShell (NSH) NuttX-12.12.0-RC0
MOTD: username=admin password=Administrator
nsh> iperf -c 10.0.1.1 -i 1 -t 3
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=1, time=3

           Interval         Transfer         Bandwidth

   0.00-   6.28 sec  359628800 Bytes  458.13 Mbits/sec
   0.00-   6.28 sec 4307517440 Bytes 5487.28 Mbits/sec
iperf exit
nsh>

```
