### PR TITLE
sched/signal: Optimize code logic

### DIFF
--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -82,56 +82,35 @@ void up_schedule_sigaction(struct tcb_s *tcb)
   sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
         this_task()->xcp.regs);
 
-  /* First, handle some special cases when the signal is
-   * being delivered to the currently executing task.
+  /* Save the return lr and cpsr and one scratch register
+   * These will be restored by the signal trampoline after
+   * the signals have been delivered.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
-    {
-      /* In this case just deliver the signal now. */
+  /* Save the current register context location */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
+  tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-  /* Otherwise, we are (1) signaling a task is not running
-   * from an interrupt handler or (2) we are not in an
-   * interrupt handler and the running task is signalling
-   * some non-running task.
+  /* Duplicate the register context.  These will be
+   * restored by the signal trampoline after the signal has been
+   * delivered.
    */
 
-  else
-    {
-      /* Save the return lr and cpsr and one scratch register
-       * These will be restored by the signal trampoline after
-       * the signals have been delivered.
-       */
+  tcb->xcp.regs            = (void *)
+                             ((uint32_t)tcb->xcp.regs -
+                                        XCPTCONTEXT_SIZE);
+  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-      /* Save the current register context location */
+  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                       XCPTCONTEXT_SIZE;
 
-      tcb->xcp.saved_regs      = tcb->xcp.regs;
+  /* Then set up to vector to the trampoline with interrupts
+   * disabled
+   */
 
-      /* Duplicate the register context.  These will be
-       * restored by the signal trampoline after the signal has been
-       * delivered.
-       */
-
-      tcb->xcp.regs            = (void *)
-                                 ((uint32_t)tcb->xcp.regs -
-                                            XCPTCONTEXT_SIZE);
-      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                           XCPTCONTEXT_SIZE;
-
-      /* Then set up to vector to the trampoline with interrupts
-       * disabled
-       */
-
-      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-      tcb->xcp.regs[REG_CPSR]  = PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT;
+  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+  tcb->xcp.regs[REG_CPSR]  = PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT;
 #ifdef CONFIG_ARM_THUMB
-      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
-    }
 }

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -90,16 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
    * being delivered to the currently executing task.
    */
 
