### PR TITLE
ghs: fix the UsageFault:INVSTATE error triggered by exception_common

### DIFF
--- a/arch/arm/src/armv7-m/arm_exception.S
+++ b/arch/arm/src/armv7-m/arm_exception.S
@@ -113,7 +113,7 @@
  */
 
 	.text
-	.section    .text.exception_common
+	.section    .text.exception_common, "ax"
 #ifdef __ghs__
 	.type	exception_common, $function
 #else

--- a/arch/arm/src/common/iar/fork.S
+++ b/arch/arm/src/common/iar/fork.S
@@ -29,7 +29,7 @@
 #include "arm_fork.h"
 
 	MODULE up_fork
-	SECTION .text:CODE:NOROOT(2)
+	SECTION .text:CODE:NOROOT(2), "ax"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/cxd56xx/cxd56_farapistub.S
+++ b/arch/arm/src/cxd56xx/cxd56_farapistub.S
@@ -21,7 +21,7 @@
  ****************************************************************************/
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -193,7 +193,7 @@ _modulelist_power_mgr:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -319,7 +319,7 @@ _modulelist_flash_mgr:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -389,7 +389,7 @@ _modulelist_rtc_mgr:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -551,7 +551,7 @@ _modulelist_gnss_pwr:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -591,7 +591,7 @@ _modulelist_aca:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -631,7 +631,7 @@ _modulelist_pinconfig:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -707,7 +707,7 @@ _modulelist_uart:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}
@@ -783,7 +783,7 @@ _modulelist_update_mgr:
     .word   0
 
     .syntax	unified
-    .section	.text.stub
+    .section	.text.stub, "ax"
     .align	1
 1:
     push    {r0-r3}

--- a/arch/arm/src/moxart/moxart_head.S
+++ b/arch/arm/src/moxart/moxart_head.S
@@ -22,7 +22,7 @@
 
 /* Place a branch to the real head at the entry point */
 
-.section	.text.start
+.section	.text.start, "ax"
 	b	__start
 
 /* Exception Vectors like they are needed for the exception vector
@@ -30,7 +30,7 @@
  * linked to appear at 0x80001c
  */
 
-.section	.text.exceptions
+.section	.text.exceptions, "ax"
 _undef_instr:
 	b	arm_vectorundefinsn
 _sw_interr:

--- a/arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S
+++ b/arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S
@@ -404,7 +404,7 @@ __irq:
 	tjl		tc32_exception
 
 ASMEND:
-	.section	.bss
+	.section	.bss, "aw"
 	.global	g_intstackalloc
 	.global	g_intstacktop
 	.align	4

