### PR TITLE
arch/arm/cmake: fix the gnu-elf.ld handle error at ghs pre-process

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -219,11 +219,30 @@ function(nuttx_generate_preprocess_target)
     ARGN
     ${ARGN})
 
+  # in greenhills, for file to pre-process, if the file name is ends with
+  # "*.ld", will report error, and we need to change the target file name to
+  # "*.ld.i" or "*.ld.tmp", this is a special corner case, and the official
+  # greenhills reference manual do not have explanation about why the only
+  # "*.ld" should handle
+  set(EXPECT_TARGET_FILE_NAME ${TARGET_FILE})
+  string(REGEX MATCH ".*\.ld$" ends_with_ld ${TARGET_FILE})
+
+  if(ends_with_ld STREQUAL ${TARGET_FILE})
+    set(EXPECT_TARGET_FILE_NAME "${TARGET_FILE}.i")
+  endif()
+
   add_custom_command(
-    OUTPUT ${TARGET_FILE}
+    OUTPUT ${EXPECT_TARGET_FILE_NAME}
     COMMAND ${PREPROCESS} -I${CMAKE_BINARY_DIR}/include -filetype.cpp
-            ${SOURCE_FILE} -o ${TARGET_FILE}
+            ${SOURCE_FILE} -o ${EXPECT_TARGET_FILE_NAME}
     DEPENDS ${SOURCE_FILE} ${DEPENDS})
+
+  if(NOT ${EXPECT_TARGET_FILE_NAME} STREQUAL ${TARGET_FILE})
+    add_custom_command(
+      OUTPUT ${TARGET_FILE}
+      COMMAND ${CMAKE_COMMAND} -E copy ${EXPECT_TARGET_FILE_NAME} ${TARGET_FILE}
+      DEPENDS ${EXPECT_TARGET_FILE_NAME})
+  endif()
 
 endfunction()
 


### PR DESCRIPTION
## Summary

Add a workaround in the Green Hills CMake build configuration to handle the compiler's restriction that preprocessed linker script files (*.ld) must have a .i output suffix. When preprocessing a file ending with .ld, the intermediate output is now generated as *.ld.i and then copied to the expected target filename.

## Impact

1. Fixes the Green Hills compilation error:
```
ccarm: Error: -o .../gnu-elf.ld has wrong suffix for -P option (expect .i)
```
2. Ensures linker scripts (e.g., gnu-elf.ld) can be preprocessed successfully when building with the Green Hills toolchain.
3. No effect on other toolchains (GCC, Clang, etc.)—the workaround is only applied for GHS builds.

## Testing

1. Verified that builds with Green Hills compiler no longer report the suffix error for *.ld files.
2. Confirmed that the final preprocessed linker script is correctly produced and used in the linking stage.
3. Ensured the change does not break preprocessing of other file types or affect non‑GHS toolchain builds.
