### PR TITLE
virtio/virtio-gpu: fbmem should transfer to pa

### DIFF
--- a/drivers/virtio/virtio-gpu.c
+++ b/drivers/virtio/virtio-gpu.c
@@ -560,7 +560,7 @@ static int virtio_gpu_probe(FAR struct virtio_device *vdev)
       goto err_init_fb;
     }
 
-  ent.addr = (uintptr_t)priv->fbmem;
+  ent.addr = up_addrenv_va_to_pa(priv->fbmem);
   ent.length = priv->fblen;
   ret = virtio_gpu_attach_backing(priv, 1, &ent, 1);
   if (ret < 0)


### PR DESCRIPTION
## Summary

Map the framebuffer memory address to the physical address to resolve the framebuffer issue in qemu with command `-device virtio-gpu-pci`.

When using the virtio-gpu-pci device, we observed that the virtio-gpu driver does not create the /dev/fb0 node. The reason is that in PCI mode, the framebuffer address needs to be translated to a physical address for proper operation.

Additionally, there is another bug in the current code related to PCI device scanning for the virtio-gpu-pci device. @CV-Bowen  will submit a patch to fix it.

## Impact

none

## Testing

qemu environment
