### PR TITLE
sched: add trace points during system startup and board initialization

### DIFF
--- a/Documentation/debugging/tasktraceuser.rst
+++ b/Documentation/debugging/tasktraceuser.rst
@@ -357,3 +357,41 @@ If no command parameters are specified, display the current filter settings as t
     11
     15
 
+System Startup and Board Initialization Trace
+=============================================
+
+NuttX has trace points during system startup and board initialization.
+
+These trace points include:
+- System startup phases (e.g., BOOT, TASKLISTS, MEMORY, HARDWARE, OSREADY, IDLELOOP)
+- Entry and exit of board_early_initialize() and board_late_initialize()
+- System RESET and PANIC events
+
+This information helps analyze the boot process and locate issues related to board initialization or early system failures.
+
+How to capture startup and board initialization trace
+-----------------------------------------------------
+1. **Ensure trace-related kernel configs are enabled** (see configuration section above).
+2. **Boot the system normally**; the trace driver will automatically record these early trace points.
+3. After boot, export the trace data with:
+
+.. code-block::
+
+   nsh> trace dump boot_trace.txt
+
+4. Open boot_trace.txt in Trace Compass. You will see the timeline of each phase, board early/late init boundaries, and RESET/PANIC events.
+
+Common trace events during the startup
+--------------------------------------
+- ``sched_trace_mark("BOOT")``        : Entering BOOT phase
+- ``sched_trace_mark("TASKLISTS")``   : Initializing task lists
+- ``sched_trace_mark("MEMORY")``      : Memory manager available
+- ``sched_trace_mark("HARDWARE")``    : Hardware resources initialized
+- ``sched_trace_mark("OSREADY")``     : Multitasking ready
+- ``sched_trace_mark("IDLELOOP")``    : Entering idle loop
+- ``boards_trace_begin/end()``         : Entry/exit of board_early_initialize/board_late_initialize
+- ``sched_trace_mark("RESET")``       : System reset
+- ``sched_trace_mark("PANIC")``       : System panic
+
+**Tip:** If you need to analyze boot or board initialization issues, always export and review the boot phase trace data first. This can help you quickly locate the problematic stage.
+

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -36,10 +36,12 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/cache.h>
+#include <nuttx/init.h>
 #include <nuttx/lib/elf.h>
 #include <nuttx/binfmt/symtab.h>
 #include <nuttx/drivers/ramdisk.h>
 #include <nuttx/reboot_notifier.h>
+#include <nuttx/trace.h>
 
 #ifdef CONFIG_NX
 #  include <nuttx/nx/nxmu.h>
@@ -412,6 +414,8 @@ int boardctl(unsigned int cmd, uintptr_t arg)
 
       case BOARDIOC_RESET:
         {
+          g_nx_initstate = OSINIT_RESET;
+          sched_trace_mark("RESET");
           reboot_notifier_call_chain(SYS_RESTART, (FAR void *)arg);
           up_flush_dcache_all();
           ret = board_reset((int)arg);

--- a/include/nuttx/init.h
+++ b/include/nuttx/init.h
@@ -73,7 +73,8 @@ enum nx_initstate_e
   OSINIT_OSREADY   = 5,  /* The OS is fully initialized and multi-tasking is
                           * active. */
   OSINIT_IDLELOOP  = 6,  /* The OS enter idle loop. */
-  OSINIT_PANIC     = 7   /* Fatal error happened. */
+  OSINIT_RESET     = 7,  /* The OS is in resetting process. */
+  OSINIT_PANIC     = 8   /* Fatal error happened. */
 };
 
 /****************************************************************************

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -318,7 +318,9 @@ static inline void nx_start_application(void)
    * configured.
    */
 
+  boards_trace_begin();
   board_late_initialize();
+  boards_trace_end();
 #endif
 
 #ifdef CONFIG_COREDUMP

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -508,6 +508,7 @@ void nx_start(void)
   /* Boot up is complete */
 
   g_nx_initstate = OSINIT_BOOT;
+  sched_trace_mark("BOOT");
 
   /* Initialize task list table *********************************************/
 
