### PR TITLE
include/notifier: fix undefined reference to spin_lock_irqsave_nopreempt

### DIFF
--- a/include/nuttx/notifier.h
+++ b/include/nuttx/notifier.h
@@ -30,7 +30,7 @@
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 #include <nuttx/mutex.h>
-#include <nuttx/spinlock_type.h>
+#include <nuttx/spinlock.h>
 
 #include <debug.h>
 #include <errno.h>


### PR DESCRIPTION
## Summary

This PR fixes a linker error in the notifier subsystem caused by incorrect header file inclusion.

### Problem Description:

When building code that uses notifier chains (e.g., clock_changed_notifier_call_chain), the linker fails with:
undefined reference to 'spin_lock_irqsave_nopreempt' in .text.clock_changed_notifier_call_chain

### Root Cause:

The `include/nuttx/notifier.h` header file was including `<nuttx/spinlock_type.h>` which only provides type definitions for spinlock structures. However, the inline functions in notifier.h actually use spinlock functions like `spin_lock_irqsave_nopreempt()`, which are implemented in `<nuttx/spinlock.h>`.

This mismatch causes the linker to fail because:
1. The compiler sees the function declarations from spinlock_type.h
2. The inline code in notifier.h calls these functions
3. But the actual function implementations are not included
4. Result: undefined reference at link time


## Impact
fix compile break

## Test

sim:nsh with enable reboot notify, compile ok
