### PR TITLE
net/ipforward: it should have a ipforward setting based interface

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -55,6 +55,7 @@
 #define IFF_POINTOPOINT    (1 << 6)  /* Is point-to-point link */
 #define IFF_NOARP          (1 << 7)  /* ARP is not required for this interface */
 #define IFF_NAT            (1 << 8)  /* NAT is enabled for this interface */
+#define IFF_FORWARD        (1 << 9)  /* ipforward is enabled for this interface */
 #define IFF_SLAVE          (1 << 11) /* Slave of a load balancer. */
 #define IFF_MULTICAST      (1 << 12) /* Supports multicast. */
 #define IFF_BROADCAST      (1 << 13) /* Broadcast address valid. */
@@ -70,6 +71,7 @@
 #define IFF_SET_RUNNING(f)     do { (f) |= IFF_RUNNING; } while (0)
 #define IFF_SET_NOARP(f)       do { (f) |= IFF_NOARP; } while (0)
 #define IFF_SET_NAT(f)         do { (f) |= IFF_NAT; } while (0)
+#define IFF_SET_FORWARD(f)     do { (f) |= IFF_FORWARD; } while (0)
 #define IFF_SET_LOOPBACK(f)    do { (f) |= IFF_LOOPBACK; } while (0)
 #define IFF_SET_POINTOPOINT(f) do { (f) |= IFF_POINTOPOINT; } while (0)
 #define IFF_SET_MULTICAST(f)   do { (f) |= IFF_MULTICAST; } while (0)
@@ -81,6 +83,7 @@
 #define IFF_CLR_RUNNING(f)     do { (f) &= ~IFF_RUNNING; } while (0)
 #define IFF_CLR_NOARP(f)       do { (f) &= ~IFF_NOARP; } while (0)
 #define IFF_CLR_NAT(f)         do { (f) &= ~IFF_NAT; } while (0)
+#define IFF_CLR_FORWARD(f)     do { (f) &= ~IFF_FORWARD; } while (0)
 #define IFF_CLR_LOOPBACK(f)    do { (f) &= ~IFF_LOOPBACK; } while (0)
 #define IFF_CLR_POINTOPOINT(f) do { (f) &= ~IFF_POINTOPOINT; } while (0)
 #define IFF_CLR_MULTICAST(f)   do { (f) &= ~IFF_MULTICAST; } while (0)
@@ -92,6 +95,7 @@
 #define IFF_IS_RUNNING(f)     (((f) & IFF_RUNNING) != 0)
 #define IFF_IS_NOARP(f)       (((f) & IFF_NOARP) != 0)
 #define IFF_IS_NAT(f)         (((f) & IFF_NAT) != 0)
+#define IFF_IS_FORWARD(f)     (((f) & IFF_FORWARD) != 0)
 #define IFF_IS_LOOPBACK(f)    (((f) & IFF_LOOPBACK) != 0)
 #define IFF_IS_POINTOPOINT(f) (((f) & IFF_POINTOPOINT) != 0)
 #define IFF_IS_MULTICAST(f)   (((f) & IFF_MULTICAST) != 0)

