### PR TITLE
fs: Fix the incorrect return value of the lseek interface.

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -1288,7 +1288,7 @@ static off_t fat_seek(FAR struct file *filep, off_t offset, int whence)
   if (position / fs->fs_hwsectorsize == filep->f_pos / fs->fs_hwsectorsize)
     {
       filep->f_pos = position;
-      return OK;
+      return position;
     }
 
   /* Make sure that the mount is still healthy */
@@ -1316,7 +1316,7 @@ static off_t fat_seek(FAR struct file *filep, off_t offset, int whence)
   filep->f_pos = position;
 
   nxmutex_unlock(&fs->fs_lock);
-  return OK;
+  return position;
 
 errout_with_lock:
   nxmutex_unlock(&fs->fs_lock);

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -579,7 +579,7 @@ static off_t romfs_seek(FAR struct file *filep, off_t offset, int whence)
 
 errout_with_lock:
   nxrmutex_unlock(&rm->rm_lock);
-  return ret;
+  return ret < 0 ? ret : position;
 }
 
 /****************************************************************************


### PR DESCRIPTION
The lseek interface needs to return the new offset in file.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
