### PR TITLE
arch/tricore: disable CPU and system watchdogs during startup

### DIFF
--- a/arch/tricore/src/common/tricore_main.c
+++ b/arch/tricore/src/common/tricore_main.c
@@ -28,8 +28,8 @@
 #include <nuttx/init.h>
 
 #include "Ifx_Types.h"
-#include "IfxScuWdt.h"
 #include "IfxCpu.h"
+#include "IfxScuWdt.h"
 
 /****************************************************************************
  * Private Functions
@@ -42,9 +42,6 @@ static void core_main(void)
   /* !!WATCHDOG0 AND SAFETY WATCHDOG ARE DISABLED HERE!!
    * Enable the watchdogs and service them periodically if it is required
    */
-
-  IfxScuWdt_disableCpuWatchdog(IfxScuWdt_getCpuWatchdogPassword());
-  IfxScuWdt_disableSafetyWatchdog(IfxScuWdt_getSafetyWatchdogPassword());
 
   /* Wait for CPU sync event */
 
@@ -66,6 +63,19 @@ static void core_main(void)
 
 void core0_main(void)
 {
+  /* All WDTs except WDTCPU0 and system watchdog WDTSYS are in
+   * disabled mode after Boot-FW execution. Disable the watchdog
+   * to ensure the normal startup of the system.
+   */
+
+#if defined(CONFIG_ARCH_CHIP_AURIX_TC3XX)
+  IfxScuWdt_disableCpuWatchdog(IfxScuWdt_getCpuWatchdogPassword());
+  IfxScuWdt_disableSafetyWatchdog(IfxScuWdt_getSafetyWatchdogPassword());
+#elif defined(CONFIG_ARCH_CHIP_AURIX_TC4XX)
+  IfxWtu_disableCpuWatchdog(IfxWtu_getCpuWatchdogPassword());
+  IfxWtu_disableSystemWatchdog(IfxWtu_getSystemWatchdogPassword());
+#endif
+
   core_main();
 }
 


### PR DESCRIPTION
Some Aurix Boot-FW configurations leave watchdogs enabled by default,
which can cause unexpected resets during early bring-up. This change
explicitly disables the CPU and system watchdogs during core0 startup to
ensure reliable system initialization.

- For TC3XX chips, call `IfxScuWdt_disableCpuWatchdog()` and
  `IfxScuWdt_disableSafetyWatchdog()`.
- For TC4XX chips, call `IfxWtu_disableCpuWatchdog()` and
  `IfxWtu_disableSystemWatchdog()`.

This is a low-risk startup change and does not alter watchdog behavior
after system initialization.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
This PR disables CPU and system watchdogs during early core0 startup on
Aurix TriCore platforms to avoid unintended resets caused by watchdogs
left enabled by Boot-FW. The code performs the appropriate disable calls
for TC3XX and TC4XX variants.

## What I changed
- `arch/tricore/src/common/tricore_main.c`: move watchdog disable calls
  into `core0_main()` and guard them per-chip (`CONFIG_ARCH_CHIP_AURIX_TC3XX`
  and `CONFIG_ARCH_CHIP_AURIX_TC4XX`).

## Files modified
- arch/tricore/src/common/tricore_main.c

## Impact
- Prevents spurious resets during early startup on affected Aurix chips.
- Low risk: only executed during early startup; normal watchdog behavior
  can be re-enabled later if required.

## Testing
- Boot the system on TC3XX and TC4XX boards and confirm system starts
  reliably without being reset by watchdogs.
- Optionally, re-enable watchdogs after initialization and verify they
  operate normally.

