### PR TITLE
drivers/mtd: support ram_mtdconfig device && lomtdconfig device

### DIFF
--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -42,6 +42,9 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/fs/loopmtd.h>
 #include <nuttx/mtd/mtd.h>
+#ifdef CONFIG_MTD_CONFIG
+#  include <nuttx/mtd/configdata.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -551,8 +554,14 @@ static int filemtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
  ****************************************************************************/
 
 #ifdef CONFIG_MTD_LOOP
+#  ifdef CONFIG_MTD_CONFIG
+static int mtd_loop_setup(FAR const char *devname, FAR const char *filename,
+                          int sectsize, int erasesize, off_t offset,
+                          int configdata)
+#  else
 static int mtd_loop_setup(FAR const char *devname, FAR const char *filename,
                           int sectsize, int erasesize, off_t offset)
+#  endif
 {
   FAR struct mtd_dev_s *mtd;
   int ret;
@@ -563,7 +572,29 @@ static int mtd_loop_setup(FAR const char *devname, FAR const char *filename,
       return -ENOENT;
     }
 
-  ret = register_mtddriver(devname, mtd, 0755, NULL);
+#  ifdef CONFIG_MTD_CONFIG
+  if (configdata)
+    {
+      if (configdata == 2)
+        {
+          /* Try to erase the entire device, before register */
+
+          FAR struct file_dev_s *fdev = (FAR struct file_dev_s *)mtd;
+          mtd->erase(mtd, offset / erasesize, fdev->nblocks);
+        }
+
+      ret = mtdconfig_register_by_path(mtd, devname);
+      if (ret == -EDEADLK)
+        {
+          ferr("ERROR: mtdconfig_register_by_path failed: %d\n", ret);
+        }
+    }
+  else
+#  endif
+    {
+      ret = register_mtddriver(devname, mtd, 0755, NULL);
+    }
+
   if (ret != OK)
     {
       filemtd_teardown(mtd);
@@ -615,7 +646,17 @@ static int mtd_loop_teardown(FAR const char *devname)
   /* Now teardown the filemtd */
 
   filemtd_teardown(&dev->mtd);
-  unregister_mtddriver(devname);
+
+#  ifdef CONFIG_MTD_CONFIG
+  if (inode->i_private)
+    {
+      mtdconfig_unregister_by_path(devname);
+    }
+  else
+#  endif
+    {
+      unregister_mtddriver(devname);
+    }
 
   return OK;
 }
@@ -674,9 +715,15 @@ static int mtd_loop_ioctl(FAR struct file *filep, int cmd,
           }
         else
           {
+#  ifdef CONFIG_MTD_CONFIG
+            ret = mtd_loop_setup(setup->devname, setup->filename,
+                                 setup->sectsize, setup->erasesize,
+                                 setup->offset, setup->configdata);
+#  else
             ret = mtd_loop_setup(setup->devname, setup->filename,
                                  setup->sectsize, setup->erasesize,
                                  setup->offset);
+#  endif
           }
       }
       break;

--- a/include/nuttx/fs/loopmtd.h
+++ b/include/nuttx/fs/loopmtd.h
@@ -75,6 +75,9 @@ struct mtd_losetup_s
   size_t          erasesize;    /* The erase size to use on the file */
   size_t          sectsize;     /* The sector / page size of the file */
   off_t           offset;       /* An offset that may be applied to the device */
+#  ifdef CONFIG_MTD_CONFIG
+  int             configdata;   /* 1: register mtdconfig device, 2: erase before register */
+#  endif
 };
 #endif
 


### PR DESCRIPTION
For nvs test in qemu

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

[*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*](mtdconfig: support ram_mtdconfig device && lomtdconfig device)

## Impact

register mtdconfig device

## Testing

CONFIG_DISABLE_MOUNTPOINT=n
CONFIG_NSH_DISABLE_LOMTD=n
CONFIG_MTD_LOOP=y
CONFIG_MTD_CONFIG=y

goldfish-armv7a-ap> ls /dev
/dev:
audio/
binder
charge/
console
crypto
fb0
goldfish_pipe
input0
kbd0
kmsg
log
loopmtd
loopmtd1
lra0
mtdnvs_flash
