### PR TITLE
CI[BB]:FIX MSVC CI break with xPack toolchain in Widows.ps1

### DIFF
--- a/tools/ci/platforms/windows.ps1
+++ b/tools/ci/platforms/windows.ps1
@@ -121,12 +121,12 @@ function arm_gcc_toolchain() {
       if (-not (Test-Path -Path "$NUTTXTOOLS\gcc-arm-none-eabi\bin\arm-none-eabi-gcc.exe")) {
         # Download the file
         Write-Host "Download: ARM GCC toolchain" -ForegroundColor Green
-        $basefile = "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi"
+        $basefile = "xpack-arm-none-eabi-gcc-13.2.1-1.1-win32-x64"
         Set-Location "$NUTTXTOOLS"
-        # Download the latest ARM GCC toolchain prebuilt by ARM
-        Invoke-WebRequest -Uri "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+        # Download ARM GCC toolchain from xPack
+        Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v13.2.1-1.1/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
         Expand-Archive "$NUTTXTOOLS\$basefile.zip"
-        Move-Item -Path "$basefile\$basefile" -Destination "gcc-arm-none-eabi"
+        Move-Item -Path "$basefile\xpack-arm-none-eabi-gcc-13.2.1-1.1" -Destination "gcc-arm-none-eabi"
         Remove-Item "$basefile*" -Force
       }
     }
@@ -146,12 +146,12 @@ function arm64_gcc_toolchain() {
       if (-not (Test-Path -Path "$NUTTXTOOLS\gcc-aarch64-none-elf\bin\aarch64-none-elf-gcc.exe")) {
         # Download the file
         Write-Host "Download: ARM64 GCC toolchain" -ForegroundColor Green
-        $basefile = "arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf"
+        $basefile = "xpack-aarch64-none-elf-gcc-13.2.1-1.1-win32-x64"
         Set-Location "$NUTTXTOOLS"
-        # Download the latest ARM64 GCC toolchain prebuilt by ARM
-        Invoke-WebRequest -Uri "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+        # Download ARM64 GCC toolchain from xPack
+        Invoke-WebRequest -Uri "https://github.com/xpack-dev-tools/aarch64-none-elf-gcc-xpack/releases/download/v13.2.1-1.1/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
         Expand-Archive "$NUTTXTOOLS\$basefile.zip"
-        Move-Item -Path "$basefile\$basefile" -Destination "gcc-aarch64-none-elf"
+        Move-Item -Path "$basefile\xpack-aarch64-none-elf-gcc-13.2.1-1.1" -Destination "gcc-aarch64-none-elf"
         Remove-Item "$basefile*" -Force
       }
     }


### PR DESCRIPTION
## Summary

This PR updates the ARM GCC toolchain download sources in the Windows CI build script to use xPack GitHub releases instead of ARM's developer website. This resolves persistent download failures caused by CDN access restrictions on `developer.arm.com`.

### Changes Made

- **arm_gcc_toolchain()**: Updated to download from xPack repository
  - Previous: `arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi` from developer.arm.com
  - Current: `xpack-arm-none-eabi-gcc-13.2.1-1.1-win32-x64` from GitHub xPack releases
  - URL: `https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v13.2.1-1.1/`

- **arm64_gcc_toolchain()**: Updated to download from xPack repository
  - Previous: `arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-elf` from developer.arm.com
  - Current: `xpack-aarch64-none-elf-gcc-13.2.1-1.1-win32-x64` from GitHub xPack releases
  - URL: `https://github.com/xpack-dev-tools/aarch64-none-elf-gcc-xpack/releases/download/v13.2.1-1.1/`

### Root Cause

The ARM developer website (`developer.arm.com`) enforces Akamai CDN-based access restrictions that block automated downloads from GitHub Actions runners. This resulted in "Access Denied" errors (Reference #18.2a0c3417...) when CI jobs attempted to download the ARM GCC toolchain.

### Why xPack

- **Reliable**: xPack maintains official releases on GitHub with no CDN restrictions
- **Compatible**: xPack provides the same toolchain binaries as ARM's official distribution
- **Maintainable**: GitHub-hosted releases are easier to reference and version-control
- **Community-supported**: Well-maintained by the xPack development team

## Impact

- **CI/CD**: Fixes failing Windows native (MSVC) CI builds on `windows-2022` runner
- **Build Process**: No impact on the final build output; only changes where toolchain binaries are sourced from
- **Compatibility**: No breaking changes; xPack toolchain is drop-in compatible with ARM's official distribution
- **Documentation**: No documentation changes needed; internal CI script update only
- **Users**: End users unaffected; this only impacts CI infrastructure

## Testing

### Test Environment
- **Host**: GitHub Actions Windows Runner (`windows-2022`)
- **Test Date**: 2026-01-21
- **Toolchain Versions**: 
  - ARM GCC: 13.2.1-1.1 (xPack)
  - ARM64 GCC: 13.2.1-1.1 (xPack)

### Test Procedure

1. **Local Validation** (Manual):
   - Downloaded both xPack toolchain files locally
   - Verified file integrity and extraction
   - Confirmed `arm-none-eabi-gcc` and `aarch64-none-elf-gcc` binaries execute correctly

2. **CI Integration** (Automated):
   - Ran full Windows MSVC CI build pipeline with updated script
   - Verified successful toolchain download and extraction
   - Confirmed all downstream build steps complete without errors

### Expected Results
- ✅ ARM GCC toolchain downloads successfully from xPack GitHub release
- ✅ ARM64 GCC toolchain downloads successfully from xPack GitHub release
- ✅ Both toolchains extract to correct directories
- ✅ Version checks pass: `arm-none-eabi-gcc --version` and `aarch64-none-elf-gcc --version`
- ✅ Windows MSVC CI build completes successfully without "Access Denied" errors

### Verification Steps for Reviewers

To verify this fix:
```powershell
# Run the Windows CI script
cd tools\ci
.\cibuild.ps1 -n -i testlist\windows.dat