### PR TITLE
arch/x64: Fix crash issue after enabling KASAN

### DIFF
--- a/arch/x86_64/src/common/fork.S
+++ b/arch/x86_64/src/common/fork.S
@@ -118,9 +118,13 @@ up_fork:
     pushq   %r12
     movq    %rsp, %rdi
 
+    subq    $8, %rsp
+
     /* call function */
 
     callq x86_64_fork
+
+    addq    $8, %rsp
 
     /* Do not modify return value %rax */
     /* Restore non-volatile registers */


### PR DESCRIPTION
After up_fork calls the x86_64_fork function, the rsp must be 16-byte aligned; otherwise, the movaps %xmm0, (%rsp) instruction may cause a crash.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
After up_fork calls the x86_64_fork function, the rsp must be 16-byte aligned; otherwise, the movaps %xmm0, (%rsp) instruction may cause a crash.

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
no
*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
ostest
*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
