### PR TITLE
drivers/analog/mcp47x6: fix configuration command

### DIFF
--- a/drivers/analog/mcp47x6.c
+++ b/drivers/analog/mcp47x6.c
@@ -305,7 +305,7 @@ static int mcp47x6_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
   uint32_t data;
   data = msg->am_data & MCP47X6_DATA_MASK;
   data <<= MCP47X6_DATA_SHIFT;
-  buffer[0] = (uint8_t)(data >> 8);
+  buffer[0] = (uint8_t)(data >> 8) | MCP47X6_COMMAND_WRITE_DAC;
   buffer[1] = (uint8_t)(data);
 
   ret = mcp47x6_i2c_write(priv, buffer, sizeof(buffer));
@@ -396,7 +396,8 @@ static int mcp47x6_ioctl(FAR struct dac_dev_s *dev, int cmd,
 
   if (command_prepared)
     {
-      ret = mcp47x6_i2c_write(priv, &priv->cmd, sizeof(priv->cmd));
+      uint8_t raw_cmd = MCP47X6_COMMAND_WRITE_CONFIG | priv->cmd;
+      ret = mcp47x6_i2c_write(priv, &raw_cmd, sizeof(raw_cmd));
     }
 
   return ret;


### PR DESCRIPTION
## Summary

The mcp47x6 DAC driver failed to send configuration commands with the proper prefix.
Thus, configuration commands were misunderstood as DAC write requests, which were rejected due to being to short (one byte instead of two).

In effect the ioctl-based configuration (reference, power-down and gain) was not applied before. 

## Impact

The configuration command is now properly prefixed with the command bits for "set volatile configuration".

## Testing

Compilation and the configuration behavior was tested on an rp2040 board.

Now the configured DAC value corresponds to the effective resulting voltage. 