### PR TITLE
libc/netdb: avoid unnecessary DNS notify if nameserver exists

### DIFF
--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -227,7 +227,9 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
           ret = OK;
         }
 
-      goto errout;
+      dns_unlock();
+      fclose(stream);
+      return ret;
     }
 
 #if CONFIG_NETDB_DNSSERVER_NAMESERVERS > 1


### PR DESCRIPTION
If the nameserver already exists, return directly without calling dns_notify_nameserver to prevent cyclic notifications and high CPU usage.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

When adding a nameserver via `dns_add_nameserver`, if the server already exists in the configuration (return value is `-EEXIST`), the function previously jumped to the `errout` label. This label executes `dns_notify_nameserver`, which sends a notification signal.

In scenarios where multiple DNS updates occur or in master/slave synchronization contexts, this can lead to cyclic notifications and high CPU usage because the notification is sent even when no actual change was made (since the server already existed).

This patch modifies the behavior to return directly when the nameserver exists, skipping the unnecessary `dns_notify_nameserver` call.

## Impact

*   **Performance:** Reduces unnecessary CPU usage and potential message loops in DNS configuration updates.
*   **Stability:** Prevents high CPU load caused by cyclic DNS notifications.
*   **Users:** Users with dynamic DNS configurations or multiple DNS servers will experience more stable system behavior.

## Testing

*   **Functional Test:**
    *   Simulated a scenario where `dns_add_nameserver` is called with an existing server address.
    *   Verified that `dns_notify_nameserver` is NOT called in this case.
    *   Verified that adding a *new* server still triggers the notification correctly.
