### PR TITLE
drivers/rpmsg: unify cpuname handling and fix pm wakelock initialization

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -196,25 +196,20 @@ int rpmsg_post(FAR struct rpmsg_endpoint *ept, FAR sem_t *sem)
 FAR const char *rpmsg_get_local_cpuname(FAR struct rpmsg_device *rdev)
 {
   FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);
-  FAR const char *cpuname = NULL;
 
   if (rpmsg == NULL)
     {
       return NULL;
     }
 
-  if (rpmsg->ops->get_local_cpuname)
-    {
-      cpuname = rpmsg->ops->get_local_cpuname(rpmsg);
-    }
-
-  return cpuname && cpuname[0] ? cpuname : CONFIG_RPMSG_LOCAL_CPUNAME;
+  return rpmsg->local_cpuname[0] ? rpmsg->local_cpuname :
+         CONFIG_RPMSG_LOCAL_CPUNAME;
 }
 
 FAR const char *rpmsg_get_cpuname(FAR struct rpmsg_device *rdev)
 {
   FAR struct rpmsg_s *rpmsg = rpmsg_get_by_rdev(rdev);
-  return rpmsg ? rpmsg->ops->get_cpuname(rpmsg) : NULL;
+  return rpmsg ? rpmsg->cpuname : NULL;
 }
 
 int rpmsg_get_signals(FAR struct rpmsg_device *rdev)
@@ -557,7 +552,7 @@ int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg)
       FAR struct rpmsg_s *rpmsg =
         metal_container_of(node, struct rpmsg_s, node);
 
