### PR TITLE
arch/stm32: Add counter reset function

### DIFF
--- a/arch/arm/src/stm32/stm32_capture.c
+++ b/arch/arm/src/stm32/stm32_capture.c
@@ -1110,8 +1110,8 @@ static int stm32_cap_setchannel(struct stm32_cap_dev_s *dev,
   switch (cfg & STM32_CAP_EDGE_MASK)
     {
       case STM32_CAP_EDGE_DISABLED:
-        regval = 0;
         ccer_en_bit = 0;
+        regval = 0;
         break;
 
       case STM32_CAP_EDGE_RISING:
@@ -1234,6 +1234,14 @@ static uint32_t stm32_cap_getcapture(struct stm32_cap_dev_s *dev,
   return stm32_getreg16(priv, offset);
 }
 
+static uint32_t stm32_cap_rstcounter(struct stm32_cap_dev_s *dev)
+{
+  const struct stm32_cap_priv_s *priv = (const struct stm32_cap_priv_s *)dev;
+
+  stm32_modifyreg16(priv, STM32_BTIM_EGR_OFFSET, 0, BTIM_EGR_UG);
+  return OK;
+}
+
 /****************************************************************************
  * Advanced Functions
  ****************************************************************************/
@@ -1253,7 +1261,8 @@ struct stm32_cap_ops_s stm32_cap_ops =
   .setisr       = &stm32_cap_setisr,
   .enableint    = &stm32_cap_enableint,
   .ackflags     = &stm32_cap_ackflags,
-  .getflags     = &stm32_cap_getflags
+  .getflags     = &stm32_cap_getflags,
+  .rstcounter   = &stm32_cap_rstcounter,
 };
 
 #ifdef CONFIG_STM32_TIM1_CAP

--- a/arch/arm/src/stm32/stm32_capture.h
+++ b/arch/arm/src/stm32/stm32_capture.h
@@ -47,6 +47,7 @@
 #define STM32_CAP_ENABLEINT(d,s,on)             ((d)->ops->enableint(d,s,on))
 #define STM32_CAP_ACKFLAGS(d,f)                 ((d)->ops->ackflags(d,f))
 #define STM32_CAP_GETFLAGS(d)                   ((d)->ops->getflags(d))
+#define STM32_CAP_RSTCOUNTER(d)                 ((d)->ops->rstcounter(d))
 
 /****************************************************************************
  * Public Types
@@ -79,6 +80,8 @@ typedef enum
   STM32_CAP_MAPPED_MASK         = (GTIM_CCMR1_CC1S_MASK),
   STM32_CAP_MAPPED_TI1          = (GTIM_CCMR_CCS_CCIN1),
   STM32_CAP_MAPPED_TI2          = (GTIM_CCMR_CCS_CCIN2),
+  STM32_CAP_MAPPED_TI3          = (GTIM_CCMR_CCS_CCIN1),
+  STM32_CAP_MAPPED_TI4          = (GTIM_CCMR_CCS_CCIN2),
 
 /* TODO STM32_CAP_MAPPED_TRC     = (GTIM_CCMR_CCS_CCINTRC), */
 
@@ -196,6 +199,7 @@ struct stm32_cap_ops_s
                     bool on);
   void (*ackflags)(struct stm32_cap_dev_s *dev, int flags);
   stm32_cap_flags_t (*getflags)(struct stm32_cap_dev_s *dev);
+  uint32_t (*rstcounter)(struct stm32_cap_dev_s *dev);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Added stm32_cap_rstcounter() function to reset the capture counter by generating an update event. The function is integrated into the capture operations structure and exposed via STM32_CAP_RSTCOUNTER macro. Also added TI3 and TI4 input mappings for extended capture channel support.

I need to measure the time of an external signal. I created my own driver for this, but for it to work, I need to reset the timer.

## Impact

On stm32 capture driver.

## Testing

On stm32f103-minimum:nsh
