### PR TITLE
drivers/pty: fix memory leak when pty_destroy

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -340,7 +340,8 @@ static int pty_close(FAR struct file *filep)
 
   /* Check if the decremented inode reference count would go to zero */
 
-  if (atomic_read(&inode->i_crefs) == 1)
+  if ((!dev->pd_master && atomic_load(&inode->i_crefs) == 2) ||
+       (dev->pd_master && atomic_load(&inode->i_crefs) == 1))
     {
       /* Did the (single) master just close its reference? */
 


### PR DESCRIPTION

## Summary

    drivers/serial/pty: fix memory leak when pty_destroy

    1. ptmx_open -> pty_register2 -> master register i_crefs 1
                                  -> salve  register i_crefs 1
    2. ptmx_open -> master unregister i_crefs 0
    3. master open i_crefs 1
       salve  open i_crefs 2
    
    4. in pty_close() master close with i_crefs 1
                      salve  close with i_crefs 2
    
    So, if correct the i_crefs judgement in pty_close()

## Impact

bug fix: https://github.com/apache/nuttx/issues/17759

## Testing

sim:nsh , enable SIM_ASAN

```c
djz:nuttx$ ./nuttx                                                                                             
==1861366==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0x7fff5543c000; bottom 0x63100000f000; size: 0x1cef5542d000 (31814253203456)                                                 
False positive error reports may follow                                                                        
For details see https://github.com/google/sanitizers/issues/189                                                                                                                                                               
                                                                                                               
NuttShell (NSH) NuttX-10.4.0                                                                                   
nsh> hello                                             
nsh> lsan                                              
nsh> poweroff  
```
