### PR TITLE
signal: add default sigaction for SIGURG

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1671,6 +1671,15 @@ config SIG_SIGPOLL_ACTION
 		Backward compatible behavior would require that the application use
 		sigaction() to ignore SIGPOLL.
 
+config SIG_SIGURG_ACTION
+	bool "SIGURG"
+	default n
+	---help---
+		Enable the default action for SIGURG (ignore the signal)
+		Make sure that your applications are expecting this POSIX behavior.
+		Backward compatible behavior would require that the application use
+		sigaction() to ignore SIGURG.
+
 endif # SIG_DEFAULT
 
 endmenu # Signal Configuration

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -149,6 +149,9 @@ static const struct nxsig_defaction_s g_defactions[] =
 #ifdef CONFIG_SIG_SIGPOLL_ACTION
   { SIGPOLL,   0,                nxsig_abnormal_termination },
 #endif
+#ifdef CONFIG_SIG_SIGURG_ACTION
+  { SIGURG,    0,                nxsig_null_action },
+#endif
 };
 
 #define NACTIONS (sizeof(g_defactions) / sizeof(struct nxsig_defaction_s))


### PR DESCRIPTION
## Summary

Add POSIX‑compliant default signal handling for SIGURG:
1. Introduce CONFIG_SIG_SIGURG_ACTION Kconfig option to enable default SIGURG behavior.
2. Register nxsig_null_action (ignore) as the default action for SIGURG when the option is selected, aligning with the POSIX requirement that SIGURG be ignored by default.

## Impact

1. Makes NuttX signal behavior conform to the POSIX standard for SIGURG.
2. Fixes the failing test case /tset/ANSI.os/signal/signal_X/T.signal_X which expects SIGURG to be ignored by default.
3. Maintains backward compatibility: existing applications that explicitly handle SIGURG are unaffected, and the feature is optional (default n).

## Testing

Verified that the /tset/ANSI.os/signal/signal_X/T.signal_X test case now passes.
