### PR TITLE
arch/stm32: Fix stm32-capture if timer don't support GTIM_CCER_CC1NP

### DIFF
--- a/arch/arm/src/stm32/stm32_capture.c
+++ b/arch/arm/src/stm32/stm32_capture.c
@@ -1126,7 +1126,11 @@ static int stm32_cap_setchannel(struct stm32_cap_dev_s *dev,
 
       case STM32_CAP_EDGE_BOTH:
         ccer_en_bit = GTIM_CCER_CC1E;
+#ifdef HAVE_GTIM_CCXNP
         regval      = GTIM_CCER_CC1P | GTIM_CCER_CC1NP;
+#else
+        regval      = GTIM_CCER_CC1P;
+#endif
         break;
 
       default:
@@ -1134,8 +1138,11 @@ static int stm32_cap_setchannel(struct stm32_cap_dev_s *dev,
     }
 
   /* Shift all CCER bits to corresponding channel */
-
+#ifdef HAVE_GTIM_CCXNP
   mask = (GTIM_CCER_CC1E | GTIM_CCER_CC1P | GTIM_CCER_CC1NP);
+#else
+  mask = (GTIM_CCER_CC1E | GTIM_CCER_CC1P);
+#endif
   mask          <<= GTIM_CCER_CCXBASE(channel);
   regval        <<= GTIM_CCER_CCXBASE(channel);
   ccer_en_bit   <<= GTIM_CCER_CCXBASE(channel);


### PR DESCRIPTION
## Summary

- Fix: Some STM32 chips don't support GTIM_CCER_CC1NP; use HAVE_GTIM_CCXNP guards to exclude it.
- stm32_cap_setchannel() in arch/arm/src/stm32/stm32_capture.c — mask and regval handling for chips without CC1NP support.
- Adds/updates #ifdef HAVE_GTIM_CCXNP guards so GTIM_CCER_CC1NP is only included when supported, preventing register writes on chips without it.

## Impact

Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES — fixes timer capture on STM32 chips without CC1NP support

## Testing

on target: arch(ARM/STM32), stm32f103-minimum:nsh