### PR TITLE
net/bluetooth: fix rmutex deadlock

### DIFF
--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -166,6 +166,8 @@ void bluetooth_conn_free(FAR struct bluetooth_conn_s *conn)
       bluetooth_container_free(container);
     }
 
+  nxrmutex_destroy(&conn->bc_conn.s_lock);
+
   /* Free the connection structure */
 
   NET_BUFPOOL_FREE(g_bluetooth_connections, conn);

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -127,6 +127,7 @@ static int bluetooth_sockif_alloc(FAR struct socket *psock)
 
   DEBUGASSERT(conn->bc_crefs == 0);
   conn->bc_crefs = 1;
+  nxrmutex_init(&conn->bc_conn.s_lock);
 
   /* Save the pre-allocated connection in the socket structure */
 


### PR DESCRIPTION
## Summary
the lock in the "bluetooth_conn" was not initialized, which resulted in a blocking situation when attempting to hold the lock for the first time.

## Impact
net/bluetooth

## Testing
nrf52840-dk/sdc_nimble
Verification of compilation.