### PR TITLE
drivers/serial: Fix SIGINT not delivered to foreground process on Ctrl-C

### DIFF
--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -354,7 +354,7 @@ void uart_recvchars_done(FAR uart_dev_t *dev)
 
   if (signo != 0)
     {
-      nxsig_tgkill(-1, dev->pid, signo);
+      nxsig_kill(dev->pid, signo);
     }
 #endif
 }

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -311,7 +311,7 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
   if (signo != 0)
     {
-      nxsig_tgkill(-1, dev->pid, signo);
+      nxsig_kill(dev->pid, signo);
     }
 #endif
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where pressing Ctrl-C in a serial console does not deliver SIGINT to the foreground process, preventing proper process termination.

### Root Cause:
The serial driver called `nxsig_tgkill(-1, dev->pid, signo)` from interrupt context. With `pid=-1`, `nxsig_dispatch()` was invoked with `thread=true`, which requires `stcb->group == this_task()->group`. However, in interrupt context, `this_task()` returns the IDLE task, whose group differs from the target process group. This caused the signal dispatch to fail with `-ESRCH`.

### Changes:
- Replace `nxsig_tgkill(-1, pid, signo)` with `nxsig_kill(pid, signo)` in serial_dma.c
- Replace `nxsig_tgkill(-1, pid, signo)` with `nxsig_kill(pid, signo)` in serial_io.c

The `nxsig_kill()` function uses `thread=false`, which routes through `group_signal()` without the same-group check, allowing signals to be delivered correctly from interrupt context.

## Impact

- **Features**: Fixes Ctrl-C signal delivery in serial console environments
- **User Experience**: Users can now properly terminate foreground processes with Ctrl-C
- **Build**: No build system changes required
- **Hardware**: Affects all platforms using serial console with signal support
- **Documentation**: No documentation changes needed
- **Security**: No security implications
- **Compatibility**: Fully backward compatible, no API changes

## Testing

Tested on sim and arm64 platforms with serial console configurations.