### PR TITLE
drivers/sensors: update upper->parsebuffer every new line

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -595,6 +595,7 @@ static void gnss_parse(FAR struct gnss_upperhalf_s *upper,
     {
       if (*buffer == '$')
         {
+          upper->parsenext = 0;
           newline = true;
         }
 


### PR DESCRIPTION
## Summary

Fix GNSS NMEA parser buffer overflow handling by resetting parse position after error.

When the NMEA parser detects a buffer overflow (line exceeds GNSS_PARSE_BUFFERSIZE), it logs an error message but fails to reset parsenext to 0. This causes subsequent NMEA sentences to be appended to the corrupted buffer, leading to:

Continuous buffer overflow errors for all following sentences
Loss of valid GNSS data until the next '$' character is encountered
Potential memory corruption if overflow detection fails

## Impact

Improves GNSS data reliability when receiving malformed or oversized NMEA sentences
Prevents data loss from cascading parse errors
No API or behavior changes for normal operation

## Testing

```bash
nsh> echo "$GPGGA,<300_char_garbage...>*00" > /dev/ttyGNSS0
nsh> echo "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47" > /dev/ttyGNSS0
```

before fix:
```bash
ERROR: NMEA buffer overflow, invalid statement:$GPGGA,<truncated>
ERROR: NMEA buffer overflow, invalid statement:GPGGA,123519,4807...
ERROR: NMEA buffer overflow, invalid statement:807.038,N,01131...
(repeating errors, no valid data parsed)
```
after fix:
```bash
ERROR: NMEA buffer overflow, invalid statement:$GPGGA,<truncated>
INFO: Parsed GPGGA: lat=48.1173, lon=11.5167, alt=545.4
(valid sentence parsed correctly after recovery)
```
