### PR TITLE
netdev_driver: add carrier_on to xxx_ifup where carrier_on is absent

### DIFF
--- a/arch/arm/src/at32/at32_can_sock.c
+++ b/arch/arm/src/at32/at32_can_sock.c
@@ -764,6 +764,8 @@ static int at32can_ifup(struct net_driver_s *dev)
 
   priv->dev.d_buf = (uint8_t *)priv->txdesc;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -794,6 +796,8 @@ static int at32can_ifdown(struct net_driver_s *dev)
   /* Reset CAN */
 
   at32can_reset(priv);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }
@@ -2481,4 +2485,3 @@ void arm_netinitialize(void)
 #endif
 }
 #endif
-

--- a/arch/arm/src/at32/at32_eth.c
+++ b/arch/arm/src/at32/at32_eth.c
@@ -2207,6 +2207,9 @@ static int at32_ifup(struct net_driver_s *dev)
   up_enable_irq(AT32_IRQ_ETH);
 
   at32_checksetup();
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2261,6 +2264,9 @@ static int at32_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return ret;
 }
 

--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -1758,6 +1758,9 @@ static int c5471_ifup(struct net_driver_s *dev)
 
   priv->c_bifup = true;
   up_enable_irq(C5471_IRQ_ETHER);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1810,6 +1813,9 @@ static int c5471_ifdown(struct net_driver_s *dev)
 
   priv->c_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/gd32f4/gd32f4xx_enet.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_enet.c
