### PR TITLE
net/icmpv6: fix crash when ipv6 address modified during autoconfig

### DIFF
--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -189,6 +189,13 @@ static int icmpv6_send_message(FAR struct net_driver_s *dev, bool advertise)
   struct icmpv6_router_s state;
   int ret;
 
+  /* Check whether the link-local address has been overwritten. */
+
+  if (netdev_ipv6_lladdr(dev) == NULL)
+    {
+      return -EADDRNOTAVAIL;
+    }
+
   /* Initialize the state structure with the network locked. */
 
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */


### PR DESCRIPTION
## Summary
During the autoconfig process, if the user modifies the link local address while waiting for the Router Advertisement message, a crash will occur when sending the ICMPv6 Neighbor Advertisement message because netdev_ipv6_lladdr returns NULL.

## Impact
icmpv6 autoconfig.

## Testing
sim:matter
before change
```
Program received signal SIGSEGV, Segmentation fault.
0x0000000040042d41 in ipv6_build_header (ipv6=0x40124d06 <g_iob_buffer+253766>, payload_len=32, prot=58, src_ip=0x0, dst_ip=0x400c57f0 <g_ipv6_allnodes>, ttl=255 '\377', tclass=0 '\000') at inet/ipv6_build_header.c:78
78	  net_ipv6addr_hdrcopy(ipv6->srcipaddr, src_ip);
(gdb) bt
#0  0x0000000040042d41 in ipv6_build_header (ipv6=0x40124d06 <g_iob_buffer+253766>, payload_len=32, prot=58, src_ip=0x0, dst_ip=0x400c57f0 <g_ipv6_allnodes>, ttl=255 '\377', tclass=0 '\000')
    at inet/ipv6_build_header.c:78
#1  0x00000000400acf0f in icmpv6_advertise (dev=0x401290c0 <g_sim_dev+32>, tgtaddr=0x0, destipaddr=0x400c57f0 <g_ipv6_allnodes>) at icmpv6/icmpv6_advertise.c:81
#2  0x000000004009289e in icmpv6_router_eventhandler (dev=0x401290c0 <g_sim_dev+32>, priv=0x7fffd7dcbb10, flags=8388608) at icmpv6/icmpv6_autoconfig.c:150
#3  0x00000000400a4dbf in devif_conn_event (dev=0x401290c0 <g_sim_dev+32>, flags=8388608, list=0x4012dc88 <g_cbprealloc_buffer+432>) at devif/devif_callback.c:460
#4  0x00000000400aaa1a in icmpv6_poll (dev=0x401290c0 <g_sim_dev+32>, conn=0x0) at icmpv6/icmpv6_poll.c:77
#5  0x00000000400a6174 in devif_poll_icmpv6 (dev=0x401290c0 <g_sim_dev+32>, callback=0x400641f5 <netdev_upper_txpoll>) at devif/devif_poll.c:506
#6  0x00000000400a66d2 in devif_poll_connections (dev=0x401290c0 <g_sim_dev+32>, callback=0x400641f5 <netdev_upper_txpoll>) at devif/devif_poll.c:1004
#7  0x00000000400a674f in devif_iob_poll (dev=0x401290c0 <g_sim_dev+32>, callback=0x400641f5 <netdev_upper_txpoll>) at devif/devif_poll.c:1082
#8  0x00000000400a67eb in devif_poll (dev=0x401290c0 <g_sim_dev+32>, callback=0x400641f5 <netdev_upper_txpoll>) at devif/devif_poll.c:1165
#9  0x0000000040064377 in netdev_upper_tx (dev=0x401290c0 <g_sim_dev+32>) at net/netdev_upperhalf.c:370
#10 0x0000000040064406 in netdev_upper_txavail_work (upper=0x7fffd7d335c0) at net/netdev_upperhalf.c:399
#11 0x00000000400649ea in netdev_upper_txavail (dev=0x401290c0 <g_sim_dev+32>) at net/netdev_upperhalf.c:918
#12 0x0000000040041277 in netdev_txnotify_dev (dev=0x401290c0 <g_sim_dev+32>, polltype=8388608) at netdev/netdev_txnotify.c:122
#13 0x00000000400929ff in icmpv6_send_message (dev=0x401290c0 <g_sim_dev+32>, advertise=true) at icmpv6/icmpv6_autoconfig.c:235
#14 0x0000000040092c72 in icmpv6_autoconfig (dev=0x401290c0 <g_sim_dev+32>) at icmpv6/icmpv6_autoconfig.c:430
#15 0x000000004008f46c in netdev_ifr_ioctl (psock=0x7fffd7e4fe00, cmd=1811, req=0x7fffd7dcc000) at netdev/netdev_ioctl.c:1029
#16 0x000000004008ffb1 in psock_vioctl (psock=0x7fffd7e4fe00, cmd=1811, ap=0x7fffd7dcbd00) at netdev/netdev_ioctl.c:1955
#17 0x00000000400900fb in psock_ioctl (psock=0x7fffd7e4fe00, cmd=1811) at netdev/netdev_ioctl.c:2063
#18 0x000000004004c5e5 in sock_file_ioctl (filep=0x7fffd7dcfca0, cmd=1811, arg=140736814956544) at socket/socket.c:152
#19 0x0000000040045f65 in file_vioctl (filep=0x7fffd7dcfca0, req=1811, ap=0x7fffd7dcbf00) at vfs/fs_ioctl.c:70
#20 0x00000000400462f4 in nx_vioctl (fd=3, req=1811, ap=0x7fffd7dcbf00) at vfs/fs_ioctl.c:208
#21 0x00000000400464d9 in ioctl (fd=3, req=1811) at vfs/fs_ioctl.c:289
#22 0x0000000040036b39 in netlib_icmpv6_autoconfiguration (ifname=0x400c0198 "eth0") at netlib_autoconfig.c:78
#23 0x00000000400247fc in netinit_net_bringup () at netinit.c:656
#24 0x0000000040024850 in netinit_configure () at netinit.c:703
#25 0x000000004002486a in netinit_bringup () at netinit.c:1052
#26 0x00000000400230a1 in nsh_initialize () at nsh_init.c:161
#27 0x0000000040022f22 in nsh_main (argc=1, argv=0x7fffd7d99a10) at nsh_main.c:69
#28 0x000000004001a127 in nxtask_startup (entrypt=0x40022eab <nsh_main>, argc=1, argv=0x7fffd7d99a10) at sched/task_startup.c:66
#29 0x000000004000ab1e in nxtask_start () at task/task_start.c:107
#30 0x0000000040020b55 in pre_start () at sim/sim_initialstate.c:57
#31 0x0000000000000000 in ?? ()
(gdb) 
```
includes this change 
```
NuttShell (NSH) NuttX-12.3.0
MOTD: username=admin password=Administrator
nsh> 
nsh> 
```