### PR TITLE
driver/note: Add tag to note_event_s and note_printf_s

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1520,6 +1520,7 @@ void sched_note_event_ip(uint32_t tag, uintptr_t ip, uint8_t event,
 
           note_common(tcb, &note->nev_cmn, length, event);
           note->nev_ip = ip;
+          note->nev_tag = tag;
           if (buf != NULL)
             {
               memcpy(note->nev_data, buf, length - SIZEOF_NOTE_EVENT(0));
@@ -1799,6 +1800,7 @@ void sched_note_vprintf_ip(uint32_t tag, uintptr_t ip, FAR const char *fmt,
           length = SIZEOF_NOTE_PRINTF(next);
           note_common(tcb, &note->npt_cmn, length, NOTE_DUMP_PRINTF);
           note->npt_ip = ip;
+          note->npt_tag = tag;
           note->npt_fmt = fmt;
           note->npt_type = type;
         }

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -472,6 +472,7 @@ struct note_printf_s
   struct note_common_s npt_cmn; /* Common note parameters */
   uintptr_t npt_ip;             /* Instruction pointer called from */
   FAR const char *npt_fmt;      /* Printf format string */
+  uint32_t npt_tag;             /* Printf tag */
   uint32_t npt_type;            /* Printf parameter type */
   char npt_data[1];             /* Print arguments */
 };
@@ -483,6 +484,7 @@ struct note_event_s
 {
   struct note_common_s nev_cmn;      /* Common note parameters */
   uintptr_t nev_ip;                  /* Instruction pointer called from */
+  uint32_t nev_tag;                  /* Event tag */
   uint8_t nev_data[1];               /* Event data */
 };
 


### PR DESCRIPTION
Record the tag in note_event_s and note_printf_s for log filtering.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request adds a `tag` field to both `note_event_s` and `note_printf_s` structures in the note driver. The tag is now recorded for each event and printf note, enabling more flexible log filtering and analysis based on tags.

- Adds `nev_tag` to `note_event_s` and `npt_tag` to `note_printf_s`.
- Updates event and printf note creation to record the tag value.

## Impact

- Enables log filtering and analysis by tag for all note events and printf notes.
- No impact on existing functionality except for the additional tag information.
- Backward compatible with previous note log consumers (new field is additive).

## Testing

- Verified that the tag is correctly recorded in both event and printf notes.
- Confirmed that log filtering by tag works as expected in downstream tools.
- No regressions observed in note logging or event handling.

