### PR TITLE
ghs.cmake: add preprocess command to the .ld script generate procedure

### DIFF
--- a/arch/arm/src/cmake/ghs.cmake
+++ b/arch/arm/src/cmake/ghs.cmake
@@ -239,8 +239,11 @@ function(nuttx_generate_preprocess_target)
 
   add_custom_command(
     OUTPUT ${EXPECT_TARGET_FILE_NAME}
-    COMMAND ${PREPROCESS} -I${CMAKE_BINARY_DIR}/include -filetype.cpp
-            ${SOURCE_FILE} -o ${EXPECT_TARGET_FILE_NAME}
+    COMMAND
+      ${PREPROCESS}
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_global,NUTTX_CPP_COMPILE_OPTIONS>>
+      -I${CMAKE_BINARY_DIR}/include -filetype.cpp ${SOURCE_FILE} -o
+      ${EXPECT_TARGET_FILE_NAME}
     DEPENDS ${SOURCE_FILE} ${DEPENDS})
 
   if(NOT ${EXPECT_TARGET_FILE_NAME} STREQUAL ${TARGET_FILE})


### PR DESCRIPTION
## Summary

Update the Green Hills linker‑script preprocessing step to automatically include the global C‑preprocessor options (such as -D defines and include paths) via CMake generator expressions:
```
$<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_global,NUTTX_CPP_COMPILE_OPTIONS>>
```

## Impact

Ensures that linker scripts are preprocessed with the same macro definitions and include‑path settings as the rest of the NuttX source code.

## Testing

Verified that the modified command line correctly expands to include all global CPP flags when building with the Green Hills toolchain.
