### PR TITLE
driver/cfi-flash: Add a config option for the page size of CFI flash.

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -1503,4 +1503,17 @@ config MTD_CFI
 	---help---
 		Support CFI(common flash interface) NOR FLASH.
 
+config MTD_CFI_PAGE_SIZE
+	int "Page Size of MTD CFI NOR FLASH (bytes)"
+	default 16
+	range 1 524288
+	depends on MTD_CFI
+	---help---
+		Configure the write page size (in bytes) used by the CFI NOR Flash
+		driver. The value must be at least 1 and should not exceed the maximum
+		write buffer size supported by the CFI device.
+		In the driver, this capability is typically exposed as the device's
+		"write page size" parameter for each write, so this configuration
+		value should be chosen such that it is equal to write page size for
+		the target flash.
 endif # MTD

--- a/drivers/mtd/cfi.c
+++ b/drivers/mtd/cfi.c
@@ -969,8 +969,9 @@ int cfi_check(FAR struct cfi_dev_s *cfi)
 
               cfi->cfi_offset = g_cfi_query_address[i];
               cfi->dev_num = cfi->bankwidth / cfi->dev_width;
-              cfi->page_size = (1 << info->max_write_bytes_num) *
-                               cfi->dev_num;
+              cfi->page_size = MIN(CONFIG_MTD_CFI_PAGE_SIZE,
+                                   (1 << info->max_write_bytes_num) *
+                                   cfi->dev_num);
 
               /* fix amd feature */
 


### PR DESCRIPTION
## Summary
We have added a defconfig configuration to set the page size of the flash. According to the CFI protocol, the flash supports a single write operation with a data volume ranging from byte size up to the maximum number of bytes. However, the MTD device structure requires defining a page size, which serves as the minimum write unit of the flash. Hence, this configuration is introduced. Any page size within the range of 1 to the maximum number of bytes is considered valid.

## Impact
Only impacts CFI-Flash writes

## Testing
We have completed the validation based on the QEMU environment.