@@ -2264,6 +2264,8 @@ static int gd32_ifup(struct net_driver_s *dev)
   priv->ifup = true;
   up_enable_irq(GD32_IRQ_ENET);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2319,6 +2321,9 @@ static int gd32_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return ret;
 }
 

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -1399,7 +1399,14 @@ static int imx_ifup(struct net_driver_s *dev)
 {
   /* The externally available ifup action includes resetting the phy */
 
-  return imx_ifup_action(dev, true);
+  int ret = imx_ifup_action(dev, true);
+
+  if (ret == OK)
+    {
+      netdev_carrier_on(dev);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -1451,6 +1458,9 @@ static int imx_ifdown(struct net_driver_s *dev)
 
   priv->bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1371,6 +1371,8 @@ static int imxrt_ifup(struct net_driver_s *dev)
 
   up_enable_irq(priv->config->irq);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1398,6 +1400,9 @@ static int imxrt_ifdown(struct net_driver_s *dev)
   imxrt_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1338,6 +1338,8 @@ static int kinetis_ifup(struct net_driver_s *dev)
 
   up_enable_irq(priv->config->mb_irq);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1365,6 +1367,9 @@ static int kinetis_ifdown(struct net_driver_s *dev)
   kinetis_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_can.c
@@ -1766,6 +1766,8 @@ static int lpc17can_ifup(struct net_driver_s *dev)
   lpc17can_rxint(priv, true);
   lpc17can_txint(priv, true);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1793,6 +1795,9 @@ static int lpc17can_ifdown(struct net_driver_s *dev)
   lpc17can_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -1507,6 +1507,9 @@ static int lpc17_40_ifup(struct net_driver_s *dev)
 #else
   up_enable_irq(LPC17_40_IRQ_ETH);
 #endif
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1546,6 +1549,9 @@ static int lpc17_40_ifdown(struct net_driver_s *dev)
   lpc17_40_ethreset(priv);
   priv->lp_ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -2097,6 +2097,9 @@ static int lpc43_ifup(struct net_driver_s *dev)
   up_enable_irq(LPC43M4_IRQ_ETHERNET);
 
   lpc43_checksetup();
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2144,6 +2147,9 @@ static int lpc43_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -1971,6 +1971,9 @@ static int lpc54_eth_ifup(struct net_driver_s *dev)
 
   priv->eth_bifup = 1;
   up_enable_irq(LPC54_IRQ_ETHERNET);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2048,6 +2051,9 @@ static int lpc54_eth_ifdown(struct net_driver_s *dev)
 
   priv->eth_bifup = 0;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -349,4 +349,3 @@ int amebaz_netdev_register(struct amebaz_dev_s *priv)
   dev->d_private = priv;
   return netdev_register(dev, NET_LL_IEEE80211);
 }
-

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -1269,7 +1269,13 @@ static int s32k1xx_ifup(struct net_driver_s *dev)
 {
   /* The externally available ifup action includes resetting the phy */
 
-  return s32k1xx_ifup_action(dev, true);
+  int ret = s32k1xx_ifup_action(dev, true);
+  if (ret == OK)
+    {
+      netdev_carrier_on(dev);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -1321,6 +1327,9 @@ static int s32k1xx_ifdown(struct net_driver_s *dev)
 
   priv->bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1323,6 +1323,8 @@ static int s32k1xx_ifup(struct net_driver_s *dev)
 
   up_enable_irq(priv->config->mb_irq);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1350,6 +1352,9 @@ static int s32k1xx_ifdown(struct net_driver_s *dev)
   s32k1xx_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/s32k3xx/s32k3xx_emac.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_emac.c
@@ -2033,7 +2033,14 @@ static int s32k3xx_ifup(struct net_driver_s *dev)
 {
   /* The externally available ifup action includes resetting the phy */
 
-  return s32k3xx_ifup_action(dev, true);
+  int ret = s32k3xx_ifup_action(dev, true);
+
+  if (ret == OK)
+    {
+      netdev_carrier_on(dev);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -2087,6 +2094,9 @@ static int s32k3xx_ifdown(struct net_driver_s *dev)
 
   priv->bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -1502,6 +1502,8 @@ static int s32k3xx_ifup(struct net_driver_s *dev)
       s32k3xx_gpiowrite(priv->config->led_pin, priv->config->led_high);
     }
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1536,6 +1538,8 @@ static int s32k3xx_ifdown(struct net_driver_s *dev)
       s32k3xx_pinconfig(priv->config->led_pin);
       s32k3xx_gpiowrite(priv->config->led_pin, !priv->config->led_high);
     }
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -1718,6 +1718,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(SAM_IRQ_EMAC);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1764,6 +1767,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -1771,6 +1771,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(SAM_IRQ_EMAC);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1817,6 +1820,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -2124,6 +2124,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(priv->attr->irq);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2170,6 +2173,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -1761,6 +1761,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(SAM_IRQ_GMAC);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1807,6 +1810,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -1726,6 +1726,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(SAM_IRQ_GMAL);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1772,6 +1775,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -2577,6 +2577,9 @@ static int sam_ifup(struct net_driver_s *dev)
 
   priv->ifup = true;
   up_enable_irq(priv->attr->irq);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2623,6 +2626,9 @@ static int sam_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/samv7/sam_lin_sock.c
+++ b/arch/arm/src/samv7/sam_lin_sock.c
@@ -427,6 +427,8 @@ static int sam_lin_ifup(struct net_driver_s *dev)
                      UART_INT_LINID | UART_INT_LINERR);
     }
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -469,6 +471,8 @@ static int sam_lin_ifdown(struct net_driver_s *dev)
           priv->tx_cache[i].can_id = 0;
         }
     }
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -762,6 +762,8 @@ static int stm32can_ifup(struct net_driver_s *dev)
 
   priv->dev.d_buf = (uint8_t *)priv->txdesc;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -792,6 +794,8 @@ static int stm32can_ifdown(struct net_driver_s *dev)
   /* Reset CAN */
 
   stm32can_reset(priv);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }
@@ -2484,4 +2488,3 @@ void arm_netinitialize(void)
 #endif
 }
 #endif
-

--- a/arch/arm/src/stm32/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32/stm32_fdcan_sock.c
@@ -2975,6 +2975,8 @@ static int fdcan_ifup(struct net_driver_s *dev)
 
   priv->dev.d_buf = (uint8_t *)priv->txdesc;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -3006,6 +3008,8 @@ static int fdcan_ifdown(struct net_driver_s *dev)
   /* Reset CAN */
 
   fdcan_reset(priv);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }
@@ -3321,4 +3325,3 @@ void arm_netinitialize(void)
 #endif
 }
 #endif
