### PR TITLE
ctucanfd: increase rwcnt bitfield width and fix structure alignment

### DIFF
--- a/drivers/can/ctucanfd.h
+++ b/drivers/can/ctucanfd.h
@@ -208,7 +208,7 @@ begin_packed_struct struct ctucanfd_frame_fmt_s
   uint32_t lbpf:1;              /* Loop-back frame */
   uint32_t brs:1;               /* Bit rate shift */
   uint32_t esi_rsv:1;           /* Error state indicator */
-  uint32_t rwcnt:4;             /* Size without FRAME_FORMAT WORD */
+  uint32_t rwcnt:5;             /* Size without FRAME_FORMAT WORD */
   uint32_t erf_pos:4;           /* Error frame position */
   uint32_t erf_erp:1;           /* Error passive state */
   uint32_t erf_type:3;          /* Error frame type */


### PR DESCRIPTION
### Summary

This change updates the definition of the rwcnt (read word count) bitfield
in ctucanfd_frame_fmt_s.

Previously, rwcnt was defined as a 4-bit field, limiting its maximum value
to 15. However, according to the CTU CAN FD hardware specification, this range
may be insufficient to correctly represent the frame size excluding the
FRAME_FORMAT word, especially for larger CAN FD frames.

To address this limitation, the bitfield width of rwcnt is increased to
support a larger range. At the same time, the layout of
ctucanfd_frame_fmt_s is adjusted to ensure that the overall structure size
remains a multiple of 4 bytes, which is required by the hardware interface and
DMA access constraints.

This change improves correctness and robustness when handling CAN FD frames
with larger payloads.

### Impact

Drivers / Hardware:
Improves compatibility with CTU CAN FD hardware by correctly representing
larger frame sizes.

API / ABI:
Internal structure layout change only; no user-facing API changes.

Compatibility:
No impact on existing applications that rely on standard CAN or smaller
CAN FD frames. Existing code continues to work as before.

Build / Documentation / Security:
No impact.

### Testing
In the QEMU environment on an Ubuntu host, the Vela project with CAN support was executed, and verification confirmed that CAN communication and data transmission operate correctly.