### PR TITLE
sys/resouce: add RLIM_NLIMITS definition

### DIFF
--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -67,6 +67,8 @@
 #define RLIMIT_RTPRIO   14          /* Limit on RT tasks priority */
 #define RLIMIT_RTTIME   15          /* Limit on timeout for RT tasks (us) */
 
+#define RLIM_NLIMITS    16          /* Limits of all supported kinds */
+
 #if defined(CONFIG_FS_LARGEFILE)
 #  define RLIM_INFINITY    UINT64_MAX /* No limit */
 #  define RLIM_SAVED_MAX   UINT64_MAX /* Unrepresentable saved hard limit */


### PR DESCRIPTION
## Summary

Add the RLIM_NLIMITS macro with value 16 to sys/resource.h, indicating the total number of supported resource limit types. This improves POSIX header completeness and aids resource enumeration in applications.

## Impact

1. Improves POSIX header completeness by providing a constant that indicates the count of defined resource‑limit identifiers.
2. Enables applications to perform bounds checking or iterate over all resource‑limit types programmatically.
3. No functional change to existing resource‑limit enforcement; purely a compile‑time definition.

## Testing

Verified that <sys/resource.h> compiles cleanly and that RLIM_NLIMITS is accessible.
