### PR TITLE
risc-v/litex: Update docs for vexriscv invalidate and no-op flush.

### DIFF
--- a/arch/risc-v/src/litex/litex_cache.S
+++ b/arch/risc-v/src/litex/litex_cache.S
@@ -52,6 +52,9 @@
   .globl  up_invalidate_dcache_all
   .type   up_invalidate_dcache_all, function
 
+/* Invalidate entire cache via the 0x500F instruction
+ * See https://github.com/SpinalHDL/VexRiscv?tab=readme-ov-file#dbuscachedplugin
+ */
 up_invalidate_dcache_all:
   .word 0x500F
 #endif
@@ -74,8 +77,9 @@ up_invalidate_dcache_all:
   .globl  up_flush_dcache_all
   .type   up_flush_dcache_all, function
 
+/* VexRiscv cache is write-through so there is no need to flush */
 up_flush_dcache_all:
-  .word 0x500F
+  nop
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Per further feedback from Litex community on Discord, the vexriscv cache is write-through so no flush is required - therefore, make it a nop.

And add a pointer to vexriscv invalidation magic instruction docs:

https://github.com/SpinalHDL/VexRiscv?tab=readme-ov-file#dbuscachedplugin

## Summary

A prior PR #17696 issued an invalidation instruction when asked to flush; but, that's not strictly necessary as the cache is write-through.  Therefore, make flush a nop.  This matches Zephyr's behavior which implements vexriscv caching:

https://github.com/zephyrproject-rtos/zephyr/pull/97925/files

I believe a nop is slightly better than trying to make flush function conditional upstream, but I'm open to modifying the PR accordingly.

## Impact

When asked to flush, NuttX won't invalidate the entire cache.

## Testing

I tested with `arty_a7:nsh` build which ran successfully locally.