### PR TITLE
notifier: prevent DEBUGASSERT recursion during system startup

### DIFF
--- a/include/nuttx/notifier.h
+++ b/include/nuttx/notifier.h
@@ -212,10 +212,12 @@ extern "C"
   do \
     { \
       FAR struct atomic_notifier_head *nh = (nhead); \
-      irqstate_t flags; \
-      flags = rspin_lock_irqsave_nopreempt(&nh->lock); \
-      notifier_call_chain(nh->head, (val), (v), -1, NULL); \
-      rspin_unlock_irqrestore_nopreempt(&nh->lock, flags); \
+      if (nh != NULL && nh->head != NULL) \
+        { \
+          irqstate_t flags = rspin_lock_irqsave_nopreempt(&nh->lock); \
+          notifier_call_chain(nh->head, (val), (v), -1, NULL); \
+          rspin_unlock_irqrestore_nopreempt(&nh->lock, flags); \
+        } \
     } \
   while(0)
 
@@ -262,12 +264,15 @@ extern "C"
   do \
     { \
       FAR struct blocking_notifier_head *nh = (nhead); \
-      if (nxmutex_lock(&nh->mutex) < 0) \
+      if (nh != NULL && nh->head != NULL) \
         { \
-          break; \
+          if (nxmutex_lock(&nh->mutex) < 0) \
+            { \
+              break; \
+            } \
+          notifier_call_chain(nh->head, (val), (v), -1, NULL); \
+          nxmutex_unlock(&nh->mutex);\
         } \
-      notifier_call_chain(nh->head, (val), (v), -1, NULL); \
-      nxmutex_unlock(&nh->mutex);\
     } \
   while(0)
 


### PR DESCRIPTION
## Summary

This PR fixes a critical recursion issue in the notifier system that occurs during early 
system startup. The problem occurs when DEBUGASSERT is triggered in sched_lock(), which 
internally calls panic_notifier_call_chain() - causing a cascading chain of recursive 
DEBUGASSERT failures.

The fix adds explicit notifier head pointer checks before executing notifier chains, 
preventing unnecessary lock operations on uninitialized notifiers during system startup 
and error handling paths.

## Problem Description

During early system startup or when DEBUGASSERT fails in the scheduler:
1. ARM64 fatal handler triggers DEBUGASSERT
2. _assert() is called
3. panic_notifier_call_chain() attempts lock acquisition
4. sched_lock() contains a DEBUGASSERT that checks `rtcb && rtcb->lockcount < MAX_LOCK_COUNT`
5. Since this_task() may return NULL during startup, the DEBUGASSERT fails again
6. Recursion cycle causes cascading failures instead of clean panic/reboot

## Changes Made

### Atomic Notifier Chain (ATOMIC_NOTIFIER_CALL macro)

**Before:**
```c
do {
  FAR struct atomic_notifier_head *nh = (nhead);
  irqstate_t flags;
  flags = rspin_lock_irqsave_nopreempt(&nh->lock);
  notifier_call_chain(nh->head, (val), (v), -1, NULL);
  rspin_unlock_irqrestore_nopreempt(&nh->lock, flags);
} while(0)