### PR TITLE
sim: Pass through unknown sockopt to system.

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostusrsock.c
+++ b/arch/sim/src/sim/posix/sim_hostusrsock.c
@@ -188,7 +188,7 @@ static int optname_to_native(int optname)
 
       default:
         syslog(LOG_ERR, "Invalid optname: %x\n", optname);
-        return -1;
+        return -ENOPROTOOPT;
     }
 }
 
@@ -197,6 +197,10 @@ static int host_usrsock_sockopt(int sockfd, int level, int optname,
                                 bool set)
 {
   int ret = -EINVAL;
+
+  /* For the parameters that nuttx does not support,
+   * return the ENOPROTOOPT.
+   */
 
   if (level == NUTTX_SOL_SOCKET)
     {
@@ -216,13 +220,13 @@ static int host_usrsock_sockopt(int sockfd, int level, int optname,
     }
   else
     {
-      return ret;
+      return -ENOPROTOOPT;
     }
 
   optname = optname_to_native(optname);
   if (optname < 0)
     {
-      return ret;
+      return optname;
     }
 
   if (set)


### PR DESCRIPTION
Remove the interception of unknown levels and option names in sim usrsock. This allows the system socket interface to handle them and return the correct error codes or behavior, rather than returning a generic error locally.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change removes the local interception of unknown socket levels and option names in the sim usrsock implementation.

Previously, the code would trap unsupported levels or options and return a generic error code locally. This behavior prevented the underlying system interfaces (when using `sim`) from handling these options or returning the correct system-level error codes. By removing this interception, `getsockopt` and `setsockopt` calls are passed through to the system, allowing for correct error reporting and handling of options supported by the host system but not explicitly mapped by the simulation layer.

## Impact

*   **Impact on user**: `getsockopt` and `setsockopt` on the simulator will now behave more consistently with the host system's network stack, returning accurate error codes for unsupported options instead of generic internal errors.
*   **Backward compatibility**: Yes.
*   **New feature**: No, bug fix.

## Testing

*   **Target**: `sim:usrsock`
*   **Verification**:
    *   Verified that calling `getsockopt`/`setsockopt` with options not explicitly handled by NuttX's `usrsock` shim now correctly propagates the return value from the host system's socket API.
    *   Passed `tools/checkpatch.sh`.
