### PR TITLE
arch/arm: armv8-r PL at startup needs to be checked

### DIFF
--- a/arch/arm/src/armv8-r/arm_head.S
+++ b/arch/arm/src/armv8-r/arm_head.S
@@ -198,10 +198,6 @@ __cpu0_start:
 	ldr		sp, .Lstackpointer
 	mov		fp, #0
 
-	/* Set Hyp/PL2 Vector table base register */
-	ldr		r0, .Lhypvectorstart
-	mcr		CP15_HVBAR(r0)
-
 	/* Invalidate caches and TLBs.
 	 *
 	 *   NOTE: "The ARMv7 Virtual Memory System Architecture (VMSA) does not
@@ -223,11 +219,6 @@ __cpu0_start:
 	bl		cp15_dcache_op_level
 	isb
 
-	bl		hsctlr_initialize  /* Init Hyp system control register */
-
-	ldr		r0, =HACTLR_INIT
-	mcr		CP15_HACTLR(r0)  /* Enable EL1 access all IMP DEFINED registers */
-
 #ifdef CONFIG_ARCH_FPU
 	bl		arm_fpuconfig
 #endif
@@ -238,7 +229,22 @@ __cpu0_start:
 	/* Platform hook for highest EL */
 	bl		arm_el_init
 
-    /* Move to PL1 SYS with all exceptions masked */
+	/* Skip hypervisor register initializition */
+	mrs		r0, CPSR
+	and		r0, r0, #PSR_MODE_MASK
+	cmp		r0, #PSR_MODE_HYP	/* Check the current processor mode */
+	bne		1f
+
+	/* Set Hyp/PL2 Vector table base register */
+	ldr		r0, .Lhypvectorstart
+	mcr		CP15_HVBAR(r0)
+
+	/* Initialize Hyp system control register */
+	bl		hsctlr_initialize	/* Init Hyp system control register */
+	ldr		r0, =HACTLR_INIT
+	mcr		CP15_HACTLR(r0)	/* Enable EL1 access all IMP DEFINED registers */
+
+	/* Move to PL1 SYS with all exceptions masked */
 	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT | PSR_A_BIT)
 	msr		spsr_hyp, r0
 


### PR DESCRIPTION
When the system startup from the PL1 SYS mode, the initialization of the PL2 HYP register needs to be skipped. Put the Hypervisor initialization code together and skip it all at once.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*This section should provide a detailed description of what you did
to verify your changes work and do not break existing code.*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
