### PR TITLE
sched/sched: Improve sched make and cmake scripts

### DIFF
--- a/sched/sched/CMakeLists.txt
+++ b/sched/sched/CMakeLists.txt
@@ -48,8 +48,7 @@ set(SRCS
     sched_sysinfo.c
     sched_get_stateinfo.c
     sched_switchcontext.c
-    sched_sleep.c
-    sched_processtimer.c)
+    sched_sleep.c)
 
 if(DEFINED CONFIG_STACKCHECK_MARGIN)
   if(NOT CONFIG_STACKCHECK_MARGIN EQUAL -1)
@@ -99,6 +98,8 @@ endif()
 
 if(CONFIG_SCHED_TICKLESS)
   list(APPEND SRCS sched_timerexpiration.c)
+else()
+  list(APPEND SRCS sched_processtimer.c)
 endif()
 
 if(CONFIG_SCHED_CRITMONITOR)

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -30,7 +30,7 @@ CSRCS += sched_yield.c sched_rrgetinterval.c sched_foreach.c
 CSRCS += sched_lock.c sched_unlock.c sched_lockcount.c
 CSRCS += sched_idletask.c sched_self.c sched_get_stackinfo.c sched_get_tls.c
 CSRCS += sched_sysinfo.c sched_get_stateinfo.c sched_getcpu.c
-CSRCS += sched_switchcontext.c sched_sleep.c sched_processtimer.c
+CSRCS += sched_switchcontext.c sched_sleep.c
 
 ifneq ($(CONFIG_STACKCHECK_MARGIN),)
   ifneq ($(CONFIG_STACKCHECK_MARGIN),-1)
@@ -80,6 +80,8 @@ endif
 
 ifeq ($(CONFIG_SCHED_TICKLESS),y)
 CSRCS += sched_timerexpiration.c
+else
+CSRCS += sched_processtimer.c
 endif
 
 ifeq ($(CONFIG_SCHED_CRITMONITOR),y)


### PR DESCRIPTION
## Summary

Improve sched make and cmake scripts to select sched_processtimer.c
and sched_timerexpiration.c separatly for tickless and non-tickless mode

## Impact

Build scripts improvement, no functional impact to NuttX

## Testing

**ostest passed on rv-virt:smp64**

```
NuttShell (NSH)
nsh> 
nsh> 
nsh> 
nsh> uname -a
NuttX 0.0.0 557d91d897-dirty Jan 15 2026 00:10:55 risc-v rv-virt
nsh> ostest

(...)

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc0e60  1fc0e60
ordblks         1        6
mxordblk  1fb5c80  1fa1180
uordblks     b1e0    18e20
fordblks  1fb5c80  1fa8040
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```

