### PR TITLE
drivers/ioexapnder/mcp23x17 : Fix write gpio output values on OLAT registers

### DIFF
--- a/drivers/ioexpander/mcp23x17.c
+++ b/drivers/ioexpander/mcp23x17.c
@@ -418,7 +418,7 @@ static int mcp23x17_writepin(FAR struct ioexpander_dev_s *dev, uint8_t pin,
       return ret;
     }
 
-  ret = mcp23x17_setbit(priv, MCP23X17_GPIOA, pin, value);
+  ret = mcp23x17_setbit(priv, MCP23X17_OLATA, pin, value);
   nxmutex_unlock(&priv->lock);
   return ret;
 }


### PR DESCRIPTION
## Summary

Gpio output value must be set on OLATA and OLATB registers.

Why is this change necessary?
This is a bug fix. The MCP23x17 driver was writing GPIO output values to incorrect registers, causing output
pins to not behave as expected.

What functional part of the code is being changed?
The MCP23x17 I/O expander driver (drivers/ioexpander/mcp23x17.c).

How does the change work?
The fix ensures GPIO output values are written to the OLATA and OLATB (Output Latch) registers instead of the
incorrect registers. The OLAT registers are the proper registers for controlling the actual output pin
states on the MCP23x17.

## Impact

- User experience: No adaptation required. This fix corrects existing broken behavior.
- Build: No impact.
- Hardware: Affects boards using the MCP23x17 I/O expander.
- Documentation: None required.
- Security: No impact.
- Compatibility: Backward compatible - fixes incorrect behavior.

## Testing

Build Host:
- OS: Ubuntu 22.04
- Compiler: arm-none-eabi-gcc

Target:
- Architecture: ARM (RP2350)
- Board: RP2350-based board
- Configuration: Custom config with MCP23x17 enabled over I2C0

Testing performed:
- Connected MCP23x17 to RP2350 via I2C0
- Attached an LED array to all 16 GPIO pins of the MCP23x17
- Configured all 16 GPIO as outputs
- Wrote a simple test application to toggle the LEDs on and off
- Before fix: LEDs did not respond correctly to output commands
- After fix: All 16 LEDs toggle on/off as expected

