### PR TITLE
fs/inode: using file_allocate and file_dup to avoid racecondition to allocate new fd

### DIFF
--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -350,18 +350,24 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
   int ret;
   int fd;
 
-  fd = file_allocate(oflags, 0, &mq);
-  if (fd < 0)
+  mq = file_allocate();
+  if (mq == NULL)
     {
-      return fd;
+      return -ENOMEM;
     }
 
   ret = file_mq_vopen(mq, mq_name, oflags, getumask(), ap, &created);
-  file_put(mq);
   if (ret < 0)
     {
-      nx_close(fd);
+      file_deallocate(mq);
       return ret;
+    }
+
+  fd = file_dup(mq, 0, oflags);
+  if (fd < 0)
+    {
+      file_close(mq);
+      file_deallocate(mq);
     }
 
   return fd;

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1036,59 +1036,6 @@ int fdlist_dupfile(FAR struct fdlist *list, int oflags, int minfd,
                    FAR struct file *filep);
 
 /****************************************************************************
- * Name: fdlist_allocate
- *
- * Description:
- *   Allocate a struct fd instance and associate it with an empty file
- *   instance. The difference between this function and
- *   file_allocate_from_inode is that this function is only used for
- *   placeholder purposes. Later, the caller will initialize the file entity
- *   through the returned filep.
- *
- *   The fd allocated by this function can be released using fdlist_close.
- *
- *   After the function call is completed, it will hold a reference count
- *   for the filep. Therefore, when the filep is no longer in use, it is
- *   necessary to call file_put to release the reference count, in order
- *   to avoid a race condition where the file might be closed during
- *   this process.
- *
- * Returned Value:
- *   Returns the file descriptor == index into the files array on success;
- *   a negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int fdlist_allocate(FAR struct fdlist *list, int oflags,
-                    int minfd, FAR struct file **filep);
-
-/****************************************************************************
- * Name: file_allocate
- *
- * Description:
- *   Allocate a struct fd instance and associate it with an empty file
- *   instance. The difference between this function and
- *   file_allocate_from_inode is that this function is only used for
- *   placeholder purposes. Later, the caller will initialize the file entity
- *   through the returned filep.
- *
- *   The fd allocated by this function can be released using nx_close.
- *
- *   After the function call is completed, it will hold a reference count
- *   for the filep. Therefore, when the filep is no longer in use, it is
- *   necessary to call file_put to release the reference count, in order
- *   to avoid a race condition where the file might be closed during
- *   this process.
- *
- * Returned Value:
- *   Returns the file descriptor == index into the files array on success;
- *   a negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int file_allocate(int oflags, int minfd, FAR struct file **filep);
-
-/****************************************************************************
  * Name: file_allocate_from_inode
  *
  * Description:
@@ -1263,6 +1210,26 @@ int fdlist_open(FAR struct fdlist *list,
  ****************************************************************************/
 
 int nx_open(FAR const char *path, int oflags, ...);
+
+/****************************************************************************
+ * Name: file_allocate
+ *
+ * Description:
+ *   Allocate a file instance and return
+ *
+ ****************************************************************************/
+
+FAR struct file *file_allocate(void);
+
+/****************************************************************************
+ * Name: file_deallocate
+ *
+ * Description:
+ *   Free a file instance.
+ *
+ ****************************************************************************/
+
+void file_deallocate(FAR struct file *filep);
 
 /****************************************************************************
  * Name: file_get2


### PR DESCRIPTION
## Summary

issue description:
task A:                                            NSH:
1.open->                                           reboot->sync->task_fsfsync
2.nx_vopen->               context switch
3.fdlist_allocate:            ---->                4.fsync->file_sync->assert(inode or priv is empty)
(new fd with empty filep)
5.file_vopen:
(init empty filep)
6.return fd

Task A allocates a new fd with an empty filep in fdlist_allocate. Before it can fully initialize the filep in file_vopen, the NSH task triggers a file - system sync operation. The sync operation encounters the empty filep associated with the newly allocated fd, causing the assertion to fail and the system to crash.

To resolve this race condition, we should modify the fd allocation process. Instead of allocating a new fd with an empty filep first and then initializing it later, we should use the file_allocate_from_inode function. This function allows us to initialize the file structure first and then bind it to the new filep when allocating the fd. By doing so, we ensure that the filep is always properly initialized before it is used in any file - system operations, thus preventing the assertion failure and the subsequent system crash.
