### PR TITLE
driver/note: Support poll threshold

### DIFF
--- a/Documentation/components/drivers/character/note.rst
+++ b/Documentation/components/drivers/character/note.rst
@@ -237,6 +237,23 @@ Noteram Device (``/dev/note``)
   :return: If success, 0 (``OK``) is returned and the given overwriter mode is set as the current settings.
     If failed, a negated ``errno`` is returned.
 
+.. c:macro:: FIONREAD
+
+  Get the number of unread bytes in the buffer
+
+  :argument: A writable pointer to ``unsigned int`` to receive the number of unread bytes.
+
+  :return: If success, 0 (``OK``) is returned and the number of unread bytes is stored into the given pointer.
+    If failed, a negated ``errno`` is returned.
+
+.. c:macro:: PIPEIOC_POLLINTHRD
+
+  Set the poll threshold for POLLIN event
+
+  :argument: An unsigned int value specifying the threshold in bytes. When the unread data in the buffer is greater than or equal to this value, POLLIN will be notified.
+
+  :return: If success, 0 (``OK``) is returned and the threshold is set. If failed, a negated ``errno`` is returned.
+
 Filter control APIs
 ===================
 


### PR DESCRIPTION
The noteram driver supports setting the poll threshold.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request adds support for configuring a poll threshold in the noteram driver. With this enhancement, users can set a threshold value, and the driver will only notify poll events when the unread data length meets or exceeds this threshold. This allows for more efficient and flexible event-driven data handling.

- Adds a `threshold` field to the noteram driver structure.
- Implements a new IOCTL command (`PIPEIOC_POLLINTHRD`) to set the poll threshold.
- Updates poll and add logic to respect the configured threshold.

## Impact

- Enables fine-grained control over when poll events are triggered in noteram.
- No impact on existing behavior unless the threshold is explicitly set.
- Backward compatible with previous noteram usage.

## Testing

- Verified that poll events are only triggered when the unread data length reaches the configured threshold.
- Tested with various threshold values to ensure correct event notification.
- No regressions observed in default or legacy usage scenarios.