-  if (tcb == rtcb && ipsr == 0)
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handle will run in a critical section!
-       */
-
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
+  if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {
       /* Context switch should be done in pendsv, for exception directly
        * last regs is not saved tcb->xcp.regs.

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -91,16 +91,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
    * being delivered to the currently executing task.
    */
 
-  if (tcb == rtcb && ipsr == 0)
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handle will run in a critical section!
-       */
-
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
+  if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {
       /* Context switch should be done in pendsv, for exception directly
        * last regs is not saved tcb->xcp.regs.

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -82,51 +82,35 @@ void up_schedule_sigaction(struct tcb_s *tcb)
   sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
         this_task()->xcp.regs);
 
-  /* First, handle some special cases when the signal is
-   * being delivered to the currently executing task.
+  /* Save the return lr and cpsr and one scratch register.  These
+   * will be restored by the signal trampoline after the signals
+   * have been delivered.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handler will run in a critical section!
-       */
+  /* Save the current register context location */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else
-    {
-      /* Save the return lr and cpsr and one scratch register.  These
-       * will be restored by the signal trampoline after the signals
-       * have been delivered.
-       */
+  tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-      /* Save the current register context location */
+  /* Duplicate the register context.  These will be
+   * restored by the signal trampoline after the signal has been
+   * delivered.
+   */
 
-      tcb->xcp.saved_regs      = tcb->xcp.regs;
+  tcb->xcp.regs            = (void *)
+                             ((uint32_t)tcb->xcp.regs -
+                                        XCPTCONTEXT_SIZE);
+  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-      /* Duplicate the register context.  These will be
-       * restored by the signal trampoline after the signal has been
-       * delivered.
-       */
+  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                       XCPTCONTEXT_SIZE;
 
-      tcb->xcp.regs            = (void *)
-                                 ((uint32_t)tcb->xcp.regs -
-                                            XCPTCONTEXT_SIZE);
-      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+  /* Then set up to vector to the trampoline with interrupts
+   * disabled
+   */
 
-      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                           XCPTCONTEXT_SIZE;
-
-      /* Then set up to vector to the trampoline with interrupts
-       * disabled
-       */
-
-      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-      tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
+  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
-    }
 }

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -91,16 +91,7 @@ void up_schedule_sigaction(struct tcb_s *tcb)
    * being delivered to the currently executing task.
    */
 
-  if (tcb == rtcb && ipsr == 0)
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handle will run in a critical section!
-       */
-
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
+  if (tcb == rtcb && ipsr != NVIC_IRQ_PENDSV)
     {
       /* Context switch should be done in pendsv, for exception directly
        * last regs is not saved tcb->xcp.regs.

--- a/arch/arm/src/armv8-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-r/arm_schedulesigaction.c
@@ -82,51 +82,35 @@ void up_schedule_sigaction(struct tcb_s *tcb)
   sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
         this_task()->xcp.regs);
 
-  /* First, handle some special cases when the signal is
-   * being delivered to the currently executing task.
+  /* Save the return lr and cpsr and one scratch register.  These
+   * will be restored by the signal trampoline after the signals
+   * have been delivered.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handler will run in a critical section!
-       */
+  /* Save the current register context location */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else
-    {
-      /* Save the return lr and cpsr and one scratch register.  These
-       * will be restored by the signal trampoline after the signals
-       * have been delivered.
-       */
+  tcb->xcp.saved_regs      = tcb->xcp.regs;
 
-      /* Save the current register context location */
+  /* Duplicate the register context.  These will be
+   * restored by the signal trampoline after the signal has been
+   * delivered.
+   */
 
-      tcb->xcp.saved_regs      = tcb->xcp.regs;
+  tcb->xcp.regs            = (void *)
+                             ((uint32_t)tcb->xcp.regs -
+                                        XCPTCONTEXT_SIZE);
+  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-      /* Duplicate the register context.  These will be
-       * restored by the signal trampoline after the signal has been
-       * delivered.
-       */
+  tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
+                                       XCPTCONTEXT_SIZE;
 
-      tcb->xcp.regs            = (void *)
-                                 ((uint32_t)tcb->xcp.regs -
-                                            XCPTCONTEXT_SIZE);
-      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
+  /* Then set up to vector to the trampoline with interrupts
+   * disabled
+   */
 
-      tcb->xcp.regs[REG_SP]    = (uint32_t)tcb->xcp.regs +
-                                           XCPTCONTEXT_SIZE;
-
-      /* Then set up to vector to the trampoline with interrupts
-       * disabled
-       */
-
-      tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-      tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
+  tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
+  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
-      tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
+  tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
-    }
 }

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -126,30 +126,14 @@ void up_schedule_sigaction(struct tcb_s *tcb)
   sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
         this_task()->xcp.regs);
 
-  /* First, handle some special cases when the signal is
-   * being delivered to the currently executing task.
+  /* Save the return lr and cpsr and one scratch register.  These
+   * will be restored by the signal trampoline after the signals
+   * have been delivered.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handler will run in a critical section!
-       */
+  tcb->xcp.saved_regs = tcb->xcp.regs;
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else
-    {
-      /* Save the return lr and cpsr and one scratch register.  These
-       * will be restored by the signal trampoline after the signals
-       * have been delivered.
-       */
+  /* create signal process context */
 
-      tcb->xcp.saved_regs = tcb->xcp.regs;
-
-      /* create signal process context */
-
-      arm64_init_signal_process(tcb, NULL);
-    }
+  arm64_init_signal_process(tcb, NULL);
 }

