### PR TITLE
arch/arm/nrf{52|53|91}: fix timer timeout value (overflow issue)

### DIFF
--- a/arch/arm/src/nrf52/nrf52_tim_lowerhalf.c
+++ b/arch/arm/src/nrf52/nrf52_tim_lowerhalf.c
@@ -50,11 +50,11 @@
 #define NRF52_TIMER_RES (NRF52_TIM_WIDTH_32B)
 #define NRF52_TIMER_MAX (4294967295ul)
 #define NRF52_TIMER_PRE (NRF52_TIM_PRE_1000000)
-#define NRF52_TIMER_PER (1000000)
+#define NRF52_TIMER_PER (1000000ull)
 
 /* Maximum supported timeout */
 
-#define NRF52_TIMER_MAXTIMEOUT (NRF52_TIMER_MAX * (1000000 / NRF52_TIMER_PER))
+#define NRF52_TIMER_MAXTIMEOUT (NRF52_TIMER_MAX * 1000000ull / NRF52_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -373,7 +373,7 @@ static int nrf52_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  cc = (timeout * NRF52_TIMER_PER / 1000000);
+  cc = (uint32_t)(timeout * NRF52_TIMER_PER / 1000000);
   NRF52_TIM_SETCC(priv->tim, NRF52_TIMER_CC, cc);
 
 errout:

--- a/arch/arm/src/nrf53/nrf53_tim_lowerhalf.c
+++ b/arch/arm/src/nrf53/nrf53_tim_lowerhalf.c
@@ -50,11 +50,11 @@
 #define NRF53_TIMER_RES (NRF53_TIM_WIDTH_32B)
 #define NRF53_TIMER_MAX (4294967295ul)
 #define NRF53_TIMER_PRE (NRF53_TIM_PRE_1000000)
-#define NRF53_TIMER_PER (1000000)
+#define NRF53_TIMER_PER (1000000ull)
 
 /* Maximum supported timeout */
 
-#define NRF53_TIMER_MAXTIMEOUT (NRF53_TIMER_MAX * (1000000 / NRF53_TIMER_PER))
+#define NRF53_TIMER_MAXTIMEOUT (NRF53_TIMER_MAX * 1000000ull / NRF53_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -373,7 +373,7 @@ static int nrf53_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  cc = (timeout * NRF53_TIMER_PER / 1000000);
+  cc = (uint32_t)(timeout * NRF53_TIMER_PER / 1000000);
   NRF53_TIM_SETCC(priv->tim, NRF53_TIMER_CC, cc);
 
 errout:

--- a/arch/arm/src/nrf91/nrf91_tim_lowerhalf.c
+++ b/arch/arm/src/nrf91/nrf91_tim_lowerhalf.c
@@ -50,11 +50,11 @@
 #define NRF91_TIMER_RES (NRF91_TIM_WIDTH_32B)
 #define NRF91_TIMER_MAX (4294967295ul)
 #define NRF91_TIMER_PRE (NRF91_TIM_PRE_1000000)
-#define NRF91_TIMER_PER (1000000)
+#define NRF91_TIMER_PER (1000000ull)
 
 /* Maximum supported timeout */
 
-#define NRF91_TIMER_MAXTIMEOUT (NRF91_TIMER_MAX * (1000000 / NRF91_TIMER_PER))
+#define NRF91_TIMER_MAXTIMEOUT (NRF91_TIMER_MAX * 1000000ull / NRF91_TIMER_PER)
 
 /****************************************************************************
  * Private Types
@@ -373,7 +373,7 @@ static int nrf91_timer_settimeout(struct timer_lowerhalf_s *lower,
       goto errout;
     }
 
-  cc = (timeout * NRF91_TIMER_PER / 1000000);
+  cc = (uint32_t)(timeout * NRF91_TIMER_PER / 1000000);
   NRF91_TIM_SETCC(priv->tim, NRF91_TIMER_CC, cc);
 
 errout:


### PR DESCRIPTION
## Summary

When setting the timeout, the timeout value is scaled wrongly. I think this was missed in commit https://github.com/apache/nuttx/commit/bcf309d80ed4156ba5111b88d080e08771cd801e @raiden00pl 

## Impact

This impacts nrf52, nrf53, and nrf91

## Testing

I tested it on the nrf52840-dk for a tickless configuration and could confirm that this patch fixes incorrect timeouts.