### PR TITLE
arch/arm/src/imxrt: Fix Ethernet RUNNING status regression

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1508,6 +1508,7 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
   imxrt_enet_modifyreg32(priv, IMXRT_ENET_EIMR_OFFSET, TX_INTERRUPTS,
                          priv->ints);
 
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -1595,6 +1596,7 @@ static int imxrt_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->bifup = false;
+  netdev_carrier_off(dev);
   leave_critical_section(flags);
   return OK;
 }

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -2286,6 +2286,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   up_enable_irq(STM32_IRQ_ETH);
 
   stm32_checksetup();
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -2351,6 +2352,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
+  netdev_carrier_off(dev);
   leave_critical_section(flags);
   return ret;
 }

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -2327,6 +2327,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   up_enable_irq(STM32_IRQ_ETH);
 
   stm32_checksetup();
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -2372,6 +2373,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
+  netdev_carrier_off(dev);
   leave_critical_section(flags);
   return OK;
 }

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -2499,6 +2499,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   up_enable_irq(STM32_IRQ_ETH);
 
   stm32_checksetup();
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -2544,6 +2545,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
+  netdev_carrier_off(dev);
   leave_critical_section(flags);
   return OK;
 }


### PR DESCRIPTION
## Summary

Recent changes in the networking stack require the `IFF_RUNNING` flag for effective traffic processing (see #18110). Several Ethernet drivers were missing the `netdev_carrier_on()` and `netdev_carrier_off()` calls required to update this status when the link goes up or down.

This PR adds these calls to the following drivers:

- `arch/arm/src/imxrt/imxrt_enet.c`
- `arch/arm/src/stm32f7/stm32_ethernet.c`
- `arch/arm/src/stm32h7/stm32_ethernet.c`
- `arch/arm/src/stm32/stm32_eth.c`

**Note**: Previous changes to `include/nuttx/trace.h` have been dropped as the corruption in master was resolved by #18142.

## Impact

- **New feature**: No
- **Bug fix**: Yes (Fixes Ethernet functional regression)
- **Impacted areas**: Ethernet drivers (IMXRT, STM32).

## Testing

### Hardware Verification Request

I do not have access to IMXRT or STM32 physical hardware for direct validation. Technical analysis confirms these changes align with the standard pattern used in other working drivers (e.g., `s32k1xx_enet.c`, `kinetis_enet.c`).

**Request for Community Testing**:
I'd appreciate validation from the community on affected hardware (basic ping, TCP/UDP tests).

CC: @PetervdPerk-NXP (Original reporter of #18110) - please verify if this resolves the RUNNING status regression on your setup.

### Software Verification

- **Code Style**: All modified files pass `./tools/checkpatch.sh`.
- **Compilation**: Verified compilation for affected targets in CI.

## PR verification Self-Check

- [x] I have read [CONTRIBUTING.md](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).
- [x] My follow NuttX [Coding Standard](https://github.com/apache/nuttx/blob/master/Documentation/contributing/coding_style.rst).
- [x] I have used `checkpatch.sh` to verify style.
- [x] Commits include `Signed-off-by`.
- [x] PR title follows `subsystem: description` format.
