### PR TITLE
libs/libc/ftok: fix sizeof(char *), after tempbuffer

### DIFF
--- a/libs/libc/misc/lib_ftok.c
+++ b/libs/libc/misc/lib_ftok.c
@@ -72,7 +72,7 @@ key_t ftok(FAR const char *pathname, int proj_id)
 
   snprintf(fullpath, PATH_MAX, "%s/",
            CONFIG_LIBC_FTOK_VFS_PATH);
-  strlcat(fullpath, pathname, sizeof(fullpath));
+  strlcat(fullpath, pathname, PATH_MAX);
   if (stat(fullpath, &st) < 0 && get_errno() == ENOENT)
     {
       /* Directory not exist, let's create one for caller */


### PR DESCRIPTION
Catched by coverity, we change full path from stack variable to ptr.