### PR TITLE
drivers/adc: Use mutexlock to replace critical section protection

### DIFF
--- a/include/nuttx/analog/adc.h
+++ b/include/nuttx/analog/adc.h
@@ -213,7 +213,7 @@ struct adc_dev_s
 
   uint8_t                     ad_ocount;     /* The number of times the device has been opened */
   uint8_t                     ad_nrxwaiters; /* Number of threads waiting to enqueue a message */
-  mutex_t                     ad_closelock;  /* Locks out new opens while close is in progress */
+  mutex_t                     ad_lock;       /* Locks use in adc open、close and read */
   sem_t                       ad_recvsem;    /* Used to wakeup user waiting for space in ad_recv.buffer */
   struct adc_fifo_s           ad_recv;       /* Describes receive FIFO */
   bool                        ad_isovr;      /* Flag to indicate an ADC overrun */


### PR DESCRIPTION
Use mutexlock to replace critical section protection when using adc_isr_thread

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

Summary
The modification replaces critical section protection with mutex locks in ADC driver functions when CONFIG_ADC_ISR_THREAD is enabled, ensuring thread-safe hardware operations without unnecessarily disabling interrupts.

Impact
Benefits:

Reduced Interrupt Latency: Interrupts remain enabled during hardware operations
Better System Throughput: Other interrupts can still be serviced
Improved Real-time Performance: Shorter critical sections mean better determinism
Testing
The ADC function was tested and verified to be working correctly using NuttX's built-in adc_drivers.（apps/examples/adc）
Test Results：
Test results: When you input adc -p in the nsh terminal, the pin corresponding to channel adc0 is shown below.

[core2] adc -p
[core2] adc_main:g_adcstate.count: 3
[core2] adc_main: Hardware initialized. Opening the ADC device: /dev/adc0
[core2] Sample:
[core2] 1: channel: 32 value: 986
[core2] 2: channel: 34 value: 933
