### PR TITLE
net: limit TCP and UDP send/recv buffer usage with throttled IOB

### DIFF
--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -146,7 +146,7 @@ static uint32_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
 
       /* Allocate an IOB to hold the frame data */
 
-      iob = net_ioballoc(false);
+      iob = net_ioballoc(true);
       if (iob == NULL)
         {
           nwarn("WARNING: Failed to allocate IOB\n");

--- a/net/devif/devif_filesend.c
+++ b/net/devif/devif_filesend.c
@@ -87,14 +87,14 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
 
   /* Append the send buffer after device buffer */
 
-  if (len > iob_navail(false) * CONFIG_IOB_BUFSIZE ||
-      netdev_iob_prepare(dev, false, 0) != OK)
+  if (len > iob_navail(true) * CONFIG_IOB_BUFSIZE ||
+      netdev_iob_prepare(dev, true, 0) != OK)
     {
       ret = -ENOMEM;
       goto errout;
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset, false);
+  iob_update_pktlen(dev->d_iob, target_offset, true);
 
   ret = file_seek(file, offset, SEEK_SET);
   if (ret < 0)
@@ -111,7 +111,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
         {
           if (iob->io_flink == NULL)
             {
-              iob->io_flink = iob_tryalloc(false);
+              iob->io_flink = iob_tryalloc(true);
               if (iob->io_flink == NULL)
                 {
                   ret = -ENOMEM;
@@ -144,7 +144,7 @@ int devif_file_send(FAR struct net_driver_s *dev, FAR struct file *file,
         }
     }
 
-  iob_update_pktlen(dev->d_iob, target_offset + len, false);
+  iob_update_pktlen(dev->d_iob, target_offset + len, true);
 
   dev->d_sndlen = len;
   return len;

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -153,7 +153,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   /* Copy the ICMP message into the I/O buffer chain (without waiting) */
 
   ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
-                          0, iob, 0, true, false);
+                          0, iob, 0, false, false);
   if (ret < 0)
     {
       iob_free_chain(iob);

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -144,7 +144,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   /* Copy the ICMPv6 message into the I/O buffer chain (without waiting) */
 
   ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
-                          iplen, iob, 0, true, false);
+                          iplen, iob, 0, false, false);
   if (ret < 0)
     {
       iob_free_chain(iob);

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -62,11 +62,7 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 
   if (dev->d_iob == NULL)
     {
-      dev->d_iob = net_iobtimedalloc(false, timeout);
-      if (dev->d_iob == NULL && throttled)
-        {
-          dev->d_iob = net_iobtimedalloc(true, timeout);
-        }
+      dev->d_iob = net_iobtimedalloc(throttled, timeout);
     }
 
   if (dev->d_iob == NULL)

--- a/net/pkt/pkt_netpoll.c
+++ b/net/pkt/pkt_netpoll.c
@@ -66,7 +66,7 @@
 
 static int psock_pkt_cansend(FAR struct pkt_conn_s *conn)
 {
-  if (iob_navail(false) <= 0
+  if (iob_navail(true) <= 0
 #if defined(CONFIG_NET_PKT_WRITE_BUFFERS) && CONFIG_NET_SEND_BUFSIZE > 0
       || iob_get_queue_size(&conn->write_q) >= conn->sndbufs
 #endif

--- a/net/pkt/pkt_sendmsg_buffered.c
+++ b/net/pkt/pkt_sendmsg_buffered.c
@@ -266,7 +266,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
 
   if (nonblock)
     {
-      iob = iob_tryalloc(false);
+      iob = iob_tryalloc(true);
     }
   else
     {
@@ -292,7 +292,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
     }
 
   iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
-  iob_update_pktlen(iob, 0, false);
+  iob_update_pktlen(iob, 0, true);
 
   /* Copy the user data into the write buffer.  We cannot wait for
    * buffer space if the socket was opened non-blocking.
@@ -305,7 +305,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
 
   if (nonblock)
     {
-      ret = iob_trycopyin(iob, buf, len, offset, false);
+      ret = iob_trycopyin(iob, buf, len, offset, true);
     }
   else
     {
@@ -315,7 +315,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
        */
 
       conn_dev_unlock(&conn->sconn, dev);
-      ret = iob_copyin(iob, buf, len, offset, false);
+      ret = iob_copyin(iob, buf, len, offset, true);
       conn_dev_lock(&conn->sconn, dev);
     }
 

--- a/net/sixlowpan/sixlowpan_framelist.c
+++ b/net/sixlowpan/sixlowpan_framelist.c
@@ -412,7 +412,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
    * necessary.
    */
 
-  iob = net_ioballoc(false);
+  iob = net_ioballoc(true);
   DEBUGASSERT(iob != NULL);
 
   fptr = iob->io_data;
@@ -630,7 +630,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
            * necessary.
            */
 
-          iob = net_ioballoc(false);
+          iob = net_ioballoc(true);
           DEBUGASSERT(iob != NULL);
 
           /* Initialize the IOB */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1523,13 +1523,15 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
                     TCP_WBPKTLEN(wrb));
               DEBUGASSERT(TCP_WBPKTLEN(wrb) > 0);
             }
-          else if (nonblock)
-            {
-              wrb = tcp_wrbuffer_tryalloc();
-              ninfo("new wrb %p (non blocking)\n", wrb);
-            }
           else
             {
+              wrb = tcp_wrbuffer_tryalloc();
+              ninfo("new wrb %p (tryalloc)\n", wrb);
+            }
+
+          if (wrb == NULL && !nonblock)
+            {
+              tcp_send_txnotify(psock, conn);
               conn_dev_unlock(&conn->sconn, conn->dev);
               wrb = tcp_wrbuffer_timedalloc(tcp_send_gettimeout(start,
                                                                 timeout));

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -80,7 +80,8 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
 
   conn_lock(&conn->sconn);
 #if CONFIG_NET_RECV_BUFSIZE > 0
-  if (conn->readahead && conn->readahead->io_pktlen > conn->rcvbufs)
+  if (conn->readahead && conn->readahead->io_pktlen > conn->rcvbufs &&
+      iob_navail(true) == 0)
     {
       conn_unlock(&conn->sconn);
       netdev_iob_release(dev);

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -832,7 +832,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   udpiplen = udpip_hdrsize(conn);
 
   iob_reserve(wrb->wb_iob, CONFIG_NET_LL_GUARDSIZE);
-  iob_update_pktlen(wrb->wb_iob, udpiplen, false);
+  iob_update_pktlen(wrb->wb_iob, udpiplen, true);
 
   /* Copy the user data into the write buffer.  We cannot wait for
    * buffer space if the socket was opened non-blocking.
@@ -843,12 +843,12 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
       if (nonblock)
         {
           ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                              len, udpiplen, false);
+                              len, udpiplen, true);
         }
       else
         {
           ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf,
-                           len, udpiplen, false);
+                           len, udpiplen, true);
         }
 
       if (ret < 0)
@@ -951,7 +951,7 @@ int psock_udp_cansend(FAR struct udp_conn_s *conn)
    * many more.
    */
 
-  if (udp_wrbuffer_test() < 0 || iob_navail(false) <= 0
+  if (udp_wrbuffer_test() < 0 || iob_navail(true) <= 0
 #if CONFIG_NET_SEND_BUFSIZE > 0
       || udp_wrbuffer_inqueue_size(conn) >= conn->sndbufs
 #endif

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -94,7 +94,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_alloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_ioballoc(false);
+  wrb->wb_iob = net_ioballoc(true);
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");
@@ -205,7 +205,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 #ifdef CONFIG_NET_JUMBO_FRAME
     iob_alloc_dynamic(len);
 #else
-    iob_tryalloc(false);
+    iob_tryalloc(true);
 #endif
   if (!wrb->wb_iob)
     {


### PR DESCRIPTION
## Summary
The main content of this submission is to limit both the TX/RX buffers of TCP/UDP to throttled IOBs, avoiding impacts on the sending and receiving of control-type messages.
and optimized TX for TCP buffered mode.


## Impact
- Prevents TCP/UDP data traffic from exhausting IOB pool and blocking control messages;
- Improves system stability under high network load or with limited IOB resources ;
- Maintains responsiveness of ICMP/ICMPv6 and other control protocols;
- Avoid the impact on TCP receiving TCP_ACK when UDP data accumulates in readahead for a long time.

## Testing
sim:matter with very small amount of IOB configuration
```
CONFIG_MM_IOB=y
CONFIG_IOB_NBUFFERS=40
CONFIG_IOB_BUFSIZE=196
CONFIG_IOB_ALIGNMENT=4
CONFIG_IOB_SECTION=""
CONFIG_IOB_NCHAINS=40
CONFIG_IOB_THROTTLE=10
```
NuttX test log:
```
nsh> iperf -c 10.0.1.1 -B 10.0.1.2
     IP: 10.0.1.2

 mode=tcp-client sip=10.0.1.2:5001,dip=10.0.1.1:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-   3.01 sec  148127744 Bytes  393.70 Mbits/sec
   3.01-   6.02 sec  147177472 Bytes  391.17 Mbits/sec
   6.02-   9.03 sec  132677632 Bytes  352.63 Mbits/sec
   9.03-  12.04 sec  143818752 Bytes  382.24 Mbits/sec
  12.04-  15.05 sec  148914176 Bytes  395.79 Mbits/sec
  15.05-  18.06 sec  158990336 Bytes  422.57 Mbits/sec
  18.06-  21.07 sec  140148736 Bytes  372.49 Mbits/sec
  21.07-  24.08 sec  127320064 Bytes  338.39 Mbits/sec
  24.08-  27.09 sec  129712128 Bytes  344.75 Mbits/sec
  27.09-  30.10 sec  133414912 Bytes  354.59 Mbits/sec
   0.00-  30.10 sec 1410301952 Bytes  374.83 Mbits/sec
iperf exit
nsh> 
```
esp32c3-devkit:wifi board 
NuttX test log:
```
nsh> iperf -c 10.212.241.242 &
iperf [13:100]
nsh>      IP: 10.212.241.66

 mode=tcp-client sip=10.212.241.66:5001,dip=10.212.241.242:5001, interval=3, time=30

           Interval         Transfer         Bandwidth
   0.00-   3.01 sec    1359872 Bytes    3.61 Mbits/sec
   3.01-   6.02 sec    1343488 Bytes    3.57 Mbits/sec
   6.02-   9.03 sec    1458176 Bytes    3.88 Mbits/sec
   9.03-  12.04 sec    1179648 Bytes    3.14 Mbits/sec
  12.04-  15.05 sec    1425408 Bytes    3.79 Mbits/sec
  15.05-  18.06 sec    1474560 Bytes    3.92 Mbits/sec
  18.06-  21.07 sec    1376256 Bytes    3.66 Mbits/sec
  21.07-  24.08 sec    1277952 Bytes    3.40 Mbits/sec
  24.08-  27.09 sec    1261568 Bytes    3.35 Mbits/sec
  27.09-  30.10 sec    1409024 Bytes    3.74 Mbits/sec
   0.00-  30.10 sec   13565952 Bytes    3.61 Mbits/sec
iperf exit
iperf -c 10.212.241.242 &
iperf [22:100]
nsh>      IP: 10.212.241.66

 mode=tcp-client sip=10.212.241.66:5001,dip=10.212.241.242:5001, interval=3, time=30

           Interval         Transfer         Bandwidth

   0.00-   3.01 sec     180224 Bytes    0.48 Mbits/sec

nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
       100        40         0         0
nsh>    3.01-   6.02 sec     376832 Bytes    1.00 Mbits/sec
   6.02-   9.03 sec     491520 Bytes    1.31 Mbits/sec
   9.03-  12.04 sec    1228800 Bytes    3.27 Mbits/sec
  12.04-  15.05 sec    1048576 Bytes    2.79 Mbits/sec
  15.05-  18.06 sec    1392640 Bytes    3.70 Mbits/sec
  18.06-  21.07 sec    1327104 Bytes    3.53 Mbits/sec
  21.07-  24.08 sec    1277952 Bytes    3.40 Mbits/sec
  24.08-  27.09 sec     278528 Bytes    0.74 Mbits/sec
  27.09-  30.10 sec    1130496 Bytes    3.00 Mbits/sec
   0.00-  30.10 sec    8732672 Bytes    2.32 Mbits/sec
iperf exit

nsh> cat /proc/iobinfo
    ntotal     nfree     nwait nthrottle
       100       100         0        60
nsh> 
nsh> 
```
My local environment has a relatively high packet loss rate, so the throughput is relatively low.