### PR TITLE
libs/libc/ftok: fix sizeof(char *), after tempbuffer

### DIFF
--- a/libs/libc/misc/lib_ftok.c
+++ b/libs/libc/misc/lib_ftok.c
@@ -72,7 +72,7 @@ key_t ftok(FAR const char *pathname, int proj_id)
 
   snprintf(fullpath, PATH_MAX, "%s/",
            CONFIG_LIBC_FTOK_VFS_PATH);
-  strlcat(fullpath, pathname, sizeof(fullpath));
+  strlcat(fullpath, pathname, PATH_MAX);
   if (stat(fullpath, &st) < 0 && get_errno() == ENOENT)
     {
       /* Directory not exist, let's create one for caller */


### PR DESCRIPTION
## Summary

Catched by coverity, change full path from stack variable to ptr.

## Impact

Previously used sizeof(fullpath) which returns pointer size instead of actual buffer size PATH_MAX, leading to incorrect path generation. This pr can correctly handle filepath.

## Testing

Created message queues using ftok() with long paths and verified that different long paths generate distinct keys

```c
int main(void)
{
    key_t msgq_key = ftok("mytestapp", 'A');
    if (msgq_key == (key_t)-1) {
        perror("ftok failed");
        return 1;
    }
    return 0;
}
``` 
before: 
[ftok DEBUG] fullpath = /var/ftok/
after:
[ftok DEBUG] fullpath = /var/ftok/mytestapp