### PR TITLE
boards/boardctl: Add BOARDCTL_MACADDR command

### DIFF
--- a/Documentation/reference/user/13_boardctl.rst
+++ b/Documentation/reference/user/13_boardctl.rst
@@ -110,6 +110,16 @@ Board information
      which to receive the board unique ID.
  
    :dependencies: Board logic must provide the :c:func:`board_uniqueid` interface.
+
+.. c:macro:: BOARDIOC_MACADDR
+
+   Get the network driver MAC address.
+
+   :Argument: A pointer to an instance of :c:struct:`boardioc_macaddr_s`.
+
+   :configuration: CONFIG_BOARDCTL_MACADDR
+
+   :dependencies: Board logic must provide the :c:func:`board_macaddr` interface.
    
 Filesystems
 -----------

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -5322,6 +5322,14 @@ config BOARDCTL_START_CPU
 		Architecture specific logic must provide the board_start_cpu()
 		interface.
 
+config BOARDCTL_MACADDR
+	bool "Get network MAC address"
+	default n
+	---help---
+		Enables support for the BOARDIOC_MACADDR boardctl() command.
+		Architecture specific logic must provide the board_macaddr()
+		interface.
+
 config BOARDCTL_IOCTL
 	bool "Board-specific boardctl() commands"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -906,6 +906,25 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_MACADDR
+      /* CMD:           BOARDIOC_MACADDR
+       * DESCRIPTION:   Get the network driver mac address.
+       * ARG:           A pointer to an instance of struct
+       *                boardioc_macaddr_s.
+       * CONFIGURATION: CONFIG_BOARDCTL_MACADDR
+       * DEPENDENCIES:  Board logic must provide board_macaddr()
+       */
+
+      case BOARDIOC_MACADDR:
+        {
+          FAR struct boardioc_macaddr_s *req =
+            (FAR struct boardioc_macaddr_s *)arg;
+
+          ret = board_macaddr(req->ifname, req->macaddr);
+        }
+        break;
+#endif
+
        default:
          {
 #ifdef CONFIG_BOARDCTL_IOCTL

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -636,6 +636,26 @@ void board_autoled_off(int led);
 #endif
 
 /****************************************************************************
+ * Name: board_macaddr
+ *
+ * Description:
+ *   Get the network driver mac address.
+ *
+ * Input Parameters:
+ *   ifname   - The interface name.
+ *   macaddr  - The mac address.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_MACADDR
+int board_macaddr(FAR const char *ifname, FAR uint8_t *macaddr);
+#endif
+
+/****************************************************************************
  * Name:  board_userled_initialize
  *
  * Description:

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -48,6 +48,11 @@
 #  include <nuttx/spinlock.h>
 #endif
 
+#ifdef CONFIG_BOARDCTL_MACADDR
+#  include <net/if.h>
+#  include <nuttx/net/netdev.h>
+#endif
+
 #ifdef CONFIG_BOARDCTL
 
 /****************************************************************************
@@ -216,6 +221,7 @@
 #define BOARDIOC_RESET_CAUSE       _BOARDIOC(0x0015)
 #define BOARDIOC_IRQ_AFFINITY      _BOARDIOC(0x0016)
 #define BOARDIOC_START_CPU         _BOARDIOC(0x0017)
+#define BOARDIOC_MACADDR           _BOARDIOC(0x0018)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -224,7 +230,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0018)
+#define BOARDIOC_USER              _BOARDIOC(0x0019)
 
 /****************************************************************************
  * Public Type Definitions
@@ -475,6 +481,14 @@ struct boardioc_reset_cause_s
   enum boardioc_reset_cause_e cause;  /* The reason of last reset */
   uint32_t flag;                      /* watchdog number when watchdog reset,
                                        * or soft-reset subreason */
+};
+#endif
+
+#ifdef CONFIG_BOARDCTL_MACADDR
+struct boardioc_macaddr_s
+{
+  char ifname[IFNAMSIZ];
+  uint8_t macaddr[RADIO_MAX_ADDRLEN];
 };
 #endif
 


### PR DESCRIPTION
This commit adds a new boardctl command BOARDCTL_MACADDR to retrieve the MAC address of the network interface. The board_macaddr function needs to be implemented by the board logic.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR introduces a new boardctl command BOARDCTL_MACADDR to allow applications (like netinit ) to retrieve the network interface MAC address from the board-specific logic.

Why In some embedded scenarios, the MAC address (especially for Wi-Fi) is stored in board-specific storage (e.g., OTP, NVM, or a config file) and needs to be retrieved by the network initialization logic at runtime. Currently, there is no standard boardctl command for this purpose.
- Add BOARDCTL_MACADDR definition in include/sys/boardctl.h .
- Add board_macaddr function prototype in include/nuttx/board.h .
- Implement dispatch logic for BOARDCTL_MACADDR in boards/boardctl.c .

## Impact

- Users : No direct impact unless BOARDCTL_MACADDR is used.
- Compatibility : Backward compatible.

## Testing

- Verified compilation with valid board configuration.
- Used by the companion PR in nuttx-apps (https://github.com/apache/nuttx-apps/pull/3315) to fetch MAC address.
