### PR TITLE
compiler: Add PRAGMA and unroll_loop.

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -175,6 +175,14 @@
 #  define offsetof(a, b) __builtin_offsetof(a, b)
 #  define return_address(x) __builtin_return_address(x)
 
+#  define PRAGMA(x)         _Pragma(#x)
+
+#  if defined(__clang__)
+#    define unroll_loop(n)  PRAGMA(clang loop unroll_count(n))
+#  else
+#    define unroll_loop(n)  PRAGMA(GCC unroll n)
+#  endif
+
 /* Attributes
  *
  * GCC supports weak symbols which can be used to reduce code size because
@@ -814,6 +822,9 @@
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
 
+#  define PRAGMA(x)
+#  define unroll_loop(n)
+
 #  define no_builtin(n)
 
 /* Warning about usage of deprecated features. */
@@ -979,6 +990,9 @@
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
 
+#  define PRAGMA(x)
+#  define unroll_loop(n)
+
 #  define no_builtin(n)
 
 /* Warning about usage of deprecated features. */
@@ -1072,6 +1086,9 @@
 
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
+
+#  define PRAGMA(x)
+#  define unroll_loop(n)
 
 #  define no_builtin(n)
 
@@ -1175,6 +1192,9 @@
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
 
+#  define PRAGMA(x)
+#  define unroll_loop(n)
+
 #  define no_builtin(n)
 
 /* Warning about usage of deprecated features. */
@@ -1276,6 +1296,9 @@
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
 
+#  define PRAGMA(x)
+#  define unroll_loop(n)
+
 #  define no_builtin(n)
 
 /* Warning about usage of deprecated features. */
@@ -1367,6 +1390,9 @@
 
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 #  define return_address(x) 0
+
+#  define PRAGMA(x)
+#  define unroll_loop(n)
 
 #  define no_builtin(n)
 


### PR DESCRIPTION
## Summary

This is part of the https://github.com/apache/nuttx/pull/17675.
This commit added `PRAGMA` and `unroll_loop` to support compiler loop-unrolling.
We can add `unroll_loop(MAX_LOOP)` before the loop to hint the compiler to do loop-unrolling, where the `MAX_LOOP` is a constant value that indiciates the max loops to be unrolled.

## Impact

It is not currently in use and will not have any impact on the system.

## Testing

Tested on `rv-virt:smp`, ostest passed.
