### PR TITLE
net/route/ramroute: replace prealloc with netpool

### DIFF
--- a/net/route/net_add_ramroute.c
+++ b/net/route/net_add_ramroute.c
@@ -82,13 +82,13 @@ int net_addroute_ipv4(in_addr_t target, in_addr_t netmask, in_addr_t router)
 
   /* Get exclusive address to the networking data structures */
 
-  net_lock();
+  net_lockroute_ipv4();
 
   /* Then add the new entry to the table */
 
   ramroute_ipv4_addlast((FAR struct net_route_ipv4_entry_s *)route,
                         &g_ipv4_routes);
-  net_unlock();
+  net_unlockroute_ipv4();
 
   netlink_route_notify(route, RTM_NEWROUTE, AF_INET);
   return OK;
@@ -119,13 +119,11 @@ int net_addroute_ipv6(net_ipv6addr_t target, net_ipv6addr_t netmask,
 
   /* Get exclusive address to the networking data structures */
 
-  net_lock();
-
-  /* Then add the new entry to the table */
+  net_lockroute_ipv6();
 
   ramroute_ipv6_addlast((FAR struct net_route_ipv6_entry_s *)route,
                         &g_ipv6_routes);
-  net_unlock();
+  net_unlockroute_ipv6();
 
   netlink_route_notify(route, RTM_NEWROUTE, AF_INET6);
   return OK;

--- a/net/route/net_foreach_ramroute.c
+++ b/net/route/net_foreach_ramroute.c
@@ -68,7 +68,7 @@ int net_foreachroute_ipv4(route_handler_ipv4_t handler, FAR void *arg)
 
   /* Prevent concurrent access to the routing table */
 
-  net_lock();
+  net_lockroute_ipv4();
 
   /* Visit each entry in the routing table */
 
@@ -82,9 +82,9 @@ int net_foreachroute_ipv4(route_handler_ipv4_t handler, FAR void *arg)
       ret  = handler(&route->entry, arg);
     }
 
-  /* Unlock the network */
+  /* Unlock the g_ipv4_routes */
 
-  net_unlock();
+  net_unlockroute_ipv4();
   return ret;
 }
 #endif
@@ -98,7 +98,7 @@ int net_foreachroute_ipv6(route_handler_ipv6_t handler, FAR void *arg)
 
   /* Prevent concurrent access to the routing table */
 
-  net_lock();
+  net_lockroute_ipv6();
 
   /* Visit each entry in the routing table */
 
@@ -112,9 +112,9 @@ int net_foreachroute_ipv6(route_handler_ipv6_t handler, FAR void *arg)
       ret  = handler(&route->entry, arg);
     }
 
-  /* Unlock the network */
+  /* Unlock the g_ipv6_routes */
 
-  net_unlock();
+  net_unlockroute_ipv6();
   return ret;
 }
 #endif

