### PR TITLE
arm64: g_mpu_region need support SMP

### DIFF
--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -73,7 +73,7 @@
  * regions.
  */
 
-static unsigned int g_mpu_region;
+static unsigned int g_mpu_region[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
  * Private Functions
@@ -153,12 +153,12 @@ static void mpu_init(void)
 unsigned int mpu_allocregion(void)
 {
   unsigned int num_regions = get_num_regions();
-  unsigned int i = ffs(~g_mpu_region) - 1;
+  unsigned int i = ffs(~g_mpu_region[this_cpu()]) - 1;
 
   /* There are not enough regions to apply */
 
   DEBUGASSERT(i < num_regions);
-  g_mpu_region |= 1 << i;
+  g_mpu_region[this_cpu()] |= 1 << i;
   return i;
 }
 
@@ -191,7 +191,7 @@ void mpu_freeregion(unsigned int region)
 
   write_sysreg(0, prbar_el1);
   write_sysreg(0, prlar_el1);
-  g_mpu_region &= ~(1 << region);
+  g_mpu_region[this_cpu()] &= ~(1 << region);
   UP_MB();
 }
 
@@ -275,7 +275,7 @@ void mpu_modify_region(unsigned int region,
 
   /* Check that the region is valid */
 
-  DEBUGASSERT(g_mpu_region & (1 << region));
+  DEBUGASSERT(g_mpu_region[this_cpu()] & (1 << region));
 
   rbar |= table->attr.rbar &
           (MPU_RBAR_XN_MSK | MPU_RBAR_AP_MSK | MPU_RBAR_SH_MSK);


### PR DESCRIPTION
## Summary

Make ARM64 MPU region tracking SMP-aware by converting the global g_mpu_region variable into a per-CPU array. This ensures that each CPU core independently tracks its allocated MPU regions, preventing cross-CPU region conflicts in multi-core systems. The change replaces all accesses to g_mpu_region with g_mpu_region[this_cpu()], enabling proper resource management in SMP configurations.

## Changes

- **arch/arm64/src/common/arm64_mpu.c**:
  - Line 76: Change `static unsigned int g_mpu_region` to `static unsigned int g_mpu_region[CONFIG_SMP_NCPUS]`
  - Line 156: Update region allocation to use `g_mpu_region[this_cpu()]` in ffs() call
  - Line 161: Update region bit-set to use `g_mpu_region[this_cpu()]` 
  - Line 194: Update region bit-clear to use `g_mpu_region[this_cpu()]`
  - Line 278: Update region validity check to use `g_mpu_region[this_cpu()]`
  - All changes consistently index the array with this_cpu() for per-CPU tracking

## Benefits & Technical Details

- **Per-CPU tracking**: Each CPU core maintains independent MPU region allocation bitmap
- **SMP correctness**: Prevents race conditions where different CPUs interfere with each other's region tracking
- **Isolation**: MPU regions allocated on one CPU don't affect region availability on other CPUs
- **Scalability**: Enables proper MPU configuration for each CPU in multi-core systems
- **Memory protection**: Each core can independently manage its memory protection regions

## Testing

- Verified each CPU core independently tracks its allocated MPU regions
- Confirmed no cross-CPU interference in region allocation and deallocation
- Tested simultaneous MPU region allocation on multiple CPUs
- Validated region modification operations on per-CPU regions
- Confirmed SMP systems properly isolate MPU configuration per core

## Impact

- **Correctness**: Fixes MPU region tracking for multi-core ARM64 systems
- **Compatibility**: No impact on single-CPU configurations (array size 1)
- **Architecture**: ARM64 specific MPU management improvement
- **Scope**: Affects all ARM64 MPU region allocation, deallocation, and modification operations