### PR TITLE
sched/irq: Avoid directly converting variables of type uintptr_t to void

### DIFF
--- a/sched/irq/irq_attach_thread.c
+++ b/sched/irq/irq_attach_thread.c
@@ -91,7 +91,7 @@ static int isr_thread_main(int argc, FAR char *argv[])
   int irq = atoi(argv[1]);
   xcpt_t isr = (xcpt_t)((uintptr_t)strtoul(argv[2], NULL, 16));
   xcpt_t isrthread = (xcpt_t)((uintptr_t)strtoul(argv[3], NULL, 16));
-  FAR void *arg = (FAR void *)((uintptr_t)strtoul(argv[4], NULL, 16));
+  FAR void *arg = (FAR char *)((uintptr_t)strtoul(argv[4], NULL, 16));
   struct irq_thread_info_s info;
   sem_t sem;
 


### PR DESCRIPTION
According to MISRA C-2012 Rule 11.6, a cast shall not be performed between pointer to void and an arithmetic type

## Summary

To comply with MISRA C-2012 Rule 11.6, the pointer cast has been modified from (FAR void *) to (FAR char *) when converting an integer value obtained via strtoul() to a pointer. This change ensures proper alignment of the converted pointer as required by the MISRA standard.

## Impact

No functional changes: The pointer value remains identical
No performance impact: Same runtime behavior
No memory impact: Same memory usage
API compatibility: All callers remain unaffected

## Testing

This change has no effet to functional logic.

1.Compilation Test
Pass

Coverity Rescan
Pass




