### PR TITLE
arch/x64: Solve the sig_nest hang issue

### DIFF
--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -468,10 +468,6 @@
 
 #define XMMAREA_REGS                (26)
 
-/* Aux register used by implementation */
-
-#define REG_AUX                     (27 + XMMAREA_REG_OFFSET)
-
 /* NOTE 2: This is not really state data.  Rather, this is just a convenient
  *   way to pass parameters from the interrupt handler to C code.
  */
@@ -489,10 +485,6 @@
 #define XCP_ALIGN_MASK              (XCPTCONTEXT_ALIGN - 1)
 #define XCP_ALIGN_DOWN(a)           ((a) & ~XCP_ALIGN_MASK)
 #define XCP_ALIGN_UP(a)             (((a) + XCP_ALIGN_MASK) & ~XCP_ALIGN_MASK)
-
-/* Aux register flags */
-
-#define REG_AUX_FULLCONTEXT         (1 << 0) /* Force full context switch */
 
 /****************************************************************************
  * Public Types

--- a/arch/x86_64/src/common/x86_64_hwdebug.c
+++ b/arch/x86_64/src/common/x86_64_hwdebug.c
@@ -234,10 +234,6 @@ static void x86_64_debug_step(bool enable)
     {
       regs[REG_RFLAGS] &= ~X86_64_RFLAGS_TF;
     }
-
-  /* Request full context switch so we update RFLAGS */
-
-  regs[REG_AUX] |= REG_AUX_FULLCONTEXT;
 }
 
 /****************************************************************************

--- a/arch/x86_64/src/intel64/intel64_vectors.S
+++ b/arch/x86_64/src/intel64/intel64_vectors.S
@@ -793,80 +793,8 @@ irq_common:
 
 	/* The common return point for irq_handler */
 
-.Lreturn:
-
-	/* Check if full context switch is required for signal handling */
-
-	movq    (8*REG_AUX)(%rax), %rcx
-	cmp     $(REG_AUX_FULLCONTEXT), %rcx
-	je      .Lfullswitch
-
-	/* EAX may possibly hold a pointer to a different register save area on
-	 * return.  Are we switching to a new context?
-	 */
-
-	cmp     %rax, %rdi
-	je      .Lnoswitch
-
-.Lfullswitch:
-	/* Reset flag */
-
-	movq    $0x0, (8*REG_AUX)(%rdi)
-
-	/* A context switch will be performed. RAX holds the address of the new
-	 * register save structure.
-	 *
-	 * Jump to x86_64_fullcontextrestore().  We perform a call here, but that function
-	 * never returns.  The address of the new register save block is the argument
-	 * to the x86_64_fullcontextrestore().
-	 */
-
 	movq    %rax, %rdi
 	call    x86_64_fullcontextrestore
-
-.Lnoswitch:
-#ifndef CONFIG_ARCH_X86_64_HAVE_XSAVE
-	fxrstorq (%rdi)
-#else
-	movl $XSAVE_STATE_COMPONENTS, %eax
-	xor     %edx, %edx
-	xrstor  (%rdi)
-#endif
-
-	movq    (8*REG_FS)(%rdi), %rax
-	mov     %fs, %ax
-	movq    (8*REG_GS)(%rdi), %rax
-	mov     %gs, %ax
-	movq    (8*REG_ES)(%rdi), %rax
-	mov     %es, %ax
-	movq    (8*REG_DS)(%rdi), %rax
-	mov     %ds, %ax
-
-	movq    (8*REG_RAX)(%rdi), %rax
-	movq    (8*REG_RBX)(%rdi), %rbx
-	movq    (8*REG_RBP)(%rdi), %rbp
-	movq    (8*REG_R10)(%rdi), %r10
-	movq    (8*REG_R11)(%rdi), %r11
-	movq    (8*REG_R12)(%rdi), %r12
-	movq    (8*REG_R13)(%rdi), %r13
-	movq    (8*REG_R14)(%rdi), %r14
-	movq    (8*REG_R15)(%rdi), %r15
-
-	movq    (8*REG_R9)(%rdi), %r9
-	movq    (8*REG_R8)(%rdi), %r8
-	movq    (8*REG_RCX)(%rdi), %rcx
-	movq    (8*REG_RDX)(%rdi), %rdx
-
-	/* Pop RDI and RSI pushed on interrupt entry */
-
-	popq   %rsi
-	popq   %rdi
-
-	/* Cleans up the pushed error code */
-
-	add     $8, %rsp
-
-	iretq                /* Pops 5 things at once: RIP, CS, RFLAGS RSP and SS */
 	.size	irq_common, . - irq_common
 	.end
 


### PR DESCRIPTION
## Summary

When an interrupt occurs, the hardware automatically pushes the current RIP/RSP onto the interrupt stack. During the interrupt return, the iretq instruction pops them back. The problem is that the RIP/RSP modified by the signal is stored in the XCP context, whereas iretq operates on the interrupt stack. As a result, the RIP/RSP modified by the signal does not take effect in the iretq instruction, causing the task receiving the signal to fail to jump correctly to the signal handler. This behavior appears as if the signal is lost

## Impact
no

## Testing
ostest

