### PR TITLE
syslog: use nx_syslog in kernel space

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -274,3 +274,26 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   lib_syslograwstream_close(&stream);
   return ret;
 }
+
+/****************************************************************************
+ * Name: nx_syslog
+ *
+ * Description:
+ *   nx_syslog() handles the system logging system calls. It is functionally
+ *   equivalent to syslog() but is used within the kernel space.
+ *
+ ****************************************************************************/
+
+void nx_syslog(int priority, FAR const IPTR char *fmt, ...)
+{
+  va_list ap;
+
+  if ((g_syslog_mask & LOG_MASK(priority)) != 0)
+    {
+      /* Let nx_vsyslog do all of the work */
+
+      va_start(ap, fmt);
+      nx_vsyslog(priority, fmt, &ap);
+      va_end(ap);
+    }
+}

--- a/include/syslog.h
+++ b/include/syslog.h
@@ -215,6 +215,22 @@ extern "C"
 
 #ifndef CONFIG_SYSLOG_TO_SCHED_NOTE
 void syslog(int priority, FAR const IPTR char *fmt, ...) syslog_like(2, 3);
+
+/****************************************************************************
+ * Name: nx_syslog
+ *
+ * Description:
+ *   nx_syslog() handles the system logging system calls. It is functionally
+ *   equivalent to syslog() but is used within the kernel space.
+ *
+ ****************************************************************************/
+
+#  ifdef __KERNEL__
+#    define syslog(priority, fmt, ...) nx_syslog(priority, fmt, ##__VA_ARGS__)
+#  endif
+
+void nx_syslog(int priority, FAR const IPTR char *fmt, ...)
+     syslog_like(2, 3);
 void vsyslog(int priority, FAR const IPTR char *fmt, va_list ap)
      syslog_like(2, 0);
 #else

--- a/libs/libc/syslog/lib_syslog.c
+++ b/libs/libc/syslog/lib_syslog.c
@@ -92,6 +92,7 @@ void vsyslog(int priority, FAR const IPTR char *fmt, va_list ap)
  *
  ****************************************************************************/
 
+#undef syslog
 void syslog(int priority, FAR const IPTR char *fmt, ...)
 {
   va_list ap;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This pull request introduces the use of `nx_syslog` in kernel space, providing a kernel-space equivalent to the standard `syslog()` function. The update ensures that system logging in the kernel is handled efficiently and consistently, while maintaining compatibility with user-space logging.

- Adds the `nx_syslog` function for kernel-space logging.
- Redefines `syslog` as `nx_syslog` when used in kernel space.
- Updates relevant headers and implementation files to support the new function.

## Impact

- Enables consistent and efficient logging in kernel space using `nx_syslog`.
- No impact on user-space logging or existing syslog usage in user applications.
- Backward compatible for user-space code; kernel code now uses the new function transparently.

## Testing

- Verified that kernel-space logging uses `nx_syslog` as expected.
- Confirmed that user-space logging remains unaffected.
- No regressions observed in system logging functionality.