-

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -786,6 +786,8 @@ static int stm32can_ifup(struct net_driver_s *dev)
 
   priv->dev.d_buf = (uint8_t *)priv->txdesc;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -816,6 +818,8 @@ static int stm32can_ifdown(struct net_driver_s *dev)
   /* Reset CAN */
 
   stm32can_reset(priv);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -1805,6 +1805,8 @@ static int fdcan_ifup(struct net_driver_s *dev)
 
   priv->bifup = true;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1832,6 +1834,8 @@ static int fdcan_ifdown(struct net_driver_s *dev)
   fdcan_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
 
   return OK;
 }
@@ -3041,4 +3045,3 @@ static void fdcan_errint(struct fdcan_driver_s *priv, bool enable)
   putreg32(regval, priv->base + STM32_FDCAN_IE_OFFSET);
 }
 #endif
-

--- a/arch/arm/src/tiva/common/tiva_sock_can.c
+++ b/arch/arm/src/tiva/common/tiva_sock_can.c
@@ -2250,6 +2250,8 @@ static int tivacan_ifup(struct net_driver_s *dev)
 
   priv->dev.d_buf = (uint8_t *)priv->tx_pool;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2278,6 +2280,8 @@ static int tivacan_ifdown(struct net_driver_s *dev)
   /* Stop processing messages */
 
   tivacan_reset(dev);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -1260,6 +1260,9 @@ static int tiva_ifup(struct net_driver_s *dev)
 
   priv->ld_bifup = true;
   leave_critical_section(flags);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1342,6 +1345,9 @@ static int tiva_ifdown(struct net_driver_s *dev)
 
   priv->ld_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -2223,6 +2223,9 @@ static int tiva_ifup(struct net_driver_s *dev)
   up_enable_irq(TIVA_IRQ_ETHCON);
 
   tiva_checksetup();
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2270,6 +2273,9 @@ static int tiva_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   spin_unlock_irqrestore(&priv->lock, flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/arm64/src/imx9/imx9_enet.c
+++ b/arch/arm64/src/imx9/imx9_enet.c
@@ -1440,7 +1440,14 @@ static int imx9_ifup(struct net_driver_s *dev)
 {
   /* The externally available ifup action includes resetting the phy */
 
-  return imx9_ifup_action(dev, true);
+  int ret = imx9_ifup_action(dev, true);
+
+  if (ret == OK)
+    {
+      netdev_carrier_on(dev);
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -1492,6 +1499,8 @@ static int imx9_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/arm64/src/imx9/imx9_flexcan.c
+++ b/arch/arm64/src/imx9/imx9_flexcan.c
@@ -1461,6 +1461,8 @@ static int imx9_ifup(struct net_driver_s *dev)
   up_enable_irq(priv->irq);
   up_enable_irq(priv->irq + 1);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1492,6 +1494,9 @@ static int imx9_ifdown(struct net_driver_s *dev)
   imx9_reset(priv);
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -448,6 +448,9 @@ static int emac_ifup(struct net_driver_s *dev)
 
   priv->d_bifup = true;
   up_enable_irq(CONFIG_HCS12_IRQ);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -491,6 +494,9 @@ static int emac_ifdown(struct net_driver_s *dev)
 
   priv->d_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -2191,6 +2191,9 @@ static int pic32mx_ifup(struct net_driver_s *dev)
 #else
   up_enable_irq(PIC32MX_IRQSRC_ETH);
 #endif
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2233,6 +2236,9 @@ static int pic32mx_ifdown(struct net_driver_s *dev)
   pic32mx_ethreset(priv);
   priv->pd_ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -2340,6 +2340,8 @@ static int pic32mz_ifup(struct net_driver_s *dev)
   up_enable_irq(PIC32MZ_IRQ_ETH);
 #endif
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2382,6 +2384,9 @@ static int pic32mz_ifdown(struct net_driver_s *dev)
   pic32mz_ethreset(priv);
   priv->pd_ifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -694,6 +694,9 @@ static int misoc_net_ifup(struct net_driver_s *dev)
 
   ethmac_sram_writer_ev_enable_write(1);
   leave_critical_section(flags);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -740,6 +743,9 @@ static int misoc_net_ifdown(struct net_driver_s *dev)
 
   priv->misoc_net_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -2073,6 +2073,9 @@ static int rx65n_ifup(struct net_driver_s *dev)
 
   priv->prevlinkstatus = ETHER_LINKUP;
   rx65n_checksetup();
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -2128,6 +2131,9 @@ static int rx65n_ifdown(struct net_driver_s *dev)
   priv->prevlinkstatus = ETHER_LINKDOWN;
 
   spin_unlock_irqrestore(&priv->lock, flags);
+
+  netdev_carrier_off(dev);
+
   return ret;
 }
 

--- a/arch/risc-v/src/litex/litex_emac.c
+++ b/arch/risc-v/src/litex/litex_emac.c
@@ -859,6 +859,8 @@ static int litex_ifup(struct net_driver_s *dev)
 
   litex_phydump(priv);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -899,6 +901,8 @@ static int litex_ifdown(struct net_driver_s *dev)
   leave_critical_section(flags);
 
   litex_phydump(priv);
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -1592,6 +1592,8 @@ static int mpfs_ifup(struct net_driver_s *dev)
            mpfs_txtimeout_expiry, (wdparm_t)priv);
 #endif
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1652,6 +1654,9 @@ static int mpfs_ifdown(struct net_driver_s *dev)
 
   priv->ifup = false;
   spin_unlock_irqrestore(&priv->lock, flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1760,6 +1760,8 @@ static int emac_ifup(struct net_driver_s *dev)
 
   leave_critical_section(flags);
 
+  netdev_carrier_on(dev);
+
   return 0;
 }
 
@@ -1817,6 +1819,8 @@ static int emac_ifdown(struct net_driver_s *dev)
   priv->ifup = false;
 
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
 
   return 0;
 }

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -1990,6 +1990,8 @@ static int ez80emac_ifup(FAR struct net_driver_s *dev)
       priv->bifup = true;
       outp(EZ80_EMAC_IEN, EMAC_EIN_HANDLED); /* Enable all interrupts */
       ret = OK;
