### PR TITLE
arch/x86_64: add support for linker map generation

### DIFF
--- a/arch/x86_64/src/common/Toolchain.defs
+++ b/arch/x86_64/src/common/Toolchain.defs
@@ -253,6 +253,16 @@ AFLAGS := $(CFLAGS) -D__ASSEMBLY__ -Wa,--divide
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden
 LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/elf/gnu-elf.ld)
 
+# Debug link map
+
+ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
+  LDFLAGS += --cref -Map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
+endif
+
+ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
+  ARCHOPTIMIZATION += $(CONFIG_DEBUG_SYMBOLS_LEVEL)
+endif
+
 # ELF module definitions
 
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden


### PR DESCRIPTION
### Summary:
    Add support for link map generation in build process

### Impact:
    This change introduces the capability to generate and output linker map files during kernel build.
    It does not affect default runtime behavior but provides additional artifacts for debugging and optimization.
    Developers working on kernel-level features or troubleshooting memory layouts will benefit.

### Testing:
    Verified successful build on QEMU target boards.
    Checked the generated linkmap files for completeness and correctness.
    No regressions observed in standard test suites (nsh, kernel boot, app start).