### PR TITLE
arch/risc-v: Fix incompatible pointer types in vector context switching

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -243,12 +243,12 @@ static inline uintreg_t *riscv_fpuregs(struct tcb_s *tcb)
 
 #ifdef CONFIG_ARCH_RV_ISA_V
 void riscv_vpuconfig(void);
-void riscv_savevpu(uintptr_t *regs, uintptr_t *vregs);
-void riscv_restorevpu(uintptr_t *regs, uintptr_t *vregs);
+void riscv_savevpu(uintreg_t *regs, uintreg_t *vregs);
+void riscv_restorevpu(uintreg_t *regs, uintreg_t *vregs);
 
 /* Get VPU register save area */
 
-static inline uintptr_t *riscv_vpuregs(struct tcb_s *tcb)
+static inline uintreg_t *riscv_vpuregs(struct tcb_s *tcb)
 {
   return tcb->xcp.vregs;
 }


### PR DESCRIPTION
## Summary

The `riscv_savevpu`, `riscv_restorevpu`, and `riscv_vpuregs` functions were using `uintptr_t *` for vector registers, but `tcb->xcp.vregs` is defined as `uintreg_t *`. This mismatch caused compilation errors on newer GCC versions (e.g., GCC 13+) due to incompatible pointer types. This patch aligns the parameter types to `uintreg_t *` to match the structure definition.

## Impact

**Build:** Fixes compilation warnings/errors on GCC 13+ toolchains regarding incompatible pointer types.
**Hardware:** RISC-V architectures with Vector extension enabled.
 **Compatibility:** No functional change in runtime behavior (since `uintptr_t` and `uintreg_t` usually have the same width on RV32/RV64), but ensures source-level type safety.

## Testing

**Host Environment:**
*   **OS:** Ubuntu 25.10 (Linux 6.17.0-8-generic)
*   **Compiler:** riscv64-unknown-elf-gcc (14.2.0+19) 14.2.0
*   **QEMU:** QEMU emulator version 10.1.50 (v10.1.0-1314-gf3f2ad1193)

**Verification Steps:**

1.  **Compilation Fix verification:**
    *   **Target:** `rv-virt:nsh` (Modified to enable Vector extension)
    *  **Command:** `make -j`
    *   **Before check:** Build fails with `error: passing argument 1 of 'riscv_savevpu' from incompatible pointer type` on GCC 14.2.0.
    *   **After check:** Build completes successfully without "incompatible pointer type" errors.


2.  **Runtime Verification:**
    Booted the image on QEMU to ensure no regression in context switching initialization.

    Command:
    ```bash
    qemu-system-riscv32 \
          -nographic \
          -M virt \
          -bios none \
          -kernel ./nuttx \
          -cpu max,vlen=256,elen=64,v=true
    ```

    **Boot Log:**
    ```text
    ABC
    NuttShell (NSH) NuttX-12.12.0
    nsh> 
    ```
