### PR TITLE
drivers/virtio: Use arc4random_buf to generate MAC address.

### DIFF
--- a/drivers/virtio/virtio-net.c
+++ b/drivers/virtio/virtio-net.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <nuttx/compiler.h>
 #include <nuttx/kmalloc.h>
@@ -624,20 +625,8 @@ static void virtio_net_set_macaddr(FAR struct virtio_net_priv_s *priv)
        *        conflicts with something else on the network.
        */
 
-      srand(time(NULL) +
-#ifdef CONFIG_NETDEV_IFINDEX
-            dev->d_ifindex
-#else
-            (uintptr_t)dev % 256
-#endif
-          );
-
       mac[0] = 0x42;
-      mac[1] = rand() % 256;
-      mac[2] = rand() % 256;
-      mac[3] = rand() % 256;
-      mac[4] = rand() % 256;
-      mac[5] = rand() % 256;
+      arc4random_buf(mac + 1, 5);
     }
 }
 


### PR DESCRIPTION
Use arc4random_buf instead of rand() to improve randomness quality and avoid using weak PRNG for MAC generation.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Replace the usage of `rand()` and `srand()` with `arc4random_buf()` for generating the MAC address in the virtio-net driver.

`rand()` is a weak pseudo-random number generator and is generally not suitable for generating unique identifiers like MAC addresses, as it can lead to collisions or predictable sequences. `arc4random_buf()` provides higher quality randomness.

## Impact

*   **Impact on user**: Reduced risk of MAC address collisions when using virtio-net.
*   **Backward compatibility**: Yes.
*   **New feature**: No, improvement/bug fix.

## Testing

*   **Target**: `qemu:virt` (virtio-net)
*   **Verification**:
    *   Built and ran on QEMU with virtio-net enabled.
    *   Verified that the network interface comes up with a valid MAC address.
    *   Passed `tools/checkpatch.sh`.
