### PR TITLE
boards/xtensa/esp32: add rtc_reserved_seg to legacy_sections

### DIFF
--- a/boards/xtensa/esp32/common/scripts/legacy_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/legacy_sections.ld
@@ -384,4 +384,21 @@ SECTIONS
     . = ALIGN (4);
     _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
+
+   /*
+    * This section holds RTC data that should have fixed addresses.
+    * The data are not initialized at power-up and are retained during deep sleep.
+    */
+  .rtc_reserved (NOLOAD):
+  {
+    . = ALIGN(4);
+    _rtc_reserved_start = ABSOLUTE(.);
+    /* New data can only be added here to ensure existing data are not moved.
+        Because data have adhered to the end of the segment and code is relied on it.
+        >> put new data here << */
+
+    *(.rtc_timer_data_in_rtc_mem .rtc_timer_data_in_rtc_mem.*)
+    KEEP(*(.bootloader_data_rtc_mem .bootloader_data_rtc_mem.*))
+    _rtc_reserved_end = ABSOLUTE(.);
+  } > rtc_reserved_seg
 }


### PR DESCRIPTION
## Summary

When building esp32_devkitc:nsh the build fails for the legacy idf format:

```console
MKIMAGE: ESP32 binary
esptool.py -c esp32 elf2image -fs 4MB -fm dio -ff "40m" -o nuttx.bin nuttx
Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
esptool v5.1.0
Creating ESP32 image...
Merged 1 ELF section.
Successfully created ESP32 image.

A fatal error occurred: Segment loaded at 0x3f403080 lands in same 64 KB flash mapping as segment loaded at 0x3f400020. Can't generate binary. Suggest changing linker script or ELF to merge sections.
make: *** [tools/Unix.mk:559: nuttx] Error 2
```

This is caused by a missing part in the `legacy_sections.ld` linker script.

To allow building the legacy_sections.ld is modified.

## Impact

*The PR makes it possible to compile for the legacy idf bootloader, it has no effect on users, build process, hardware, documentation, security, compatibility, ... other than being able to generate images for the legacy bootloader.