### PR TITLE
net/can: fix poll setup to properly find and use free pollfd slots

### DIFF
--- a/net/can/Kconfig
+++ b/net/can/Kconfig
@@ -165,5 +165,12 @@ config NET_CAN_NBUFFERS
 		This setting determines the number of preallocated CAN buffers
 		available for packet data.
 
+config NET_CAN_NPOLLWAITERS
+	int "Number of poll threads"
+	default 4
+	---help---
+		Maximum number of threads than can be waiting for POLL events.
+		Default: 4
+
 endif # NET_CAN
 endmenu # CAN Socket Support

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -124,7 +124,7 @@ struct can_conn_s
    * socket events.
    */
 
-  struct can_poll_s pollinfo[4]; /* FIXME make dynamic */
+  struct can_poll_s pollinfo[CONFIG_NET_CAN_NPOLLWAITERS];
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
   struct can_filter filters[CONFIG_NET_CAN_RAW_FILTER_MAX];


### PR DESCRIPTION
## Summary

Bug Description:
The original code always used conn->pollinfo[0] (the first element) to store new poll setup context, regardless of whether that slot was already in use. This caused multiple poll operations on the same CAN socket to overwrite each other's context, leading to:
- Lost poll waiters when multiple threads poll the same socket
- Memory corruption in pollfd structures
- Undefined behavior when poll_teardown tries to clean up

Root Cause:
The code directly assigned `info = conn->pollinfo` without checking if the slot was available, effectively always using pollinfo[0]. When a second thread called poll() on the same socket, it would overwrite the first thread's poll context.

Solution:
1. Initialize info to NULL instead of conn->pollinfo
2. Before setting up poll, iterate through all CONFIG_NET_CAN_NPOLLWAITERS slots to find the first free slot (where fds == NULL)
3. Return -EBUSY if no free slots are available
4. During teardown, properly mark the slot as free by setting fds = NULL

Additional Changes:
- Added CONFIG_NET_CAN_NPOLLWAITERS Kconfig option (default 4) to make the maximum number of concurrent poll waiters configurable
- Changed hardcoded array size from 4 to CONFIG_NET_CAN_NPOLLWAITERS
- Fixed lock ordering in teardown to ensure fds is cleared before unlock

Impact:


## Impact

- Enables multiple threads to safely poll the same CAN socket concurrently
- Prevents poll context corruption in multi-threaded applications
- Provides proper resource management with -EBUSY when all slots are full
- Makes the number of supported concurrent pollers configurable per use case


## Testing

can_send
can_dump
pass base on qemu

```c
sudo ./prebuilts/qemu/linux-x86_64/bin/qemu-system-arm -L ./prebuilts/qemu/linux-x86_64/share/qemu -M virt,virtualization=on,highmem=off -semihosting -nographic -cpu cortex-r52 -device loader,file=./out/qemu_caros_bmp/nuttx -device loader,file=./out/qemu_caros_bmp/nuttx_user -smp 4 -device virtio-net-device,netdev=b1 -netdev bridge,br=nuttx0,id=b1,helper=/usr/lib/qemu/qemu-bridge-helper -object can-bus,id=canbus0-bus  -object can-host-socketcan,if=can0,canbus=canbus0-bus,id=canbus0-socketcan -device ctucan_pci,canbus0=canbus0-bus,canbus1=canbus0-bus
```

<img width="1643" height="68" alt="image" src="https://github.com/user-attachments/assets/0d9987ef-7d5a-40c3-b937-babb7853b5ad" />
