### PR TITLE
tcp_timer.c: send TCP_RST when keepalive timeout

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -695,7 +695,15 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
 
                       devif_conn_event(conn->dev, TCP_ABORT,
                                        conn->sconn.list);
-                      tcp_stop_monitor(conn, TCP_ABORT);
+
+                      /* We also send a reset packet to the remote host. */
+
+                      tcp_send(dev, conn, TCP_RST | TCP_ACK, hdrlen);
+
+                      /* Stop the timer work */
+
+                      conn->keeptimer = 0;
+                      conn->timer     = 0;
                     }
                   else
                     {


### PR DESCRIPTION
## Summary
The RFC requires sending an TCP_RST packet in this scenario, so to better comply with the standard definition, the sending of TCP_RST is added.

## Impact
tcp keepalive timeout

## Testing
two sim:matter
NuttX test log:
```
15:09:37.982173 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [S], seq 1282192172, win 16384, options [mss 1460], length 0
15:09:37.985750 IP 10.0.1.3.7777 > 10.0.1.2.15149: Flags [S.], seq 1282192172, ack 1282192173, win 16384, options [mss 1460], length 0
15:09:37.992246 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:44.002307 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:46.012481 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:47.173766 IP 10.0.1.3.7777 > 10.0.1.2.15149: Flags [.], ack 1, win 16384, length 0
15:09:49.129417 IP 10.0.1.3.7777 > 10.0.1.2.15149: Flags [.], ack 1, win 16384, length 0
15:09:51.142228 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:53.152534 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:55.162201 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [.], ack 1, win 16384, length 0
15:09:57.172304 IP 10.0.1.2.15149 > 10.0.1.3.7777: Flags [R.], seq 1, ack 1, win 16384, length 0
```