### PR TITLE
net/route: need clear old cached route info when do reset cache

### DIFF
--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -400,6 +400,7 @@ static void net_reset_ipv4_cache(void)
 
   for (i = 0; i < CONFIG_ROUTE_MAX_IPv4_CACHEROUTES; i++)
     {
+      memset(&g_prealloc_ipv4cache[i], 0, sizeof(g_prealloc_ipv4cache[i]));
       net_add_newest_ipv4(&g_prealloc_ipv4cache[i]);
     }
 }
@@ -417,6 +418,7 @@ static void net_reset_ipv6_cache(void)
 
   for (i = 0; i < CONFIG_ROUTE_MAX_IPv6_CACHEROUTES; i++)
     {
+      memset(&g_prealloc_ipv6cache[i], 0, sizeof(g_prealloc_ipv6cache[i]));
       net_add_newest_ipv6(&g_prealloc_ipv6cache[i]);
     }
 }


### PR DESCRIPTION
When do net_flushcache_ip4/6, it may have old info at that time.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Just read the code, and this is something need to be fixed.

## Impact
Without set the memory to 0, it may have old dirty route info which already updated.

## Testing

do route configure.

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
