### PR TITLE
libc: add creat function implementation

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -160,13 +160,6 @@
 #define F_SEAL_WRITE        0x0008 /* Prevent writes */
 #define F_SEAL_FUTURE_WRITE 0x0010 /* Prevent future writes while mapped */
 
-/* int creat(const char *path, mode_t mode);
- *
- * is equivalent to open with O_WRONLY|O_CREAT|O_TRUNC.
- */
-
-#define creat(path, mode) open(path, O_WRONLY|O_CREAT|O_TRUNC, mode)
-
 #if defined(CONFIG_FS_LARGEFILE)
 #  define F_GETLK64         F_GETLK
 #  define F_SETLK64         F_SETLK
@@ -215,6 +208,7 @@ extern "C"
 
 /* POSIX-like File System Interfaces */
 
+int creat(FAR const char *pathname, mode_t mode);
 int open(FAR const char *path, int oflag, ...);
 int openat(int dirfd, FAR const char *path, int oflag, ...);
 int fcntl(int fd, int cmd, ...);

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -28,6 +28,7 @@ list(
   SRCS
   lib_bitmap.c
   lib_circbuf.c
+  lib_creat.c
   lib_mknod.c
   lib_umask.c
   lib_utsname.c

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -22,11 +22,11 @@
 
 # Add the internal C files to the build
 
-CSRCS += lib_bitmap.c lib_circbuf.c lib_mknod.c lib_umask.c lib_utsname.c
-CSRCS += lib_getrandom.c lib_xorshift128.c lib_tea_encrypt.c lib_tea_decrypt.c
-CSRCS += lib_cxx_initialize.c lib_impure.c lib_memfd.c lib_mutex.c
-CSRCS += lib_fchmodat.c lib_fstatat.c lib_getfullpath.c lib_openat.c
-CSRCS += lib_mkdirat.c lib_utimensat.c lib_mallopt.c
+CSRCS += lib_bitmap.c lib_circbuf.c lib_creat.c lib_mknod.c lib_umask.c
+CSRCS += lib_utsname.c lib_getrandom.c lib_xorshift128.c lib_tea_encrypt.c
+CSRCS += lib_tea_decrypt.c lib_cxx_initialize.c lib_impure.c lib_memfd.c
+CSRCS += lib_mutex.c lib_fchmodat.c lib_fstatat.c lib_getfullpath.c
+CSRCS += lib_openat.c lib_mkdirat.c lib_utimensat.c lib_mallopt.c
 CSRCS += lib_idr.c lib_getnprocs.c
 
 ifeq ($(CONFIG_LIBC_TEMPBUFFER),y)

--- a/libs/libc/misc/lib_creat.c
+++ b/libs/libc/misc/lib_creat.c
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * libs/libc/misc/lib_creat.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <fcntl.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: creat
+ *
+ * Description:
+ *   The creat() function is just a simple wrapper of open() function
+ *
+ * Input Parameters:
+ *   path  - The path for the file to create on
+ *   mode  - the access mode
+ *
+ * Returned Value:
+ *   Return a file descriptor of the file that created success,
+ *   return -1 if error occurd on creat new file, and errno is setup
+ *
+ ****************************************************************************/
+
+int creat(FAR const char *path, mode_t mode)
+{
+  return open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+}


### PR DESCRIPTION
## Summary

Add a function implementation of creat() to the C library to meet PSE52 VSX test suite requirements. The implementation provides a callable function that mirrors the behavior of the existing creat() macro.

## Impact

Enables the PSE52 test suite to compile and run correctly when it expects creat() to be a callable function (e.g., when taking its address or using it in function-pointer contexts).

## Testing

Verified that PSE52 VSX tests referencing creat() as a function now build and execute successfully.