--- a/net/route/net_initroute.c
+++ b/net/route/net_initroute.c
@@ -52,10 +52,6 @@
 
 void net_init_route(void)
 {
-#if defined(CONFIG_ROUTE_IPv4_RAMROUTE) || defined(CONFIG_ROUTE_IPv6_RAMROUTE)
-  net_init_ramroute();
-#endif
-
 #if defined(CONFIG_ROUTE_IPv4_CACHEROUTE) || defined(CONFIG_ROUTE_IPv6_CACHEROUTE)
   net_init_cacheroute();
 #endif

--- a/net/route/ramroute.h
+++ b/net/route/ramroute.h
@@ -120,25 +120,6 @@ extern struct net_route_ipv6_queue_s g_ipv6_routes;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: net_init_ramroute
- *
- * Description:
- *   Initialize the in-memory, RAM routing table
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Called early in initialization so that no special protection is needed.
- *
- ****************************************************************************/
-
-void net_init_ramroute(void);
-
-/****************************************************************************
  * Name: net_allocroute_ipv4 and net_allocroute_ipv6
  *
  * Description:
@@ -181,6 +162,32 @@ void net_freeroute_ipv4(FAR struct net_route_ipv4_s *route);
 
 #ifdef CONFIG_ROUTE_IPv6_RAMROUTE
 void net_freeroute_ipv6(FAR struct net_route_ipv6_s *route);
+#endif
+
+/****************************************************************************
+ * Name: net_lockroute_ipv4 and net_unlockroute_ipv4
+ *
+ * Description:
+ *   Lock and unlock the g_ipv4routes pool
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ROUTE_IPv4_RAMROUTE
+void net_lockroute_ipv4(void);
+void net_unlockroute_ipv4(void);
+#endif
+
+/****************************************************************************
+ * Name: net_lockroute_ipv6 and net_unlockroute_ipv6
+ *
+ * Description:
+ *   Lock and unlock the g_ipv6routes pool
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ROUTE_IPv6_RAMROUTE
+void net_lockroute_ipv6(void);
+void net_unlockroute_ipv6(void);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
reuse the netpool module to optimize the code implementation.

## Impact
net route in memory mode.

## Testing
sim:matter with enable CONFIG_NET_ROUTE
NuttX test log:
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> 
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:e1:c4:3f:48:dd at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: 3380::40e1:c4ff:fe3f:48dd/64
	inet6 DRaddr: fe80::a096:6ff:fe65:382a

lo	Link encap:Local Loopback at RUNNING mtu 1518
	inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
	inet6 addr: ::1/128
	inet6 DRaddr: ::1

nsh> route ipv4
SEQ   TARGET          NETMASK         ROUTER          
   1. 0.0.0.0         0.0.0.0         10.0.1.1        
nsh> ping -c 3 8.8.8.8
PING 8.8.8.8 56 bytes of data
56 bytes from 8.8.8.8: icmp_seq=0 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=1 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=2 time=40.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 40.000/40.000/40.000/0.000 ms
nsh> delroute 0.0.0.0 0.0.0.0
nsh> ping -c 3 8.8.8.8
PING 8.8.8.8 56 bytes of data
56 bytes from 8.8.8.8: icmp_seq=0 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=1 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=2 time=40.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 40.000/40.000/40.000/0.000 ms
nsh> route ipv4
nsh> addroute 0.0.0.0 0.0.0.0 127.0.0.1
nsh> route ipv4
SEQ   TARGET          NETMASK         ROUTER          
   1. 0.0.0.0         0.0.0.0         127.0.0.1       
nsh> ping -c 3 8.8.8.8
PING 8.8.8.8 56 bytes of data
No response from 8.8.8.8: icmp_seq=0 time=1000 ms
No response from 8.8.8.8: icmp_seq=1 time=1000 ms
No response from 8.8.8.8: icmp_seq=2 time=1000 ms
3 packets transmitted, 0 received, 100% packet loss, time 3030 ms
nsh> addroute 0.0.0.0 0.0.0.0 10.0.1.1
nsh> route ipv4
SEQ   TARGET          NETMASK         ROUTER          
   1. 0.0.0.0         0.0.0.0         127.0.0.1       
   2. 0.0.0.0         0.0.0.0         10.0.1.1        
nsh> ping -c 3 8.8.8.8
PING 8.8.8.8 56 bytes of data
No response from 8.8.8.8: icmp_seq=0 time=1000 ms
No response from 8.8.8.8: icmp_seq=1 time=1000 ms
No response from 8.8.8.8: icmp_seq=2 time=1000 ms
3 packets transmitted, 0 received, 100% packet loss, time 3030 ms
nsh> delroute 0.0.0.0 0.0.0.0
nsh> route ipv4
SEQ   TARGET          NETMASK         ROUTER          
   1. 0.0.0.0         0.0.0.0         10.0.1.1        
nsh> ping -c 3 8.8.8.8
PING 8.8.8.8 56 bytes of data
56 bytes from 8.8.8.8: icmp_seq=0 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=1 time=40.0 ms
56 bytes from 8.8.8.8: icmp_seq=2 time=40.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 40.000/40.000/40.000/0.000 ms
nsh> 
nsh> poweroff
```