### PR TITLE
libs/libxx: change libcxxmini to libminiabi

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -24,20 +24,16 @@ if HAVE_CXX
 
 choice
 	prompt "C++ Library"
-	default LIBCXXMINI
+	default LIBCXXNONE
+
+config LIBCXXNONE
+	bool "No default C++ Standard Template Library"
 
 config LIBCXXTOOLCHAIN
 	bool "Toolchain C++ support"
 	select HAVE_CXXINITIALIZE
 	---help---
 		Use Standard C++ library from toolchain.
-
-config LIBCXXMINI
-	bool "Basic C++ support"
-	---help---
-		A fragmentary C++ library that will allow to build only
-		the simplest of C++ applications. Only contain basic C++
-		runtime support function.
 
 config LIBCXX
 	bool "LLVM libc++ C++ Standard Library"
@@ -60,17 +56,23 @@ endchoice
 
 config ETL
 	bool "Embedded Template Library (ETL)"
-	depends on LIBCXXMINI && ALLOW_MIT_COMPONENTS
+	depends on ALLOW_MIT_COMPONENTS
 	---help---
 		ETL A C++ Template library for Embedded applications
 		Implements C++ templates such as containers, string
 		singleton math without C++ STL libraries
 
-if !LIBCXXMINI
-
 choice
 	prompt "C++ low level library select"
+	default LIBMINIABI if LIBCXXNONE
 	default LIBSUPCXX_TOOLCHAIN
+
+config LIBMINIABI
+	bool "Basic C++ support"
+	---help---
+		A fragmentary C++ library that will allow to build only
+		the simplest of C++ applications. Only contain basic C++
+		runtime support function.
 
 config LIBCXXABI
 	bool "LLVM low level C++ Library"
@@ -92,8 +94,6 @@ config LIBSUPCXX_TOOLCHAIN
 		level c++ library.
 
 endchoice
-
-endif
 
 config LIBCXXABI_VERSION
 	string "Select libcxxabi version"

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -35,8 +35,6 @@ ifeq ($(CONFIG_UCLIBCXX),y)
 include uClibc++/Make.defs
 else ifeq ($(CONFIG_LIBCXX),y)
 include libcxx/Make.defs
-else ifeq ($(CONFIG_LIBCXXMINI),y)
-include libcxxmini/Make.defs
 endif
 
 ifeq ($(CONFIG_ETL),y)
@@ -45,6 +43,8 @@ endif
 
 ifeq ($(CONFIG_LIBCXXABI),y)
 include libcxxabi/Make.defs
+else ifeq ($(CONFIG_LIBMINIABI),y)
+include libminiabi/Make.defs
 endif
 
 # Object Files

--- a/libs/libxx/libminiabi/CMakeLists.txt
+++ b/libs/libxx/libminiabi/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# libs/libxx/libcxxmini/CMakeLists.txt
+# libs/libxx/libminiabi/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,16 +20,16 @@
 #
 # ##############################################################################
 
-if(CONFIG_LIBCXXMINI)
+if(CONFIG_LIBMINIABI)
 
