### PR TITLE
drivers/sensors  optimizes the sensor rpmsg driver proxy waiting mechanism to improve reliability. part 2

### DIFF
--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -51,7 +51,7 @@
 #define SENSOR_RPMSG_PUBLISH       6
 #define SENSOR_RPMSG_IOCTL         7
 #define SENSOR_RPMSG_IOCTL_ACK     8
-#define SENSOR_RPMSG_IOCTL_TIMEOUT 5
+#define SENSOR_RPMSG_IOCTL_TIMEOUT 1
 
 #define SENSOR_RPMSG_FUNCTION(name, cmd, arg1, arg2, size, wait, type) \
 static int sensor_rpmsg_##name(FAR struct sensor_lowerhalf_s *lower, \


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This patch series optimizes the sensor rpmsg driver proxy waiting mechanism to improve reliability and performance in multi-core sensor communication scenarios.

Changes include:
Added proxy creation synchronization mechanism: Introduced a semaphore (proxysem) to synchronize and wait for remote proxy creation, solving the race condition where ioctl commands were sent before the remote core proxy was ready.

Optimized wait logic: Modified the wait logic to only block on ioctl commands that require synchronous responses (when wait parameter is true). Asynchronous ioctl calls no longer wait for proxy creation, improving performance.

Adjusted timeout value: Changed the proxy wait timeout from potentially infinite to 1 second (SENSOR_RPMSG_IOCTL_TIMEOUT), preventing indefinite blocking while still providing sufficient time for remote resource initialization.

## Impact
Users:
Improved reliability: Eliminates race conditions in sensor ioctl operations across cores
Better error handling: Provides clear timeout errors instead of silent  ailures
Performance optimization: Asynchronous operations are no longer blocked by proxy creation

Build Process:
No impact on build process
No new dependencies introduced
Compatibility:
Backward compatible with existing sensor drivers
Changes are internal to sensor_rpmsg driver implementation
API remains unchanged
Performance:
Reduced unnecessary blocking for asynchronous operations
1-second timeout prevents indefinite waits
Minimal overhead from semaphore operations

## Testing

25,50, 100 Switching will trigger ioctl.
~~~

uorb_listener -n 10 -r 25 sensor_accel

Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:765227619700):timestamp:1280331305527,x:-0.246707,y:-0.061278,z:9.906841,temperature:30.085938
sensor_accel(now:765227620100):timestamp:1280331345807,x:-0.239524,y:-0.056489,z:9.890082,temperature:30.085938
sensor_accel(now:765227621500):timestamp:1280331386087,x:-0.225159,y:-0.068460,z:9.825438,temperature:30.085938
sensor_accel(now:765227622900):timestamp:1280331426367,x:-0.277832,y:-0.020576,z:9.856564,temperature:30.085938
sensor_accel(now:765227624300):timestamp:1280331466647,x:-0.220371,y:-0.111556,z:9.851775,temperature:30.085938
sensor_accel(now:765227658100):timestamp:1280331505447,x:-0.208400,y:-0.030153,z:9.789525,temperature:30.085938
[01/21 08:58:34] [ 0] [audio] CPU USAGE: busy=1 cpu_sleep=0 bus_sleep=0 subsys_sleep=99(pd)
sensor_accel(now:765227698200):timestamp:1280331545747,x:-0.280226,y:-0.157046,z:9.842198,temperature:30.085938
sensor_accel(now:765227739000):timestamp:1280331586047,x:-0.244313,y:-0.056489,z:9.885294,temperature:30.085938
sensor_accel(now:765227778900):timestamp:1280331626247,x:-0.215582,y:-0.080431,z:9.830227,temperature:30.085938
sensor_accel(now:765227819200):timestamp:1280331666547,x:-0.215582,y:-0.034942,z:9.863746,temperature:30.085938
Object name:sensor_accel0, recieved:10
Total number of received Message:10/10
ap>

Total number of received Message:10/10


ap> uorb_listener -n 10 -r 50 sensor_accel

Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:765246572300):timestamp:1280350267887,x:-0.239524,y:-0.049307,z:9.868534,temperature:30.085938
sensor_accel(now:765246572600):timestamp:1280350308127,x:-0.213188,y:-0.070855,z:9.849380,temperature:30.085938
sensor_accel(now:765246574000):timestamp:1280350348367,x:-0.292197,y:-0.097191,z:9.875717,temperature:30.085938
sensor_accel(now:765246575400):timestamp:1280350388607,x:-0.184458,y:-0.109162,z:9.854169,temperature:30.085938
sensor_accel(now:765246576800):timestamp:1280350428847,x:-0.285014,y:-0.111556,z:9.717699,temperature:30.085938
[01/21 08:58:53] [ 0] [audio] CPU USAGE: busy=1 cpu_sleep=0 bus_sleep=0 subsys_sleep=99(pd)
sensor_accel(now:765246612400):timestamp:1280350469147,x:-0.256284,y:-0.109162,z:9.885294,temperature:30.085938
sensor_accel(now:765246628800):timestamp:1280350487747,x:-0.275437,y:-0.094797,z:9.921206,temperature:30.085938
sensor_accel(now:765246652400):timestamp:1280350509347,x:-0.165304,y:-0.058884,z:9.914024,temperature:30.085938
sensor_accel(now:765246669000):timestamp:1280350527847,x:-0.308956,y:-0.101980,z:9.835015,temperature:30.060547
sensor_accel(now:765246692700):timestamp:1280350549547,x:-0.296985,y:-0.125922,z:9.837410,temperature:30.060547
Object name:sensor_accel0, recieved:10
Total number of received Message:10/10
ap>

ap> 
uorb_listener -n 10 -r 100 sensor_accel

Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:765274683900):timestamp:1280378364287,x:-0.318533,y:-0.058884,z:9.894871,temperature:30.095703
sensor_accel(now:765274684300):timestamp:1280378404527,x:-0.320927,y:-0.085220,z:9.789525,temperature:30.095703
sensor_accel(now:765274685700):timestamp:1280378444767,x:-0.292197,y:-0.090008,z:9.878111,temperature:30.095703
sensor_accel(now:765274687100):timestamp:1280378485007,x:-0.189246,y:-0.080431,z:9.523769,temperature:30.095703
sensor_accel(now:765274688500):timestamp:1280378525247,x:-0.241919,y:-0.063672,z:9.993032,temperature:30.095703
sensor_accel(now:765274689900):timestamp:1280378538097,x:-0.261072,y:-0.075643,z:9.772766,temperature:30.095703
sensor_accel(now:765274691300):timestamp:1280378545347,x:-0.325716,y:-0.111556,z:9.858957,temperature:30.095703
sensor_accel(now:765274700200):timestamp:1280378554647,x:-0.311350,y:-0.128316,z:9.981062,temperature:30.095703
sensor_accel(now:765274700400):timestamp:1280378563947,x:-0.249101,y:-0.097191,z:9.799102,temperature:30.095703
[01/21 08:59:22] [ 0] [audio] CPU USAGE: busy=1 cpu_sleep=0 bus_sleep=0 subsys_sleep=99(pd)
sensor_accel(now:765274723900):timestamp:1280378574747,x:-0.227553,y:-0.101980,z:9.765583,temperature:30.095703
Object name:sensor_accel0, recieved:10
Total number of received Message:10/10
ap>

~~~