### PR TITLE
sched/sched: Modify the critical section interface name

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1400,7 +1400,7 @@ void sched_note_wdog(uint8_t event, FAR void *handler, FAR const void *arg)
   FAR struct tcb_s *tcb = this_task();
   irqstate_t flags;
 
-  flags = enter_critical_section_wo_note();
+  flags = enter_critical_section_notrace();
   for (driver = g_note_drivers; *driver; driver++)
     {
       if (note_wdog(*driver, event, handler, arg))
@@ -1426,7 +1426,7 @@ void sched_note_wdog(uint8_t event, FAR void *handler, FAR const void *arg)
       note_add(*driver, &note, sizeof(note));
     }
 
-  leave_critical_section_wo_note(flags);
+  leave_critical_section_notrace(flags);
 }
 #endif
 

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -318,13 +318,13 @@ int irqchain_detach(int irq, xcpt_t isr, FAR void *arg);
       defined(CONFIG_SCHED_INSTRUMENTATION_CSECTION)
 irqstate_t enter_critical_section(void) noinstrument_function;
 #  else
-#    define enter_critical_section() enter_critical_section_wo_note()
+#    define enter_critical_section() enter_critical_section_notrace()
 #  endif
 
-irqstate_t enter_critical_section_wo_note(void) noinstrument_function;
+irqstate_t enter_critical_section_notrace(void) noinstrument_function;
 #else
 #  define enter_critical_section() up_irq_save()
-#  define enter_critical_section_wo_note() up_irq_save()
+#  define enter_critical_section_notrace() up_irq_save()
 #endif
 
 /****************************************************************************
@@ -356,13 +356,13 @@ irqstate_t enter_critical_section_wo_note(void) noinstrument_function;
       defined(CONFIG_SCHED_INSTRUMENTATION_CSECTION)
 void leave_critical_section(irqstate_t flags) noinstrument_function;
 #  else
-#    define leave_critical_section(f) leave_critical_section_wo_note(f)
+#    define leave_critical_section(f) leave_critical_section_notrace(f)
 #  endif
 
-void leave_critical_section_wo_note(irqstate_t flags) noinstrument_function;
+void leave_critical_section_notrace(irqstate_t flags) noinstrument_function;
 #else
 #  define leave_critical_section(f) up_irq_restore(f)
-#  define leave_critical_section_wo_note(f) up_irq_restore(f)
+#  define leave_critical_section_notrace(f) up_irq_restore(f)
 #endif
 
 /****************************************************************************

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -79,7 +79,7 @@ volatile uint8_t g_cpu_nestcount[CONFIG_SMP_NCPUS];
  ****************************************************************************/
 
 /****************************************************************************
- * Name: enter_critical_section_wo_note
+ * Name: enter_critical_section_notrace
  *
  * Description:
  *   Take the CPU IRQ lock and disable interrupts on all CPUs.  A thread-
@@ -89,7 +89,7 @@ volatile uint8_t g_cpu_nestcount[CONFIG_SMP_NCPUS];
  ****************************************************************************/
 
 #ifdef CONFIG_SMP
-irqstate_t enter_critical_section_wo_note(void)
+irqstate_t enter_critical_section_notrace(void)
 {
   FAR struct tcb_s *rtcb;
   irqstate_t ret;
@@ -255,7 +255,7 @@ irqstate_t enter_critical_section_wo_note(void)
 
 #else
 
-irqstate_t enter_critical_section_wo_note(void)
+irqstate_t enter_critical_section_notrace(void)
 {
   irqstate_t ret;
 
@@ -290,7 +290,7 @@ irqstate_t enter_critical_section(void)
 {
   FAR struct tcb_s *rtcb;
   irqstate_t flags;
-  flags = enter_critical_section_wo_note();
+  flags = enter_critical_section_notrace();
 
   if (!up_interrupt_context())
     {
@@ -311,7 +311,7 @@ irqstate_t enter_critical_section(void)
 #endif
 
 /****************************************************************************
- * Name: leave_critical_section_wo_note
+ * Name: leave_critical_section_notrace
  *
  * Description:
  *   Decrement the IRQ lock count and if it decrements to zero then release
@@ -320,7 +320,7 @@ irqstate_t enter_critical_section(void)
  ****************************************************************************/
 
 #ifdef CONFIG_SMP
-void leave_critical_section_wo_note(irqstate_t flags)
+void leave_critical_section_notrace(irqstate_t flags)
 {
   int cpu;
 
@@ -420,7 +420,7 @@ void leave_critical_section_wo_note(irqstate_t flags)
   up_irq_restore(flags);
 }
 #else
-void leave_critical_section_wo_note(irqstate_t flags)
+void leave_critical_section_notrace(irqstate_t flags)
 {
   /* Check if we were called from an interrupt handler and that the tasks
    * lists have been initialized.
@@ -465,6 +465,6 @@ void leave_critical_section(irqstate_t flags)
         }
     }
 
-  leave_critical_section_wo_note(flags);
+  leave_critical_section_notrace(flags);
 }
 #endif

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -86,13 +86,13 @@ void sched_lock(void)
         {
 #if (CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0) || \
     defined(CONFIG_SCHED_INSTRUMENTATION_PREEMPTION)
-          irqstate_t flags = enter_critical_section_wo_note();
+          irqstate_t flags = enter_critical_section_notrace();
 
           /* Note that we have pre-emption locked */
 
           nxsched_critmon_preemption(rtcb, true, return_address(0));
           sched_note_preemption(rtcb, true);
-          leave_critical_section_wo_note(flags);
+          leave_critical_section_notrace(flags);
 #endif
         }
     }

--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -72,7 +72,7 @@ void sched_unlock(void)
 
       if (rtcb->lockcount == 1)
         {
-          irqstate_t flags = enter_critical_section_wo_note();
+          irqstate_t flags = enter_critical_section_notrace();
           FAR struct tcb_s *ptcb;
 
           rtcb->lockcount = 0;
@@ -170,7 +170,7 @@ void sched_unlock(void)
             }
 #endif
 
-          leave_critical_section_wo_note(flags);
+          leave_critical_section_notrace(flags);
         }
       else
         {


### PR DESCRIPTION
## Summary

This PR renames the non-instrumented critical-section API identifiers from the `_wo_note` suffix to `_notrace` to more clearly indicate the absence of tracing/notes. The change is a symbol rename and macro-update only; it does not alter runtime logic.

Details:
- Replace `enter_critical_section_wo_note()` -> `enter_critical_section_notrace()`
- Replace `leave_critical_section_wo_note(flags)` -> `leave_critical_section_notrace(flags)`
- Update `include/nuttx/irq.h` to map `enter_critical_section()`/`leave_critical_section()` to `_notrace` variants when instrumentation is disabled.
- Update implementation names and internal calls in `sched/irq/irq_csection.c`.
- Update call sites in `drivers/note/note_driver.c`, `sched/sched/sched_lock.c`, and `sched/sched/sched_unlock.c`.


## Impact

- Users: Minimal functional impact; behaviour unchanged when all references are updated. External modules referencing the old `_wo_note` symbols will fail to link until updated.
- Build: In-tree builds should succeed if all occurrences were updated; third-party code that references `_wo_note` will break.
- Hardware: No hardware-specific changes.
- Documentation: References to `_wo_note` should be updated.
- Security: None.
- Compatibility: API-level rename; consider adding deprecated compatibility macros if downstream stability is desired.

## Testing

ostest PASS
