### PR TITLE
drivers/can:  replace critical-section mutex with spinlock

### DIFF
--- a/include/nuttx/can/sja1000.h
+++ b/include/nuttx/can/sja1000.h
@@ -112,10 +112,7 @@ struct sja1000_dev_s
   uint8_t filters;                      /* STD/EXT filter bit allocator. */
   uint8_t nalloc;                       /* Number of allocated filters */
   uint32_t base;                        /* SJA1000 register base address */
-
-#ifdef CONFIG_ARCH_HAVE_MULTICPU
-  spinlock_t lock; /* Device specific lock */
-#endif             /* CONFIG_ARCH_HAVE_MULTICPU */
+  spinlock_t lock;                      /* Device specific lock */
 
   /* Register read/write callbacks.  These operations all hidden behind
    * callbacks to isolate the driver from differences in register read/write


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change replaces mutex-based critical section protection with
spinlocks in scheduler-sensitive code paths.

## Impact

This change is internal to the kernel and transparent to user space.

## Testing
