### PR TITLE
Rpmsg port uart: add low power support for rpmsg port uart

### DIFF
--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -723,6 +723,31 @@ void rpmsg_port_queue_add_buffer(FAR struct rpmsg_port_queue_s *queue,
 }
 
 /****************************************************************************
+ * Name: rpmsg_port_drop_packets
+ ****************************************************************************/
+
+void rpmsg_port_drop_packets(FAR struct rpmsg_port_s *rport, uint8_t type)
+{
+  FAR struct rpmsg_port_header_s *hdr;
+
+  if (type & RPMSG_PORT_DROP_TXQ)
+    {
+      while (!!(hdr = rpmsg_port_queue_get_buffer(&rport->txq, false)))
+        {
+          rpmsg_port_queue_return_buffer(&rport->txq, hdr);
+        }
+    }
+
+  if (type & RPMSG_PORT_DROP_RXQ)
+    {
+      while (!!(hdr = rpmsg_port_queue_get_buffer(&rport->rxq, false)))
+        {
+          rpmsg_port_queue_return_buffer(&rport->rxq, hdr);
+        }
+    }
+}
+
+/****************************************************************************
  * Name: rpmsg_port_register
  ****************************************************************************/
 

--- a/drivers/rpmsg/rpmsg_port.h
+++ b/drivers/rpmsg/rpmsg_port.h
@@ -38,6 +38,14 @@
 #include <nuttx/rpmsg/rpmsg_port.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RPMSG_PORT_DROP_TXQ     0x01
+#define RPMSG_PORT_DROP_RXQ     0x02
+#define RPMSG_PORT_DROP_ALL     0x03
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -263,6 +271,12 @@ uint16_t rpmsg_port_queue_nused(FAR struct rpmsg_port_queue_s *queue)
 {
   return atomic_read(&queue->ready.num);
 }
+
+/****************************************************************************
+ * Name: rpmsg_port_drop_packets
+ ****************************************************************************/
+
+void rpmsg_port_drop_packets(FAR struct rpmsg_port_s *rport, uint8_t type);
 
 /****************************************************************************
  * Name: rpmsg_port_initialize


### PR DESCRIPTION
## Summary
This PR enhances the RPMSG UART port driver with power management and reliability improvements for inter-processor communication over UART. The changes introduce comprehensive power state management, connection handling, and packet management capabilities.

### 1 Wakeup Support
Added wakeup mechanism to wake peer processors from low power mode, enabling efficient power-managed communication
### 2 Poweroff Handling
Implemented graceful poweroff command support allowing peers to shutdown UART devices and wait for reconnection
### 3 Signal State Management
Enhanced signal handling to reflect suspend/resume states, accessible via rpmsg_get_signals() API
### 4 Packet Drop on Reconnect
Refactored packet dropping logic from port SPI to common port layer, ensuring clean state during peer reconnection.

## Impact
Rpmsg Port Uart/SPI Transport

## Testing
qemu-armv8a:rpserver and rpproxy
```c
❯ qemu-system-aarch64 -cpu cortex-a53 -nographic \
-machine virt,virtualization=on,gic-version=3 \
-chardev stdio,id=con,mux=on -serial chardev:con \
-object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes \
-device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb \
-device virtio-serial-device,bus=virtio-mmio-bus.0 \
-chardev socket,path=/tmp/rpmsg_port_uart_socket,server=on,wait=off,id=foo \
-device virtconsole,chardev=foo \
-mon chardev=con,mode=readline -kernel ./nuttx/cmake_out/v8a_server/nuttx \
-gdb tcp::7775
[    0.000000] [ 0] [  INFO] [server] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=proxy, master=1
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] ivshmem_probe: shmem addr=0x10400000 size=4194304 reg=0x10008000
[    0.000000] [ 3] [  INFO] [server] rptun_ivshmem_probe: shmem addr=0x10400000 size=4194304

NuttShell (NSH) NuttX-12.10.0
server> 
server> 
server> [    0.000000] [ 0] [  INFO] [proxy] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=server, master=0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] ivshmem_probe: shmem addr=0x10400000 size=4194304 reg=0x10008000
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: shmem addr=0x10400000 size=4194304
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: Start the wdog

server> 
server> 
server> 
server> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008160 0001792  21.9%  Idle_Task
    1     0     0 192 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008096 0001344  16.6%  hpwork 0x40475c60 0x40475ce0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008096 0001344  16.6%  lpwork 0x40475d10 0x40475d90
    4     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008096 0002032  25.0%  rptun proxy 0x40495bb8
    5     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008096 0001984  24.5%  rpmsg-uart-rx proxy2 0x404a11f0
    6     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008096 0001968  24.3%  rpmsg-uart-tx proxy2 0x404a11f0
    7     7     0 100 FIFO     Task      - Running            0000000000000000 0008128 0004176  51.3%  nsh_main
server> 
server> 
server> 
server> 
server> 
server> 
server> rpmsg dump all
[    0.000000] [ 7] [ EMERG] [server] Remote: proxy2 state: 1
[    0.000000] [ 7] [ EMERG] [server] ept NS
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue RX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue TX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
server> rpmsg ping all 1 1 1 1 
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 2024, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 19960144 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 19960144 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 19960144 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.006813 Mbits/sec
server> rptun ping all 1 1 1 1
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 2032, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 11192240 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 11192240 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 11192240 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.012151 Mbits/sec
server> 
server> rptun dump all
[    0.000000] [ 7] [ EMERG] [server] Remote: proxy headrx 8
[    0.000000] [ 7] [ EMERG] [server] Dump rpmsg info between cpu (master: yes)server <==> proxy:
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq RX:
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq TX:
[    0.000000] [ 7] [ EMERG] [server]   rpmsg ept list:
[    0.000000] [ 7] [ EMERG] [server]     ept NS
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-syslog
[    0.000000] [ 7] [ EMERG] [server]   rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server]     RX buffer, total 8, pending 0
[    0.000000] [ 7] [ EMERG] [server]     TX buffer, total 8, pending 0
server> 
server> uname -a
NuttX server 12.10.0 171b8039298 Jan  8 2026 20:08:00 arm64 qemu-armv8a
```
