### PR TITLE
crypto/blake2s.h: fix tasking compile warning

### DIFF
--- a/include/nuttx/crypto/blake2s.h
+++ b/include/nuttx/crypto/blake2s.h
@@ -88,7 +88,7 @@ typedef struct blake2s_param__
   uint8_t personal[BLAKE2S_PERSONALBYTES];      /* 32 */
 } blake2s_param;
 
-#ifdef __GNUC__ > 3
+#if defined(__GNUC__) && __GNUC__ > 3
 #define BLAKE2_UNALIGNED 1
 typedef uint32_t uint32_alias_t __attribute__((may_alias));
 typedef uint16_t uint16_alias_t __attribute__((may_alias));


### PR DESCRIPTION
## Crypto: Fix Blake2S Header Compilation Warning

### Summary

This PR fixes a compilation warning in the Blake2S header file caused by invalid preprocessing directive syntax. The change improves code quality and ensures clean compilation with strict compiler settings.

### Changes

#### Files Modified

1. **include/nuttx/crypto/blake2s.h**
   - Fix preprocessing directive syntax from `#ifdef __GNUC__ > 3` to `#if defined(__GNUC__) && __GNUC__ > 3`
   - Ensures proper version checking for GCC compiler features

### Technical Details

**Issue:**
- The original preprocessing directive `#ifdef __GNUC__ > 3` is invalid syntax
- Preprocessors cannot use comparison operators in `#ifdef` directives
- This causes compilation warnings with strict compiler toolchains (e.g., TASKING compiler)

**Solution:**
- Use proper `#if defined()` syntax combined with logical AND operator
- Allows correct detection of GCC compiler and version checking
- Maintains the same functional behavior while using valid preprocessor syntax

**Benefits:**
- Eliminates compilation warnings in strict compiler environments
- Improves code portability across different toolchains
- Uses standard preprocessor conditional syntax

### Impact

- **Compatibility**: Improves compatibility with strict compiler toolchains
- **Code Quality**: Eliminates compiler warnings
- **Functionality**: No change to actual code functionality; only fixes syntax

### Testing

No functional impact; existing Blake2S functionality remains unchanged.

---

**Author**: makejian <makejian@xiaomi.com>