### PR TITLE
xtensa/esp32s3: fix dcache flush error in up_flush_dcache

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_cache.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cache.c
@@ -353,7 +353,7 @@ void up_invalidate_dcache(uintptr_t start, uintptr_t end)
 {
   uint32_t items = (end - start) / up_get_dcache_linesize();
 
-  cache_invalidate_dcache_items((uint32_t)start, end);
+  cache_invalidate_dcache_items((uint32_t)start, items);
 }
 #endif
 
@@ -466,7 +466,7 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 
   cache_writeback_addr((uint32_t)start, (uint32_t)(end - start));
 
-  cache_invalidate_dcache_items((uint32_t)start, end);
+  cache_invalidate_dcache_items((uint32_t)start, items);
 }
 #endif
 


### PR DESCRIPTION
## Summary

In up_flush_dcache, items is not used, and we should use it in cache_invalidate_dcache_items.
`extern void cache_invalidate_dcache_items(uint32_t addr, uint32_t items);`

And this will cause lvgl crash in https://github.com/apache/nuttx-apps/pull/3253

## Impact

None

## Testing

lckfb-szpi-esp32s3 board
