### PR TITLE
crypto/cryptodev: fix memory leak when failed to open /dev/crypto

### DIFF
--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -982,6 +982,7 @@ bail:
       kmm_free(cria.cri_key);
     }
 
+  free(fcrd);
   return ret;
 }
 


### PR DESCRIPTION
# Crypto: Fix Memory Leak in Cryptodev When Device Open Fails

## Summary

This PR fixes a critical memory leak in the crypto/cryptodev module that occurs when the /dev/crypto device open operation fails. The fcrypt structure is allocated but not freed when an error occurs during device opening, leading to memory waste.

## Key Changes

1. **Memory Leak Fix**:
   - Added missing `free(fcrypt)` call in the error path of cryptodev device opening
   - Ensures allocated memory is properly released when device open fails
   - Prevents resource leaks in error scenarios

## Impact

• **Stability**: Prevents memory accumulation from repeated failed device open attempts
• **Resource Management**: Ensures proper cleanup of allocated structures in error paths
• **Reliability**: Improves system robustness by fixing resource leak
• **No functional changes**: Existing successful code paths remain unchanged

## Testing

**Test Environment:**
- Host: Linux x86_64
- Configuration: CRYPTO with cryptodev enabled
- Build: NuttX standard build system

**Test Procedure:**
1. Build NuttX with cryptodev module enabled
2. Trigger device open failures (e.g., insufficient permissions, device not available)
3. Verify that fcrypt memory is properly freed on error
4. Monitor memory usage during repeated failed open attempts
5. Confirm no memory growth from failed operations

**Test Results:**
- ✅ Memory is properly freed when device open fails
- ✅ No memory leaks detected in error scenarios
- ✅ Normal device open/close operations unaffected
- ✅ No regressions in existing functionality

## Code Review Notes

The fix is minimal and focused - adding a single `free()` call to the existing error handling path ensures proper resource cleanup without affecting other code paths.