### PR TITLE
boards/{nrf53|stm32h7}: mark shmem region as NOLOAD

### DIFF
--- a/boards/arm/nrf53/common/scripts/flash_app.ld
+++ b/boards/arm/nrf53/common/scripts/flash_app.ld
@@ -126,7 +126,7 @@ SECTIONS
 
     /* Shmem */
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_app.ld
+++ b/boards/arm/nrf53/nrf5340-audio-dk/scripts/flash_app.ld
@@ -103,7 +103,7 @@ SECTIONS
 
     /* Shmem */
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/nrf53/nrf5340-dk/scripts/flash_app.ld
+++ b/boards/arm/nrf53/nrf5340-dk/scripts/flash_app.ld
@@ -103,7 +103,7 @@ SECTIONS
 
     /* Shmem */
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/nrf53/thingy53/scripts/flash_app.ld
+++ b/boards/arm/nrf53/thingy53/scripts/flash_app.ld
@@ -103,7 +103,7 @@ SECTIONS
 
     /* Shmem */
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
@@ -117,7 +117,7 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/stm32h7/portenta-h7/scripts/flash.ld
+++ b/boards/arm/stm32h7/portenta-h7/scripts/flash.ld
@@ -123,7 +123,7 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
@@ -193,7 +193,7 @@ SECTIONS
     } > sram
 
 #ifdef CONFIG_STM32H7_CORTEXM4_ENABLED
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);

--- a/boards/arm/stm32h7/stm32h750b-dk/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h750b-dk/scripts/flash.ld
@@ -192,7 +192,7 @@ SECTIONS
     } > sram
 
 #ifdef CONFIG_STM32H7_CORTEXM4_ENABLED
-    .shmem :
+    .shmem (NOLOAD):
     {
         . = ALIGN(4);
         *(.shmem);


### PR DESCRIPTION

## Summary
Shmem region lives in RAM and should not be load in FLASH.

This fixes the issue with wrong binary size when build AMP configurations with RPTUN enabled. Before this change shmem region was exported by objcopy to binary file which caused the bin size to be huge and impossible to flash.

## Impact

Fix binary file with RPTUN enabled.

## Testing

Without this change bin file is 641M (wrong!):
```
[raiden00:~/git/RTOS/nuttx/nuttx]$ ll nuttx.bin                                                                                                                                                                                                                       
-rwxr-xr-x 1 raiden00 raiden00 641M Dec 30 12:54 nuttx.bin*
```

With this change bin file is 168K (OK!):

```
[raiden00:~/git/RTOS/nuttx/nuttx]$ ll nuttx.bin                                                                                                                                                                                                           
-rwxr-xr-x 1 raiden00 raiden00 168K Dec 30 12:53 nuttx.bin*
```
