### PR TITLE
spinlock: Simplify instrumentation interface by removing wrapper functions

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -1155,10 +1155,10 @@ void sched_note_csection(FAR struct tcb_s *tcb, bool enter)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
-void sched_note_spinlock(FAR struct tcb_s *tcb,
-                         FAR volatile spinlock_t *spinlock,
+void sched_note_spinlock(FAR volatile spinlock_t *spinlock,
                          int type)
 {
+  FAR struct tcb_s *tcb = running_task();
   struct note_spinlock_s note;
   FAR struct note_driver_s **driver;
   bool formatted = false;
@@ -1196,27 +1196,6 @@ void sched_note_spinlock(FAR struct tcb_s *tcb,
       note_add(*driver, &note, sizeof(struct note_spinlock_s));
     }
 }
-
-void sched_note_spinlock_lock(FAR volatile spinlock_t *spinlock)
-{
-  sched_note_spinlock(this_task(), spinlock, NOTE_SPINLOCK_LOCK);
-}
-
-void sched_note_spinlock_locked(FAR volatile spinlock_t *spinlock)
-{
-  sched_note_spinlock(this_task(), spinlock, NOTE_SPINLOCK_LOCKED);
-}
-
-void sched_note_spinlock_abort(FAR volatile spinlock_t *spinlock)
-{
-  sched_note_spinlock(this_task(), spinlock, NOTE_SPINLOCK_ABORT);
-}
-
-void sched_note_spinlock_unlock(FAR volatile spinlock_t *spinlock)
-{
-  sched_note_spinlock(this_task(), spinlock, NOTE_SPINLOCK_UNLOCK);
-}
-
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -632,11 +632,9 @@ void sched_note_csection(FAR struct tcb_s *tcb, bool enter);
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS
-void sched_note_spinlock(FAR struct tcb_s *tcb,
-                         FAR volatile spinlock_t *spinlock,
-                         int type);
+void sched_note_spinlock(FAR volatile spinlock_t *spinlock, int type);
 #else
-#  define sched_note_spinlock(tcb, spinlock, type)
+#  define sched_note_spinlock(spinlock, type)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL


### PR DESCRIPTION
## Summary

This pull request refactors the spinlock instrumentation interface to eliminate redundant wrapper functions. Instead of calling separate `sched_note_spinlock_lock()`, `sched_note_spinlock_locked()`, `sched_note_spinlock_abort()`, and `sched_note_spinlock_unlock()` functions, the code now directly calls the unified `sched_note_spinlock()` function with the appropriate event type parameter. This simplification reduces code duplication, improves maintainability, and eliminates unnecessary function call overhead.

## Changes

**File modifications:**
- `include/nuttx/spinlock.h`: Removed 4 wrapper function declarations, updated all inline calls to use `sched_note_spinlock(spinlock, type)` directly, added include for `<nuttx/sched_note.h>`
- `drivers/note/note_driver.c`: Removed 4 wrapper function implementations, modified `sched_note_spinlock()` to accept `(spinlock, type)` and get current task internally via `running_task()`
- `include/nuttx/sched_note.h`: Updated `sched_note_spinlock()` function signature and stub macro

**Statistics**: 14 insertions(+), 48 deletions(-) - net reduction of 34 lines

## Impact

- **Code Quality**: Eliminates 4 redundant wrapper functions, reduces duplication
- **Maintainability**: Single unified interface instead of 5 variations
- **Performance**: Removes wrapper function call overhead in critical spinlock path
- **API Design**: Cleaner interface with explicit event type parameter
- **Backward Compatibility**: Internal API change only, no impact on external users

## Technical Justification

**Why consolidate instrumentation?**

1. **Reduce duplication**: Four wrapper functions performing nearly identical operations
2. **Unified interface**: Single function handles all spinlock instrumentation events
3. **Explicit semantics**: Type parameter clearly indicates which event is being recorded
4. **Easier maintenance**: Changes to spinlock instrumentation happen in one place
5. **Lower overhead**: Direct function calls eliminate wrapper invocation cost

**Signature change:**
- Before: `sched_note_spinlock(tcb, spinlock, type)`
- After: `sched_note_spinlock(spinlock, type)` with `tcb` obtained via `running_task()`

## Testing

Verified with:
- ✅ Spinlock instrumentation captures all event types correctly
- ✅ Build succeeds with CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS enabled/disabled
- ✅ No functional regression in spinlock operations
- ✅ Trace events properly recorded for LOCK, LOCKED, ABORT, UNLOCK states
- ✅ Performance metrics stable or improved

## Related Work

Part of spinlock optimization series focusing on code simplification and interface consolidation.