### PR TITLE
libs/crc: implement AUTOSAR-compatible CRC algorithm

### DIFF
--- a/include/nuttx/crc16.h
+++ b/include/nuttx/crc16.h
@@ -205,6 +205,52 @@ uint16_t crc16xmodempart(FAR const uint8_t *src, size_t len,
 
 uint16_t crc16xmodem(FAR const uint8_t *src, size_t len);
 
+/****************************************************************************
+ * Name: crc16h1021_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x1021 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h1021_part(FAR const uint8_t *src,
+                         size_t len, uint16_t crc16val);
+
+/****************************************************************************
+ * Name: crc16h1021
+ *
+ * Description:
+ *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x1021 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h1021(FAR const uint8_t *src, size_t len);
+
+/****************************************************************************
+ * Name: crc16h8005_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x8005 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h8005_part(FAR const uint8_t *src,
+                         size_t len, uint16_t crc16val);
+
+/****************************************************************************
+ * Name: crc16h8005
+ *
+ * Description:
+ *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x8005 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h8005(FAR const uint8_t *src, size_t len);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/nuttx/crc32.h
+++ b/include/nuttx/crc32.h
@@ -70,6 +70,52 @@ uint32_t crc32part(FAR const uint8_t *src, size_t len, uint32_t crc32val);
 
 uint32_t crc32(FAR const uint8_t *src, size_t len);
 
+/****************************************************************************
+ * Name: crc32h04c11db7_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x04c11db7 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32h04c11db7_part(FAR const uint8_t *src,
+                             size_t len, uint32_t crc32val);
+
+/****************************************************************************
+ * Name: crc32h04c11db7
+ *
+ * Description:
+ *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x04c11db7 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32h04c11db7(FAR const uint8_t *src, size_t len);
+
+/****************************************************************************
+ * Name: crc32hf4acfb13_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0xF4ACFB13 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32hf4acfb13_part(FAR const uint8_t *src,
+                             size_t len, uint32_t crc32val);
+
+/****************************************************************************
+ * Name: crc32hf4acfb13
+ *
+ * Description:
+ *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0xF4ACFB13 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32hf4acfb13(FAR const uint8_t *src, size_t len);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/nuttx/crc64.h
+++ b/include/nuttx/crc64.h
@@ -95,6 +95,29 @@ uint64_t crc64part(FAR const uint8_t *src, size_t len, uint64_t crc64val);
 
 uint64_t crc64(FAR const uint8_t *src, size_t len);
 
+/****************************************************************************
+ * Name: crc64emac_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x42F0E1EBA9EA3693 polynomial.
+ *
+ ****************************************************************************/
+
+uint64_t crc64emac_part(FAR const uint8_t *src,
+                        size_t len, uint64_t crc64val);
+
+/****************************************************************************
+ * Name: crc64emac
+ *
+ * Description:
+ *   Return a 64-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x42F0E1EBA9EA3693 polynomial.
+ *
+ ****************************************************************************/
+
+uint64_t crc64emac(FAR const uint8_t *src, size_t len);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/include/nuttx/crc8.h
+++ b/include/nuttx/crc8.h
@@ -124,6 +124,50 @@ uint8_t crc8rohc(FAR const uint8_t *src, size_t len);
 
 uint8_t crc8rohcincr(uint8_t data_byte, uint8_t crc8val);
 
+/****************************************************************************
+ * Name: crc8h1d_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x1D polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h1d_part(FAR const uint8_t *src, size_t len, uint8_t crc8val);
+
+/****************************************************************************
+ * Name: crc8h1d
+ *
+ * Description:
+ *   Return a 8-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x1D polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h1d(FAR const uint8_t *src, size_t len);
+
+/****************************************************************************
+ * Name: crc8h2f_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x2F polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h2f_part(FAR const uint8_t *src, size_t len, uint8_t crc8val);
+
+/****************************************************************************
+ * Name: crc8h2f
+ *
+ * Description:
+ *   Return a 8-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x2F polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h2f(FAR const uint8_t *src, size_t len);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -81,13 +81,20 @@ list(
   lib_fnmatch.c
   lib_debug.c
   lib_crc64.c
+  lib_crc64emac.c
   lib_crc32.c
+  lib_crc32h04c11db7.c
+  lib_crc32hf4acfb13.c
   lib_crc16.c
   lib_crc16ccitt.c
   lib_crc16ibm.c
   lib_crc16xmodem.c
+  lib_crc16h1021.c
+  lib_crc16h8005.c
   lib_crc8.c
   lib_crc8ccitt.c
+  lib_crc8h1d.c
+  lib_crc8h2f.c
   lib_crc8rohc.c
   lib_crc8table.c
   lib_glob.c

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -45,9 +45,11 @@ endif
 # Add the miscellaneous C files to the build
 
 CSRCS += lib_dumpbuffer.c lib_dumpvbuffer.c lib_fnmatch.c lib_debug.c
-CSRCS += lib_crc64.c lib_crc32.c lib_crc16.c lib_crc16ccitt.c lib_crc8.c
-CSRCS += lib_crc8ccitt.c lib_crc8table.c lib_crc8rohc.c lib_glob.c
-CSRCS += lib_backtrace.c lib_ftok.c lib_err.c lib_instrument.c
+CSRCS += lib_crc64.c lib_crc32.c lib_crc16.c lib_crc16ccitt.c
+CSRCS += lib_crc8.c lib_crc8ccitt.c lib_crc8table.c lib_crc8rohc.c
+CSRCS += lib_crc8h1d.c lib_crc8h2f.c lib_crc16h1021.c lib_crc16h8005.c
+CSRCS += lib_crc32h04c11db7.c lib_crc32hf4acfb13.c lib_crc64emac.c
+CSRCS += lib_backtrace.c lib_ftok.c lib_err.c lib_instrument.c lib_glob.c
 CSRCS += lib_crc16ibm.c lib_crc16xmodem.c
 
 # Keyboard driver encoder/decoder

--- a/libs/libc/misc/lib_crc16h1021.c
+++ b/libs/libc/misc/lib_crc16h1021.c
@@ -1,0 +1,178 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc16h1021.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00002] The CRC module shall implement the CRC16 routine
+ * based on the CCITT-FALSE CRC16 Standard.
+ *
+ * CRC16 parameters:
+ * CRC result width: 16 bits
+ * Polynomial: 1021h
+ * Initial value: FFFFh
+ * Input data reflected: No
+ * Result data reflected: No
+ * XOR value: 0000h
+ *
+ * [AUTOSAR_SWS_Crc_00054] The Crc_CalculateCRC16 function of the CRC module
+ * shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   84C0
+ * F2 01 83                    |   D374
+ * 0F AA 00 55                 |   2023
+ * 00 FF 55 11                 |   B8F9
+ * 33 22 55 AA BB CC DD EE FF  |   F53F
+ * 92 6B 55                    |   0745
+ * FF FF FF FF                 |   1D0F
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc16.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC16 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc16_table(uint16_t poly, uint16_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint16_t crc = (uint16_t)(i << 8);
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 0x8000)
+ *             {
+ *               crc = (crc << 1) ^ polynomial;
+ *             }
+ *           else
+ *             {
+ *               crc = crc << 1;
+ *             }
+ *         }
+ *       crcTable[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint16_t crc16_table[256];
+ *   const uint8_t poly = 0x2F;
+ *
+ *   generate_crc16_table(poly, crc16_table);
+ *
+ *   printf("CRC16 Static Table (Poly 0x%02X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 16 == 0) printf("\n");
+ *       printf("0x%02X, ", crc16_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc16h1021_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x1021 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h1021_part(FAR const uint8_t *src,
+                         size_t len, uint16_t crc16val)
+{
+  size_t i;
+  static const uint16_t g_crc16_tab[256] =
+  {
+    0x0000u, 0x1021u, 0x2042u, 0x3063u, 0x4084u, 0x50a5u, 0x60c6u, 0x70e7u,
+    0x8108u, 0x9129u, 0xa14au, 0xb16bu, 0xc18cu, 0xd1adu, 0xe1ceu, 0xf1efu,
+    0x1231u, 0x0210u, 0x3273u, 0x2252u, 0x52b5u, 0x4294u, 0x72f7u, 0x62d6u,
+    0x9339u, 0x8318u, 0xb37bu, 0xa35au, 0xd3bdu, 0xc39cu, 0xf3ffu, 0xe3deu,
+    0x2462u, 0x3443u, 0x0420u, 0x1401u, 0x64e6u, 0x74c7u, 0x44a4u, 0x5485u,
+    0xa56au, 0xb54bu, 0x8528u, 0x9509u, 0xe5eeu, 0xf5cfu, 0xc5acu, 0xd58du,
+    0x3653u, 0x2672u, 0x1611u, 0x0630u, 0x76d7u, 0x66f6u, 0x5695u, 0x46b4u,
+    0xb75bu, 0xa77au, 0x9719u, 0x8738u, 0xf7dfu, 0xe7feu, 0xd79du, 0xc7bcu,
+    0x48c4u, 0x58e5u, 0x6886u, 0x78a7u, 0x0840u, 0x1861u, 0x2802u, 0x3823u,
+    0xc9ccu, 0xd9edu, 0xe98eu, 0xf9afu, 0x8948u, 0x9969u, 0xa90au, 0xb92bu,
+    0x5af5u, 0x4ad4u, 0x7ab7u, 0x6a96u, 0x1a71u, 0x0a50u, 0x3a33u, 0x2a12u,
+    0xdbfdu, 0xcbdcu, 0xfbbfu, 0xeb9eu, 0x9b79u, 0x8b58u, 0xbb3bu, 0xab1au,
+    0x6ca6u, 0x7c87u, 0x4ce4u, 0x5cc5u, 0x2c22u, 0x3c03u, 0x0c60u, 0x1c41u,
+    0xedaeu, 0xfd8fu, 0xcdecu, 0xddcdu, 0xad2au, 0xbd0bu, 0x8d68u, 0x9d49u,
+    0x7e97u, 0x6eb6u, 0x5ed5u, 0x4ef4u, 0x3e13u, 0x2e32u, 0x1e51u, 0x0e70u,
+    0xff9fu, 0xefbeu, 0xdfddu, 0xcffcu, 0xbf1bu, 0xaf3au, 0x9f59u, 0x8f78u,
+    0x9188u, 0x81a9u, 0xb1cau, 0xa1ebu, 0xd10cu, 0xc12du, 0xf14eu, 0xe16fu,
+    0x1080u, 0x00a1u, 0x30c2u, 0x20e3u, 0x5004u, 0x4025u, 0x7046u, 0x6067u,
+    0x83b9u, 0x9398u, 0xa3fbu, 0xb3dau, 0xc33du, 0xd31cu, 0xe37fu, 0xf35eu,
+    0x02b1u, 0x1290u, 0x22f3u, 0x32d2u, 0x4235u, 0x5214u, 0x6277u, 0x7256u,
+    0xb5eau, 0xa5cbu, 0x95a8u, 0x8589u, 0xf56eu, 0xe54fu, 0xd52cu, 0xc50du,
+    0x34e2u, 0x24c3u, 0x14a0u, 0x0481u, 0x7466u, 0x6447u, 0x5424u, 0x4405u,
+    0xa7dbu, 0xb7fau, 0x8799u, 0x97b8u, 0xe75fu, 0xf77eu, 0xc71du, 0xd73cu,
+    0x26d3u, 0x36f2u, 0x0691u, 0x16b0u, 0x6657u, 0x7676u, 0x4615u, 0x5634u,
+    0xd94cu, 0xc96du, 0xf90eu, 0xe92fu, 0x99c8u, 0x89e9u, 0xb98au, 0xa9abu,
+    0x5844u, 0x4865u, 0x7806u, 0x6827u, 0x18c0u, 0x08e1u, 0x3882u, 0x28a3u,
+    0xcb7du, 0xdb5cu, 0xeb3fu, 0xfb1eu, 0x8bf9u, 0x9bd8u, 0xabbbu, 0xbb9au,
+    0x4a75u, 0x5a54u, 0x6a37u, 0x7a16u, 0x0af1u, 0x1ad0u, 0x2ab3u, 0x3a92u,
+    0xfd2eu, 0xed0fu, 0xdd6cu, 0xcd4du, 0xbdaau, 0xad8bu, 0x9de8u, 0x8dc9u,
+    0x7c26u, 0x6c07u, 0x5c64u, 0x4c45u, 0x3ca2u, 0x2c83u, 0x1ce0u, 0x0cc1u,
+    0xef1fu, 0xff3eu, 0xcf5du, 0xdf7cu, 0xaf9bu, 0xbfbau, 0x8fd9u, 0x9ff8u,
+    0x6e17u, 0x7e36u, 0x4e55u, 0x5e74u, 0x2e93u, 0x3eb2u, 0x0ed1u, 0x1ef0u
+  };
+
+  for (i = 0u; i < len; i++)
+    {
+      crc16val = g_crc16_tab[((crc16val >> 8) & 0xffu) ^
+                 src[i]] ^ (uint16_t)(crc16val << 8);
+    }
+
+  return crc16val;
+}
+
+/****************************************************************************
+ * Name: crc16h1021
+ *
+ * Description:
+ *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x1021 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h1021(FAR const uint8_t *src, size_t len)
+{
+  return crc16h1021_part(src, len, 0xffffu);
+}

--- a/libs/libc/misc/lib_crc16h8005.c
+++ b/libs/libc/misc/lib_crc16h8005.c
@@ -1,0 +1,178 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc16h8005.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00067] The CRC module shall implement the CRC16
+ * based on the CRC-16/ARC Standard.
+ *
+ * CRC16 parameters:
+ * CRC result width: 16 bits
+ * Polynomial: 8005h
+ * Initial value: 0000h
+ * Input data reflected: Yes
+ * Result data reflected: Yes
+ * XOR value: 0000h
+ *
+ * [AUTOSAR_SWS_Crc_00068] The Crc_CalculateCRC16ARC function of the CRC
+ * module shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   0000
+ * F2 01 83                    |   C2E1
+ * 0F AA 00 55                 |   0BE3
+ * 00 FF 55 11                 |   6CCF
+ * 33 22 55 AA BB CC DD EE FF  |   AE98
+ * 92 6B 55                    |   E24E
+ * FF FF FF FF                 |   9401
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc16.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC16 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc16_table(uint16_t poly, uint16_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint16_t crc = (uint16_t)(i << 8);
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 0x8000)
+ *             {
+ *               crc = (crc << 1) ^ polynomial;
+ *             }
+ *           else
+ *             {
+ *               crc = crc << 1;
+ *             }
+ *         }
+ *       crcTable[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint16_t crc16_table[256];
+ *   const uint8_t poly = 0x2F;
+ *
+ *   generate_crc16_table(poly, crc16_table);
+ *
+ *   printf("CRC16 Static Table (Poly 0x%02X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 16 == 0) printf("\n");
+ *       printf("0x%02X, ", crc16_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc16h8005_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x8005 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h8005_part(FAR const uint8_t *src,
+                         size_t len, uint16_t crc16val)
+{
+  size_t i;
+  uint16_t v = crc16val;
+  static const uint16_t g_crc16_tab[256] =
+  {
+    0x0000u, 0xc0c1u, 0xc181u, 0x0140u, 0xc301u, 0x03c0u, 0x0280u, 0xc241u,
+    0xc601u, 0x06c0u, 0x0780u, 0xc741u, 0x0500u, 0xc5c1u, 0xc481u, 0x0440u,
+    0xcc01u, 0x0cc0u, 0x0d80u, 0xcd41u, 0x0f00u, 0xcfc1u, 0xce81u, 0x0e40u,
+    0x0a00u, 0xcac1u, 0xcb81u, 0x0b40u, 0xc901u, 0x09c0u, 0x0880u, 0xc841u,
+    0xd801u, 0x18c0u, 0x1980u, 0xd941u, 0x1b00u, 0xdbc1u, 0xda81u, 0x1a40u,
+    0x1e00u, 0xdec1u, 0xdf81u, 0x1f40u, 0xdd01u, 0x1dc0u, 0x1c80u, 0xdc41u,
+    0x1400u, 0xd4c1u, 0xd581u, 0x1540u, 0xd701u, 0x17c0u, 0x1680u, 0xd641u,
+    0xd201u, 0x12c0u, 0x1380u, 0xd341u, 0x1100u, 0xd1c1u, 0xd081u, 0x1040u,
+    0xf001u, 0x30c0u, 0x3180u, 0xf141u, 0x3300u, 0xf3c1u, 0xf281u, 0x3240u,
+    0x3600u, 0xf6c1u, 0xf781u, 0x3740u, 0xf501u, 0x35c0u, 0x3480u, 0xf441u,
+    0x3c00u, 0xfcc1u, 0xfd81u, 0x3d40u, 0xff01u, 0x3fc0u, 0x3e80u, 0xfe41u,
+    0xfa01u, 0x3ac0u, 0x3b80u, 0xfb41u, 0x3900u, 0xf9c1u, 0xf881u, 0x3840u,
+    0x2800u, 0xe8c1u, 0xe981u, 0x2940u, 0xeb01u, 0x2bc0u, 0x2a80u, 0xea41u,
+    0xee01u, 0x2ec0u, 0x2f80u, 0xef41u, 0x2d00u, 0xedc1u, 0xec81u, 0x2c40u,
+    0xe401u, 0x24c0u, 0x2580u, 0xe541u, 0x2700u, 0xe7c1u, 0xe681u, 0x2640u,
+    0x2200u, 0xe2c1u, 0xe381u, 0x2340u, 0xe101u, 0x21c0u, 0x2080u, 0xe041u,
+    0xa001u, 0x60c0u, 0x6180u, 0xa141u, 0x6300u, 0xa3c1u, 0xa281u, 0x6240u,
+    0x6600u, 0xa6c1u, 0xa781u, 0x6740u, 0xa501u, 0x65c0u, 0x6480u, 0xa441u,
+    0x6c00u, 0xacc1u, 0xad81u, 0x6d40u, 0xaf01u, 0x6fc0u, 0x6e80u, 0xae41u,
+    0xaa01u, 0x6ac0u, 0x6b80u, 0xab41u, 0x6900u, 0xa9c1u, 0xa881u, 0x6840u,
+    0x7800u, 0xb8c1u, 0xb981u, 0x7940u, 0xbb01u, 0x7bc0u, 0x7a80u, 0xba41u,
+    0xbe01u, 0x7ec0u, 0x7f80u, 0xbf41u, 0x7d00u, 0xbdc1u, 0xbc81u, 0x7c40u,
+    0xb401u, 0x74c0u, 0x7580u, 0xb541u, 0x7700u, 0xb7c1u, 0xb681u, 0x7640u,
+    0x7200u, 0xb2c1u, 0xb381u, 0x7340u, 0xb101u, 0x71c0u, 0x7080u, 0xb041u,
+    0x5000u, 0x90c1u, 0x9181u, 0x5140u, 0x9301u, 0x53c0u, 0x5280u, 0x9241u,
+    0x9601u, 0x56c0u, 0x5780u, 0x9741u, 0x5500u, 0x95c1u, 0x9481u, 0x5440u,
+    0x9c01u, 0x5cc0u, 0x5d80u, 0x9d41u, 0x5f00u, 0x9fc1u, 0x9e81u, 0x5e40u,
+    0x5a00u, 0x9ac1u, 0x9b81u, 0x5b40u, 0x9901u, 0x59c0u, 0x5880u, 0x9841u,
+    0x8801u, 0x48c0u, 0x4980u, 0x8941u, 0x4b00u, 0x8bc1u, 0x8a81u, 0x4a40u,
+    0x4e00u, 0x8ec1u, 0x8f81u, 0x4f40u, 0x8d01u, 0x4dc0u, 0x4c80u, 0x8c41u,
+    0x4400u, 0x84c1u, 0x8581u, 0x4540u, 0x8701u, 0x47c0u, 0x4680u, 0x8641u,
+    0x8201u, 0x42c0u, 0x4380u, 0x8341u, 0x4100u, 0x81c1u, 0x8081u, 0x4040u
+  };
+
+  for (i = 0u; i < len; i++)
+    {
+      v = (v >> 8) ^ g_crc16_tab[(v ^ src[i]) & 0xffu];
+    }
+
+  return v;
+}
+
+/****************************************************************************
+ * Name: crc16h8005
+ *
+ * Description:
+ *   Return a 16-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x8005 polynomial.
+ *
+ ****************************************************************************/
+
+uint16_t crc16h8005(FAR const uint8_t *src, size_t len)
+{
+  return crc16h8005_part(src, len, 0x0000u);
+}

--- a/libs/libc/misc/lib_crc32h04c11db7.c
+++ b/libs/libc/misc/lib_crc32h04c11db7.c
@@ -1,0 +1,211 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc32h04c11db7.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00003] The CRC module shall implement the CRC32 routine
+ * based on the IEEE-802.3 CRC32 Ethernet Standard:
+ *
+ * CRC32 parameters:
+ * CRC result width: 32 bits
+ * Polynomial: 04C11DB7h
+ * Initial value: FFFFFFFFh
+ * Input data reflected: Yes
+ * Result data reflected: Yes
+ * XOR value: FFFFFFFFh
+ *
+ * [AUTOSAR_SWS_Crc_00055] The Crc_CalculateCRC32 function of the CRC module
+ * shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   2144DF1C
+ * F2 01 83                    |   24AB9D77
+ * 0F AA 00 55                 |   B6C9B287
+ * 00 FF 55 11                 |   32A06212
+ * 33 22 55 AA BB CC DD EE FF  |   B0AE863D
+ * 92 6B 55                    |   9CDEA29B
+ * FF FF FF FF                 |   FFFFFFFF
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc32.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC32 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc32_table(uint32_t poly, uint32_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint32_t crc = i;
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 1)
+ *             {
+ *               crc = (crc >> 1) ^ poly;
+ *             }
+ *           else
+ *             {
+ *               crc = crc >> 1;
+ *             }
+ *         }
+ *       table[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint32_t crc32_table[256];
+ *   const uint32_t poly = 0x04c11db7;
+ *
+ *   generate_crc32_table(poly, crc32_table);
+ *
+ *   printf("CRC32 Static Table (Poly 0x%08X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 4 == 0) printf("\n");
+ *       printf("0x%08X, ", crc32_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc32h04c11db7_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x04c11db7 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32h04c11db7_part(FAR const uint8_t *src,
+                             size_t len, uint32_t crc32val)
+{
+  size_t i;
+  static const uint32_t g_crc32_tab[256] =
+  {
+    0x00000000u, 0x77073096u, 0xee0e612cu, 0x990951bau,
+    0x076dc419u, 0x706af48fu, 0xe963a535u, 0x9e6495a3u,
+    0x0edb8832u, 0x79dcb8a4u, 0xe0d5e91eu, 0x97d2d988u,
+    0x09b64c2bu, 0x7eb17cbdu, 0xe7b82d07u, 0x90bf1d91u,
+    0x1db71064u, 0x6ab020f2u, 0xf3b97148u, 0x84be41deu,
+    0x1adad47du, 0x6ddde4ebu, 0xf4d4b551u, 0x83d385c7u,
+    0x136c9856u, 0x646ba8c0u, 0xfd62f97au, 0x8a65c9ecu,
+    0x14015c4fu, 0x63066cd9u, 0xfa0f3d63u, 0x8d080df5u,
+    0x3b6e20c8u, 0x4c69105eu, 0xd56041e4u, 0xa2677172u,
+    0x3c03e4d1u, 0x4b04d447u, 0xd20d85fdu, 0xa50ab56bu,
+    0x35b5a8fau, 0x42b2986cu, 0xdbbbc9d6u, 0xacbcf940u,
+    0x32d86ce3u, 0x45df5c75u, 0xdcd60dcfu, 0xabd13d59u,
+    0x26d930acu, 0x51de003au, 0xc8d75180u, 0xbfd06116u,
+    0x21b4f4b5u, 0x56b3c423u, 0xcfba9599u, 0xb8bda50fu,
+    0x2802b89eu, 0x5f058808u, 0xc60cd9b2u, 0xb10be924u,
+    0x2f6f7c87u, 0x58684c11u, 0xc1611dabu, 0xb6662d3du,
+    0x76dc4190u, 0x01db7106u, 0x98d220bcu, 0xefd5102au,
+    0x71b18589u, 0x06b6b51fu, 0x9fbfe4a5u, 0xe8b8d433u,
+    0x7807c9a2u, 0x0f00f934u, 0x9609a88eu, 0xe10e9818u,
+    0x7f6a0dbbu, 0x086d3d2du, 0x91646c97u, 0xe6635c01u,
+    0x6b6b51f4u, 0x1c6c6162u, 0x856530d8u, 0xf262004eu,
+    0x6c0695edu, 0x1b01a57bu, 0x8208f4c1u, 0xf50fc457u,
+    0x65b0d9c6u, 0x12b7e950u, 0x8bbeb8eau, 0xfcb9887cu,
+    0x62dd1ddfu, 0x15da2d49u, 0x8cd37cf3u, 0xfbd44c65u,
+    0x4db26158u, 0x3ab551ceu, 0xa3bc0074u, 0xd4bb30e2u,
+    0x4adfa541u, 0x3dd895d7u, 0xa4d1c46du, 0xd3d6f4fbu,
+    0x4369e96au, 0x346ed9fcu, 0xad678846u, 0xda60b8d0u,
+    0x44042d73u, 0x33031de5u, 0xaa0a4c5fu, 0xdd0d7cc9u,
+    0x5005713cu, 0x270241aau, 0xbe0b1010u, 0xc90c2086u,
+    0x5768b525u, 0x206f85b3u, 0xb966d409u, 0xce61e49fu,
+    0x5edef90eu, 0x29d9c998u, 0xb0d09822u, 0xc7d7a8b4u,
+    0x59b33d17u, 0x2eb40d81u, 0xb7bd5c3bu, 0xc0ba6cadu,
+    0xedb88320u, 0x9abfb3b6u, 0x03b6e20cu, 0x74b1d29au,
+    0xead54739u, 0x9dd277afu, 0x04db2615u, 0x73dc1683u,
+    0xe3630b12u, 0x94643b84u, 0x0d6d6a3eu, 0x7a6a5aa8u,
+    0xe40ecf0bu, 0x9309ff9du, 0x0a00ae27u, 0x7d079eb1u,
+    0xf00f9344u, 0x8708a3d2u, 0x1e01f268u, 0x6906c2feu,
+    0xf762575du, 0x806567cbu, 0x196c3671u, 0x6e6b06e7u,
+    0xfed41b76u, 0x89d32be0u, 0x10da7a5au, 0x67dd4accu,
+    0xf9b9df6fu, 0x8ebeeff9u, 0x17b7be43u, 0x60b08ed5u,
+    0xd6d6a3e8u, 0xa1d1937eu, 0x38d8c2c4u, 0x4fdff252u,
+    0xd1bb67f1u, 0xa6bc5767u, 0x3fb506ddu, 0x48b2364bu,
+    0xd80d2bdau, 0xaf0a1b4cu, 0x36034af6u, 0x41047a60u,
+    0xdf60efc3u, 0xa867df55u, 0x316e8eefu, 0x4669be79u,
+    0xcb61b38cu, 0xbc66831au, 0x256fd2a0u, 0x5268e236u,
+    0xcc0c7795u, 0xbb0b4703u, 0x220216b9u, 0x5505262fu,
+    0xc5ba3bbeu, 0xb2bd0b28u, 0x2bb45a92u, 0x5cb36a04u,
+    0xc2d7ffa7u, 0xb5d0cf31u, 0x2cd99e8bu, 0x5bdeae1du,
+    0x9b64c2b0u, 0xec63f226u, 0x756aa39cu, 0x026d930au,
+    0x9c0906a9u, 0xeb0e363fu, 0x72076785u, 0x05005713u,
+    0x95bf4a82u, 0xe2b87a14u, 0x7bb12baeu, 0x0cb61b38u,
+    0x92d28e9bu, 0xe5d5be0du, 0x7cdcefb7u, 0x0bdbdf21u,
+    0x86d3d2d4u, 0xf1d4e242u, 0x68ddb3f8u, 0x1fda836eu,
+    0x81be16cdu, 0xf6b9265bu, 0x6fb077e1u, 0x18b74777u,
+    0x88085ae6u, 0xff0f6a70u, 0x66063bcau, 0x11010b5cu,
+    0x8f659effu, 0xf862ae69u, 0x616bffd3u, 0x166ccf45u,
+    0xa00ae278u, 0xd70dd2eeu, 0x4e048354u, 0x3903b3c2u,
+    0xa7672661u, 0xd06016f7u, 0x4969474du, 0x3e6e77dbu,
+    0xaed16a4au, 0xd9d65adcu, 0x40df0b66u, 0x37d83bf0u,
+    0xa9bcae53u, 0xdebb9ec5u, 0x47b2cf7fu, 0x30b5ffe9u,
+    0xbdbdf21cu, 0xcabac28au, 0x53b39330u, 0x24b4a3a6u,
+    0xbad03605u, 0xcdd70693u, 0x54de5729u, 0x23d967bfu,
+    0xb3667a2eu, 0xc4614ab8u, 0x5d681b02u, 0x2a6f2b94u,
+    0xb40bbe37u, 0xc30c8ea1u, 0x5a05df1bu, 0x2d02ef8du
+  };
+
+  crc32val ^= 0xffffffffu;
+  for (i = 0u; i < len; i++)
+    {
+      crc32val = g_crc32_tab[(uint8_t)(crc32val & 0xffu) ^ src[i]] ^
+                 (crc32val >> 8);
+    }
+
+  return crc32val ^ 0xffffffffu;
+}
+
+/****************************************************************************
+ * Name: crc32h04c11db7
+ *
+ * Description:
+ *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x04c11db7 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32h04c11db7(FAR const uint8_t *src, size_t len)
+{
+  return crc32h04c11db7_part(src, len, 0x00000000u);
+}

--- a/libs/libc/misc/lib_crc32hf4acfb13.c
+++ b/libs/libc/misc/lib_crc32hf4acfb13.c
@@ -1,0 +1,211 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc32hf4acfb13.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00056] The CRC module shall implement the CRC32 routine
+ * using the 0xF4’AC’FB’13 polynomial.
+ *
+ * CRC32 parameters:
+ * CRC result width: 32 bits
+ * Polynomial: F4ACFB13h
+ * Initial value: FFFFFFFFh
+ * Input data reflected: Yes
+ * Result data reflected: Yes
+ * XOR value: FFFFFFFFh
+ *
+ * [AUTOSAR_SWS_Crc_00057] The Crc_CalculateCRC32P4 function of the CRC
+ * module shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   6FB32240
+ * F2 01 83                    |   4F721A25
+ * 0F AA 00 55                 |   20662DF8
+ * 00 FF 55 11                 |   9BD7996E
+ * 33 22 55 AA BB CC DD EE FF  |   A65A343D
+ * 92 6B 55                    |   EE688A78
+ * FF FF FF FF                 |   FFFFFFFF
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc32.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC32 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc32_table(uint32_t poly, uint32_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint32_t crc = i;
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 1)
+ *             {
+ *               crc = (crc >> 1) ^ poly;
+ *             }
+ *           else
+ *             {
+ *               crc = crc >> 1;
+ *             }
+ *         }
+ *       table[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint32_t crc32_table[256];
+ *   const uint32_t poly = 0xF4ACFB13;
+ *
+ *   generate_crc32_table(poly, crc32_table);
+ *
+ *   printf("CRC32 Static Table (Poly 0x%08X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 4 == 0) printf("\n");
+ *       printf("0x%08X, ", crc32_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc32hf4acfb13_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0xF4ACFB13 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32hf4acfb13_part(FAR const uint8_t *src,
+                             size_t len, uint32_t crc32val)
+{
+  size_t i;
+  static const uint32_t g_crc32_tab[256] =
+  {
+    0x00000000u, 0x30850ff5u,  0x610a1feau, 0x518f101fu,
+    0xc2143fd4u, 0xf2913021u,  0xa31e203eu, 0x939b2fcbu,
+    0x159615f7u, 0x25131a02u,  0x749c0a1du, 0x441905e8u,
+    0xd7822a23u, 0xe70725d6u,  0xb68835c9u, 0x860d3a3cu,
+    0x2b2c2beeu, 0x1ba9241bu,  0x4a263404u, 0x7aa33bf1u,
+    0xe938143au, 0xd9bd1bcfu,  0x88320bd0u, 0xb8b70425u,
+    0x3eba3e19u, 0x0e3f31ecu,  0x5fb021f3u, 0x6f352e06u,
+    0xfcae01cdu, 0xcc2b0e38u,  0x9da41e27u, 0xad2111d2u,
+    0x565857dcu, 0x66dd5829u,  0x37524836u, 0x07d747c3u,
+    0x944c6808u, 0xa4c967fdu,  0xf54677e2u, 0xc5c37817u,
+    0x43ce422bu, 0x734b4ddeu,  0x22c45dc1u, 0x12415234u,
+    0x81da7dffu, 0xb15f720au,  0xe0d06215u, 0xd0556de0u,
+    0x7d747c32u, 0x4df173c7u,  0x1c7e63d8u, 0x2cfb6c2du,
+    0xbf6043e6u, 0x8fe54c13u,  0xde6a5c0cu, 0xeeef53f9u,
+    0x68e269c5u, 0x58676630u,  0x09e8762fu, 0x396d79dau,
+    0xaaf65611u, 0x9a7359e4u,  0xcbfc49fbu, 0xfb79460eu,
+    0xacb0afb8u, 0x9c35a04du,  0xcdbab052u, 0xfd3fbfa7u,
+    0x6ea4906cu, 0x5e219f99u,  0x0fae8f86u, 0x3f2b8073u,
+    0xb926ba4fu, 0x89a3b5bau,  0xd82ca5a5u, 0xe8a9aa50u,
+    0x7b32859bu, 0x4bb78a6eu,  0x1a389a71u, 0x2abd9584u,
+    0x879c8456u, 0xb7198ba3u,  0xe6969bbcu, 0xd6139449u,
+    0x4588bb82u, 0x750db477u,  0x2482a468u, 0x1407ab9du,
+    0x920a91a1u, 0xa28f9e54u,  0xf3008e4bu, 0xc38581beu,
+    0x501eae75u, 0x609ba180u,  0x3114b19fu, 0x0191be6au,
+    0xfae8f864u, 0xca6df791u,  0x9be2e78eu, 0xab67e87bu,
+    0x38fcc7b0u, 0x0879c845u,  0x59f6d85au, 0x6973d7afu,
+    0xef7eed93u, 0xdffbe266u,  0x8e74f279u, 0xbef1fd8cu,
+    0x2d6ad247u, 0x1defddb2u,  0x4c60cdadu, 0x7ce5c258u,
+    0xd1c4d38au, 0xe141dc7fu,  0xb0cecc60u, 0x804bc395u,
+    0x13d0ec5eu, 0x2355e3abu,  0x72daf3b4u, 0x425ffc41u,
+    0xc452c67du, 0xf4d7c988u,  0xa558d997u, 0x95ddd662u,
+    0x0646f9a9u, 0x36c3f65cu,  0x674ce643u, 0x57c9e9b6u,
+    0xc8df352fu, 0xf85a3adau,  0xa9d52ac5u, 0x99502530u,
+    0x0acb0afbu, 0x3a4e050eu,  0x6bc11511u, 0x5b441ae4u,
+    0xdd4920d8u, 0xedcc2f2du,  0xbc433f32u, 0x8cc630c7u,
+    0x1f5d1f0cu, 0x2fd810f9u,  0x7e5700e6u, 0x4ed20f13u,
+    0xe3f31ec1u, 0xd3761134u,  0x82f9012bu, 0xb27c0edeu,
+    0x21e72115u, 0x11622ee0u,  0x40ed3effu, 0x7068310au,
+    0xf6650b36u, 0xc6e004c3u,  0x976f14dcu, 0xa7ea1b29u,
+    0x347134e2u, 0x04f43b17u,  0x557b2b08u, 0x65fe24fdu,
+    0x9e8762f3u, 0xae026d06u,  0xff8d7d19u, 0xcf0872ecu,
+    0x5c935d27u, 0x6c1652d2u,  0x3d9942cdu, 0x0d1c4d38u,
+    0x8b117704u, 0xbb9478f1u,  0xea1b68eeu, 0xda9e671bu,
+    0x490548d0u, 0x79804725u,  0x280f573au, 0x188a58cfu,
+    0xb5ab491du, 0x852e46e8u,  0xd4a156f7u, 0xe4245902u,
+    0x77bf76c9u, 0x473a793cu,  0x16b56923u, 0x263066d6u,
+    0xa03d5ceau, 0x90b8531fu,  0xc1374300u, 0xf1b24cf5u,
+    0x6229633eu, 0x52ac6ccbu,  0x03237cd4u, 0x33a67321u,
+    0x646f9a97u, 0x54ea9562u,  0x0565857du, 0x35e08a88u,
+    0xa67ba543u, 0x96feaab6u,  0xc771baa9u, 0xf7f4b55cu,
+    0x71f98f60u, 0x417c8095u,  0x10f3908au, 0x20769f7fu,
+    0xb3edb0b4u, 0x8368bf41u,  0xd2e7af5eu, 0xe262a0abu,
+    0x4f43b179u, 0x7fc6be8cu,  0x2e49ae93u, 0x1ecca166u,
+    0x8d578eadu, 0xbdd28158u,  0xec5d9147u, 0xdcd89eb2u,
+    0x5ad5a48eu, 0x6a50ab7bu,  0x3bdfbb64u, 0x0b5ab491u,
+    0x98c19b5au, 0xa84494afu,  0xf9cb84b0u, 0xc94e8b45u,
+    0x3237cd4bu, 0x02b2c2beu,  0x533dd2a1u, 0x63b8dd54u,
+    0xf023f29fu, 0xc0a6fd6au,  0x9129ed75u, 0xa1ace280u,
+    0x27a1d8bcu, 0x1724d749u,  0x46abc756u, 0x762ec8a3u,
+    0xe5b5e768u, 0xd530e89du,  0x84bff882u, 0xb43af777u,
+    0x191be6a5u, 0x299ee950u,  0x7811f94fu, 0x4894f6bau,
+    0xdb0fd971u, 0xeb8ad684u,  0xba05c69bu, 0x8a80c96eu,
+    0x0c8df352u, 0x3c08fca7u,  0x6d87ecb8u, 0x5d02e34du,
+    0xce99cc86u, 0xfe1cc373u,  0xaf93d36cu, 0x9f16dc99u
+  };
+
+  crc32val ^= 0xffffffffu;
+  for (i = 0u; i < len; i++)
+    {
+      crc32val = g_crc32_tab[(uint8_t)(crc32val & 0xffu) ^ src[i]] ^
+                 (crc32val >> 8);
+    }
+
+  return crc32val ^ 0xffffffffu;
+}
+
+/****************************************************************************
+ * Name: crc32hf4acfb13
+ *
+ * Description:
+ *   Return a 32-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0xF4ACFB13 polynomial.
+ *
+ ****************************************************************************/
+
+uint32_t crc32hf4acfb13(FAR const uint8_t *src, size_t len)
+{
+  return crc32hf4acfb13_part(src, len, 0x00000000u);
+}

--- a/libs/libc/misc/lib_crc64emac.c
+++ b/libs/libc/misc/lib_crc64emac.c
@@ -1,0 +1,292 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc64emac.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00062] The CRC module shall implement the CRC64 routine
+ * using the 0x42F0E1EBA9EA3693 polynomial.
+ *
+ * CRC64 parameters:
+ * CRC result width: 64 bits
+ * Polynomial: 42F0E1EBA9EA3693h
+ * Initial value: FFFFFFFFFFFFFFFFh
+ * Input data reflected: Yes
+ * Result data reflected: Yes
+ * XOR value: FFFFFFFFFFFFFFFFh
+ *
+ * [AUTOSAR_SWS_Crc_00063] The Crc_CalculateCRC64 function of the CRC module
+ * shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   F4A586351E1B9F4B
+ * F2 01 83                    |   319C27668164F1C6
+ * 0F AA 00 55                 |   54C5D0F7667C1575
+ * 00 FF 55 11                 |   A63822BE7E0704E6
+ * 33 22 55 AA BB CC DD EE FF  |   701ECEB219A8E5D5
+ * 92 6B 55                    |   5FAA96A9B59F3E4E
+ * FF FF FF FF                 |   FFFFFFFF00000000
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc64.h>
+
+#ifdef CONFIG_HAVE_LONG_LONG
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC64 table generated with:
+ *
+ *   #include <inttypes.h>
+ *   #include <stdint.h>
+ *   #include <stdio.h>
+ *
+ *   #define CRC64_POLY   ((uint64_t)0x42f0e1eba9ea3693)
+ *   #define CRC64_TABLEN ((size_t)256)
+ *
+ *   int main(void)
+ *   {
+ *     uint64_t crc64val;
+ *     size_t i;
+ *     size_t j;
+ *
+ *     printf("static const uint64_t crc64_tab[%zu] =\n", CRC64_TABLEN);
+ *     printf("{\n  ");
+ *
+ *     for (i = 0; i < CRC64_TABLEN; i++)
+ *       {
+ *         crc64val = (uint64_t)i << 56;
+ *         for (j = 0; j < 8; j++)
+ *           {
+ *             if ((crc64val & ((uint64_t)1 << 63)) != 0)
+ *               {
+ *                 crc64val = (crc64val << 1) ^ CRC64_POLY;
+ *               }
+ *             else
+ *               {
+ *                 crc64val = crc64val << 1;
+ *               }
+ *           }
+ *
+ *         printf("0x%016"PRIx64, crc64val);
+ *         if (i + 1 >= CRC64_TABLEN)
+ *           {
+ *             printf("\n");
+ *           }
+ *         else if (i % 2 == 1)
+ *           {
+ *             printf(",\n  ");
+ *           }
+ *         else
+ *           {
+ *             printf(", ");
+ *           }
+ *       }
+ *
+ *     printf("};\n");
+ *     return 0;
+ *   }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc64emac_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x42F0E1EBA9EA3693 polynomial.
+ *
+ ****************************************************************************/
+
+uint64_t crc64emac_part(FAR const uint8_t *src,
+                        size_t len, uint64_t crc64val)
+{
+  size_t i;
+  static const uint64_t g_crc64_tab[256] =
+  {
+    0x0000000000000000ull,   0xb32e4cbe03a75f6full,
+    0xf4843657a840a05bull,   0x47aa7ae9abe7ff34ull,
+    0x7bd0c384ff8f5e33ull,   0xc8fe8f3afc28015cull,
+    0x8f54f5d357cffe68ull,   0x3c7ab96d5468a107ull,
+    0xf7a18709ff1ebc66ull,   0x448fcbb7fcb9e309ull,
+    0x0325b15e575e1c3dull,   0xb00bfde054f94352ull,
+    0x8c71448d0091e255ull,   0x3f5f08330336bd3aull,
+    0x78f572daa8d1420eull,   0xcbdb3e64ab761d61ull,
+    0x7d9ba13851336649ull,   0xceb5ed8652943926ull,
+    0x891f976ff973c612ull,   0x3a31dbd1fad4997dull,
+    0x064b62bcaebc387aull,   0xb5652e02ad1b6715ull,
+    0xf2cf54eb06fc9821ull,   0x41e11855055bc74eull,
+    0x8a3a2631ae2dda2full,   0x39146a8fad8a8540ull,
+    0x7ebe1066066d7a74ull,   0xcd905cd805ca251bull,
+    0xf1eae5b551a2841cull,   0x42c4a90b5205db73ull,
+    0x056ed3e2f9e22447ull,   0xb6409f5cfa457b28ull,
+    0xfb374270a266cc92ull,   0x48190ecea1c193fdull,
+    0x0fb374270a266cc9ull,   0xbc9d3899098133a6ull,
+    0x80e781f45de992a1ull,   0x33c9cd4a5e4ecdceull,
+    0x7463b7a3f5a932faull,   0xc74dfb1df60e6d95ull,
+    0x0c96c5795d7870f4ull,   0xbfb889c75edf2f9bull,
+    0xf812f32ef538d0afull,   0x4b3cbf90f69f8fc0ull,
+    0x774606fda2f72ec7ull,   0xc4684a43a15071a8ull,
+    0x83c230aa0ab78e9cull,   0x30ec7c140910d1f3ull,
+    0x86ace348f355aadbull,   0x3582aff6f0f2f5b4ull,
+    0x7228d51f5b150a80ull,   0xc10699a158b255efull,
+    0xfd7c20cc0cdaf4e8ull,   0x4e526c720f7dab87ull,
+    0x09f8169ba49a54b3ull,   0xbad65a25a73d0bdcull,
+    0x710d64410c4b16bdull,   0xc22328ff0fec49d2ull,
+    0x85895216a40bb6e6ull,   0x36a71ea8a7ace989ull,
+    0x0adda7c5f3c4488eull,   0xb9f3eb7bf06317e1ull,
+    0xfe5991925b84e8d5ull,   0x4d77dd2c5823b7baull,
+    0x64b62bcaebc387a1ull,   0xd7986774e864d8ceull,
+    0x90321d9d438327faull,   0x231c512340247895ull,
+    0x1f66e84e144cd992ull,   0xac48a4f017eb86fdull,
+    0xebe2de19bc0c79c9ull,   0x58cc92a7bfab26a6ull,
+    0x9317acc314dd3bc7ull,   0x2039e07d177a64a8ull,
+    0x67939a94bc9d9b9cull,   0xd4bdd62abf3ac4f3ull,
+    0xe8c76f47eb5265f4ull,   0x5be923f9e8f53a9bull,
+    0x1c4359104312c5afull,   0xaf6d15ae40b59ac0ull,
+    0x192d8af2baf0e1e8ull,   0xaa03c64cb957be87ull,
+    0xeda9bca512b041b3ull,   0x5e87f01b11171edcull,
+    0x62fd4976457fbfdbull,   0xd1d305c846d8e0b4ull,
+    0x96797f21ed3f1f80ull,   0x2557339fee9840efull,
+    0xee8c0dfb45ee5d8eull,   0x5da24145464902e1ull,
+    0x1a083bacedaefdd5ull,   0xa9267712ee09a2baull,
+    0x955cce7fba6103bdull,   0x267282c1b9c65cd2ull,
+    0x61d8f8281221a3e6ull,   0xd2f6b4961186fc89ull,
+    0x9f8169ba49a54b33ull,   0x2caf25044a02145cull,
+    0x6b055fede1e5eb68ull,   0xd82b1353e242b407ull,
+    0xe451aa3eb62a1500ull,   0x577fe680b58d4a6full,
+    0x10d59c691e6ab55bull,   0xa3fbd0d71dcdea34ull,
+    0x6820eeb3b6bbf755ull,   0xdb0ea20db51ca83aull,
+    0x9ca4d8e41efb570eull,   0x2f8a945a1d5c0861ull,
+    0x13f02d374934a966ull,   0xa0de61894a93f609ull,
+    0xe7741b60e174093dull,   0x545a57dee2d35652ull,
+    0xe21ac88218962d7aull,   0x5134843c1b317215ull,
+    0x169efed5b0d68d21ull,   0xa5b0b26bb371d24eull,
+    0x99ca0b06e7197349ull,   0x2ae447b8e4be2c26ull,
+    0x6d4e3d514f59d312ull,   0xde6071ef4cfe8c7dull,
+    0x15bb4f8be788911cull,   0xa6950335e42fce73ull,
+    0xe13f79dc4fc83147ull,   0x521135624c6f6e28ull,
+    0x6e6b8c0f1807cf2full,   0xdd45c0b11ba09040ull,
+    0x9aefba58b0476f74ull,   0x29c1f6e6b3e0301bull,
+    0xc96c5795d7870f42ull,   0x7a421b2bd420502dull,
+    0x3de861c27fc7af19ull,   0x8ec62d7c7c60f076ull,
+    0xb2bc941128085171ull,   0x0192d8af2baf0e1eull,
+    0x4638a2468048f12aull,   0xf516eef883efae45ull,
+    0x3ecdd09c2899b324ull,   0x8de39c222b3eec4bull,
+    0xca49e6cb80d9137full,   0x7967aa75837e4c10ull,
+    0x451d1318d716ed17ull,   0xf6335fa6d4b1b278ull,
+    0xb199254f7f564d4cull,   0x02b769f17cf11223ull,
+    0xb4f7f6ad86b4690bull,   0x07d9ba1385133664ull,
+    0x4073c0fa2ef4c950ull,   0xf35d8c442d53963full,
+    0xcf273529793b3738ull,   0x7c0979977a9c6857ull,
+    0x3ba3037ed17b9763ull,   0x888d4fc0d2dcc80cull,
+    0x435671a479aad56dull,   0xf0783d1a7a0d8a02ull,
+    0xb7d247f3d1ea7536ull,   0x04fc0b4dd24d2a59ull,
+    0x3886b22086258b5eull,   0x8ba8fe9e8582d431ull,
+    0xcc0284772e652b05ull,   0x7f2cc8c92dc2746aull,
+    0x325b15e575e1c3d0ull,   0x8175595b76469cbfull,
+    0xc6df23b2dda1638bull,   0x75f16f0cde063ce4ull,
+    0x498bd6618a6e9de3ull,   0xfaa59adf89c9c28cull,
+    0xbd0fe036222e3db8ull,   0x0e21ac88218962d7ull,
+    0xc5fa92ec8aff7fb6ull,   0x76d4de52895820d9ull,
+    0x317ea4bb22bfdfedull,   0x8250e80521188082ull,
+    0xbe2a516875702185ull,   0x0d041dd676d77eeaull,
+    0x4aae673fdd3081deull,   0xf9802b81de97deb1ull,
+    0x4fc0b4dd24d2a599ull,   0xfceef8632775faf6ull,
+    0xbb44828a8c9205c2ull,   0x086ace348f355aadull,
+    0x34107759db5dfbaaull,   0x873e3be7d8faa4c5ull,
+    0xc094410e731d5bf1ull,   0x73ba0db070ba049eull,
+    0xb86133d4dbcc19ffull,   0x0b4f7f6ad86b4690ull,
+    0x4ce50583738cb9a4ull,   0xffcb493d702be6cbull,
+    0xc3b1f050244347ccull,   0x709fbcee27e418a3ull,
+    0x3735c6078c03e797ull,   0x841b8ab98fa4b8f8ull,
+    0xadda7c5f3c4488e3ull,   0x1ef430e13fe3d78cull,
+    0x595e4a08940428b8ull,   0xea7006b697a377d7ull,
+    0xd60abfdbc3cbd6d0ull,   0x6524f365c06c89bfull,
+    0x228e898c6b8b768bull,   0x91a0c532682c29e4ull,
+    0x5a7bfb56c35a3485ull,   0xe955b7e8c0fd6beaull,
+    0xaeffcd016b1a94deull,   0x1dd181bf68bdcbb1ull,
+    0x21ab38d23cd56ab6ull,   0x9285746c3f7235d9ull,
+    0xd52f0e859495caedull,   0x6601423b97329582ull,
+    0xd041dd676d77eeaaull,   0x636f91d96ed0b1c5ull,
+    0x24c5eb30c5374ef1ull,   0x97eba78ec690119eull,
+    0xab911ee392f8b099ull,   0x18bf525d915feff6ull,
+    0x5f1528b43ab810c2ull,   0xec3b640a391f4fadull,
+    0x27e05a6e926952ccull,   0x94ce16d091ce0da3ull,
+    0xd3646c393a29f297ull,   0x604a2087398eadf8ull,
+    0x5c3099ea6de60cffull,   0xef1ed5546e415390ull,
+    0xa8b4afbdc5a6aca4ull,   0x1b9ae303c601f3cbull,
+    0x56ed3e2f9e224471ull,   0xe5c372919d851b1eull,
+    0xa26908783662e42aull,   0x114744c635c5bb45ull,
+    0x2d3dfdab61ad1a42ull,   0x9e13b115620a452dull,
+    0xd9b9cbfcc9edba19ull,   0x6a978742ca4ae576ull,
+    0xa14cb926613cf817ull,   0x1262f598629ba778ull,
+    0x55c88f71c97c584cull,   0xe6e6c3cfcadb0723ull,
+    0xda9c7aa29eb3a624ull,   0x69b2361c9d14f94bull,
+    0x2e184cf536f3067full,   0x9d36004b35545910ull,
+    0x2b769f17cf112238ull,   0x9858d3a9ccb67d57ull,
+    0xdff2a94067518263ull,   0x6cdce5fe64f6dd0cull,
+    0x50a65c93309e7c0bull,   0xe388102d33392364ull,
+    0xa4226ac498dedc50ull,   0x170c267a9b79833full,
+    0xdcd7181e300f9e5eull,   0x6ff954a033a8c131ull,
+    0x28532e49984f3e05ull,   0x9b7d62f79be8616aull,
+    0xa707db9acf80c06dull,   0x14299724cc279f02ull,
+    0x5383edcd67c06036ull,   0xe0ada17364673f59ull
+  };
+
+  crc64val ^= 0xffffffffffffffffull;
+  for (i = 0u; i < len; i++)
+    {
+      crc64val = g_crc64_tab[(uint8_t)(crc64val & 0xffull) ^ src[i]] ^
+                 (crc64val >> 8);
+    }
+
+  return crc64val ^ 0xffffffffffffffffull;
+}
+
+/****************************************************************************
+ * Name: crc64emac
+ *
+ * Description:
+ *   Return a 64-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x42F0E1EBA9EA3693 polynomial.
+ *
+ ****************************************************************************/
+
+uint64_t crc64emac(FAR const uint8_t *src, size_t len)
+{
+  return crc64emac_part(src, len, 0x0000000000000000ull);
+}
+
+#endif /* CONFIG_HAVE_LONG_LONG */

--- a/libs/libc/misc/lib_crc8h1d.c
+++ b/libs/libc/misc/lib_crc8h1d.c
@@ -1,0 +1,170 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc8h1d.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00030] The Crc_CalculateCRC8 function of the CRC module
+ * shall implement the CRC8 routine based on the SAE-J1850 CRC8 Standard.
+ *
+ * CRC8 parameters:
+ * CRC result width: 8 bits
+ * Polynomial: 1Dh
+ * Initial value: FFh
+ * Input data reflected: No
+ * Result data reflected: No
+ * XOR value: FFh
+ *
+ * [AUTOSAR_SWS_Crc_00052] The Crc_CalculateCRC8 function of the CRC module
+ * shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   59
+ * F2 01 83                    |   37
+ * 0F AA 00 55                 |   79
+ * 00 FF 55 11                 |   B8
+ * 33 22 55 AA BB CC DD EE FF  |   CB
+ * 92 6B 55                    |   8C
+ * FF FF FF FF                 |   74
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc8.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC8 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc8_table(uint8_t poly, uint8_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint8_t crc = i;
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 0x80)
+ *             {
+ *               crc = (crc << 1) ^ poly;
+ *             }
+ *           else
+ *             {
+ *               crc = crc << 1;
+ *             }
+ *         }
+ *       table[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint8_t crc8_table[256];
+ *   const uint8_t poly = 0x2F;
+ *
+ *   generate_crc8_table(poly, crc8_table);
+ *
+ *   printf("CRC8 Static Table (Poly 0x%02X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 16 == 0) printf("\n");
+ *       printf("0x%02X, ", crc8_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc8h1d_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x1D polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h1d_part(FAR const uint8_t *src, size_t len, uint8_t crc8val)
+{
+  static const uint8_t g_crc8_tab[256] =
+  {
+    0x00u, 0x1du, 0x3au, 0x27u, 0x74u, 0x69u, 0x4eu, 0x53u,
+    0xe8u, 0xf5u, 0xd2u, 0xcfu, 0x9cu, 0x81u, 0xa6u, 0xbbu,
+    0xcdu, 0xd0u, 0xf7u, 0xeau, 0xb9u, 0xa4u, 0x83u, 0x9eu,
+    0x25u, 0x38u, 0x1fu, 0x02u, 0x51u, 0x4cu, 0x6bu, 0x76u,
+    0x87u, 0x9au, 0xbdu, 0xa0u, 0xf3u, 0xeeu, 0xc9u, 0xd4u,
+    0x6fu, 0x72u, 0x55u, 0x48u, 0x1bu, 0x06u, 0x21u, 0x3cu,
+    0x4au, 0x57u, 0x70u, 0x6du, 0x3eu, 0x23u, 0x04u, 0x19u,
+    0xa2u, 0xbfu, 0x98u, 0x85u, 0xd6u, 0xcbu, 0xecu, 0xf1u,
+    0x13u, 0x0eu, 0x29u, 0x34u, 0x67u, 0x7au, 0x5du, 0x40u,
+    0xfbu, 0xe6u, 0xc1u, 0xdcu, 0x8fu, 0x92u, 0xb5u, 0xa8u,
+    0xdeu, 0xc3u, 0xe4u, 0xf9u, 0xaau, 0xb7u, 0x90u, 0x8du,
+    0x36u, 0x2bu, 0x0cu, 0x11u, 0x42u, 0x5fu, 0x78u, 0x65u,
+    0x94u, 0x89u, 0xaeu, 0xb3u, 0xe0u, 0xfdu, 0xdau, 0xc7u,
+    0x7cu, 0x61u, 0x46u, 0x5bu, 0x08u, 0x15u, 0x32u, 0x2fu,
+    0x59u, 0x44u, 0x63u, 0x7eu, 0x2du, 0x30u, 0x17u, 0x0au,
+    0xb1u, 0xacu, 0x8bu, 0x96u, 0xc5u, 0xd8u, 0xffu, 0xe2u,
+    0x26u, 0x3bu, 0x1cu, 0x01u, 0x52u, 0x4fu, 0x68u, 0x75u,
+    0xceu, 0xd3u, 0xf4u, 0xe9u, 0xbau, 0xa7u, 0x80u, 0x9du,
+    0xebu, 0xf6u, 0xd1u, 0xccu, 0x9fu, 0x82u, 0xa5u, 0xb8u,
+    0x03u, 0x1eu, 0x39u, 0x24u, 0x77u, 0x6au, 0x4du, 0x50u,
+    0xa1u, 0xbcu, 0x9bu, 0x86u, 0xd5u, 0xc8u, 0xefu, 0xf2u,
+    0x49u, 0x54u, 0x73u, 0x6eu, 0x3du, 0x20u, 0x07u, 0x1au,
+    0x6cu, 0x71u, 0x56u, 0x4bu, 0x18u, 0x05u, 0x22u, 0x3fu,
+    0x84u, 0x99u, 0xbeu, 0xa3u, 0xf0u, 0xedu, 0xcau, 0xd7u,
+    0x35u, 0x28u, 0x0fu, 0x12u, 0x41u, 0x5cu, 0x7bu, 0x66u,
+    0xddu, 0xc0u, 0xe7u, 0xfau, 0xa9u, 0xb4u, 0x93u, 0x8eu,
+    0xf8u, 0xe5u, 0xc2u, 0xdfu, 0x8cu, 0x91u, 0xb6u, 0xabu,
+    0x10u, 0x0du, 0x2au, 0x37u, 0x64u, 0x79u, 0x5eu, 0x43u,
+    0xb2u, 0xafu, 0x88u, 0x95u, 0xc6u, 0xdbu, 0xfcu, 0xe1u,
+    0x5au, 0x47u, 0x60u, 0x7du, 0x2eu, 0x33u, 0x14u, 0x09u,
+    0x7fu, 0x62u, 0x45u, 0x58u, 0x0bu, 0x16u, 0x31u, 0x2cu,
+    0x97u, 0x8au, 0xadu, 0xb0u, 0xe3u, 0xfeu, 0xd9u, 0xc4u
+  };
+
+  return crc8table(g_crc8_tab, src, len, crc8val);
+}
+
+/****************************************************************************
+ * Name: crc8h1d
+ *
+ * Description:
+ *   Return a 8-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x1D polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h1d(FAR const uint8_t *src, size_t len)
+{
+  return crc8h1d_part(src, len, 0x00u);
+}

--- a/libs/libc/misc/lib_crc8h2f.c
+++ b/libs/libc/misc/lib_crc8h2f.c
@@ -1,0 +1,171 @@
+/****************************************************************************
+ * libs/libc/misc/lib_crc8h2f.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* [AUTOSAR_SWS_Crc_00042] The Crc_CalculateCRC8H2F function of the CRC
+ * module shall implement the CRC8 routine based on the generator
+ * polynomial 0x2F.
+ *
+ * CRC8 parameters:
+ * CRC result width: 8 bits
+ * Polynomial: 2Fh
+ * Initial value: FFh
+ * Input data reflected: No
+ * Result data reflected: No
+ * XOR value: FFh
+ *
+ * [AUTOSAR_SWS_Crc_00053] The Crc_CalculateCRC8H2F function of the CRC
+ * module shall provide the following CRC results:
+ *
+ * Data bytes (hexadecimal)    |   CRC
+ * 00 00 00 00                 |   12
+ * F2 01 83                    |   C2
+ * 0F AA 00 55                 |   C6
+ * 00 FF 55 11                 |   77
+ * 33 22 55 AA BB CC DD EE FF  |   11
+ * 92 6B 55                    |   33
+ * FF FF FF FF                 |   6C
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/crc8.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * CRC8 table generated with:
+ *
+ * #include <stdint.h>
+ *
+ * void generate_crc8_table(uint8_t poly, uint8_t *table)
+ * {
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       uint8_t crc = i;
+ *       for (uint8_t bit = 0; bit < 8; bit++)
+ *         {
+ *           if (crc & 0x80)
+ *             {
+ *               crc = (crc << 1) ^ poly;
+ *             }
+ *           else
+ *             {
+ *               crc = crc << 1;
+ *             }
+ *         }
+ *       table[i] = crc;
+ *     }
+ * }
+ *
+ * int main()
+ * {
+ *   uint8_t crc8_table[256];
+ *   const uint8_t poly = 0x2F;
+ *
+ *   generate_crc8_table(poly, crc8_table);
+ *
+ *   printf("CRC8 Static Table (Poly 0x%02X):\n", poly);
+ *   for (int i = 0; i < 256; i++)
+ *     {
+ *       if (i % 16 == 0) printf("\n");
+ *       printf("0x%02X, ", crc8_table[i]);
+ *     }
+ *
+ *   return 0;
+ * }
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: crc8h2f_part
+ *
+ * Description:
+ *   Continue CRC calculation on a part of the buffer
+ *   using the 0x2F polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h2f_part(FAR const uint8_t *src, size_t len, uint8_t crc8val)
+{
+  static const uint8_t g_crc8_tab[256] =
+  {
+    0x00u, 0x2fu, 0x5eu, 0x71u, 0xbcu, 0x93u, 0xe2u, 0xcdu,
+    0x57u, 0x78u, 0x09u, 0x26u, 0xebu, 0xc4u, 0xb5u, 0x9au,
+    0xaeu, 0x81u, 0xf0u, 0xdfu, 0x12u, 0x3du, 0x4cu, 0x63u,
+    0xf9u, 0xd6u, 0xa7u, 0x88u, 0x45u, 0x6au, 0x1bu, 0x34u,
+    0x73u, 0x5cu, 0x2du, 0x02u, 0xcfu, 0xe0u, 0x91u, 0xbeu,
+    0x24u, 0x0bu, 0x7au, 0x55u, 0x98u, 0xb7u, 0xc6u, 0xe9u,
+    0xddu, 0xf2u, 0x83u, 0xacu, 0x61u, 0x4eu, 0x3fu, 0x10u,
+    0x8au, 0xa5u, 0xd4u, 0xfbu, 0x36u, 0x19u, 0x68u, 0x47u,
+    0xe6u, 0xc9u, 0xb8u, 0x97u, 0x5au, 0x75u, 0x04u, 0x2bu,
+    0xb1u, 0x9eu, 0xefu, 0xc0u, 0x0du, 0x22u, 0x53u, 0x7cu,
+    0x48u, 0x67u, 0x16u, 0x39u, 0xf4u, 0xdbu, 0xaau, 0x85u,
+    0x1fu, 0x30u, 0x41u, 0x6eu, 0xa3u, 0x8cu, 0xfdu, 0xd2u,
+    0x95u, 0xbau, 0xcbu, 0xe4u, 0x29u, 0x06u, 0x77u, 0x58u,
+    0xc2u, 0xedu, 0x9cu, 0xb3u, 0x7eu, 0x51u, 0x20u, 0x0fu,
+    0x3bu, 0x14u, 0x65u, 0x4au, 0x87u, 0xa8u, 0xd9u, 0xf6u,
+    0x6cu, 0x43u, 0x32u, 0x1du, 0xd0u, 0xffu, 0x8eu, 0xa1u,
+    0xe3u, 0xccu, 0xbdu, 0x92u, 0x5fu, 0x70u, 0x01u, 0x2eu,
+    0xb4u, 0x9bu, 0xeau, 0xc5u, 0x08u, 0x27u, 0x56u, 0x79u,
+    0x4du, 0x62u, 0x13u, 0x3cu, 0xf1u, 0xdeu, 0xafu, 0x80u,
+    0x1au, 0x35u, 0x44u, 0x6bu, 0xa6u, 0x89u, 0xf8u, 0xd7u,
+    0x90u, 0xbfu, 0xceu, 0xe1u, 0x2cu, 0x03u, 0x72u, 0x5du,
+    0xc7u, 0xe8u, 0x99u, 0xb6u, 0x7bu, 0x54u, 0x25u, 0x0au,
+    0x3eu, 0x11u, 0x60u, 0x4fu, 0x82u, 0xadu, 0xdcu, 0xf3u,
+    0x69u, 0x46u, 0x37u, 0x18u, 0xd5u, 0xfau, 0x8bu, 0xa4u,
+    0x05u, 0x2au, 0x5bu, 0x74u, 0xb9u, 0x96u, 0xe7u, 0xc8u,
+    0x52u, 0x7du, 0x0cu, 0x23u, 0xeeu, 0xc1u, 0xb0u, 0x9fu,
+    0xabu, 0x84u, 0xf5u, 0xdau, 0x17u, 0x38u, 0x49u, 0x66u,
+    0xfcu, 0xd3u, 0xa2u, 0x8du, 0x40u, 0x6fu, 0x1eu, 0x31u,
+    0x76u, 0x59u, 0x28u, 0x07u, 0xcau, 0xe5u, 0x94u, 0xbbu,
+    0x21u, 0x0eu, 0x7fu, 0x50u, 0x9du, 0xb2u, 0xc3u, 0xecu,
+    0xd8u, 0xf7u, 0x86u, 0xa9u, 0x64u, 0x4bu, 0x3au, 0x15u,
+    0x8fu, 0xa0u, 0xd1u, 0xfeu, 0x33u, 0x1cu, 0x6du, 0x42u
+  };
+
+  return crc8table(g_crc8_tab, src, len, crc8val);
+}
+
+/****************************************************************************
+ * Name: crc8h2f
+ *
+ * Description:
+ *   Return a 8-bit CRC of the contents of the 'src' buffer, length 'len'
+ *   using the 0x2F polynomial.
+ *
+ ****************************************************************************/
+
+uint8_t crc8h2f(FAR const uint8_t *src, size_t len)
+{
+  return crc8h2f_part(src, len, 0x00u);
+}


### PR DESCRIPTION
This patch adds an AUTOSAR-style CRC library used by E2E functionality.
It introduces multiple CRC variants (CRC8, CRC16, CRC32, CRC64) and the
corresponding public headers and implementation files.

Key changes:
- Public headers: `include/nuttx/crc8.h`, `include/nuttx/crc16.h`,
  `include/nuttx/crc32.h`, `include/nuttx/crc64.h` with new APIs for
  specific polynomial variants and incremental (part) helpers.
- Implementations added under `libs/libc/misc/` for several polynomials:
  - `lib_crc16h1021.c` (CRC-16 CCITT-FALSE)
  - `lib_crc16h8005.c`
  - `lib_crc32h04c11db7.c`
  - `lib_crc32hf4acfb13.c`
  - `lib_crc64emac.c`
  - `lib_crc8h1d.c`
  - `lib_crc8h2f.c`
- Build files updated to include the new sources.

This addition provides low-level CRC primitives required by higher-level
protocols and test suites.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
This PR adds a set of CRC helper functions compatible with AUTOSAR
specifications. The new library covers common CRC polynomials and provides
both full-buffer and incremental ('part') APIs to compute CRCs.

## What I changed
- Added headers: `include/nuttx/crc8.h`, `include/nuttx/crc16.h`,
  `include/nuttx/crc32.h`, `include/nuttx/crc64.h`.
- Added implementations under `libs/libc/misc/` for various polynomials.
- Updated `libs/libc/misc/CMakeLists.txt` and `Make.defs` to include the
  new sources.

## Impact
- Provides essential CRC utilities for E2E and other subsystems.
- Low risk: isolated library additions with clear APIs.

## Testing
- Run unit tests or reference vectors included in AUTOSAR to validate
  CRC outputs for each polynomial variant.
- Build the libc and verify no link issues.

