### PR TITLE
driver/cfi: fix write failed issue for unalign length with bankwidth

### DIFF
--- a/drivers/mtd/cfi.c
+++ b/drivers/mtd/cfi.c
@@ -810,7 +810,7 @@ static ssize_t cfi_write_unalign(FAR struct cfi_dev_s *cfi, off_t offset,
 
   /* handle unaligned start */
 
-  if ((delta = offset - wp) == 0)
+  if ((delta = offset - wp) == 0 && nbytes >= cfi->bankwidth)
     {
       return 0;
     }
@@ -1096,7 +1096,7 @@ int cfi_write(FAR struct cfi_dev_s *cfi, off_t offset, size_t nbytes,
 
           if (size > nbytes)
             {
-              size = nbytes;
+              size = ALIGN_DOWN(nbytes, cfi->bankwidth);
             }
 
           ret = cfi_write_buffer(cfi, offset, size, buffer);


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. In cfi_write_unalign(): Add additional check to ensure nbytes is at least bankwidth size before skipping unaligned start handling. This prevents incorrect behavior when writing small amounts of data that are less than bankwidth.

2. In cfi_write(): Align down the write size to bankwidth boundary when the remaining nbytes is less than the buffer write size. This ensures the buffer write operation always works with properly aligned data size, preventing write failures.))

## Impact

bug fix

## Testing

```c

#include <nuttx/config.h>
--
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <fcntl.h>
#include <errno.h>
#include <unistd.h>
 
#include <nuttx/streams.h>
 
/****************************************************************************
* Pre-processor Definitions
****************************************************************************/
 
#define MTD_DEVICE "/dev/cfi-flash1"
#define MAX_TEST_SIZE 1024
 
/****************************************************************************
* Private Functions
****************************************************************************/
 
static bool nputs = false;
 
/****************************************************************************
* Name: test_mtd_write_read
*
* Description:
*   Test MTD write and read with specific data size
*
****************************************************************************/
 
static int test_mtd_write_read(size_t size)
{
struct lib_mtdoutstream_s mtdstream;
FAR uint8_t *write_buf;
FAR uint8_t *read_buf;
int ret;
int fd;
size_t i;
ssize_t nread;
bool pass = true;
 
printf("\n=== Testing size: %zu bytes ===\n", size);
 
/* Allocate buffers */
 
write_buf = malloc(size);
read_buf = malloc(size);
if (!write_buf \|\| !read_buf)
{
printf("ERROR: Failed to allocate buffers\n");
ret = -ENOMEM;
goto errout;
}
 
/* Initialize write buffer with pattern */
 
for (i = 0; i < size; i++)
{
write_buf[i] = (uint8_t)(i & 0xff);
}
 
/* Open MTD output stream */
 
ret = lib_mtdoutstream_open(&mtdstream, MTD_DEVICE);
if (ret < 0)
{
printf("ERROR: Failed to open MTD stream: %d\n", ret);
goto errout_with_buf;
}
 
/* Write data through stream */
 
if (nputs)
{
lib_stream_puts(&mtdstream.common, (FAR const char *)write_buf, size);
printf("Wrote data using lib_stream_puts():%zu\n", size);
}
else
{
for (i = 0; i < size; i++)
{
lib_stream_putc(&mtdstream.common, write_buf[i]);
}
}
 
/* Flush the stream to ensure data is written to flash */
 
lib_stream_flush(&mtdstream.common);
printf("Write complete: %zu bytes written and flushed\n", size);
 
/* Close MTD output stream */
 
lib_mtdoutstream_close(&mtdstream);
 
/* Open MTD device for reading */
 
fd = open(MTD_DEVICE, O_RDONLY);
if (fd < 0)
{
printf("ERROR: Failed to open MTD device for read: %d\n", errno);
ret = -errno;
goto errout_with_buf;
}
 
/* Read data back */
 
nread = read(fd, read_buf, size);
if (nread != size)
{
printf("ERROR: Read failed, expected %zu, got %zd (errno=%d)\n",
size, nread, errno);
ret = -EIO;
close(fd);
goto errout_with_buf;
}
 
close(fd);
printf("Read complete: %zu bytes read\n", size);
 
/* Compare data */
 
for (i = 0; i < size; i++)
{
if (write_buf[i] != read_buf[i])
{
printf("ERROR: Data mismatch at offset %zu: "
"wrote 0x%02x, read 0x%02x\n",
i, write_buf[i], read_buf[i]);
pass = false;
 
/* Show first few mismatches only */
 
if (i > 10)
{
printf("... (stopping after first mismatches)\n");
break;
}
}
}
 
if (pass)
{
printf("PASS: Data verified successfully\n");
ret = 0;
}
else
{
ret = -1;
}
 
errout_with_buf:
if (write_buf)
{
free(write_buf);
}
 
if (read_buf)
{
free(read_buf);
}
 
errout:
return ret;
}
 
/****************************************************************************
* Public Functions
****************************************************************************/
 
/****************************************************************************
* hello_main
****************************************************************************/
 
int main(int argc, FAR char *argv[])
{
int ret = 0;
size_t size;
int failed = 0;
int passed = 0;
 
printf("Hello, World!!\n");

printf("\n");
printf("MTD Output Stream Test\n");
printf("======================\n");
printf("Device: %s\n", MTD_DEVICE);
printf("\n");
 
if (argc > 2)
nputs = true;
 
/* Test power-of-2 sizes from 1 to 1024 bytes */
 
#if 1
for (size = 1; size <= MAX_TEST_SIZE; size *= 2)
{
ret = test_mtd_write_read(size);
if (ret < 0)
{
printf("Test FAILED for size %zu\n\n", size);
failed++;
break;
}
else
{
passed++;
}
}
#endif
 
/* Test some odd sizes */
 
const size_t odd_sizes[] =
{
3, 5, 7, 10, 15, 31, 63, 127, 255, 511, 1023
};
 
for (size_t idx = 0; idx < sizeof(odd_sizes) / sizeof(odd_sizes[0]); idx++)
{
size = odd_sizes[idx];
ret = test_mtd_write_read(size);
if (ret < 0)
{
printf("Test FAILED for size %zu\n\n", size);
failed++;
break;
}
else
{
passed++;
}
}
 
/* Print summary */
 
printf("\n");
printf("========================================\n");
printf("Test Summary:\n");
printf("  Passed: %d\n", passed);
printf("  Failed: %d\n", failed);
printf("  Total:  %d\n", passed + failed);
printf("========================================\n");
 
return failed > 0 ? -1 : 0;
}

```
<img width="538" height="278" alt="image" src="https://github.com/user-attachments/assets/cc162db7-5d3c-4a49-a54f-0b8b601278bb" />
