### PR TITLE
sched/irq: handle NULL ISR handler in irq_default_handler

### DIFF
--- a/sched/irq/irq_attach_thread.c
+++ b/sched/irq/irq_attach_thread.c
@@ -72,8 +72,10 @@ static int irq_default_handler(int irq, FAR void *regs, FAR void *arg)
   FAR struct irq_thread_info_s *info = arg;
   int ret = IRQ_WAKE_THREAD;
 
-  DEBUGASSERT(info->handler != NULL);
-  ret = info->handler(irq, regs, info->arg);
+  if (info->handler != NULL)
+    {
+      ret = info->handler(irq, regs, info->arg);
+    }
 
   if (ret == IRQ_WAKE_THREAD)
     {
@@ -133,7 +135,7 @@ static int isr_thread_main(int argc, FAR char *argv[])
  *   irq - Irq num
  *   isr - Function to be called when the IRQ occurs, called in interrupt
  *   context.
- *   If isr is NULL the default handler is installed(irq_default_handler).
+ *   If isr is NULL, isrthread will be called.
  *   isrthread - called in thread context, If the isrthread is NULL,
  *   then the ISR is being detached.
  *   arg - privdate data

--- a/sched/irq/irq_attach_wqueue.c
+++ b/sched/irq/irq_attach_wqueue.c
@@ -128,9 +128,12 @@ static void irq_work_handler(FAR void *arg)
 static int irq_default_handler(int irq, FAR void *regs, FAR void *arg)
 {
   FAR struct irq_work_info_s *info = arg;
-  int ret;
+  int ret = IRQ_WAKE_THREAD;
 
-  ret = info->handler(irq, regs, arg);
+  if (info->handler != NULL)
+    {
+      ret = info->handler(irq, regs, info->arg);
+    }
 
   if (ret == IRQ_WAKE_THREAD)
     {
@@ -156,7 +159,7 @@ static int irq_default_handler(int irq, FAR void *regs, FAR void *arg)
  *   irq - Irq num
  *   isr - Function to be called when the IRQ occurs, called in interrupt
  *   context.
- *   If isr is NULL the default handler is installed(irq_default_handler).
+ *   If isr is NULL, isrthread will be called.
  *   isrwork - called in thread context, If the isrwork is NULL,
  *   then the ISR is being detached.
  *   arg - privdate data


### PR DESCRIPTION
## Summary

Add null-check protection for ISR handler invocation in threaded interrupt mode. When `isr` is NULL, the system now safely handles the irq_default_handler without attempting to call a null function pointer. This improves robustness of the interrupt handling subsystem and aligns with the documented behavior that NULL ISR triggers isrthread execution.

## Changes

- **sched/irq/irq_attach_thread.c**: 
  - Replace `DEBUGASSERT(info->handler != NULL)` with safe null-check conditional
  - Only invoke handler if non-NULL, preventing potential null pointer dereference
  - Update comment documentation to clarify behavior when isr is NULL

- **sched/irq/irq_attach_wqueue.c**:
  - Add null-check guard for info->handler before invocation
  - Initialize `ret` variable to `IRQ_WAKE_THREAD` for correct default behavior
  - Fix handler call parameter from generic `arg` to `info->arg` for consistency
  - Update comment to accurately reflect NULL isr behavior

## Benefits & Technical Details

- **Safety**: Eliminates null pointer dereference risk when NULL ISR is passed during handler attachment/detachment
- **Documentation alignment**: Comment now accurately reflects implementation - NULL isr triggers isrthread callback
- **Consistency**: Both irq_attach_thread and irq_attach_wqueue use identical null-check pattern
- **Correct parameter passing**: Fixed parameter type in irq_attach_wqueue to pass correct context data

## Testing

- Verified irq_default_handler correctly handles NULL handler pointers without crashing
- Confirmed isrthread is properly invoked when isr is NULL during IRQ attachment
- Tested IRQ attachment and detachment with both NULL and non-NULL ISR handlers
- Validated on systems with threaded and work queue based interrupt handlers

## Impact

- **Robustness**: Safer interrupt handler attachment/detachment sequence
- **Compatibility**: No API changes, fully backward compatible
- **Documentation**: Corrected and clarified ISR NULL handling behavior
- **Scope**: Affects threaded interrupt mode (CONFIG_ARCH_IRQHANDLER_ATTACH_THREAD) and work queue based IRQ handling