--- a/arch/avr/src/avr/avr_schedulesigaction.c
+++ b/arch/avr/src/avr/avr_schedulesigaction.c
@@ -90,67 +90,40 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save registers that must be protected while the signal
+       * handler runs. These will be restored by the signal
+       * trampoline after the signal(s) have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
-
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following
-       * logic would fail in the strange case where we are in an
-       * interrupt handler, the thread is signalling itself, but
-       * a context switch to another task has occurred so that
-       * g_current_regs does not refer to the thread of this_task()!
-       */
-
-      else
-        {
-          /* Save registers that must be protected while the signal
-           * handler runs. These will be restored by the signal
-           * trampoline after the signal(s) have been delivered.
-           */
-
-          tcb->xcp.saved_pc0  = up_current_regs()[REG_PC0];
-          tcb->xcp.saved_pc1  = up_current_regs()[REG_PC1];
+      tcb->xcp.saved_pc0  = up_current_regs()[REG_PC0];
+      tcb->xcp.saved_pc1  = up_current_regs()[REG_PC1];
 #if defined(REG_PC2)
-          tcb->xcp.saved_pc2  = up_current_regs()[REG_PC2];
+      tcb->xcp.saved_pc2  = up_current_regs()[REG_PC2];
 #endif
 #if defined(REG_RAMPZ)
-          tcb->xcp.saved_rampz = up_current_regs()[REG_RAMPZ];
+      tcb->xcp.saved_rampz = up_current_regs()[REG_RAMPZ];
 #endif
-          tcb->xcp.saved_sreg = up_current_regs()[REG_SREG];
+      tcb->xcp.saved_sreg = up_current_regs()[REG_SREG];
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
 #if !defined(REG_PC2)
-          up_current_regs()[REG_PC0] = (uint16_t)reg_ptr >> 8;
-          up_current_regs()[REG_PC1] = (uint16_t)reg_ptr & 0xff;
+      up_current_regs()[REG_PC0] = (uint16_t)reg_ptr >> 8;
+      up_current_regs()[REG_PC1] = (uint16_t)reg_ptr & 0xff;
 #else
-          up_current_regs()[REG_PC0] = (uint32_t)reg_ptr >> 16;
-          up_current_regs()[REG_PC1] = (uint32_t)reg_ptr >> 8;
-          up_current_regs()[REG_PC2] = (uint32_t)reg_ptr & 0xff;
+      up_current_regs()[REG_PC0] = (uint32_t)reg_ptr >> 16;
+      up_current_regs()[REG_PC1] = (uint32_t)reg_ptr >> 8;
+      up_current_regs()[REG_PC2] = (uint32_t)reg_ptr & 0xff;
 #endif
-          up_current_regs()[REG_SREG] &= ~(1 << SREG_I);
+      up_current_regs()[REG_SREG] &= ~(1 << SREG_I);
 
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          avr_savestate(tcb->xcp.regs);
-        }
+      avr_savestate(tcb->xcp.regs);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/avr/src/avr32/avr_schedulesigaction.c
+++ b/arch/avr/src/avr32/avr_schedulesigaction.c
@@ -88,53 +88,26 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save registers that must be protected while the signal
+       * handler runs. These will be restored by the signal
+       * trampoline after the signal(s) have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+      tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following
-       * logic would fail in the strange case where we are in an
-       * interrupt handler, the thread is signalling itself, but
-       * a context switch to another task has occurred so that
-       * g_current_regs does not refer to the thread of this_task()!
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save registers that must be protected while the signal
-           * handler runs. These will be restored by the signal
-           * trampoline after the signal(s) have been delivered.
-           */
+      up_current_regs()[REG_PC]  = (uint32_t)avr_sigdeliver;
+      up_current_regs()[REG_SR] |= AVR32_SR_GM_MASK;
 
