### PR TITLE
github/build.yml: fix python venv installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,10 +192,9 @@ jobs:
           BLOBDIR: /tools/blobs
         with:
           run: |
-            # install venv
+            # install python venv
             apt-get update
-            apt install -y python3-dev
-            apt install -y python3-venv
+            apt-get install -y python3 python3-dev python3-venv
 
             # get NTFC sources
             git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-ntfc


### PR DESCRIPTION
## Summary  
install venv package in one command to avoid issues with ubuntu mirrors

fix for apps here: https://github.com/apache/nuttx-apps/pull/3311
    
## Impact
fix broken CI after the python3.10-venv package was updated in ubuntu mirrors

## Testing
CI

venv installed successfully:
https://github.com/apache/nuttx/actions/runs/20917293948/job/60094100146#step:10:207

<img width="1234" height="308" alt="image" src="https://github.com/user-attachments/assets/e6553a80-ffad-4861-9def-65794132081b" />

