### PR TITLE
net can: modify the return value of can_datahandler API.

### DIFF
--- a/net/can/can.h
+++ b/net/can/can.h
@@ -254,8 +254,8 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
  *   conn - A pointer to the CAN connection structure
  *
  * Returned Value:
- *   The number of bytes actually buffered is returned.  This will be either
- *   zero or equal to buflen; partial packets are not buffered.
+ *   The number of bytes actually buffered is returned.  This will be
+ *   negative or zero or equal to buflen; partial packets are not buffered.
  *
  * Assumptions:
  * - The caller has checked that CAN_NEWDATA is set in flags and that is no
@@ -264,8 +264,8 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t can_datahandler(FAR struct net_driver_s *dev,
-                         FAR struct can_conn_s *conn);
+int can_datahandler(FAR struct net_driver_s *dev,
+                    FAR struct can_conn_s *conn);
 
 /****************************************************************************
  * Name: can_recvmsg

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -67,7 +67,7 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
                uint32_t flags)
 {
   int buflen = dev->d_len;
-  uint16_t recvlen;
+  int recvlen;
   uint32_t ret;
 
 #ifdef CONFIG_NET_TIMESTAMP
@@ -193,8 +193,8 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t can_datahandler(FAR struct net_driver_s *dev,
-                         FAR struct can_conn_s *conn)
+int can_datahandler(FAR struct net_driver_s *dev,
+                    FAR struct can_conn_s *conn)
 {
   FAR struct iob_s *iob = dev->d_iob;
   int ret = 0;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The `can_datahandler()` API calls `iob_tryadd_queue()` to enqueue received
CAN data into an IOB queue. However, `iob_tryadd_queue()` may return a
negative value on failure, which was not properly propagated to the
caller.

This change updates `can_datahandler()` to correctly handle and return
the error code from `iob_tryadd_queue()`, allowing callers to detect
queueing failures and react appropriately.

## Impact

This change improves error handling robustness in the CAN receive path.
There are no API changes, no impact on the build process, and no changes
to hardware behavior, security, or compatibility.

## Testing

Tested in an automotive integration project using continuous CAN traffic.
