### PR TITLE
drivers/mtd: add nvs cache buffer

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -201,6 +201,14 @@ config MTD_CONFIG_BLOCKSIZE_MULTIPLE
 	---help---
 		The size of a multiple of blocksize compared to erasize
 
+config MTD_CONFIG_CACHE_SIZE
+	int "Non-volatile Storage lookup cache size"
+	default 0
+	depends on MTD_CONFIG_FAIL_SAFE
+	help
+	  Number of entries in Non-volatile Storage lookup cache.
+	  It is recommended that it be a power of 2.
+
 endif # MTD_CONFIG
 
 comment "MTD Device Drivers"


### PR DESCRIPTION
improve the speed of finding the target ate

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Enhancing the read/write speed of the NVS module by adding a cache.

## Impact

key-value read/write functionality

## Testing

This has been tested and passed in qemu

test_nvs_mount: test begin
test_nvs_mount: success
test_nvs_write: test begin
test_nvs_write: success
test_nvs_corrupt_expire: test begin
test_nvs_corrupt_expire: success
test_nvs_corrupted_write: test begin
test_nvs_corrupted_write: success
test_nvs_gc: test begin
test_nvs_gc: success
test_nvs_gc_3sectors: test begin
test_nvs_gc_3sectors: success
test_nvs_corrupted_sector_close: test begin
test_nvs_corrupted_sector_close: success
test_nvs_full_sector: test begin
test_nvs_full_sector: success
test_nvs_gc_corrupt_close_ate: test begin
test_nvs_gc_corrupt_close_ate: success
test_nvs_gc_corrupt_ate: test begin
test_nvs_gc_corrupt_ate: success
test_nvs_gc_touched_deleted_ate: test begin
test_nvs_gc_touched_deleted_ate: success
test_nvs_gc_touched_expired_ate: test begin
test_nvs_gc_touched_expired_ate: success
test_nvs_gc_not_touched_expired_ate: test begin
test_nvs_gc_not_touched_expired_ate: success