-          tcb->xcp.saved_pc = up_current_regs()[REG_PC];
-          tcb->xcp.saved_sr = up_current_regs()[REG_SR];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          up_current_regs()[REG_PC]  = (uint32_t)avr_sigdeliver;
-          up_current_regs()[REG_SR] |= AVR32_SR_GM_MASK;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          avr_savestate(tcb->xcp.regs);
-        }
+      avr_savestate(tcb->xcp.regs);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -91,62 +91,35 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_epc    = up_current_regs()[REG_EPC];
+      tcb->xcp.saved_status = up_current_regs()[REG_STATUS];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following
-       * logic would fail in the strange case where we are in an
-       * interrupt handler, the thread is signalling itself, but
-       * a context switch to another task has occurred so that
-       * g_current_regs does not refer to the thread of this_task()!
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save the return EPC and STATUS registers.  These will be
-           * restored by the signal trampoline after the signals have
-           * been delivered.
-           */
+      up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
+      status  = up_current_regs()[REG_STATUS];
+      status &= ~CP0_STATUS_INT_MASK;
+      status |= CP0_STATUS_INT_SW0;
+      up_current_regs()[REG_STATUS]  = status;
 
-          tcb->xcp.saved_epc    = up_current_regs()[REG_EPC];
-          tcb->xcp.saved_status = up_current_regs()[REG_STATUS];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      mips_savestate(tcb->xcp.regs);
 
-          up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
-          status  = up_current_regs()[REG_STATUS];
-          status &= ~CP0_STATUS_INT_MASK;
-          status |= CP0_STATUS_INT_SW0;
-          up_current_regs()[REG_STATUS]  = status;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          mips_savestate(tcb->xcp.regs);
-
-          sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
-                " New: %08" PRIx32 "/%08" PRIx32 "\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                up_current_regs()[REG_EPC],
-                up_current_regs()[REG_STATUS]);
-        }
+      sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
+            " New: %08" PRIx32 "/%08" PRIx32 "\n",
+            tcb->xcp.saved_epc, tcb->xcp.saved_status,
+            up_current_regs()[REG_EPC],
+            up_current_regs()[REG_STATUS]);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -88,57 +88,30 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save the return EPC and STATUS registers.  These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_epc = up_current_regs()[REG_EPC];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following
-       * logic would fail in the strange case where we are in an
-       * interrupt handler, the thread is signalling itself, but
-       * a context switch to another task has occurred so that
-       * g_current_regs does not refer to the thread of this_task()!
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save the return EPC and STATUS registers.  These will be
-           * restored by the signal trampoline after the signals have
-           * been delivered.
-           */
+      up_current_regs()[REG_EPC]     = (uint32_t)lm32_sigdeliver;
+      up_current_regs()[REG_INT_CTX] = 0;
 
-          tcb->xcp.saved_epc = up_current_regs()[REG_EPC];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      misoc_savestate(tcb->xcp.regs);
 
-          up_current_regs()[REG_EPC]     = (uint32_t)lm32_sigdeliver;
-          up_current_regs()[REG_INT_CTX] = 0;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          misoc_savestate(tcb->xcp.regs);
-
-          sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
-                up_current_regs()[REG_EPC],
-                up_current_regs()[REG_STATUS]);
-        }
+      sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
+            tcb->xcp.saved_epc, tcb->xcp.saved_status,
+            up_current_regs()[REG_EPC],
+            up_current_regs()[REG_STATUS]);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/or1k/src/common/or1k_schedulesigaction.c
+++ b/arch/or1k/src/common/or1k_schedulesigaction.c
@@ -87,56 +87,29 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save the return lr and cpsr and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
-
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following
-       * logic would fail in the strange case where we are in an
-       * interrupt handler, the thread is signalling itself, but
-       * a context switch to another task has occurred so that
-       * current_regs does not refer to the thread of this_task()!
+      /* tcb->xcp.saved_pc   = up_current_regs()[REG_PC];
+       * tcb->xcp.saved_cpsr = up_current_regs()[REG_CPSR];
        */
 
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
+       */
 
