### PR TITLE
arm64/toolchain: fix compile warnning

### DIFF
--- a/arch/arm64/src/common/Make.defs
+++ b/arch/arm64/src/common/Make.defs
@@ -47,7 +47,6 @@ CMN_CSRCS += arm64_arch_timer.c arm64_cache.c
 CMN_CSRCS += arm64_doirq.c arm64_fatal.c
 CMN_CSRCS += arm64_syscall.c
 CMN_CSRCS += arm64_modifyreg8.c arm64_modifyreg16.c arm64_modifyreg32.c
-CMN_CSRCS += arm64_hwdebug.c
 
 ifeq ($(CONFIG_ENABLE_ALL_SIGNALS),y)
 CMN_CSRCS += arm64_schedulesigaction.c arm64_sigdeliver.c


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Configuration/Tool: qemu-armv8a/mte
5282026-01-16 13:11:30
529------------------------------------------------------------------------------------ 530  Cleaning...
531  Configuring...
532  Building NuttX...
533Makefile:142: target 'arm64_hwdebug.o' given more than once in the same rule 534Makefile:142: target 'arm64_hwdebug.o' given more than once in the same rule 535Makefile:142: target 'arm64_hwdebug.o' given more than once in the same rule 536Makefile:142: target 'arm64_hwdebug.o' given more than once in the same rule 537Makefile:142: target 'arm64_hwdebug.o' given more than once in the same rule 538

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
