### PR TITLE
note/noteram: add FIONREAD ioctl to report unread buffer size

### DIFF
--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -602,6 +602,18 @@ static int noteram_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           }
         break;
 
+      case FIONREAD:
+        if (arg == 0)
+          {
+            ret = -EINVAL;
+          }
+        else
+          {
+            *(FAR unsigned int *)arg = noteram_unread_length(drv);
+            ret = OK;
+          }
+        break;
+
       default:
           break;
     }


### PR DESCRIPTION
Add handling for the FIONREAD ioctl in noteram_ioctl to return the number of unread bytes in the circular note buffer (noteram_unread_length()). Validate the argument pointer and return -EINVAL if it is NULL.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This patch adds support for the FIONREAD ioctl command in the noteram driver to allow user-space to query the number of unread bytes in the circular note buffer.

## Motivation

User-space consumers of /dev/note/ram can benefit from being able to query the available unread size for efficient reads without blocking or to size buffers appropriately.

## What was changed

- `drivers/note/noteram_driver.c`
  - Added handling for `FIONREAD` in `noteram_ioctl()` to return the result of `noteram_unread_length()` when a valid pointer is passed.

## Impact

- Functional behavior: Adds a new ioctl handler; no behavior change to existing functionality.
- API/ABI: Adds support for a commonly used ioctl (FIONREAD) on the device node.
- Risks: Minimal. The added code verifies `arg` and returns -EINVAL for null pointer.

## Testing

- Compiled and ran on development board. Verified `ioctl(fd, FIONREAD, &size)` returns expected available bytes.

