### PR TITLE
Kconfig: Add ALLOW_CUSTOM_PERMISSIVE_COMPONENTS license option

### DIFF
--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -151,3 +151,22 @@ Multiple config fragments can be merged manually using the tools/merge_config.py
 
    $ cd nuttx
    $ ./tools/merge_config.py -o defconfig .config1 .config2
+
+License Setup
+=============
+
+NuttX includes components with various open source licenses. To use these components,
+you must explicitly enable the corresponding license configuration option in the
+:menuselection:`License Setup` menu:
+
+* ``CONFIG_ALLOW_BSD_COMPONENTS`` - BSD licensed components (NFS, SPIFFS, Bluetooth LE, etc.)
+* ``CONFIG_ALLOW_GPL_COMPONENTS`` - GPL/LGPL licensed components
+* ``CONFIG_ALLOW_MIT_COMPONENTS`` - MIT licensed components
+* ``CONFIG_ALLOW_BSDNORDIC_COMPONENTS`` - 5-Clause Nordic licensed components (NRF chips only)
+* ``CONFIG_ALLOW_ECLIPSE_COMPONENTS`` - Eclipse Public License components
+* ``CONFIG_ALLOW_ICS_COMPONENTS`` - ICS licensed components
+* ``CONFIG_ALLOW_CUSTOM_PERMISSIVE_COMPONENTS`` - Custom permissive licensed components
+
+.. warning::
+   Please carefully review the license terms for each enabled component to ensure
+   compliance with your project's licensing requirements.

--- a/Kconfig
+++ b/Kconfig
@@ -97,6 +97,22 @@ config ALLOW_ICS_COMPONENTS
 		NOTE: Please check that the license for each enabled
 		component matches your project license.
 
+config ALLOW_CUSTOM_PERMISSIVE_COMPONENTS
+	bool "Use components that have custom permissive licenses"
+	default n
+	---help---
+		When this option is enabled the project will allow the use
+		of components that have custom permissive licenses which
+		are not covered by the standard license options above.
+
+		This includes components with custom permissive licenses
+		that allow free use, modification, and distribution but
+		may have specific attribution or notice requirements.
+
+		NOTE: Please carefully review the license terms for each
+		enabled component to ensure compliance with your project
+		requirements.
+
 endmenu # License Setup
 
 menu "Build Setup"


### PR DESCRIPTION
## Kconfig: Add ALLOW_CUSTOM_PERMISSIVE_COMPONENTS license option

### Summary

This PR adds a new license configuration option `ALLOW_CUSTOM_PERMISSIVE_COMPONENTS` for components that have custom permissive licenses which are not covered by the standard license options. This addresses the need identified in nuttx-apps#3343 for handling components like the Whetstone benchmark which have custom permissive license terms.

### Changes

#### Files Modified

1. **Kconfig**
   - Added new `ALLOW_CUSTOM_PERMISSIVE_COMPONENTS` config option under "License Setup" menu
   - Follows the existing pattern of other license options (BSD, GPL, MIT, etc.)

2. **Documentation/quickstart/configuring.rst**
   - Added documentation for the new License Setup section
   - Lists all available `ALLOW_*_COMPONENTS` options with descriptions

### Technical Details

**New License Option:**
- Enables projects to explicitly opt-in to using components with custom permissive licenses
- Covers licenses that allow free use, modification, and distribution
- Covers licenses with specific attribution or notice requirements
- Does not cover restrictive/proprietary licenses

**Integration:**
- Placed after `ALLOW_ICS_COMPONENTS` in the License Setup menu
- Default value is `n` (disabled) for safety
- Components with custom permissive licenses should add `depends on ALLOW_CUSTOM_PERMISSIVE_COMPONENTS`

### Impact

- **License Compliance**: Provides explicit opt-in mechanism for custom permissive licensed code
- **User Awareness**: Forces users to acknowledge custom license requirements
- **Consistency**: Follows established NuttX license configuration patterns

### Usage

Enable option with:
CONFIG_ALLOW_CUSTOM_PERMISSIVE_COMPONENTS=y

### Testing

Configuration option verified.

### Reference

which discussed in https://github.com/apache/nuttx-apps/pull/3343