### PR TITLE
libc/pthread: Avoid compiler optimizations for once_control->done

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -402,7 +402,7 @@ typedef struct pthread_barrier_s pthread_barrier_t;
 
 struct pthread_once_s
 {
-  bool done;
+  volatile bool done;
   pthread_mutex_t mutex;
 };
 


### PR DESCRIPTION

Summary
- Change the `done` field in the `pthread_once` control structure to `volatile` to prevent compiler reordering or caching from producing stale reads that could break the once-initialization semantics.

Changes
- Modified file: `include/pthread.h`
- Commit: 5ced04f670761d66c65e60e218bd455f5b884912
- Change: `bool done;` -> `volatile bool done;`

Motivation and Impact
- Motivation: Under aggressive optimization levels or on certain architectures, compiler or CPU optimizations may allow threads to observe stale values, which can cause `pthread_once` to be invoked multiple times or its initialization to fail.
- Impact: Fixes a potential concurrency bug in `pthread_once` initialization. This is a backward-compatible bugfix that does not change the public API. The performance impact is expected to be minimal.

Test Recommendations
Environment
- Target: `sim` or any board/config with pthread support (ensure `CONFIG_PTHREAD=y`).
- Platform: Prefer platforms with optimizations enabled and multi-thread support (e.g. x86_64-sim, multi-core ARM).

Steps
1. Build and run an image or application with pthread enabled.
2. Run a test program that spawns many threads (e.g. 10–100 threads). Each thread should call the same `pthread_once` once-routine.
3. Verify that the once-routine is executed exactly once and that there are no crashes, duplicate initializations, or deadlocks.

Example verification (conceptual)
- Build: use your existing build flow to build the selected board/config with pthread enabled.
- Run: execute the test binary under NSH or as an application and inspect logs for a single initialization message.

Rollback and Compatibility
- This change only adds a type qualifier and can be safely reverted if needed. It does not modify the external API.