### PR TITLE
build/cmake: add missing libcxxtoolchain support

### DIFF
--- a/arch/arm/src/cmake/platform.cmake
+++ b/arch/arm/src/cmake/platform.cmake
@@ -85,10 +85,11 @@ if(CONFIG_LIBSUPCXX_TOOLCHAIN)
   nuttx_find_toolchain_lib(libsupc++.a)
 endif()
 
-if(CONFIG_COVERAGE_TOOLCHAIN)
-  nuttx_find_toolchain_lib(libgcov.a)
-endif()
-
 if(CONFIG_LIBCXXTOOLCHAIN)
   nuttx_find_toolchain_lib(libstdc++.a)
+  list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_DIR}/include/cxx)
+endif()
+
+if(CONFIG_COVERAGE_TOOLCHAIN)
+  nuttx_find_toolchain_lib(libgcov.a)
 endif()

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -274,6 +274,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 ifeq ($(CONFIG_COVERAGE_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcov.a))
 endif

--- a/arch/arm64/src/cmake/platform.cmake
+++ b/arch/arm64/src/cmake/platform.cmake
@@ -45,6 +45,11 @@ if(CONFIG_LIBSUPCXX_TOOLCHAIN)
   nuttx_find_toolchain_lib(libsupc++.a)
 endif()
 
+if(CONFIG_LIBCXXTOOLCHAIN)
+  nuttx_find_toolchain_lib(libstdc++.a)
+  list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_DIR}/include/cxx)
+endif()
+
 if(CONFIG_COVERAGE_TOOLCHAIN)
   nuttx_find_toolchain_lib(libgcov.a)
 endif()

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -205,6 +205,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 # Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -101,6 +101,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 ## Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -316,6 +316,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 # Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -132,6 +132,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 # Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -80,6 +80,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 # Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -118,6 +118,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 # Loadable module definitions
 
 CMODULEFLAGS = $(CFLAGS) -fvisibility=hidden

--- a/arch/risc-v/src/cmake/platform.cmake
+++ b/arch/risc-v/src/cmake/platform.cmake
@@ -37,41 +37,23 @@ endforeach()
 
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-          --print-libgcc-file-name
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  OUTPUT_VARIABLE extra_library)
-
-list(APPEND EXTRA_LIB ${extra_library})
+nuttx_find_toolchain_lib()
 
 if(CONFIG_LIBM_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libm.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libm.a)
 endif()
 
 if(CONFIG_LIBSUPCXX_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libsupc++.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libsupc++.a)
+endif()
+
+if(CONFIG_LIBCXXTOOLCHAIN)
+  nuttx_find_toolchain_lib(libstdc++.a)
+  list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_DIR}/include/cxx)
 endif()
 
 if(CONFIG_COVERAGE_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libgcov.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libgcov.a)
 endif()
-
-nuttx_add_extra_library(${EXTRA_LIB})
 
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -431,6 +431,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 ifeq ($(CONFIG_COVERAGE_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcov.a))
 endif

--- a/arch/tricore/src/cmake/platform.cmake
+++ b/arch/tricore/src/cmake/platform.cmake
@@ -40,38 +40,20 @@ endforeach()
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 
 if(CONFIG_TRICORE_TOOLCHAIN_GNU)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-libgcc-file-name
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib()
   if(CONFIG_LIBM_TOOLCHAIN)
-    execute_process(
-      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-              --print-file-name=libm.a
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      OUTPUT_VARIABLE extra_library)
-    list(APPEND EXTRA_LIB ${extra_library})
+    nuttx_find_toolchain_lib(libm.a)
   endif()
   if(CONFIG_LIBSUPCXX)
-    execute_process(
-      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-              --print-file-name=libsupc++.a
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      OUTPUT_VARIABLE extra_library)
-    list(APPEND EXTRA_LIB ${extra_library})
+    nuttx_find_toolchain_lib(libsupc++.a)
+  endif()
+  if(CONFIG_LIBCXXTOOLCHAIN)
+    nuttx_find_toolchain_lib(libstdc++.a)
+    list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_DIR}/include/cxx)
   endif()
   if(CONFIG_COVERAGE_TOOLCHAIN)
