### PR TITLE
drivers/sensors: add get_info interface for gnss_uorb

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -110,6 +110,9 @@ static int gnss_set_interval(FAR struct sensor_lowerhalf_s *lower,
                              FAR uint32_t *interval);
 static int gnss_control(FAR struct sensor_lowerhalf_s *lower,
                         FAR struct file *filep, int cmd, unsigned long arg);
+static int gnss_get_info(FAR struct sensor_lowerhalf_s *lower,
+                         FAR struct file *filep,
+                         FAR struct sensor_device_info_s *info);
 
 static int     gnss_open(FAR struct file *filep);
 static int     gnss_close(FAR struct file *filep);
@@ -131,6 +134,7 @@ static const struct sensor_ops_s g_gnss_sensor_ops =
   .activate     = gnss_activate,
   .set_interval = gnss_set_interval,
   .control      = gnss_control,
+  .get_info     = gnss_get_info,
 };
 
 static const struct file_operations g_gnss_fops =
@@ -203,6 +207,21 @@ static int gnss_set_interval(FAR struct sensor_lowerhalf_s *lower,
     }
 
   return upper->lower->ops->set_interval(upper->lower, filep, interval);
+}
+
+static int gnss_get_info(FAR struct sensor_lowerhalf_s *lower,
+                         FAR struct file *filep,
+                         FAR struct sensor_device_info_s *info)
+{
+  FAR struct gnss_sensor_s *dev = (FAR struct gnss_sensor_s *)lower;
+  FAR struct gnss_upperhalf_s *upper = dev->upper;
+
+  if (upper->lower->ops->get_info == NULL)
+    {
+      return -ENOTSUP;
+    }
+
+  return upper->lower->ops->get_info(upper->lower, filep, info);
 }
 
 static int gnss_control(FAR struct sensor_lowerhalf_s *lower,

--- a/include/nuttx/sensors/gnss.h
+++ b/include/nuttx/sensors/gnss.h
@@ -28,6 +28,7 @@
  ****************************************************************************/
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/sensors/sensor.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -98,6 +99,28 @@ struct gnss_ops_s
   CODE int (*set_interval)(FAR struct gnss_lowerhalf_s *lower,
                            FAR struct file *filep,
                            FAR uint32_t *period_us);
+
+  /**************************************************************************
+   * Name: get_info
+   *
+   * With this method, the user can obtain information about the current
+   * device. The name and vendor information cannot exceed
+   * SENSOR_INFO_NAME_SIZE.
+   *
+   * Input Parameters:
+   *   lower   - The instance of lower half sensor driver.
+   *   filep   - The pointer of file, represents each user using sensor.
+   *   info    - Device information structure pointer.
+   *
+   * Returned Value:
+   *   Zero (OK) on success; a negated errno value on failure.
+   *   -ENOTTY - The cmd don't support.
+   *
+   **************************************************************************/
+
+  CODE int (*get_info)(FAR struct gnss_lowerhalf_s *lower,
+                       FAR struct file *filep,
+                       FAR struct sensor_device_info_s *info);
 
   /**************************************************************************
    * Name: control


### PR DESCRIPTION
## Summary

Implement gnss_get_info callback function to support device information query for GNSS sensor devices through the sensor framework.

## Impact

Completes the sensor operation interface defined in g_gnss_sensor_ops

## Testing

 Code compiles without warnings
 Follows NuttX coding style and conventions
 Tested with GNSS hardware that implements get_info operation
 Verified proper error handling when operation is not supported
