### PR TITLE
pthread: reorganized the locations of pthread-related functions and constants

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -774,11 +774,6 @@ int pthread_rwlock_clockwrlock(FAR pthread_rwlock_t *lock,
 int pthread_rwlock_trywrlock(FAR pthread_rwlock_t *lock);
 int pthread_rwlock_unlock(FAR pthread_rwlock_t *lock);
 
-/* Pthread signal management APIs */
-
-int pthread_kill(pthread_t thread, int sig);
-int pthread_sigmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);
-
 #ifdef CONFIG_PTHREAD_SPINLOCKS
 /* Pthread spinlocks */
 
@@ -820,48 +815,9 @@ int pthread_atfork(CODE void (*prepare)(void),
  * available in any inclusion ordering.
  */
 
-#ifndef __PTHREAD_KEY_T_DEFINED
-typedef int pthread_key_t;
-#  define __PTHREAD_KEY_T_DEFINED 1
-#endif
-
 #ifndef __PTHREAD_ADDR_T_DEFINED
 typedef FAR void *pthread_addr_t;
 #  define __PTHREAD_ADDR_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_ATTR_T_DEFINED
-struct pthread_attr_s;
-typedef struct pthread_attr_s pthread_attr_t;
-#  define __PTHREAD_ATTR_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_T_DEFINED
-typedef pid_t pthread_t;
-#  define __PTHREAD_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_CONDATTR_T_DEFINED
-typedef struct pthread_condattr_s pthread_condattr_t;
-#  define __PTHREAD_CONDATTR_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_COND_T_DEFINED
-struct pthread_cond_s;
-typedef struct pthread_cond_s pthread_cond_t;
-#  define __PTHREAD_COND_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_MUTEXATTR_T_DEFINED
-struct pthread_mutexattr_s;
-typedef struct pthread_mutexattr_s pthread_mutexattr_t;
-#  define __PTHREAD_MUTEXATTR_T_DEFINED 1
-#endif
-
-#ifndef __PTHREAD_MUTEX_T_DEFINED
-struct pthread_mutex_s;
-typedef struct pthread_mutex_s pthread_mutex_t;
-#  define __PTHREAD_MUTEX_T_DEFINED 1
 #endif
 
 #ifndef __PTHREAD_BARRIERATTR_T_DEFINED
@@ -895,11 +851,5 @@ typedef struct pthread_spinlock_s pthread_spinlock_t;
 #    define __PTHREAD_SPINLOCK_T_DEFINED 1
 #  endif
 #endif /* CONFIG_PTHREAD_SPINLOCKS */
-
-#ifndef __PTHREAD_ONCE_T_DEFINED
-struct pthread_once_s;
-typedef struct pthread_once_s pthread_once_t;
-#  define __PTHREAD_ONCE_T_DEFINED 1
-#endif
 
 #endif /* __INCLUDE_PTHREAD_H */

--- a/include/signal.h
+++ b/include/signal.h
@@ -486,6 +486,11 @@ int  sigwaitinfo(FAR const sigset_t *set, FAR struct siginfo *value);
 int  sigaltstack(FAR const stack_t *ss, FAR stack_t *oss);
 int  siginterrupt(int signo, int flag);
 
+/* Pthread signal management APIs */
+
+int pthread_kill(pthread_t thread, int sig);
+int pthread_sigmask(int how, FAR const sigset_t *set, FAR sigset_t *oset);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -323,6 +323,51 @@ enum
   OK = 0
 };
 
+#ifndef __PTHREAD_ATTR_T_DEFINED
+struct pthread_attr_s;
+typedef struct pthread_attr_s pthread_attr_t;
+#  define __PTHREAD_ATTR_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_COND_T_DEFINED
+struct pthread_cond_s;
+typedef struct pthread_cond_s pthread_cond_t;
+#  define __PTHREAD_COND_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_CONDATTR_T_DEFINED
+typedef struct pthread_condattr_s pthread_condattr_t;
+#  define __PTHREAD_CONDATTR_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_KEY_T_DEFINED
+typedef int pthread_key_t;
+#  define __PTHREAD_KEY_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_MUTEX_T_DEFINED
+struct pthread_mutex_s;
+typedef struct pthread_mutex_s pthread_mutex_t;
+#  define __PTHREAD_MUTEX_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_MUTEXATTR_T_DEFINED
+struct pthread_mutexattr_s;
+typedef struct pthread_mutexattr_s pthread_mutexattr_t;
+#  define __PTHREAD_MUTEXATTR_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_T_DEFINED
+typedef pid_t pthread_t;
+#  define __PTHREAD_T_DEFINED 1
+#endif
+
+#ifndef __PTHREAD_ONCE_T_DEFINED
+struct pthread_once_s;
+typedef struct pthread_once_s pthread_once_t;
+#  define __PTHREAD_ONCE_T_DEFINED 1
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Reorganize pthread‑related declarations to follow POSIX header‑placement requirements:
1. Move pthread_kill() and pthread_sigmask() from <pthread.h> to <signal.h>, as these signal‑related functions belong in the signal header per POSIX.
2. Relocate pthread type definitions (pthread_t, pthread_attr_t, pthread_mutex_t, etc.) from <pthread.h> to <sys/types.h>, aligning with POSIX type‑definition conventions.

## Impact

1. Improves POSIX header‑layout compliance, enabling standards‑based applications and test suites (e.g., PSE52 VSX) to locate pthread declarations in the expected headers.
2. No functional change—only the location of declarations is adjusted; all APIs remain available with the same semantics.

## Testing

Verified that the moved functions (pthread_kill, pthread_sigmask) are still accessible when including <signal.h>.

