### PR TITLE
arm64_head.S: fix the asm code build error

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -37,6 +37,8 @@
  * Type Definitions
  ****************************************************************************/
 
+#ifndef __ASSEMBLY__
+
 /* The <stddef.h> header shall define the following types:
  *
  * ptrdiff_t
@@ -83,5 +85,7 @@ typedef struct
   float max_align_f;
 #endif
 } max_align_t;
+
+#endif /* __ASSEMBLY__ */
 
 #endif /* __INCLUDE_STDDEF_H */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -156,6 +156,8 @@
  * Public Types
  ****************************************************************************/
 
+#ifndef __ASSEMBLY__
+
 /* Exact-width integer types.  NOTE that these types are defined in
  * architecture-specific logic with leading underscore character. This file
  * typedef's these to the final name without the underscore character.  This
@@ -253,6 +255,8 @@ typedef _uint_farptr_t      uint_farptr_t;
 
 typedef _intmax_t           intmax_t;
 typedef _uintmax_t          uintmax_t;
+
+#endif /* __ASSEMBLY__ */
 
 #endif /* CONFIG_ARCH_STDINT_H */
 #endif /* __INCLUDE_STDINT_H */


### PR DESCRIPTION
## Summary

Add #ifndef __ASSEMBLY__ / #endif guards around the C‑language type definitions in include/stddef.h and include/stdint.h to prevent assembly source files (e.g., arm64_head.S) from attempting to parse typedef statements, which triggers “unknown mnemonic” errors during assembly.

## Impact

Fixes assembly‑file build errors where the assembler incorrectly interprets C typedef keywords as assembly instructions.

## Testing

Verified that arm64_head.S (and other assembly files) now compile cleanly without “unknown mnemonic” errors.
