### PR TITLE
sched/irq: Change the function parameter "regs" to "context"

### DIFF
--- a/sched/irq/irq_attach_thread.c
+++ b/sched/irq/irq_attach_thread.c
@@ -67,14 +67,15 @@ static pid_t g_irq_thread_pid[NR_IRQS];
  * Useful for oneshot interrupts.
  */
 
-static int irq_thread_default_handler(int irq, FAR void *regs, FAR void *arg)
+static int irq_thread_default_handler(int irq, FAR void *context,
+                                      FAR void *arg)
 {
   FAR struct irq_thread_info_s *info = arg;
   int ret = IRQ_WAKE_THREAD;
 
   if (info->handler != NULL)
     {
-      ret = info->handler(irq, regs, info->arg);
+      ret = info->handler(irq, context, info->arg);
     }
 
   if (ret == IRQ_WAKE_THREAD)

--- a/sched/irq/irq_attach_wqueue.c
+++ b/sched/irq/irq_attach_wqueue.c
@@ -126,14 +126,14 @@ static void irq_work_handler(FAR void *arg)
   info->isrwork(info->irq, NULL, info->arg);
 }
 
-static int irq_default_handler(int irq, FAR void *regs, FAR void *arg)
+static int irq_default_handler(int irq, FAR void *context, FAR void *arg)
 {
   FAR struct irq_work_info_s *info = arg;
   int ret = IRQ_WAKE_THREAD;
 
   if (info->handler != NULL)
     {
-      ret = info->handler(irq, regs, info->arg);
+      ret = info->handler(irq, context, info->arg);
     }
 
   if (ret == IRQ_WAKE_THREAD)


### PR DESCRIPTION
The identifier regs has been used to represent a type, and cannot be used in here. So change the "regs" to "context"

## Summary

To address issues reported by the Coverity static code analysis tool, rename the function parameter from regs to context. This change only affects the parameter name and does not modify data types, parameter count, or functional logic.

Specific Changes:
Original parameter: regs (could be misinterpreted as "registers")
New parameter: context (more accurately represents "execution context")

## Impact

Positive Impacts
1.Improved Code Clarity: context more accurately describes parameter content than regs
2.Eliminated Static Analysis Warnings: Resolves Coverity-reported quality issues
3.Maintained Consistency: Aligns with existing similar functions using context in the project
4.Self-documenting: Parameter name itself provides better documentation

## Testing

This change only affects the parameter name and does not modify data types, parameter count, or functional logic.

1.Compilation Test
Pass

2. Coverity Rescan
Pass
