### PR TITLE
tcp_input.c: standardize the processing of urgent data

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1600,33 +1600,7 @@ skip_rtt:
           }
 
 #else /* CONFIG_NET_TCPURGDATA */
-        /* Check the URG flag.  If this is set, We must gracefully ignore
-         * and discard the urgent data.
-         */
-
-        if ((tcp->flags & TCP_URG) != 0)
-          {
-            uint16_t urglen = (tcp->urgp[0] << 8) | tcp->urgp[1];
-            if (urglen > dev->d_len)
-              {
-                /* There is more urgent data in the next segment to come. */
-
-                urglen = dev->d_len;
-              }
-
-             /* The d_len field contains the length of the incoming data;
-              * The d_appdata field points to the any "normal" data that
-              * may follow the urgent data.
-              *
-              * NOTE: If the urgent data continues in the next packet, then
-              * d_len will be zero and d_appdata will point past the end of
-              * the payload (which is OK).
-              */
-
-            net_incr32(conn->rcvseq, urglen);
-            dev->d_len     -= urglen;
-            dev->d_appdata += urglen;
-          }
+        /* Urgent data needs to be treated as normal data */
 #endif /* CONFIG_NET_TCPURGDATA */
 
 #ifdef CONFIG_NET_TCP_KEEPALIVE


### PR DESCRIPTION
## Summary
urgent data needs to be treated as normal data when CONFIG_NET_TCPURGDATA disable. some test sets will verify this behavior, correct the processing logic.

## Impact
tcp urgent data.

## Testing
sim:matter with host and disable CONFIG_NET_TCPURGDATA.
test code on the host:
```
#define SERVER_IP "10.0.1.2"
#define PORT 7777
#define BUFFER_SIZE 1024

sockfd = socket(AF_INET, SOCK_STREAM, 0);
connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
send(sockfd, "oob", strlen("oob"), MSG_OOB);
send(sockfd, "hello", strlen("hello"), 0);
```
test code on the NuttX:
```
#define SERVER_IP "0.0.0.0"
#define PORT 7777
#define BUFFER_SIZE 1024

server_fd = socket(AF_INET, SOCK_STREAM, 0);
bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
listen(server_fd, 5);
client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &addr_len);
ret = recv(client_fd, buffer, BUFFER_SIZE, 0);
printf("Received message: [%d] %s\n", ret, buffer);
```
test log without this change:
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> hello
Received message: [5] hello
nsh> 
```
test log with this change:
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> hello
Received message: [8] oobhello
nsh>
```

