### PR TITLE
nuttx/mutex: correct documentation for nxmutex_destroy

### DIFF
--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -461,10 +461,10 @@ static inline_function bool nxmutex_is_locked(FAR mutex_t *mutex)
  * Name: nxmutex_destroy
  *
  * Description:
- *   This function initializes the UNNAMED mutex. Following a
- *   successful call to nxmutex_init(), the mutex may be used in subsequent
- *   calls to nxmutex_lock(), nxmutex_unlock(), and nxmutex_trylock().  The
- *   mutex remains usable until it is destroyed.
+ *   This function destroys the specified mutex. After a successful call,
+ *   the mutex is no longer valid and must not be used in subsequent calls
+ *   to nxmutex_lock(), nxmutex_unlock(), or nxmutex_trylock() unless it is
+ *   reinitialized with nxmutex_init().
  *
  * Parameters:
  *   mutex - Semaphore to be destroyed


### PR DESCRIPTION
## Mutex: Correct Documentation for nxmutex_destroy Function

### Summary

This PR corrects the documentation note for the `nxmutex_destroy()` function in the mutex header file. The previous documentation incorrectly described the function as initializing the mutex instead of destroying it, causing confusion about the function's actual behavior and safety considerations.

### Changes

#### Files Modified

1. **include/nuttx/mutex.h**
   - Correct the `nxmutex_destroy()` function documentation
   - Replace misleading text about initialization with accurate destruction behavior description
   - Clarify that the mutex becomes invalid after destruction and cannot be used until reinitialized

### Technical Details

**Issue:**
- The documentation for `nxmutex_destroy()` incorrectly described the function as initializing the mutex
- This caused confusion about the function's actual purpose (destroying the mutex)
- Missing important information about post-destruction behavior and requirements

**Solution:**
- Update the documentation to accurately describe the destroy operation
- Clarify that after destruction, the mutex is no longer valid
- Document that the mutex must not be used until reinitialized with `nxmutex_init()`
- Improve clarity regarding safety considerations in OS context

**Changes:**
- Old: "This function initializes the UNNAMED mutex..."
- New: "This function destroys the specified mutex. After a successful call, the mutex is no longer valid and must not be used..."

### Impact

- **Documentation**: Improves accuracy and clarity of API documentation
- **Clarity**: Prevents confusion about mutex lifecycle and destruction behavior
- **Safety**: Emphasizes important safety considerations after destruction
- **Developer Experience**: Helps developers understand proper mutex usage patterns

### Testing

Documentation-only change; no functional code changes.

---

**Author**: makejian <makejian@xiaomi.com>