### PR TITLE
drivers/net: Fix crash in wifi_sim disconnect.

### DIFF
--- a/drivers/net/wifi_sim.c
+++ b/drivers/net/wifi_sim.c
@@ -146,6 +146,7 @@ enum WLAN_STA_STATE_E
   WLAN_STA_STATE_INIT,
   WLAN_STA_STATE_CONNECTING,
   WLAN_STA_STATE_CONNECTED,
+  WLAN_STA_STATE_DISCONNECTED,
 };
 
 enum WLAN_STA_CONNERR_E
@@ -915,6 +916,8 @@ static int wifidriver_start_disconnect(FAR struct wifi_sim_s *wifidev)
         {
           if (wifidev->state == WLAN_STA_STATE_CONNECTED)
             {
+              wifidev->state = WLAN_STA_STATE_DISCONNECTED;
+
               /* free the connected_ap */
 
               free(wifidev->connected_ap);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fix a race condition in the `wifi_sim` driver that leads to a crash during disconnection.

**Issue:**
When a process (Process A) initiates a Wi-Fi disconnect, it frees the `wifidev->connected_ap` structure. However, if the Wi-Fi state is not updated immediately, another process (Process B) might attempt to access `wifidev->connected_ap` (e.g., to retrieve RSSI) while the state is still considered `CONNECTED`. This results in an invalid memory access (use-after-free) and causes the simulator to crash.

**Fix:**
Explicitly update the Wi-Fi state to `WLAN_STA_STATE_DISCONNECTED` *before* freeing `wifidev->connected_ap`. This ensures that other processes check the correct state and avoid accessing the released memory.

## Impact

   **Impact on user**: Improves the stability of the Wi-Fi simulator by preventing crashes during disconnection, especially in multi-threaded environments or when multiple applications are accessing the network interface.
*   **Backward compatibility**: Yes.
*   **New feature**: No, bug fix.

## Testing

*   **Target**: `sim:wifi`
*   **Verification**:
    *   Simulated the race condition scenario by disconnecting Wi-Fi while concurrently querying station status.
    *   Verified that the simulator no longer crashes after the fix.
    *   Passed `tools/checkpatch.sh`.
