### PR TITLE
arm64: fix stack pointer initialization when CONFIG_STACK_COLORATION …

### DIFF
--- a/arch/arm64/src/common/arm64_head.S
+++ b/arch/arm64/src/common/arm64_head.S
@@ -179,6 +179,8 @@ real_start:
     str    w2, [x24], #4
     cmp    w1, #0
     bne    .loop
+#  else
+    add    x24, x24, #(SMP_STACK_SIZE)
 #  endif
 
     /* Initialize percpu reg tpidr_el1 */


### PR DESCRIPTION
## Summary

Fix ARM64 multi-core stack pointer initialization when CONFIG_STACK_COLORATION is not defined. The boot code now correctly advances the stack pointer (x24) by SMP_STACK_SIZE for each CPU even when stack coloration is disabled, preventing adjacent CPU stacks from overlapping. The fix adds a missing else clause to handle the non-coloration code path.

## Changes

- **arch/arm64/src/common/arm64_head.S**:
  - Add else clause after CONFIG_STACK_COLORATION conditional in real_start label
  - In the non-coloration path, advance x24 (current stack pointer) by SMP_STACK_SIZE
  - Ensures proper per-CPU stack spacing regardless of CONFIG_STACK_COLORATION setting

## Benefits & Technical Details

- **Correct stack layout**: Each CPU stack occupies SMP_STACK_SIZE bytes without overlap
- **Configuration independence**: Stack initialization works correctly with or without coloration enabled
- **Boot safety**: Prevents stack corruption from concurrent CPU initialization
- **Multi-core correctness**: Ensures each CPU has properly isolated stack space
- **Consistency**: Matches stack pointer advancement behavior from coloration code path

## Testing

- Verified stack pointers correctly spaced by SMP_STACK_SIZE for each CPU without coloration
- Confirmed no stack corruption when multiple CPUs boot simultaneously without coloration enabled
- Tested system boot with CONFIG_STACK_COLORATION disabled on multi-core ARM64
- Validated stack traces show correct stack boundaries for each CPU
- Confirmed no memory overlap between different CPU stacks

## Impact

- **Correctness**: Fixes multi-core stack initialization bug when coloration is disabled
- **Compatibility**: Fully backward compatible, no API changes
- **Configuration**: Particularly important for builds without CONFIG_STACK_COLORATION
- **Scope**: Affects ARM64 multi-core boot sequence and stack initialization