@@ -520,6 +521,7 @@ void nx_start(void)
   /* Task lists are initialized */
 
   g_nx_initstate = OSINIT_TASKLISTS;
+  sched_trace_mark("TASKLISTS");
 
   /* Initialize RTOS Data ***************************************************/
 
@@ -613,6 +615,7 @@ void nx_start(void)
   /* The memory manager is available */
 
   g_nx_initstate = OSINIT_MEMORY;
+  sched_trace_mark("MEMORY");
 
   /* Initialize tasking data structures */
 
@@ -682,12 +685,15 @@ void nx_start(void)
    * that cannot wait until board_late_initialize.
    */
 
+  boards_trace_begin();
   board_early_initialize();
+  boards_trace_end();
 #endif
 
   /* Hardware resources are now available */
 
   g_nx_initstate = OSINIT_HARDWARE;
+  sched_trace_mark("HARDWARE");
 
   /* Setup for Multi-Tasking ************************************************/
 
@@ -734,6 +740,7 @@ void nx_start(void)
   /* The OS is fully initialized and we are beginning multi-tasking */
 
   g_nx_initstate = OSINIT_OSREADY;
+  sched_trace_mark("OSREADY");
 
   /* Create initial tasks and bring-up the system */
 
@@ -742,6 +749,7 @@ void nx_start(void)
   /* Enter to idleloop */
 
   g_nx_initstate = OSINIT_IDLELOOP;
+  sched_trace_mark("IDLELOOP");
 
   /* Let other threads have access to the memory manager */
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -45,6 +45,7 @@
 #include <nuttx/syslog/syslog.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <nuttx/mm/kasan.h>
+#include <nuttx/trace.h>
 
 #include <assert.h>
 #include <debug.h>
@@ -860,6 +861,7 @@ void _assert(FAR const char *filename, int linenum,
       /* Fatal error, enter panic state. */
 
       g_nx_initstate = OSINIT_PANIC;
+      sched_trace_mark("PANIC");
 
       /* Disable KASAN to avoid false positive */
 


### PR DESCRIPTION
Add trace points to record transitions of g_nx_initstate and to mark board early/late initialization boundaries. Also add trace marks for RESET and PANIC to improve boot-time diagnostics and failure analysis.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This patch introduces trace points at key moments during system startup and board-level initialization to improve boot-time diagnostics and tracing. It records transitions of `g_nx_initstate`, adds begin/end trace markers around board initialization, and marks important events such as RESET and PANIC.

## Motivation

Tracing the system initialization sequence helps debugging bring-up and failure analysis on multi-core and board bring-up scenarios. Recording `g_nx_initstate` transitions and board init boundaries provides better visibility into the boot sequence.

## What was changed

- `boards/boardctl.c`
  - Include `<nuttx/trace.h>` and mark `RESET` when board reset is requested. Set `g_nx_initstate = OSINIT_RESET` before calling reboot notifier.

- `sched/init/nx_bringup.c`
  - Wrap `board_late_initialize()` with `boards_trace_begin()` / `boards_trace_end()`.

- `sched/init/nx_start.c`
  - Emit `sched_trace_mark()` calls when updating `g_nx_initstate` for states: BOOT, TASKLISTS, MEMORY, HARDWARE, OSREADY, IDLELOOP.
  - Wrap `board_early_initialize()` with `boards_trace_begin()` / `boards_trace_end()`.

- `sched/misc/assert.c`
  - Include `<nuttx/trace.h>` and emit a `PANIC` trace mark when entering the panic state.

## Impact

- Functional behavior: No functional changes to logic; only additional trace calls. Should be safe when tracing is disabled.
- API/ABI: No public API or ABI changes.
- Risks: Minimal. Trace calls add negligible overhead when enabled.

## Testing

- Built and booted on target device used during development.
- Observed trace markers during normal boot and when triggering reset/panic.
- Example observed marks: RESET, BOOT, TASKLISTS, MEMORY, HARDWARE, OSREADY, IDLELOOP, PANIC.

