### PR TITLE
arch/x86_64: optimize assembly instructions for size and performance

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -272,8 +272,8 @@ start32:
 
 	/* Jump to 64 bit initialization if this is AP core */
 	mov     bsp_done, %eax
-	cmp     $0, %eax
-	jne     start64_init
+	test	%eax, %eax
+	jnz     start64_init
 
 	/* initialize rest of the page directory */
 	lea     g_pd_low, %edi
@@ -383,8 +383,8 @@ start64:
 
 	/* Start BSP or AP */
 	mov     bsp_done, %eax
-	cmp     $0, %eax
-	jne     ap_start
+	test    %eax, %eax
+	jnz     ap_start
 
 	/* Properly setup RSP to idle stack */
 	movabs  $g_idle_topstack,    %rbx
@@ -502,8 +502,8 @@ __enable_sse_avx:
 	/* Configure XSAVE/XRSTOR for user state*/
 	mov     $X86_XCR0_VAL, %eax
 
-	xor     %rdx,  %rdx
-	xor     %rcx,  %rcx
+	xor     %edx,  %edx
+	xor     %ecx,  %ecx
 	xsetbv
 
 #else

--- a/arch/x86_64/src/intel64/intel64_saveusercontext.S
+++ b/arch/x86_64/src/intel64/intel64_saveusercontext.S
@@ -107,10 +107,9 @@ up_saveusercontext:
 
 #ifdef CONFIG_ARCH_HAVE_SYSCALL
 	/* Save CS and SS if we support syscalls */
-	xor     %rax, %rax
-	mov     %cs, %ax
+	mov     %cs, %eax
 	movq    %rax, (8*REG_CS)(%rdi)
-	mov     %ss, %ax
+	mov     %ss, %eax
 	movq    %rax, (8*REG_SS)(%rdi)
 #endif
 
@@ -133,7 +132,7 @@ up_saveusercontext:
 	 * 'ret' will remove the RIP from the top of the stack.
 	 */
 
-	xor     %rax, %rax
+	xor     %eax, %eax
 	ret
 	.size    up_saveusercontext, . - up_saveusercontext
 	.end

--- a/arch/x86_64/src/intel64/intel64_vectors.S
+++ b/arch/x86_64/src/intel64/intel64_vectors.S
@@ -767,14 +767,13 @@ irq_common:
 	movq    %rbp, (8*REG_RBP)(%rdi)
 	movq    %rbx, (8*REG_RBX)(%rdi)
 
-	xor     %rax, %rax             /* Reset rax */
-	mov     %ds, %ax               /* Lower 16-bits of rax. */
+	mov     %ds, %eax              /* Lower 16-bits of rax. */
 	movq    %rax, (8*REG_DS)(%rdi) /* Save the data segment descriptor */
-	mov     %es, %ax               /* Lower 16-bits of rax. */
+	mov     %es, %eax              /* Lower 16-bits of rax. */
 	movq    %rax, (8*REG_ES)(%rdi) /* Save the data segment descriptor */
-	mov     %gs, %ax               /* Lower 16-bits of rax. */
+	mov     %gs, %eax              /* Lower 16-bits of rax. */
 	movq    %rax, (8*REG_GS)(%rdi) /* Save the data segment descriptor */
-	mov     %fs, %ax               /* Lower 16-bits of rax. */
+	mov     %fs, %eax              /* Lower 16-bits of rax. */
 	movq    %rax, (8*REG_FS)(%rdi) /* Save the data segment descriptor */
 
 #ifdef CONFIG_SCHED_THREAD_LOCAL


### PR DESCRIPTION
## Summary

This PR optimizes the x86_64 assembly code to reduce code size and reduce length changing prefix (LCP) stalls in hot code.

key optimizations include:

- Reducing the use of length changing prefixes (LCPs) which cause bottlenecks in instruction predecoders in modern x86_64 microarchitectures
- Using xor reg32, reg32 instead of xor reg64, reg64 to zero registers. In x86_64 32 bit operations are zero extended to 64 bits. This saves us one byte (the REX.W prefix) per instruction
- Replacing cmp $0, reg with test reg, reg to reduce instruction length by one byte

## Impact

- Minor reduction in code size for the x86_64 kernel
- Performance optimization in irq_common and up_saveusercontext by reducing predecoder stalls on microarchitectures sensitive to LCPs

## Testing

- Host: Linux x86_64
- Board: qemu-intel64:nsh
- ostest passed
