### PR TITLE
sched_getfiles: Consolidate return statements in nxsched_get_fdlist_from_tcb() for MISRA HIS compliance

### DIFF
--- a/sched/sched/sched_getfiles.c
+++ b/sched/sched/sched_getfiles.c
@@ -51,6 +51,7 @@
 FAR struct fdlist *nxsched_get_fdlist_from_tcb(FAR struct tcb_s *tcb)
 {
   FAR struct task_group_s *group = tcb->group;
+  FAR struct fdlist *ret = NULL;
 
   /* The group may be NULL under certain conditions.  For example, if
    * debug output is attempted from the IDLE thead before the group has
@@ -60,12 +61,12 @@ FAR struct fdlist *nxsched_get_fdlist_from_tcb(FAR struct tcb_s *tcb)
 
   if (group)
     {
-      return &group->tg_fdlist;
+      ret = &group->tg_fdlist;
     }
 
   /* Higher level logic must handle the NULL gracefully */
 
-  return NULL;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Consolidate multiple return statements in the `nxsched_get_fdlist_from_tcb()` 
function into a single exit point to improve code quality and comply with MISRA 
HIS coding standards for safety-critical systems.

## Motivation and Problem
The original implementation had multiple return points (early return for success 
and return at the end for failure), which violates MISRA HIS metric rules for 
safety-critical code. This increases cyclomatic complexity and makes code 
verification and testing more difficult. Consolidating returns to a single exit 
point improves maintainability and compliance with automotive safety standards.

## Changes
- Introduce a result variable (`ret`) initialized to NULL
- Replace early success return with assignment to `ret`
- Perform single return at function end with the result variable

## Impact
- **Code Quality**: Reduced cyclomatic complexity
- **Compliance**: Achieves MISRA HIS compliance for return statement metrics
- **Verifiability**: Single exit point improves static analysis and code verification
- **Backward Compatibility**: No functional changes; identical runtime behavior
- **Performance**: No performance impact; compiler optimizations identical

## Verification
- [x] Code compiles without warnings on ARM GCC 10.x
- [x] Verified on QEMU ARMv7-A simulator with multimedia profile
- [x] File descriptor list retrieval verified
- [x] NULL return for invalid task group verified
- [x] Valid file descriptor list pointer return verified
- [x] Static analysis shows improved complexity metrics

## Testing
Tested with:
- ARM GCC 10.x compiler
- QEMU ARMv7-A simulation
- Task file descriptor list operations:
  - Valid task group with file descriptors
  - Invalid/NULL task group handling
  - File descriptor list pointer validity



## Files Changed
- `sched/sched/sched_getfiles.c` (5 lines: 3 insertions, 2 deletions)