### PR TITLE
drivers/rpmsg: router double free and reconnect related bugs fix

### DIFF
--- a/drivers/rpmsg/rpmsg_router_hub.c
+++ b/drivers/rpmsg/rpmsg_router_hub.c
@@ -138,7 +138,16 @@ static void rpmsg_router_hub_unbind(FAR struct rpmsg_endpoint *ept)
 
   if (dst_ept)
     {
-      rpmsg_destroy_ept(dst_ept);
+      /* Possible failure to execute create_ept at rpmsg_router_hub_bound */
+
+      if (dst_ept->cb)
+        {
+          rpmsg_destroy_ept(dst_ept);
+        }
+      else
+        {
+          kmm_free(dst_ept);
+        }
     }
 
   /* Destroy source edge ept */


### PR DESCRIPTION
## Summary
This PR fixes critical memory management and crash issues in the rpmsg router hub component during device reconnection and teardown scenarios.

### Problem 1: Double Free Issue
The rpmsg router hub implementation had a double-free vulnerability in rpmsg_router_hub_unbind(). When endpoints were destroyed, the function would call rpmsg_destroy_ept() which internally frees the endpoint memory through the release_cb callback, but then the function would attempt to free the same memory again with kmm_free(), leading to a double-free crash.

### Problem 2: Invalid List Operation During Reconnect
During device reconnection, if the destination endpoint creation failed at rpmsg_router_hub_bound(), the unbind callback would still attempt to call rpmsg_destroy_ept() on a partially initialized endpoint (without a valid callback), causing a crash when trying to delete from an uninitialized list.

### Solution:
Added rpmsg_router_hub_ept_release() callback to properly handle endpoint memory deallocation through the OpenAMP framework's release mechanism
Modified rpmsg_router_hub_unbind() to remove redundant kmm_free() calls, letting the framework handle memory cleanup
Added a check to verify endpoint callback validity before calling rpmsg_destroy_ept(), directly freeing memory with kmm_free() for incomplete endpoints
These changes ensure proper memory lifecycle management and prevent crashes during rpmsg device reconnection scenarios, particularly with rpmsg_port_spi transport.

## Impact
RPMSG router hub subsystem (drivers/rpmsg/rpmsg_router_hub.c)
Systems using RPMSG router with multiple CPU communication
Applications utilizing rpmsg_port_spi and other transport layers

## Testing
Test Environment: internal AMP system projects
Platform: Multi-core system with RPMSG router hub


