### PR TITLE
libc: Add Kconfig option to disable hex-string to float parsing

### DIFF
--- a/libs/libc/stdlib/Kconfig
+++ b/libs/libc/stdlib/Kconfig
@@ -46,4 +46,14 @@ config LIBC_MAX_EXITFUNS
 		Configure the amount of exit functions for atexit/on_exit. The ANSI
 		default is 32, but most likely we don't need as many.
 
+config LIBC_DISABLE_HEXSTR_TO_FLOAT
+	bool "Disable hex-string to float/double conversions"
+	default DEFAULT_SMALL
+	---help---
+		Disables parsing of hexadecimal floating-point constants (C99 %a),
+		e.g., "0x1.fp3", in strtod(), strtof(), strtold(), and sscanf("%a").
+		This saves flash space since hex-float parsing adds significant code
+		and is rarely needed in embedded systems. Decimal float parsing remains
+		available.
+
 endmenu # stdlib Options

--- a/libs/libc/stdlib/lib_strtold.c
+++ b/libs/libc/stdlib/lib_strtold.c
@@ -432,7 +432,7 @@ static long_double decfloat(FAR char *ptr, FAR char **endptr)
  *   A long_double number about ptr
  *
  ****************************************************************************/
-
+#ifndef CONFIG_LIBC_DISABLE_HEXSTR_TO_FLOAT
 static long_double hexfloat(FAR char *ptr,
                             FAR char **endptr, int bits, int emin)
 {
@@ -618,6 +618,7 @@ static long_double hexfloat(FAR char *ptr,
 
   return scalbnx(y, 2., e2);
 }
+#endif
 
 /****************************************************************************
  * Name: strtox
@@ -644,6 +645,7 @@ static long_double strtox(FAR const char *str, FAR char **endptr, int flag)
   long_double y = 0;
   int i = 0;
 
+#ifndef CONFIG_LIBC_DISABLE_HEXSTR_TO_FLOAT
   int bits;
   int emin;
 
@@ -664,6 +666,7 @@ static long_double strtox(FAR const char *str, FAR char **endptr, int flag)
       default:
         return 0;
     }
+#endif
 
   /* Skip leading whitespace */
 
@@ -712,12 +715,15 @@ static long_double strtox(FAR const char *str, FAR char **endptr, int flag)
   /* Process optional 0x prefix */
 
   s -= i;
+#ifndef CONFIG_LIBC_DISABLE_HEXSTR_TO_FLOAT
   if (*s == '0' && (*(s + 1) | 32) == 'x')
     {
       s += 2;
       y = hexfloat(s, endptr, bits, emin);
     }
-  else if (isdigit(*s) || (*s == '.' && isdigit(*(s + 1))))
+  else
+#endif
+  if (isdigit(*s) || (*s == '.' && isdigit(*(s + 1))))
     {
       y = decfloat(s, endptr);
     }


### PR DESCRIPTION
## Summary
After upgrading from 10.3.0 to 12.12.0, we observed a significant increase in flash usage. This appears to be caused by new features added in the newer version that we do not use but cannot disable, resulting in dead code and tighter flash constraints.

This PR introduce CONFIG_LIBC_DISABLE_HEXSTR_TO_FLOAT to remove support for parsing hexadecimal floating-point constants (C99 %a) in strtod(), strtof(), strtold(), and sscanf("%a") which wasn't available in 10.3.0 as well. This feature is rarely used in embedded systems and its removal saves significant flash space. Decimal float parsing remains unaffected.

## Impact

On DEFAULT_SMALL targets hexstr will be disabled reducing flash requirement by 1kB.

## Testing
ostest on mr-canhukb344
```
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
