### PR TITLE
sys/types.h: Fixed the conflict issue with the "OK" constant definition

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -317,6 +317,10 @@ typedef CODE int (*main_t)(int argc, FAR char *argv[]);
 
 /* POSIX-like OS return values: */
 
+#ifdef OK
+#  undef OK
+#endif
+
 enum
 {
   ERROR = -1,


### PR DESCRIPTION
## Summary

Add `#undef OK` before the enum that defines `OK` in `<sys/types.h>` to prevent macro‑definition conflicts when cross‑compiling with external frameworks (notably the VSX/PSE52 test suite) that may define OK as a preprocessor macro.

## Impact

1. Resolves compilation errors where an external OK macro expands incorrectly inside the NuttX type definitions.
2. Ensures the NuttX enum constant OK is used as intended, regardless of macro definitions from third‑party headers.

## Testing

1. Verified that the modified header compiles cleanly both with and without an external OK macro definition.
2. Tested cross‑compilation scenarios with VSX/PSE52 test frameworks to confirm the conflict is resolved.
