### PR TITLE
Revert "net: limit TCP and UDP send/recv buffer usage with throttled IOB

### DIFF
--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -146,7 +146,7 @@ static uint32_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
 
       /* Allocate an IOB to hold the frame data */
 
-      iob = net_ioballoc(true);
+      iob = net_ioballoc(false);
       if (iob == NULL)
         {
           nwarn("WARNING: Failed to allocate IOB\n");

--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -87,14 +87,14 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
 
   /* Append the send buffer after device buffer */
 
-  if (len > iob_navail(true) * CONFIG_IOB_BUFSIZE ||
-      netdev_iob_prepare(dev, true, 0) != OK)
+  if (len > iob_navail(false) * CONFIG_IOB_BUFSIZE ||
+      netdev_iob_prepare(dev, false, 0) != OK)
     {
       ret = -ENOMEM;
       goto errout;
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset, true);
+  iob_update_pktlen(dev->d_iob, target_offset, false);
 
   ret = file_seek(file, offset, SEEK_SET);
   if (ret < 0)
@@ -111,7 +111,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
         {
           if (iob->io_flink == NULL)
             {
-              iob->io_flink = iob_tryalloc(true);
+              iob->io_flink = iob_tryalloc(false);
               if (iob->io_flink == NULL)
                 {
                   ret = -ENOMEM;
@@ -144,7 +144,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
         }
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset + len, true);
+  iob_update_pktlen(dev->d_iob, target_offset + len, false);
 
   dev->d_sndlen = len;
   return len;

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -153,7 +153,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   /* Copy the ICMP message into the I/O buffer chain (without waiting) */
 
   ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
-                          0, iob, 0, false, false);
+                          0, iob, 0, true, false);
   if (ret < 0)
     {
       iob_free_chain(iob);

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -144,7 +144,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   /* Copy the ICMPv6 message into the I/O buffer chain (without waiting) */
 
   ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
-                          iplen, iob, 0, false, false);
+                          iplen, iob, 0, true, false);
   if (ret < 0)
     {
       iob_free_chain(iob);

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -62,7 +62,11 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 
   if (dev->d_iob == NULL)
     {
-      dev->d_iob = net_iobtimedalloc(throttled, timeout);
+      dev->d_iob = net_iobtimedalloc(false, timeout);
+      if (dev->d_iob == NULL && throttled)
+        {
+          dev->d_iob = net_iobtimedalloc(true, timeout);
+        }
     }
 
   if (dev->d_iob == NULL)

--- a/net/pkt/pkt_netpoll.c
+++ b/net/pkt/pkt_netpoll.c
@@ -66,7 +66,7 @@
 
 static int psock_pkt_cansend(FAR struct pkt_conn_s *conn)
 {
-  if (iob_navail(true) <= 0
+  if (iob_navail(false) <= 0
 #if defined(CONFIG_NET_PKT_WRITE_BUFFERS) && CONFIG_NET_SEND_BUFSIZE > 0
       || iob_get_queue_size(&conn->write_q) >= conn->sndbufs
 #endif

--- a/net/pkt/pkt_sendmsg_buffered.c
+++ b/net/pkt/pkt_sendmsg_buffered.c
@@ -266,7 +266,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
 
   if (nonblock)
     {
-      iob = iob_tryalloc(true);
+      iob = iob_tryalloc(false);
     }
   else
     {
@@ -292,7 +292,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
     }
 
   iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
-  iob_update_pktlen(iob, 0, true);
+  iob_update_pktlen(iob, 0, false);
 
   /* Copy the user data into the write buffer.  We cannot wait for
    * buffer space if the socket was opened non-blocking.
@@ -305,7 +305,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
 
   if (nonblock)
     {
-      ret = iob_trycopyin(iob, buf, len, offset, true);
+      ret = iob_trycopyin(iob, buf, len, offset, false);
     }
   else
     {
@@ -315,7 +315,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
        */
 
       conn_dev_unlock(&conn->sconn, dev);
-      ret = iob_copyin(iob, buf, len, offset, true);
+      ret = iob_copyin(iob, buf, len, offset, false);
       conn_dev_lock(&conn->sconn, dev);
     }
 

--- a/net/sixlowpan/sixlowpan_framelist.c
+++ b/net/sixlowpan/sixlowpan_framelist.c
@@ -412,7 +412,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
    * necessary.
    */
 
-  iob = net_ioballoc(true);
+  iob = net_ioballoc(false);
   DEBUGASSERT(iob != NULL);
 
   fptr = iob->io_data;
@@ -630,7 +630,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
            * necessary.
            */
 
-          iob = net_ioballoc(true);
+          iob = net_ioballoc(false);
           DEBUGASSERT(iob != NULL);
 
           /* Initialize the IOB */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1083,7 +1083,7 @@ static uint32_t psock_send_eventhandler(FAR struct net_driver_s *dev,
            * the maximum size packet that would fit.
            */
 
-          if (sndlen > iob_navail(true) * CONFIG_IOB_BUFSIZE)
+          if (sndlen > iob_navail(false) * CONFIG_IOB_BUFSIZE)
             {
               nwarn("Running low on iobs, limiting packet size\n");
               sndlen = CONFIG_IOB_BUFSIZE;

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -80,8 +80,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
 
   conn_lock(&conn->sconn);
 #if CONFIG_NET_RECV_BUFSIZE > 0
-  if (conn->readahead && conn->readahead->io_pktlen > conn->rcvbufs &&
-      iob_navail(true) == 0)
+  if (conn->readahead && conn->readahead->io_pktlen > conn->rcvbufs)
     {
       conn_unlock(&conn->sconn);
       netdev_iob_release(dev);

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -832,7 +832,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   udpiplen = udpip_hdrsize(conn);
 
   iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
-  iob_update_pktlen(wrb->wb_iob, udpiplen, true);
+  iob_update_pktlen(wrb->wb_iob, udpiplen, false);
 
   /* Copy the user data into the write buffer.  We cannot wait for
    * buffer space if the socket was opened non-blocking.
@@ -843,12 +843,12 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       if (nonblock)
         {
           ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                              len, udpiplen, true);
+                              len, udpiplen, false);
         }
       else
         {
           ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                           len, udpiplen, true);
+                           len, udpiplen, false);
         }
 
       if (ret < 0)
@@ -951,7 +951,7 @@ int psock_udp_cansend(FAR struct udp_conn_s *conn)
    * many more.
    */
 
-  if (udp_wrbuffer_test() < 0 || iob_navail(true) <= 0
+  if (udp_wrbuffer_test() < 0 || iob_navail(false) <= 0
 #if CONFIG_NET_SEND_BUFSIZE > 0
       || udp_wrbuffer_inqueue_size(conn) >= conn->sndbufs
 #endif

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -94,7 +94,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_alloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_ioballoc(true);
+  wrb->wb_iob = net_ioballoc(false);
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");
@@ -205,7 +205,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 #ifdef CONFIG_NET_JUMBO_FRAME
     iob_alloc_dynamic(len);
 #else
-    iob_tryalloc(true);
+    iob_tryalloc(false);
 #endif
   if (!wrb->wb_iob)
     {


### PR DESCRIPTION
## Summary
This reverts commit fa652f9c2467f6a95b45aad9f6d3952038077f23.

When testing iperf on boards such as ESP32-C6, ESP32-C3, and ESP32, blocking issues are encountered, so the patch is reverted.

## Impact
**TCP**: **tcp_recvwindow.c**, **tcp_send_buffered.c**
**UDP**: **udp_wrbuffer.c**, **tcp_callback.c**, **udp_send_buffered.c**
**ICMP/ICMPv6**: **icmp_input.c**, **icmpv6_input.c**
**Packet**: **pkt_netpool.c**, **pkt_sendmsg_buffered.c**

## Testing
There are relevant test results on the https://github.com/apache/nuttx/pull/18011
