### PR TITLE
include/sys: extend the IOCTL defintion that compatible with linux kernel

### DIFF
--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -68,6 +68,13 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* The compatibility IOCTL definitions */
+
+#define _IO(type,nr)        _IOC((type),(nr))
+
+#define FS_IOC_GETFLAGS     FIOC_GETFLAGS
+#define FS_IOC_SETFLAGS     FIOC_SETFLAGS
+
 #undef EXTERN
 #if defined(__cplusplus)
 #define EXTERN extern "C"


### PR DESCRIPTION
## Summary

Extended the ioctl.h header to add Linux kernel-compatible macro definitions:
1. Added the _IO(type, nr) macro as a direct mapping to _IOC()
2. Introduced FS_IOC_GETFLAGS and FS_IOC_SETFLAGS macros aliased to existing FIOC_GETFLAGS and FIOC_SETFLAGS

## Impact

Enables easier porting of LTP linux kernel testcases code to NuttX without modifying ioctl command definitions

## Testing

1. Verified compilation with existing codebase to ensure no regression