-          /* tcb->xcp.saved_pc   = up_current_regs()[REG_PC];
-           * tcb->xcp.saved_cpsr = up_current_regs()[REG_CPSR];
-           */
+      /* up_current_regs()[REG_PC]   = (uint32_t)or1k_sigdeliver;
+       * up_current_regs()[REG_CPSR] = SVC_MODE | PSR_I_BIT |
+       *                          PSR_F_BIT;
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* up_current_regs()[REG_PC]   = (uint32_t)or1k_sigdeliver;
-           * up_current_regs()[REG_CPSR] = SVC_MODE | PSR_I_BIT |
-           *                          PSR_F_BIT;
-           */
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          or1k_savestate(tcb->xcp.regs);
-        }
+      or1k_savestate(tcb->xcp.regs);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -87,49 +87,28 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save the return PC and SR and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_pc[0] = up_current_regs()[REG_PC];
+      tcb->xcp.saved_pc[1] = up_current_regs()[REG_PC + 1];
+      tcb->xcp.saved_flg   = up_current_regs()[REG_FLG];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save the return PC and SR and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
+      up_current_regs()[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
+      up_current_regs()[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
+      up_current_regs()[REG_FLG] &= ~M16C_FLG_I;
 
-          tcb->xcp.saved_pc[0] = up_current_regs()[REG_PC];
-          tcb->xcp.saved_pc[1] = up_current_regs()[REG_PC + 1];
-          tcb->xcp.saved_flg   = up_current_regs()[REG_FLG];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          up_current_regs()[REG_PC] = (uint32_t)renesas_sigdeliver >> 8;
-          up_current_regs()[REG_PC + 1] = (uint32_t)renesas_sigdeliver;
-          up_current_regs()[REG_FLG] &= ~M16C_FLG_I;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          renesas_copystate(tcb->xcp.regs, up_current_regs());
-        }
+      renesas_copystate(tcb->xcp.regs, up_current_regs());
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -87,47 +87,26 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      /* Save the return PC and SR and one scratch register
+       * These will be restored by the signal trampoline after
+       * the signals have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_pc = up_current_regs()[REG_PC];
+      tcb->xcp.saved_sr = up_current_regs()[REG_SR];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the
-       * interrupted task is the same as the one that
-       * must receive the signal, then we will have to modify
-       * the return state as well as the state in the TCB.
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save the return PC and SR and one scratch register
-           * These will be restored by the signal trampoline after
-           * the signals have been delivered.
-           */
+      up_current_regs()[REG_PC]  = (uint32_t)renesas_sigdeliver;
+      up_current_regs()[REG_SR] |= 0x000000f0;
 
-          tcb->xcp.saved_pc = up_current_regs()[REG_PC];
-          tcb->xcp.saved_sr = up_current_regs()[REG_SR];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          up_current_regs()[REG_PC]  = (uint32_t)renesas_sigdeliver;
-          up_current_regs()[REG_SR] |= 0x000000f0;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          renesas_copystate(tcb->xcp.regs, up_current_regs());
-        }
+      renesas_copystate(tcb->xcp.regs, up_current_regs());
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -85,56 +85,40 @@ void up_schedule_sigaction(struct tcb_s *tcb)
   sinfo("tcb=%p, rtcb=%p current_regs=%p\n", tcb, this_task(),
         this_task()->xcp.regs);
 
-  /* First, handle some special cases when the signal is being delivered
-   * to task that is currently executing on any CPU.
+  /* Save the return EPC and STATUS registers.  These will be
+   * by the signal trampoline after the signal has been delivered.
    */
 
