### PR TITLE
arch/risc-v: Enable VPU initialization for QEMU RV

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -166,9 +166,11 @@ void qemu_rv_start(int mhartid, const char *dtb)
     }
 #endif
 
-  /* Configure FPU */
+  /* Configure FPU and VPU */
 
   riscv_fpuconfig();
+
+  riscv_vpuconfig();
 
   if (mhartid > 0)
     {


### PR DESCRIPTION
## Summary

This PR fixes a runtime crash on QEMU `rv-virt` when the RISC-V Vector extension is enabled.

The `riscv_vpuconfig()` function, responsible for initializing the `mstatus.VS` bit (Vector Status), was defined but never called during the board-specific startup in `qemu_rv_start()` for the `rv-virt` platform. This oversight caused `mstatus.VS` to remain in the `Off` state (0x00), leading to an `Illegal Instruction` exception (MCAUSE: 0x2) when the OS attempted to save or restore vector context .

This patch adds the necessary call to `riscv_vpuconfig()` in `arch/risc-v/src/qemu-rv/qemu_rv_start.c`, ensuring the VPU is correctly initialized on boot.

## Impact

*   **Is new feature added?** No.
*   **Is existing feature changed?** Yes. Fixes broken Vector extension support on QEMU.
*   **Impact on user:** Users enabling RISC-V Vector extensions on QEMU (`rv-virt`) can now compile and boot successfully without runtime crashes. Users not enabling Vector extensions are unaffected.
*   **Impact on build:** No direct impact on the build process.
*   **Impact on hardware:** Validated on QEMU RISC-V 32-bit. No changes to physical hardware are implied.
*   **Impact on documentation:** No.
*   **Impact on security:** No.
*   **Impact on compatibility:** This fix addresses a pre-existing runtime failure. It improves compatibility for systems configured with RISC-V Vector extensions.

## Testing

**Host Environment:**
*   **OS:** Ubuntu 25.10 (Linux 6.17.0-8-generic)
*   **Compiler:** riscv64-unknown-elf-gcc (14.2.0+19) 14.2.0
*   **QEMU:** QEMU emulator version 10.1.50 (v10.1.0-1314-gf3f2ad1193)

**Verification Steps:**

1.  **Build Verification:**
    *   **Target:** `rv-virt:nsh` (Configured with `CONFIG_ARCH_RV_ISA_V=y`).
    *   **Command:** `make -j`
    *   **Result:** Build completes successfully (provided that prerequisite type-fixing patch PR #17762 is applied).

2.  **Runtime Verification:**
    *   **Command:**
        ```bash
        qemu-system-riscv32 \
              -nographic \
              -M virt \
              -bios none \
              -kernel ./nuttx \
              -cpu max,vlen=256,elen=64
        ```
    *   **Before check:** System boots to NSH, but after executing a few NSH commands (typically within 2-3 commands) crashes with: 
    ```text
        riscv_exception: EXCEPTION: Illegal instruction. MCAUSE: 00000002, EPC: 80000xxx, MTVAL: 0c3073d7  # vsetvli instruction
    ```
    This occurs because `mstatus.VS` is not correctly initialized, preventing vector instructions from executing.
    *   **After check:** System boots to NSH and runs stably, allowing execution of NSH commands (e.g., `ls`, `ps`). The `Illegal Instruction` exception is no longer observed.

    **Boot Log (After Fix):**
    ```text
    ABC
    NuttShell (NSH) NuttX-12.12.0
    nsh> ls
    /:
     dev/
     proc/
    nsh> ps
      TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
        0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0002032 0000420  20.6%  Idle_Task
        1     1     0 100 RR       Task      - Running            0000000000000000 0002000 0001636  81.8%! nsh_main
    nsh> 
    ``````
