### PR TITLE
ghs: move the -fmacro-prefix-map compile option to compiler specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,22 +502,6 @@ if(CONFIG_NDEBUG)
   add_compile_options(-DNDEBUG)
 endif()
 
-# Cmake build provide absolute paths to compile files. If __FILE__ macros are
-# used in the source code(ASSERT), the binary will contain many invalid paths.
-# This saves some memory, stops exposing build systems locations in binaries,
-# make failure logs more deterministic and most importantly makes builds more
-# failure logs more deterministic and most importantly makes builds more
-# deterministic. Debuggers usually have a path mapping feature to ensure the
-# files are still found.
-if(NOT MSVC)
-  if(CONFIG_OUTPUT_STRIP_PATHS)
-    add_compile_options(-fmacro-prefix-map=${NUTTX_DIR}=)
-    add_compile_options(-fmacro-prefix-map=${NUTTX_APPS_DIR}=)
-    add_compile_options(-fmacro-prefix-map=${NUTTX_BOARD_ABS_DIR}=)
-    add_compile_options(-fmacro-prefix-map=${NUTTX_CHIP_ABS_DIR}=)
-  endif()
-endif()
-
 add_definitions(-D__NuttX__)
 
 add_compile_options($<$<COMPILE_LANGUAGE:ASM>:-D__ASSEMBLY__>)

--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -30,6 +30,22 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   endif()
 endif()
 
+# Cmake build provide absolute paths to compile files. If __FILE__ macros are
+# used in the source code(ASSERT), the binary will contain many invalid paths.
+# This saves some memory, stops exposing build systems locations in binaries,
+# make failure logs more deterministic and most importantly makes builds more
+# failure logs more deterministic and most importantly makes builds more
+# deterministic. Debuggers usually have a path mapping feature to ensure the
+# files are still found.
+if((NOT MSVC) AND (NOT CONFIG_ARCH_TOOLCHAIN_GHS))
+  if(CONFIG_OUTPUT_STRIP_PATHS)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_APPS_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_BOARD_ABS_DIR}=)
+    add_compile_options(-fmacro-prefix-map=${NUTTX_CHIP_ABS_DIR}=)
+  endif()
+endif()
+
 # Support CMake to define additional configuration options
 
 if(EXTRA_FLAGS)


### PR DESCRIPTION
## Summary

Move the -fmacro-prefix-map compile option from the common CMake configuration to toolchain‑specific sections, ensuring it is only applied to GCC/Clang/ArmClang toolchains. This prevents Green Hills (GHS) compiler warnings about unrecognized options.

## Impact

1. Eliminates spurious warnings (“Unknown option ‘-fmacro-prefix-map=...’ passed to linker”) when building with the Green Hills toolchain.
2. Maintains the intended build‑path mapping behavior for GCC‑family toolchains (GCC, Clang, ArmClang).
3. No functional change to the generated binaries; only a cleanup of build‑system noise.

## Testing

Verified that GHS builds no longer report warnings about -fmacro-prefix-map.