+
+      netdev_carrier_on(dev);
     }
 
   return ret;
@@ -2039,6 +2041,9 @@ static int ez80emac_ifdown(FAR struct net_driver_s *dev)
 
   priv->bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/can/kvaser_pci.c
+++ b/drivers/can/kvaser_pci.c
@@ -1023,6 +1023,8 @@ static int kvaser_sock_ifup(FAR struct netdev_lowerhalf_s *dev)
   kvaser_txint(priv, true);
   kvaser_rxint(priv, true);
 
+  netdev_lower_carrier_on(dev);
+
   return OK;
 }
 
@@ -1050,6 +1052,8 @@ static int kvaser_sock_ifdown(FAR struct netdev_lowerhalf_s *dev)
   /* Sleep mode */
 
   kvaser_sleep(priv);
+
+  netdev_lower_carrier_off(dev);
 
   return OK;
 }

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -1396,6 +1396,9 @@ static int dm9x_ifup(FAR struct net_driver_s *dev)
 
   priv->dm_bifup = true;
   up_enable_irq(CONFIG_DM9X_IRQ);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1442,6 +1445,9 @@ static int dm9x_ifdown(FAR struct net_driver_s *dev)
 
   priv->dm_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -1936,6 +1936,7 @@ static int enc_ifup(struct net_driver_s *dev)
 
       priv->ifstate = ENCSTATE_UP;
       priv->lower->enable(priv->lower);
+      netdev_carrier_on(dev);
     }
 
   /* Un-lock the SPI bus */
@@ -1990,6 +1991,8 @@ static int enc_ifdown(struct net_driver_s *dev)
 
   priv->ifstate = ENCSTATE_DOWN;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
 
   /* Un-lock the SPI bus */
 

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -1064,6 +1064,9 @@ static int ftmac100_ifup(struct net_driver_s *dev)
 
   priv->ft_bifup = true;
   up_enable_irq(CONFIG_FTMAC100_IRQ);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1111,6 +1114,9 @@ static int ftmac100_ifdown(struct net_driver_s *dev)
 
   priv->ft_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/net/lan9250.c
