### PR TITLE
syscall: add sched_note_event_ip syscall for instrumentation dump

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -401,4 +401,5 @@ SYSCALL_LOOKUP(signal,                     2)
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
   SYSCALL_LOOKUP(sched_note_vprintf_ip,    5)
+  SYSCALL_LOOKUP(sched_note_event_ip,      5)
 #endif

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -136,6 +136,7 @@
 "sched_getscheduler","sched.h","","int","pid_t"
 "sched_lock","sched.h","","void"
 "sched_lockcount","sched.h","","int"
+"sched_note_event_ip","nuttx/sched_note.h","defined(CONFIG_SCHED_INSTRUMENTATION_DUMP)","void","uint32_t","uintptr_t","uint8_t","FAR const void *","size_t"
 "sched_note_vprintf_ip","nuttx/sched_note.h","defined(CONFIG_SCHED_INSTRUMENTATION_DUMP)","void","uint32_t","uintptr_t","FAR const IPTR char *","uint32_t","FAR va_list *"
 "sched_rr_get_interval","sched.h","","int","pid_t","struct timespec *"
 "sched_setaffinity","sched.h","defined(CONFIG_SMP)","int","pid_t","size_t","FAR const cpu_set_t*"


### PR DESCRIPTION
Export the sched_note_event_ip function as a syscall under CONFIG_SCHED_INSTRUMENTATION_DUMP. This allows user-space or other kernel components to trigger event-type logs via the instrumentation dump mechanism.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR adds the `sched_note_event_ip` syscall, making the function available to user-space or other kernel components when `CONFIG_SCHED_INSTRUMENTATION_DUMP` is enabled. This change updates the syscall lookup table and syscall definition to support event-type log output through instrumentation.

## Impact

- Adds a new syscall entry for `sched_note_event_ip` (only effective if `CONFIG_SCHED_INSTRUMENTATION_DUMP` is enabled).
- No impact on existing features or configurations unless the instrumentation dump is enabled.

## Testing

- Verified that the syscall is generated and available when the configuration is enabled.
- Confirmed that the build passes and the syscall can be invoked as expected.