-  if (tcb == this_task() && !up_interrupt_context())
-    {
-      /* In this case just deliver the signal now.
-       * REVISIT:  Signal handler will run in a critical section!
-       */
+  /* Save the current register context location */
 
-      (tcb->sigdeliver)(tcb);
-      tcb->sigdeliver = NULL;
-    }
-  else
-    {
-      /* Save the return EPC and STATUS registers.  These will be
-       * by the signal trampoline after the signal has been delivered.
-       */
+  tcb->xcp.saved_regs        = tcb->xcp.regs;
 
-      /* Save the current register context location */
+  /* Duplicate the register context.  These will be
+   * restored by the signal trampoline after the signal has been
+   * delivered.
+   */
 
-      tcb->xcp.saved_regs        = tcb->xcp.regs;
+  tcb->xcp.regs              = (uintreg_t *)
+                               ((uintptr_t)tcb->xcp.regs -
+                                           XCPTCONTEXT_SIZE);
 
-      /* Duplicate the register context.  These will be
-       * restored by the signal trampoline after the signal has been
-       * delivered.
-       */
+  memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
 
-      tcb->xcp.regs              = (uintreg_t *)
-                                   ((uintptr_t)tcb->xcp.regs -
-                                               XCPTCONTEXT_SIZE);
-
-      memcpy(tcb->xcp.regs, tcb->xcp.saved_regs, XCPTCONTEXT_SIZE);
-
-      tcb->xcp.regs[REG_SP]      = (uintptr_t)tcb->xcp.regs +
+  tcb->xcp.regs[REG_SP]      = (uintptr_t)tcb->xcp.regs +
                                               XCPTCONTEXT_SIZE;
 
-      /* Then set up to vector to the trampoline with interrupts
-       * disabled.  We must already be in privileged thread mode to be
-       * here.
-       */
+  /* Then set up to vector to the trampoline with interrupts
+   * disabled.  We must already be in privileged thread mode to be
+   * here.
+   */
 
-      tcb->xcp.regs[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
+  tcb->xcp.regs[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
 
-      int_ctx                    = tcb->xcp.regs[REG_INT_CTX];
-      int_ctx                   &= ~STATUS_PIE;
+  int_ctx                    = tcb->xcp.regs[REG_INT_CTX];
+  int_ctx                   &= ~STATUS_PIE;
 #ifndef CONFIG_BUILD_FLAT
-      int_ctx                   |= STATUS_PPP;
+  int_ctx                   |= STATUS_PPP;
 #endif
 
-      tcb->xcp.regs[REG_INT_CTX] = int_ctx;
-    }
+  tcb->xcp.regs[REG_INT_CTX] = int_ctx;
 }

--- a/arch/x86/src/i486/i486_schedulesigaction.c
+++ b/arch/x86/src/i486/i486_schedulesigaction.c
@@ -83,53 +83,26 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and a task is
-       * signalling itself for some reason.
+      /* Save the return lr and cpsr and one scratch register. These
+       * will be restored by the signal trampoline after the signals
+       * have been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_eip    = up_current_regs()[REG_EIP];
+      tcb->xcp.saved_eflags = up_current_regs()[REG_EFLAGS];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted task
-       * is the same as the one that must receive the signal, then we
-       * will have to modify the return state as well as the state in the
-       * TCB.
-       *
-       * Hmmm... there looks like a latent bug here: The following logic
-       * would fail in the strange case where we are in an interrupt
-       * handler, the thread is signalling itself, but a context switch
-       * to another task has occurred so that g_current_regs does not
-       * refer to the thread of this_task()!
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          /* Save the return lr and cpsr and one scratch register. These
-           * will be restored by the signal trampoline after the signals
-           * have been delivered.
-           */
+      up_current_regs()[REG_EIP]    = (uint32_t)x86_sigdeliver;
+      up_current_regs()[REG_EFLAGS] = 0;
 
-          tcb->xcp.saved_eip    = up_current_regs()[REG_EIP];
-          tcb->xcp.saved_eflags = up_current_regs()[REG_EFLAGS];
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
+       */
 
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-          up_current_regs()[REG_EIP]    = (uint32_t)x86_sigdeliver;
-          up_current_regs()[REG_EFLAGS] = 0;
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          x86_savestate(tcb->xcp.regs);
-        }
+      x86_savestate(tcb->xcp.regs);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -87,50 +87,29 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and
-       * a task is signalling itself for some reason.
+      FAR uint32_t *current_pc  =
+        (FAR uint32_t *)&up_current_regs()[REG_PC];
+
+      /* Save the return address and interrupt state. These will be
+       * restored by the signal trampoline after the signals have
+       * been delivered.
        */
 
