### PR TITLE
fs: add fs dump in ROMFS/LITTLEFS

### DIFF
--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -187,4 +187,10 @@ config FS_LITTLEFS_DISK_VERSION
 		0x00020000 means 2.0.
 		0x00020001 means 2.1.
 
+config FS_LITTLEFS_DEBUG
+	bool "LITTLEFS file system read/write double check"
+	depends on DEBUG_FS_ERROR
+	---help---
+		Enable LITTLEFS file system read/write double check.
+
 endif

--- a/fs/romfs/Kconfig
+++ b/fs/romfs/Kconfig
@@ -27,4 +27,10 @@ config FS_ROMFS_CACHE_FILE_NSECTORS
 	---help---
 		The number of file cache sector
 
+config FS_ROMFS_DEBUG
+	bool "ROMFS file system read/write double check"
+	depends on DEBUG_FS_ERROR
+	---help---
+		Enable ROMFS file system read/write double check.
+
 endif


### PR DESCRIPTION
add read/write double check in ROMFS/LITTLEFS file system

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
In Littlefs and Romfs,  if reading the content of the same address twice is inconsistent, it is a driver side issue rather than a fs issue; 
Similarly, if the continuously written content and the read content are inconsistent, it is a driver side issue rather than a fs issue

## Impact
Only in Littlefs and Romfs, FS_LITTLEFS_DEBUG/FS_ROMFS_DEBUG is enabled,  which will check whether the written and read contents are correct

## Testing
enable FS_LITTLEFS_DEBUG and FS_ROMFS_DEBUG

**Does not affect the correct reading and writing functions**
goldfish-armv7a-ap> df -h
  Filesystem      Size      Used  Available Mounted on
  binfs             0B        0B         0B /bin
  fatfs           510M      140M       370M /data
  romfs           729K      729K         0B /etc
  hostfs            0B        0B         0B /host
  procfs            0B        0B         0B /proc
  v9fs            915G      845G        69G /share
  romfs            43M       43M         0B /system
  littlefs       8000K      512B      7999K /test
  tmpfs            12K     2560B      9728B /tmp
goldfish-armv7a-ap> cd /etc
goldfish-armv7a-ap> ls
/etc:
 build.prop
 dbus-1/
 init.d/
 media/
 mobile-broadband-provider-info/
 ssl/
 uikit_video_config.json
 wifi/
 zoneinfo/
goldfish-armv7a-ap> cat build.prop
ro.build.codename=DEV
ro.build.version.release=12.0.0
ro.product.model=Emulator-Vela
ro.product.device=Emulator-Vela
ro.product.name=Emulator-Vela
ro.product.brand=Vela
ro.product.manufacturer=Xiaomi
ro.product.board=Emulator
goldfish-armv7a-ap> cd test
goldfish-armv7a-ap> ls
/test:
 .
 ..
goldfish-armv7a-ap> echo test1 > 1.log
goldfish-armv7a-ap> cat 1.log
test123

**The modification of buffer content by littlefs_check previously resulted in an error, which aligns with expectations**
uint8_t *buf_test = buffer;
buf_test[0] = 'E';
littlefs_check(drv, block, size, buffer, geo);

[    0.668051] [ 7] [ ALERT] [ap] dump_assert_info: Current Version: NuttX  12.3.0 7429835fdf6 Jan 19 2026 11:35:04 arm
[    0.668402] [ 7] [ ALERT] [ap] dump_assert_info: Assertion failed : at file: ../../nuttx/fs/littlefs/lfs_vfs.c:1168 task: nsh_main process: nsh_main 0x63e81d
[    0.668706] [ 7] [ ALERT] [ap] up_dump_register: R0: 4135d490 R1: 00000490 R2: 00000000  R3: 4135cc94
[    0.668919] [ 7] [ ALERT] [ap] up_dump_register: R4: 4156b060 R5: 00000000 R6: 012ce060  R7: 4135cc10
[    0.669192] [ 7] [ ALERT] [ap] up_dump_register: R8: 4135d490 R9: 00000490 R10: 4135210c R11: 00000000
[    0.669405] [ 7] [ ALERT] [ap] up_dump_register: R12: 413523b0 SP: 41351f28 LR: 006313af  PC: 006313af
[    0.669649] [ 7] [ ALERT] [ap] up_dump_register: CPSR: 200100df
[    0.669822] [ 7] [ ALERT] [ap] dump_stackinfo: IRQ Stack:
[    0.669994] [ 7] [ ALERT] [ap] dump_stackinfo:   base: 0x41351900
[    0.670135] [ 7] [ ALERT] [ap] dump_stackinfo:   size: 00002048
[    0.670274] [ 7] [ ALERT] [ap] dump_stackinfo:     sp: 0x41351f28
