### PR TITLE
stm32: disable UART up_putc when semihosting

### DIFF
--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -3688,6 +3688,7 @@ void stm32_serial_dma_poll(void)
  *
  ****************************************************************************/
 
+#ifndef CONFIG_ARM_SEMIHOSTING_SYSLOG
 void up_putc(int ch)
 {
 #if CONSOLE_UART > 0
@@ -3704,6 +3705,7 @@ void up_putc(int ch)
   up_restoreusartint(priv, ie);
 #endif
 }
+#endif
 
 #else /* USE_SERIALDRIVER */
 
@@ -3715,11 +3717,13 @@ void up_putc(int ch)
  *
  ****************************************************************************/
 
+#ifndef CONFIG_ARM_SEMIHOSTING_SYSLOG
 void up_putc(int ch)
 {
 #if CONSOLE_UART > 0 || CONSOLE_LPUART > 0
   arm_lowputc(ch);
 #endif
 }
+#endif
 
 #endif /* USE_SERIALDRIVER */


### PR DESCRIPTION
## Summary

Disable building up_putc from `stm32_serial.c` when `CONFIG_ARM_SEMIHOSTING_SYSLOG` is defined.

## Impact

Enables semihosting on STM32 platforms even when CONFIG_STM32_USART=y, allowing for firmware projects where both semihosting console and UART are used.

## Testing

These changes were tested on top of NuttX 12.12.0 on a STM32F405RGT6 development board connected to an official ST-Link V2 debugger.

Build machine was a Macintosh running macOS 15.7.3, with `Arm GNU Toolchain 15.2.Rel1 (Build arm-15.86)` as the cross-compiler.

Board configuration is a custom `pyb1-1`, based off `stm32f411-minimum` with minimal modifications to work on Pyboard 1.1 (STM32F405RGT6).

defconfig was the following:

```
CONFIG_ARCH="arm"
CONFIG_ARCH_BOARD="pyb1-1"
CONFIG_ARCH_BOARD_PYB1_1=y
CONFIG_ARCH_CHIP="stm32"
CONFIG_ARCH_CHIP_STM32=y
CONFIG_ARCH_CHIP_STM32F405RG=y
CONFIG_ARCH_INTERRUPTSTACK=2048
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARM_SEMIHOSTING_SYSLOG=y
CONFIG_BOARD_LOOPSPERMSEC=8499
CONFIG_BUILTIN=y
CONFIG_DEBUG_ASSERTIONS=y
CONFIG_DEBUG_ASSERTIONS_EXPRESSION=y
CONFIG_DEBUG_FEATURES=y
CONFIG_DEBUG_MM=y
CONFIG_DEBUG_MM_ERROR=y
CONFIG_DEBUG_MM_INFO=y
CONFIG_DEBUG_MM_WARN=y
CONFIG_HAVE_CXX=y
CONFIG_HOST_MACOS=y
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_INTELHEX_BINARY=y
CONFIG_LINE_MAX=64
CONFIG_NDEBUG=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_RAM_SIZE=131072
CONFIG_RAM_START=0x20000000
CONFIG_RAW_BINARY=y
CONFIG_RR_INTERVAL=200
CONFIG_SCHED_WAITPID=y
CONFIG_START_DAY=6
CONFIG_START_MONTH=6
CONFIG_START_YEAR=2020
CONFIG_STM32_FLASH_CONFIG_E=y
CONFIG_STM32_JTAG_SW_ENABLE=y
CONFIG_SYSLOG_BUFFER=y
CONFIG_SYSTEM_NSH=y
CONFIG_TASK_NAME_SIZE=0
```

Compiling NuttX with no changes gave me a linker error:

```
LD: nuttx
arm-none-eabi-ld: [redacted]/nuttx/staging/libarch.a(arm_semi_syslog.o): in function `up_putc':
arm_semi_syslog.c:(.text.up_putc+0x0): multiple definition of `up_putc'; [redacted]/nuttx/staging/libarch.a(stm32_serial.o):stm32_serial.c:(.text.up_putc+0x0): first defined here
```

Which was fixed with these changes.