### PR TITLE
sched: call spinlock nopreempt when need disable context swi…

### DIFF
--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -2408,8 +2408,7 @@ static void hciuart_dma_rxcallback(DMA_HANDLE handle, uint8_t status,
 
   if (config.state->rxdmastream == NULL)
     {
-      spin_unlock_irqrestore(&config->lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&config->lock, flags);
       return;
     }
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -849,8 +849,7 @@ void _assert(FAR const char *filename, int linenum,
   flags = 0; /* suppress GCC warning */
   if (os_ready)
     {
-      flags = spin_lock_irqsave(&g_assert_lock);
-      sched_lock();
+      flags = spin_lock_irqsave_nopreempt(&g_assert_lock);
     }
 
 #if CONFIG_BOARD_RESET_ON_ASSERT < 2
@@ -925,7 +924,6 @@ void _assert(FAR const char *filename, int linenum,
 
   if (os_ready)
     {
-      spin_unlock_irqrestore(&g_assert_lock, flags);
-      sched_unlock();
+      spin_unlock_irqrestore_nopreempt(&g_assert_lock, flags);
     }
 }


### PR DESCRIPTION
## Summary

Call spinlock nopreempt when need disable context switch.
    
    Using spin_lock_irqsave_nopreempt and spin_unlock_irqrestore_nopreempt to replace the following case.
    flags = spin_lock_irqsave(lock);
    sched_lock();
    .....
    spin_unlock_irqrestore(lock, flags);
    sched_unlock();

## Impact

None

## Testing

ostest
