### PR TITLE
libs/libc: replace critical section with spinlock in hostname operations

### DIFF
--- a/libs/libc/unistd/lib_gethostname.c
+++ b/libs/libc/unistd/lib_gethostname.c
@@ -46,6 +46,7 @@
 #include <unistd.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 /* Further, in the protected and kernel build modes where kernel and
  * application code are separated, the hostname is a common system property
@@ -74,6 +75,7 @@
 /* This is the system hostname */
 
 char g_hostname[HOST_NAME_MAX + 1] = CONFIG_LIBC_HOSTNAME;
+spinlock_t g_hostname_lock = SP_UNLOCKED;
 
 /****************************************************************************
  * Public Functions
@@ -111,9 +113,9 @@ int gethostname(FAR char *name, size_t namelen)
    * that it could change while we are copying it.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_hostname_lock);
   strlcpy(name, g_hostname, namelen);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_hostname_lock, flags);
 
   return 0;
 }

--- a/libs/libc/unistd/lib_sethostname.c
+++ b/libs/libc/unistd/lib_sethostname.c
@@ -47,6 +47,7 @@
 #include <unistd.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 /* Further, in the protected and kernel build modes where kernel and
  * application code are separated, the hostname is a common system property
@@ -67,6 +68,7 @@
 /* This is the system hostname (defined in lib_gethostname). */
 
 extern char g_hostname[HOST_NAME_MAX + 1];
+extern spinlock_t g_hostname_lock;
 
 /****************************************************************************
  * Public Functions
@@ -105,9 +107,9 @@ int sethostname(FAR const char *name, size_t namelen)
    * are setting it.
    */
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&g_hostname_lock);
   strlcpy(g_hostname, name, sizeof(g_hostname));
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&g_hostname_lock, flags);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

This PR optimizes the hostname operations by replacing global critical section 
locks with a lightweight spinlock. The hostname is a shared system property that 
needs synchronization, but using global critical sections causes unnecessary 
interrupt latency throughout the system. A dedicated spinlock provides better 
performance and scalability.

## Changes

The optimization involves synchronization changes in two files:

1. **libs/libc/unistd/lib_gethostname.c** - Add spinlock for hostname reading:
   - Add `#include <nuttx/spinlock.h>` header
   - Define static spinlock: `spinlock_t g_hostname_lock = SP_UNLOCKED`
   - Replace `enter_critical_section()` with `spin_lock_irqsave(&g_hostname_lock)`
   - Replace `leave_critical_section()` with `spin_unlock_irqrestore(&g_hostname_lock, flags)`
   - Protects hostname reading during string copy

2. **libs/libc/unistd/lib_sethostname.c** - Add spinlock for hostname writing:
   - Add `#include <nuttx/spinlock.h>` header
   - Declare external spinlock: `extern spinlock_t g_hostname_lock`
   - Replace `enter_critical_section()` with `spin_lock_irqsave(&g_hostname_lock)`
   - Replace `leave_critical_section()` with `spin_unlock_irqrestore(&g_hostname_lock, flags)`
   - Protects hostname writing during string copy

## Benefits

- **Performance**: Reduces interrupt latency by using spinlock instead of global critical section
- **Scalability**: Per-subsystem spinlock allows other code to proceed without delay
- **Correctness**: Maintains proper synchronization for the shared hostname resource
- **Efficiency**: Lightweight spinlock is appropriate for short critical sections

## Technical Details

**Why spinlock instead of critical section?**
- Critical sections disable interrupts globally, blocking all interrupt handlers
- Spinlock only protects access to the specific shared resource
- Reduces latency for unrelated operations

**Synchronization scope:**
- `gethostname()`: Protects reading g_hostname during copy to user buffer
- `sethostname()`: Protects writing g_hostname from user-provided buffer

## Testing

Tested on:
- **Platform**: NuttX with multi-core support
- **Configuration**: User-mode and kernel-mode builds
- **Test scenarios**:
  - Concurrent reads from multiple tasks
  - Concurrent writes with various hostname lengths
  - Signal handling during hostname operations
  - Network stack hostname access patterns
  - Interrupt latency measurements
- **Result**:
  - Hostname operations work correctly with spinlock
  - Reduced interrupt latency vs. critical sections
  - No data corruption or race conditions
  - Improved system responsiveness

## Impact

- **Performance**: Improved system-wide interrupt latency
- **Stability**: Maintains correct hostname synchronization
- **Compatibility**: No API changes; internal optimization only
- **Code Quality**: Cleaner synchronization model