### PR TITLE
libs/libcxx: port for Infineon TASKING compiler.

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -104,6 +104,7 @@ config LIBCXXABI_VERSION
 
 config CXX_STANDARD
 	string "Language standard"
+	default "c++14"   if TRICORE_TOOLCHAIN_TASKING
 	default "gnu++20" if LIBCXX
 	default "gnu++17" if !LIBCXX
 	---help---

--- a/libs/libxx/libcxx/CMakeLists.txt
+++ b/libs/libxx/libcxx/CMakeLists.txt
@@ -91,12 +91,29 @@ if(CONFIG_LIBCXX)
   endif()
 
   file(GLOB SRCS ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/*.cpp)
-  file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/experimental/*.cpp)
-  list(APPEND SRCS ${SRCSTMP})
-  file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/filesystem/*.cpp)
-  list(APPEND SRCS ${SRCSTMP})
-  file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/ryu/*.cpp)
-  list(APPEND SRCS ${SRCSTMP})
+
+  string(REGEX MATCH "[0-9]+$" CPP_STD_VER "${CONFIG_CXX_STANDARD}")
+  if(${CPP_STD_VER} GREATER_EQUAL 20)
+    file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/experimental/*.cpp)
+    list(APPEND SRCS ${SRCSTMP})
+    file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/filesystem/*.cpp)
+    list(APPEND SRCS ${SRCSTMP})
+    file(GLOB SRCSTMP ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/ryu/*.cpp)
+    list(APPEND SRCS ${SRCSTMP})
+  endif()
+
+  if(${CPP_STD_VER} LESS_EQUAL 14)
+    file(
+      GLOB
+      SRCSTMP
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/any.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/variant.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/optional.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/memory_resource.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/pstl/*.cpp
+      ${CMAKE_CURRENT_LIST_DIR}/libcxx/src/legacy_debug_handler.cpp)
+    list(REMOVE_ITEM SRCS ${SRCSTMP})
+  endif()
 
   if(NOT CONFIG_CXX_LOCALIZATION)
     file(
@@ -111,8 +128,10 @@ if(CONFIG_LIBCXX)
     list(REMOVE_ITEM SRCS ${SRCSTMP})
   endif()
 
-  set(FLAGS -Wno-attributes -Wno-deprecated-declarations -Wno-shadow
-            -Wno-sign-compare -Wno-cpp)
+  if(NOT CONFIG_TRICORE_TOOLCHAIN_TASKING)
+    set(FLAGS -Wno-attributes -Wno-deprecated-declarations -Wno-shadow
+              -Wno-sign-compare -Wno-cpp)
+  endif()
 
   if(GCCVER GREATER_EQUAL 12)
     list(APPEND FLAGS -Wno-maybe-uninitialized -Wno-alloc-size-larger-than)

--- a/libs/libxx/libcxx/Make.defs
+++ b/libs/libxx/libcxx/Make.defs
@@ -72,9 +72,22 @@ ifeq ($(shell expr "$(GCCVER)" \>= 12), 1)
 endif
 
 CPPSRCS += $(wildcard libcxx/libcxx/src/*.cpp)
-CPPSRCS += $(wildcard libcxx/libcxx/src/experimental/*.cpp)
-CPPSRCS += $(wildcard libcxx/libcxx/src/filesystem/*.cpp)
-CPPSRCS += $(wildcard libcxx/libcxx/src/ryu/*.cpp)
+CPP_STD_VER := $(shell echo $(CONFIG_CXX_STANDARD) | sed -E 's/.*\+\+([0-9]+)$$/\1/')
+ifeq ($(shell [ $(CPP_STD_VER) -ge 20 ] && echo true),true)
+  CPPSRCS += $(wildcard libcxx/libcxx/src/experimental/*.cpp)
+  CPPSRCS += $(wildcard libcxx/libcxx/src/filesystem/*.cpp)
+  CPPSRCS += $(wildcard libcxx/libcxx/src/ryu/*.cpp)
+endif
+
+ifeq ($(shell [ $(CPP_STD_VER) -le 14 ] && echo true),true)
+  EXCLUDE_CPP := libcxx/libcxx/src/any.cpp
+  EXCLUDE_CPP += libcxx/libcxx/src/variant.cpp
+  EXCLUDE_CPP += libcxx/libcxx/src/optional.cpp
+  EXCLUDE_CPP += libcxx/libcxx/src/memory_resource.cpp
+  EXCLUDE_CPP += libcxx/libcxx/src/legacy_debug_handler.cpp
+  EXCLUDE_CPP += $(wildcard libcxx/libcxx/src/pstl/*.cpp)
+  CPPSRCS := $(filter-out $(EXCLUDE_FILES), $(CPPSRCS))
+endif
 
 ifeq ($(CONFIG_CXX_LOCALIZATION),)
   LOCALE_CPPSRCS := libcxx/libcxx/src/ios.cpp


### PR DESCRIPTION
Exclude cpp files beyong c++14 e.g. filesystem/, ryu/, variant.cpp etc.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Update libcxx/CMakeLists.txt to support Infineon TASKING compiler(supports up to c++14).

## Impact

non-TASKING users will not be impacted.

## Testing

CI test.
