### PR TITLE
arch/arm: add -ffunction-sections and -fdata-sections compile options

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -147,6 +147,12 @@ if(CONFIG_ARM_THUMB)
   add_compile_options(-thumb)
 endif()
 
+# Optimization of unused sections
+
+if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
+  add_compile_options(-ffunction-sections -fdata-sections)
+endif()
+
 # Debug --whole-archive
 
 if(CONFIG_DEBUG_LINK_WHOLE_ARCHIVE)

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -438,8 +438,8 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),)
   ifeq ($(CONFIG_DEBUG_OPT_UNUSED_SECTIONS),y)
     ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),)
       LDFLAGS          += --gc-sections
-      ARCHOPTIMIZATION += -ffunction-sections -fdata-sections
     endif
+    ARCHOPTIMIZATION += -ffunction-sections -fdata-sections
   endif
 endif
 


### PR DESCRIPTION
## Summary

1. Enable -ffunction-sections and -fdata-sections compiler options for Green Hills (GHS) toolchain builds when CONFIG_DEBUG_OPT_UNUSED_SECTIONS is configured.
2. Adjust Toolchain.defs to apply these optimization flags consistently across all ARM toolchains (outside the GHS exception), improving linker garbage collection behavior.

## Impact

1. Allows Green Hills toolchain users to benefit from section-level dead code elimination, reducing final binary size through linker garbage collection.
2. Ensures uniform optimization behavior across different ARM toolchains (GCC, Clang, GHS) when CONFIG_DEBUG_OPT_UNUSED_SECTIONS is enabled.

## Testing

1. Verified compilation with Green Hills toolchain using CONFIG_DEBUG_OPT_UNUSED_SECTIONS=y to ensure the flags are correctly added.
2. Confirmed that the modified Toolchain.defs does not break existing GCC/Clang builds and still applies the optimization flags as expected.
