### PR TITLE
arch/arm/imxrt: fix error header guard

### DIFF
--- a/arch/arm/src/imxrt/imxrt_clockconfig_ver1.h
+++ b/arch/arm/src/imxrt/imxrt_clockconfig_ver1.h
@@ -21,7 +21,7 @@
  ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_IMXRT_IMXRT_CLOCKCONFIG_VER1_H
-#define __ARCH_ARM_SRC_IMXRT_IMXRT_CLOCKCONFIG_VER2_H
+#define __ARCH_ARM_SRC_IMXRT_IMXRT_CLOCKCONFIG_VER1_H
 
 /****************************************************************************
  * Included Files


### PR DESCRIPTION
## Summary

- fix chip/imxrt_clockconfig_ver1.h:23: error: header guard '__ARCH_ARM_SRC_IMXRT_IMXRT_CLOCKCONFIG_VER1_H' followed by '#define' of a different macro [-Werror=header-guard]

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

locally

```
===================================================================================
Configuration/Tool: teensy-4.x/nsh-4.1,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2026-01-14 13:42:35
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
  [1/1] Normalize teensy-4.x/nsh-4.1
==================================================================================
==
```