### PR TITLE
arm64: add the interrupt status in the syscall

### DIFF
--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -164,6 +164,10 @@ uint64_t *arm64_syscall(uint64_t *regs)
   uint64_t             spsr;
 #endif
 
+  /* Set irq flag */
+
+  write_sysreg((uintptr_t)tcb | 1, tpidr_el1);
+
   /* Nested interrupts are not supported */
 
   DEBUGASSERT(regs);
@@ -314,6 +318,10 @@ uint64_t *arm64_syscall(uint64_t *regs)
       default:
         {
           svcerr("ERROR: Bad SYS call: 0x%" PRIx64 "\n", cmd);
+
+          /* Clear irq flag */
+
+          write_sysreg((uintptr_t)tcb & ~1ul, tpidr_el1);
           return 0;
         }
         break;
@@ -326,5 +334,9 @@ uint64_t *arm64_syscall(uint64_t *regs)
    */
 
   (*running_task)->xcp.regs = NULL;
+
+  /* Clear irq flag */
+
+  write_sysreg((uintptr_t)tcb & ~1ul, tpidr_el1);
   return regs;
 }


### PR DESCRIPTION
## Summary

This PR adds proper interrupt status tracking to the ARM64 syscall handler.
The interrupt status is encoded in the least significant bit (LSB) of the 
tpidr_el1 register to indicate whether the CPU is currently executing within 
an interrupt/exception context. This allows the kernel to determine execution 
context and enforce appropriate restrictions on certain operations that are 
only safe in normal task context.

## Changes

The syscall handler now properly manages interrupt status flags:

1. **Entry (set interrupt flag)**:
   - When entering `arm64_syscall()`, set the LSB of tpidr_el1 to indicate 
     IRQ-in-progress state
   - Enables other code to check if execution is in interrupt context

2. **Exit (clear interrupt flag)**:
   - When exiting `arm64_syscall()` normally, clear the LSB of tpidr_el1
   - Also clears the flag on error paths (default case in syscall switch)
   - Ensures proper context tracking even when returning from invalid syscalls

3. **Implementation details**:
   - Use `write_sysreg((uintptr_t)tcb | 1, tpidr_el1)` to set the flag
   - Use `write_sysreg((uintptr_t)tcb & ~1ul, tpidr_el1)` to clear the flag
   - The TCB pointer is preserved in the upper bits while using bit 0 for status

## Testing

Tested on:
- **Platform**: ARM64 NuttX simulator and hardware targets
- **Scenario**: Normal syscall flow and error handling paths
- **Method**:
  - Verified interrupt flag is set when entering syscall
  - Verified interrupt flag is cleared on normal syscall exit
  - Verified interrupt flag is cleared on invalid syscall paths
  - Tested context switching and signal handling with proper flag state
- **Result**: 
  - Interrupt status correctly reflects syscall handler execution
  - No impact on normal task scheduling or context switching
  - Error handling maintains proper flag state

## Impact

- **Stability**: Enables proper synchronization primitives and operations that 
  depend on execution context
- **Correctness**: Allows kernel code to verify safe execution context before 
  performing context-sensitive operations
- **Compatibility**: No breaking changes; existing code continues to work 
  unchanged
- **Performance**: Minimal overhead; only adds two register write operations 
  per syscall
- **Code Quality**: Improves kernel robustness by enforcing execution context 
  awareness