### PR TITLE
mps:fix AN524 Kconfig symbol (MPS3, not MPS2)

### DIFF
--- a/arch/arm/src/mps/hardware/mps_memorymap.h
+++ b/arch/arm/src/mps/hardware/mps_memorymap.h
@@ -111,7 +111,7 @@
 
 #endif /* CONFIG_MM_REGIONS > 1 */
 
-#elif defined(CONFIG_ARCH_CHIP_MPS2_AN524)
+#elif defined(CONFIG_ARCH_CHIP_MPS3_AN524)
 
 /* Internal SRAM1 (16MB) */
 #define MPS_SRAM1_START    0x20000000


### PR DESCRIPTION
## Summary

*The code currently checks CONFIG_ARCH_CHIP_MPS2_AN524, but the corresponding Kconfig option is ARCH_CHIP_MPS3_AN524(i.e. CONFIG_ARCH_CHIP_MPS3_AN524) in arch/arm/src/mps/Kconfig
.*

## Impact

N/A

## Testing

N/A
