### PR TITLE
net/ipv6: Drop IP packet shorter than length in IP header

### DIFF
--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -224,6 +224,8 @@ static int ipv6_in(FAR struct net_driver_s *dev)
 
   /* Get the size of the packet minus the size of link layer header */
 
+  dev->d_len -= NET_LL_HDRLEN(dev);
+
   if (IPv6_HDRLEN > dev->d_len)
     {
       nwarn("WARNING: Packet shorter than IPv6 header\n");


### PR DESCRIPTION


## Summary

If the length of received ip packet is shorter than length in ip header, drop it.

## Impact
ipv6

## Testing
```
#!/usr/bin/env python3
from scapy.all import *
import time
import sys

def send_custom_icmpv6_echo(dst_ip, iface=None):
    """
    发送自定义的ICMPv6 Echo Request报文
    """

    if not iface:
        iface = conf.iface

    packet = Ether() / \
             IPv6(
                 src="fe80::501c:16ff:fe3d:b4c8",
                 dst=dst_ip,
                 plen=100,
                 hlim=64  # Hop Limit
             ) / \
             ICMPv6EchoRequest(
                 id=0x1234,
                 seq=0x1,
                 data=b"Custom ICMPv6 Echo Request" + b"\x00" * 20
             )

    try:
        sendp(packet, iface=iface, verbose=True)

    except PermissionError:
        sys.exit(1)

if __name__ == "__main__":
    send_custom_icmpv6_echo("fe80::40e1:c4ff:fe3f:48dd", "nuttx0")

```
test result:
```
mi@mi-ThinkCentre-M760t:~$ sudo tcpdump -i nuttx0 -nn
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on nuttx0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
19:22:40.112912 IP6 fe80::501c:16ff:fe3d:b4c8 > fe80::40e1:c4ff:fe3f:48dd: ICMP6, echo request, id 4660, seq 1, length 54
19:22:40.120683 IP6 fe80::40e1:c4ff:fe3f:48dd > ff02::1:ff3d:b4c8: ICMP6, neighbor solicitation, who has fe80::501c:16ff:fe3d:b4c8, length 32
19:22:40.120750 IP6 fe80::501c:16ff:fe3d:b4c8 > fe80::40e1:c4ff:fe3f:48dd: ICMP6, neighbor advertisement, tgt is fe80::501c:16ff:fe3d:b4c8, length 32
19:22:40.122106 IP6 fe80::40e1:c4ff:fe3f:48dd > fe80::501c:16ff:fe3d:b4c8: ICMP6, echo reply, id 4660, seq 1, length 54
19:22:45.123449 IP6 fe80::501c:16ff:fe3d:b4c8 > fe80::40e1:c4ff:fe3f:48dd: ICMP6, neighbor solicitation, who has fe80::40e1:c4ff:fe3f:48dd, length 32
19:22:45.132076 IP6 fe80::40e1:c4ff:fe3f:48dd > fe80::501c:16ff:fe3d:b4c8: ICMP6, neighbor advertisement, tgt is fe80::40e1:c4ff:fe3f:48dd, length 32
19:23:48.462063 IP6 fe80::40e1:c4ff:fe3f:48dd > ff02::1: HBH (rtalert: invalid len 0) [|hbhopt]
19:23:51.720750 IP6 fe80::40e1:c4ff:fe3f:48dd > ff02::1: HBH (rtalert: invalid len 0) [|hbhopt]
19:23:53.689460 IP6 truncated-ip6 - 46 bytes missing!fe80::501c:16ff:fe3d:b4c8 > fe80::40e1:c4ff:fe3f:48dd: ICMP6, echo request, id 4660, seq 1, length 100
19:25:06.434749 IP6 truncated-ip6 - 46 bytes missing!fe80::501c:16ff:fe3d:b4c8 > fe80::40e1:c4ff:fe3f:48dd: ICMP6, echo request, id 4660, seq 1, length 100
19:25:53.471989 IP6 fe80::40e1:c4ff:fe3f:48dd > ff02::1: HBH (rtalert: invalid len 0) [|hbhopt]

```