### PR TITLE
sched/task: fix null pointer dereference in fork address environment …

### DIFF
--- a/sched/task/task_fork.c
+++ b/sched/task/task_fork.c
@@ -147,19 +147,6 @@ FAR struct tcb_s *nxtask_setup_fork(start_t retaddr)
 
   child->flags |= TCB_FLAG_FREE_TCB;
 
-#if defined(CONFIG_ARCH_ADDRENV)
-  /* Join the parent address environment (REVISIT: vfork() only) */
-
-  if (ttype != TCB_FLAG_TTYPE_KERNEL)
-    {
-      ret = addrenv_join(parent, child);
-      if (ret < 0)
-        {
-          goto errout_with_tcb;
-        }
-    }
-#endif
-
   /* Initialize the task join */
 
   nxtask_joininit(child);
@@ -175,6 +162,19 @@ FAR struct tcb_s *nxtask_setup_fork(start_t retaddr)
     {
       goto errout_with_tcb;
     }
+
+#if defined(CONFIG_ARCH_ADDRENV)
+  /* Join the parent address environment */
+
+  if (ttype != TCB_FLAG_TTYPE_KERNEL)
+    {
+      ret = addrenv_join(parent, child);
+      if (ret < 0)
+        {
+          goto errout_with_tcb;
+        }
+    }
+#endif
 
   /* Duplicate the parent tasks environment */
 


### PR DESCRIPTION
## Summary

Fix null pointer dereference in fork operation when setting up address environments. The addrenv_join() function accesses the child task's group pointer (child->group), which is initialized by group_initialize(). By moving addrenv_join() to occur after group_initialize(), the code ensures child->group is properly set before it is accessed, eliminating the null pointer dereference.

## Changes

- **sched/task/task_fork.c**:
  - Move address environment join block in nxtask_setup_fork() from before group_initialize() to after it
  - Relocate addrenv_join() call and its error handling to execute after group_initialize()
  - Maintain all other fork operation sequencing and error handling

## Benefits & Technical Details

- **Null pointer safety**: child->group is now guaranteed to be initialized before addrenv_join() accesses it
- **Correct sequencing**: Task group initialization must precede address environment operations
- **Error handling**: All error paths correctly handled with existing cleanup logic
- **Fork correctness**: Child task inherits parent's address environment with proper initialization

## Testing

- Verified fork operations complete without null pointer dereference
- Confirmed child task group is properly initialized before address environment join
- Tested fork with CONFIG_ARCH_ADDRENV enabled and disabled
- Validated child task inherits correct address environment from parent
- Confirmed no regression in fork functionality or child task creation

## Impact

- **Correctness**: Fixes crash in fork when CONFIG_ARCH_ADDRENV is enabled
- **Compatibility**: Fully backward compatible, no API changes
- **Configuration**: Particularly important for builds with CONFIG_ARCH_ADDRENV
- **Scope**: Affects fork-based task creation with address environment support