### PR TITLE
arch: fix cmake error

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -786,16 +786,19 @@ if ARCH_ADDRENV && ARCH_NEED_ADDRENV_MAPPING
 
 config ARCH_TEXT_VBASE
 	hex "Virtual .text base"
+	default 0x0
 	---help---
 		The virtual address of the beginning the .text region
 
 config ARCH_DATA_VBASE
 	hex "Virtual .bss/.data base"
+	default 0x0
 	---help---
 		The virtual address of the beginning of the .bss/.data region.
 
 config ARCH_HEAP_VBASE
 	hex "Virtual heap base"
+	default 0x0
 	---help---
 		The virtual address of the beginning of the heap region.
 


### PR DESCRIPTION
## Summary

This PR fixes CMake configuration errors that occur during NuttX initialization when virtual address base configuration options are not explicitly set. The build system was throwing invalid value warnings for hex-type configuration options without defaults.

### Changes Made
- Add `default 0x0` to ARCH_TEXT_VBASE configuration
- Add `default 0x0` to ARCH_DATA_VBASE configuration  
- Add `default 0x0` to ARCH_HEAP_VBASE configuration

### Impact

• Stability: Eliminates CMake configuration warnings during initialization
• Compatibility: No breaking changes, provides sensible defaults for optional configurations
• Code Quality: Improves build system stability and cleaner initialization output
• No breaking changes: All changes are backward compatible

### Testing

Test Environment:

• Host: Linux x86_64
• Configuration: Default NuttX cmake configuration without explicit virtual address settings

Test Procedure:

1. Ran NuttX cmake initialization without setting ARCH_TEXT_VBASE, ARCH_DATA_VBASE, ARCH_HEAP_VBASE
2. Verified no cmake configuration warnings are generated
3. Tested on multiple architectures with ARCH_ADDRENV and ARCH_NEED_ADDRENV_MAPPING enabled

Test Results:

✅ CMake initialization completes without configuration warnings
✅ Default values (0x0) properly applied to all three virtual base configurations
✅ Backward compatibility maintained for existing configurations
✅ Build successful on tested architectures

Verification:

• ✅ Configuration warnings resolved
• ✅ Build system initialization cleaner
• ✅ No regressions in existing functionality