### PR TITLE
fix cmake build

### DIFF
--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -88,3 +88,7 @@ endif()
 if(CONFIG_COVERAGE_TOOLCHAIN)
   nuttx_find_toolchain_lib(libgcov.a)
 endif()
+
+if(CONFIG_LIBCXXTOOLCHAIN)
+  nuttx_find_toolchain_lib(libstdc++.a)
+endif()


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR fixes CMake-based builds when `CONFIG_LIBCXXTOOLCHAIN` is enabled by ensuring the C++ standard library from the toolchain is explicitly located and linked.

Previously, the CMake build did not consistently pick up `libstdc++.a`, which could result in the toolchain STL headers
being included without the corresponding library. This mismatch caused conflicts between NuttX libc headers and the toolchain headers, leading to build failures.

The issue does not appear when building with the legacy Make system, which already handles this case correctly.

This change aligns the CMake behavior with the Make build logic by conditionally locating the toolchain C++ standard library:

- When `CONFIG_LIBCXXTOOLCHAIN` is enabled
- `libstdc++.a` is explicitly discovered via `nuttx_find_toolchain_lib()`

Related issue:
- https://github.com/apache/nuttx/issues/16775#issuecomment-3716482986

## Impact

- Fixes CMake build failures when using the C++ STL toolchain
- No impact on Make-based builds
- No runtime behavior changes
- Improves consistency between Make and CMake build systems
- No impact on existing configurations that do not enable  `CONFIG_LIBCXXTOOLCHAIN`

## Testing

**Host:**
- Ubuntu 22.04 (x86_64)
- arm-none-eabi-gcc toolchain

**Board / Configuration:**
- `xmc4800-relax:nsh`

**Tested scenarios:**
- CMake build:
  ```sh
  rm -rf build
  cmake -B build -DBOARD_CONFIG=xmc4800-relax:nsh -GNinja
  cmake --build build
  ```
  
- CMake build completes successfully
- No warnings or header conflicts observed


## TODO:
Add cmake build to CI for regression testing (I would like people opinion on this matter). This can be addressed in a seperate issue and PR 