### PR TITLE
style: Fix case statement formatting in power management callbacks.

### DIFF
--- a/boards/arm/at32/at32f437-mini/src/at32_userleds.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_userleds.c
@@ -96,7 +96,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -104,7 +104,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -112,13 +112,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/efm32/efm32-g8xx-stk/src/efm32_userleds.c
+++ b/boards/arm/efm32/efm32-g8xx-stk/src/efm32_userleds.c
@@ -95,25 +95,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_userleds.c
+++ b/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_userleds.c
@@ -95,25 +95,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_userleds.c
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_userleds.c
@@ -97,7 +97,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -105,7 +105,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -113,13 +113,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_userleds.c
+++ b/boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_userleds.c
@@ -99,7 +99,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -107,7 +107,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -115,13 +115,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp2040/w5500-evb-pico/src/rp2040_userleds.c
+++ b/boards/arm/rp2040/w5500-evb-pico/src/rp2040_userleds.c
@@ -97,7 +97,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -105,7 +105,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -113,13 +113,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_userleds.c
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_userleds.c
@@ -94,7 +94,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -102,7 +102,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -110,13 +110,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_userleds.c
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_userleds.c
@@ -94,7 +94,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -102,7 +102,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -110,13 +110,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/rp23xx/xiao-rp2350/src/rp23xx_userleds.c
+++ b/boards/arm/rp23xx/xiao-rp2350/src/rp23xx_userleds.c
@@ -94,7 +94,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case (PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -102,7 +102,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -110,13 +110,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case (PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/samd5e5/metro-m4/src/sam_autoleds.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_autoleds.c
@@ -123,25 +123,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/samd5e5/metro-m4/src/sam_userleds.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_userleds.c
@@ -105,25 +105,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/samd5e5/same54-xplained-pro/src/sam_autoleds.c
+++ b/boards/arm/samd5e5/same54-xplained-pro/src/sam_autoleds.c
@@ -120,25 +120,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/samd5e5/same54-xplained-pro/src/sam_userleds.c
+++ b/boards/arm/samd5e5/same54-xplained-pro/src/sam_userleds.c
@@ -103,25 +103,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/cloudctrl/src/stm32_autoleds.c
+++ b/boards/arm/stm32/cloudctrl/src/stm32_autoleds.c
@@ -262,25 +262,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/fire-stm32v2/src/stm32_autoleds.c
+++ b/boards/arm/stm32/fire-stm32v2/src/stm32_autoleds.c
@@ -246,25 +246,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/nucleo-f401re/src/stm32_userleds.c
+++ b/boards/arm/stm32/nucleo-f401re/src/stm32_userleds.c
@@ -86,25 +86,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/nucleo-f410rb/src/stm32_userleds.c
+++ b/boards/arm/stm32/nucleo-f410rb/src/stm32_userleds.c
@@ -85,25 +85,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/nucleo-f411re/src/stm32_userleds.c
+++ b/boards/arm/stm32/nucleo-f411re/src/stm32_userleds.c
@@ -86,25 +86,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/omnibusf4/src/stm32_userleds.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_userleds.c
@@ -97,25 +97,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/shenzhou/src/stm32_autoleds.c
+++ b/boards/arm/stm32/shenzhou/src/stm32_autoleds.c
@@ -262,25 +262,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/stm3210e-eval/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm3210e-eval/src/stm32_lcd.c
@@ -1135,7 +1135,7 @@ static void stm3210e_pm_notify(struct pm_callback_s *cb, int domain,
 
   switch (pmstate)
     {
-      case (PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LCD operation */
 
@@ -1152,7 +1152,7 @@ static void stm3210e_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Reduce LCD light */
 
@@ -1172,7 +1172,7 @@ static void stm3210e_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Turn display backlight off */
 
@@ -1182,7 +1182,7 @@ static void stm3210e_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Turn off LCD */
 

--- a/boards/arm/stm32/stm3210e-eval/src/stm32_leds.c
+++ b/boards/arm/stm32/stm3210e-eval/src/stm32_leds.c
@@ -258,25 +258,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/stm32f401rc-rs485/src/stm32_userleds.c
+++ b/boards/arm/stm32/stm32f401rc-rs485/src/stm32_userleds.c
@@ -96,25 +96,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_userleds.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_userleds.c
@@ -95,25 +95,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_userleds.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_userleds.c
@@ -96,25 +96,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/src/stm32_userleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/src/stm32_userleds.c
@@ -85,25 +85,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/src/stm32_userleds.c
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/src/stm32_userleds.c
@@ -85,25 +85,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_userleds.c
+++ b/boards/arm/stm32h7/linum-stm32h753bi/src/stm32_userleds.c
@@ -98,25 +98,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_userleds.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_userleds.c
@@ -85,25 +85,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32l4/nucleo-l452re/src/stm32_userleds.c
+++ b/boards/arm/stm32l4/nucleo-l452re/src/stm32_userleds.c
@@ -86,25 +86,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_userleds.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_userleds.c
@@ -85,25 +85,25 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_buttons.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_buttons.c
@@ -103,7 +103,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal buttons operation
            * XXX turn on any GPIO
@@ -111,7 +111,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - buttons
            * XXX turn on any GPIO
@@ -119,7 +119,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here
            * XXX turn off any GPIO
@@ -127,7 +127,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here
            * XXX turn off any GPIO

--- a/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_userleds.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_userleds.c
@@ -85,7 +85,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -99,7 +99,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -108,7 +108,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
 
@@ -117,7 +117,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_buttons.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_buttons.c
@@ -103,7 +103,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal buttons operation
            * XXX turn on any GPIO
@@ -111,7 +111,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - buttons
            * XXX turn on any GPIO
@@ -119,7 +119,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here
            * XXX turn off any GPIO
@@ -127,7 +127,7 @@ static void button_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here
            * XXX turn off any GPIO

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_userleds.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_userleds.c
@@ -85,7 +85,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -99,7 +99,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -108,7 +108,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
 
@@ -117,7 +117,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
 

--- a/boards/arm/stm32wb/nucleo-wb55rg/src/stm32_userleds.c
+++ b/boards/arm/stm32wb/nucleo-wb55rg/src/stm32_userleds.c
@@ -84,13 +84,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case(PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
         }
         break;
 
-      case(PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -99,7 +99,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
 
@@ -108,7 +108,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case(PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
 

--- a/boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_userleds.c
+++ b/boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_userleds.c
@@ -94,7 +94,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
 {
   switch (pmstate)
     {
-      case (PM_NORMAL):
+      case PM_NORMAL:
         {
           /* Restore normal LEDs operation */
 
@@ -102,7 +102,7 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_IDLE):
+      case PM_IDLE:
         {
           /* Entering IDLE mode - Turn leds off */
 
@@ -110,13 +110,13 @@ static void led_pm_notify(struct pm_callback_s *cb, int domain,
         }
         break;
 
-      case (PM_STANDBY):
+      case PM_STANDBY:
         {
           /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
         }
         break;
 
-      case (PM_SLEEP):
+      case PM_SLEEP:
         {
           /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
         }

--- a/tools/rp2040/make_flash_fs.c
+++ b/tools/rp2040/make_flash_fs.c
@@ -126,13 +126,27 @@ void put_name(const char * cp)
     {
       switch (*cp)
         {
-          case '\"': printf("\\\""); break;
-          case '\'': printf("\\\'"); break;
-          case '\\': printf("\\\\"); break;
-          case '\a': printf("\\a");  break;
-          case '\b': printf("\\b");  break;
-          case '\n': printf("\\n");  break;
-          case '\t': printf("\\t");  break;
+          case '\"':
+            printf("\\\"");
+            break;
+          case '\'':
+            printf("\\\'");
+            break;
+          case '\\':
+            printf("\\\\");
+            break;
+          case '\a':
+            printf("\\a");
+            break;
+          case '\b':
+            printf("\\b");
+            break;
+          case '\n':
+            printf("\\n");
+            break;
+          case '\t':
+            printf("\\t");
+            break;
           default:
             if (iscntrl(*cp))
               {


### PR DESCRIPTION
## Summary

Fix checkpatch style violations by removing unnecessary parentheses around case labels in switch statements for power management callback functions across multiple board-specific LED and LCD drivers.

## Impact

- Impact on user: NO - Pure style fix, no functional changes
- Impact on build: NO - Only formatting changes
- Impact on hardware: NO
- Impact on documentation: NO
- Impact on security: NO
- Impact on compatibility: NO

## Testing

Verified `./tools/checkpatch.sh -` on staged changes passes:
```
✔️ All checks pass.
```

Modified 38 files:
- 37 board-specific LED/LCD drivers (`boards/arm/*`, `boards/risc-v/*`)
- 1 tool script (`tools/rp2040/make_flash_fs.c`)
