### PR TITLE
Doc: Correct XIAO ESP32C3 board configuration name

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-xiao/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-xiao/index.rst
@@ -72,7 +72,7 @@ Installation
   $ git clone https://github.com/apache/nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
-  $ ./tools/configure.sh xiao-esp32c3:usbnsh
+  $ ./tools/configure.sh esp32c3-xiao:usbnsh
   $ make V=1
 
 2. Connect the Seeed Studio XIAO ESP32C3, and enter "Bootloader" mode,


### PR DESCRIPTION
## Summary

The documentation for the Seeed Studio XIAO ESP32C3 incorrectly referenced the board configuration command as `xiao-esp32c3`. However, the actual directory structure in the NuttX codebase identifies this board as [esp32c3-xiao](cci:7://file:///Users/aviralgarg/Everything/nuttx/boards/risc-v/esp32c3/esp32c3-xiao:0:0-0:0) (located at [boards/risc-v/esp32c3/esp32c3-xiao](cci:7://file:///Users/aviralgarg/Everything/nuttx/boards/risc-v/esp32c3/esp32c3-xiao:0:0-0:0)).

This change updates [Documentation/platforms/risc-v/esp32c3/boards/esp32c3-xiao/index.rst](cci:7://file:///Users/aviralgarg/Everything/nuttx/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-xiao/index.rst:0:0-0:0) to reflect the correct command:
`./tools/configure.sh esp32c3-xiao:usbnsh`

## Impact

*   **Documentation**: Users following the Seeed Studio XIAO ESP32C3 getting started guide will now be provided with the correct configuration command, preventing "path not found" errors during the initial setup.

## Testing

I verified this change by:
1.  **Codebase Analysis**: Searched for all occurrences of `xiao-esp32c3` in the `Documentation` directory and confirmed this was the primary incorrect reference.
2.  **Filesystem Verification**: Confirmed the board directory exists at [boards/risc-v/esp32c3/esp32c3-xiao/](cci:7://file:///Users/aviralgarg/Everything/nuttx/boards/risc-v/esp32c3/esp32c3-xiao:0:0-0:0).
3.  **Command Validation**: Verified that [./tools/configure.sh](cci:7://file:///Users/aviralgarg/Everything/nuttx/tools/configure.sh:0:0-0:0) correctly resolves [esp32c3-xiao](cci:7://file:///Users/aviralgarg/Everything/nuttx/boards/risc-v/esp32c3/esp32c3-xiao:0:0-0:0) while `xiao-esp32c3` fails.

**Host Information:**
- OS: macOS
- NuttX Branch: `fix-xiao-esp32c3-doc`