### PR TITLE
crypto/siphash: avoid redefine name issue

### DIFF
--- a/crypto/siphash.c
+++ b/crypto/siphash.c
@@ -126,11 +126,11 @@ void siphash_final(FAR void *dst, FAR SIPHASH_CTX *ctx, int rc, int rf)
 {
   uint64_t r;
 
-  htolem64(&r, siphash_end(ctx, rc, rf));
+  htolem64(&r, siphash_finish(ctx, rc, rf));
   memcpy(dst, &r, sizeof r);
 }
 
-uint64_t siphash_end(FAR SIPHASH_CTX *ctx, int rc, int rf)
+uint64_t siphash_finish(FAR SIPHASH_CTX *ctx, int rc, int rf)
 {
   uint64_t r;
   size_t left;
@@ -158,7 +158,7 @@ uint64_t siphash(FAR const SIPHASH_KEY *key,
 
   siphash_init(&ctx, key);
   siphash_update(&ctx, rc, rf, src, len);
-  return (siphash_end(&ctx, rc, rf));
+  return (siphash_finish(&ctx, rc, rf));
 }
 
 #define SIP_ROTL(x, b) ((x) << (b)) | ( (x) >> (64 - (b)))

--- a/include/crypto/siphash.h
+++ b/include/crypto/siphash.h
@@ -75,20 +75,20 @@ typedef struct
 
 void siphash_init(FAR SIPHASH_CTX *, FAR const SIPHASH_KEY *);
 void siphash_update(FAR SIPHASH_CTX *, int, int, FAR const void *, size_t);
-uint64_t siphash_end(FAR SIPHASH_CTX *, int, int);
+uint64_t siphash_finish(FAR SIPHASH_CTX *, int, int);
 void siphash_final(FAR void *, FAR SIPHASH_CTX *, int, int);
 uint64_t siphash(FAR const SIPHASH_KEY *,
                  int, int, FAR const void *, size_t);
 
 #define SipHash24_Init(_c, _k)        siphash_init((_c), (_k))
 #define SipHash24_Update(_c, _p, _l)  siphash_update((_c), 2, 4, (_p), (_l))
-#define SipHash24_End(_d)             siphash_end((_d), 2, 4)
+#define SipHash24_Finish(_d)          siphash_finish((_d), 2, 4)
 #define SipHash24_Final(_d, _c)       siphash_final((_d), (_c), 2, 4)
 #define SipHash24(_k, _p, _l)         siphash((_k), 2, 4, (_p), (_l))
 
 #define SipHash48_Init(_c, _k)        siphash_init((_c), (_k))
 #define SipHash48_Update(_c, _p, _l)  siphash_update((_c), 4, 8, (_p), (_l))
-#define SipHash48_End(_d)             siphash_end((_d), 4, 8)
+#define SipHash48_Finish(_d)          siphash_finish((_d), 4, 8)
 #define SipHash48_Final(_d, _c)       siphash_final((_d), (_c), 4, 8)
 #define SipHash48(_k, _p, _l)         siphash((_k), 4, 8, (_p), (_l))
 


### PR DESCRIPTION
## Crypto: Rename SipHash Symbol to Avoid Naming Conflict

### Summary

This PR renames SipHash-related symbols to avoid conflicts with compiler-generated section names. The Tricore-gcc compiler generates function sections with an '_end' suffix, which conflicts with the `siphash_end` symbol. This change improves compatibility with various compiler toolchains.

### Changes

#### Files Modified

1. **crypto/siphash.c**
   - Rename function `siphash_end()` to `siphash_finish()`
   - Update all function calls to use the new name

2. **include/crypto/siphash.h**
   - Update function declaration from `siphash_end()` to `siphash_finish()`
   - Update SipHash24 macro from `SipHash24_End` to `SipHash24_Finish`
   - Update SipHash48 macro from `SipHash48_End` to `SipHash48_Finish`

### Technical Details

**Issue:**
- Tricore-gcc compiler generates function sections with '_end' suffix (e.g., `function_end`)
- The `siphash_end` symbol name conflicts with compiler-generated section names
- This causes linker or naming conflicts when using Tricore-gcc toolchain

**Solution:**
- Rename `siphash_end` to `siphash_finish` throughout the codebase
- Rename corresponding macros to maintain consistency
- Avoids conflicts while preserving API functionality

**Benefits:**
- Improves compatibility with Tricore-gcc and similar toolchains
- Eliminates naming conflicts
- Maintains consistent naming convention across SipHash API

### Impact

- **Compatibility**: Improves support for Tricore-gcc compiler
- **Naming**: Updates symbol names to avoid conflicts
- **API**: Existing code using these functions will need to be updated with new symbol names
- **Testing**: No functional changes; SipHash algorithm behavior remains identical

### Testing

SipHash functionality remains unchanged; only symbol names are updated.

---

**Author**: makejian <makejian@xiaomi.com>