### PR TITLE
sched_cpuload: Move static wdog to block scope for MISRA C 2012 Rule 8.9

### DIFF
--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -90,10 +90,6 @@ volatile clock_t g_cpuload_total;
  * Private Data
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_CPULOAD_SYSCLK
-static struct wdog_s g_cpuload_wdog;
-#endif
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -287,7 +283,9 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload)
 #ifdef CONFIG_SCHED_CPULOAD_SYSCLK
 void cpuload_init(void)
 {
-  wd_start(&g_cpuload_wdog, CPULOAD_SAMPLING_PERIOD, cpuload_callback,
-           (wdparm_t)&g_cpuload_wdog);
+  static struct wdog_s cpuload_wdog;
+
+  wd_start(&cpuload_wdog, CPULOAD_SAMPLING_PERIOD, cpuload_callback,
+           (wdparm_t)&cpuload_wdog);
 }
 #endif


### PR DESCRIPTION
## Summary
Refactor the CPU load monitoring module to improve code quality by moving the static `g_cpuload_wdog` watchdog timer from file scope to block scope within the `cpuload_init()` function. This change addresses a MISRA C 2012 Rule 8.9 violation and enhances code maintainability through proper variable scope discipline.

## Motivation and Problem
MISRA C 2012 Rule 8.9 states that "An object should be defined at block scope if its identifier only appears in a single function." The static `g_cpuload_wdog` watchdog structure was defined at file scope but is only used within the `cpuload_init()` function, creating an unnecessary global scope binding.



