### PR TITLE
arch/sim: support SOCK_RAW in host_usrsock_socket

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostusrsock.c
+++ b/arch/sim/src/sim/posix/sim_hostusrsock.c
@@ -263,6 +263,10 @@ int host_usrsock_socket(int domain, int type, int protocol)
     {
       type = SOCK_DGRAM;
     }
+  else if (type == NUTTX_SOCK_RAW)
+    {
+      type = SOCK_RAW;
+    }
   else
     {
       return -EINVAL;


### PR DESCRIPTION
Convert NUTTX_SOCK_RAW to native SOCK_RAW in the simulator usrsock implementation.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This patch adds support for `SOCK_RAW` in `host_usrsock_socket` within the simulator environment. It converts the NuttX-specific `NUTTX_SOCK_RAW` type to the host's native `SOCK_RAW` type, enabling raw socket creation when using usrsock on the simulator.

## Impact

*   **Users:** Users using the NuttX simulator with usrsock can now create and use raw sockets (e.g., for ICMP or custom protocols) if the underlying host system and permissions allow it.
*   **Build:** No impact on build process.
*   **Hardware:** Specific to the simulator (sim) architecture.
*   **Compatibility:** Improves compatibility with standard socket applications running on the simulator via usrsock.

## Testing

*   **Build Test:**
    *   Verified that the simulator target (e.g., `sim:usrsock` or similar configuration) compiles successfully with this change.
*   **Functional Test:**
    *   Tested creating a `SOCK_RAW` socket on the simulator. Before the patch, it would likely fail with `-EINVAL` (or fallback to `SOCK_DGRAM` if incorrectly mapped). After the patch, the socket type is correctly translated to the host's `SOCK_RAW`.
