### PR TITLE
doc: Update Host Tools section.

### DIFF
--- a/Documentation/components/tools/index.rst
+++ b/Documentation/components/tools/index.rst
@@ -1,16 +1,14 @@
-=====================
-``/tools`` Host Tools
-=====================
+==========
+Host Tools
+==========
 
-This page discusses the contents of the NuttX tools/ directory.
+This page discusses the ``tools/`` directory containing miscellaneous scripts
+and host C programs that are important parts of the NuttX build system:
 
-The tools/ directory contains miscellaneous scripts and host C programs
-that are necessary parts of the NuttX build system.
-
-.. toctree::
-   :maxdepth: 2
-
-   parsetrace
+.. contents::
+    :local:
+    :backlinks: entry
+    :depth: 2
 
 cmpconfig.c
 -----------
@@ -1233,7 +1231,14 @@ See also indent.sh and nxstyle.c
 parsetrace.py
 -------------
 
-``parsetrace.py`` is a Python script for parsing and converting NuttX trace logs. See :doc:`parsetrace` for details.
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   parsetrace
+
+``parsetrace.py`` is a Python script for parsing and converting NuttX trace
+logs. See dedicated :doc:`parsetrace` section for details.
 
 zds
 ---


### PR DESCRIPTION
## Summary

* Remove `tools/` from the section name (it was `tools/ Host Tools` before).
* Generate local TOC that lists described tools.
* Update new parsetrace.py utility (https://github.com/apache/nuttx/pull/18124) toctree location to fix indexing and display.

## Impact

Documentation: Host Tools display, indexing, references.

## Testing

```
% uname -a
FreeBSD hexagon 14.3-RELEASE-p7 FreeBSD 14.3-RELEASE-p7 GENERIC amd64

% cd Documentation
% pipenv shell
% gmake autobuild
(..)
build succeeded.

The HTML pages are in _build.
[sphinx-autobuild] Serving on http://127.0.0.1:8000
[sphinx-autobuild] Detected changes (_tags)
[sphinx-autobuild] Rebuilding...
```