### PR TITLE
netinet/in.h: Rename imr_interface to imr_address in struct ip_mreqn.

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -287,7 +287,7 @@ struct ip_mreq
 struct ip_mreqn
 {
   struct in_addr  imr_multiaddr;    /* IPv4 multicast address of group */
-  struct in_addr  imr_interface;    /* Local IPv4 address of interface */
+  struct in_addr  imr_address;      /* Local IPv4 address of interface */
   unsigned int    imr_ifindex;      /* Local interface index */
 };
 

--- a/net/inet/ipv4_setsockopt.c
+++ b/net/inet/ipv4_setsockopt.c
@@ -267,7 +267,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
             {
               if (net_ipv4addr_cmp(mreq.imr_multiaddr.s_addr, INADDR_ANY))
                 {
-                  conn->mreq.imr_interface.s_addr = 0;
+                  conn->mreq.imr_address.s_addr = 0;
                   conn->mreq.imr_ifindex = 0;
                   ret = OK;
                   break;
@@ -299,7 +299,7 @@ int ipv4_setsockopt(FAR struct socket *psock, int option,
             }
 #endif
 
-          conn->mreq.imr_interface.s_addr = mreq.imr_multiaddr.s_addr;
+          conn->mreq.imr_address.s_addr = mreq.imr_multiaddr.s_addr;
           conn->mreq.imr_ifindex = mreq.imr_ifindex;
           ret = OK;
           break;


### PR DESCRIPTION
Rename imr_interface to imr_address in struct ip_mreqn to match the Linux definition. This ensures compatibility with standard socket APIs and existing Linux applications.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change is necessary to align the structure definition with the Linux standard (as seen in `man 7 ip`), where `struct ip_mreqn` uses `imr_address` for the local IP address of the interface. This ensures source-level compatibility for applications porting from Linux that access this field.

## Impact

*   **Impact on user**: Improves compatibility for POSIX/Linux network applications using `IP_ADD_MEMBERSHIP` / `IP_DROP_MEMBERSHIP` with `struct ip_mreqn`.
*   **Build process**: Requires recompilation of code accessing `struct ip_mreqn`.
*   **Compatibility**: Backward compatible logic-wise, but breaks API for any existing NuttX-specific code explicitly using the old `imr_interface` name (though `imr_address` is the standard name).

## Testing

*   **Verification**:
    1.  Compiled without errors.
    2.  Ran `tools/checkpatch.sh` and it passed without errors.
