### PR TITLE
arch/x86_64: Better implementation for spinlock.

### DIFF
--- a/arch/x86_64/include/spinlock.h
+++ b/arch/x86_64/include/spinlock.h
@@ -95,5 +95,25 @@ typedef uintptr_t spinlock_t;
 
 /* See prototype in nuttx/include/nuttx/spinlock.h */
 
+#if defined(CONFIG_ARCH_HAVE_TESTSET)
+static inline_function spinlock_t up_testset(volatile spinlock_t *lock)
+{
+  /* Perform the 32-bit CAS operation */
+
+  unsigned char ret;
+  uint32_t new_val = SP_LOCKED;
+  uint32_t old_val = SP_UNLOCKED;
+
+  asm volatile (
+                "lock cmpxchgl %[val], %[ptr]\n\
+                 sete %0\n"
+                : "=q" (ret), [ptr] "+m" (*lock), "+a" (old_val)
+                : [val]"r" (new_val)
+                : "memory");
+
+  return !ret;
+}
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_X86_64_INCLUDE_SPINLOCK_H */

--- a/arch/x86_64/src/intel64/CMakeLists.txt
+++ b/arch/x86_64/src/intel64/CMakeLists.txt
@@ -65,10 +65,6 @@ if(CONFIG_MM_PGALLOC)
   list(APPEND SRCS intel64_pgalloc.c)
 endif()
 
-if(CONFIG_ARCH_HAVE_TESTSET)
-  list(APPEND SRCS intel64_testset.S)
-endif()
-
 if(CONFIG_SMP)
   list(APPEND SRCS intel64_cpuidlestack.c intel64_smpcall.c intel64_cpustart.c)
 endif()

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -52,10 +52,6 @@ ifeq ($(CONFIG_MM_PGALLOC),y)
 CHIP_CSRCS += intel64_pgalloc.c
 endif
 
-ifeq ($(CONFIG_ARCH_HAVE_TESTSET), y)
-CHIP_ASRCS += intel64_testset.S
-endif
-
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += intel64_cpuidlestack.c
 CHIP_CSRCS += intel64_smpcall.c


### PR DESCRIPTION
This commit provided better implementation for spinlock.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
 Better implementation for spinlock.

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
no
*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
ostest
*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