-      if (!cpuname || !strcmp(rpmsg_get_cpuname(rpmsg->rdev), cpuname))
+      if (!cpuname || !strcmp(rpmsg->cpuname, cpuname))
         {
           ret = rpmsg_dev_ioctl_(rpmsg, cmd, arg);
           if (ret < 0)

--- a/drivers/rpmsg/rpmsg_port.h
+++ b/drivers/rpmsg/rpmsg_port.h
@@ -123,12 +123,6 @@ struct rpmsg_port_s
   struct rpmsg_port_queue_s         txq;    /* Port tx queue */
   struct rpmsg_port_queue_s         rxq;    /* Port rx queue */
 
-  char                              local_cpuname[RPMSG_NAME_SIZE];
-
-  /* Remote cpu name of this port connected to */
-
-  char                              cpuname[RPMSG_NAME_SIZE];
-
   /* Ops need implemented by drivers under port layer */
 
   const FAR struct rpmsg_port_ops_s *ops;

--- a/drivers/rpmsg/rpmsg_port_spi.c
+++ b/drivers/rpmsg/rpmsg_port_spi.c
@@ -213,7 +213,8 @@ static void rpmsg_port_spi_exchange(FAR struct rpmsg_port_spi_s *rpspi)
     {
       txhdr = rpspi->cmdhdr;
       txhdr->cmd = RPMSG_PORT_SPI_CMD_CONNECT;
-      strlcpy((FAR char *)(txhdr + 1), rpspi->port.cpuname, RPMSG_NAME_SIZE);
+      strlcpy((FAR char *)(txhdr + 1), rpspi->port.rpmsg.cpuname,
+              RPMSG_NAME_SIZE);
     }
   else if (rpspi->txavail > 0 &&
            rpmsg_port_queue_nused(&rpspi->port.txq) > 0)

--- a/drivers/rpmsg/rpmsg_port_spi_slave.c
+++ b/drivers/rpmsg/rpmsg_port_spi_slave.c
@@ -175,7 +175,8 @@ static void rpmsg_port_spi_exchange(FAR struct rpmsg_port_spi_s *rpspi)
     {
       txhdr = rpspi->cmdhdr;
       txhdr->cmd = RPMSG_PORT_SPI_CMD_CONNECT;
-      strlcpy((FAR char *)(txhdr + 1), rpspi->port.cpuname, RPMSG_NAME_SIZE);
+      strlcpy((FAR char *)(txhdr + 1), rpspi->port.rpmsg.cpuname,
+              RPMSG_NAME_SIZE);
     }
   else if (rpspi->txavail > 0 &&
            rpmsg_port_queue_nused(&rpspi->port.txq) > 0)

--- a/drivers/rpmsg/rpmsg_virtio_lite.c
+++ b/drivers/rpmsg/rpmsg_virtio_lite.c
@@ -82,10 +82,6 @@ static int rpmsg_virtio_lite_wait(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
 static int rpmsg_virtio_lite_post(FAR struct rpmsg_s *rpmsg, FAR sem_t *sem);
 static void rpmsg_virtio_lite_panic(FAR struct rpmsg_s *rpmsg);
 static void rpmsg_virtio_lite_dump(FAR struct rpmsg_s *rpmsg);
-static FAR const char *
-rpmsg_virtio_lite_get_local_cpuname(FAR struct rpmsg_s *rpmsg);
-static FAR const char *
-rpmsg_virtio_lite_get_cpuname(FAR struct rpmsg_s *rpmsg);
 
 static int
 rpmsg_virtio_lite_create_virtqueues_(FAR struct virtio_device *vdev,
@@ -113,8 +109,6 @@ static const struct rpmsg_ops_s g_rpmsg_virtio_lite_ops =
   .post               = rpmsg_virtio_lite_post,
   .panic              = rpmsg_virtio_lite_panic,
   .dump               = rpmsg_virtio_lite_dump,
-  .get_local_cpuname  = rpmsg_virtio_lite_get_local_cpuname,
-  .get_cpuname        = rpmsg_virtio_lite_get_cpuname,
 };
 
 static const struct virtio_dispatch g_rpmsg_virtio_lite_dispatch =
@@ -540,24 +534,6 @@ static void rpmsg_virtio_lite_dump(FAR struct rpmsg_s *rpmsg)
 }
 #endif
 
-static FAR const char *
-rpmsg_virtio_lite_get_local_cpuname(FAR struct rpmsg_s *rpmsg)
-{
-  FAR struct rpmsg_virtio_lite_priv_s *priv =
-    (FAR struct rpmsg_virtio_lite_priv_s *)rpmsg;
-
-  return RPMSG_VIRTIO_LITE_GET_LOCAL_CPUNAME(priv->dev);
-}
-
-static FAR const char *
-rpmsg_virtio_lite_get_cpuname(FAR struct rpmsg_s *rpmsg)
-{
-  FAR struct rpmsg_virtio_lite_priv_s *priv =
-    (FAR struct rpmsg_virtio_lite_priv_s *)rpmsg;
-
-  return RPMSG_VIRTIO_LITE_GET_CPUNAME(priv->dev);
-}
-
 static void
 rpmsg_virtio_lite_wakeup_rx(FAR struct rpmsg_virtio_lite_priv_s *priv)
 {
@@ -784,8 +760,8 @@ int rpmsg_virtio_lite_initialize(FAR struct rpmsg_virtio_lite_s *dev)
 {
   FAR struct rpmsg_virtio_lite_priv_s *priv;
   FAR char *argv[3];
+  char name[64];
   char arg1[32];
-  char name[32];
   int ret;
 
   priv = kmm_zalloc(sizeof(struct rpmsg_virtio_lite_priv_s));
@@ -797,9 +773,13 @@ int rpmsg_virtio_lite_initialize(FAR struct rpmsg_virtio_lite_s *dev)
   priv->dev = dev;
   nxsem_init(&priv->semrx, 0, 0);
   nxsem_init(&priv->semtx, 0, 0);
+  strlcpy(priv->rpmsg.cpuname, RPMSG_VIRTIO_LITE_GET_CPUNAME(dev),
+          sizeof(priv->rpmsg.cpuname));
+  strlcpy(priv->rpmsg.local_cpuname,
+          RPMSG_VIRTIO_LITE_GET_LOCAL_CPUNAME(dev),
+          sizeof(priv->rpmsg.local_cpuname));
 
-  snprintf(name, sizeof(name), "/dev/rpmsg/%s",
-           RPMSG_VIRTIO_LITE_GET_CPUNAME(dev));
+  snprintf(name, sizeof(name), "/dev/rpmsg/%s", priv->rpmsg.cpuname);
   ret = rpmsg_register(name, &priv->rpmsg, &g_rpmsg_virtio_lite_ops);
   if (ret < 0)
     {
@@ -807,7 +787,7 @@ int rpmsg_virtio_lite_initialize(FAR struct rpmsg_virtio_lite_s *dev)
     }
 
   snprintf(arg1, sizeof(arg1), "%p", priv);
-  argv[0] = (FAR char *)RPMSG_VIRTIO_LITE_GET_CPUNAME(dev);
+  argv[0] = (FAR char *)priv->rpmsg.cpuname;
   argv[1] = arg1;
   argv[2] = NULL;
 
@@ -820,8 +800,7 @@ int rpmsg_virtio_lite_initialize(FAR struct rpmsg_virtio_lite_s *dev)
     }
 
 #ifdef CONFIG_RPMSG_VIRTIO_LITE_PM
-  snprintf(name, sizeof(name), "rpmsg-virtio-%s",
-           RPMSG_VIRTIO_LITE_GET_CPUNAME(dev));
+  snprintf(name, sizeof(name), "rpmsg-virtio-%s", priv->rpmsg.cpuname);
   pm_wakelock_init(&priv->wakelock, name, PM_IDLE_DOMAIN, PM_IDLE);
 #endif
 

--- a/include/nuttx/rpmsg/rpmsg.h
+++ b/include/nuttx/rpmsg/rpmsg.h
@@ -58,6 +58,8 @@ struct rpmsg_s
   struct metal_list            bind;
   rmutex_t                     lock;
   struct metal_list            node;
+  char                         local_cpuname[RPMSG_NAME_SIZE];
+  char                         cpuname[RPMSG_NAME_SIZE];
   FAR const struct rpmsg_ops_s *ops;
 #ifdef CONFIG_RPMSG_PING
   struct rpmsg_endpoint        ping;
@@ -83,8 +85,6 @@ struct rpmsg_ops_s
   CODE int (*ioctl)(FAR struct rpmsg_s *rpmsg, int cmd, unsigned long arg);
   CODE void (*panic)(FAR struct rpmsg_s *rpmsg);
   CODE void (*dump)(FAR struct rpmsg_s *rpmsg);
-  CODE FAR const char *(*get_local_cpuname)(FAR struct rpmsg_s *rpmsg);
-  CODE FAR const char *(*get_cpuname)(FAR struct rpmsg_s *rpmsg);
 };
 
 CODE typedef void (*rpmsg_dev_cb_t)(FAR struct rpmsg_device *rdev,


### PR DESCRIPTION
## Summary
This PR contains two improvements to the RPMSG subsystem:

Unify cpuname/local_cpuname to struct rpmsg_s: Move the cpuname and local_cpuname fields from individual driver structures (rpmsg_port, rpmsg_virtio, rpmsg_virtio_lite, rpmsg_router_edge) to the common struct rpmsg_s. This eliminates the need for ops->get_cpuname and ops->get_local_cpuname callbacks in struct rpmsg_ops_s, simplifying the code and reducing duplication across different RPMSG backends.

Fix pm wakelock initialization in rpmsg_virtio_lite: Add missing pm wakelock name initialization that was not picked up during the rename from rpmsg_virtio to rpmsg_virtio_lite. This ensures proper power management functionality when CONFIG_RPMSG_VIRTIO_LITE_PM is enabled.

## Impact
Code simplification: Removes ~120 lines of duplicated code across multiple RPMSG drivers
API cleanup: Removes two function pointers from struct rpmsg_ops_s
Bug fix: Restores pm wakelock functionality in rpmsg_virtio_lite driver
No breaking changes: Internal refactoring only, public API unchanged

## Testing
Build test with qemu-armv8a:v8a_server and qemu-armv8a:v8a_proxy configurations:
```c
cmake -B cmake_out/v8a_server -DBOARD_CONFIG=qemu-armv8a:v8a_server -GNinja
cmake --build cmake_out/v8a_server

cmake -B cmake_out/v8a_proxy -DBOARD_CONFIG=qemu-armv8a:v8a_proxy -GNinja
cmake --build cmake_out/v8a_proxy
```

RPMSG communication verified between server and proxy cores:
```c
❯ qemu-system-aarch64 -cpu cortex-a53 -nographic \
-machine virt,virtualization=on,gic-version=3 \
-chardev stdio,id=con,mux=on -serial chardev:con \
-object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes \
-device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb \
-device virtio-serial-device,bus=virtio-mmio-bus.0 \
-chardev socket,path=/tmp/rpmsg_port_uart_socket,server=on,wait=off,id=foo \
-device virtconsole,chardev=foo \
-mon chardev=con,mode=readline -kernel ./nuttx/cmake_out/v8a_server/nuttx \
-gdb tcp::7775
[    0.000000] [ 0] [  INFO] [server] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=proxy, master=1
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] ivshmem_probe: shmem addr=0x10400000 size=4194304 reg=0x10008000
[    0.000000] [ 3] [  INFO] [server] rptun_ivshmem_probe: shmem addr=0x10400000 size=4194304

NuttShell (NSH) NuttX-12.10.0
server> 
server> 
server> [    0.000000] [ 0] [  INFO] [proxy] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=server, master=0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] ivshmem_probe: shmem addr=0x10400000 size=4194304 reg=0x10008000
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: shmem addr=0x10400000 size=4194304
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: Start the wdog

server> 
server> 
server> 
server> uname -a
NuttX server 12.10.0 9dd4ad28038 Jan 22 2026 20:09:56 arm64 qemu-armv8a
server> 
server> rpmsg ping all 1 1 1 1
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 1520, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 25131856 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 25131856 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 25131856 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.005411 Mbits/sec
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 2024, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 13549200 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 13549200 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 13549200 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.010037 Mbits/sec
server> 
server> rpmsg dump all
[    0.000000] [ 7] [ EMERG] [server] Local: server Remote: proxy Headrx 8
[    0.000000] [ 7] [ EMERG] [server] Dump rpmsg info between cpu (master: yes)server <==> proxy:
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq RX:
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq TX:
[    0.000000] [ 7] [ EMERG] [server]   rpmsg ept list:
[    0.000000] [ 7] [ EMERG] [server]     ept NS
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-syslog
[    0.000000] [ 7] [ EMERG] [server]   rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server]     RX buffer, total 8, pending 0
[    0.000000] [ 7] [ EMERG] [server]     TX buffer, total 8, pending 0
[    0.000000] [ 7] [ EMERG] [server] Remote: proxy2 state: 1
[    0.000000] [ 7] [ EMERG] [server] ept NS
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue RX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue TX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
server> 
```