-      if (!up_current_regs())
-        {
-          /* In this case just deliver the signal now. */
+      tcb->xcp.saved_pc = *current_pc;
+      tcb->xcp.saved_i  = up_current_regs()[REG_FLAGS];
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted
-       * task is the same as the one that must receive the signal, then
-       * we will have to modify the return state as well as the state
-       * in the TCB.
+      /* Then set up to vector to the trampoline with interrupts
+       * disabled
        */
 
-      else
-        {
-          FAR uint32_t *current_pc  =
-            (FAR uint32_t *)&up_current_regs()[REG_PC];
+      *current_pc = (uint32_t)z16_sigdeliver;
+      up_current_regs()[REG_FLAGS] = 0;
 
-          /* Save the return address and interrupt state. These will be
-           * restored by the signal trampoline after the signals have
-           * been delivered.
-           */
+      /* And make sure that the saved context in the TCB is the
+       * same as the interrupt return context.
+       */
 
-          tcb->xcp.saved_pc = *current_pc;
-          tcb->xcp.saved_i  = up_current_regs()[REG_FLAGS];
-
-          /* Then set up to vector to the trampoline with interrupts
-           * disabled
-           */
-
-         *current_pc = (uint32_t)z16_sigdeliver;
-          up_current_regs()[REG_FLAGS] = 0;
-
-          /* And make sure that the saved context in the TCB is the
-           * same as the interrupt return context.
-           */
-
-          z16_copystate(tcb->xcp.regs, up_current_regs());
-        }
+      z16_copystate(tcb->xcp.regs, up_current_regs());
     }
 
   /* Otherwise, we are (1) signaling a task is not running from an

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -111,38 +111,17 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and a task is
-       * signalling itself for some reason.
+      /* Set up to vector to the trampoline with interrupts
+       * disabled.
        */
 
-      if (!IN_INTERRUPT())
-        {
-          /* In this case just deliver the signal now. */
+      ez80_sigsetup(tcb, (chipreg_t *)IRQ_STATE());
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted task
-       * is the same as the one that must receive the signal, then we
-       * will have to modify the return state as well as the state in
-       * the TCB.
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
        */
 
-      else
-        {
-          /* Set up to vector to the trampoline with interrupts
-           * disabled.
-           */
-
-          ez80_sigsetup(tcb, (chipreg_t *)IRQ_STATE());
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          SAVE_IRQCONTEXT(tcb);
-        }
+      SAVE_IRQCONTEXT(tcb);
     }
 
   /* Otherwise, we are (1) signaling a task is not running from an

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -114,38 +114,17 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and a task is
-       * signalling itself for some reason.
+      /* Set up to vector to the trampoline with interrupts
+       * disabled.
        */
 
