### PR TITLE
if_ether.h: add the definition of ETH_P_TSN

### DIFF
--- a/include/netinet/if_ether.h
+++ b/include/netinet/if_ether.h
@@ -50,6 +50,7 @@
 #define ETH_P_IP    ETHERTYPE_IP
 #define ETH_P_IPV6  ETHERTYPE_IPV6
 #define ETH_P_ARP   ETHERTYPE_ARP
+#define ETH_P_TSN   0x22F0  /* TSN (IEEE 1722) packet */
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary
add macro definitions used by third-party libraries to resolve compilation errors.

## Impact
include/netinet/if_ether.h

## Testing
sim:matter with Open1722 library.
