### PR TITLE
arm64: When returning from a system call, regs[REG_SP_EL0] will overw…

### DIFF
--- a/arch/arm64/src/common/arm64_syscall.c
+++ b/arch/arm64/src/common/arm64_syscall.c
@@ -265,13 +265,13 @@ uint64_t *arm64_syscall(uint64_t *regs)
 
               /* Create a frame for info and copy the kernel info */
 
-              rtcb->xcp.ustkptr = (uintptr_t *)read_sysreg(sp_el0);
+              rtcb->xcp.ustkptr = (uintptr_t *)regs[REG_SP_EL0];
               usp = (uintptr_t)rtcb->xcp.ustkptr - sizeof(siginfo_t);
               memcpy((void *)usp, (void *)regs[REG_X2], sizeof(siginfo_t));
 
               /* Now set the updated SP and user copy of "info" to R2 */
 
-              write_sysreg(usp, sp_el0);
+              regs[REG_SP_EL0] = usp;
               regs[REG_X2] = usp;
             }
 #endif


### PR DESCRIPTION
## Summary

Fix ARM64 SP_EL0 (userspace stack pointer) handling in the syscall return path. When processing system calls that deliver signals, the code now correctly uses the stack pointer value from the saved register context (regs[REG_SP_EL0]) instead of directly reading/writing the SP_EL0 system register. This ensures that when syscall returns and registers are restored, the userspace stack pointer is correctly updated without clobbering signal stack setup.

## Changes

- **arch/arm64/src/common/arm64_syscall.c**:
  - Line 268: Replace `read_sysreg(sp_el0)` with `regs[REG_SP_EL0]` when saving userspace stack pointer to rtcb->xcp.ustkptr
  - Line 274: Replace `write_sysreg(usp, sp_el0)` with `regs[REG_SP_EL0] = usp` to update stack pointer in register context
  - Ensures SP_EL0 modifications occur in register context, not directly to system register

## Benefits & Technical Details

- **Register consistency**: Stack pointer modifications happen in the saved register context which will be restored on return
- **Signal handling**: Signal frame is correctly positioned on userspace stack with proper SP_EL0 value
- **Context correctness**: When iret or similar syscall return instruction restores registers, SP_EL0 is properly set
- **Race prevention**: Avoids potential races between system register and register context values
- **User space safety**: Userspace stack pointer correctly reflects signal frame location

## Testing

- Verified signal delivery with system call interception works correctly
- Confirmed userspace stack pointer is properly set for signal frame
- Tested signal handler execution and return from within syscall context
- Validated stack unwinding in debugger shows correct userspace SP
- Confirmed no stack corruption or misalignment in signal paths

## Impact

- **Correctness**: Fixes improper SP_EL0 handling that could corrupt userspace stack during signal delivery
- **Compatibility**: Fully backward compatible, no API changes
- **Architecture**: ARM64 specific fix for syscall signal delivery path
- **Scope**: Affects system calls that deliver signals to userspace processes