### PR TITLE
esp32s3: Remove redundant I2S include directive

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c
@@ -68,10 +68,6 @@
 #  include "espressif/esp_i2s.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_I2S
-#  include "espressif/esp_i2s.h"
-#endif
-
 #ifdef CONFIG_WATCHDOG
 #  include "esp32s3_board_wdt.h"
 #endif


### PR DESCRIPTION
## Summary

Remove redundant I2S include directive

## Impact

N/A

## Testing

run `tools/configure.sh -l esp32s3-devkit:wifible`

and enable

```
CONFIG_AUDIO=y
CONFIG_I2S=y
CONFIG_DRIVERS_AUDIO=y
CONFIG_AUDIO_I2S=y
CONFIG_ESPRESSIF_I2S0=y
CONFIG_ESPRESSIF_I2S1=y
```

build passed