### PR TITLE
fpathconf: add _POSIX_PRIO_IO definition to comply with PSE52 standard

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -97,7 +97,7 @@
 
 #define _POSIX_SYNC_IO 1
 #undef  _POSIX_ASYNC_IO
-#undef  _POSIX_PRIO_IO
+#define  _POSIX_PRIO_IO 1
 
 #define _XOPEN_UNIX 1
 #define _XOPEN_VERSION 700L

--- a/libs/libc/unistd/lib_pathconf.c
+++ b/libs/libc/unistd/lib_pathconf.c
@@ -137,7 +137,7 @@ long fpathconf(int fildes, int name)
         return _POSIX_MAX_INPUT;
 
       case _PC_PRIO_IO:
-        return -1;
+        return _POSIX_PRIO_IO;
 
       default:
 


### PR DESCRIPTION
## Summary

Define `_POSIX_PRIO_IO` as `1` in `<unistd.h>` and update `fpathconf()` to return this value for the` _PC_PRIO_IO` query, fixing the failing PSE52 test case `/tset/rt.os/files/fpathconf/T.fpathconf{1}` which expects the constant to be defined.

## Impact

Fixes the test failure where `_POSIX_ASYNC_IO` was reported as undefined—the test actually requires `_POSIX_PRIO_IO` to be defined and returned by `fpathconf()`.

## Testing

Verified that PSE52 `/tset/rt.os/files/fpathconf/T.fpathconf{1}` now passes.
