### PR TITLE
arch/risc-v: fix timer initialization for SMP mode using mtimer

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -123,6 +123,8 @@ void riscv_cpu_boot(int cpu)
   sched_note_cpu_started(this_task());
 #endif
 
+  riscv_timer_secondary_init();
+
   up_irq_enable();
 
   /* Then transfer control to the IDLE task */

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -365,6 +365,7 @@ void riscv_color_intstack(void);
 #ifdef CONFIG_SMP
 void riscv_cpu_boot(int cpu);
 int riscv_smp_call_handler(int irq, void *c, void *arg);
+void riscv_timer_secondary_init(void);
 #endif
 
 #ifdef CONFIG_ARCH_RV_CPUID_MAP


### PR DESCRIPTION
## Summary

Correct timer initialization issue in risc-v SMP mode to ensure
per-hart timers are properly set up during boot.

## Impact

This change is isolated in riscv qemu port improvement

## Testing

**ostest passed on rv-virt:smp64**

```
NuttShell (NSH)
nsh> 
nsh> 
nsh> 
nsh> uname -a
NuttX 0.0.0 f616af34b4 Jan 27 2026 13:35:10 risc-v rv-virt
nsh> ostest

(...)

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc1220  1fc1220
ordblks         1        7
mxordblk  1fb6110  1fa03a8
uordblks     b110    174a0
fordblks  1fb6110  1fa9d80
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```

