### PR TITLE
boards/arm: fix div64_const not compatible for pre-process macro

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -321,25 +321,24 @@ extern "C"
 
 #endif
 
-#if defined(CONFIG_HAVE_LONG_LONG) && defined(CONFIG_HAVE_EXPRESSION_STATEMENT)
-#  define div64_const(n, base) \
-    ({ \
-      uint64_t __n = (n); \
-      uint32_t __base = (base); \
-      if (IS_POWER_OF_2(__base)) \
-        { \
-          (__n) >>= LOG2_FLOOR(__base); \
-        } \
-      else if (UINTPTR_MAX == UINT32_MAX) \
-        { \
-          div64_const32(__n, __base); \
-        } \
-      else \
-        { \
-          __n /= __base; \
-        } \
-        __n; \
-      })
+#ifdef CONFIG_HAVE_LONG_LONG
+static inline_function uint64_t div64_const(uint64_t n, uint32_t base)
+{
+  if (IS_POWER_OF_2(base))
+    {
+      n >>= LOG2_FLOOR(base);
+    }
+  else if (UINTPTR_MAX == UINT32_MAX)
+    {
+      div64_const32(n, base);
+    }
+  else
+    {
+      n /= base;
+    }
+
+  return n;
+}
 
 #  define div_const(n, base) \
     ((sizeof(typeof(n)) == sizeof(uint64_t)) ? div64_const(n, base) : ((n) / (base)))


### PR DESCRIPTION


## Summary

from board/cxd56_automount.c:34:
 board/cxd56_automount.c:94:19: error: braced-group within expression allowed only inside a function
 94 | .ddelay = MSEC2TICK(CONFIG_CXD56_SDCARD_AUTOMOUNT_DDELAY),
 | ^~~~~~~~~
 board/cxd56_automount.c:95:19: error: braced-group within expression allowed only inside a function
 95 | .udelay = MSEC2TICK(CONFIG_CXD56_SDCARD_AUTOMOUNT_UDELAY),
 | ^~~~~~~~~

Compile-time assignment uses regular division, and runtime assignment uses high-performance division

## Impact

None

## Testing

ostest PASS
