### PR TITLE
arch/x86_64i:Fix issue 02 Compile acpidump crash problem

### DIFF
--- a/arch/x86_64/src/common/x86_64_acpi.c
+++ b/arch/x86_64/src/common/x86_64_acpi.c
@@ -835,10 +835,13 @@ void acpi_dump(void)
           break;
         }
 
-      acpi_info("Found LAPIC for CPU %d %p", i, lapic);
-      acpi_info("    ACPI ID %d", lapic->acpi_id);
-      acpi_info("    APIC ID %d", lapic->apic_id);
-      acpi_info("    flags %d", lapic->flags);
+      if (lapic != NULL)
+        {
+          acpi_info("Found LAPIC for CPU %d %p", i, lapic);
+          acpi_info("    ACPI ID %d", lapic->acpi_id);
+          acpi_info("    APIC ID %d", lapic->apic_id);
+          acpi_info("    flags %d", lapic->flags);
+        }
 
       /* IO_APIC */
 


### PR DESCRIPTION
At certain optimization levels, GCC/Clang may insert UD2 if it detects undefined behavior (such as integer overflow or illegal pointer access), causing the program to crash immediately instead of executing unpredictable code.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Fix issue 02 Compile acpidump crash problem

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact
no

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing
ostest

*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
