### PR TITLE
drivers/serial/Kconfig-16550: fix non-existent option

### DIFF
--- a/drivers/serial/Kconfig-16550
+++ b/drivers/serial/Kconfig-16550
@@ -92,7 +92,8 @@ config 16550_UART0_DMA
 	bool "16550 UART0 DMA support"
 	default n
 	select ARCH_DMA
-	select SERIAL_DMA
+	select SERIAL_TXDMA
+	select SERIAL_RXDMA
 	---help---
 		Enable DMA transfers on 16550 UART0
 
@@ -205,7 +206,8 @@ config 16550_UART1_DMA
 	bool "16550 UART1 DMA support"
 	default n
 	select ARCH_DMA
-	select SERIAL_DMA
+	select SERIAL_TXDMA
+	select SERIAL_RXDMA
 	---help---
 		Enable DMA transfers on 16550 UART1
 
@@ -318,7 +320,8 @@ config 16550_UART2_DMA
 	bool "16550 UART2 DMA support"
 	default n
 	select ARCH_DMA
-	select SERIAL_DMA
+	select SERIAL_TXDMA
+	select SERIAL_RXDMA
 	---help---
 		Enable DMA transfers on 16550 UART2
 
@@ -431,7 +434,8 @@ config 16550_UART3_DMA
 	bool "16550 UART3 DMA support"
 	default n
 	select ARCH_DMA
-	select SERIAL_DMA
+	select SERIAL_TXDMA
+	select SERIAL_RXDMA
 	---help---
 		Enable DMA transfers on 16550 UART3
 


### PR DESCRIPTION
## Summary
there is no SERIAL_DMA option, it was removed long time ago in: 0d203fd5358b529173e6e3f83a2b2f3b34f949a2

It should be SERIAL_TXDMA and SERIAL_RXDMA

## Impact

fix https://github.com/apache/nuttx/issues/18000

## Testing

CI only. 

I have no idea if DMA works with the 16550.