### PR TITLE
note/ram: support multiple noterams to dump data when panic occurs

### DIFF
--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -112,7 +112,8 @@ extern struct noteram_driver_s g_noteram_driver;
 int noteram_register(void);
 
 FAR struct note_driver_s *
-noteram_initialize(FAR const char *devpath, size_t bufsize, bool overwrite);
+noteram_initialize(FAR const char *devpath, size_t bufsize,
+                   bool overwrite, bool crashdump);
 #endif
 
 #endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */


### PR DESCRIPTION
When creating a noteram, you can choose whether to dump this noteram when the system crashes.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request adds support for multiple noteram instances to participate in crash dump collection when a system panic occurs. Previously, only a single noteram could be used for crash dumps. With this change, each noteram can be individually configured to enable or disable crash dump support at initialization.

- Adds a `crashdump` parameter to `noteram_initialize()` to control whether the noteram instance registers for crash dump notification.
- Refactors the crash dump registration logic to be per-instance, rather than global.
- Updates the driver structure to include a notifier block for each noteram instance.

## Impact

- Enables more flexible and fine-grained crash dump collection for systems with multiple noteram buffers.
- No impact on existing systems unless the new `crashdump` parameter is used.
- Maintains backward compatibility for existing APIs.

## Testing

- Manual testing with multiple noteram instances, verifying that only those with `crashdump=true` participate in crash dump collection.
- Confirmed that crash dump registration and dumping works as expected on panic.
- No regressions observed in normal operation or single-noteram configurations.

