### PR TITLE
libs/libc/regex: remove logically dead code in regcomp.c

### DIFF
--- a/libs/libc/regex/regcomp.c
+++ b/libs/libc/regex/regcomp.c
@@ -2290,10 +2290,6 @@ static reg_errcode_t tre_copy_ast(tre_mem_t mem, tre_stack_t *stack,
   while (status == REG_OK && tre_stack_num_objects(stack) > bottom)
     {
       tre_ast_node_t *node;
-      if (status != REG_OK)
-        {
-          break;
-        }
 
       symbol = (tre_copyast_symbol_t)tre_stack_pop_int(stack);
       switch (symbol)
@@ -2462,11 +2458,6 @@ static reg_errcode_t tre_expand_ast(tre_mem_t mem, tre_stack_t *stack,
     {
       tre_ast_node_t            *node;
       tre_expand_ast_symbol_t   symbol;
-
-      if (status != REG_OK)
-        {
-          break;
-        }
 
       symbol    = (tre_expand_ast_symbol_t)tre_stack_pop_int(stack);
       node      = tre_stack_pop_voidptr(stack);


### PR DESCRIPTION
This change removes redundant and unreachable checks of `status != REG_OK`
that were reported by static code scanning. Two occurrences were fixed in
`libs/libc/regex/regcomp.c`

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
This PR removes logically dead checks in the libc regex implementation
(`regcomp.c`) that were flagged by static code scanning. The removed
conditions were unreachable and therefore had no effect on program
behavior.

## What I changed
- Removed an unreachable `if (status != REG_OK) { break; }` block in
  `tre_copy_ast` in `libs/libc/regex/regcomp.c`.
- Removed an unreachable `if (status != REG_OK) { break; }` block in
  `tre_expand_ast` in `libs/libc/regex/regcomp.c`.

## Files modified
- libs/libc/regex/regcomp.c (small deletions only)

## Impact
- No functional changes; behavior is preserved.
- Improves code readability and addresses findings from static analysis.
- Low risk for regressions.

## Testing
- Build the libc and run existing unit tests that exercise regex code,
  for example:
  1. Build NuttX for a host target (or relevant board) that includes the
     libc regex implementation.
  2. Run any available regex tests or reproduce scenarios that use
     `regcomp`/`regexec`.
- If no dedicated tests exist, a full build and smoke test are recommended.