-      if (!IN_INTERRUPT())
-        {
-          /* In this case just deliver the signal now. */
+      z180_sigsetup(tcb, IRQ_STATE());
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted task
-       * is the same as the one that must receive the signal, then we
-       * will have to modify the return state as well as the state in
-       * the TCB.
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
        */
 
-      else
-        {
-          /* Set up to vector to the trampoline with interrupts
-           * disabled.
-           */
-
-          z180_sigsetup(tcb, IRQ_STATE());
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          SAVE_IRQCONTEXT(tcb);
-        }
+      SAVE_IRQCONTEXT(tcb);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -111,38 +111,17 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and a task is
-       * signalling itself for some reason.
+      /* Set up to vector to the trampoline with interrupts
+       * disabled.
        */
 
-      if (!IN_INTERRUPT())
-        {
-          /* In this case just deliver the signal now. */
+      z8_sigsetup(tcb, IRQ_STATE());
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted task
-       * is the same as the one that must receive the signal, then we
-       * will have to modify the return state as well as the state in
-       * the TCB.
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
        */
 
-      else
-        {
-          /* Set up to vector to the trampoline with interrupts
-           * disabled.
-           */
-
-          z8_sigsetup(tcb, IRQ_STATE());
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          SAVE_IRQCONTEXT(tcb);
-        }
+      SAVE_IRQCONTEXT(tcb);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -112,38 +112,17 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb)
 
   if (tcb == this_task())
     {
-      /* CASE 1:  We are not in an interrupt handler and a task is
-       * signalling itself for some reason.
+      /* Set up to vector to the trampoline with interrupts
+       * disabled.
        */
 
-      if (!IN_INTERRUPT())
-        {
-          /* In this case just deliver the signal now. */
+      z80_sigsetup(tcb, IRQ_STATE());
 
-          (tcb->sigdeliver)(tcb);
-          tcb->sigdeliver = NULL;
-        }
-
-      /* CASE 2:  We are in an interrupt handler AND the interrupted task
-       * is the same as the one that must receive the signal, then we
-       * will have to modify the return state as well as the state in
-       * the TCB.
+      /* And make sure that the saved context in the TCB
+       * is the same as the interrupt return context.
        */
 
-      else
-        {
-          /* Set up to vector to the trampoline with interrupts
-           * disabled.
-           */
-
-          z80_sigsetup(tcb, IRQ_STATE());
-
-          /* And make sure that the saved context in the TCB
-           * is the same as the interrupt return context.
-           */
-
-          SAVE_IRQCONTEXT(tcb);
-        }
+      SAVE_IRQCONTEXT(tcb);
     }
 
   /* Otherwise, we are (1) signaling a task is not running

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -185,7 +185,17 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb,
 #endif
                 {
                   stcb->sigdeliver = nxsig_deliver;
-                  up_schedule_sigaction(stcb);
+                  if (stcb == this_task() && !up_interrupt_context())
+                    {
+                      /* In this case just deliver the signal now. */
+
+                      (stcb->sigdeliver)(stcb);
+                      stcb->sigdeliver = NULL;
+                    }
+                  else
+                    {
+                      up_schedule_sigaction(stcb);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Summary
-------
This change reorganizes signal delivery so that immediate delivery of a
pending signal for the current task (when not in interrupt context) is
performed in the common signal dispatch path rather than being handled as a
special-case inside architecture-specific `up_schedule_sigaction()`
implementations. In addition, many `up_schedule_sigaction()` implementations
were simplified to always prepare the task context for trampoline-based
signal delivery (save/duplicate register context and set up the trampoline
entry), removing duplicated special-case branches.

Key changes:
- Move immediate in-thread signal delivery into `nxsig_queue_action` /
  `nxsig_tcbdispatch` path: when `stcb == this_task()` and not in interrupt
  context, deliver the signal directly (leave critical section, call
  `sigdeliver`, re-enter critical section and clear `sigdeliver`).
- Simplify and unify `up_schedule_sigaction()` across many architectures so
  that they always prepare and duplicate the register context, set up the
  architecture trampoline entry point, and copy/register state as needed.
- Remove per-arch special-case branches that delivered immediately from
  inside `up_schedule_sigaction()`.

Files touched (representative):
- sched/signal/sig_dispatch.c
- arch/*/src/*_schedulesigaction.c (many architectures: renesas, sh1,
  riscv, sparc, tricore, x86/i486/intel64, xtensa, z16, z80, etc.)

Impact
------
- Behavior: Functionally the intention is preserved (signals destined for
  the current task are still delivered immediately when appropriate), but
  the point of delivery has moved into the common signal-dispatch code.
  This reduces duplication, centralizes locking behavior, and makes the
  delivery path easier to reason about.

Testing
-------
armv7a:smp ostest PASS