### PR TITLE
sched/task: fix Redundant memory allocation.

### DIFF
--- a/Documentation/guides/kernel_threads_with_custom_stacks.rst
+++ b/Documentation/guides/kernel_threads_with_custom_stacks.rst
@@ -31,7 +31,7 @@ Here is the body of some function.  It expects to have the following inputs:
     * used to that all fields of the new TCB will be zeroed.
     */
 
-    tcb = kmm_zalloc(sizeof(struct tcb_s) + sizeof(struct task_group_s));
+    tcb = kmm_zalloc(sizeof(struct tcb_s));
     if (tcb == NULL)
     {
         return -ENOMEM;

--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -137,7 +137,7 @@ FAR struct tcb_s *nxtask_setup_fork(start_t retaddr)
 
   /* Allocate a TCB for the child task. */
 
-  child = kmm_zalloc(sizeof(struct tcb_s) + sizeof(struct task_group_s));
+  child = kmm_zalloc(sizeof(struct tcb_s));
   if (!child)
     {
       serr("ERROR: Failed to allocate TCB\n");


### PR DESCRIPTION
## Summary

Since the task and group structures are no longer allocated in the same space, the memory for group is allocated in the group_allocate() function, and no further allocation is needed during the task allocation process.

## Impact

None.

## Testing

ostest


