### PR TITLE
sched_profil: Move static variable to block scope for MISRA C 2012 compliance

### DIFF
--- a/sched/sched/sched_profil.c
+++ b/sched/sched/sched_profil.c
@@ -58,9 +58,8 @@ static int profil_timer_handler_cpu(FAR void *arg);
  * Private Data
  ****************************************************************************/
 
-static struct profinfo_s g_prof;
-
 #ifdef CONFIG_SMP
+static struct profinfo_s g_prof;
 static struct smp_call_data_s g_call_data =
 SMP_CALL_INITIALIZER(profil_timer_handler_cpu, &g_prof);
 #endif
@@ -137,6 +136,9 @@ static void profil_timer_handler(wdparm_t arg)
 int profil(FAR unsigned short *buf, size_t bufsiz,
            size_t offset, unsigned int scale)
 {
+#ifndef CONFIG_SMP
+  static struct profinfo_s g_prof;
+#endif
   FAR struct profinfo_s *prof = &g_prof;
   irqstate_t flags;
   uintptr_t highpc;


### PR DESCRIPTION
## Summary
Move the static `g_prof` variable declaration to block scope within the `profil()`
function when CONFIG_SMP is disabled, to comply with MISRA C 2012 Rule 8.9 which
requires objects used by only one function to be declared within that function's scope.

## Motivation and Problem
MISRA C 2012 Rule 8.9 enforces improved code locality by requiring that objects
with internal linkage be declared at the smallest possible scope. The original
code declared `g_prof` at file scope globally, even though it is only used within
the `profil()` function when CONFIG_SMP is not enabled. When CONFIG_SMP is enabled,
`g_prof` is used in SMP call data initialization, requiring file-scope visibility.
This change optimizes the scope based on build configuration, improving code clarity
and compliance with embedded systems coding standards.

## Changes
- Remove unconditional file-scope `static struct profinfo_s g_prof` declaration
- Add conditional CONFIG_SMP block at file scope containing g_prof and g_call_data
- Add local `static struct profinfo_s g_prof` declaration inside profil() function
  when CONFIG_SMP is disabled, restricting scope to only where it's used

## Impact
- **MISRA Compliance**: Achieves MISRA C 2012 Rule 8.9 compliance for scope management
- **Code Quality**: Improves code locality and reduces global variable exposure
- **Maintainability**: Clearer intent about variable usage within build configurations
- **Verifiability**: Easier static analysis with properly scoped variables
- **Backward Compatibility**: No functional changes; identical runtime behavior
- **Performance**: No performance impact; scope changes are compile-time only

## Verification
- [x] Code compiles without warnings on ARM GCC 10.x
- [x] Verified on QEMU ARMv7-A simulator with CONFIG_SMP disabled and enabled
- [x] Profiling functionality verified in both SMP and non-SMP configurations
- [x] Timer handler and profil function behavior unchanged
- [x] SMP-specific code paths verified in CONFIG_SMP builds
- [x] Static analysis shows improved compliance metrics

## Testing
Tested with:
- ARM GCC 10.x compiler
- QEMU ARMv7-A simulation
- Profiling scenarios:
  - Non-SMP configuration (g_prof in profil() function scope)
  - SMP configuration (g_prof at file scope with g_call_data)
  - Timer handler invocation and profiling data collection
  - Scale and offset parameter handling



## Files Changed
- `sched/sched/sched_profil.c` (6 lines: 4 insertions, 2 deletions)