### PR TITLE
drivers/usbhost_hidkbd: Fix small typo in usbhost_hidkbd.c

### DIFF
--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -616,7 +616,7 @@ static const uint8_t ucmap[USBHID_NUMSCANCODES] =
   0,    0,       0,      0,      0,    0,    0,      0,    /* 0xa0-0xa7: Out,Oper,Clear,CrSel,Excel,(reserved) */
   0,    0,       0,      0,      0,    0,    0,      0,    /* 0xa8-0xaf: (reserved) */
   0,    0,       0,      0,      0,    0,    '(',    ')',  /* 0xb0-0xb7: 00,000,ThouSeparator,DecSeparator,CurrencyUnit,SubUnit,(,) */
-  '{',  '}',    '\t',    \177,   'A',  'B',  'C',    'D',  /* 0xb8-0xbf: {,},tab,backspace,A-D */
+  '{',  '}',    '\t',    '\177', 'A',  'B',  'C',    'D',  /* 0xb8-0xbf: {,},tab,backspace,A-D */
   'F',  'F',     0,      '^',    '%',  '<', '>',     '&',  /* 0xc0-0xc7: E-F,XOR,^,%,<,>,& */
   0,    '|',     0,      ':',    '%',  ' ', '@',     '!',  /* 0xc8-0xcf: &&,|,||,:,#, ,@,! */
   0,    0,       0,      0,      0,    0,   0,       0,    /* 0xd0-0xd7: Memory Store,Recall,Clear,Add,Subtract,Multiply,Divide,+/- */


### PR DESCRIPTION
## Summary

There were missing quotes for key "backspace" for scancodes.
This issue was found by github user @StagiaireAbritek

He opened an PR in github to fix it:
https://github.com/apache/nuttx/pull/15917

However he decided to abandon and close the PR, but because it is an important fix I decided submit it upstream.
## Impact

It will fix a compilation issue and user will get keyboard backspace working.

## Testing

BEFORE :

Register: nsh
Register: sh
CC: usbhost/usbhost_hidkbd.c usbhost/usbhost_hidkbd.c:620:26: error: stray '' in program
620 | '{', '}', '\t', \177, 'A', 'B', 'C', 'D', /* 0xb8-0xbf: {,},tab,backspace,A-D */
| ^
make[1]: *** [Makefile:109: usbhost_hidkbd.o] Error 1
make: *** [tools/LibTargets.mk:107: drivers/libdrivers.a] Error 2

AFTER:

no error
