### PR TITLE
timer: add timer operation support

### DIFF
--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -325,6 +325,24 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       }
       break;
 
+    case TCIOC_TICK_GETSTATUS:
+      {
+        FAR struct timer_status_s *status;
+
+        /* Get the current timer status */
+
+        status = (FAR struct timer_status_s *)((uintptr_t)arg);
+        if (status)
+          {
+            ret = TIMER_TICK_GETSTATUS(lower, status);
+          }
+        else
+          {
+            ret = -EINVAL;
+          }
+      }
+      break;
+
     /* cmd:         TCIOC_SETTIMEOUT
      * Description: Reset the timeout to this value
      * Argument:    A 32-bit timeout value in microseconds.
@@ -338,6 +356,22 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         /* Set a new timeout value (and reset the timer) */
 
         ret = TIMER_SETTIMEOUT(lower, (uint32_t)arg);
+      }
+      break;
+
+    /* cmd:         TCIOC_TICK_SETTIMEOUT
+     * Description: Reset the timeout to this value
+     * Argument:    A 32-bit timeout value in ticks.
+     *
+     * TODO: pass pointer to uint64 ns? Need to determine if these timers
+     * are 16 or 32 bit...
+     */
+
+    case TCIOC_TICK_SETTIMEOUT:
+      {
+        /* Set a new timeout value (and reset the timer) */
+
+        ret = TIMER_TICK_SETTIMEOUT(lower, (uint32_t)arg);
       }
       break;
 
@@ -374,6 +408,19 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         /*  Get the maximum supported timeout value */
 
         ret = TIMER_MAXTIMEOUT(lower, (FAR uint32_t *)arg);
+      }
+      break;
+
+    /* cmd:         TCIOC_TICK_MAXTIMEOUT
+     * Description: Get the maximum supported timeout value
+     * Argument:    A 32-bit timeout value in ticks.
+     */
+
+    case TCIOC_TICK_MAXTIMEOUT:
+      {
+        /*  Get the maximum supported timeout value */
+
+        ret = TIMER_TICK_MAXTIMEOUT(lower, (FAR uint32_t *)arg);
       }
       break;
 

--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -68,6 +68,13 @@
  *                      struct timer_notify_s.
  * TCIOC_MAXTIMEOUT   - Get the maximum supported timeout value
  *                      Argument: A 32-bit timeout value in microseconds.
+ * TCIOC_TICK_GETSTATUS  - Get the status of the timer.
+ *                         Argument:  A writeable pointer to struct
+ *                         timer_status_s.
+ * TCIOC_TICK_SETTIMEOUT - Reset the timer timeout to this value
+ *                         Argument: A 32-bit timeout value in ticks.
+ * TCIOC_TICK_MAXTIMEOUT - Get the maximum supported timeout value
+ *                         Argument: A 32-bit timeout value in ticks.
  *
  * WARNING: May change TCIOC_SETTIMEOUT to pass pointer to 64bit nanoseconds
  * or timespec structure.
@@ -78,12 +85,15 @@
  * range.
  */
 
-#define TCIOC_START        _TCIOC(0x0001)
-#define TCIOC_STOP         _TCIOC(0x0002)
-#define TCIOC_GETSTATUS    _TCIOC(0x0003)
-#define TCIOC_SETTIMEOUT   _TCIOC(0x0004)
-#define TCIOC_NOTIFICATION _TCIOC(0x0005)
-#define TCIOC_MAXTIMEOUT   _TCIOC(0x0006)
+#define TCIOC_START           _TCIOC(0x0001)
+#define TCIOC_STOP            _TCIOC(0x0002)
+#define TCIOC_GETSTATUS       _TCIOC(0x0003)
+#define TCIOC_SETTIMEOUT      _TCIOC(0x0004)
+#define TCIOC_NOTIFICATION    _TCIOC(0x0005)
+#define TCIOC_MAXTIMEOUT      _TCIOC(0x0006)
+#define TCIOC_TICK_GETSTATUS  _TCIOC(0x0007)
+#define TCIOC_TICK_SETTIMEOUT _TCIOC(0x0008)
+#define TCIOC_TICK_MAXTIMEOUT _TCIOC(0x0009)
 
 /* Bit Settings *************************************************************/
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change introduces timer operation support in the kernel,
providing a basic API. The new operations enable consistent timer
handling for kernel modules and drivers that depend on timing services.

## Impact

- Adds timer operation interfaces without altering existing APIs.
- No functional regressions are expected.
- No changes to existing build, hardware support, or security.

## Testing

Built and exercised on a target platform with continuous timer
callbacks. Verified that timers can be registered, started, stopped,
and callback functions are invoked as expected. No regressions seen in
related tests.
