### PR TITLE
arch/arm: GPIO IMX9 Add support for IRQ line1 and GPIO5

### DIFF
--- a/arch/arm/include/imx9/chip.h
+++ b/arch/arm/include/imx9/chip.h
@@ -47,6 +47,6 @@
 #define NVIC_SYSH_PRIORITY_MAX        0x00 /* Zero is maximum priority */
 #define NVIC_SYSH_PRIORITY_STEP       0x40 /* Two bits of interrupt pri used */
 
-#define IMX9_GPIO_NPORTS          4
+#define IMX9_GPIO_NPORTS          5
 
 #endif /* __ARCH_ARM_INCLUDE_IMX9_CHIP_H */

--- a/arch/arm/src/imx9/Kconfig
+++ b/arch/arm/src/imx9/Kconfig
@@ -382,17 +382,117 @@ config IMX9_GPIO1_IRQ
 	bool "GPIO1 Interrupt"
 	default n
 
+choice
+	prompt "GPIO1 IRQ output select"
+	depends on IMX9_GPIO1_IRQ
+	default IMX9_GPIO1_IRQ_OUT_LINE1
+	---help---
+		Each IMX9 GPIO controller provides two IRQ output lines. These
+		lines may be shared with other cores or domains in the SoC
+		(e.g. A55 vs M7), so selecting the correct line avoids conflicts.
+
+		By default this subsystem uses IRQ line 1, leaving line 0 available
+		for the A55 or other system components that typically rely on it.
+
+config IMX9_GPIO1_IRQ_OUT_LINE0
+	bool "Use GPIO1 IRQ line 0"
+
+config IMX9_GPIO1_IRQ_OUT_LINE1
+	bool "Use GPIO1 IRQ line 1"
+endchoice
+
 config IMX9_GPIO2_IRQ
 	bool "GPIO2 Interrupt"
 	default n
+
+choice
+	prompt "GPIO2 IRQ output select"
+	depends on IMX9_GPIO2_IRQ
+	default IMX9_GPIO2_IRQ_OUT_LINE1
+	---help---
+		Each IMX9 GPIO controller provides two IRQ output lines. These
+		lines may be shared with other cores or domains in the SoC
+		(e.g. A55 vs M7), so selecting the correct line avoids conflicts.
+
+		By default this subsystem uses IRQ line 1, leaving line 0 available
+		for the A55 or other system components that typically rely on it.
+
+config IMX9_GPIO2_IRQ_OUT_LINE0
+	bool "Use GPIO2 IRQ line 0"
+
+config IMX9_GPIO2_IRQ_OUT_LINE1
+	bool "Use GPIO2 IRQ line 1"
+endchoice
 
 config IMX9_GPIO3_IRQ
 	bool "GPIO3 Interrupt"
 	default n
 
+choice
+	prompt "GPIO3 IRQ output select"
+	depends on IMX9_GPIO3_IRQ
+	default IMX9_GPIO3_IRQ_OUT_LINE1
+	---help---
+		Each IMX9 GPIO controller provides two IRQ output lines. These
+		lines may be shared with other cores or domains in the SoC
+		(e.g. A55 vs M7), so selecting the correct line avoids conflicts.
+
+		By default this subsystem uses IRQ line 1, leaving line 0 available
+		for the A55 or other system components that typically rely on it.
+
+config IMX9_GPIO3_IRQ_OUT_LINE0
+	bool "Use GPIO3 IRQ line 0"
+
+config IMX9_GPIO3_IRQ_OUT_LINE1
+	bool "Use GPIO3 IRQ line 1"
+endchoice
+
 config IMX9_GPIO4_IRQ
 	bool "GPIO4 Interrupt"
 	default n
+
+choice
+	prompt "GPIO4 IRQ output select"
+	depends on IMX9_GPIO4_IRQ
+	default IMX9_GPIO4_IRQ_OUT_LINE1
+	---help---
+		Each IMX9 GPIO controller provides two IRQ output lines. These
+		lines may be shared with other cores or domains in the SoC
+		(e.g. A55 vs M7), so selecting the correct line avoids conflicts.
+
+		By default this subsystem uses IRQ line 1, leaving line 0 available
+		for the A55 or other system components that typically rely on it.
+
+config IMX9_GPIO4_IRQ_OUT_LINE0
+	bool "Use GPIO4 IRQ line 0"
+
+config IMX9_GPIO4_IRQ_OUT_LINE1
+	bool "Use GPIO4 IRQ line 1"
+endchoice
+
+config IMX9_GPIO5_IRQ
+	bool "GPIO5 Interrupt"
+	default n
+
+choice
+	prompt "GPIO5 IRQ output select"
+	depends on IMX9_GPIO5_IRQ
+	default IMX9_GPIO5_IRQ_OUT_LINE1
+	---help---
+		Each IMX9 GPIO controller provides two IRQ output lines. These
+		lines may be shared with other cores or domains in the SoC
+		(e.g. A55 vs M7), so selecting the correct line avoids conflicts.
+
+		By default this subsystem uses IRQ line 1, leaving line 0 available
+		for the A55 or other system components that typically rely on it.
+
+config IMX9_GPIO5_IRQ_OUT_LINE0
+	bool "Use GPIO5 IRQ line 0"
+
+config IMX9_GPIO5_IRQ_OUT_LINE1
+	bool "Use GPIO5 IRQ line 1"
+endchoice
+
 
 endmenu # GPIO Interrupt Configuration
 

--- a/arch/arm/src/imx9/imx9_gpio.c
+++ b/arch/arm/src/imx9/imx9_gpio.c
@@ -124,8 +124,13 @@ static int imx9_gpio_configinput(gpio_pinset_t pinset)
 {
   uint32_t port = (pinset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
   uint32_t pin  = (pinset & GPIO_PIN_MASK) >> GPIO_PIN_SHIFT;
+  uint32_t reg;
 
   DEBUGASSERT((unsigned int)port < IMX9_GPIO_NPORTS);
+
+  reg = getreg32(IMX9_GPIO_PCNS(port));
+  reg &= ~(1 << pin);
+  putreg32(reg, IMX9_GPIO_PCNS(port));
 
   /* Configure pin as in input */
 


### PR DESCRIPTION
## Summary

Adds support to select irq line 1 to share the same GPIO with Linux Also added GPIO5 definiton for IRQ

## Impact

Fixes IMX95 M7 GPIO IRQ

## Testing
NavQ95 button