### PR TITLE
drivers/pipe: fix POLLHUP handling in poll()

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -731,9 +731,13 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
           eventset |= POLLIN;
         }
 
-      /* Notify the POLLHUP event if the pipe is empty and no writers */
+      /* Notify the POLLHUP event if the pipe is empty,
+       * while no writers and policy 0.
+       */
 
-      if (nbytes == 0 && dev->d_nwriters <= 0)
+      if (nbytes == 0 &&
+          dev->d_nwriters <= 0 &&
+          PIPE_IS_POLICY_0(dev->d_flags))
         {
           eventset |= POLLHUP;
         }


### PR DESCRIPTION
For POLICY_0, when a pipe only has a reader and no writer,
if the pipe is empty, set POLLHUP.

For POLICY_1, when a pipe only has a reader but no writer,
if the pipe is empty, POLLHUP will not be set.

This change corrects poll() behavior to match the two pipe policies.
No API changes.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
This change corrects the handling of POLLHUP in the pipe driver's `poll()` implementation so that behavior matches the configured pipe policy semantics.

## Motivation
- The previous `poll()` logic treated POLLHUP inconsistently across the two supported pipe policies, which could lead to incorrect poll events when a pipe has readers but no writers.
- Proper POLLHUP signaling is important for user programs and drivers that rely on poll/select semantics to detect end-of-stream or writer absence.

## What changed
- Adjusted `poll()` behavior so:
  - For POLICY_0: when a pipe has only readers (no writers) and is empty, `POLLHUP` is set.
  - For POLICY_1: when a pipe has only readers and is empty, `POLLHUP` is not set.
- No public API changes; logic update is internal to the driver.

Likely affected files:
- `drivers/pipe/*` (poll implementation)

## Impact
- Behavioral change is limited to `poll()` event reporting for pipes under specific policy/configurations.
- No ABI/API changes; existing code that depends on correct POLLHUP semantics will behave correctly after this fix.
- Code that relied on the previous (incorrect) POLLHUP behavior may observe different poll results — this is a correctness fix.

## Testing
Suggested validation steps:
1. Build with the target configuration:
   - Ensure pipe driver is enabled with both POLICY_0 and POLICY_1 variants (if configurable).
2. Run poll-based testcases:
   - Scenario A (POLICY_0): create a pipe, launch reader(s) only, ensure `poll()` reports `POLLHUP` when pipe is empty.
   - Scenario B (POLICY_1): same setup but verify `POLLHUP` is not reported when empty.
3. Confirm no regressions in normal read/write behavior and no unintended wakeups.

Expected test result examples:
- POLICY_0: poll reports POLLHUP when no writers and buffer empty.
- POLICY_1: poll does not report POLLHUP under the same conditions.

