### PR TITLE
simwifi: Fix compilation warning

### DIFF
--- a/arch/sim/src/sim/sim_netdriver.c
+++ b/arch/sim/src/sim/sim_netdriver.c
@@ -271,7 +271,7 @@ static void netdriver_rxready_interrupt(void *priv)
 static void sim_netdev_work(void *arg)
 {
   struct sim_netdev_s *priv = (struct sim_netdev_s *)arg;
-  struct netdev_lowerhalf_s *dev = &priv->dev;
+  struct netdev_lowerhalf_s *dev = (struct netdev_lowerhalf_s *)&priv->dev;
 
   if (sim_netdev_avail(DEVIDX(dev)))
     {

--- a/arch/sim/src/sim/sim_wifihost.c
+++ b/arch/sim/src/sim/sim_wifihost.c
@@ -32,6 +32,7 @@
 #include <netpacket/netlink.h>
 #include <nuttx/net/netlink.h>
 #include <sys/time.h>
+#include <nuttx/kmalloc.h>
 
 #include "sim_internal.h"
 #include "sim_wifihost.h"


### PR DESCRIPTION
## Summary

Added the `<nuttx/kmalloc.h>` header file to avoid indirect use of kmm_alloc.
Fixed the implicit pointer conversion issue.

## Impact

This only fixes compiler warnings and does not affect code functionality.

## Testing

Compiler warnings fixed; no testing required.