### PR TITLE
note: add NOTE_DUMP_BINARY support for binary log dumping

### DIFF
--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -1212,11 +1212,30 @@ static int noteram_dump_one(FAR uint8_t *p, FAR struct lib_outstream_s *s,
       break;
     case NOTE_DUMP_MARK:
       {
-        int len = note->nc_length - sizeof(struct note_event_s);
         FAR struct note_event_s *nbi = (FAR struct note_event_s *)p;
+        int len = note->nc_length - SIZEOF_NOTE_EVENT(0);
+
         ret += noteram_dump_header(s, &nbi->nev_cmn, ctx);
         ret += lib_sprintf(s, "tracing_mark_write: I|%d|%.*s\n",
                            pid, len, (FAR const char *)nbi->nev_data);
+      }
+      break;
+      case NOTE_DUMP_BINARY:
+      {
+        FAR struct note_event_s *nbi = (FAR struct note_event_s *)p;
+        int len = note->nc_length - SIZEOF_NOTE_EVENT(0);
+        int i;
+
+        ret += noteram_dump_header(s, &nbi->nev_cmn, ctx);
+        ret += lib_sprintf(s, "tracing_mark_write: I|%d|", pid);
+
+        for (i = 0; i < len; i++)
+          {
+            ret += lib_sprintf(s, "%02x ", nbi->nev_data[i]);
+          }
+
+        lib_stream_putc(s, '\n');
+        ret++;
       }
       break;
     case NOTE_DUMP_COUNTER:

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -271,6 +271,7 @@ enum note_type_e
   NOTE_DUMP_BEGIN,
   NOTE_DUMP_END,
   NOTE_DUMP_MARK,
+  NOTE_DUMP_BINARY,
   NOTE_DUMP_COUNTER,
 
   /* Always last */


### PR DESCRIPTION
Add NOTE_DUMP_BINARY to the note_type_e enum and implement its handling in noteram_dump_one. This enables the recording and dumping of binary logs in hexadecimal format, improving traceability for binary event data.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR adds support for a new note type, `NOTE_DUMP_BINARY`, to the NuttX scheduler note system. The change extends the `note_type_e` enumeration and updates the `noteram_dump_one` function to handle binary dump events. When a `NOTE_DUMP_BINARY` event is encountered, the driver will output the associated data in hexadecimal format, enabling the recording and analysis of binary logs.

## Impact

- Adds a new note type for binary log dumping.
- Enhances the debugging and traceability capabilities for binary event data.
- No impact on existing note types or normal operation.

## Testing

- Verified that NOTE_DUMP_BINARY events are correctly recorded and dumped in hexadecimal format.
- Existing note dump and mark functionalities remain unaffected.
- No regressions observed in standard note tracing scenarios.

