### PR TITLE
arch/imx9: Modify default ddr config handling

### DIFF
--- a/arch/arm64/src/imx9/ddr/imx9_ddr_training.c
+++ b/arch/arm64/src/imx9/ddr/imx9_ddr_training.c
@@ -37,6 +37,7 @@
 #include "hardware/imx93/imx93_memorymap.h"
 #include "hardware/imx9_ddr_training.h"
 #include <arch/board/imx9_ddr_training.h>
+#include "imx9_ddr_training.h"
 
 #include "imx9_trdc.h"
 
@@ -98,42 +99,6 @@ static uint32_t g_ccd_rr_max;
 static uint32_t g_ccd_rw_max;
 static uint32_t g_ccd_wr_max;
 static uint32_t g_ccd_ww_max;
-
-static struct dram_fsp_msg ddr_dram_fsp_msg[] =
-{
-  {
-    /* P0 3733 1D */
-
-    .drate = 3733,
-    .fw_type = FW_1D_IMAGE,
-    .fsp_cfg = ddr_fsp0_cfg,
-    .fsp_cfg_num = nitems(ddr_fsp0_cfg),
-  },
-  {
-    /* P0 3733 2D */
-
-    .drate = 3733,
-    .fw_type = FW_2D_IMAGE,
-    .fsp_cfg = ddr_fsp0_2d_cfg,
-    .fsp_cfg_num = nitems(ddr_fsp0_2d_cfg),
-  },
-};
-
-/* DDR timing config params */
-
-struct dram_timing_info dram_timing_default =
-{
-  .ddrc_cfg = ddr_ddrc_cfg,
-  .ddrc_cfg_num = nitems(ddr_ddrc_cfg),
-  .ddrphy_cfg = ddr_ddrphy_cfg,
-  .ddrphy_cfg_num = nitems(ddr_ddrphy_cfg),
-  .fsp_msg = ddr_dram_fsp_msg,
-  .fsp_msg_num = nitems(ddr_dram_fsp_msg),
-  .ddrphy_pie = ddr_phy_pie,
-  .ddrphy_pie_num = nitems(ddr_phy_pie),
-  .fsp_cfg = ddr_dram_fsp_cfg,
-  .fsp_cfg_num = nitems(ddr_dram_fsp_cfg),
-};
 
 /****************************************************************************
  * Private Functions
@@ -1465,7 +1430,7 @@ static int imx9_ddr_init(struct dram_timing_info *dram_timing)
 
 int imx9_dram_init(void)
 {
-  struct dram_timing_info *ptiming = &dram_timing_default;
+  struct dram_timing_info *ptiming = imx9_ddr_config();
 
   return imx9_ddr_init(ptiming);
 }

--- a/arch/arm64/src/imx9/ddr/imx9_ddr_training.h
+++ b/arch/arm64/src/imx9/ddr/imx9_ddr_training.h
@@ -40,4 +40,21 @@
 
 int imx9_dram_init(void);
 
+/****************************************************************************
+ * Name: imx9_ddr_config
+ *
+ * Description:
+ *   i.MX9 architectures must provide the following entry point
+ *   if CONFIG_IMX9_DDR_TRAINING is defined.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Pointer to dram_timing_info struct
+ *
+ ****************************************************************************/
+
+struct dram_timing_info *imx9_ddr_config(void);
+
 #endif

--- a/boards/arm64/imx9/imx93-evk/src/Makefile
+++ b/boards/arm64/imx9/imx93-evk/src/Makefile
@@ -44,6 +44,11 @@ ifeq ($(CONFIG_IMX9_USDHC),y)
 CSRCS += imx9_usdhc.c
 endif
 
+ifeq ($(CONFIG_IMX9_DDR_TRAINING),y)
+CSRCS += imx9_ddr_config.c
+endif
+
+
 include $(TOPDIR)/boards/Board.mk
 
 ifeq ($(CONFIG_IMX9_BOOTLOADER),y)

--- a/boards/arm64/imx9/imx93-evk/src/imx9_ddr_config.c
+++ b/boards/arm64/imx9/imx93-evk/src/imx9_ddr_config.c
@@ -1,0 +1,96 @@
+/****************************************************************************
+ * boards/arm64/imx9/imx93-evk/src/imx9_ddr_config.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/board.h>
+#include <arch/board/board.h>
+#include <chip.h>
+#include <debug.h>
+#include "arm64_internal.h"
+#include "arm64_mmu.h"
+#include "hardware/imx9_memorymap.h"
+
+#include "ddr/hardware/imx9_ddr_training.h"
+#include <arch/board/imx9_ddr_training.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* PHY Initialize Configuration */
+
+static struct dram_fsp_msg ddr_dram_fsp_msg[] =
+{
+  {
+    /* P0 3733 1D */
+
+    .drate = 3733,
+    .fw_type = FW_1D_IMAGE,
+    .fsp_cfg = ddr_fsp0_cfg,
+    .fsp_cfg_num = nitems(ddr_fsp0_cfg),
+  },
+  {
+    /* P0 3733 2D */
+
+    .drate = 3733,
+    .fw_type = FW_2D_IMAGE,
+    .fsp_cfg = ddr_fsp0_2d_cfg,
+    .fsp_cfg_num = nitems(ddr_fsp0_2d_cfg),
+  },
+};
+
+/* DDR timing config params */
+
+struct dram_timing_info dram_timing_default_config =
+{
+  .ddrc_cfg = ddr_ddrc_cfg,
+  .ddrc_cfg_num = nitems(ddr_ddrc_cfg),
+  .ddrphy_cfg = ddr_ddrphy_cfg,
+  .ddrphy_cfg_num = nitems(ddr_ddrphy_cfg),
+  .fsp_msg = ddr_dram_fsp_msg,
+  .fsp_msg_num = nitems(ddr_dram_fsp_msg),
+  .ddrphy_pie = ddr_phy_pie,
+  .ddrphy_pie_num = nitems(ddr_phy_pie),
+  .fsp_cfg = ddr_dram_fsp_cfg,
+  .fsp_cfg_num = nitems(ddr_dram_fsp_cfg),
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+struct dram_timing_info *imx9_ddr_config(void)
+{
+  return &dram_timing_default_config;
+}


### PR DESCRIPTION
Remove default ddr config
Add imx9_ddr_config() function  to return default config

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Modify ddr config handling so that default config is read with imx9_ddr_config() function.
This way diffent boards can possible variate ddr config with different ddr variants

## Impact

Only affects imx9 platform and bootloader code.
Default ddr config has not changed
Only enables future ddr config modifications

## Testing

Tested with custom imx9 hw
imx9 evk compilation tested
