### PR TITLE
sched: Remove FS_PROCFS dependency for SCHED_CRITMONITOR

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -910,7 +910,6 @@ config SCHED_IRQMONITOR
 config SCHED_CRITMONITOR
 	bool "Enable Critical Section monitoring"
 	default n
-	depends on FS_PROCFS
 	select IRQCOUNT
 	---help---
 		Enables logic that monitors the duration of time that a thread keeps


### PR DESCRIPTION
## Summary

sched: Remove FS_PROCFS dependency for SCHED_CRITMONITOR

Allow SCHED_CRITMONITOR to be enabled without requiring FS_PROCFS,
so it can be used in scenarios like calculating CPU load via
SCHED_CPULOAD_CRITMONITOR where procfs is not available.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

select SCHED_CRITMONITOR without FS_PROCFS