+++ b/drivers/net/lan9250.c
@@ -2189,6 +2189,7 @@ static int lan9250_ifup(FAR struct net_driver_s *dev)
             (uint8_t)(mac_addr[0] >> 24), (uint8_t)(mac_addr[0] >> 16),
             (uint8_t)(mac_addr[0] >>  8), (uint8_t)(mac_addr[0] >>  0));
 #endif
+      netdev_carrier_on(dev);
     }
 
   /* Un-lock the SPI bus */
@@ -2240,6 +2241,7 @@ static int lan9250_ifdown(FAR struct net_driver_s *dev)
 
   IFF_CLR_UP(priv->dev.d_flags);
   leave_critical_section(flags);
+  netdev_carrier_off(dev);
 
   /* Un-lock the SPI bus */
 

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -657,6 +657,9 @@ static int skel_ifup(FAR struct net_driver_s *dev)
   priv->sk_bifup = true;
   up_enable_irq(CONFIG_NET_SKELETON_IRQ);
   spin_unlock_irqrestore(&priv->sk_lock, flags);
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -701,6 +704,9 @@ static int skel_ifdown(FAR struct net_driver_s *dev)
 
   priv->sk_bifup = false;
   spin_unlock_irqrestore(&priv->sk_lock, flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -837,6 +837,8 @@ static int slip_ifup(FAR struct net_driver_s *dev)
 
   self->bifup = true;
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -869,6 +871,8 @@ static int slip_ifdown(FAR struct net_driver_s *dev)
   /* Mark the device "down" */
 
   self->bifup = false;
+
+  netdev_carrier_off(dev);
 
   return OK;
 }

--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -1772,6 +1772,8 @@ static int w5500_ifup(FAR struct net_driver_s *dev)
   self->w_bifup = true;
   self->lower->enable(self->lower, true);
 
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1818,6 +1820,9 @@ static int w5500_ifdown(FAR struct net_driver_s *dev)
 
   self->w_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1164,6 +1164,7 @@ static int rndis_transmit(FAR struct rndis_dev_s *priv)
 
 static int rndis_ifup(FAR struct net_driver_s *dev)
 {
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -1177,6 +1178,7 @@ static int rndis_ifup(FAR struct net_driver_s *dev)
 
 static int rndis_ifdown(FAR struct net_driver_s *dev)
 {
+  netdev_carrier_off(dev);
   return OK;
 }
 

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -2347,6 +2347,9 @@ static int cdcmbim_ifup(FAR struct net_driver_s *dev)
     }
 
   priv->bifup = true;
+
+  netdev_lower_carrier_on(dev);
+
   return OK;
 }
 
@@ -2379,6 +2382,9 @@ static int cdcmbim_ifdown(FAR struct net_driver_s *dev)
   priv->bifup = false;
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
+
+  netdev_lower_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -680,6 +680,7 @@ static int xbeenet_ifup(FAR struct net_driver_s *dev)
 
       priv->xd_bifup = true;
       ret = OK;
+      netdev_carrier_on(dev);
     }
 
   return ret;
@@ -720,6 +721,9 @@ static int xbeenet_ifdown(FAR struct net_driver_s *dev)
 
   priv->xd_bifup = false;
   leave_critical_section(flags);
+
+  netdev_carrier_off(dev);
+
   return OK;
 }
 

--- a/drivers/wireless/spirit/drivers/spirit_netdev.c
+++ b/drivers/wireless/spirit/drivers/spirit_netdev.c
@@ -1777,6 +1777,7 @@ static int spirit_ifup(FAR struct net_driver_s *dev)
       /* We are up! */
 
       priv->ifup = true;
+      netdev_carrier_on(dev);
     }
 
   return OK;
@@ -1875,6 +1876,7 @@ static int spirit_ifdown(FAR struct net_driver_s *dev)
         }
 
       priv->ifup = false;
+      netdev_carrier_off(dev);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
Since the judgment for network card selection was changed from IS_UP to IS_RUNNING, drivers that lack carrier_on need to add the carrier_on operation; otherwise, network access issues will occur.

## Impact
All network card drivers that implement d_ifup and lack a call to carrier_on.

## Testing
Too many network cards have been modified. I haven't conducted functional tests, but the modified logic is relatively simple. I'd like to run CI first to verify if there are any compilation issues.
