### PR TITLE
crypto/cryptosoft: replace macro howmany with common macro div_round_up

### DIFF
--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -31,6 +31,7 @@
 #include <endian.h>
 #include <strings.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/lib/math32.h>
 #include <crypto/bn.h>
 #include <crypto/cryptodev.h>
 #include <crypto/cryptosoft.h>
@@ -41,10 +42,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#ifndef howmany
-#  define howmany(x, y)  (((x) + ((y) - 1)) / (y))
-#endif
 
 /****************************************************************************
  * Private Data
@@ -275,7 +272,7 @@ int swcr_hash(FAR struct cryptop *crp,
 
 int swcr_authenc(FAR struct cryptop *crp)
 {
-  uint32_t blkbuf[howmany(EALG_MAX_BLOCK_LEN, sizeof(uint32_t))];
+  uint32_t blkbuf[div_round_up(EALG_MAX_BLOCK_LEN, sizeof(uint32_t))];
   FAR u_char *blk = (u_char *)blkbuf;
   u_char aalg[AALG_MAX_RESULT_LEN];
   u_char iv[EALG_MAX_BLOCK_LEN];


### PR DESCRIPTION
## Crypto Soft: Replace howmany with div_round_up

### Summary

This PR replaces the non-standard `howmany` macro with the common `div_round_up` macro in the cryptosoft implementation. This improves code consistency across the NuttX codebase and enhances maintainability.

### Changes

#### Files Modified

1. **crypto/cryptosoft.c**
   - Replace `howmany` macro calls with standard `div_round_up` macro
   - Improves code consistency with NuttX standards

### Technical Details

**Macro Replacement:**
- The `howmany` macro is a non-standard implementation for division with rounding up
- `div_round_up` is the common NuttX standard macro for the same operation
- This change maintains identical functionality while improving consistency

**Benefits:**
- Aligns with NuttX coding standards
- Reduces use of non-standard macros
- Improves code readability and maintainability
- Facilitates future refactoring and maintenance

### Impact

- **Consistency**: Improves code consistency across the crypto subsystem
- **Maintainability**: Easier to maintain and understand
- **Standards**: Follows NuttX standard patterns
- **Compatibility**: No functional impact; maintains existing behavior

### Testing

No functional changes, existing tests continue to pass.

---

**Author**: makejian <makejian@xiaomi.com>