### PR TITLE
net/vlan: add a documentation for vconfig

### DIFF
--- a/Documentation/applications/netutils/vconfig/index.rst
+++ b/Documentation/applications/netutils/vconfig/index.rst
@@ -1,0 +1,34 @@
+============================
+``vconfig`` VLAN Config Tool
+============================
+
+vconfig is a utility for managing VLAN (Virtual LAN) interfaces in NuttX.
+It allows users to add, remove, and display VLANs on network interfaces.
+
+USAGE
+-----
+
+Usage is straightforward::
+
+    nsh> help ; vconfig
+    Usage: vconfig add <interface> <vlan_id> [priority]
+           vconfig rem|del <vlan-interface>
+
+Examples
+~~~~~~~~
+
+Add a VLAN interface::
+
+    nsh> vconfig add eth0 10
+
+Remove a VLAN interface::
+
+    nsh> vconfig rem|del eth0.10
+
+Resources
+~~~~~~~~~
+
+* https://en.wikipedia.org/wiki/Virtual_LAN
+* https://www.nuttx.org/
+
+


### PR DESCRIPTION

## Summary

Users can add or delete Vlan interfaces through the vconfig tool. This document describes the usage of vconfig.

## Impact

vconfig tools documentation. Will not affect network functionality.

## Testing

Use `vconfig  add eth0 10` to add vlan interface,  and use  ifconfig  to check the vlan interface. Then configure the IP address of the Vlan interface and verify that the Vlan interface can communicate normally.

Use `vconfig del eth0.10` to delete vlan interface, and use  ifconfig  to check the vlan interface. 
