### PR TITLE
libcxxabi: It is impossible to open libsupcxx/libsupcxx_toolchian in …

### DIFF
--- a/libs/libxx/libcxxabi/CMakeLists.txt
+++ b/libs/libxx/libcxxabi/CMakeLists.txt
@@ -77,13 +77,7 @@ if(CONFIG_LIBCXXABI)
     cxa_vector.cpp
     cxa_virtual.cpp)
   add_compile_definitions(_LIBCPP_BUILDING_LIBRARY)
-  if(CONFIG_LIBSUPCXX_TOOLCHAIN)
-    add_compile_definitions(__GLIBCXX__)
-  endif()
 
-  if(CONFIG_LIBSUPCXX)
-    add_compile_definitions(__GLIBCXX__)
-  endif()
   # C++ STL files
   list(APPEND SRCS stdlib_exception.cpp stdlib_new_delete.cpp
        stdlib_stdexcept.cpp stdlib_typeinfo.cpp)


### PR DESCRIPTION
…Cmake of libcxxabi, so remove the relevant judgment.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

It's impossible to use gcc's libsupc++ library in libcxxabi.

## Impact

Null.

## Testing

CI test.
