### PR TITLE
drivers/serial: fix crash when buffer is full and only recvbuf is imp…

### DIFF
--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -166,7 +166,7 @@ void uart_recvchars(FAR uart_dev_t *dev)
     {
       int nexthead = rxbuf->head + 1 < rxbuf->size ? rxbuf->head + 1 : 0;
       bool is_full = (nexthead == rxbuf->tail);
-      FAR char *pbuf;
+      FAR char *pbuf = NULL;
       char ch;
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS
@@ -217,38 +217,52 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
       /* Get this next character from the hardware */
 
-      if (!is_full && dev->ops->recvbuf)
+      if (dev->ops->recvbuf)
         {
           ssize_t ret;
 
-          if (rxbuf->tail > rxbuf->head)
+          if (!is_full)
             {
-              nbytes = rxbuf->tail - rxbuf->head - 1;
-            }
-          else if (rxbuf->tail)
-            {
-              nbytes = rxbuf->size - rxbuf->head;
+              if (rxbuf->tail > rxbuf->head)
+                {
+                  nbytes = rxbuf->tail - rxbuf->head - 1;
+                }
+              else if (rxbuf->tail)
+                {
+                  nbytes = rxbuf->size - rxbuf->head;
+                }
+              else
+                {
+                  nbytes = rxbuf->size - rxbuf->head - 1;
+                }
+
+              pbuf = &rxbuf->buffer[rxbuf->head];
+              ret = uart_recvbuf(dev, pbuf, nbytes);
+              if (ret <= 0)
+                {
+                  continue;
+                }
+
+              nbytes = ret;
+              rxbuf->head += nbytes;
+              if (rxbuf->head >= rxbuf->size)
+                {
+                  rxbuf->head = 0;
+                }
             }
           else
             {
-              nbytes = rxbuf->size - rxbuf->head - 1;
-            }
+              pbuf = &ch;
+              nbytes = 1;
 
-          pbuf = &rxbuf->buffer[rxbuf->head];
-          ret = uart_recvbuf(dev, pbuf, nbytes);
-          if (ret <= 0)
-            {
-              continue;
-            }
-
-          nbytes = ret;
-          rxbuf->head += nbytes;
-          if (rxbuf->head >= rxbuf->size)
-            {
-              rxbuf->head = 0;
+              ret = uart_recvbuf(dev, pbuf, nbytes);
+              if (ret <= 0)
+                {
+                  continue;
+                }
             }
         }
-      else
+      else if(dev->ops->receive)
         {
           unsigned int status;
 


### PR DESCRIPTION
## Summary

This PR fixes a critical crash issue in the serial driver when the receive buffer is full and the driver only implements the `recvbuf` operation without implementing the `receive` operation.

### Problem Description:
When the receive buffer becomes full, the original code would attempt to call the `receive` operation even when it's NULL, causing a crash. This scenario occurs when:
1. The serial driver implements `recvbuf` but not `receive`
2. The receive buffer fills up completely
3. The code tries to call `dev->ops->receive()` which is NULL

### Root Cause:
The original logic had the following issues:
- When buffer is full and `!is_full` condition fails, it would fall through to call `receive` operation
- No NULL check for `dev->ops->receive` before calling it
- When buffer is full, hardware FIFO continues to accumulate data with no way to drain it

### Solution:
This patch fixes the issue by:

1. **Add NULL check for receive operation**: Check `dev->ops->receive` exists before calling it to prevent crash
2. **Drain hardware FIFO when buffer is full**: When buffer is full but `recvbuf` is available, use a temporary buffer (`&ch`) to drain hardware FIFO and prevent data accumulation
3. **Restructure conditional logic**: Properly handle the case when only `recvbuf` is implemented
4. **Initialize pbuf to NULL**: Prevent potential uninitialized variable usage

### Code Changes:
- Modified `uart_recvchars()` in `drivers/serial/serial_io.c`
- Added proper NULL checks and conditional logic
- Improved buffer full handling to drain hardware FIFO

## Impact

### Stability:
- **Critical Fix**: Prevents NULL pointer dereference crash when buffer is full
- **Positive**: Prevents hardware FIFO overflow by draining data even when buffer is full
- **Positive**: Makes serial driver more robust for drivers that only implement `recvbuf`

### Compatibility:
- **No breaking changes**: Maintains existing API and behavior
- **Backward compatible**: Works with all existing serial drivers
- **Improved compatibility**: Now works correctly with drivers that only implement `recvbuf`

### Code Quality:
- **Improved**: Better structured conditional logic
- **Improved**: Fixed potential NULL pointer dereference
- **Improved**: Fixed potential uninitialized variable issue

## Testing


### Test Steps:
1. Built NuttX with sim:nsh configuration
2. Configured serial driver to only implement `recvbuf` operation
3. Filled receive buffer completely with high-speed data transmission
4. Verified no crash occurs when buffer is full
5. Verified hardware FIFO is properly drained

### Test Results:

**Before the patch:**
```bash
# System crashes with NULL pointer dereference when buffer fills up
# Crash occurs in uart_recvchars() when calling dev->ops->receive()
