### PR TITLE
fs/mqueue: fix inverted 'created' flag in file_mq_vopen

### DIFF
--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -269,7 +269,7 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
 
       if (created)
         {
-          *created = 1;
+          *created = 0;
         }
     }
   else
@@ -321,7 +321,7 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
 
       if (created)
         {
-          *created = 0;
+          *created = 1;
         }
     }
 


### PR DESCRIPTION

## Summary

The 'created' flag values were incorrectly inverted in file_mq_vopen():

1. When opening an existing message queue (inode_find succeeds):
   - Before: incorrectly set *created = 1 (indicating new creation)
   - After: correctly set *created = 0 (indicating existing queue)

2. When creating a new message queue (inode_find fails):
   - Before: incorrectly set *created = 0 (indicating existing queue)
   - After: correctly set *created = 1 (indicating new creation)

This bug could lead to incorrect resource management and cleanup behavior in the calling function nxmq_vopen() when file_allocate() returns an error, as it relies on the 'created' flag to determine whether the message queue was newly created and needs to be cleaned up.

## Impact

- Resource leak when opening existing queues that should not be released
- Missing cleanup when creating new queues that should be released on error
*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Testing

```c
  ltp_interfaces_mq_open_11_1
  ltp_interfaces_mq_open_1_1
  ltp_interfaces_mq_open_12_1
  ltp_interfaces_mq_open_13_1
  ltp_interfaces_mq_open_15_1
  ltp_interfaces_mq_open_16_1
  ltp_interfaces_mq_open_18_1
  ltp_interfaces_mq_open_19_1
  ltp_interfaces_mq_open_20_1
  ltp_interfaces_mq_open_21_1
  ltp_interfaces_mq_open_2_1
  ltp_interfaces_mq_open_23_1
  ltp_interfaces_mq_open_25_2
  ltp_interfaces_mq_open_27_1
  ltp_interfaces_mq_open_27_2
  ltp_interfaces_mq_open_29_1
  ltp_interfaces_mq_open_3_1
  ltp_interfaces_mq_open_7_1
  ltp_interfaces_mq_open_7_2
  ltp_interfaces_mq_open_7_3
  ltp_interfaces_mq_open_8_1
  ltp_interfaces_mq_open_8_2
  ltp_interfaces_mq_open_9_1
```


