### PR TITLE
boards/nrf53: correct rptun names

### DIFF
--- a/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
@@ -96,7 +96,7 @@ static int nrf53_appcore_bleinit(void)
 #ifdef CONFIG_BLUETOOTH_RPMSG
   struct bt_driver_s *bt_dev = NULL;
 
-  bt_dev = rpmsghci_register("appcore", "bthci");
+  bt_dev = rpmsghci_register("netcore", "bthci");
   if (bt_dev == NULL)
     {
       syslog(LOG_ERR, "ERROR: rpmsghci_register() failed: %d\n", -errno);
@@ -157,9 +157,9 @@ static int nrf53_netcore_bleinit(void)
 void rpmsg_serialinit(void)
 {
 #ifdef CONFIG_NRF53_APPCORE
-  uart_rpmsg_init("appcore", "proxy", 4096, false);
+  uart_rpmsg_init("netcore", "proxy", 4096, false);
 #else
-  uart_rpmsg_init("netcore", "proxy", 4096, true);
+  uart_rpmsg_init("appcore", "proxy", 4096, true);
 #endif
 }
 #endif
@@ -225,9 +225,9 @@ int nrf53_bringup(void)
 
 #ifdef CONFIG_RPTUN
 #ifdef CONFIG_NRF53_APPCORE
-  nrf53_rptun_init("appcore");
-#else
   nrf53_rptun_init("netcore");
+#else
+  nrf53_rptun_init("appcore");
 #endif
 #endif
 

--- a/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
@@ -83,7 +83,7 @@ static int nrf53_appcore_bleinit(void)
 #ifdef CONFIG_BLUETOOTH_RPMSG
   struct bt_driver_s *bt_dev = NULL;
 
-  bt_dev = rpmsghci_register("appcore", "bthci");
+  bt_dev = rpmsghci_register("netcore", "bthci");
   if (bt_dev == NULL)
     {
       syslog(LOG_ERR, "ERROR: rpmsghci_register() failed: %d\n", -errno);
@@ -144,9 +144,9 @@ static int nrf53_netcore_bleinit(void)
 void rpmsg_serialinit(void)
 {
 #ifdef CONFIG_NRF53_APPCORE
-  uart_rpmsg_init("appcore", "proxy", 4096, false);
+  uart_rpmsg_init("netcore", "proxy", 4096, false);
 #else
-  uart_rpmsg_init("netcore", "proxy", 4096, true);
+  uart_rpmsg_init("appcore", "proxy", 4096, true);
 #endif
 }
 #endif
@@ -192,9 +192,9 @@ int nrf53_bringup(void)
 
 #ifdef CONFIG_RPTUN
 #ifdef CONFIG_NRF53_APPCORE
-  nrf53_rptun_init("appcore");
-#else
   nrf53_rptun_init("netcore");
+#else
+  nrf53_rptun_init("appcore");
 #endif
 #endif
 


### PR DESCRIPTION


## Summary
- boards/nrf53: correct rptun names
after recent changes in rptun framework, HCI over rptun was broken due to wrong cpu names.

## Impact

fix HCI over RPTUN for nrf53

## Testing
nimble for master is currently broken, with this PR and after reverting the breaking commit (https://github.com/apache/nuttx/issues/18053) everything works fine:


```
NuttShell (NSH) NuttX-10.4.0
nsh> 
nsh> 
nsh> nimble
btnet_txavail: Available=1
btnet_req_data: Received framelist
bt_buf_alloc: buf 0x20006ec8 type 0 reserve 0
rpmsghci_bt_send: rpmsghci_bt_send 0
bt_buf_release: buf 0x20006ec8 ref 1 type 0
bt_buf_release: Buffer freed: 0x20006ec8
rpmsghci_recv_handler: rpmsghci_recv_handler 1
bt_receive: data 0x20078d01 len 6
bt_buf_alloc: buf 0x20006ec8 type 1 reserve 1
bt_buf_extend: buf 0x20006ec8 len 6
priority_rx_work: list 0x20006c90
priority_rx_work: buf 0x20006ec8 type 1 len 6
btnet_hci_received: Received frame
bt_buf_release: buf 0x20006ec8 ref 1 type 1
bt_buf_release: Buffer freed: 0x20006ec8
btnet_txavail: Available=1
btnet_req_data: Received framelist


```
