### PR TITLE
sched: add spinlock to sched_note_preemption and nxsched_critmon_pree…

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -171,7 +171,8 @@ FAR static struct note_driver_s *
 static struct note_taskname_s g_note_taskname;
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_FILTER)
+#if defined(CONFIG_SCHED_INSTRUMENTATION_FILTER) || \
+    defined(CONFIG_SCHED_INSTRUMENTATION_PREEMPTION)
 static spinlock_t g_note_lock;
 #endif
 
@@ -1056,7 +1057,9 @@ void sched_note_preemption(FAR struct tcb_s *tcb, bool locked)
   struct note_preempt_s note;
   FAR struct note_driver_s **driver;
   bool formatted = false;
+  irqstate_t flags;
 
+  flags = spin_lock_irqsave_notrace(&g_note_lock);
   for (driver = g_note_drivers; *driver; driver++)
     {
       if (!note_isenabled(*driver))
@@ -1088,6 +1091,8 @@ void sched_note_preemption(FAR struct tcb_s *tcb, bool locked)
 
       note_add(*driver, &note, sizeof(struct note_preempt_s));
     }
+
+  spin_unlock_irqrestore_notrace(&g_note_lock, flags);
 }
 #endif
 

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -87,6 +87,14 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
+static spinlock_t g_crimonitor_lock = SP_UNLOCKED;
+#endif
+
+/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -175,6 +183,9 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
                                 FAR void *caller)
 {
   clock_t current = perf_gettime();
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave_notrace(&g_crimonitor_lock);
 
   /* Are we enabling or disabling pre-emption */
 
@@ -206,6 +217,8 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state,
           g_preemp_max[cpu] = elapsed;
         }
     }
+
+  spin_unlock_irqrestore_notrace(&g_crimonitor_lock, flags);
 }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0 */
 


### PR DESCRIPTION
## Summary

Add spinlock synchronization to sched_note_preemption and nxsched_critmon_preemption functions. This change ensures thread-safe access to global state during preemption notification and critical section monitoring, preventing race conditions in SMP and interrupt-driven environments.

## Changes

**Files modified:**
- `drivers/note/note_driver.c`
- `sched/sched/sched_critmonitor.c`

**Key changes:**
- Added spinlock protection (`g_note_lock`) to sched_note_preemption to guard access to the global note driver list and prevent concurrent modifications.
- Introduced a new spinlock (`g_crimonitor_lock`) in sched_critmonitor.c to protect global state in nxsched_critmon_preemption.
- Wrapped all critical sections in both functions with spin_lock_irqsave_notrace/spin_unlock_irqrestore_notrace.

**Synchronization pattern:**
```c
irqstate_t flags;
flags = spin_lock_irqsave_notrace(&lock);
// critical section
spin_unlock_irqrestore_notrace(&lock, flags);