### PR TITLE
arm64: fix FIQ mask initialization in task state

### DIFF
--- a/arch/arm64/src/common/arm64_initialstate.c
+++ b/arch/arm64/src/common/arm64_initialstate.c
@@ -91,6 +91,10 @@ void arm64_new_task(struct tcb_s * tcb)
   xcp->regs[REG_SCTLR_EL1] |= SCTLR_TCF1_BIT;
 #endif
 
+#ifndef CONFIG_ARM64_DECODEFIQ
+  xcp->regs[REG_SPSR]     |= DAIF_FIQ_BIT;
+#endif
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   xcp->regs[REG_SPSR]     |= (DAIF_IRQ_BIT | DAIF_FIQ_BIT);
 #endif /* CONFIG_SUPPRESS_INTERRUPTS */


### PR DESCRIPTION
## Summary

Fix FIQ interrupt mask initialization in ARM64 task initial state setup. Add DAIF_FIQ_BIT masking in the SPSR register when creating new tasks, unless CONFIG_ARM64_DECODEFIQ is enabled. This ensures FIQ interrupts are properly masked by default in new task contexts, maintaining consistent interrupt handling behavior.

## Changes

- **arch/arm64/src/common/arm64_initialstate.c**:
  - Add FIQ bit masking to REG_SPSR in arm64_new_task() function
  - Apply DAIF_FIQ_BIT mask unless CONFIG_ARM64_DECODEFIQ configuration option is enabled
  - Ensure FIQ masking happens after TCF1_BIT setup but before CONFIG_SUPPRESS_INTERRUPTS check

## Benefits & Technical Details

- **Correct interrupt state**: FIQ interrupts are masked by default in new task context unless explicitly enabled
- **Consistency**: Aligns with IRQ masking behavior which already applies DAIF_IRQ_BIT in task initialization
- **Configuration control**: Respects CONFIG_ARM64_DECODEFIQ option for systems requiring FIQ handling
- **Completeness**: Fixes missing DAIF_FIQ_BIT initialization that was overlooked in initial state setup

## Testing

- Verified new tasks have FIQ bit properly set in SPSR register
- Confirmed FIQ interrupts remain masked unless CONFIG_ARM64_DECODEFIQ is enabled
- Tested task creation and context switching with corrected SPSR state
- Validated interrupt handling behavior matches expected default masking
- Confirmed no regression in systems using CONFIG_ARM64_DECODEFIQ

## Impact

- **Correctness**: Fixes incomplete SPSR initialization for FIQ masking
- **Compatibility**: Fully backward compatible, no API changes
- **Architecture**: ARM64 specific interrupt mask initialization
- **Scope**: Affects all new ARM64 task creation and initial state setup