### PR TITLE
drivers/sensors/fakesensor: Remove GNSS dependency

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -74,7 +74,6 @@ config SENSORS_WTGAHRS2
 
 config SENSORS_FAKESENSOR
 	bool "Fake Sensor Support"
-	depends on SENSORS_GNSS
 	default n
 	---help---
 		Simulate physical sensor by reading data from csv file.


### PR DESCRIPTION
## Summary

This commit removes the dependency of the fakesensor API on `SENSORS_GNSS`. All of the logic for handling fake GNSS sensors is conditionally compiled only if GNSS features are enabled. Other fake sensors can be used without GNSS logic being included in the build.

Closes #17817.

## Impact

Users can now use the fakesensor API without needing to include `SENSOR_GNSS`
logic (and thus downloading the MINMEA lib).

## Testing

Compilation for simulator with `SENSORS_FAKESENSOR` enabled and not `SENSOR_GNSS`:
```
Create version.h
LN: platform/board to /home/linguini/coding/nuttx-space/apps/platform/dummy
Register: gpio
Register: dumpstack
Register: hello
Register: nsh
Register: sh
Register: gcov
Register: ostest
Register: dd
CP:  /home/linguini/coding/nuttx-space/nuttx/include/nuttx/config.h
LD:  nuttx
Pac SIM with dynamic libs..
'/usr/lib/libm.so.6' -> 'sim-pac/libs/libm.so.6'
'/usr/lib/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/usr/lib/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/usr/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/libs/ld-linux-x86-64.so.2'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
```

Compilation with fakesensor and GNSS enabled:

```
Create version.h
LN: platform/board to /home/linguini/coding/nuttx-space/apps/platform/dummy
Register: hello
Register: nsh
Register: sh
Register: gcov
Register: dumpstack
Register: gpio
Register: dd
Register: ostest
Downloading: gnssutils/minmea
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 23182 100 23182   0     0 44318     0  --:--:-- --:--:-- --:--:-- 44318
Archive:  db46128e73cee26d6a6eb0482dcba544ee1ea9f5.zip
db46128e73cee26d6a6eb0482dcba544ee1ea9f5
  inflating: gnssutils/minmea/c-cpp.yml
  inflating: gnssutils/minmea/.gitignore
  inflating: gnssutils/minmea/CMakeLists.txt
  inflating: gnssutils/minmea/COPYING
  inflating: gnssutils/minmea/README.md
  inflating: gnssutils/minmea/minmea_compat_ti-rtos.h
  inflating: gnssutils/minmea/minmea_compat_windows.h
  inflating: gnssutils/minmea/example.c
  inflating: gnssutils/minmea/minmea.c
  inflating: gnssutils/minmea/minmea.h
  inflating: gnssutils/minmea/tests.c
CP:  /home/linguini/coding/nuttx-space/nuttx/include/nuttx/config.h
LD:  nuttx
Pac SIM with dynamic libs..
'/usr/lib/libm.so.6' -> 'sim-pac/libs/libm.so.6'
'/usr/lib/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/usr/lib/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/usr/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/libs/ld-linux-x86-64.so.2'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
```

Testing without GNSS enabled using a custom application to register a fake
barometer:

```
NuttShell (NSH) NuttX-12.12.0
nsh> fake_baro; uorb_listener sensor_baro
Registered fake sensor_baro0 using CSV 'data/data.csv'

Monitor objects num:2
object_name:sensor_baro, object_instance:1
object_name:sensor_baro, object_instance:0
sensor_baro(now:9330000):timestamp:9330157,pressure:1013.250000,temperature:25.000000
sensor_baro(now:9350000):timestamp:9350158,pressure:1013.272034,temperature:25.000000
sensor_baro(now:9370000):timestamp:9370203,pressure:1013.272034,temperature:25.000000
sensor_baro(now:9390000):timestamp:9390161,pressure:1013.239563,temperature:25.000000
sensor_baro(now:9410000):timestamp:9410214,pressure:1013.229126,temperature:25.000000
sensor_baro(now:9430000):timestamp:9430209,pressure:1013.229126,temperature:25.000000
sensor_baro(now:9450000):timestamp:9450171,pressure:1013.239563,temperature:25.000000
sensor_baro(now:9470000):timestamp:9470095,pressure:1013.217468,temperature:25.000000
```

Testing *with* GNSS enabled using a custom application to register a fake
barometer:

```
NuttShell (NSH) NuttX-12.12.0
nsh> fake_baro; uorb_listener sensor_baro
Registered fake sensor_baro0 using CSV 'data/data.csv'

Monitor objects num:2
object_name:sensor_baro, object_instance:1
object_name:sensor_baro, object_instance:0
sensor_baro(now:8730000):timestamp:8730171,pressure:1013.250000,temperature:25.000000
sensor_baro(now:8750000):timestamp:8750085,pressure:1013.272034,temperature:25.000000
sensor_baro(now:8770000):timestamp:8770139,pressure:1013.272034,temperature:25.000000
sensor_baro(now:8790000):timestamp:8790179,pressure:1013.239563,temperature:25.000000
sensor_baro(now:8810000):timestamp:8810066,pressure:1013.229126,temperature:25.000000
sensor_baro(now:8830000):timestamp:8830178,pressure:1013.229126,temperature:25.000000
sensor_baro(now:8850000):timestamp:8850171,pressure:1013.239563,temperature:25.000000
sensor_baro(now:8870000):timestamp:8870125,pressure:1013.217468,temperature:25.000000
sensor_baro(now:8890000):timestamp:8890172,pressure:1013.455505,temperature:25.000000
sensor_baro(now:8910000):timestamp:8910083,pressure:1013.119995,temperature:25.000000
sensor_baro(now:8930000):timestamp:8930238,pressure:1013.207031,temperature:25.000000
```

Code for registering fakesensor in `fake_baro`:

```c
int main(int argc, char **argv)
{
  int err;

  err = fakesensor_init(SENSOR_TYPE_BAROMETER,
                        CONFIG_ROCKETALT_FAKE_BARO_CSVPATH, 0,
                        CONFIG_ROCKETALT_FAKE_BARO_QLEN);
  if (err)
    {
      syslog(LOG_ERR | LOG_USER, "Could not register fake sensor_baro0: %d\n",
             err);
      return EXIT_FAILURE;
    }

  syslog(LOG_INFO | LOG_USER, "Registered fake sensor_baro0 using CSV "
                              "'" CONFIG_ROCKETALT_FAKE_BARO_CSVPATH "'\n");
  return EXIT_SUCCESS;
}
```