### PR TITLE
github/ci: use user repo to export sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,13 @@ jobs:
             # Determine the repo and leave that unset to use the normal checkout behavior
             # of using the merge commit instead of HEAD
             case $GITHUB_REPOSITORY in
-              "apache/nuttx")
+              "$GITHUB_ACTOR/nuttx")
                 # OS
                 echo "Triggered by change in OS"
                 APPS_REF=$REF_NAME
                 ;;
 
-              "apache/nuttx-apps" )
+              "$GITHUB_ACTOR/nuttx-apps" )
                 # APPS
                 OS_REF=$REF_NAME
                 echo "Triggered by change in APPS"
@@ -98,7 +98,7 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v6
         with:
-          repository: apache/nuttx
+          repository: ${{ github.actor }}/nuttx
           ref: ${{ steps.gittargets.outputs.os_ref }}
           path: sources/nuttx
           fetch-depth: 1
@@ -108,7 +108,7 @@ jobs:
       - name: Checkout apps repo
         uses: actions/checkout@v6
         with:
-          repository: apache/nuttx-apps
+          repository: ${{ github.actor }}/nuttx-apps
           ref: ${{ steps.gittargets.outputs.apps_ref }}
           path: sources/apps
           fetch-depth: 1


### PR DESCRIPTION
## Summary
Use user repo to export sources instead of hardcoded Apache repositories. Otherwise, CI doesn't work well when testing external repositories because it can't download the correct source-bundle.

## Impact
remove hardcoded repositories for CI

## Testing
I tested this change in this PR: https://github.com/szafonimateusz-mi/nuttx/pull/1
CI successfully run new workflow logic: https://github.com/szafonimateusz-mi/nuttx/actions/runs/20572926208/job/59083775156?pr=1

Without this modification, source-bundle doesn't contain the changes from this PR, it downloads master from `apache/nuttx`.
With this modification CI creates source-bundle based on `szafonimateusz-mi/nuttx` and `szafonimateusz-mi/nuttx-apps`

I'm not sure if this can break something, mainly when it comes to external CI workflows. I'm also not sure if the current operation was intentional, if so I'll abandon this PR.

Ping @lupyuen @simbit18 @btashton 