### PR TITLE
driver/syslog: Implement the rate limiting function for ramlog driver.

### DIFF
--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -88,6 +88,11 @@
 
 #define SYSLOGIOC_SETFILTER _SYSLOGIOC(0x0002)
 
+/* Set/Get syslog ratelimit */
+
+#define SYSLOGIOC_SETRATELIMIT _SYSLOGIOC(0x0003)
+#define SYSLOGIOC_GETRATELIMIT _SYSLOGIOC(0x0004)
+
 #define SYSLOG_CHANNEL_NAME_LEN       32
 
 #define SYSLOG_CHANNEL_DISABLE        0x01
@@ -125,6 +130,12 @@ struct syslog_channel_ops_s
   syslog_write_t sc_write;        /* Write multiple bytes */
   syslog_write_t sc_write_force;  /* Write multiple bytes for interrupt handlers */
   syslog_close_t sc_close;        /* Channel close callback */
+};
+
+struct syslog_ratelimit_s
+{
+  unsigned int interval; /* The interval in seconds */
+  unsigned int burst;    /* The max allowed note number during interval */
 };
 
 struct syslog_channel_info_s


### PR DESCRIPTION
Limit the maximum number of log entries allowed within the specified time interval in seconds.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request implements rate limiting for the ramlog driver. The new feature allows users to limit the maximum number of log entries allowed within a specified time interval (in seconds), helping to prevent log flooding and improve system stability.

- Adds a `ramlog_ratelimit_s` structure to track interval, burst, and statistics.
- Implements rate limiting logic in the ramlog driver.
- Adds IOCTL commands (`SYSLOGIOC_SETRATELIMIT` and `SYSLOGIOC_GETRATELIMIT`) to configure and query rate limiting parameters.
- Updates the syslog header to define the new IOCTLs and ratelimit structure.

## Impact

- Prevents excessive log output by limiting log entry rate in ramlog.
- No impact on existing systems unless rate limiting is configured.
- Backward compatible with previous ramlog and syslog usage.

## Testing

- Verified that log entries are limited according to the configured interval and burst values.
- Tested IOCTL set/get operations for rate limiting parameters.
- No regressions observed in normal or legacy ramlog operation.

