### PR TITLE
net/netdev: a valid netdev for ipv4 should have ipv4 addr configured

### DIFF
--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -347,7 +347,15 @@ FAR struct net_driver_s *netdev_findby_ripv4addr(in_addr_t lipaddr,
            * about that here.
            */
 
-          return netdev_default();
+          dev = netdev_default();
+          if (dev && net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
+            {
+              return NULL;
+            }
+          else
+            {
+              return dev;
+            }
         }
       else
         {
@@ -393,7 +401,15 @@ FAR struct net_driver_s *netdev_findby_ripv4addr(in_addr_t lipaddr,
    * try the default network device.
    */
 
-  return netdev_default();
+  dev = netdev_default();
+  if (dev && net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
+    {
+      return NULL;
+    }
+  else
+    {
+      return dev;
+    }
 }
 #endif /* CONFIG_NET_IPv4 */
 


### PR DESCRIPTION
## Summary
This PR adds a valid ipv4 address check when  netdev_findby_ripv4addr return with netdev_default. 
It's not a valid netdev if without ipv4 address.

## Impact
Take ping as example: if without this patch, network communication with ip src address 0.0.0.0 will be there when capture the net device transfer data. 

## Testing

  I confirm that changes are verified on local setup and works as intended:
I tested with a BES EVB board.

  Testing logs before change:
<img width="1660" height="411" alt="image" src="https://github.com/user-attachments/assets/12f2c4a8-371f-4009-be74-b9c05382aa77" />

  ```
  build and runtime logs before change goes here
  ```

  Testing logs after change:
no packet with 0 ip.
  ```
  build and runtime logs after change goes here
  ```

## PR verification Self-Check

  * [ *] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [ ] My PR is ready for review and can be safely merged into a codebase.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Without this patch, if do ping on a system which only has ipv6 address, then it will generate ip packet with ip.src == 0.0.0.0.
with this patch, it will report send error which is more sensible. it reduces security concern.
