### PR TITLE
drivers/misc/optee: add missing addrenv header include

### DIFF
--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -36,6 +36,7 @@
 #include <sys/param.h>
 
 #ifdef CONFIG_ARCH_ADDRENV
+#  include <nuttx/addrenv.h>
 #  include <nuttx/pgalloc.h>
 #  include <nuttx/sched.h>
 #  include <nuttx/arch.h>


### PR DESCRIPTION
## Summary

This PR fixes a compilation error in the OPTEE driver that occurs when 
CONFIG_ARCH_ADDRENV is enabled. The driver's `optee_va_to_pa()` function 
references the `struct addrenv_s` type, but the required header file was not 
included, causing undefined type errors during compilation.

## Changes

The fix adds the missing include directive:

1. **drivers/misc/optee.c**:
   - Add `#include <nuttx/addrenv.h>` within the `CONFIG_ARCH_ADDRENV` 
     conditional block
   - This provides the definition for `struct addrenv_s` needed by the 
     `optee_va_to_pa()` function
   - Placed before the existing `CONFIG_ARCH_ADDRENV` includes for proper 
     ordering of dependencies

## Testing

Tested on:
- **Platform**: NuttX with CONFIG_ARCH_ADDRENV enabled
- **Configuration**: OPTEE driver enabled with memory management support
- **Method**: 
  - Verified compilation succeeds with CONFIG_ARCH_ADDRENV=y
  - Verified OPTEE driver can be built without address environment support
  - Tested with different architecture configurations
- **Result**: 
  - No compilation errors when CONFIG_ARCH_ADDRENV is enabled
  - No impact on builds with CONFIG_ARCH_ADDRENV disabled
  - OPTEE driver functionality verified

## Impact

- **Stability**: Fixes build failures that prevent OPTEE support from being 
  compiled with address environment features
- **Correctness**: Ensures proper type definitions are available where needed
- **Compatibility**: 
  - No breaking changes
  - Only affects builds with CONFIG_ARCH_ADDRENV enabled
  - Existing code continues to work unchanged
- **Code Quality**: Improves build robustness by ensuring all required types 
  are properly declared