-  nuttx_add_system_library(libcxxmini)
+  nuttx_add_system_library(libminiabi)
 
   if(NOT CONFIG_XTENSA_TOOLCHAIN_XCC)
     add_compile_options(-Wno-missing-exception-spec)
   endif()
 
   target_sources(
-    libcxxmini
+    libminiabi
     PRIVATE libxx_cxa_guard.cxx
             libxx_cxapurevirtual.cxx
             libxx_delete.cxx

--- a/libs/libxx/libminiabi/Make.defs
+++ b/libs/libxx/libminiabi/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# libs/libxx/libcxxmini/Make.defs
+# libs/libxx/libminiabi/Make.defs
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -29,5 +29,5 @@ ifneq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
   CXXFLAGS += -Wno-missing-exception-spec
 endif
 
-DEPPATH += --dep-path libcxxmini
-VPATH += libcxxmini
+DEPPATH += --dep-path libminiabi
+VPATH += libminiabi

--- a/libs/libxx/libminiabi/libxx_cxa_guard.cxx
+++ b/libs/libxx/libminiabi/libxx_cxa_guard.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libcxxmini/libxx_delete.cxx
+// libs/libxx/libminiabi/libxx_cxa_guard.cxx
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -16,6 +16,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 // License for the specific language governing permissions and limitations
+// under the License.
 //
 //***************************************************************************
 
@@ -23,48 +24,72 @@
 // Included Files
 //***************************************************************************
 
-#include <nuttx/config.h>
-
-#include <cstddef>
-
-#include <nuttx/lib/lib.h>
+#include <nuttx/compiler.h>
 
 //***************************************************************************
-// Operators
+// Pre-processor Definitions
 //***************************************************************************
 
 //***************************************************************************
-// Name: delete
+// Private Types
 //***************************************************************************
 
-void operator delete(FAR void *ptr) throw()
+#ifdef __ARM_EABI__
+// The 32-bit ARM C++ ABI specifies that the guard is a 32-bit
+// variable and the least significant bit contains 0 prior to
+// initialization, and 1 after.
+
+typedef int __guard;
+
+#else
+// The "standard" C++ ABI specifies that the guard is a 64-bit
+// variable and the first byte contains 0 prior to initialization, and
+// 1 after.
+
+__extension__ typedef int __guard __attribute__((mode(__DI__)));
+#endif
+
+//***************************************************************************
+// Private Data
+//***************************************************************************
+
+//***************************************************************************
+// Public Functions
+//***************************************************************************
+
+extern "C"
 {
-  lib_free(ptr);
+  //*************************************************************************
+  // Name: __cxa_guard_acquire
+  //*************************************************************************
+
+  int __cxa_guard_acquire(FAR __guard *g)
+  {
+#ifdef __ARM_EABI__
+    return !(*g & 1);
+#else
+    return !*(FAR char *)g;
+#endif
+  }
+
+  //*************************************************************************
+  // Name: __cxa_guard_release
+  //*************************************************************************
+
+  void __cxa_guard_release(FAR __guard *g)
+  {
+#ifdef __ARM_EABI__
+    *g = 1;
+#else
+    *(FAR char *)g = 1;
+#endif
+  }
+
+  //*************************************************************************
+  // Name: __cxa_guard_abort
+  //*************************************************************************
+
+  void __cxa_guard_abort(FAR __guard *)
+  {
+  }
 }
-
-#ifdef CONFIG_HAVE_CXX14
-
-//***************************************************************************
-// Operators
-//***************************************************************************
-
-//***************************************************************************
-// Name: delete
-//
-// NOTE:
-//   This should take a type of size_t.  But size_t has an unknown underlying
-//   type.  In the nuttx sys/types.h header file, size_t is typed as uint32_t
-//   (which is determined by architecture-specific logic).  But the C++
-//   compiler may believe that size_t is of a different type resulting in
-//   compilation errors in the operator.  Using the underlying integer type
-//   instead of size_t seems to resolve the compilation issues. Need to
-//   REVISIT this.
-//
-//***************************************************************************
-
-void operator delete(FAR void *ptr, std::size_t size)
-{
-  lib_free(ptr);
-}
-
-#endif /* CONFIG_HAVE_CXX14 */

--- a/libs/libxx/libminiabi/libxx_cxapurevirtual.cxx
+++ b/libs/libxx/libminiabi/libxx_cxapurevirtual.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libcxxmini/libxx_cxapurevirtual.cxx
+// libs/libxx/libminiabi/libxx_cxapurevirtual.cxx
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/libs/libxx/libminiabi/libxx_deletea.cxx
+++ b/libs/libxx/libminiabi/libxx_deletea.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libcxxmini/libxx_deletea.cxx
+// libs/libxx/libminiabi/libxx_deletea.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with

--- a/libs/libxx/libminiabi/libxx_dynamic_cast.cxx
+++ b/libs/libxx/libminiabi/libxx_dynamic_cast.cxx
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libxx/libcxxmini/libxx_dynamic_cast.cxx
+ * libs/libxx/libminiabi/libxx_dynamic_cast.cxx
  *
  * Copyright 2010-2011 PathScale, Inc. All rights reserved.
  *

--- a/libs/libxx/libminiabi/libxx_new.cxx
+++ b/libs/libxx/libminiabi/libxx_new.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libcxxmini/libxx_newa.cxx
+// libs/libxx/libminiabi/libxx_new.cxx
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,14 +31,6 @@
 #include <nuttx/lib/lib.h>
 
 //***************************************************************************
-// Pre-processor Definitions
-//***************************************************************************
-
-//***************************************************************************
-// Private Data
-//***************************************************************************
-
-//***************************************************************************
 // Operators
 //***************************************************************************
 
@@ -56,7 +48,7 @@
 //
 //***************************************************************************
 
-FAR void *operator new[](std::size_t nbytes)
+FAR void *operator new(std::size_t nbytes)
 {
   // Perform the allocation
 
@@ -79,7 +71,7 @@ FAR void *operator new[](std::size_t nbytes)
   return alloc;
 }
 
-FAR void *operator new[](std::size_t nbytes, FAR void *ptr)
+FAR void *operator new(std::size_t nbytes, FAR void *ptr)
 {
   DEBUGASSERT(ptr != NULL);
 

--- a/libs/libxx/libminiabi/libxx_newa.cxx
+++ b/libs/libxx/libminiabi/libxx_newa.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libcxxmini/libxx_new.cxx
+// libs/libxx/libminiabi/libxx_newa.cxx
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,6 +31,14 @@
 #include <nuttx/lib/lib.h>
 
 //***************************************************************************
+// Pre-processor Definitions
+//***************************************************************************
+
+//***************************************************************************
+// Private Data
+//***************************************************************************
+
+//***************************************************************************
 // Operators
 //***************************************************************************
 
@@ -48,7 +56,7 @@
 //
 //***************************************************************************
 
-FAR void *operator new(std::size_t nbytes)
+FAR void *operator new[](std::size_t nbytes)
 {
   // Perform the allocation
 
@@ -71,7 +79,7 @@ FAR void *operator new(std::size_t nbytes)
   return alloc;
 }
 
-FAR void *operator new(std::size_t nbytes, FAR void *ptr)
+FAR void *operator new[](std::size_t nbytes, FAR void *ptr)
 {
   DEBUGASSERT(ptr != NULL);
 

--- a/libs/libxx/libminiabi/libxx_typeinfo.cxx
+++ b/libs/libxx/libminiabi/libxx_typeinfo.cxx
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libxx/libcxxmini/libxx_typeinfo.cxx
+ * libs/libxx/libminiabi/libxx_typeinfo.cxx
  *
  * Copyright 2010-2011 PathScale, Inc. All rights reserved.
  *

--- a/libs/libxx/libminiabi/libxx_typeinfo.h
+++ b/libs/libxx/libminiabi/libxx_typeinfo.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libxx/libcxxmini/libxx_typeinfo.h
+ * libs/libxx/libminiabi/libxx_typeinfo.h
  *
  * Copyright 2010-2011 PathScale, Inc. All rights reserved.
  *


### PR DESCRIPTION
libcxxmini shall not stay the same layer of LIBCXX, move it down to ABI library layer.

This is a quick fix for compilation error in https://github.com/apache/nuttx/pull/17968

## Summary

Add a new macro LIBCXXNONE in c++ STL layer, which means there is no default STL library(remain same behavior as before).
Move libcxxmini library from STL layer to the ABI layer and also change its name to libminiabi.

## Impact

The default behavior i.e. no default c++ STL library but with a default ABI library(i.e. libminiabi) remains unchanged, so no impact on existing behavior.

## Testing

CI test.
