### PR TITLE
arm64: add missing REG_SCTLR_EL1 initialization in signal processing

### DIFF
--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -66,6 +66,11 @@ static void arm64_init_signal_process(struct tcb_s *tcb, uint64_t *regs)
   tcb->xcp.regs[REG_SPSR]   = SPSR_MODE_EL1H | DAIF_FIQ_BIT | DAIF_IRQ_BIT;
 #endif
 
+  tcb->xcp.regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1);
+#ifdef CONFIG_ARM64_MTE
+  tcb->xcp.regs[REG_SCTLR_EL1] |= SCTLR_TCF1_BIT;
+#endif
+
 #ifdef CONFIG_ARCH_KERNEL_STACK
   tcb->xcp.regs[REG_SP_EL0] = regs[REG_SP_EL0];
 #else


### PR DESCRIPTION
## Summary

Add missing initialization of the ARM64 system control register (REG_SCTLR_EL1) when setting up the register context for signal handlers in `arm64_init_signal_process()`. The system control register was previously overlooked when initializing the signal processing context, which could cause signal handlers to run with incorrect control register settings. This fix ensures proper system control configuration when executing signal handlers.

## Changes

- **arch/arm64/src/common/arm64_schedulesigaction.c**:
  - Add REG_SCTLR_EL1 initialization in arm64_init_signal_process() using current sctlr_el1 value
  - Apply CONFIG_ARM64_MTE tag setting (SCTLR_TCF1_BIT) to match system configuration
  - Place initialization after SPSR setup to maintain logical register initialization order

## Benefits & Technical Details

- **Register consistency**: Signal handlers now run with correct system control register settings matching the interrupted context
- **MTE support**: ARM64 Memory Tagging Extension configuration is properly propagated to signal handlers when enabled
- **Correctness**: Fixes regression where signal handler context initialization was incomplete
- **Safety**: Ensures signal handlers execute with expected system control configuration state

## Testing

- Verified signal handlers execute with correct SCTLR_EL1 register values
- Confirmed CONFIG_ARM64_MTE tag settings are properly applied in signal handler context
- Tested signal handler execution on ARM64 systems with and without MTE enabled
- Validated register context setup matches interrupted task's system control configuration
- Confirmed signal handler completion and return to interrupted context works correctly

## Impact

- **Correctness**: Fixes signal handler register context initialization regression
- **Compatibility**: No API changes, fully backward compatible
- **Scope**: Affects ARM64 signal handler context setup during signal dispatch
- **Architecture**: ARM64 specific fix for system control register handling