### PR TITLE
fs/tmpfs: Check for existing mapping before adding new entry

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1788,10 +1788,19 @@ static int tmpfs_mmap(FAR struct file *filep, FAR struct mm_map_entry_s *map)
   if (map->offset >= 0 && map->offset < tfo->tfo_size &&
       map->length && map->offset + map->length <= tfo->tfo_size)
     {
+      FAR struct mm_map_s *mm = get_current_mm();
       map->vaddr = tfo->tfo_data + map->offset;
-      map->priv.p = tfo;
-      map->munmap = tmpfs_unmap;
-      ret = mm_map_add(get_current_mm(), map);
+
+      if (mm_map_find(mm, map->vaddr, map->length))
+        {
+          ret = 0;
+        }
+      else
+        {
+          map->priv.p = tfo;
+          map->munmap = tmpfs_unmap;
+          ret = mm_map_add(mm, map);
+        }
 
       if (ret >= 0)
         {


### PR DESCRIPTION


## Summary

Add pre-check before mm_map_add to avoid duplicate memory mappings

Reproduce testcase:
test(void)
{
  void *buffer;
  int memfd = memfd_create("optee", O_CREAT | O_CLOEXEC);
  ftruncate(memfd, size);
  buffer = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0);
  close(memfd);

  *((int *)buffer) = 0xdeadbeef;
  usleep(10);
  *((int *)buffer) = 0xdeadbeef;

  munmap(buffer, size);
}

loop run test() in several pthreads, you will find used-after-free

Root cause:

thread 1:                             thread2:
memfd_create() -- refs = 1
ftruncate()    -- alloc mem
mmap()         -- refs = 2
close()        -- refs = 1

                                      memfd_create() -- refs = 2
                                      ftruncate()
                                      mmap()         -- refs = 3
                                      close()        -- refs = 2
                                      munmap()       -- refs = 2
                                      munmap()       -- refs = 1 //error
                                                     -- free mem
access used after free
mmap()         -- refs = 1
                  free mem


## Impact

None

## Testing

ostest PASS