### PR TITLE
arch/arm/samv7: fix incorrect Kconfig SAMV7_EMAC0_RMII dependency

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -3258,7 +3258,6 @@ config SAMV7_EMAC0_MII
 
 config SAMV7_EMAC0_RMII
 	bool "RMII"
-	depends on !ARCH_CHIP_SAM4E
 	---help---
 		Support Ethernet RMII interface (vs MII).
 


### PR DESCRIPTION
## Summary
`SAMV7_EMAC0_RMII` should not depend on `ARCH_CHIP_SAM4E` as this is a completely different chip. This is likely a relict from copying the code base.

## Impact

None as `ARCH_CHIP_SAM4E` can't be set anyway if SAMv7 chip is used.
