### PR TITLE
crypto/cryptosoft: Fix HMAC-SHA when a long key is used

### DIFF
--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -755,10 +755,17 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
                 return -ENOBUFS;
               }
 
+            /* If the key is too long, hash it first using ictx */
+
             if (cri->cri_klen / 8 > axf->keysize)
               {
-                swcr_freesession(i);
-                return -EINVAL;
+                axf->init((*swd)->sw_ictx);
+                axf->update((*swd)->sw_ictx,
+                            (FAR uint8_t *)cri->cri_key,
+                            cri->cri_klen / 8);
+                axf->final((unsigned char *)cri->cri_key,
+                           (*swd)->sw_ictx);
+                cri->cri_klen = axf->hashsize * 8;
               }
 
             for (k = 0; k < cri->cri_klen / 8; k++)

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -333,7 +333,7 @@ const struct enc_xform enc_xform_null =
 const struct auth_hash auth_hash_hmac_md5_96 =
 {
   CRYPTO_MD5_HMAC, "HMAC-MD5",
-  16, 16, 12, sizeof(MD5_CTX), HMAC_MD5_BLOCK_LEN,
+  HMAC_MD5_BLOCK_LEN, 16, 12, sizeof(MD5_CTX), HMAC_MD5_BLOCK_LEN,
   (void (*) (FAR void *)) md5init, NULL, NULL,
   md5update_int,
   (void (*) (FAR uint8_t *, FAR void *)) md5final
@@ -342,7 +342,7 @@ const struct auth_hash auth_hash_hmac_md5_96 =
 const struct auth_hash auth_hash_hmac_sha1_96 =
 {
   CRYPTO_SHA1_HMAC, "HMAC-SHA1",
-  20, 20, 12, sizeof(SHA1_CTX), HMAC_SHA1_BLOCK_LEN,
+  HMAC_SHA1_BLOCK_LEN, 20, 12, sizeof(SHA1_CTX), HMAC_SHA1_BLOCK_LEN,
   (void (*) (FAR void *)) sha1init, NULL, NULL,
   sha1update_int,
   (void (*) (FAR uint8_t *, FAR void *)) sha1final
@@ -360,7 +360,7 @@ const struct auth_hash auth_hash_hmac_ripemd_160_96 =
 const struct auth_hash auth_hash_hmac_sha2_256_128 =
 {
   CRYPTO_SHA2_256_HMAC, "HMAC-SHA2-256",
-  32, 32, 16, sizeof(SHA2_CTX), HMAC_SHA2_256_BLOCK_LEN,
+  HMAC_SHA2_256_BLOCK_LEN, 32, 16, sizeof(SHA2_CTX), HMAC_SHA2_256_BLOCK_LEN,
   (void (*)(FAR void *)) sha256init, NULL, NULL,
   sha256update_int,
   (void (*)(FAR uint8_t *, FAR void *)) sha256final
@@ -369,7 +369,7 @@ const struct auth_hash auth_hash_hmac_sha2_256_128 =
 const struct auth_hash auth_hash_hmac_sha2_384_192 =
 {
   CRYPTO_SHA2_384_HMAC, "HMAC-SHA2-384",
-  48, 48, 24, sizeof(SHA2_CTX), HMAC_SHA2_384_BLOCK_LEN,
+  HMAC_SHA2_384_BLOCK_LEN, 48, 24, sizeof(SHA2_CTX), HMAC_SHA2_384_BLOCK_LEN,
   (void (*)(FAR void *)) sha384init, NULL, NULL,
   sha384update_int,
   (void (*)(FAR uint8_t *, FAR void *)) sha384final
@@ -378,7 +378,7 @@ const struct auth_hash auth_hash_hmac_sha2_384_192 =
 const struct auth_hash auth_hash_hmac_sha2_512_256 =
 {
   CRYPTO_SHA2_512_HMAC, "HMAC-SHA2-512",
-  64, 64, 32, sizeof(SHA2_CTX), HMAC_SHA2_512_BLOCK_LEN,
+  HMAC_SHA2_512_BLOCK_LEN, 64, 32, sizeof(SHA2_CTX), HMAC_SHA2_512_BLOCK_LEN,
   (void (*)(FAR void *)) sha512init, NULL, NULL,
   sha512update_int,
   (void (*)(FAR uint8_t *, FAR void *)) sha512final


### PR DESCRIPTION

Hi all, I discovered a bug within the HMAC-SHA implementation, here is my proposed fix. However, I have a couple of questions that need some clarification, apologies if this isn't the proper channel.

## Summary

Using HMAC-SHA with longer keys results in a failed test.
This can be seen using the changes I made in [this PR](https://github.com/apache/nuttx-apps/pull/3376)
The changes from the PR are also used to validate my fix.

The issue stems from the code explicitly refusing keys larger than `auth_hash.keysize`. In reality, the RFC standard doesn't mention any key size limit. Instead, if a key is larger than the algorithm's block size, the key should first be hashed before using. ([2.Definition of HMAC](https://datatracker.ietf.org/doc/html/rfc2104#section-2))

The fix is fairly straightforward, it adds a key context (kctx) to be used along ictx and octx. When needed, the keys are hashed first.
Updated values for `auth_hash.keysize` are also included.

Modified files:

crypto/cryptosoft.c - adds operation for hashing keys that are too long
include/crypto/cryptosoft.h - adds kctx field
crypto/xform.c - fixes keysize

## Impact

The bug affects the software implementation as well as the hardware ESP32 implementation. I haven't checked the other hardware implementations. Currently, the PR only fixes the software implementation, although I plan to update it with the fix for ESP32 as well. Here, the first question appears:

**As far as I can tell, the fix for ESP32 will be identical with the software one. Since I also have the hardware available I will also test the fix. If there are other platforms affected by this, and if the fix for them would be the same, should I also port the fix there, even if I can't test it on real hardware?**

My second question is:

**When searching for loose ends, I stumbled across [this file](https://github.com/apache/nuttx/blob/master/crypto/hmac.c). Best I can tell the functions inside aren't used anywhere? The init functions appear to be processing this edge case correctly, but as I've said, they aren't used. So, what to do about this file?**

## Testing

Development was done using ESP32 DevkitC.
Building was done on Ubuntu 24.04 VM.
For testing, I ran the official crypto HMAC test, to which I added cases for this specific case from the RFC doc.
```
nsh> hmac
hmac md5 success
hmac md5 success
hmac md5 success
hmac md5 success
hmac md5 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
```