--- a/net/ipforward/ipfwd_forward.c
+++ b/net/ipforward/ipfwd_forward.c
@@ -50,6 +50,70 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: ipforward_enable
+ *
+ * Description:
+ *   Enable forward function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which will be enabled forward function.
+ *
+ * Returned Value:
+ *   Zero is returned if forward function is successfully enabled;
+ *   A negated errno value is returned if failed.
+ *
+ ****************************************************************************/
+
+int ipforward_enable(FAR struct net_driver_s *dev)
+{
+  netdev_lock();
+
+  if (IFF_IS_FORWARD(dev->d_flags))
+    {
+      nwarn("WARNING: FORWARD was already enabled for %s!\n", dev->d_ifname);
+      netdev_unlock();
+      return -EEXIST;
+    }
+
+  IFF_SET_FORWARD(dev->d_flags);
+
+  netdev_unlock();
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ipforward_disable
+ *
+ * Description:
+ *   Disable forward function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the ipforward function will be disabled.
+ *
+ * Returned Value:
+ *   Zero is returned if ipforward function is successfully disabled;
+ *   A negated errno value is returned if failed.
+ *
+ ****************************************************************************/
+
+int ipforward_disable(FAR struct net_driver_s *dev)
+{
+  netdev_lock();
+
+  if (!IFF_IS_FORWARD(dev->d_flags))
+    {
+      nwarn("WARNING: ipforward was not enabled for %s!\n", dev->d_ifname);
+      netdev_unlock();
+      return -ENODEV;
+    }
+
+  IFF_CLR_FORWARD(dev->d_flags);
+
+  netdev_unlock();
+  return OK;
+}
+
+/****************************************************************************
  * Name: forward_ipselect
  *
  * Description:

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -374,7 +374,7 @@ static int ipv4_forward_callback(FAR struct net_driver_s *fwddev,
   /* Only IFF_RUNNING device and non-loopback device need forward packet */
 
   if (!IFF_IS_RUNNING(fwddev->d_flags) ||
-      fwddev->d_lltype == NET_LL_LOOPBACK)
+      !IFF_IS_FORWARD(dev->d_flags))
     {
       return OK;
     }
@@ -471,7 +471,8 @@ int ipv4_forward(FAR struct net_driver_s *dev, FAR struct ipv4_hdr_s *ipv4)
   srcipaddr  = net_ip4addr_conv32(ipv4->srcipaddr);
 
   fwddev     = netdev_findby_ripv4addr(srcipaddr, destipaddr);
-  if (fwddev == NULL)
+  if (fwddev == NULL ||
+      !IFF_IS_FORWARD(fwddev->d_flags))
     {
       nwarn("WARNING: Not routable\n");
       ret = -ENETUNREACH;

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -513,7 +513,7 @@ static int ipv6_forward_callback(FAR struct net_driver_s *fwddev,
   /* Only IFF_RUNNING device and non-loopback device need forward packet */
 
   if (!IFF_IS_RUNNING(fwddev->d_flags) ||
-      fwddev->d_lltype == NET_LL_LOOPBACK)
+      !IFF_IS_FORWARD(dev->d_flags))
     {
       return OK;
     }
@@ -606,7 +606,8 @@ int ipv6_forward(FAR struct net_driver_s *dev, FAR struct ipv6_hdr_s *ipv6)
   /* Search for a device that can forward this packet. */
 
   fwddev = netdev_findby_ripv6addr(ipv6->srcipaddr, ipv6->destipaddr);
-  if (fwddev == NULL)
+  if (fwddev == NULL ||
+      !IFF_IS_FORWARD(fwddev->d_flags))
     {
       nwarn("WARNING: Not routable\n");
       ret = -ENETUNREACH;


### PR DESCRIPTION
## Summary

It's like option "net.ipv4.conf.eth0.forwarding" in linux.
It's a useful setting if we need control ip forward by network interface level. Such like a LTE modem, a LTE modem usually has 3 net interfaces, while only one can be used data communication. It allows us configure the net device usage more flexible. 

## Impact

  * Nuttx support ipforward control, while it is a system level control for all network interfaces. This commit is to improve configure flexibility.
  * This need user application to enable a network interface forward capability. we can set ipfoward flag is enabled by default if we need to keep backward compatibility.  it's a  reasonable to choose ipforward flag disabled by default.  
  * Impact on build (will build process change)? NO 
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO 
  * Impact on documentation (is update required / provided)? YES (If enable CONFIG_NET_IPFORWARD, need enable at least one net interface as "ipforward").
  * Impact on security (any sort of implications)?  YES (This helps improve the security, since we choose specific net interface that can do ipforward,  before the fwdev is choose by default.).
  * Impact on compatibility (backward/forward/interoperability)?  YES (as mentioned  above, it do changes some behavior, while it's something that deserve).


## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): OS (Linux,BSD,macOS,Windows,..), CPU(Intel,AMD,ARM), compiler(GCC,CLANG,version), etc.
  * Target(s): ARM, BES chips.

  Testing logs before change:

any device can be chosen as ipforward net interface.
 
  Testing logs after change:

with this commit, only network interface with flag "IFF_FORWARD" can forward ip packet.

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [ ] My PR is ready for review and can be safely merged into a codebase.