### PR TITLE
nuttx/sched: fix bug about task exit

### DIFF
--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -86,7 +86,7 @@ static void addrenv_destroy(FAR void *arg)
 
   /* Then finally release the memory */
 
-  kmm_free(addrenv);
+  kmm_delayfree(addrenv);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

When a task exits, the memory should be released later, otherwise task may continues try  get mutex, this moment task'state is already inactive.

```c
nxtask_exit() ->
   nxsched_release_tcb() ->
      addrenv_leave() ->
           addrenv_destroy() ->
               kmm_free()
``` 

## Impact

optimization task exit process when system enable addrenv

## Testing
Just test it when task exit.
