### PR TITLE
arch/xtensa/espressif: ESP32 simpleboot improvements

### DIFF
--- a/boards/xtensa/esp32/common/scripts/esp32_sections.ld
+++ b/boards/xtensa/esp32/common/scripts/esp32_sections.ld
@@ -533,16 +533,14 @@ SECTIONS
    * i.e. the lower 16 bits of both the virtual address (address seen by the
    * CPU) and the load address (physical address of the external flash) must
    * be equal.
+   * For the simpleboot format this is done by esptool.
    */
 
-#ifndef CONFIG_ESP32_APP_FORMAT_MCUBOOT
-  .flash.rodata_dummy (NOLOAD) :
-  {
-    . = ALIGN(0x10000);
-  } > ROM
-#endif
-
+#ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
   .flash.rodata : ALIGN(0x10000)
+#else
+  .flash.rodata :
+#endif
   {
     _rodata_reserved_start = ABSOLUTE(.);
 
@@ -666,17 +664,14 @@ SECTIONS
    * i.e. the lower 16 bits of both the virtual address (address seen by the
    * CPU) and the load address (physical address of the external flash) must
    * be equal.
+   * For the simpleboot format this is done by esptool.
    */
 
-#ifndef CONFIG_ESP32_APP_FORMAT_MCUBOOT
-  .flash.text_dummy (NOLOAD) :
-  {
-    . += SIZEOF(.flash.rodata);
-    . = ALIGN(0x10000);
-  } >default_code_seg AT> ROM
-#endif
-
+#ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
   .flash.text : ALIGN(0x00010000)
+#else
+  .flash.text :
+#endif
   {
     _stext = .;
     _text_start = ABSOLUTE(.);


### PR DESCRIPTION
## Summary

The simpleboot image format is used to create NuttX images that can boot directly from the ROM based bootloader on espressif devices. A custom bootloader can also use this format by copying the RAM segments and starting NuttX from RAM, this will then setup the irom/drom mappings and caches.

The PR enables the creation of such images for a custom bootloader. For these images flash space savings can be applied by leaving esptool.py the possibility to place the ram and rom segments in an optimal way, to enable this aligment segmenst have been removed from the linker script. The flash space savings does not apply to images generated for the ROM based bootloader as this needs the ram sections to be placed at the start of the image.

## Impact

* The PR has no impact on users, build process, hardware, documentation, security, compatibility, ...

## Testing

Building and flashing for `esp32-devkitc:nsh`:
 
```
rst:0x1 (POWERON_RESET),boot:0x17 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3ffb2030,len:3632
load:0x40080000,len:30504
entry 0x40082878
*** Booting NuttX ***
dram: lma 0x00001020 vma 0x3ffb2030 len 0xe30    (3632)
iram: lma 0x00001e58 vma 0x40080000 len 0x7728   (30504)
padd: lma 0x00009598 vma 0x00000000 len 0x6a80   (27264)
imap: lma 0x00010020 vma 0x400d0020 len 0x12058  (73816)
padd: lma 0x00022080 vma 0x00000000 len 0xdf98   (57240)
dmap: lma 0x00030020 vma 0x3f400020 len 0x2d48   (11592)
total segments stored 6
WARNING: NuttX supports ESP32 chip revision >= v3.0 (chip is v1.0).
Ignoring this error and continuing because `ESP32_IGNORE_CHIP_REVISION_CHECK` is set...
THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!

NuttShell (NSH) NuttX-12.8.0
nsh> uname -a
NuttX 12.8.0 d9f033f00d Jan 27 2026 10:18:55 xtensa esp32-devkitc
```