### PR TITLE
arch/arm/nrf: fix rtc functions return param

### DIFF
--- a/arch/arm/src/nrf52/nrf52_tickless_rtc.c
+++ b/arch/arm/src/nrf52/nrf52_tickless_rtc.c
@@ -202,8 +202,6 @@ static void rtc_cancel_ack(void)
   g_tickless_dev.alarm_set = false;
 
   leave_critical_section(flags);
-
-  return OK;
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf53/nrf53_tickless_rtc.c
+++ b/arch/arm/src/nrf53/nrf53_tickless_rtc.c
@@ -200,8 +200,6 @@ static void rtc_cancel_ack(void)
   g_tickless_dev.alarm_set = false;
 
   leave_critical_section(flags);
-
-  return OK;
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf91/nrf91_modem_os.c
+++ b/arch/arm/src/nrf91/nrf91_modem_os.c
@@ -28,6 +28,7 @@
 
 #include <arch/irq.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/mutex.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/signal.h>

--- a/arch/arm/src/nrf91/nrf91_tickless_rtc.c
+++ b/arch/arm/src/nrf91/nrf91_tickless_rtc.c
@@ -196,8 +196,6 @@ static void rtc_cancel_ack(void)
   g_tickless_dev.alarm_set = false;
 
   leave_critical_section(flags);
-
-  return OK;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fixed return type of void functions and include of arch header for future Dockerfile update. 
