### PR TITLE
doc: Improve sphinx build time + add autobuild help info.

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -24,8 +24,8 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 # Ignore the _tags directory as per sphinx-tags docs to avoid infinite loop
-SPHINXOPTS      ?= -j 1 -W -A nuttx_versions="latest,${NUTTX_VERSIONS}"
-SPHINXAUTOOPTS  ?= -j 8 -W --ignore "_tags/*"
+SPHINXOPTS      ?= -j auto -W -A nuttx_versions="latest,${NUTTX_VERSIONS}"
+SPHINXAUTOOPTS  ?= -j auto -W --ignore "_tags/*"
 SPHINXBUILD     ?= sphinx-build
 SPHINXAUTOBUILD ?= sphinx-autobuild
 SOURCEDIR       = .
@@ -33,6 +33,10 @@ BUILDDIR        = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
+	$(info =>)
+	$(info => Use `make autobuild` to build live preview of the documentation.)
+	$(info => You can then watch live edit changes at http://localhost:8000.)
+	$(info =>)
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile


### PR DESCRIPTION
## Summary

* Update previous `-j 1` and `-j 8` switch to `-j auto` to use all CPUs.
* This improves doc build time 62s -> 25s on 24 core CPU.
* Add information about `make autobuild` to `make help`.
* Auotbuild is very handy for quick edits preview and was not in help before.

## Impact

Documentation build time is improved ~2.5x on modern CPUs.

## Testing

```
% uname -a
FreeBSD hexagon 14.3-RELEASE-p7 FreeBSD 14.3-RELEASE-p7 GENERIC amd64

% cd Documentation
% pipenv shell
```

Before change:

```
% /usr/bin/time -h gmake clean html
Removing everything under '_build'...
Running Sphinx v6.2.1
(..)
build succeeded.

The HTML pages are in _build/html.
	1m4,40s real		1m3,62s user		0,72s sys
```

After change:

```
% /usr/bin/time gmake clean html
Removing everything under '_build'...
Running Sphinx v6.2.1
(..)
build succeeded.

The HTML pages are in _build/html.
       25,31 real        72,79 user         7,26 sys
```