### PR TITLE
boards/stm32f103-minimum: Add GPIO in/out/int define

### DIFF
--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_gpio.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_gpio.c
@@ -62,18 +62,25 @@ struct stm32gpint_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
+#if BOARD_NGPIOIN > 0
 static int gpin_read(struct gpio_dev_s *dev, bool *value);
+#endif /* BOARD_NGPIOIN > 0 */
+#if BOARD_NGPIOOUT > 0
 static int gpout_read(struct gpio_dev_s *dev, bool *value);
 static int gpout_write(struct gpio_dev_s *dev, bool value);
+#endif /* BOARD_NGPIOOUT > 0 */
+#if BOARD_NGPIOINT > 0
 static int gpint_read(struct gpio_dev_s *dev, bool *value);
 static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
 static int gpint_enable(struct gpio_dev_s *dev, bool enable);
+#endif /* BOARD_NGPIOINT > 0 */
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
+#if BOARD_NGPIOIN > 0
 static const struct gpio_operations_s gpin_ops =
 {
   .go_read   = gpin_read,
@@ -81,7 +88,9 @@ static const struct gpio_operations_s gpin_ops =
   .go_attach = NULL,
   .go_enable = NULL,
 };
+#endif /* BOARD_NGPIOIN > 0 */
 
+#if BOARD_NGPIOOUT > 0
 static const struct gpio_operations_s gpout_ops =
 {
   .go_read   = gpout_read,
@@ -89,7 +98,9 @@ static const struct gpio_operations_s gpout_ops =
   .go_attach = NULL,
   .go_enable = NULL,
 };
+#endif /* BOARD_NGPIOOUT > 0 */
 
+#if BOARD_NGPIOINT > 0
 static const struct gpio_operations_s gpint_ops =
 {
   .go_read   = gpint_read,
@@ -97,6 +108,7 @@ static const struct gpio_operations_s gpint_ops =
   .go_attach = gpint_attach,
   .go_enable = gpint_enable,
 };
+#endif /* BOARD_NGPIOINT > 0 */
 
 #if BOARD_NGPIOIN > 0
 /* This array maps the GPIO pins used as INPUT */
@@ -109,7 +121,7 @@ static const uint32_t g_gpioinputs[BOARD_NGPIOIN] =
 static struct stm32gpio_dev_s g_gpin[BOARD_NGPIOIN];
 #endif
 
-#if BOARD_NGPIOOUT
+#if BOARD_NGPIOOUT > 0
 /* This array maps the GPIO pins used as OUTPUT */
 
 static const uint32_t g_gpiooutputs[BOARD_NGPIOOUT] =
@@ -135,6 +147,7 @@ static struct stm32gpint_dev_s g_gpint[BOARD_NGPIOINT];
  * Private Functions
  ****************************************************************************/
 
+ #if BOARD_NGPIOINT > 0
 static int stm32gpio_interrupt(int irq, void *context, void *arg)
 {
   struct stm32gpint_dev_s *stm32gpint =
@@ -147,7 +160,9 @@ static int stm32gpio_interrupt(int irq, void *context, void *arg)
                        stm32gpint->stm32gpio.id);
   return OK;
 }
+#endif /* BOARD_NGPIOINT > 0 */
 
+#if BOARD_NGPIOIN > 0
 static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
   struct stm32gpio_dev_s *stm32gpio =
@@ -160,7 +175,9 @@ static int gpin_read(struct gpio_dev_s *dev, bool *value)
   *value = stm32_gpioread(g_gpioinputs[stm32gpio->id]);
   return OK;
 }
+#endif /* BOARD_NGPIOIN > 0*/
 
+#if BOARD_NGPIOOUT > 0
 static int gpout_read(struct gpio_dev_s *dev, bool *value)
 {
   struct stm32gpio_dev_s *stm32gpio =
@@ -186,7 +203,9 @@ static int gpout_write(struct gpio_dev_s *dev, bool value)
   stm32_gpiowrite(g_gpiooutputs[stm32gpio->id], value);
   return OK;
 }
+#endif /* BOARD_NGPIOOUT > 0 */
 
+#if BOARD_NGPIOINT > 0
 static int gpint_read(struct gpio_dev_s *dev, bool *value)
 {
   struct stm32gpint_dev_s *stm32gpint =
@@ -245,6 +264,7 @@ static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 
   return OK;
 }
+#endif /* BOARD_NGPIOINT > 0 */
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary

Added conditional compilation guards (#if/#endif) around GPIO function prototypes, operation structures, and interrupt handler to ensure proper compilation when GPIO input, output, or interrupt features are disabled (when BOARD_NGPIOIN, BOARD_NGPIOOUT, or BOARD_NGPIOINT are set to 0). Fixed inconsistent conditional check for BOARD_NGPIOOUT (changed from `#if BOARD_NGPIOOUT` to `#if BOARD_NGPIOOUT > 0` for consistency with other GPIO type checks).

## Impact

This change ensures that the stm32f103-minimum board GPIO driver compiles correctly when any GPIO type (input, output, or interrupt) is disabled via configuration. No functional changes for existing configurations. Build process: prevents compilation errors when GPIO features are disabled. Compatibility: maintains backward compatibility with existing configurations.

## Testing

Tested compilation on stm32f103-minimum board with default configuration (all GPIO types enabled: BOARD_NGPIOIN=1, BOARD_NGPIOOUT=1, BOARD_NGPIOINT=1) and with each GPIO type disabled individually:
- BOARD_NGPIOIN=0, BOARD_NGPIOOUT=1, BOARD_NGPIOINT=1
- BOARD_NGPIOIN=1, BOARD_NGPIOOUT=0, BOARD_NGPIOINT=1
- BOARD_NGPIOIN=1, BOARD_NGPIOOUT=1, BOARD_NGPIOINT=0
