### PR TITLE
libc/spawn: support get/set priority

### DIFF
--- a/Documentation/reference/user/01_task_control.rst
+++ b/Documentation/reference/user/01_task_control.rst
@@ -78,10 +78,12 @@ Standard ``posix_spawn`` interfaces:
   - :c:func:`posix_spawnattr_getflags`
   - :c:func:`posix_spawnattr_getschedparam`
   - :c:func:`posix_spawnattr_getschedpolicy`
+  - :c:func:`posix_spawnattr_getpriority`
   - :c:func:`posix_spawnattr_getsigmask`
   - :c:func:`posix_spawnattr_setflags`
   - :c:func:`posix_spawnattr_setschedparam`
   - :c:func:`posix_spawnattr_setschedpolicy`
+  - :c:func:`posix_spawnattr_setpriority`
   - :c:func:`posix_spawnattr_setsigmask`
 
 Non-standard task control interfaces inspired by ``posix_spawn``:
@@ -735,6 +737,17 @@ Functions
   :return: On success, this function returns 0; on failure it
     will return an error number from ``<errno.h>``
 
+.. c:function:: uint8_t posix_spawnattr_getpriority(FAR posix_spawnattr_t *attr)
+
+  The ``posix_spawnattr_getpriority()`` function will obtain
+  the value of the *spawn-priority* attribute from the attributes object
+  referenced by ``attr``.
+
+  This is a non-standard helper API.
+
+  :param attr: The address spawn attributes to be queried.
+  :return: The priority value stored in the attributes object.
+
 .. c:function:: int posix_spawnattr_getsigmask(FAR const posix_spawnattr_t *attr, FAR sigset_t *sigmask)
 
   ``posix_spawnattr_getsigdefault()`` function will
@@ -776,6 +789,19 @@ Functions
 
   :param attr: The address spawn attributes to be used.
   :param policy: The new value of the *spawn-schedpolicy* attribute.
+  :return: On success, this function returns 0; on failure it
+    will return an error number from ``<errno.h>``
+
+.. c:function:: int posix_spawnattr_setpriority(FAR posix_spawnattr_t *attr, uint8_t priority)
+
+  The ``posix_spawnattr_setpriority()`` function will set
+  the *spawn-priority* attribute in an initialized attributes object
+  referenced by ``attr``.
+
+  This is a non-standard helper API.
+
+  :param attr: The address spawn attributes to be used.
+  :param priority: The new priority value to set.
   :return: On success, this function returns 0; on failure it
     will return an error number from ``<errno.h>``
 

--- a/include/spawn.h
+++ b/include/spawn.h
@@ -208,7 +208,9 @@ int posix_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr,
                                  FAR size_t *stacksize);
 int posix_spawnattr_setstacksize(FAR posix_spawnattr_t *attr,
                                  size_t stacksize);
-
+int posix_spawnattr_setpriority(FAR posix_spawnattr_t *attr,
+                                uint8_t priority);
+uint8_t posix_spawnattr_getpriority(FAR posix_spawnattr_t *attr);
 #ifndef CONFIG_BUILD_KERNEL
 int posix_spawnattr_getstackaddr(FAR const posix_spawnattr_t *attr,
                                  FAR void **stackaddr);

--- a/libs/libc/spawn/CMakeLists.txt
+++ b/libs/libc/spawn/CMakeLists.txt
@@ -38,6 +38,8 @@ set(SRCS
     lib_psa_setsigmask.c
     lib_psa_getstacksize.c
     lib_psa_setstacksize.c
+    lib_psa_getpriority.c
+    lib_psa_setpriority.c
     lib_psa_destroy.c)
 
 if(NOT CONFIG_BUILD_KERNEL)

--- a/libs/libc/spawn/Make.defs
+++ b/libs/libc/spawn/Make.defs
@@ -29,6 +29,7 @@ CSRCS += lib_psa_getflags.c lib_psa_getschedparam.c lib_psa_getschedpolicy.c
 CSRCS += lib_psa_init.c lib_psa_setflags.c lib_psa_setschedparam.c
 CSRCS += lib_psa_setschedpolicy.c lib_psa_getsigmask.c lib_psa_setsigmask.c
 CSRCS += lib_psa_getstacksize.c lib_psa_setstacksize.c lib_psa_destroy.c