-    execute_process(
-      COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-              --print-file-name=libgcov.a
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      OUTPUT_VARIABLE extra_library)
-    list(APPEND EXTRA_LIB ${extra_library})
+    nuttx_find_toolchain_lib(libgcov.a)
   endif()
-
-  nuttx_add_extra_library(${EXTRA_LIB})
 
   set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
 endif()

--- a/arch/x86_64/src/cmake/platform.cmake
+++ b/arch/x86_64/src/cmake/platform.cmake
@@ -37,51 +37,28 @@ endforeach()
 
 separate_arguments(CMAKE_C_FLAG_ARGS NATIVE_COMMAND ${CMAKE_C_FLAGS})
 
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-          --print-libgcc-file-name
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  OUTPUT_VARIABLE extra_library)
-
-list(APPEND EXTRA_LIB ${extra_library})
+nuttx_find_toolchain_lib()
 
 if(CONFIG_LIBM_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libm.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libm.a)
 endif()
 
 if(CONFIG_LIBSUPCXX_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libsupc++.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libsupc++.a)
+endif()
+
+if(CONFIG_LIBCXXTOOLCHAIN)
+  nuttx_find_toolchain_lib(libstdc++.a)
+  list(APPEND CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${NUTTX_DIR}/include/cxx)
 endif()
 
 if(CONFIG_COVERAGE_TOOLCHAIN)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libgcov.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libgcov.a)
 endif()
 
 if(CONFIG_CXX_EXCEPTION)
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
-            --print-file-name=libgcc_eh.a
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE extra_library)
-  list(APPEND EXTRA_LIB ${extra_library})
+  nuttx_find_toolchain_lib(libgcc_eh.a)
 endif()
-
-nuttx_add_extra_library(${EXTRA_LIB})
 
 set(PREPROCESS ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} -E -P -x c)
 

--- a/arch/xtensa/src/cmake/platform.cmake
+++ b/arch/xtensa/src/cmake/platform.cmake
@@ -58,6 +58,14 @@ if(CONFIG_LIBSUPCXX_TOOLCHAIN)
     OUTPUT_VARIABLE extra_library)
   list(APPEND EXTRA_LIB ${extra_library})
 endif()
+if(CONFIG_LIBCXXTOOLCHAIN)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --print-file-name=libstdc++.a
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE extra_library)
+  list(APPEND EXTRA_LIB ${extra_library})
+endif()
 if(CONFIG_COVERAGE_TOOLCHAIN)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -218,6 +218,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 ifeq ($(CONFIG_COVERAGE_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcov.a))
 endif

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -222,6 +222,10 @@ ifeq ($(CONFIG_LIBSUPCXX_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a))
 endif
 
+ifeq ($(CONFIG_LIBCXXTOOLCHAIN),y)
+  EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libstdc++.a))
+endif
+
 ifeq ($(CONFIG_COVERAGE_TOOLCHAIN),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcov.a))
 endif


### PR DESCRIPTION
## Summary
Closes #17799

This PR extends the fix for CMake-based builds with `CONFIG_LIBCXXTOOLCHAIN` 
to all remaining platforms. It builds upon the previous PR that addressed 
this issue for a specific platform.

**Problem:** When `CONFIG_LIBCXXTOOLCHAIN` is enabled, CMake builds do not 
consistently locate and link `libstdc++.a` from the toolchain. This causes 
toolchain STL headers to be included without the corresponding library, 
resulting in conflicts between NuttX libc headers and toolchain headers, 
leading to build failures.

**Solution:** Explicitly locate the toolchain C++ standard library using 
`nuttx_find_toolchain_lib()` for all platforms when `CONFIG_LIBCXXTOOLCHAIN` 
is enabled. This aligns CMake build behavior with the legacy Make system, 
which already handles this case correctly.

## Impact

- **Build System:** Affects CMake-based builds across all platforms when 
  `CONFIG_LIBCXXTOOLCHAIN` is enabled.
- **Users:** Projects using the toolchain's C++ standard library with CMake 
  will now build successfully without header/library conflicts.
- **Compatibility:** Aligns CMake build behavior with the existing Make 
  build system. No impact on Make-based builds.
- **Dependencies:** Requires CMake build system; no new external dependencies.

## Testing

**Host Environment:**
- OS: Ubuntu 24.04

PS: I took the opportunity to refactor to use the built in cmake function to link libs for some platforms
