### PR TITLE
sched/hrtimer: fix Kconfig typo

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -2017,6 +2017,5 @@ config HRTIMER
 	bool "High resolution timer support"
 	depends on SYSTEM_TIME64
 	default n
-	depends on SYSTEM_TIME64
 	---help---
 		Enable to support high resolution timer


### PR DESCRIPTION
  ## Summary

Remove the duplicated dependency on SYSTEM_TIME64.

## Impact

Fixes a Kconfig typo with no impact on existing functionality or performance.

## Testing

**ostest passed on a2g-tc397-5v-tft**

```
NuttShell (NSH)
nsh>
nsh>
nsh> uname -a
NuttX 0.0.0 32a11acd9e-dirty Jan 15 2026 11:19:29 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         7        6
mxordblk    1f890    1f890
uordblks     5574     5574
fordblks    23888    23888

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f890    1f890
uordblks     5574     5574
fordblks    23888    23888

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24208    1f890
uordblks     4bf4     5574
fordblks    24208    23888
user_main: Exiting
ostest_main: Exiting with status 0

```

