### PR TITLE
ghs: update the compile option to recommended options

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -151,6 +151,9 @@ endif()
 
 if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
   add_compile_options(-ffunction-sections -fdata-sections)
+
+  # instruct the exlr deletet the unused functions during link procedure
+  add_link_options(-delete)
 endif()
 
 # Debug --whole-archive
@@ -163,10 +166,29 @@ endif()
 
 if(CONFIG_DEBUG_LINK_MAP)
   add_link_options(-map=nuttx.map)
+  # instruct the exlr the contents that needs to be contained in the generated
+  # map file
+  add_link_options(-Mn -map_eofn_symbols -Mx -Ms -Mu -Ml)
+
+  # instruct the compiler to keep the temp files generated at compile time after
+  # they are used
+  add_compile_options(-keeptempfiles)
+  # instruct the compiler to generate a source listing of the asm file
+  add_compile_options(-list)
 endif()
 
 if(CONFIG_DEBUG_SYMBOLS)
-  add_compile_options(-G -gdwarf-2)
+  add_compile_options(-G -dual_debug)
+  # instruct the exlr to ignore relocations from DWARF debug sections when using
+  # -delete
+  add_link_options(-ignore_debug_references)
+
+  # instruct the exlr to dump verbose information during link procedure
+  add_link_options(-v)
+
+  # instruct the gsize to generate a "*.siz" file that contains the detailed
+  # section size
+  add_link_options(-gsize)
 endif()
 
 add_compile_options(
@@ -200,6 +222,20 @@ endif()
 if(NOT CONFIG_CXX_RTTI)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 endif()
+
+# instruct the compiler to treat the functions referenced or called when no
+# prototype has been provided as error
+
+add_compile_options(--prototype_errors)
+
+# instruct the compiler to treat #pragma directives that using wrong syntax as
+# warnings
+
+add_compile_options(--incorrect_pragma_warnings)
+
+# instruct the exlr do not link the start files into executable
+
+add_link_options(-nostartfiles)
 
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P)
 

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -443,7 +443,10 @@ ZIGFLAGS = -target $(ZARCH)-freestanding-$(ZEABI) $(ZARCHCPUFLAGS)
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),)
   ifeq ($(CONFIG_DEBUG_OPT_UNUSED_SECTIONS),y)
-    ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),)
+    ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
+      # instruct the exlr deletet the unused functions during link procedure
+      LDFLAGS += -delete
+    else
       LDFLAGS          += --gc-sections
     endif
     ARCHOPTIMIZATION += -ffunction-sections -fdata-sections
@@ -461,6 +464,15 @@ endif
 ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
   ifeq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)
     LDFLAGS += -map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
+    # instruct the compiler to keep the temp files generated at
+    # compile time after they are used
+    ARCHOPTIMIZATION += -keeptempfiles
+
+    # instruct the compiler to generate a source listing of the asm file
+    ARCHOPTIMIZATION += -list
+
+    # instruct the exlr the contents that needs to be contained in the generated map file
+    LDFLAGS += -map_eofn_symbols -Mn -Mx -Ms -Mu -Ml
   else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),)
     LDFLAGS += --cref -Map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
   else
@@ -476,8 +488,32 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
       LDFLAGS += --debug
     endif
   else
-    ARCHOPTIMIZATION += -G -gdwarf-2
+    # instruct the exlr to ignore relocations from DWARF debug sections when using -delete
+    LDFLAGS += -ignore_debug_references
+
+    # instruct the exlr to dump verbose information during link procedure
+    LDFLAGS += -v
+
+    # instruct the gsize to generate a "*.siz" file that contains the detailed section size
+    LDFLAGS += -gsize
+
+    ARCHOPTIMIZATION += -G -dual_debug
   endif
+endif
+
+ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
+
+  # instruct the compiler to treat the functions referenced or called when no prototype has
+  # been provided as error
+  ARCHCFLAGS += --prototype_errors
+  ARCHCXXFLAGS += --prototype_errors
+
+  # instruct the compiler to treat #pragma directives that using wrong syntax as warnings
+  ARCHCFLAGS += --incorrect_pragma_warnings
+  ARCHCXXFLAGS += --incorrect_pragma_warnings
+
+  # instruct the exlr do not link the start files into executable
+  LDFLAGS += -nostartfiles
 endif
 
 # Add the builtin library


### PR DESCRIPTION
## Summary

Incorporate a set of production‑recommended Green Hills (GHS) compiler and linker options to enhance debugging, diagnostics, and build quality:

1. Map file enhancements (-Mn -map_eofn_symbols -Mx -Ms -Mu -Ml): generate detailed symbol, section, and relocation information.
2. Debug improvements (-dual_debug, -ignore_debug_references, -v, -gsize): enable dual debug format, ignore debug‑section references during -delete, verbose linking, and section‑size reporting.
3. Additional compile‑time checks (--prototype_errors, --incorrect_pragma_warnings): flag missing prototypes and incorrect pragma syntax.
4. Build utilities (-keeptempfiles, -list, -nostartfiles): retain intermediate files, produce assembly listings, and suppress standard startup files.

## Impact

1. Provides richer debug information and more precise map files for post‑build analysis.
2. Catches potential code issues earlier through stricter prototype and pragma checking.

## Testing

1. Verified that all new options are accepted by the Green Hills toolchain and do not cause build errors.
2. Confirmed that the enhanced map file (nuttx.map) contains the expected additional details (symbols, sections, relocations).
3. Ensured debug builds still produce usable debug information and that -gsize generates the expected .siz file.
