### PR TITLE
arch/arm64: fix mpu_freeregion

### DIFF
--- a/arch/arm64/src/common/arm64_mpu.c
+++ b/arch/arm64/src/common/arm64_mpu.c
@@ -187,10 +187,14 @@ void mpu_freeregion(unsigned int region)
   write_sysreg(region, prselr_el1);
   UP_DSB();
 
-  /* Set the region base, limit and attribute */
+  /* Set the region base, limit and attribute
+   * Have to set limit register first as the enable/disable bit of the
+   * region is in the limit register.
+   */
 
-  write_sysreg(0, prbar_el1);
   write_sysreg(0, prlar_el1);
+  write_sysreg(0, prbar_el1);
+
   g_mpu_region[this_cpu()] &= ~(1 << region);
   UP_MB();
 }


### PR DESCRIPTION
## Summary

Fix the RPMSG RTC driver's MPU region free operation by correcting the register write order. The hardware requires writing the limit register first as it contains the enable/disable bit for the region.

### Changes Made
- Reorder register writes in `mpu_freeregion()` to write limit register before base register
- Add clarifying comments explaining the hardware requirement
- Ensure proper region disable operation during memory region cleanup

### Impact
- **Stability**: Fixes potential issues with MPU region management in ARM64
- **Compatibility**: No breaking changes, only corrects hardware sequencing
- **Code Quality**: Improves code clarity with better documentation

### Testing
Tested on ARM64 platform with MPU configuration enabled.

Fixes: None (Bug fix for register sequencing)

### Related Issues
None