### PR TITLE
libs/libxx: libcxxabi script updates

### DIFF
--- a/libs/libxx/libcxxabi/CMakeLists.txt
+++ b/libs/libxx/libcxxabi/CMakeLists.txt
@@ -77,6 +77,7 @@ if(CONFIG_LIBCXXABI)
     cxa_vector.cpp
     cxa_virtual.cpp)
   add_compile_definitions(_LIBCPP_BUILDING_LIBRARY)
+  add_compile_definitions(LIBCXXABI_BAREMETAL)
 
   # C++ STL files
   list(APPEND SRCS stdlib_exception.cpp stdlib_new_delete.cpp

--- a/libs/libxx/libcxxabi/Make.defs
+++ b/libs/libxx/libcxxabi/Make.defs
@@ -86,6 +86,7 @@ ifeq ($(CONFIG_ARCH_ARM),y)
 endif
 
 CXXFLAGS += -DLIBCXXABI_NON_DEMANGLING_TERMINATE
+CXXFLAGS += -DLIBCXXABI_BAREMETAL
 
 DEPPATH += --dep-path libcxxabi/libcxxabi/src
 VPATH += libcxxabi/libcxxabi/src


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This relation chain contains below libcxxabi scripts updates:
1) remove duplicate definition for _URC_FAILURE
2) remove gcc's libsupcxx because it's impossible to apply libsupcxx in libcxxabi
3) port libcxxabi with Infineon TASKING compiler
4) always enable LIBCXXABI_BAREMETAL for libcxxabi

## Impact

Null.

## Testing

CI test.
