### PR TITLE
net/can: allow errmask to be set to CAN_ERR_FLAG

### DIFF
--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -133,7 +133,7 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
             return -EINVAL;
           }
 
-        conn->err_mask = *(FAR can_err_mask_t *)value & CAN_ERR_MASK;
+        conn->err_mask = *(FAR can_err_mask_t *)value;
         break;
 #endif
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change is to allow errmask to be set to CAN_ERR_FLAG, so that error frames with id 0 can also pass the err filter.
e,g, for LIN protocol, the error frame ID can be 0. 

## Impact

socketcan err mask
