### PR TITLE
fs/epoll: release refs count and add TLS cleanup handler to release epoll fd reference on thread exit

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -42,6 +42,7 @@
 #include <nuttx/list.h>
 #include <nuttx/mutex.h>
 #include <nuttx/signal.h>
+#include <nuttx/tls.h>
 
 #include "inode/inode.h"
 #include "fs_heap.h"
@@ -392,6 +393,19 @@ static int epoll_teardown(FAR epoll_head_t *eph, FAR struct epoll_event *evs,
 
   nxmutex_unlock(&eph->lock);
   return i;
+}
+
+/****************************************************************************
+ * Name: epoll_cleanup
+ *
+ * Description:
+ *   Cleanup the epoll operation.
+ *
+ ****************************************************************************/
+
+static void epoll_cleanup(FAR void *arg)
+{
+  file_put(arg);
 }
 
 /****************************************************************************
@@ -754,6 +768,12 @@ retry:
 
   nxsig_procmask(SIG_SETMASK, sigmask, &oldsigmask);
 
+  /* Push a cancellation point onto the stack.  This will be called if
+   * the thread is canceled.
+   */
+
+  tls_cleanup_push(tls_get_info(), epoll_cleanup, filep);
+
   if (timeout == 0)
     {
       ret = -ETIMEDOUT;
@@ -766,6 +786,10 @@ retry:
     {
       ret = nxsem_wait(&eph->sem);
     }
+
+  /* Pop the cancellation point */
+
+  tls_cleanup_pop(tls_get_info(), 0);
 
   nxsig_procmask(SIG_SETMASK, &oldsigmask, NULL);
   if (ret < 0 && ret != -ETIMEDOUT)
@@ -825,6 +849,12 @@ retry:
       goto err;
     }
 
+  /* Push a cancellation point onto the stack.  This will be called if
+   * the thread is canceled.
+   */
+
+  tls_cleanup_push(tls_get_info(), epoll_cleanup, filep);
+
   /* Wait the poll ready */
 
   if (timeout == 0)
@@ -839,6 +869,10 @@ retry:
     {
       ret = nxsem_wait(&eph->sem);
     }
+
+  /* Pop the cancellation point */
+
+  tls_cleanup_pop(tls_get_info(), 0);
 
   if (ret < 0 && ret != -ETIMEDOUT)
     {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

### patch 1:
When an epoll fd is closed, the file descriptors in the teardown and
oneshot lists were not being properly dereferenced, leading to fd leaks.

This fix ensures that all fds in the teardown and oneshot lists are
properly released via file_put() during epoll_do_close(), matching the
behavior for fds in the setup list.

### patch 2
When a thread is terminated via pthread_exit() while blocked in epoll_wait(),
the file reference taken at the beginning of epoll_wait() is not properly
released, leading to resource leaks.

## Impact

### patch1
- Prevents fd leaks when epoll fd is closed
- Ensures proper cleanup of all tracked file descriptors
- Critical for applications using EPOLLONESHOT or fd removal operations

### patch2
- Prevents epoll fd reference count leaks on thread cancellation
- Ensures proper cleanup even when epoll_wait() is interrupted by pthread_exit
- Critical for multi-threaded applications using signals and thread termination
- Works together with previous fix for teardown/oneshot list cleanup

## Testing

uv_run_test tcp_ping_pong
<img width="1212" height="1662" alt="image" src="https://github.com/user-attachments/assets/ca24ea6d-2f5c-4dae-ae72-b6d407700383" />

