### PR TITLE
arch/arm: replace the "-Wall" build option with the "-ghstd=last"

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -60,7 +60,7 @@ endif()
 # Architecture flags
 
 add_link_options(-entry=__start)
-add_compile_options(--no_commons -Wall -Wshadow -Wundef -nostdlib)
+add_compile_options(--no_commons --ghstd=last -Wshadow -Wundef -nostdlib)
 add_compile_options(--option=305)
 
 if(CONFIG_DEBUG_CUSTOMOPT)

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -410,7 +410,14 @@ ARCHOPTIMIZATION += --no_commons
 else
 ARCHOPTIMIZATION += -fno-common
 endif
-ARCHOPTIMIZATION += -Wall -Wshadow -Wundef
+
+ifeq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)
+  ARCHOPTIMIZATION += --ghstd=last
+else
+  ARCHOPTIMIZATION += -Wall
+endif
+
+ARCHOPTIMIZATION += -Wshadow -Wundef
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   ARCHOPTIMIZATION += -nostdlib


### PR DESCRIPTION
## Summary

Update Green Hills (GHS) toolchain warning configuration by replacing the deprecated -Wall flag with the recommended -ghstd=last option in both CMake and Makefile build systems. This change applies only when building with the GHS toolchain, while other toolchains continue to use -Wall.

## Impact

1. Aligns NuttX build configuration with Green Hills compiler best practices and documentation recommendations
2. No impact on other toolchains (GCC, Clang, etc.) which continue to use -Wall

## Testing

1. Verified successful compilation with Green Hills toolchain using the new -ghstd=last flag
2. Confirmed that the change is properly conditionalized and does not affect non-GHS toolchain builds
