### PR TITLE
sched/hrtimer: add option for list-based hrtimer management

### DIFF
--- a/include/nuttx/hrtimer.h
+++ b/include/nuttx/hrtimer.h
@@ -31,6 +31,7 @@
 #include <nuttx/clock.h>
 #include <nuttx/compiler.h>
 #include <nuttx/spinlock.h>
+#include <nuttx/list.h>
 
 #include <stdint.h>
 #include <sys/tree.h>
@@ -68,7 +69,11 @@ typedef CODE uint64_t (*hrtimer_entry_t)(FAR const struct hrtimer_s *hrtimer,
 
 typedef struct hrtimer_node_s
 {
+#ifdef CONFIG_HRTIMER_TREE
   RB_ENTRY(hrtimer_node_s) entry;  /* RB-tree linkage */
+#else
+  struct list_node entry;  /* List linkage */
+#endif
 } hrtimer_node_t;
 
 /* High-resolution timer object

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -2067,3 +2067,28 @@ config HRTIMER
 	default n
 	---help---
 		Enable to support high resolution timer
+
+if HRTIMER
+
+choice
+    prompt "HRTimer management data structure type"
+    default HRTIMER_TREE
+
+config HRTIMER_LIST
+    bool "List-based timer management"
+    help
+        Use a simple list to manage timers. This method is
+        suitable for systems with a small number of timers.
+        It is more memory-efficient but may become slower
+        as the number of timers increases.
+
+config HRTIMER_TREE
+    bool "RB-tree-based timer management"
+    help
+        Use a red-black tree to manage timers. This method
+        provides better performance for systems with many
+        timers, at the cost of slightly higher memory usage.
+
+endchoice
+
+endif # HRTIMER

--- a/sched/hrtimer/hrtimer_initialize.c
+++ b/sched/hrtimer/hrtimer_initialize.c
@@ -57,7 +57,11 @@ spinlock_t g_hrtimer_spinlock = SP_UNLOCKED;
  * The tree is ordered by absolute expiration time.
  */
 
+#ifdef CONFIG_HRTIMER_TREE
 struct hrtimer_tree_s g_hrtimer_tree = RB_INITIALIZER(g_hrtimer_tree);
+#else
+struct list_node g_hrtimer_list = LIST_INITIAL_VALUE(g_hrtimer_list);
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -83,4 +87,6 @@ struct hrtimer_tree_s g_hrtimer_tree = RB_INITIALIZER(g_hrtimer_tree);
  *     core (e.g., hrtimer_start(), hrtimer_cancel(), and expire paths).
  ****************************************************************************/
 
+#ifdef CONFIG_HRTIMER_TREE
 RB_GENERATE(hrtimer_tree_s, hrtimer_node_s, entry, hrtimer_compare);
+#endif


### PR DESCRIPTION
## Summary

Add list-based support for hrtimer management. 
Using a simple list reduces memory usage compared to an RB-tree 
and is advantageous when handling a relatively small number of hrtimers.

## Impact

Enhance hrtimer implementation; changes are isolated and do not affect other NuttX functions

## Testing

ostest passed using list-based hrtimer:

**rv-virt:smp64**

<img width="603" height="329" alt="image" src="https://github.com/user-attachments/assets/3f3a16fe-a67c-48d4-8416-8ddab9d3ac08" />

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 cc94a9e19a-dirty Jan 20 2026 09:45:29 risc-v rv-virt
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc0fa0  1fc0fa0
ordblks         8        8
mxordblk  1f81ab0  1f81ab0
uordblks    15c90    17480
fordblks  1fab310  1fa9b20

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc0fa0  1fc0fa0
ordblks         1        8
mxordblk  1fb5ea8  1f81ab0
uordblks     b0f8    17480
fordblks  1fb5ea8  1fa9b20
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```

**a2g-tc397-5v-tft:nsh**

<img width="511" height="409" alt="image" src="https://github.com/user-attachments/assets/f679af0e-07a5-49e9-9092-0a8043a1e9f2" />

```
NuttShell (NSH)
nsh>
nsh> uname -a
NuttX 0.0.0 cc94a9e19a-dirty Jan 20 2026 09:49:11 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         6        6
mxordblk    1f890    1f890
uordblks     5578     5578
fordblks    23888    23888

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        6
mxordblk    24208    1f890
uordblks     4bf8     5578
fordblks    24208    23888
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```




