### PR TITLE
boards/arm/kinetis: fix freeform-k28f usbhshost undeclared 'errcode'

### DIFF
--- a/boards/arm/kinetis/freedom-k28f/src/k28_usbhshost.c
+++ b/boards/arm/kinetis/freedom-k28f/src/k28_usbhshost.c
@@ -377,7 +377,7 @@ static void usb_msc_disconnect(void *arg)
 
       else
         {
-          ferr("ERROR: Unmount failed: %d\n", errcode);
+          ferr("ERROR: Unmount failed: %d\n", ret);
         }
     }
 }


### PR DESCRIPTION
arm/kinetis/freedom-k28f: fix usb automount compile error

This patch fix k28_usbhshost.c:380:47: error: 'errcode' undeclared

Signed-off-by: lipan118 <lp.xiao@foxmail.com>