### PR TITLE
net/udp: fix udp message cannot be sent to the network card

### DIFF
--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -219,9 +219,9 @@ static uint32_t sendto_eventhandler(FAR struct net_driver_s *dev,
                 iob_update_pktlen(dev->d_iob, udpip_hdrsize(pstate->st_conn),
                                   false);
                 dev->d_sndlen = 0;
-                dev->d_len = dev->d_iob->io_pktlen;
             }
 
+          dev->d_len = dev->d_iob->io_pktlen;
 #ifdef NEED_IPDOMAIN_SUPPORT
           /* If both IPv4 and IPv6 support are enabled, then we will need to
            * select which one to use when generating the outgoing packet.


### PR DESCRIPTION

## Summary
To fix the issue [17758](https://github.com/apache/nuttx/issues/17758)
Udp message cannt be sent to the network card

## Impact

It only fixes the issue and will not affect the api, function and performance.

## Testing

Build the sim: userfs environment, and verify that issue 17758 can be fixed. 
Set up the sim: matter environment, enable CONFIG_EXAMPLES_UDP, modify udp_client. c, and send data with udp_len greater than or equal to 0 at the same time. The results show that both types of data can be sent to the host side.

