### PR TITLE
net/icmp: Fix devif_loopback dead loop when unrecognized ICMP packet

### DIFF
--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -443,6 +443,10 @@ void icmp_input(FAR struct net_driver_s *dev)
 
           goto icmp_send_nothing;
         }
+      else
+        {
+          goto typeerr;
+        }
     }
 #endif
   else if (icmp->type == ICMP_TIMESTAMP_REQUEST)


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

When an unrecognized ICMP (type=3, code=2) packet is received, the ICMP flow does not set dev->d_len to 0, causing a devif_loopback dead loop.

Therefore, in ICMP input processing, when an ICMP_DEST_UNREACHABLE message is received, if it is not ICMP_FRAG_NEEDED code, jump to typeerr for proper error handling.

## Impact

Fixes a endless loop in devif_loopback when handling unrecognized ICMP packets (specifically type 3, code 2). This improves system stability when facing unexpected network traffic.

## Testing

Verified with ICMP packets (type=3, code=2). The system no longer enters a dead loop and correctly handles the error.
