### PR TITLE
net: Support no-lto option for the network build.

### DIFF
--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -27,4 +27,8 @@ if(CONFIG_NET)
 
   target_sources(net PRIVATE net_initialize.c)
   target_include_directories(net PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+  if(CONFIG_NET_NO_LTO)
+    add_compile_options(-fno-lto)
+  endif()
 endif()

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -457,4 +457,19 @@ endmenu # Network Topologies
 
 source "net/route/Kconfig"
 
+config NET_NO_LTO
+	bool "Support no-lto option for the network Makefile"
+	default n
+	---help---
+		This option disables Link Time Optimization (LTO) specifically for the
+		network subsystem.
+
+		LTO can sometimes introduce build issues, excessive compilation time,
+		or difficult-to-debug runtime behaviors in complex network stacks
+		depending on the compiler version and architecture.
+
+		Enable this option if you encounter LTO-related issues in the network
+		stack or need to debug network code without the aggressive optimizations
+		introduced by LTO, while keeping LTO enabled for the rest of the system.
+
 endif # NET

--- a/net/Makefile
+++ b/net/Makefile
@@ -70,6 +70,10 @@ COBJS = $(CSRCS:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS)
 OBJS = $(AOBJS) $(COBJS)
 
+ifeq ($(CONFIG_NET_NO_LTO),y)
+CFLAGS += -fno-lto
+endif
+
 BIN = libnet$(LIBEXT)
 
 all: $(BIN)


### PR DESCRIPTION
Add CONFIG_NET_NO_LTO to allow compiling the network stack with -fno-lto. This is useful for avoiding LTO-related issues in the network layer.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR adds a new Kconfig option `CONFIG_NET_NO_LTO` to control Link Time Optimization (LTO) specifically for the network subsystem. When enabled, it appends `-fno-lto` to the compilation flags for network files in `net/Makefile` and `net/CMakeLists.txt`.

This change is introduced to address the following scenarios:

1.  **Debugging Support**: LTO can heavily inline functions and optimize away symbols, making the debugging of complex network protocol stacks difficult. Disabling LTO locally preserves the code structure for easier analysis.

2.  **Compiler Compatibility**: In certain build environments or with specific toolchain versions, enabling LTO globally may trigger internal compiler errors or produce incorrect code for the network stack state machines.

3.  **Build Performance**: Disabling LTO for the network subsystem can reduce the link time and memory usage during the build process on resource-constrained build machines.

This granular control allows users to keep LTO enabled for the rest of the system to maintain performance while disabling it for the network layer if needed for debugging or stability.

## Impact

*   **Impact on user**: Users can now optionally disable LTO for the network stack via `menuconfig` -> `Networking Support` -> `Support no-lto option for the network Makefile`.
*   **Build process**: If `CONFIG_NET_NO_LTO=y`, the `-fno-lto` flag is added to the CFLAGS for network sources.
*   **Compatibility**: Backward compatible; default is `n` (disabled), preserving existing behavior.

## Testing

*   **Verification**:
    1.  Configured with `CONFIG_NET_NO_LTO=y`.
    2.  Verified via `make --dry-run` that `-fno-lto` appears in the compilation commands for files under `net/`.
    3.  Configured with `CONFIG_NET_NO_LTO=n`.
    4.  Verified that `-fno-lto` is absent.
    5.  Passed `tools/checkpatch.sh`.

