### PR TITLE
libxx: fix __config_site for libcxx compile errors

### DIFF
--- a/libs/libxx/__config_site
+++ b/libs/libxx/__config_site
@@ -18,7 +18,7 @@
 /* #undef _LIBCPP_HAS_NO_THREADS */
 /* #undef _LIBCPP_HAS_NO_MONOTONIC_CLOCK */
 /* #undef _LIBCPP_HAS_MUSL_LIBC */
-/* #undef _LIBCPP_HAS_THREAD_API_PTHREAD */
+#define _LIBCPP_HAS_THREAD_API_PTHREAD 1
 /* #undef _LIBCPP_HAS_THREAD_API_EXTERNAL */
 /* #undef _LIBCPP_HAS_THREAD_API_WIN32 */
 /* #undef _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS */
@@ -55,13 +55,14 @@
 #  pragma clang diagnostic ignored "-Wmacro-redefined"
 #endif
 
-
-
-
 #ifdef __clang__
 #  pragma clang diagnostic pop
 #endif
 
 #define _SYS_REENT_H_
+
+#ifndef __ULong
+#define __ULong unsigned long
+#endif
 
 #endif // _LIBCPP___CONFIG_SITE


### PR DESCRIPTION
## Summary

Fix two libcxx compilation errors:
1) define macro _LIBCPP_HAS_THREAD_API_PTHREAD for error 'No thread API'
2) define macro __ULong for '__ULong undefined'

## Impact

libcxx library compilation.

## Testing

CI test.
