### PR TITLE
tools/parsetrace.py: Fix get_typesize bug in parsetrace.py

### DIFF
--- a/Documentation/components/tools/index.rst
+++ b/Documentation/components/tools/index.rst
@@ -7,6 +7,11 @@ This page discusses the contents of the NuttX tools/ directory.
 The tools/ directory contains miscellaneous scripts and host C programs
 that are necessary parts of the NuttX build system.
 
+.. toctree::
+   :maxdepth: 2
+
+   parsetrace
+
 cmpconfig.c
 -----------
 
@@ -1224,6 +1229,11 @@ Binaries for both Windows and Linux are available at:
     https://sourceforge.net/projects/uncrustify/files/
 
 See also indent.sh and nxstyle.c
+
+parsetrace.py
+-------------
+
+``parsetrace.py`` is a Python script for parsing and converting NuttX trace logs. See :doc:`parsetrace` for details.
 
 zds
 ---

--- a/Documentation/components/tools/parsetrace.rst
+++ b/Documentation/components/tools/parsetrace.rst
@@ -1,0 +1,75 @@
+parsetrace.py
+=============
+
+`parsetrace.py` is a trace log parsing tool for the NuttX RTOS. It supports converting binary or text trace logs into a human-readable systrace format, and can resolve symbols and type information from ELF files. The tool also supports real-time trace data parsing via serial port.
+
+Features
+--------
+- Supports parsing both binary and text trace log formats.
+- Integrates with ELF files to resolve symbols and type information for improved log readability.
+- Supports real-time trace data parsing from a serial device.
+- Outputs systrace-compatible format for performance analysis and debugging.
+
+Dependencies
+------------
+- Python 3
+- pyelftools
+- cxxfilt
+- pydantic
+- parse
+- pycstruct
+- colorlog
+- serial
+
+Install dependencies:
+
+.. code-block:: bash
+
+   pip install pyelftools cxxfilt pydantic parse pycstruct colorlog serial
+
+Usage
+-----
+
+.. code-block:: bash
+
+   python3 tools/parsetrace.py -t <trace_file> -e <elf_file> [-o <output_file>] [-v]
+
+Arguments:
+
+- ``-t, --trace``: Path to the original trace file (supports binary or text format)
+- ``-e, --elf``: Path to the NuttX ELF file (for symbol resolution)
+- ``-o, --output``: Output file path, default is ``trace.systrace``
+- ``-v, --verbose``: Enable verbose output
+- ``-d, --device``: Serial device name (for real-time trace parsing)
+- ``-b, --baudrate``: Serial baud rate, default is 115200
+
+Examples
+--------
+
+Parse a text trace log and output as systrace format:
+
+.. code-block:: bash
+
+   python3 tools/parsetrace.py -t trace.log -e nuttx.elf -o trace.systrace
+
+Parse a binary trace log:
+
+.. code-block:: bash
+
+   python3 tools/parsetrace.py -t trace.bin -e nuttx.elf
+
+Parse trace data from a serial device in real time:
+
+.. code-block:: bash
+
+   python3 tools/parsetrace.py -d /dev/ttyUSB0 -e nuttx.elf
+
+Main Classes and Functions
+--------------------------
+
+- ``SymbolTables``: Handles ELF symbol and type information parsing.
+- ``Trace``: Parses text trace logs.
+- ``ParseBinaryLogTool``: Parses binary trace logs.
+- ``TraceDecoder``: Parses real-time trace data from serial port.
+
+For more details, refer to the source code in ``tools/parsetrace.py``.

--- a/tools/parsetrace.py
+++ b/tools/parsetrace.py
@@ -133,9 +133,14 @@ class SymbolTables(object):
                     if name == type_name:
                         if "DW_AT_type" in DIE.attributes:
                             type_attr = DIE.attributes["DW_AT_type"]
-                            base_type_die = dwarfinfo.get_DIE_from_refaddr(
-                                type_attr.value + CU.cu_offset
-                            )
+                            if type_attr.form == "DW_FORM_ref_addr":
+                                base_type_die = dwarfinfo.get_DIE_from_refaddr(
+                                    type_attr.value
+                                )
+                            else:
+                                base_type_die = dwarfinfo.get_DIE_from_refaddr(
+                                    type_attr.value + CU.cu_offset
+                                )
                             if base_type_die.tag == "DW_TAG_base_type":
                                 size = base_type_die.attributes["DW_AT_byte_size"].value
                             elif base_type_die.tag == "DW_TAG_typedef":


### PR DESCRIPTION
For the following code, we need to check 'type_attr.form'. type_attr = DIE.attributes["DW_AT_type"]
base_type_die = dwarfinfo.get_DIE_from_refaddr(xxx)

When type_attr.form==DW_FORM_ref_addr, 'type_attr.value' means global reference (across compilation units).

When type_attr.form==DW_FORM_ref4, 'type_attr.value' means local reference (within the same compilation unit).

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request fixes a bug in `tools/parsetrace.py` related to the handling of DWARF type references in the `get_typesize` logic. The update ensures that the code correctly distinguishes between global and local DWARF references when resolving type information.

- Checks `type_attr.form` to determine if the reference is global (`DW_FORM_ref_addr`) or local (`DW_FORM_ref4`).
- Uses the appropriate offset calculation for each case when calling `get_DIE_from_refaddr`.

## Problem analysis


### DWARF Reference Handling in SymbolTables.get_typesize

This PR addresses the following code in `parsetrace.py`:

```python
base_type_die = dwarfinfo.get_DIE_from_refaddr(
    type_attr.value + CU.cu_offset
)
```

### What does this code do?
- This code retrieves a type definition (DIE, Debugging Information Entry) via a reference (refaddr) in DWARF debug information.
- `type_attr.value` is the reference value of a type attribute (such as DW_AT_type), usually an offset pointing to another DIE.
- `CU.cu_offset` is the starting offset of the current Compilation Unit (CU).
- Adding them gives the absolute offset of the target DIE in the DWARF file, and `get_DIE_from_refaddr` retrieves the DIE's details (base type, struct, etc).

### DWARF Version Differences and Compatibility
- **DWARF 2/3/4:** Reference attributes like `DW_AT_type` are usually CU-relative offsets. The code is generally correct for these versions.
- **DWARF 5:** Reference forms can be either global or CU-relative. If the reference is global, adding `CU.cu_offset` is incorrect and will cause errors. If CU-relative, the code is correct.
- **Compatibility:** The current code assumes all references are CU-relative, so it works for DWARF 2/3/4 but may fail for DWARF 5 with global references.

Parse the note data with `DWARF 2` elf file:
![20260126-221524](https://github.com/user-attachments/assets/82551b9f-4438-4f1d-9e1e-3cab1c1d8c44)

Parse the note data with `DWARF 5` elf file:
![20260126-221517](https://github.com/user-attachments/assets/0fb2f3f9-62d8-4a12-b57f-be1ec04ab384)

### Recommendation
To support all DWARF versions, check `type_attr.form` to determine the reference type and handle global and CU-relative offsets separately. For DWARF 5 compatibility, refer to pyelftools or the DWARF 5 standard for dynamic reference handling.

## Impact

- Fixes incorrect type resolution in trace parsing, especially for cross-compilation unit references.
- Improves compatibility with different DWARF reference forms.
- No impact on other tools or code outside `parsetrace.py`.

## Testing

- Verified correct type size resolution for both global and local DWARF references.
- Tested with multiple ELF files containing different DWARF reference forms.
- No regressions observed in trace parsing or symbol table handling.

