### PR TITLE
timer: rename tick_settimeouot to tick_settimeout

### DIFF
--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -111,7 +111,7 @@
   ((l)->ops->settimeout ? (l)->ops->settimeout(l,t) : timer_settimeout(l,t))
 
 #define TIMER_TICK_SETTIMEOUT(l,t) \
-  ((l)->ops->tick_setttimeout ? (l)->ops->tick_setttimeout(l,t) : timer_tick_settimeout(l,t))
+  ((l)->ops->tick_settimeout ? (l)->ops->tick_settimeout(l,t) : timer_tick_settimeout(l,t))
 
 #define TIMER_MAXTIMEOUT(l,t) \
   ((l)->ops->maxtimeout ? (l)->ops->maxtimeout(l,t) : timer_maxtimeout(l,t))
@@ -209,7 +209,7 @@ struct timer_ops_s
 
   /* Set a new tick timeout value of (and reset the timer) */
 
-  CODE int (*tick_setttimeout)(FAR struct timer_lowerhalf_s *lower,
+  CODE int (*tick_settimeout)(FAR struct timer_lowerhalf_s *lower,
                                uint32_t timeout);
 
   /* Get the maximum supported tick timeout value */
@@ -276,12 +276,12 @@ static inline
 int timer_settimeout(FAR struct timer_lowerhalf_s *lower,
                      uint32_t timeout)
 {
-  if (lower->ops->tick_setttimeout == NULL)
+  if (lower->ops->tick_settimeout == NULL)
     {
       return -ENOTSUP;
     }
 
-  return lower->ops->tick_setttimeout(lower, USEC2TICK(timeout));
+  return lower->ops->tick_settimeout(lower, USEC2TICK(timeout));
 }
 
 static inline


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change renames the incorrectly spelled timeout-related identifier
`tick_settimeouot` to the correct spelling `tick_settimeout`.

## Impact

- No functional behavior changes are introduced.
- No API semantics are altered; only the identifier name is corrected.
- No impact on the build process, hardware support, or security.


## Testing

- Built the kernel and applications successfully with the rename.
- Performed local testing on the target board (describe board here, if
  applicable).
- Verified that scheduler timeout behavior remains unchanged.
- No regressions observed in relevant tests that exercise tick timeout
  functionality.
