### PR TITLE
can: fix can driver error about hdr is not initilized

### DIFF
--- a/drivers/can/ctucanfd_pci.c
+++ b/drivers/can/ctucanfd_pci.c
@@ -739,6 +739,8 @@ static void ctucanfd_chardev_receive(FAR struct ctucanfd_can_s *priv)
   uint16_t                     frc    = 0;
   uint32_t                     regval = 0;
 
+  memset(&hdr, 0, sizeof(hdr));
+
   /* Get frame count */
 
   regval = ctucanfd_getreg(priv, CTUCANFD_RXSETSTAT);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

In `ctucanfd_chardev_receive()` logic, the CAN message header was not fully initialized, which could result in  uninitialized fields and unexpected gaps in header, This caused upper-layer applications to fail when comparing packet 
contents using `memcmp()`

## Impact

Fixes incorrect CAN message contents caused by uninitialized header
fields. No API changes and no impact on existing correct use cases.

## Testing

Tested in an automotive integration project under SIL conditions.