### PR TITLE
libs/libs: fix wqueue config typo

### DIFF
--- a/libs/libc/wqueue/CMakeLists.txt
+++ b/libs/libc/wqueue/CMakeLists.txt
@@ -20,6 +20,6 @@
 #
 # ##############################################################################
 
-if(CONFIG_LIB_USRWORK)
+if(CONFIG_LIBC_USRWORK)
   target_sources(c PRIVATE work_usrthread.c work_queue.c work_cancel.c)
 endif()


### PR DESCRIPTION
## Summary

Fix a typo in libs/libc/wqueue/CMakeLists.txt where the condition CONFIG_LIB_USRWORK is corrected to CONFIG_LIBC_USRWORK, ensuring the correct Kconfig symbol is used to enable user work queue source compilation.

## Impact

Enables the correct compilation of user work queue source files (work_usrthread.c, work_queue.c, work_cancel.c) when CONFIG_LIBC_USRWORK is selected in the configuration.

## Testing

Verified that the corrected CMake condition now properly includes the user work queue sources when CONFIG_LIBC_USRWORK=y.

