### PR TITLE
drivers/net: fix igc build error

### DIFF
--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -652,7 +652,7 @@ static FAR netpkt_t *igc_receive(FAR struct netdev_lowerhalf_s *dev)
   if (rx->errors)
     {
       nerr("RX error reported (%"PRIu8")\n", rx->errors);
-      NETDEV_RXERRORS(&priv->dev);
+      NETDEV_RXERRORS(&priv->dev.netdev);
       netpkt_free(dev, pkt, NETPKT_RX);
       return NULL;
     }
@@ -691,7 +691,7 @@ static void igc_txdone(FAR struct netdev_lowerhalf_s *dev)
       if (!(priv->tx[priv->tx_done].status & IGC_TDESC_STATUS_DD))
         {
           nerr("tx failed: 0x%" PRIx32 "\n", priv->tx[priv->tx_done].status);
-          NETDEV_TXERRORS(priv->dev);
+          NETDEV_TXERRORS(&priv->dev.netdev);
         }
 
       /* Free net packet */


### PR DESCRIPTION
## Summary
otherwise, enable CONFIG_NETDEV_STATISTICS will result in a compile error.

## Impact
igc network device driver.

## Testing
local intel board, verified the compile.

