### PR TITLE
net/neighbor: fix compilation with CONFIG_NET_ICMPv6_NO_STACK

### DIFF
--- a/net/neighbor/neighbor_ethernet_out.c
+++ b/net/neighbor/neighbor_ethernet_out.c
@@ -155,7 +155,7 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
 
       if (neighbor_lookup(ipaddr, &laddr) < 0)
         {
-#ifdef CONFIG_NET_ICMPv6
+#ifdef NET_ICMPv6_HAVE_STACK
           /* No ARP packet if this device do not support ARP */
 
           if (IFF_IS_NOARP(dev->d_flags))
@@ -163,7 +163,7 @@ void neighbor_ethernet_out(FAR struct net_driver_s *dev)
               return;
             }
 
-           ninfo("IPv6 Neighbor solicitation for IPv6\n");
+          ninfo("IPv6 Neighbor solicitation for IPv6\n");
 
           /* The destination address was not in our Neighbor Table, so we
            * overwrite the IPv6 packet with an ICMPv6 Neighbor Solicitation


### PR DESCRIPTION
When CONFIG_NET_ICMPv6_NO_STACK is enabled, icmpv6_solicit should not be called.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

When `CONFIG_NET_ICMPv6_NO_STACK` is enabled, the ICMPv6 stack logic (specifically `icmpv6_solicit`) is not available. However, `net/neighbor/neighbor_ethernet_out.c` unconditionally calls `icmpv6_solicit` when `CONFIG_NET_ICMPv6` is defined, even if the stack is disabled.

This causes a compilation error because `icmpv6_solicit` is undefined or excluded from the build.

This patch changes the guard macro from `#ifdef CONFIG_NET_ICMPv6` to `#ifdef NET_ICMPv6_HAVE_STACK`. This ensures that the neighbor solicitation logic (which depends on the stack) is only compiled when the ICMPv6 stack is actually present.

## Impact

*   **Build:** Fixes compilation error when `CONFIG_NET_ICMPv6=y` and `CONFIG_NET_ICMPv6_NO_STACK=y`.
*   **Users:** Users can now compile NuttX with ICMPv6 enabled but the stack logic disabled (e.g., for offloading or specialized use cases) without errors.
*   **Compatibility:** No impact on existing configurations where the full ICMPv6 stack is enabled (`NET_ICMPv6_HAVE_STACK` is defined in those cases).

## Testing

*   **Build Test:**
    *   Verified compilation with a configuration enabling `CONFIG_NET_ICMPv6` and `CONFIG_NET_ICMPv6_NO_STACK`.
    *   Before patch: Compilation failed due to undefined reference to `icmpv6_solicit`.
    *   After patch: Compilation succeeds.