--- a/arch/arm64/src/imx9/ddr/imx9_ddr_training.c
+++ b/arch/arm64/src/imx9/ddr/imx9_ddr_training.c
@@ -58,7 +58,7 @@
 /* DDR training binaries via incbin */
 
 __asm__ (
-  "   .section .rodata                   \n"
+  "   .section .rodata, \"a\"            \n"
   "   .balign  64                        \n"
   "   .globl   g_dmem1d_begin            \n"
   "g_dmem1d_begin:                       \n"

--- a/boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.c
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    ".section .rodata\n"
+    ".section .rodata, \"a\"\n"
     ".balign  16\n"
     ".globl   romfs_data_begin\n"
 "romfs_data_begin:\n"

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs_initialize.c
@@ -71,7 +71,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_romfs_initialize.c
@@ -71,7 +71,7 @@
  ****************************************************************************/
 
 __asm__ (
-  "   .section .rodata                            \n"
+  "   .section .rodata, \"a\"                     \n"
   "   .balign  16                                 \n"
   "   .globl   romfs_data_begin                   \n"
   "romfs_data_begin:                              \n"

--- a/boards/arm/stm32/omnibusf4/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_romfs_initialize.c
@@ -83,7 +83,7 @@
  ****************************************************************************/
 
 __asm__ (
-    ".section .rodata\n"
+    ".section .rodata, \"a\"\n"
     ".balign  16\n"
     ".globl   romfs_data_begin\n"
 "romfs_data_begin:\n"

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_romfs_initialize.c
@@ -84,7 +84,7 @@
  ****************************************************************************/
 
 __asm__ (
-    ".section .rodata\n"
+    ".section .rodata, \"a\"\n"
     ".balign  16\n"
     ".globl   romfs_data_begin\n"
 "romfs_data_begin:\n"

--- a/boards/arm/stm32f7/common/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32f7/common/src/stm32_romfs_initialize.c
@@ -83,7 +83,7 @@
  ****************************************************************************/
 
 __asm__ (
-    ".section .rodata\n"
+    ".section .rodata, \"a\"\n"
     ".balign  16\n"
     ".globl   romfs_data_begin\n"
 "romfs_data_begin:\n"

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs_initialize.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 __asm__ (
-    "   .section .rodata                            \n"
+    "   .section .rodata, \"a\"                     \n"
     "   .balign  16                                 \n"
     "   .globl   romfs_data_begin                   \n"
     "romfs_data_begin:                              \n"

--- a/libs/libc/machine/arm/armv7-m/arch_memchr.S
+++ b/libs/libc/machine/arm/armv7-m/arch_memchr.S
@@ -136,7 +136,7 @@
  */
 
 	.text
-	.section .text.memchr
+	.section .text.memchr, "ax"
 	.thumb_func
 	.align 4
 	.p2align 4,,15

--- a/libs/libc/machine/arm/armv7-m/arch_memcpy.S
+++ b/libs/libc/machine/arm/armv7-m/arch_memcpy.S
@@ -94,7 +94,7 @@
 
 	.syntax unified
 	.text
-	.section .text.memcpy
+	.section .text.memcpy, "ax"
 	.align	2
 	.global	ARCH_LIBCFUN(memcpy)
 	.thumb

--- a/libs/libc/machine/arm/armv7-m/arch_strcmp.S
+++ b/libs/libc/machine/arm/armv7-m/arch_strcmp.S
@@ -72,7 +72,7 @@
 
 	.macro def_fn f p2align=0
 	.text
-	.section .text.strcmp
+	.section .text.strcmp, "ax"
 	.p2align \p2align
 	.global \f
 	.type \f, %function

--- a/libs/libc/machine/arm/armv7-m/arch_strcpy.S
+++ b/libs/libc/machine/arm/armv7-m/arch_strcpy.S
@@ -60,7 +60,7 @@
 
     .syntax unified
     .text
-    .section .text.strcpy
+    .section .text.strcpy, "ax"
     .align  2
     .global ARCH_LIBCFUN(strcpy)
     .thumb

--- a/libs/libc/machine/arm/armv7-m/arch_strlen.S
+++ b/libs/libc/machine/arm/armv7-m/arch_strlen.S
@@ -70,7 +70,7 @@
 
 	.macro def_fn f p2align=0
 	.text
-	.section .text.strlen
+	.section .text.strlen, "ax"
 	.p2align \p2align
 	.global \f
 	.type \f, %function


### PR DESCRIPTION
## Summary

when we build with greenhills compiler, if the exception_common function is put into a separate section: ".text.exception_common", then the address of exception_common function is an even number, for example "0x16a6c", in this case, it will trigger the UsageFaults:INVSTATE error. The reason for this error is that in the GHS compiler, a section declared through the ".section" directive must specify at least the "a" attribute. Otherwise, this section will not be linked into the final file, and this is why the address of exception_common function is invalid. The following is the official explanation in the GHS compiler documentation: "The reason for this error is that in the GHS compiler, a section declared through the .section directive must specify at least the "a" attribute. Otherwise, this section will not be linked into the final file. The following is the official explanation in the documentation: "Sections that are intended be part of the final linked output should have at least the `a` attribute"
and for GHS compiler, the .text section is recommended specify the attribute of `ax`.

## Impact

1. Fixes runtime UsageFault:INVSTATE errors when using the Green Hills toolchain on ARMv7-M targets.
2. No impact on other toolchains (GCC, Clang, etc.)—the added attributes are compatible with standard ARM assembly syntax.

## Testing

Verified that builds with Green Hills compiler no longer produce UsageFault:INVSTATE errors during exception handling.