### TEST
```
test log in hardware with esp32s3-devkit:nsh
nsh> uname -a
NuttX 12.12.0 5d41a8015dc-dirty Jan 29 2026 09:53:04 xtensa esp32s3-devkit
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=3

## cov-log
hujun5@hujun5-ThinkCentre-M760t:~/ssd/default_safety-mk$ cov-build --dir /home/hujun5/ssd/result --tmpdir /home/hujun5/ssd/tmp --emit-complementary-info --encoding UTF-8 ./nuttx/tools/build.sh vendor/qemu/boards/caros/configs/caros/ --cmake -j25
Coverity Build Capture (64-bit) version 2024.6.0 on Linux 6.14.0-29-generic x86_64
Internal version numbers: 948d9eb9dd p-2024.6-push-47


Warning: rustup not found, skipping Rust toolchain setup
including vendor/infineon/boards/aurix/build/vendorsetup.sh
including vendor/infineon/boards/aurix_tc3/build/vendorsetup.sh
including vendor/qemu/boards/miwear/build/vendorsetup.sh
including vendor/qemu/boards/module/build/vendorsetup.sh
including vendor/qemu/boards/smartspeaker/build/vendorsetup.sh
including vendor/qemu/boards/vela/build/vendorsetup.sh
including vendor/sim/boards/miot/build/vendorsetup.sh
including vendor/sim/boards/miwear/build/vendorsetup.sh
including vendor/sim/boards/smartspeaker/build/vendorsetup.sh
including vendor/sim/boards/vela/build/vendorsetup.sh
  cmake --build cmake_out/caros_caros -j25 
[73/1803] Building C object arch/CMakeFiles/arch.dir/arm/src/armv8-r/arm_syscall.c.obj
/home/hujun5/ssd/default_safety-mk/nuttx/arch/arm/src/armv8-r/arm_syscall.c: In function 'arm_syscall':
/home/hujun5/ssd/default_safety-mk/nuttx/arch/arm/src/armv8-r/arm_syscall.c:217:9: warning: implicit declaration of function 'addrenv_switch' [-Wimplicit-function-declaration]
  217 |         addrenv_switch(tcb);
      |         ^~~~~~~~~~~~~~
[1289/1803] cd /home/hujun5/ssd/default_safety-mk/cmake_out/caros_caros/syscall && cmake --build /home/hujun5/ssd/default_safety-mk/cmake_out/caros_caros/bin_host --target mksyscall
[ 25%] Building C object CMakeFiles/csvparser.dir/csvparser.c.o
[ 50%] Linking C static library libcsvparser.a
[ 50%] Built target csvparser
[ 75%] Building C object CMakeFiles/mksyscall.dir/mksyscall.c.o
[100%] Linking C executable mksyscall
[100%] Built target mksyscall
[1759/1803] Building C object apps/frameworks/system/autocore/os/CMakeFiles/kautocore.dir/src/os_task_inner.c.obj
/home/hujun5/ssd/default_safety-mk/apps/frameworks/system/autocore/os/src/os_task_inner.c: In function 'OS_TASK_generic_wrapper':
/home/hujun5/ssd/default_safety-mk/apps/frameworks/system/autocore/os/src/os_task_inner.c:75:23: warning: passing argument 1 of 'up_task_start' from incompatible pointer type [-Wincompatible-pointer-types]
   75 |         up_task_start(user_entry, 0, NULL);
      |                       ^~~~~~~~~~
      |                       |
      |                       os_entry_t {aka void (*)(void)}
In file included from /home/hujun5/ssd/default_safety-mk/nuttx/sched/sched/sched.h:36,
                 from /home/hujun5/ssd/default_safety-mk/apps/frameworks/system/autocore/os/src/os_task_inner.c:28:
/home/hujun5/ssd/default_safety-mk/nuttx/include/nuttx/arch.h:626:27: note: expected 'main_t' {aka 'int (*)(int,  char **)'} but argument is of type 'os_entry_t' {aka 'void (*)(void)'}
  626 | void up_task_start(main_t taskentry, int argc, FAR char *argv[])
      |                    ~~~~~~~^~~~~~~~~
[1783/1803] Linking C executable nuttx_user
Memory region         Used Size  Region Size  %age Used
          kflash:          0 GB       512 KB      0.00%
          uflash:       43308 B       512 KB      8.26%
           ksram:          0 GB         8 MB      0.00%
           usram:       51520 B         8 MB      0.61%
[1799/1803] Linking C executable nuttx
/home/hujun5/ssd/default_safety-mk/prebuilts/gcc/linux-x86_64/arm-none-eabi/bin/../lib/gcc/arm-none-eabi/13.2.1/../../../../arm-none-eabi/bin/ld: warning: nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
          kflash:      138560 B       512 KB     26.43%
          uflash:          0 GB       512 KB      0.00%
           ksram:         96 KB         8 MB      1.17%
           usram:          0 GB         8 MB      0.00%
[1803/1803] cd /home/hujun5/ssd/default_safety-mk/cmake_out/caros_caros && arm-none-eabi-objc... cp nuttx_user.map vela_safetydemo_user.mapfile && cp User.map vela_safetydemo_user.SystemMa
Attempting to detect unconfigured compilers in build
|0----------25-----------50----------75---------100|
****************************************************
Emitted 1759 C/C++ compilation units (100%) successfully

2070 C/C++ compilation units (100%) are ready for analysis
The cov-build utility completed successfully.
hujun5@hujun5-ThinkCentre-M760t:~/ssd/default_safety-mk$ cov-analyze --dir /home/hujun5/ssd/result        --enable-fnptr --enable-virtual --enable-callgraph-metrics --enable-constraint-fpp               --security                                                                         --enable ASSERT_SIDE_EFFECT --checker-option UNINIT:enable_write_context:true --coding-standard-config /home/hujun5/downloads/MISRA_c2012_007.config
Coverity Static Analysis version 2024.6.0 on Linux 6.14.0-29-generic x86_64
Internal version numbers: 948d9eb9dd p-2024.6-push-47

/home/hujun5/downloads/MISRA_c2012_007.config:212:5: [WARNING] Trailing commas in objects are deprecated for coding standard configuration files
Using 8 workers as limited by setting
Looking for translation units
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Computing links for 1437 translation units
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Computing function pointers
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Computing virtual overrides
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Resolving dataflow directives
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Computing callgraph
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Topologically sorting 2941 functions
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Preparing for source code analysis
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Running Sigma analysis
[STATUS] Computing node costs
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Running analysis
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Exporting summaries
|0----------25-----------50----------75---------100|
****************************************************
[STATUS] Computing callgraph metrics for 2934 functions
|0----------25-----------50----------75---------100|
****************************************************
Analysis summary report:
------------------------
Files analyzed                       : 1644 Total
    C                                : 1641
    C++                              : 3
Total LoC input to cov-analyze       : 140098
Functions analyzed                   : 2709
Classes/structs analyzed             : 330
Paths analyzed                       : 243139
Time taken by analysis               : 00:00:25
Defects/Coding rule violations found : 5440 Total
                                          2 BAD_FREE
                                          2 BAD_SHIFT
                                          2 CHECKED_RETURN
                                          4 DC.WEAK_CRYPTO
                                         10 DEADCODE
                                          6 DIVIDE_BY_ZERO
                                          1 FORWARD_NULL
                                          2 HIS_CALLING
                                          1 HIS_CALLS
                                         23 HIS_CCM
                                         94 HIS_GOTO
                                          1 HIS_PARAM
                                          4 HIS_PATH
                                        567 HIS_RETURN
                                          8 HIS_VOCF
                                         24 INTEGER_OVERFLOW
                                         47 MISRA C-2012 Directive 4.12
                                         13 MISRA C-2012 Rule 10.2
                                        874 MISRA C-2012 Rule 10.3
                                       1797 MISRA C-2012 Rule 10.4
                                          1 MISRA C-2012 Rule 11.2
                                         70 MISRA C-2012 Rule 11.6
                                        351 MISRA C-2012 Rule 15.1
                                       1126 MISRA C-2012 Rule 15.5
                                          1 MISRA C-2012 Rule 17.3
                                          3 MISRA C-2012 Rule 2.1
                                         67 MISRA C-2012 Rule 21.13
                                          8 MISRA C-2012 Rule 21.18
                                          1 MISRA C-2012 Rule 21.4
                                          2 MISRA C-2012 Rule 22.2
                                        189 MISRA C-2012 Rule 22.5
                                          4 MISRA C-2012 Rule 5.7
                                         84 MISRA C-2012 Rule 8.9
                                          1 MISRA C-2012 Rule 9.7
                                          2 NEGATIVE_RETURNS
                                         13 NO_EFFECT
                                          1 NULL_RETURNS
                                          5 OVERRUN
                                          3 RESOURCE_LEAK
                                          1 REVERSE_INULL
                                          5 SECURE_TEMP
                                          1 TAINTED_SCALAR
                                          8 TOCTOU
                                          3 UNUSED_VALUE
                                          8 Y2K38_SAFETY

hujun5@hujun5-ThinkCentre-M760t:~/ssd/default_safety-mk$ cov-format-errors --dir /home/hujun5/ssd/result --html-output ./cov-html-quick --include-files "/nuttx/sched/sched/*"
Processing 1 error.

0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
Processed error.

```
![img_v3_02ud_bd7848a1-a51a-4a9a-9f06-d415b1643e5g](https://github.com/user-attachments/assets/e8d134ca-c6ee-481c-a314-553f890d8011)


![img_v3_02ud_06a79951-9464-4e4c-8c02-4d33f94bfa4g](https://github.com/user-attachments/assets/fd47d886-9c19-4267-9af6-0a5965f999f6)