+CSRCS += lib_psa_getpriority.c lib_psa_setpriority.c
 
 ifneq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += lib_psa_getstackaddr.c lib_psa_setstackaddr.c

--- a/libs/libc/spawn/lib_psa_getpriority.c
+++ b/libs/libc/spawn/lib_psa_getpriority.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * libs/libc/spawn/lib_psa_getpriority.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sched.h>
+#include <spawn.h>
+#include <assert.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: posix_spawnattr_getpriority
+ *
+ * Description:
+ *   Retrieves the priority attribute from an initialized attributes object
+ *   referenced by attr.
+ *
+ * Input Parameters:
+ *   attr - The address of the spawn attributes to be used.
+ *
+ * Returned Value:
+ *   The priority value stored in the attributes object.
+ *
+ ****************************************************************************/
+
+uint8_t posix_spawnattr_getpriority(FAR posix_spawnattr_t *attr)
+{
+  DEBUGASSERT(attr);
+
+  return attr->priority;
+}

--- a/libs/libc/spawn/lib_psa_setpriority.c
+++ b/libs/libc/spawn/lib_psa_setpriority.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * libs/libc/spawn/lib_psa_setpriority.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sched.h>
+#include <spawn.h>
+#include <assert.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: posix_spawnattr_setpriority
+ *
+ * Description:
+ *   Sets the priority attribute in an initialized attributes object
+ *   referenced by attr.
+ *
+ * Input Parameters:
+ *   attr    - The address of the spawn attributes to be used.
+ *   priority - The new priority to set.
+ *
+ * Returned Value:
+ *   On success, returns 0;
+ *
+ ****************************************************************************/
+
+int posix_spawnattr_setpriority(FAR posix_spawnattr_t *attr,
+                                uint8_t priority)
+{
+  DEBUGASSERT(attr);
+
+  attr->priority = priority;
+  return OK;
+}


### PR DESCRIPTION
## Summary

  * Add two new POSIX spawn attribute helper APIs: `posix_spawnattr_getpriority()` and `posix_spawnattr_setpriority()`.
  * This enables callers to read/write the `priority` field in `posix_spawnattr_t` through a stable interface.
  * Scope of change is limited to `libs/libc/spawn/` and build system integration (CMakeLists.txt / Make.defs).
  * Related NuttX Issue reference if applicable: N/A.
  * Related NuttX Apps Issue / Pull Request reference if applicable: N/A.

## Impact

  * Is new feature added? Is existing feature changed? NO / YES (please describe if yes).
    * YES: Adds two new public libc/spawn APIs (additive change).
  * Impact on user (will user need to adapt to change)? NO / YES (please describe if yes).
    * NO.
  * Impact on build (will build process change)? NO / YES (please describe if yes).
    * YES: New source files are added to libc/spawn build inputs.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO / YES (please describe if yes).
    * NO.
  * Impact on documentation (is update required / provided)? NO / YES (please describe if yes).
    * NO.
  * Impact on security (any sort of implications)? NO / YES (please describe if yes).
    * NO.
  * Impact on compatibility (backward/forward/interoperability)? NO / YES (please describe if yes).
    * NO: API-only addition.
  * Anything else to consider or add?
    * N/A.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): N/A (not tested; API-only addition).
  * Target(s): N/A.
  * Command(s): N/A.

  Testing logs before change:

  ```
  N/A (baseline log not captured)
  ```

  Testing logs after change:

  ```
  N/A (not tested)
  ```

## PR verification Self-Check

  * [X] This PR introduces only one functional change.
  * [X] I have updated all required description fields above.
  * [X] My PR adheres to Contributing Guidelines and Documentation (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [X] My PR is ready for review and can be safely merged into a codebase.

please ignore:
```
../nuttx/tools/checkpatch.sh -c -u -m -g f6f8acafbbfe5a00f6613f3f418586c19ec7dbb4..HEAD
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:959:8: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:960:8: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:963:8: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:963:32: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:984:11: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:984:27: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:984:43: error: Mixed case identifier found
Error: /home/runner/work/nuttx/nuttx/nuttx/arch/xtensa/include/xtensa/core.h:984:89: error: Mixed case identifier found
```